### PR TITLE
Lower the default stack buffer size for calling getpwXXX_r methods.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
@@ -11,6 +11,8 @@ internal static partial class Interop
     {
         internal unsafe struct Passwd
         {
+            internal const int InitialBufferSize = 256;
+
             internal byte* Name;
             internal byte* Password;
             internal uint  UserId;

--- a/src/Common/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Unix.cs
@@ -97,7 +97,7 @@ namespace System.IO
                 // if we simply couldn't find a home directory for the current user.
                 // In that case, we pass back the null value and let the caller decide
                 // what to do.
-                const int BufLen = 1024;
+                const int BufLen = Interop.Sys.Passwd.InitialBufferSize;
                 byte* stackBuf = stackalloc byte[BufLen];
                 if (TryGetHomeDirectoryFromPasswd(stackBuf, BufLen, out userHomeDirectory))
                     return userHomeDirectory;

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -627,7 +627,7 @@ namespace System.Diagnostics
             // First try with a buffer that should suffice for 99% of cases.
             // Note: on CentOS/RedHat 7.1 systems, getpwnam_r returns 'user not found' if the buffer is too small
             // see https://bugs.centos.org/view.php?id=7324
-            const int BufLen = 1024;
+            const int BufLen = Interop.Sys.Passwd.InitialBufferSize;
             byte* stackBuf = stackalloc byte[BufLen];
             if (TryGetPasswd(userName, stackBuf, BufLen, out passwd))
             {

--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -368,7 +368,7 @@ namespace System
             {
                 // First try with a buffer that should suffice for 99% of cases.
                 string username;
-                const int BufLen = 1024;
+                const int BufLen = Interop.Sys.Passwd.InitialBufferSize;
                 byte* stackBuf = stackalloc byte[BufLen];
                 if (TryGetUserNameFromPasswd(stackBuf, BufLen, out username))
                 {


### PR DESCRIPTION
By default, 1K is too large of a buffer to allocate on the stack.

Fixes #26959