### PR TITLE
Fix SocketsHttpHandler connection pool accounting for dropped connections

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection
+    internal partial class HttpConnection
     {
         private sealed class ChunkedEncodingReadStream : HttpContentReadStream
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection : IDisposable
+    internal partial class HttpConnection : IDisposable
     {
         private sealed class ChunkedEncodingWriteStream : HttpContentWriteStream
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection : IDisposable
+    internal partial class HttpConnection : IDisposable
     {
         private sealed class ConnectionCloseReadStream : HttpContentReadStream
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection : IDisposable
+    internal partial class HttpConnection : IDisposable
     {
         private sealed class ContentLengthReadStream : HttpContentReadStream
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection : IDisposable
+    internal partial class HttpConnection : IDisposable
     {
         private sealed class ContentLengthWriteStream : HttpContentWriteStream
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/EmptyReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/EmptyReadStream.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection : IDisposable
+    internal partial class HttpConnection : IDisposable
     {
         private sealed class EmptyReadStream : HttpContentReadStream
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionContent.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection : IDisposable
+    internal partial class HttpConnection : IDisposable
     {
         private sealed class HttpConnectionContent : HttpContent
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionHandler.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
 
         public HttpConnectionHandler(HttpConnectionSettings settings)
         {
-            _connectionPools = new HttpConnectionPools(settings, settings._maxConnectionsPerServer, usingProxy: false);
+            _connectionPools = new HttpConnectionPools(settings, usingProxy: false);
         }
 
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -209,7 +209,9 @@ namespace System.Net.Http
                 transportContext = sslStream.TransportContext;
             }
 
-            return new HttpConnection(this, stream, transportContext);
+            return _maxConnections == int.MaxValue ?
+                new HttpConnection(this, stream, transportContext) :
+                new HttpConnectionWithFinalizer(this, stream, transportContext); // finalizer needed to signal the pool when a connection is dropped
         }
 
         /// <summary>Enqueues a waiter to the waiters list.</summary>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPools.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPools.cs
@@ -43,11 +43,11 @@ namespace System.Net.Http
         // CONSIDER: We are passing HttpConnectionSettings here, but all we really need are the SSL settings.
         // When we refactor the SSL settings to use SslAuthenticationOptions, just pass that here.
 
-        public HttpConnectionPools(HttpConnectionSettings settings, int maxConnectionsPerServer, bool usingProxy)
+        public HttpConnectionPools(HttpConnectionSettings settings, bool usingProxy)
         {
             _settings = settings;
             _usingProxy = usingProxy;
-            _maxConnectionsPerServer = maxConnectionsPerServer;
+            _maxConnectionsPerServer = settings._maxConnectionsPerServer;
             _pools = new ConcurrentDictionary<HttpConnectionKey, HttpConnectionPool>();
             // Start out with the timer not running, since we have no pools.
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpProxyConnectionHandler.cs
@@ -26,7 +26,7 @@ namespace System.Net.Http
             _innerHandler = innerHandler;
             _proxy = settings._proxy ?? ConstructSystemProxy();
             _defaultCredentials = settings._defaultProxyCredentials;
-            _connectionPools = new HttpConnectionPools(settings, settings._maxConnectionsPerServer, usingProxy: true);
+            _connectionPools = new HttpConnectionPools(settings, usingProxy: true);
         }
 
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection : IDisposable
+    internal partial class HttpConnection : IDisposable
     {
         private sealed class RawConnectionStream : HttpContentDuplexStream
         {


### PR DESCRIPTION
When MaxConnectionsPerServer is set to anything other than int.MaxValue, the SocketsHttpHandler pool keeps track of the number of connections handed out, and this count is updated when a connection is disposed.  But if a response stream isn't disposed of, resulting in the connection never being disposed of, the count may never be updated.  This fix adds an HttpConnection derived type that simply adds a finalizer, making it pay-for-play when MaxConnectionsPerServer is set to something other than the default.

cc: @geoffkizer, @davidsh, @Priya91, @wfurt 