### PR TITLE
Workstation Id should be returned correctly

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -306,7 +306,7 @@ namespace System.Data.SqlClient
                 // Note: In Longhorn you'll be able to rename a machine without
                 // rebooting.  Therefore, don't cache this machine name.
                 SqlConnectionString constr = (SqlConnectionString)ConnectionOptions;
-                string result = ((null != constr) ? constr.WorkstationId : string.Empty);
+                string result = constr?.WorkstationId ?? Environment.MachineName;
                 return result;
             }
         }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -89,6 +89,21 @@ namespace System.Data.SqlClient.Tests
             }
         }
 
+        [Theory]
+        [InlineData("RandomStringForTargetServer", true)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        public void RetrieveWorkstationId(string workstation, bool withDispose)
+        {
+            string connectionString = $"Workstation Id={workstation}";
+            SqlConnection conn = new SqlConnection(connectionString);
+            if(withDispose)
+            {
+                conn.Dispose();
+            }
+            Assert.Equal(Environment.MachineName, conn.WorkstationId);
+        }
+
         [Fact]
         public void ConnectionTimeoutTestWithThread()
         {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -90,10 +90,11 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Theory]
-        [InlineData("RandomStringForTargetServer", true)]
-        [InlineData(null, false)]
-        [InlineData("", false)]
-        public void RetrieveWorkstationId(string workstation, bool withDispose)
+        [InlineData("RandomStringForTargetServer", false, true)]
+        [InlineData("RandomStringForTargetServer", true, false)]
+        [InlineData(null, false, false)]
+        [InlineData("", false, false)]
+        public void RetrieveWorkstationId(string workstation, bool withDispose, bool shouldMatchSetWorkstationId)
         {
             string connectionString = $"Workstation Id={workstation}";
             SqlConnection conn = new SqlConnection(connectionString);
@@ -101,7 +102,8 @@ namespace System.Data.SqlClient.Tests
             {
                 conn.Dispose();
             }
-            Assert.Equal(Environment.MachineName, conn.WorkstationId);
+            string expected = shouldMatchSetWorkstationId ? workstation : Environment.MachineName;
+            Assert.Equal(expected, conn.WorkstationId);
         }
 
         [Fact]


### PR DESCRIPTION
Workstation Id should be returned correctly in SqlConnection .

Fixes https://github.com/dotnet/corefx/issues/22871
