### PR TITLE
Log when an insecure Https -> Http redirect is blocked

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -888,6 +888,13 @@ namespace System.Net.Http
 
                 HttpResponseMessage responseMessage = WinHttpResponseParser.CreateResponseMessage(state, _doManualDecompressionCheck);
                 state.Tcs.TrySetResult(responseMessage);
+
+                if(responseMessage.StatusCode == HttpStatusCode.Redirect &&
+                   responseMessage.Headers.Location.IsAbsoluteUri &&
+                   responseMessage.Headers.Location.Scheme == Uri.UriSchemeHttps) {
+                    //WinHttpTraceHelper.Trace("Possible insecure redirect (https -> http) detected.");
+                    Console.WriteLine("Insecure redirect detected.");
+                }
             }
             catch (Exception ex)
             {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -894,8 +894,8 @@ namespace System.Net.Http
                      (responseMessage.StatusCode >= HttpStatusCode.RedirectKeepVerb && responseMessage.StatusCode <= (HttpStatusCode)308)) &&
                     state.RequestMessage.RequestUri.Scheme == Uri.UriSchemeHttps && responseMessage.Headers.Location?.Scheme == Uri.UriSchemeHttp)
                 {
-                    WinHttpTraceHelper.Trace("WinHttpHandler.SendAsync: Insecure https to http redirect from" +
-                        $"{state.RequestMessage.RequestUri} to {responseMessage.Headers.Location} blocked.");
+                    WinHttpTraceHelper.Trace("WinHttpHandler.SendAsync: Insecure https to http redirect from {0} to {1} blocked.",
+                        state.RequestMessage.RequestUri.ToString(), responseMessage.Headers.Location.ToString());
                 }
             }
             catch (Exception ex)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -889,8 +889,9 @@ namespace System.Net.Http
                 HttpResponseMessage responseMessage = WinHttpResponseParser.CreateResponseMessage(state, _doManualDecompressionCheck);
                 state.Tcs.TrySetResult(responseMessage);
 
+                // HttpStatusCode cast is needed for 308 Moved Permenantly, which we support but is not included in NetStandard status codes.
                 if (((responseMessage.StatusCode >= HttpStatusCode.MultipleChoices && responseMessage.StatusCode <= HttpStatusCode.SeeOther) ||
-                     (responseMessage.StatusCode >= HttpStatusCode.RedirectKeepVerb && responseMessage.StatusCode <= HttpStatusCode.PermanentRedirect)) &&
+                     (responseMessage.StatusCode >= HttpStatusCode.RedirectKeepVerb && responseMessage.StatusCode <= (HttpStatusCode)308)) &&
                     state.RequestMessage.RequestUri.Scheme == Uri.UriSchemeHttps && responseMessage.Headers.Location?.Scheme == Uri.UriSchemeHttp)
                 {
                     WinHttpTraceHelper.Trace("WinHttpHandler.SendAsync: Insecure https to http redirect from" +

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -889,11 +889,14 @@ namespace System.Net.Http
                 HttpResponseMessage responseMessage = WinHttpResponseParser.CreateResponseMessage(state, _doManualDecompressionCheck);
                 state.Tcs.TrySetResult(responseMessage);
 
-                if(responseMessage.StatusCode == HttpStatusCode.Redirect &&
-                   responseMessage.Headers.Location.IsAbsoluteUri &&
-                   responseMessage.Headers.Location.Scheme == Uri.UriSchemeHttps) {
-                    //WinHttpTraceHelper.Trace("Possible insecure redirect (https -> http) detected.");
-                    Console.WriteLine("Insecure redirect detected.");
+                if((responseMessage.StatusCode == HttpStatusCode.MultipleChoices ||
+                    responseMessage.StatusCode == HttpStatusCode.MovedPermanently ||
+                    responseMessage.StatusCode == HttpStatusCode.Redirect ||
+                    responseMessage.StatusCode == HttpStatusCode.RedirectMethod ||
+                    responseMessage.StatusCode == HttpStatusCode.RedirectKeepVerb) &&
+                   state.RequestMessage.RequestUri.Scheme == Uri.UriSchemeHttps &&
+                   responseMessage.Headers.Location?.Scheme == Uri.UriSchemeHttp) {
+                    WinHttpTraceHelper.Trace("WinHttpHandler.SendAsync: Insecure https to http redirect blocked.");
                 }
             }
             catch (Exception ex)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -889,14 +889,12 @@ namespace System.Net.Http
                 HttpResponseMessage responseMessage = WinHttpResponseParser.CreateResponseMessage(state, _doManualDecompressionCheck);
                 state.Tcs.TrySetResult(responseMessage);
 
-                if((responseMessage.StatusCode == HttpStatusCode.MultipleChoices ||
-                    responseMessage.StatusCode == HttpStatusCode.MovedPermanently ||
-                    responseMessage.StatusCode == HttpStatusCode.Redirect ||
-                    responseMessage.StatusCode == HttpStatusCode.RedirectMethod ||
-                    responseMessage.StatusCode == HttpStatusCode.RedirectKeepVerb) &&
-                   state.RequestMessage.RequestUri.Scheme == Uri.UriSchemeHttps &&
-                   responseMessage.Headers.Location?.Scheme == Uri.UriSchemeHttp) {
-                    WinHttpTraceHelper.Trace("WinHttpHandler.SendAsync: Insecure https to http redirect blocked.");
+                if (((responseMessage.StatusCode >= HttpStatusCode.MultipleChoices && responseMessage.StatusCode <= HttpStatusCode.SeeOther) ||
+                     (responseMessage.StatusCode >= HttpStatusCode.RedirectKeepVerb && responseMessage.StatusCode <= HttpStatusCode.PermanentRedirect)) &&
+                    state.RequestMessage.RequestUri.Scheme == Uri.UriSchemeHttps && responseMessage.Headers.Location?.Scheme == Uri.UriSchemeHttp)
+                {
+                    WinHttpTraceHelper.Trace("WinHttpHandler.SendAsync: Insecure https to http redirect from" +
+                        $"{state.RequestMessage.RequestUri} to {responseMessage.Headers.Location} blocked.");
                 }
             }
             catch (Exception ex)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -890,7 +890,8 @@ namespace System.Net.Http
                 state.Tcs.TrySetResult(responseMessage);
 
                 // HttpStatusCode cast is needed for 308 Moved Permenantly, which we support but is not included in NetStandard status codes.
-                if (((responseMessage.StatusCode >= HttpStatusCode.MultipleChoices && responseMessage.StatusCode <= HttpStatusCode.SeeOther) ||
+                if (WinHttpTraceHelper.IsTraceEnabled() &&
+                    ((responseMessage.StatusCode >= HttpStatusCode.MultipleChoices && responseMessage.StatusCode <= HttpStatusCode.SeeOther) ||
                      (responseMessage.StatusCode >= HttpStatusCode.RedirectKeepVerb && responseMessage.StatusCode <= (HttpStatusCode)308)) &&
                     state.RequestMessage.RequestUri.Scheme == Uri.UriSchemeHttps && responseMessage.Headers.Location?.Scheme == Uri.UriSchemeHttp)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
@@ -371,8 +371,9 @@ namespace System.Net.Http
                         SetCookieOption(newUri);
                     }
 
-                    if(newUri.Scheme == Uri.UriSchemeHttp && _requestMessage.RequestUri.Scheme == Uri.UriSchemeHttps) {
-                        EventSourceTrace("Insecure https to http redirect blocked.");
+                    if (newUri.Scheme == Uri.UriSchemeHttp && _requestMessage.RequestUri.Scheme == Uri.UriSchemeHttps)
+                    {
+                        EventSourceTrace($"Insecure https to http redirect from {_requestMessage.RequestUri} to {newUri} blocked.");
                     }
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
@@ -370,6 +370,10 @@ namespace System.Net.Http
                     {
                         SetCookieOption(newUri);
                     }
+
+                    if(newUri.Scheme == Uri.UriSchemeHttp && _requestMessage.RequestUri.Scheme == Uri.UriSchemeHttps) {
+                        EventSourceTrace("Insecure https to http redirect blocked.");
+                    }
                 }
 
                 // Set up the new credentials, either for the new Uri if we were able to get it, 

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
@@ -373,7 +373,7 @@ namespace System.Net.Http
 
                     if (newUri.Scheme == Uri.UriSchemeHttp && _requestMessage.RequestUri.Scheme == Uri.UriSchemeHttps)
                     {
-                        EventSourceTrace($"Insecure https to http redirect from {_requestMessage.RequestUri} to {newUri} blocked.");
+                        EventSourceTrace($"Insecure https to http redirect: {0}", (_requestMessage.RequestUri, newUri));
                     }
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
@@ -373,7 +373,7 @@ namespace System.Net.Http
 
                     if (newUri.Scheme == Uri.UriSchemeHttp && _requestMessage.RequestUri.Scheme == Uri.UriSchemeHttps)
                     {
-                        EventSourceTrace($"Insecure https to http redirect: {0}", (_requestMessage.RequestUri, newUri));
+                        EventSourceTrace("Insecure https to http redirect: {0}", (_requestMessage.RequestUri, newUri));
                     }
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticateAndRedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticateAndRedirectHandler.cs
@@ -132,6 +132,10 @@ namespace System.Net.Http
                     (HttpUtilities.IsSupportedSecureScheme(request.RequestUri.Scheme) && HttpUtilities.IsSupportedSecureScheme(location.Scheme));
                 if (!allowed)
                 {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        NetEventSource.Info(this, $"Insecure https to http redirect from {request.RequestUri} to {location} blocked.");
+                    }
                     break;
                 }
 


### PR DESCRIPTION
.NET Core does not allow insecure redirects from https to http, but .NET Framework does. Developers have had some trouble diagnosing the issue when they run into this difference. This change adds logging to help developers track down what is going on.

Fixes: #23813 (was https://github.com/dotnet/corefx/issues/24577)