### PR TITLE
reorganize and cleanup some LoopbackServer code

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -104,9 +104,7 @@ namespace System.Net.Test.Common
 
         public async Task AcceptConnectionAsync(Func<Connection, Task> funcAsync)
         {
-            Socket s = await _listenSocket.AcceptAsync().ConfigureAwait(false);
-
-            using (s)
+            using (Socket s = await _listenSocket.AcceptAsync().ConfigureAwait(false))
             {
                 s.NoDelay = true;
 

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -81,27 +81,6 @@ namespace System.Net.Test.Common
             });
         }
 
-        private static string GetDefaultHttpResponse() => $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n";
-
-        public async Task<List<string>> AcceptConnectionSendResponseAndCloseAsync(string response)
-        {
-            List<string> lines = null;
-
-            // Note, we assume there's no request body.  
-            // We'll close the connection after reading the request header and sending the response.
-            await AcceptConnectionAsync(async connection =>
-            {
-                lines = await connection.ReadRequestHeaderAndSendResponseAsync(response);
-            });
-
-            return lines;
-        }
-
-        public Task<List<string>> AcceptConnectionSendDefaultResponseAndCloseAsync()
-        {
-            return AcceptConnectionSendResponseAndCloseAsync(GetDefaultHttpResponse());
-        }
-
         public async Task AcceptConnectionAsync(Func<Connection, Task> funcAsync)
         {
             using (Socket s = await _listenSocket.AcceptAsync().ConfigureAwait(false))
@@ -134,6 +113,102 @@ namespace System.Net.Test.Common
                 }
             }
         }
+
+        public async Task<List<string>> AcceptConnectionSendCustomResponseAndCloseAsync(string response)
+        {
+            List<string> lines = null;
+
+            // Note, we assume there's no request body.  
+            // We'll close the connection after reading the request header and sending the response.
+            await AcceptConnectionAsync(async connection =>
+            {
+                lines = await connection.ReadRequestHeaderAndSendCustomResponseAsync(response);
+            });
+
+            return lines;
+        }
+
+        public async Task<List<string>> AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null)
+        {
+            List<string> lines = null;
+
+            // Note, we assume there's no request body.  
+            // We'll close the connection after reading the request header and sending the response.
+            await AcceptConnectionAsync(async connection =>
+            {
+                lines = await connection.ReadRequestHeaderAndSendResponseAsync(statusCode, additionalHeaders, content);
+            });
+
+            return lines;
+        }
+
+        // Stolen from HttpStatusDescription code in the product code
+        private static string GetStatusDescription(HttpStatusCode code)
+        {
+            switch ((int)code)
+            {
+                case 100: return "Continue";
+                case 101: return "Switching Protocols";
+                case 102: return "Processing";
+
+                case 200: return "OK";
+                case 201: return "Created";
+                case 202: return "Accepted";
+                case 203: return "Non-Authoritative Information";
+                case 204: return "No Content";
+                case 205: return "Reset Content";
+                case 206: return "Partial Content";
+                case 207: return "Multi-Status";
+
+                case 300: return "Multiple Choices";
+                case 301: return "Moved Permanently";
+                case 302: return "Found";
+                case 303: return "See Other";
+                case 304: return "Not Modified";
+                case 305: return "Use Proxy";
+                case 307: return "Temporary Redirect";
+
+                case 400: return "Bad Request";
+                case 401: return "Unauthorized";
+                case 402: return "Payment Required";
+                case 403: return "Forbidden";
+                case 404: return "Not Found";
+                case 405: return "Method Not Allowed";
+                case 406: return "Not Acceptable";
+                case 407: return "Proxy Authentication Required";
+                case 408: return "Request Timeout";
+                case 409: return "Conflict";
+                case 410: return "Gone";
+                case 411: return "Length Required";
+                case 412: return "Precondition Failed";
+                case 413: return "Request Entity Too Large";
+                case 414: return "Request-Uri Too Long";
+                case 415: return "Unsupported Media Type";
+                case 416: return "Requested Range Not Satisfiable";
+                case 417: return "Expectation Failed";
+                case 422: return "Unprocessable Entity";
+                case 423: return "Locked";
+                case 424: return "Failed Dependency";
+                case 426: return "Upgrade Required"; // RFC 2817
+
+                case 500: return "Internal Server Error";
+                case 501: return "Not Implemented";
+                case 502: return "Bad Gateway";
+                case 503: return "Service Unavailable";
+                case 504: return "Gateway Timeout";
+                case 505: return "Http Version Not Supported";
+                case 507: return "Insufficient Storage";
+            }
+            return null;
+        }
+
+        public static string GetHttpResponse(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null) =>
+            $"HTTP/1.1 {(int)statusCode} {GetStatusDescription(statusCode)}\r\n" +
+            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+            $"Content-Length: {(content == null ? 0 : content.Length)}\r\n" + 
+            additionalHeaders +
+            "\r\n" + 
+            content;
 
         public class Options
         {
@@ -196,18 +271,23 @@ namespace System.Net.Test.Common
                 return lines;
             }
 
-            public async Task<List<string>> ReadRequestHeaderAndSendResponseAsync(string response)
+            public async Task SendResponseAsync(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null)
+            {
+                await _writer.WriteAsync(GetHttpResponse(statusCode, additionalHeaders, content));
+            }
+
+            public async Task<List<string>> ReadRequestHeaderAndSendCustomResponseAsync(string response)
             {
                 List<string> lines = await ReadRequestHeaderAsync().ConfigureAwait(false);
-
-                await _writer.WriteAsync(response).ConfigureAwait(false);
-
+                await _writer.WriteAsync(response);
                 return lines;
             }
 
-            public Task<List<string>> ReadRequestHeaderAndSendDefaultResponseAsync()
+            public async Task<List<string>> ReadRequestHeaderAndSendResponseAsync(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null)
             {
-                return ReadRequestHeaderAndSendResponseAsync(GetDefaultHttpResponse());
+                List<string> lines = await ReadRequestHeaderAsync().ConfigureAwait(false);
+                await SendResponseAsync(statusCode, additionalHeaders, content);
+                return lines;
             }
         }
     }

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -4,23 +4,138 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Net.NetworkInformation;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net.Test.Common
 {
-    public class LoopbackServer
+    public sealed class LoopbackServer : IDisposable
     {
-        public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> AllowAllCertificates = (_, __, ___, ____) => true;
+        private Socket _listenSocket;
+        private Options _options;
+        private Uri _uri;
+
+        // Use CreateServerAsync or similar to create
+        private LoopbackServer(Socket listenSocket, Options options)
+        {
+            _listenSocket = listenSocket;
+            _options = options;
+
+            var localEndPoint = (IPEndPoint)listenSocket.LocalEndPoint;
+            string host = options.Address.AddressFamily == AddressFamily.InterNetworkV6 ?
+                $"[{localEndPoint.Address}]" :
+                localEndPoint.Address.ToString();
+
+            string scheme = options.UseSsl ? "https" : "http";
+            if (options.WebSocketEndpoint)
+            {
+                scheme = options.UseSsl ? "wss" : "ws";
+            }
+
+            _uri = new Uri($"{scheme}://{host}:{localEndPoint.Port}/");
+        }
+
+        public void Dispose()
+        {
+            if (_listenSocket != null)
+            {
+                _listenSocket.Dispose();
+                _listenSocket = null;
+            }
+        }
+
+        public Uri Uri => _uri;
+
+        public static async Task CreateServerAsync(Func<LoopbackServer, Task> funcAsync, Options options = null)
+        {
+            options = options ?? new Options();
+
+            using (var listenSocket = new Socket(options.Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listenSocket.Bind(new IPEndPoint(options.Address, 0));
+                listenSocket.Listen(options.ListenBacklog);
+
+                using (var server = new LoopbackServer(listenSocket, options))
+                {
+                    await funcAsync(server);
+                }
+            }
+        }
+
+        public static Task CreateServerAsync(Func<LoopbackServer, Uri, Task> funcAsync, Options options = null)
+        {
+            return CreateServerAsync(server => funcAsync(server, server.Uri), options);
+        }
+
+        public static Task CreateClientAndServerAsync(Func<Uri, Task> clientFunc, Func<LoopbackServer, Task> serverFunc)
+        {
+            return CreateServerAsync(async server =>
+            {
+                Task clientTask = clientFunc(server.Uri);
+                Task serverTask = serverFunc(server);
+
+                await new Task[] { clientTask, serverTask }.WhenAllOrAnyFailed();
+            });
+        }
+
+        private static string GetDefaultHttpResponse() => $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n";
+
+        public async Task<List<string>> AcceptConnectionSendResponseAndCloseAsync(string response)
+        {
+            List<string> lines = null;
+
+            // Note, we assume there's no request body.  
+            // We'll close the connection after reading the request header and sending the response.
+            await AcceptConnectionAsync(async connection =>
+            {
+                lines = await connection.ReadRequestHeaderAndSendResponseAsync(response);
+            });
+
+            return lines;
+        }
+
+        public Task<List<string>> AcceptConnectionSendDefaultResponseAndCloseAsync()
+        {
+            return AcceptConnectionSendResponseAndCloseAsync(GetDefaultHttpResponse());
+        }
+
+        public async Task AcceptConnectionAsync(Func<Connection, Task> funcAsync)
+        {
+            Socket s = await _listenSocket.AcceptAsync().ConfigureAwait(false);
+
+            using (s)
+            {
+                s.NoDelay = true;
+
+                Stream stream = new NetworkStream(s, ownsSocket: false);
+                if (_options.UseSsl)
+                {
+                    var sslStream = new SslStream(stream, false, delegate { return true; });
+                    using (var cert = Configuration.Certificates.GetServerCertificate())
+                    {
+                        await sslStream.AuthenticateAsServerAsync(
+                            cert,
+                            clientCertificateRequired: true, // allowed but not required
+                            enabledSslProtocols: _options.SslProtocols,
+                            checkCertificateRevocation: false).ConfigureAwait(false);
+                    }
+                    stream = sslStream;
+                }
+
+                if (_options.StreamWrapper != null)
+                {
+                    stream = _options.StreamWrapper(stream);
+                }
+
+                using (var connection = new Connection(s, stream))
+                {
+                    await funcAsync(connection);
+                }
+            }
+        }
 
         public class Options
         {
@@ -29,249 +144,73 @@ namespace System.Net.Test.Common
             public bool UseSsl { get; set; } = false;
             public SslProtocols SslProtocols { get; set; } = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
             public bool WebSocketEndpoint { get; set; } = false;
-            public Func<Stream, Stream> ResponseStreamWrapper { get; set; }
+            public Func<Stream, Stream> StreamWrapper { get; set; }
         }
 
-        public static Task CreateServerAsync(Func<Socket, Uri, Task> funcAsync, Options options = null)
+        public sealed class Connection : IDisposable
         {
-            IPEndPoint ignored;
-            return CreateServerAsync(funcAsync, out ignored, options);
-        }
+            private Socket _socket;
+            private Stream _stream;
+            private StreamReader _reader;
+            private StreamWriter _writer;
 
-        public static Task CreateServerAsync(Func<Socket, Uri, Task> funcAsync, out IPEndPoint localEndPoint, Options options = null)
-        {
-            options = options ?? new Options();
-            try
+            public Connection(Socket socket, Stream stream)
             {
-                var server = new Socket(options.Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                _socket = socket;
+                _stream = stream;
 
-                server.Bind(new IPEndPoint(options.Address, 0));
-                server.Listen(options.ListenBacklog);
-
-                localEndPoint = (IPEndPoint)server.LocalEndPoint;
-                string host = options.Address.AddressFamily == AddressFamily.InterNetworkV6 ? 
-                    $"[{localEndPoint.Address}]" :
-                    localEndPoint.Address.ToString();
-
-                string scheme = options.UseSsl ? "https" : "http";
-                if (options.WebSocketEndpoint)
-                {
-                    scheme = options.UseSsl ? "wss" : "ws";
-                }
-
-                var url = new Uri($"{scheme}://{host}:{localEndPoint.Port}/");
-
-                return funcAsync(server, url).ContinueWith(t =>
-                {
-                    server.Dispose();
-                    t.GetAwaiter().GetResult();
-                }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
-            }
-            catch (Exception e)
-            {
-                localEndPoint = null;
-                return Task.FromException(e);
-            }
-        }
-
-        public static Task CreateServerAndClientAsync(Func<Uri, Task> clientFunc, Func<Socket, Task> serverFunc)
-        {
-            return CreateServerAsync(async (server, uri) =>
-            {
-                Task clientTask = clientFunc(uri);
-                Task serverTask = serverFunc(server);
-
-                await new Task[] { clientTask, serverTask }.WhenAllOrAnyFailed();
-            });
-        }
-
-        public static string DefaultHttpResponse => $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n";
-
-        public static IPAddress GetIPv6LinkLocalAddress() =>
-            NetworkInterface
-                .GetAllNetworkInterfaces()
-                .SelectMany(i => i.GetIPProperties().UnicastAddresses)
-                .Select(a => a.Address)
-                .Where(a => a.IsIPv6LinkLocal)
-                .FirstOrDefault();
-
-        public static Task<List<string>> ReadRequestAndSendResponseAsync(Socket server, string response = null, Options options = null)
-        {
-            return AcceptSocketAsync(server, (s, stream, reader, writer) => ReadWriteAcceptedAsync(s, reader, writer, response), options);
-        }
-
-        public static async Task<List<string>> ReadWriteAcceptedAsync(Socket s, StreamReader reader, StreamWriter writer, string response = null)
-        {
-            // Read request line and headers. Skip any request body.
-            var lines = new List<string>();
-            string line;
-            while (!string.IsNullOrEmpty(line = await reader.ReadLineAsync().ConfigureAwait(false)))
-            {
-                lines.Add(line);
+                _reader = new StreamReader(stream, Encoding.ASCII);
+                _writer = new StreamWriter(stream, Encoding.ASCII) { AutoFlush = true };
             }
 
-            await writer.WriteAsync(response ?? DefaultHttpResponse).ConfigureAwait(false);
+            public Socket Socket => _socket;
+            public Stream Stream => _stream;
+            public StreamReader Reader => _reader;
+            public StreamWriter Writer => _writer;
 
-            return lines;
-        }
-
-        public static async Task<bool> WebSocketHandshakeAsync(Socket s, StreamReader reader, StreamWriter writer)
-        {
-            string serverResponse = null;
-            string currentRequestLine;
-            while (!string.IsNullOrEmpty(currentRequestLine = await reader.ReadLineAsync().ConfigureAwait(false)))
-            {
-                string[] tokens = currentRequestLine.Split(new char[] { ':' }, 2);
-                if (tokens.Length == 2)
-                {
-                    string headerName = tokens[0];
-                    if (headerName == "Sec-WebSocket-Key")
-                    {
-                        string headerValue = tokens[1].Trim();
-                        string responseSecurityAcceptValue = ComputeWebSocketHandshakeSecurityAcceptValue(headerValue);
-                        serverResponse =
-                            "HTTP/1.1 101 Switching Protocols\r\n" +
-                            "Upgrade: websocket\r\n" +
-                            "Connection: Upgrade\r\n" +
-                            "Sec-WebSocket-Accept: " + responseSecurityAcceptValue + "\r\n\r\n";
-                    }
-                }
-            }
-
-            if (serverResponse != null)
-            {
-                // We received a valid WebSocket opening handshake. Send the appropriate response.
-                await writer.WriteAsync(serverResponse).ConfigureAwait(false);
-                return true;
-            }
-
-            return false;
-        }
-
-        private static string ComputeWebSocketHandshakeSecurityAcceptValue(string secWebSocketKey)
-        {
-            // GUID specified by RFC 6455.
-            const string Rfc6455Guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-            string combinedKey = secWebSocketKey + Rfc6455Guid;
-
-            // Use of SHA1 hash is required by RFC 6455.
-            SHA1 sha1Provider = new SHA1CryptoServiceProvider();
-            byte[] sha1Hash = sha1Provider.ComputeHash(Encoding.UTF8.GetBytes(combinedKey));
-            return Convert.ToBase64String(sha1Hash);
-        }
-
-        public static async Task<List<string>> AcceptSocketAsync(Socket server, Func<Socket, Stream, StreamReader, StreamWriter, Task<List<string>>> funcAsync, Options options = null)
-        {
-            options = options ?? new Options();
-            Socket s = await server.AcceptAsync().ConfigureAwait(false);
-            s.NoDelay = true;
-            try
-            {
-                Stream stream = new NetworkStream(s, ownsSocket: false);
-                if (options.UseSsl)
-                {
-                    var sslStream = new SslStream(stream, false, delegate { return true; });
-                    using (var cert = Configuration.Certificates.GetServerCertificate())
-                    {
-                        await sslStream.AuthenticateAsServerAsync(
-                            cert,
-                            clientCertificateRequired: true, // allowed but not required
-                            enabledSslProtocols: options.SslProtocols,
-                            checkCertificateRevocation: false).ConfigureAwait(false);
-                    }
-                    stream = sslStream;
-                }
-
-                using (var reader = new StreamReader(stream, Encoding.ASCII))
-                using (var writer = new StreamWriter(options?.ResponseStreamWrapper?.Invoke(stream) ?? stream, Encoding.ASCII) { AutoFlush = true })
-                {
-                    return await funcAsync(s, stream, reader, writer).ConfigureAwait(false);
-                }
-            }
-            finally
+            public void Dispose()
             {
                 try
                 {
-                    s.Shutdown(SocketShutdown.Send);
-                    s.Dispose();
+                    // Try to shutdown the send side of the socket.
+                    // This seems to help avoid connection reset issues caused by buffered data
+                    // that has not been sent/acked when the graceful shutdown timeout expires.
+                    // This may throw if the socket was already closed, so eat any exception.
+                    _socket.Shutdown(SocketShutdown.Send);
                 }
-                catch (ObjectDisposedException)
+                catch (Exception) { }
+
+                _reader.Dispose();
+                _writer.Dispose();
+                _stream.Dispose();
+                _socket.Dispose();
+            }
+
+            public async Task<List<string>> ReadRequestHeaderAsync()
+            {
+                var lines = new List<string>();
+                string line;
+                while (!string.IsNullOrEmpty(line = await _reader.ReadLineAsync().ConfigureAwait(false)))
                 {
-                    // In case the test itself disposes of the socket
+                    lines.Add(line);
                 }
+
+                return lines;
+            }
+
+            public async Task<List<string>> ReadRequestHeaderAndSendResponseAsync(string response)
+            {
+                List<string> lines = await ReadRequestHeaderAsync().ConfigureAwait(false);
+
+                await _writer.WriteAsync(response).ConfigureAwait(false);
+
+                return lines;
+            }
+
+            public Task<List<string>> ReadRequestHeaderAndSendDefaultResponseAsync()
+            {
+                return ReadRequestHeaderAndSendResponseAsync(GetDefaultHttpResponse());
             }
         }
-
-        public enum TransferType
-        {
-            None = 0,
-            ContentLength,
-            Chunked
-        }
-
-        public enum TransferError
-        {
-            None = 0,
-            ContentLengthTooLarge,
-            ChunkSizeTooLarge,
-            MissingChunkTerminator
-        }
-
-        public static Task StartTransferTypeAndErrorServer(
-            TransferType transferType,
-            TransferError transferError,
-            out IPEndPoint localEndPoint)
-        {
-            return CreateServerAsync((server, url) => AcceptSocketAsync(server, async (client, stream, reader, writer) =>
-            {
-                // Read past request headers.
-                string line;
-                while (!string.IsNullOrEmpty(line = reader.ReadLine())) ;
-
-                // Determine response transfer headers.
-                string transferHeader = null;
-                string content = "This is some response content.";
-                if (transferType == TransferType.ContentLength)
-                {
-                    transferHeader = transferError == TransferError.ContentLengthTooLarge ?
-                        $"Content-Length: {content.Length + 42}\r\n" :
-                        $"Content-Length: {content.Length}\r\n";
-                }
-                else if (transferType == TransferType.Chunked)
-                {
-                    transferHeader = "Transfer-Encoding: chunked\r\n";
-                }
-
-                // Write response header
-                await writer.WriteAsync("HTTP/1.1 200 OK\r\n").ConfigureAwait(false);
-                await writer.WriteAsync($"Date: {DateTimeOffset.UtcNow:R}\r\n").ConfigureAwait(false);
-                await writer.WriteAsync("Content-Type: text/plain\r\n").ConfigureAwait(false);
-                if (!string.IsNullOrEmpty(transferHeader))
-                {
-                    await writer.WriteAsync(transferHeader).ConfigureAwait(false);
-                }
-                await writer.WriteAsync("\r\n").ConfigureAwait(false);
-
-                // Write response body
-                if (transferType == TransferType.Chunked)
-                {
-                    string chunkSizeInHex = string.Format(
-                        "{0:x}\r\n",
-                        content.Length + (transferError == TransferError.ChunkSizeTooLarge ? 42 : 0));
-                    await writer.WriteAsync(chunkSizeInHex).ConfigureAwait(false);
-                    await writer.WriteAsync($"{content}\r\n").ConfigureAwait(false);
-                    if (transferError != TransferError.MissingChunkTerminator)
-                    {
-                        await writer.WriteAsync("0\r\n\r\n").ConfigureAwait(false);
-                    }
-                }
-                else
-                {
-                    await writer.WriteAsync($"{content}").ConfigureAwait(false);
-                }
-
-                return null;
-            }), out localEndPoint);
-        }        
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -148,7 +148,7 @@ namespace System.Net.Http.Functional.Tests
                     {
                         LoopbackServer.CreateServerAsync(async (server, url) =>
                         {
-                            Task<List<string>> requestLines = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                            Task<List<string>> requestLines = server.AcceptConnectionSendResponseAndCloseAsync();
                             Task<HttpResponseMessage> response = client.GetAsync(url);
                             await Task.WhenAll(response, requestLines);
 
@@ -185,7 +185,7 @@ namespace System.Net.Http.Functional.Tests
                             await LoopbackServer.CreateServerAsync(async (server, url) =>
                             {
                                 await TestHelper.WhenAllCompletedOrAnyFailed(
-                                    server.AcceptConnectionSendDefaultResponseAndCloseAsync(),
+                                    server.AcceptConnectionSendResponseAndCloseAsync(),
                                     client.GetAsync(url));
                             });
 
@@ -286,7 +286,7 @@ namespace System.Net.Http.Functional.Tests
                             Task request = server.AcceptConnectionAsync(connection =>
                                 {
                                     tcs.Cancel();
-                                    return connection.ReadRequestHeaderAndSendDefaultResponseAsync();
+                                    return connection.ReadRequestHeaderAndSendResponseAsync();
                                 });
                             Task response = client.GetAsync(url, tcs.Token);
                             await Assert.ThrowsAnyAsync<Exception>(() => TestHelper.WhenAllCompletedOrAnyFailed(response, request));
@@ -356,7 +356,7 @@ namespace System.Net.Http.Functional.Tests
                     {
                         LoopbackServer.CreateServerAsync(async (server, url) =>
                         {
-                            Task<List<string>> requestLines = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                            Task<List<string>> requestLines = server.AcceptConnectionSendResponseAndCloseAsync();
                             Task<HttpResponseMessage> response = client.GetAsync(url);
                             await Task.WhenAll(response, requestLines);
 
@@ -610,7 +610,7 @@ namespace System.Net.Http.Functional.Tests
                             Task request = server.AcceptConnectionAsync(connection =>
                             {
                                 tcs.Cancel();
-                                return connection.ReadRequestHeaderAndSendDefaultResponseAsync();
+                                return connection.ReadRequestHeaderAndSendResponseAsync();
                             });
                             Task response = client.GetAsync(url, tcs.Token);
                             await Assert.ThrowsAnyAsync<Exception>(() => TestHelper.WhenAllCompletedOrAnyFailed(response, request));

--- a/src/System.Net.Http/tests/FunctionalTests/DribbleStream.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DribbleStream.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public sealed class DribbleStream : Stream
+    {
+        private readonly Stream _wrapped;
+        private readonly bool _clientDisconnectAllowed;
+
+        public DribbleStream(Stream wrapped, bool clientDisconnectAllowed = false)
+        {
+            _wrapped = wrapped;
+            _clientDisconnectAllowed = clientDisconnectAllowed;
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    await _wrapped.WriteAsync(buffer, offset + i, 1);
+                    await Task.Yield(); // introduce short delays, enough to send packets individually but not so long as to extend test duration significantly
+                }
+            }
+            catch (IOException) when (_clientDisconnectAllowed)
+            {
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    _wrapped.Write(buffer, offset + i, 1);
+                }
+            }
+            catch (IOException) when (_clientDisconnectAllowed)
+            {
+            }
+        }
+
+        public override bool CanRead => _wrapped.CanRead;
+        public override bool CanSeek => _wrapped.CanSeek;
+        public override bool CanWrite => _wrapped.CanWrite;
+        public override long Length => _wrapped.Length;
+        public override long Position { get => _wrapped.Position; set => _wrapped.Position = value; }
+        public override void Flush() => _wrapped.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => _wrapped.FlushAsync(cancellationToken);
+        public override int Read(byte[] buffer, int offset, int count) => _wrapped.Read(buffer, offset, count);
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => _wrapped.ReadAsync(buffer, offset, count, cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => _wrapped.Seek(offset, origin);
+        public override void SetLength(long value) => _wrapped.SetLength(value);
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => _wrapped.CopyToAsync(destination, bufferSize, cancellationToken);
+        public override void Close() => _wrapped.Close();
+        protected override void Dispose(bool disposing) => _wrapped.Dispose();
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -52,7 +52,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                        server.AcceptConnectionSendDefaultResponseAndCloseAsync(),
+                        server.AcceptConnectionSendResponseAndCloseAsync(),
                         client.GetAsync(url));
                 }, options);
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -52,7 +52,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server, options: options),
+                        server.AcceptConnectionSendDefaultResponseAndCloseAsync(),
                         client.GetAsync(url));
                 }, options);
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -239,7 +239,7 @@ namespace System.Net.Http.Functional.Tests
                     {
                         SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);
                         Assert.Equal(cert, sslStream.RemoteCertificate);
-                        await connection.ReadRequestHeaderAndSendDefaultResponseAsync();
+                        await connection.ReadRequestHeaderAndSendResponseAsync();
                     }));
             };
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
@@ -97,9 +97,9 @@ namespace System.Net.Http.Functional.Tests
                     handler.MaxConnectionsPerServer = 1;
 
                     // Let server handle two requests.
-                    const string Response = "HTTP/1.1 200 OK\r\nContent-Length: 26\r\n\r\nabcdefghijklmnopqrstuvwxyz";
-                    Task serverTask1 = LoopbackServer.ReadRequestAndSendResponseAsync(server, Response);
-                    Task serverTask2 = LoopbackServer.ReadRequestAndSendResponseAsync(server, Response);
+                    const string ResponseContent = "abcdefghijklmnopqrstuvwxyz";
+                    Task serverTask1 = server.AcceptConnectionSendResponseAndCloseAsync(content: ResponseContent);
+                    Task serverTask2 = server.AcceptConnectionSendResponseAndCloseAsync(content: ResponseContent);
 
                     // Make first request and drop the response, not explicitly disposing of it.
                     void MakeAndDropRequest() => client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead); // separated out to enable GC of response

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -74,7 +74,7 @@ namespace System.Net.Http.Functional.Tests
                         var cts = new CancellationTokenSource();
                         Task serverTask = Task.Run(async delegate
                         {
-                            await connection.ReadRequestHeaderAndSendResponseAsync("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nMyInfiniteHeader: ");
+                            await connection.ReadRequestHeaderAndSendCustomResponseAsync("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nMyInfiniteHeader: ");
                             try
                             {
                                 while (!cts.IsCancellationRequested)
@@ -118,7 +118,7 @@ namespace System.Net.Http.Functional.Tests
 
                     await server.AcceptConnectionAsync(async connection =>
                     {
-                        Task serverTask = connection.ReadRequestHeaderAndSendResponseAsync(responseHeaders);
+                        Task serverTask = connection.ReadRequestHeaderAndSendCustomResponseAsync(responseHeaders);
 
                         if (shouldSucceed)
                         {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -61,7 +61,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                        server.AcceptConnectionSendDefaultResponseAndCloseAsync(),
+                        server.AcceptConnectionSendResponseAndCloseAsync(),
                         client.GetAsync(url));
                 });
                 Assert.Throws<InvalidOperationException>(() => handler.SslProtocols = SslProtocols.Tls12);
@@ -119,7 +119,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                        server.AcceptConnectionSendDefaultResponseAndCloseAsync(),
+                        server.AcceptConnectionSendResponseAndCloseAsync(),
                         client.GetAsync(url));
                 }, options);
             }
@@ -232,7 +232,7 @@ namespace System.Net.Http.Functional.Tests
                         server.AcceptConnectionAsync(async connection =>
                         {
                             Assert.Equal(SslProtocols.Tls12, Assert.IsType<SslStream>(connection.Stream).SslProtocol);
-                            await connection.ReadRequestHeaderAndSendDefaultResponseAsync();
+                            await connection.ReadRequestHeaderAndSendResponseAsync();
                         }));
                 }, options);
             }
@@ -258,7 +258,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                        Assert.ThrowsAsync(exceptedServerException, () => server.AcceptConnectionSendDefaultResponseAndCloseAsync()),
+                        Assert.ThrowsAsync(exceptedServerException, () => server.AcceptConnectionSendResponseAndCloseAsync()),
                         Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url)));
                 }, options);
             }
@@ -283,7 +283,7 @@ namespace System.Net.Http.Functional.Tests
                     await LoopbackServer.CreateServerAsync(async (server, url) =>
                     {
                         await TestHelper.WhenAllCompletedOrAnyFailed(
-                            Assert.ThrowsAsync<IOException>(() => server.AcceptConnectionSendDefaultResponseAndCloseAsync()),
+                            Assert.ThrowsAsync<IOException>(() => server.AcceptConnectionSendResponseAndCloseAsync()),
                             Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url)));
                     }, options);
 
@@ -293,7 +293,7 @@ namespace System.Net.Http.Functional.Tests
                         await LoopbackServer.CreateServerAsync(async (server, url) =>
                         {
                             await TestHelper.WhenAllCompletedOrAnyFailed(
-                                server.AcceptConnectionSendDefaultResponseAndCloseAsync(),
+                                server.AcceptConnectionSendResponseAndCloseAsync(),
                                 client.GetAsync(url));
                         }, options);
                     }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -361,12 +361,12 @@ namespace System.Net.Http.Functional.Tests
         {
             using (HttpClient client = CreateHttpClient())
             {
-                var options = new LoopbackServer.Options { Address = LoopbackServer.GetIPv6LinkLocalAddress() };
+                var options = new LoopbackServer.Options { Address = TestHelper.GetIPv6LinkLocalAddress() };
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     _output.WriteLine(url.ToString());
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server, options: options),
+                        server.AcceptConnectionSendDefaultResponseAndCloseAsync(),
                         client.GetAsync(url));
                 }, options);
             }
@@ -384,7 +384,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     _output.WriteLine(url.ToString());
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server, options: options),
+                        server.AcceptConnectionSendDefaultResponseAndCloseAsync(),
                         client.GetAsync(url));
                 }, options);
             }
@@ -560,7 +560,7 @@ namespace System.Net.Http.Functional.Tests
                 using (var client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server, responseHeaders);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(responseHeaders);
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
                     using (HttpResponseMessage response = await getResponseTask)
@@ -616,7 +616,7 @@ namespace System.Net.Http.Functional.Tests
                     await LoopbackServer.CreateServerAsync(async (redirServer, redirUrl) =>
                     {
                         // Original URL will redirect to a different URL
-                        Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
+                        Task<List<string>> serverTask = origServer.AcceptConnectionSendResponseAndCloseAsync(
                                 $"HTTP/1.1 {statusCode} OK\r\n" +
                                 $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                                 $"Location: {redirUrl}\r\n" +
@@ -626,7 +626,7 @@ namespace System.Net.Http.Functional.Tests
                         await serverTask;
 
                         // Redirected URL answers with success
-                        serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(redirServer,
+                        serverTask = redirServer.AcceptConnectionSendResponseAndCloseAsync(
                                 $"HTTP/1.1 200 OK\r\n" +
                                 $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                                 "\r\n");
@@ -729,7 +729,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     Task<HttpResponseMessage> getTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
                             $"HTTP/1.1 302 OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             "\r\n");
@@ -854,14 +854,15 @@ namespace System.Net.Http.Functional.Tests
                     {
                         Task<HttpResponseMessage> getResponseTask = client.GetAsync(origUrl);
 
-                        Task redirectTask = LoopbackServer.ReadRequestAndSendResponseAsync(redirectServer);
+                        Task redirectTask = redirectServer.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                         await TestHelper.WhenAllCompletedOrAnyFailed(
                             getResponseTask,
-                            LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
+                            origServer.AcceptConnectionSendResponseAndCloseAsync(
                                 $"HTTP/1.1 {statusCode} OK\r\n" +
                                 $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                                 $"Location: {redirectUrl}\r\n" +
+                                "Content-Length: 0\r\n" +
                                 "\r\n"));
 
                         using (HttpResponseMessage response = await getResponseTask)
@@ -899,14 +900,14 @@ namespace System.Net.Http.Functional.Tests
                     Uri expectedUrl = new Uri(origUrl.ToString() + expectedFragment);
 
                     Task<HttpResponseMessage> getResponse = client.GetAsync(origUrl);
-                    Task firstRequest = LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
+                    Task firstRequest = origServer.AcceptConnectionSendResponseAndCloseAsync(
                             $"HTTP/1.1 302 OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             $"Location: {redirectUrl}\r\n" +
                             "\r\n");
                     Assert.Equal(firstRequest, await Task.WhenAny(firstRequest, getResponse));
 
-                    Task secondRequest = LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
+                    Task secondRequest = origServer.AcceptConnectionSendResponseAndCloseAsync(
                             $"HTTP/1.1 200 OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             "\r\n");
@@ -1060,7 +1061,7 @@ namespace System.Net.Http.Functional.Tests
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         getResponseTask,
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        server.AcceptConnectionSendResponseAndCloseAsync(
                             "HTTP/1.1 200 OK\r\n" +
                             "Transfer-Encoding: chunked\r\n" +
                             (includeTrailerHeader ? "Trailer: MyCoolTrailerHeader\r\n" : "") +
@@ -1101,7 +1102,7 @@ namespace System.Net.Http.Functional.Tests
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         getResponseTask,
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        server.AcceptConnectionSendResponseAndCloseAsync(
                             "HTTP/1.1 200 OK\r\n" +
                             "Transfer-Encoding: chunked\r\n" +
                             "\r\n" +
@@ -1155,13 +1156,11 @@ namespace System.Net.Http.Functional.Tests
                         $"{chunkSize}\r\n";
 
                     var tcs = new TaskCompletionSource<bool>();
-                    Task serverTask =
-                        LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                    Task serverTask = server.AcceptConnectionAsync(async connection =>
                         {
-                            var list = await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, partialResponse);
+                            await connection.ReadRequestHeaderAndSendResponseAsync(partialResponse);
                             await tcs.Task;
-                            return list;
-                        }, null);
+                        });
 
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
                     tcs.SetResult(true);
@@ -1182,10 +1181,10 @@ namespace System.Net.Http.Functional.Tests
 
                     var cts = new CancellationTokenSource();
                     var tcs = new TaskCompletionSource<bool>();
-                    Task serverTask = LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                    Task serverTask = server.AcceptConnectionAsync(async connection =>
                     {
-                        while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
-                        await writer.WriteAsync("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
+                        await connection.ReadRequestHeaderAndSendResponseAsync("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
+                        TextWriter writer = connection.Writer;
                         try
                         {
                             while (!cts.IsCancellationRequested) // infinite to make sure implementation doesn't OOM
@@ -1195,8 +1194,7 @@ namespace System.Net.Http.Functional.Tests
                             }
                         }
                         catch { }
-                        return null;
-                    }, null);
+                    });
 
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
                     cts.Cancel();
@@ -1279,10 +1277,9 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Task<HttpResponseMessage> getResponse = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
 
-                    await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                    await server.AcceptConnectionAsync(async connection =>
                     {
-                        while (!string.IsNullOrEmpty(reader.ReadLine())) ;
-                        await writer.WriteAsync(
+                        await connection.ReadRequestHeaderAndSendResponseAsync(
                             "HTTP/1.1 200 OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             "Content-Length: 16000\r\n" +
@@ -1299,8 +1296,6 @@ namespace System.Net.Http.Functional.Tests
                                 Assert.True(bytesRead < buffer.Length, "bytesRead should be less than buffer.Length");
                             }
                         }
-
-                        return null;
                     });
                 }
             });
@@ -1318,40 +1313,35 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAsync(async (socket1, url1) =>
+            await LoopbackServer.CreateServerAsync(async (server1, url1) =>
             {
-                await LoopbackServer.CreateServerAsync(async (socket2, url2) =>
+                await LoopbackServer.CreateServerAsync(async (server2, url2) =>
                 {
-                    await LoopbackServer.CreateServerAsync(async (socket3, url3) =>
+                    await LoopbackServer.CreateServerAsync(async (server3, url3) =>
                     {
                         var unblockServers = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
 
                         // First server connects but doesn't send any response yet
-                        Task server1 = LoopbackServer.AcceptSocketAsync(socket1, async (s, stream, reader, writer) =>
+                        Task serverTask1 = server1.AcceptConnectionAsync(async connection1 =>
                         {
                             await unblockServers.Task;
-                            return null;
                         });
 
                         // Second server connects and sends some but not all headers
-                        Task server2 = LoopbackServer.AcceptSocketAsync(socket2, async (s, stream, reader, writer) =>
+                        Task serverTask2 = server2.AcceptConnectionAsync(async connection2 =>
                         {
-                            while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
-                            await writer.WriteAsync($"HTTP/1.1 200 OK\r\n");
+                            await connection2.ReadRequestHeaderAndSendResponseAsync($"HTTP/1.1 200 OK\r\n");
                             await unblockServers.Task;
-                            return null;
                         });
 
                         // Third server connects and sends all headers and some but not all of the body
-                        Task server3 = LoopbackServer.AcceptSocketAsync(socket3, async (s, stream, reader, writer) =>
+                        Task serverTask3 = server3.AcceptConnectionAsync(async connection3 =>
                         {
-                            while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
-                            await writer.WriteAsync($"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 20\r\n\r\n");
-                            await writer.WriteAsync("1234567890");
+                            await connection3.ReadRequestHeaderAndSendResponseAsync($"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 20\r\n\r\n");
+                            await connection3.Writer.WriteAsync("1234567890");
                             await unblockServers.Task;
-                            await writer.WriteAsync("1234567890");
-                            s.Shutdown(SocketShutdown.Send);
-                            return null;
+                            await connection3.Writer.WriteAsync("1234567890");
+                            connection3.Socket.Shutdown(SocketShutdown.Send);
                         });
 
                         // Make three requests
@@ -1396,7 +1386,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    await server.AcceptConnectionSendResponseAndCloseAsync(
                             $"HTTP/1.1 {statusCode}\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             "\r\n");
@@ -1680,11 +1670,10 @@ namespace System.Net.Http.Functional.Tests
         {
             await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Task responseTask = LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
+                Task responseTask = server.AcceptConnectionAsync(async connection =>
                 {
                     var buffer = new byte[1000];
-                    while (await socket.ReceiveAsync(new ArraySegment<byte>(buffer, 0, buffer.Length), SocketFlags.None) != 0);
-                    return null;
+                    while (await connection.Socket.ReceiveAsync(new ArraySegment<byte>(buffer, 0, buffer.Length), SocketFlags.None) != 0);
                 });
 
                 using (var client = CreateHttpClient())
@@ -2099,7 +2088,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     Task<HttpResponseMessage> getResponse = client.SendAsync(request);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponse, serverTask);
 
                     List<string> receivedRequest = await serverTask;
@@ -2282,7 +2271,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
                     List<string> receivedRequest = await serverTask;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -626,10 +626,7 @@ namespace System.Net.Http.Functional.Tests
                         await serverTask;
 
                         // Redirected URL answers with success
-                        serverTask = redirServer.AcceptConnectionSendResponseAndCloseAsync(
-                                $"HTTP/1.1 200 OK\r\n" +
-                                $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                                "\r\n");
+                        serverTask = redirServer.AcceptConnectionSendDefaultResponseAndCloseAsync();
                         await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                         List<string> receivedRequest = await serverTask;
@@ -907,10 +904,7 @@ namespace System.Net.Http.Functional.Tests
                             "\r\n");
                     Assert.Equal(firstRequest, await Task.WhenAny(firstRequest, getResponse));
 
-                    Task secondRequest = origServer.AcceptConnectionSendResponseAndCloseAsync(
-                            $"HTTP/1.1 200 OK\r\n" +
-                            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                            "\r\n");
+                    Task secondRequest = origServer.AcceptConnectionSendDefaultResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(secondRequest, getResponse);
 
                     using (HttpResponseMessage response = await getResponse)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -125,7 +125,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     Task<string> getTask = client.GetStringAsync(url);
-                    Task serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Length: {contentLength}\r\n" +
@@ -417,7 +417,7 @@ namespace System.Net.Http.Functional.Tests
                     await Task.Delay(TimeSpan.FromSeconds(.5));
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         getTask,
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server));
+                        server.AcceptConnectionSendDefaultResponseAndCloseAsync());
                 });
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -125,12 +125,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     Task<string> getTask = client.GetStringAsync(url);
-                    Task serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        $"Content-Length: {contentLength}\r\n" +
-                        "\r\n" +
-                        new string('s', contentLength));
+                    Task serverTask = server.AcceptConnectionSendResponseAndCloseAsync(content: new string('s', contentLength));
                     Task bothTasks = TestHelper.WhenAllCompletedOrAnyFailed(getTask, serverTask);
 
                     if (exceptionExpected)
@@ -417,7 +412,7 @@ namespace System.Net.Http.Functional.Tests
                     await Task.Delay(TimeSpan.FromSeconds(.5));
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         getTask,
-                        server.AcceptConnectionSendDefaultResponseAndCloseAsync());
+                        server.AcceptConnectionSendResponseAndCloseAsync());
                 });
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -45,7 +45,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -68,7 +68,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -111,7 +111,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -141,7 +141,7 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     List<string> requestLines = await serverTask;
 
@@ -171,7 +171,7 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", "C=3");
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     List<string> requestLines = await serverTask;
 
@@ -216,7 +216,7 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -259,7 +259,7 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", "B=2");
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -302,7 +302,7 @@ namespace System.Net.Http.Functional.Tests
             const string path1 = "/foo";
             const string path2 = "/bar";
 
-            await LoopbackServer.CreateServerAndClientAsync(async url =>
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 Uri url1 = new Uri(url, path1);
                 Uri url2 = new Uri(url, path2);
@@ -321,13 +321,13 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                List<string> request1Lines = await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                List<string> request1Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
                     $"HTTP/1.1 302 Found\r\nContent-Length: 0\r\nLocation: {path2}\r\nConnection: close\r\n\r\n");
 
                 Assert.Contains($"Cookie: cookie1=value1", request1Lines);
                 Assert.Equal(1, request1Lines.Count(s => s.StartsWith("Cookie:")));
 
-                List<string> request2Lines = await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                List<string> request2Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
                     $"HTTP/1.1 200 OK\r\nContent-Length: {s_simpleContent.Length}\r\n\r\n{s_simpleContent}");
 
                 Assert.Contains($"Cookie: cookie2=value2", request2Lines);
@@ -351,7 +351,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 Ok\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: {GetCookieHeaderValue(cookieName, cookieValue)}\r\n\r\n{s_simpleContent}");
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -381,7 +381,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Set-Cookie: A=1; Path=/\r\n" +
@@ -419,7 +419,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 Ok\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: {s_cookieName}={newCookieValue}\r\n\r\n{s_simpleContent}");
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -442,7 +442,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 Ok\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: {s_cookieName}=; Expires=Sun, 06 Nov 1994 08:49:37 GMT\r\n\r\n{s_simpleContent}");
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -458,7 +458,7 @@ namespace System.Net.Http.Functional.Tests
             const string path1 = "/foo";
             const string path2 = "/bar";
 
-            await LoopbackServer.CreateServerAndClientAsync(async url =>
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 Uri url1 = new Uri(url, path1);
 
@@ -482,12 +482,12 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                List<string> request1Lines = await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                List<string> request1Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
                     $"HTTP/1.1 302 Found\r\nContent-Length: 0\r\nLocation: {path2}\r\nSet-Cookie: A=1; Path=/\r\nConnection: close\r\n\r\n");
 
                 Assert.Equal(0, request1Lines.Count(s => s.StartsWith("Cookie:")));
 
-                List<string> request2Lines = await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                List<string> request2Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
                     $"HTTP/1.1 200 OK\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: B=2; Path=/\r\n\r\n{s_simpleContent}");
 
                 Assert.Contains($"Cookie: A=1", request2Lines);
@@ -505,7 +505,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAndClientAsync(async url =>
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.Credentials = new NetworkCredential("user", "pass");
@@ -528,20 +528,16 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                await LoopbackServer.AcceptSocketAsync(server, async (_, stream, reader, writer) =>
+                await server.AcceptConnectionAsync(async connection =>
                 {
-                    List<string> request1Lines = await LoopbackServer.ReadWriteAcceptedAsync(server, reader, writer, 
-                        $"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nWWW-Authenticate: Basic realm=\"WallyWorld\"\r\nSet-Cookie: A=1; Path=/\r\n\r\n");
+                    List<string> request1Lines = await connection.ReadRequestHeaderAndSendResponseAsync($"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nWWW-Authenticate: Basic realm=\"WallyWorld\"\r\nSet-Cookie: A=1; Path=/\r\n\r\n");
 
                     Assert.Equal(0, request1Lines.Count(s => s.StartsWith("Cookie:")));
 
-                    List<string> request2Lines = await LoopbackServer.ReadWriteAcceptedAsync(server, reader, writer,
-                        $"HTTP/1.1 200 OK\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: B=2; Path=/\r\n\r\n{s_simpleContent}");
+                    List<string> request2Lines = await connection.ReadRequestHeaderAndSendResponseAsync($"HTTP/1.1 200 OK\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: B=2; Path=/\r\n\r\n{s_simpleContent}");
 
                     Assert.Contains($"Cookie: A=1", request2Lines);
                     Assert.Equal(1, request2Lines.Count(s => s.StartsWith("Cookie:")));
-
-                    return null;
                 });
             });
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -45,7 +45,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -68,7 +68,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -111,7 +111,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -141,7 +141,7 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     List<string> requestLines = await serverTask;
 
@@ -171,7 +171,7 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", "C=3");
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     List<string> requestLines = await serverTask;
 
@@ -216,7 +216,7 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -259,7 +259,7 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", "B=2");
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     List<string> requestLines = await serverTask;
@@ -321,14 +321,12 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                List<string> request1Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
-                    $"HTTP/1.1 302 Found\r\nContent-Length: 0\r\nLocation: {path2}\r\nConnection: close\r\n\r\n");
+                List<string> request1Lines = await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.Found, $"Location: {path2}\r\n");
 
                 Assert.Contains($"Cookie: cookie1=value1", request1Lines);
                 Assert.Equal(1, request1Lines.Count(s => s.StartsWith("Cookie:")));
 
-                List<string> request2Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
-                    $"HTTP/1.1 200 OK\r\nContent-Length: {s_simpleContent.Length}\r\n\r\n{s_simpleContent}");
+                List<string> request2Lines = await server.AcceptConnectionSendResponseAndCloseAsync(content: s_simpleContent);
 
                 Assert.Contains($"Cookie: cookie2=value2", request2Lines);
                 Assert.Equal(1, request2Lines.Count(s => s.StartsWith("Cookie:")));
@@ -352,7 +350,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 Ok\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: {GetCookieHeaderValue(cookieName, cookieValue)}\r\n\r\n{s_simpleContent}");
+                        HttpStatusCode.OK, $"Set-Cookie: {GetCookieHeaderValue(cookieName, cookieValue)}\r\n", s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     CookieCollection collection = handler.CookieContainer.GetCookies(url);
@@ -382,14 +380,11 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        HttpStatusCode.OK,
                         $"Set-Cookie: A=1; Path=/\r\n" +
                         $"Set-Cookie   : B=2; Path=/\r\n" + // space before colon to verify header is trimmed and recognized
-                        $"Set-Cookie:    C=3; Path=/\r\n" +
-                        $"Content-Length: {s_simpleContent.Length}\r\n" +
-                        $"\r\n" +
-                        $"{s_simpleContent}");
+                        $"Set-Cookie:    C=3; Path=/\r\n",
+                        s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     CookieCollection collection = handler.CookieContainer.GetCookies(url);
@@ -420,7 +415,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 Ok\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: {s_cookieName}={newCookieValue}\r\n\r\n{s_simpleContent}");
+                        HttpStatusCode.OK, $"Set-Cookie: {s_cookieName}={newCookieValue}\r\n", s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     CookieCollection collection = handler.CookieContainer.GetCookies(url);
@@ -443,7 +438,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 Ok\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: {s_cookieName}=; Expires=Sun, 06 Nov 1994 08:49:37 GMT\r\n\r\n{s_simpleContent}");
+                        HttpStatusCode.OK, $"Set-Cookie: {s_cookieName}=; Expires=Sun, 06 Nov 1994 08:49:37 GMT\r\n", s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     CookieCollection collection = handler.CookieContainer.GetCookies(url);
@@ -483,12 +478,12 @@ namespace System.Net.Http.Functional.Tests
             async server =>
             {
                 List<string> request1Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
-                    $"HTTP/1.1 302 Found\r\nContent-Length: 0\r\nLocation: {path2}\r\nSet-Cookie: A=1; Path=/\r\nConnection: close\r\n\r\n");
+                    HttpStatusCode.Found, $"Location: {path2}\r\nSet-Cookie: A=1; Path=/\r\n");
 
                 Assert.Equal(0, request1Lines.Count(s => s.StartsWith("Cookie:")));
 
                 List<string> request2Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
-                    $"HTTP/1.1 200 OK\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: B=2; Path=/\r\n\r\n{s_simpleContent}");
+                    HttpStatusCode.OK, $"Set-Cookie: B=2; Path=/\r\n", s_simpleContent);
 
                 Assert.Contains($"Cookie: A=1", request2Lines);
                 Assert.Equal(1, request2Lines.Count(s => s.StartsWith("Cookie:")));
@@ -530,11 +525,16 @@ namespace System.Net.Http.Functional.Tests
             {
                 await server.AcceptConnectionAsync(async connection =>
                 {
-                    List<string> request1Lines = await connection.ReadRequestHeaderAndSendResponseAsync($"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nWWW-Authenticate: Basic realm=\"WallyWorld\"\r\nSet-Cookie: A=1; Path=/\r\n\r\n");
+                    List<string> request1Lines = await connection.ReadRequestHeaderAndSendResponseAsync(
+                        HttpStatusCode.Unauthorized,
+                        $"WWW-Authenticate: Basic realm=\"WallyWorld\"\r\nSet-Cookie: A=1; Path=/\r\n");
 
                     Assert.Equal(0, request1Lines.Count(s => s.StartsWith("Cookie:")));
 
-                    List<string> request2Lines = await connection.ReadRequestHeaderAndSendResponseAsync($"HTTP/1.1 200 OK\r\nContent-Length: {s_simpleContent.Length}\r\nSet-Cookie: B=2; Path=/\r\n\r\n{s_simpleContent}");
+                    List<string> request2Lines = await connection.ReadRequestHeaderAndSendResponseAsync(
+                        HttpStatusCode.OK,
+                        $"Set-Cookie: B=2; Path=/\r\n",
+                        s_simpleContent);
 
                     Assert.Contains($"Cookie: A=1", request2Lines);
                     Assert.Equal(1, request2Lines.Count(s => s.StartsWith("Cookie:")));

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -29,16 +29,15 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+                        server.AcceptConnectionSendResponseAndCloseAsync(
+                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     var requestLines = await serverTask;
                     Assert.Equal($"GET {url.PathAndQuery} HTTP/1.0", requestLines[0]);
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
         [Fact]
@@ -53,16 +52,15 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+                        server.AcceptConnectionSendResponseAndCloseAsync(
+                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     var requestLines = await serverTask;
                     Assert.Equal($"GET {url.PathAndQuery} HTTP/1.1", requestLines[0]);
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
         [Theory]
@@ -90,9 +88,8 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream_ClientDisconnectOk });
+                        server.AcceptConnectionSendResponseAndCloseAsync(
+                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     if (exceptionType == null)
                     {
@@ -105,7 +102,7 @@ namespace System.Net.Http.Functional.Tests
                         await Assert.ThrowsAsync(exceptionType, (() => TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask)));
                     }
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk});
         }
 
         [Theory]
@@ -133,9 +130,8 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream_ClientDisconnectOk });
+                        server.AcceptConnectionSendResponseAndCloseAsync(
+                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     if (exceptionType == null)
                     {
@@ -148,7 +144,7 @@ namespace System.Net.Http.Functional.Tests
                         await Assert.ThrowsAsync(exceptionType, (() => TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask)));
                     }
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk });
         }
 
         [Theory]
@@ -165,9 +161,8 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                            $"HTTP/1.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+                        server.AcceptConnectionSendResponseAndCloseAsync(
+                            $"HTTP/1.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -177,7 +172,7 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Equal(responseMinorVersion, response.Version.Minor);
                     }
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
         [Theory]
@@ -197,9 +192,8 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                            $"HTTP/1.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+                        server.AcceptConnectionSendResponseAndCloseAsync(
+                            $"HTTP/1.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -222,7 +216,7 @@ namespace System.Net.Http.Functional.Tests
                         }
                     }
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // Uap ignores response version if not 1.0 or 1.1
@@ -243,9 +237,8 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                            $"HTTP/0.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream_ClientDisconnectOk });
+                        server.AcceptConnectionSendResponseAndCloseAsync(
+                            $"HTTP/0.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     if (reportAs10)
                     {
@@ -262,7 +255,7 @@ namespace System.Net.Http.Functional.Tests
                         await Assert.ThrowsAsync<HttpRequestException>(async () => await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask));
                     }
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk });
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // Uap ignores response version if not 1.0 or 1.1
@@ -300,9 +293,8 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                            $"HTTP/{responseMajorVersion}.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream_ClientDisconnectOk });
+                        server.AcceptConnectionSendResponseAndCloseAsync(
+                            $"HTTP/{responseMajorVersion}.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     if (reportAs00)
                     {
@@ -339,7 +331,7 @@ namespace System.Net.Http.Functional.Tests
                         await Assert.ThrowsAsync<HttpRequestException>(async () => await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask));
                     }
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk });
         }
 
         [Theory]
@@ -399,18 +391,18 @@ namespace System.Net.Http.Functional.Tests
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         getResponseTask,
-                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        server.AcceptConnectionSendResponseAndCloseAsync(
                             $"{statusLine}\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                            "\r\n",
-                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream }));
+                            "Content-Length: 0\r\n" +
+                            "\r\n"));
                     using (HttpResponseMessage response = await getResponseTask)
                     {
                         Assert.Equal(expectedStatusCode, (int)response.StatusCode);
                         Assert.Equal(expectedReason, response.ReasonPhrase);
                     }
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
         public static IEnumerable<string> GetInvalidStatusLine()
@@ -512,14 +504,12 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    Task ignoredServerTask = LoopbackServer.ReadRequestAndSendResponseAsync(
-                        server,
-                        responseString + "\r\nContent-Length: 0\r\n\r\n",
-                        new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+                    Task ignoredServerTask = server.AcceptConnectionSendResponseAndCloseAsync(
+                        responseString + "\r\nContent-Length: 0\r\n\r\n");
 
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]   // Does not support LF-only
@@ -533,9 +523,8 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
-                        $"HTTP/1.1 200 OK{lineEnding}Date: {DateTimeOffset.UtcNow:R}{lineEnding}Server: TestServer{lineEnding}Content-Length: 0{lineEnding}{lineEnding}",
-                        new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
+                        $"HTTP/1.1 200 OK{lineEnding}Date: {DateTimeOffset.UtcNow:R}{lineEnding}Server: TestServer{lineEnding}Content-Length: 0{lineEnding}{lineEnding}");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -546,7 +535,7 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Equal("TestServer", response.Headers.Server.ToString());
                     }
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
     }
 
@@ -554,44 +543,5 @@ namespace System.Net.Http.Functional.Tests
     {
         protected override Stream GetStream(Stream s) => new DribbleStream(s);
         protected override Stream GetStream_ClientDisconnectOk(Stream s) => new DribbleStream(s, true);
-
-        private sealed class DribbleStream : Stream
-        {
-            private readonly Stream _wrapped;
-            private readonly bool _clientDisconnectAllowed;
-
-            public DribbleStream(Stream wrapped, bool clientDisconnectAllowed = false)
-            {
-                _wrapped = wrapped;
-                _clientDisconnectAllowed = clientDisconnectAllowed;
-            }
-
-            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                try
-                {
-                    for (int i = 0; i < count; i++)
-                    {
-                        await _wrapped.WriteAsync(buffer, offset + i, 1);
-                        await Task.Yield(); // introduce short delays, enough to send packets individually but not so long as to extend test duration significantly
-                    }
-                }
-                catch (IOException) when (_clientDisconnectAllowed)
-                {
-                }
-            }
-
-            public override bool CanRead => false;
-            public override bool CanSeek => false;
-            public override bool CanWrite => _wrapped.CanWrite;
-            public override long Length => throw new NotSupportedException();
-            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
-            public override void Flush() => _wrapped.Flush();
-            public override Task FlushAsync(CancellationToken cancellationToken) => _wrapped.FlushAsync(cancellationToken);
-            public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
-            public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
-            public override void SetLength(long value) => throw new NotImplementedException();
-            public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
-        }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Version = HttpVersion.Version10;
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -49,7 +49,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Version = HttpVersion.Version11;
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -83,7 +83,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Version = new Version(0, minorVersion);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     if (exceptionType == null)
                     {
@@ -123,7 +123,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Version = new Version(majorVersion, minorVersion);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     if (exceptionType == null)
                     {
@@ -153,7 +153,7 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        server.AcceptConnectionSendResponseAndCloseAsync(
+                        server.AcceptConnectionSendCustomResponseAndCloseAsync(
                             $"HTTP/1.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
@@ -184,7 +184,7 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        server.AcceptConnectionSendResponseAndCloseAsync(
+                        server.AcceptConnectionSendCustomResponseAndCloseAsync(
                             $"HTTP/1.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
@@ -229,7 +229,7 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        server.AcceptConnectionSendResponseAndCloseAsync(
+                        server.AcceptConnectionSendCustomResponseAndCloseAsync(
                             $"HTTP/0.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     if (reportAs10)
@@ -285,7 +285,7 @@ namespace System.Net.Http.Functional.Tests
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
                     Task<List<string>> serverTask =
-                        server.AcceptConnectionSendResponseAndCloseAsync(
+                        server.AcceptConnectionSendCustomResponseAndCloseAsync(
                             $"HTTP/{responseMajorVersion}.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
                     if (reportAs00)
@@ -383,7 +383,7 @@ namespace System.Net.Http.Functional.Tests
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         getResponseTask,
-                        server.AcceptConnectionSendResponseAndCloseAsync(
+                        server.AcceptConnectionSendCustomResponseAndCloseAsync(
                             $"{statusLine}\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             "Content-Length: 0\r\n" +
@@ -496,7 +496,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    Task ignoredServerTask = server.AcceptConnectionSendResponseAndCloseAsync(
+                    Task ignoredServerTask = server.AcceptConnectionSendCustomResponseAndCloseAsync(
                         responseString + "\r\nContent-Length: 0\r\n\r\n");
 
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
@@ -515,7 +515,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
+                    Task<List<string>> serverTask = server.AcceptConnectionSendCustomResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK{lineEnding}Date: {DateTimeOffset.UtcNow:R}{lineEnding}Server: TestServer{lineEnding}Content-Length: 0{lineEnding}{lineEnding}");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -28,9 +28,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Version = HttpVersion.Version10;
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask =
-                        server.AcceptConnectionSendResponseAndCloseAsync(
-                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -51,9 +49,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Version = HttpVersion.Version11;
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask =
-                        server.AcceptConnectionSendResponseAndCloseAsync(
-                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -87,9 +83,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Version = new Version(0, minorVersion);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask =
-                        server.AcceptConnectionSendResponseAndCloseAsync(
-                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     if (exceptionType == null)
                     {
@@ -129,9 +123,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Version = new Version(majorVersion, minorVersion);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask =
-                        server.AcceptConnectionSendResponseAndCloseAsync(
-                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     if (exceptionType == null)
                     {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
@@ -15,12 +15,6 @@ namespace System.Net.Http.Functional.Tests
     public class HttpRetryProtocolTests : HttpClientTestBase
     {
         private static readonly string s_simpleContent = "Hello World\r\n";
-        private static readonly string s_simpleResponse =
-            $"HTTP/1.1 200 OK\r\n" +
-            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-            $"Content-Length: {s_simpleContent.Length}\r\n" +
-            "\r\n" +
-            s_simpleContent;
 
         // Retry logic is supported by SocketsHttpHandler, CurlHandler, uap, and netfx.  Only WinHttp does not support. 
         private bool IsRetrySupported => !IsWinHttpHandler;
@@ -56,14 +50,14 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     // Initial response
-                    await connection.ReadRequestHeaderAndSendResponseAsync(s_simpleResponse);
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: s_simpleContent);
 
                     // Second response: Read request headers, then close connection
                     await connection.ReadRequestHeaderAsync();
                 });
 
                 // Client should reconnect.  Accept that connection and send response.
-                await server.AcceptConnectionSendResponseAndCloseAsync(s_simpleResponse);
+                await server.AcceptConnectionSendResponseAndCloseAsync(content: s_simpleContent);
             });
         }
 
@@ -104,7 +98,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     // Initial response
-                    await connection.ReadRequestHeaderAndSendResponseAsync(s_simpleResponse);
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: s_simpleContent);
 
                     // Second response: Read request headers, then close connection
                     List<string> lines = await connection.ReadRequestHeaderAsync();
@@ -122,7 +116,7 @@ namespace System.Net.Http.Functional.Tests
                     string contentLine = await connection.Reader.ReadLineAsync();
                     Assert.Equal(s_simpleContent, contentLine + "\r\n");
 
-                    await connection.Writer.WriteAsync(s_simpleResponse);
+                    await connection.SendResponseAsync(content: s_simpleContent);
                 });
             });
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
@@ -34,7 +34,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAndClientAsync(async url =>
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 using (HttpClient client = CreateHttpClient())
                 {
@@ -52,20 +52,18 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                // Accept first connection
+                await server.AcceptConnectionAsync(async connection =>
                 {
                     // Initial response
-                    await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, s_simpleResponse);
+                    await connection.ReadRequestHeaderAndSendResponseAsync(s_simpleResponse);
 
                     // Second response: Read request headers, then close connection
-                    await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, "");
-                    s.Close();
-
-                    // Client should reconnect.  Accept that connection and send response.
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(server, s_simpleResponse);
-
-                    return null;
+                    await connection.ReadRequestHeaderAsync();
                 });
+
+                // Client should reconnect.  Accept that connection and send response.
+                await server.AcceptConnectionSendResponseAndCloseAsync(s_simpleResponse);
             });
         }
 
@@ -77,7 +75,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAndClientAsync(async url =>
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 using (HttpClient client = CreateHttpClient())
                 {
@@ -102,33 +100,29 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                // Accept first connection
+                await server.AcceptConnectionAsync(async connection =>
                 {
                     // Initial response
-                    await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, s_simpleResponse);
+                    await connection.ReadRequestHeaderAndSendResponseAsync(s_simpleResponse);
 
                     // Second response: Read request headers, then close connection
-                    List<string> lines = await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, "");
+                    List<string> lines = await connection.ReadRequestHeaderAsync();
                     Assert.Contains("Expect: 100-continue", lines);
-                    s.Close();
+                });
 
-                    // Client should reconnect.  Accept that connection and send response.
-                    await LoopbackServer.AcceptSocketAsync(server, async (s2, stream2, reader2, writer2) =>
-                    {
-                        List<string> lines2 = await LoopbackServer.ReadWriteAcceptedAsync(s2, reader2, writer2, "");
-                        Assert.Contains("Expect: 100-continue", lines2);
+                // Client should reconnect.  Accept that connection and send response.
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    List<string> lines = await connection.ReadRequestHeaderAsync();
+                    Assert.Contains("Expect: 100-continue", lines);
 
-                        await writer2.WriteAsync("HTTP/1.1 100 Continue\r\n\r\n");
+                    await connection.Writer.WriteAsync("HTTP/1.1 100 Continue\r\n\r\n");
 
-                        string contentLine = await reader2.ReadLineAsync();
-                        Assert.Equal(s_simpleContent, contentLine + "\r\n");
+                    string contentLine = await connection.Reader.ReadLineAsync();
+                    Assert.Equal(s_simpleContent, contentLine + "\r\n");
 
-                        await writer2.WriteAsync(s_simpleResponse);
-
-                        return null;
-                    });
-
-                    return null;
+                    await connection.Writer.WriteAsync(s_simpleResponse);
                 });
             });
         }

--- a/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
@@ -36,7 +36,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(uri);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server, LoopbackServer.DefaultHttpResponse);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -69,7 +69,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Headers.Host = hostname;
                     request.Headers.Referrer = uri;
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server, LoopbackServer.DefaultHttpResponse);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -101,7 +101,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(serverUrl);
-                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server, 
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 302 Redirect\r\nLocation: http://{uri.IdnHost}/\r\n\r\n");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);

--- a/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
@@ -36,7 +36,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(uri);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -69,7 +69,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Headers.Host = hostname;
                     request.Headers.Referrer = uri;
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -102,7 +102,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(serverUrl);
                     Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 302 Redirect\r\nLocation: http://{uri.IdnHost}/\r\n\r\n");
+                        HttpStatusCode.Found, "Location: http://{uri.IdnHost}/\r\n");
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -208,44 +208,112 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [InlineData(LoopbackServer.TransferType.ContentLength, LoopbackServer.TransferError.ContentLengthTooLarge)]
-        [InlineData(LoopbackServer.TransferType.Chunked, LoopbackServer.TransferError.MissingChunkTerminator)]
-        [InlineData(LoopbackServer.TransferType.Chunked, LoopbackServer.TransferError.ChunkSizeTooLarge)]
+        [InlineData(TransferType.ContentLength, TransferError.ContentLengthTooLarge)]
+        [InlineData(TransferType.Chunked, TransferError.MissingChunkTerminator)]
+        [InlineData(TransferType.Chunked, TransferError.ChunkSizeTooLarge)]
         public async Task ReadAsStreamAsync_InvalidServerResponse_ThrowsIOException(
-            LoopbackServer.TransferType transferType,
-            LoopbackServer.TransferError transferError)
+            TransferType transferType,
+            TransferError transferError)
         {
-            IPEndPoint serverEndPoint;
-            Task serverTask = LoopbackServer.StartTransferTypeAndErrorServer(transferType, transferError, out serverEndPoint);
-
-            await Assert.ThrowsAsync<IOException>(() => ReadAsStreamHelper(serverEndPoint));
-
-            await serverTask;
+            await StartTransferTypeAndErrorServer(transferType, transferError, async uri =>
+            {
+                await Assert.ThrowsAsync<IOException>(() => ReadAsStreamHelper(uri));
+            });
         }
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [InlineData(LoopbackServer.TransferType.None, LoopbackServer.TransferError.None)]
-        [InlineData(LoopbackServer.TransferType.ContentLength, LoopbackServer.TransferError.None)]
-        [InlineData(LoopbackServer.TransferType.Chunked, LoopbackServer.TransferError.None)]
+        [InlineData(TransferType.None, TransferError.None)]
+        [InlineData(TransferType.ContentLength, TransferError.None)]
+        [InlineData(TransferType.Chunked, TransferError.None)]
         public async Task ReadAsStreamAsync_ValidServerResponse_Success(
-            LoopbackServer.TransferType transferType,
-            LoopbackServer.TransferError transferError)
+            TransferType transferType,
+            TransferError transferError)
         {
-            IPEndPoint serverEndPoint;
-            Task serverTask = LoopbackServer.StartTransferTypeAndErrorServer(transferType, transferError, out serverEndPoint);
-
-            await ReadAsStreamHelper(serverEndPoint);
-
-            await serverTask;
+            await StartTransferTypeAndErrorServer(transferType, transferError, async uri =>
+            {
+                await ReadAsStreamHelper(uri);
+            });
         }
 
-        private async Task ReadAsStreamHelper(IPEndPoint serverEndPoint)
+        public enum TransferType
+        {
+            None = 0,
+            ContentLength,
+            Chunked
+        }
+
+        public enum TransferError
+        {
+            None = 0,
+            ContentLengthTooLarge,
+            ChunkSizeTooLarge,
+            MissingChunkTerminator
+        }
+
+        public static Task StartTransferTypeAndErrorServer(
+            TransferType transferType,
+            TransferError transferError,
+            Func<Uri, Task> clientFunc)
+        {
+            return LoopbackServer.CreateClientAndServerAsync(
+                clientFunc,
+                server => server.AcceptConnectionAsync(async connection =>
+                {
+                    // Read past request headers.
+                    await connection.ReadRequestHeaderAsync();
+
+                    // Determine response transfer headers.
+                    string transferHeader = null;
+                    string content = "This is some response content.";
+                    if (transferType == TransferType.ContentLength)
+                    {
+                        transferHeader = transferError == TransferError.ContentLengthTooLarge ?
+                            $"Content-Length: {content.Length + 42}\r\n" :
+                            $"Content-Length: {content.Length}\r\n";
+                    }
+                    else if (transferType == TransferType.Chunked)
+                    {
+                        transferHeader = "Transfer-Encoding: chunked\r\n";
+                    }
+
+                    // Write response header
+                    TextWriter writer = connection.Writer;
+                    await writer.WriteAsync("HTTP/1.1 200 OK\r\n").ConfigureAwait(false);
+                    await writer.WriteAsync($"Date: {DateTimeOffset.UtcNow:R}\r\n").ConfigureAwait(false);
+                    await writer.WriteAsync("Content-Type: text/plain\r\n").ConfigureAwait(false);
+                    if (!string.IsNullOrEmpty(transferHeader))
+                    {
+                        await writer.WriteAsync(transferHeader).ConfigureAwait(false);
+                    }
+                    await writer.WriteAsync("\r\n").ConfigureAwait(false);
+
+                    // Write response body
+                    if (transferType == TransferType.Chunked)
+                    {
+                        string chunkSizeInHex = string.Format(
+                            "{0:x}\r\n",
+                            content.Length + (transferError == TransferError.ChunkSizeTooLarge ? 42 : 0));
+                        await writer.WriteAsync(chunkSizeInHex).ConfigureAwait(false);
+                        await writer.WriteAsync($"{content}\r\n").ConfigureAwait(false);
+                        if (transferError != TransferError.MissingChunkTerminator)
+                        {
+                            await writer.WriteAsync("0\r\n\r\n").ConfigureAwait(false);
+                        }
+                    }
+                    else
+                    {
+                        await writer.WriteAsync($"{content}").ConfigureAwait(false);
+                    }
+                }));
+        }
+
+        private async Task ReadAsStreamHelper(Uri serverUri)
         {
             using (HttpClient client = CreateHttpClient())
             {
                 using (var response = await client.GetAsync(
-                    new Uri($"http://{serverEndPoint.Address}:{(serverEndPoint).Port}/"),
+                    serverUri,
                     HttpCompletionOption.ResponseHeadersRead))
                 using (var stream = await response.Content.ReadAsStreamAsync())
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http.Functional.Tests
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (var client = new HttpClient(handler))
             {
-                handler.ServerCertificateCustomValidationCallback = LoopbackServer.AllowAllCertificates;
+                handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
                 server.Start();
 
                 var tasks = new Task[2];

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -281,7 +281,7 @@ namespace System.Net.Http.Functional.Tests
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
                     await server.AcceptConnectionAsync(async connection =>
                     {
-                        Task<List<string>> serverTask = connection.ReadRequestHeaderAndSendResponseAsync($"HTTP/1.1 101 Switching Protocols\r\nDate: {DateTimeOffset.UtcNow:R}\r\n\r\n");
+                        Task<List<string>> serverTask = connection.ReadRequestHeaderAndSendCustomResponseAsync($"HTTP/1.1 101 Switching Protocols\r\nDate: {DateTimeOffset.UtcNow:R}\r\n\r\n");
 
                         await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -375,7 +375,7 @@ namespace System.Net.Http.Functional.Tests
                     for (int i = 0; i < 2; i++)
                     {
                         Task<string> request = client.GetStringAsync(uri);
-                        await server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                        await server.AcceptConnectionSendResponseAndCloseAsync();
                         await request;
 
                         if (i == 0)
@@ -405,14 +405,14 @@ namespace System.Net.Http.Functional.Tests
                     Task<string> request1 = client.GetStringAsync(uri);
                     await server.AcceptConnectionAsync(async connection1 =>
                     {
-                        await connection1.ReadRequestHeaderAndSendResponseAsync(responseBody);
+                        await connection1.ReadRequestHeaderAndSendCustomResponseAsync(responseBody);
                         await request1;
 
                         // Make second request and expect it to be served from a different connection.
                         Task<string> request2 = client.GetStringAsync(uri);
                         await server.AcceptConnectionAsync(async connection2 =>
                         {
-                            await connection2.ReadRequestHeaderAndSendResponseAsync(responseBody);
+                            await connection2.ReadRequestHeaderAndSendCustomResponseAsync(responseBody);
                             await request2;
                         });
                     });
@@ -442,7 +442,7 @@ namespace System.Net.Http.Functional.Tests
                         Task<string> request1 = client.GetStringAsync(uri);
                         await server.AcceptConnectionAsync(async connection =>
                         {
-                            await connection.ReadRequestHeaderAndSendDefaultResponseAsync();
+                            await connection.ReadRequestHeaderAndSendResponseAsync();
                             await request1;
 
                             // Wait a small amount of time before making the second request, to give the first request time to timeout.
@@ -452,7 +452,7 @@ namespace System.Net.Http.Functional.Tests
                             Task<string> request2 = client.GetStringAsync(uri);
                             await server.AcceptConnectionAsync(async connection2 =>
                             {
-                                await connection2.ReadRequestHeaderAndSendDefaultResponseAsync();
+                                await connection2.ReadRequestHeaderAndSendResponseAsync();
                                 await request2;
                             });
                         });

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -74,6 +74,7 @@
     </Compile>
     <Compile Include="ByteArrayContentTest.cs" />
     <Compile Include="ChannelBindingAwareContent.cs" />
+    <Compile Include="DribbleStream.cs" />
     <Compile Include="CustomContent.cs" />
     <Compile Include="DelegatingHandlerTest.cs" />
     <Compile Include="FakeDiagnosticSourceListenerObserver.cs" />

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -173,7 +173,7 @@ namespace System.Net.Tests
             {
                 HttpWebRequest request = WebRequest.CreateHttp(uri);
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                await server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                await server.AcceptConnectionSendResponseAndCloseAsync();
                 using (WebResponse response = await getResponse)
                 {
                     Assert.Throws<InvalidOperationException>(() => request.AutomaticDecompression = DecompressionMethods.Deflate);
@@ -745,7 +745,7 @@ namespace System.Net.Tests
                 request.ProtocolVersion = requestVersion;
 
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                 using (HttpWebResponse response = (HttpWebResponse) await getResponse)
                 {

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -173,7 +173,7 @@ namespace System.Net.Tests
             {
                 HttpWebRequest request = WebRequest.CreateHttp(uri);
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                await server.AcceptConnectionSendDefaultResponseAndCloseAsync();
                 using (WebResponse response = await getResponse)
                 {
                     Assert.Throws<InvalidOperationException>(() => request.AutomaticDecompression = DecompressionMethods.Deflate);
@@ -745,7 +745,7 @@ namespace System.Net.Tests
                 request.ProtocolVersion = requestVersion;
 
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                Task<List<string>> serverTask = server.AcceptConnectionSendDefaultResponseAndCloseAsync();
 
                 using (HttpWebResponse response = (HttpWebResponse) await getResponse)
                 {

--- a/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -32,7 +32,7 @@ namespace System.Net.Tests
                 request.ContinueDelegate = continueDelegate;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {utcNow:R}\r\n" +
                         "Content-Type: application/json;charset=UTF-8\r\n" +
@@ -53,7 +53,7 @@ namespace System.Net.Tests
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {utcNow:R}\r\n" +
                         "Content-Type: application/json;charset=UTF-8\r\n" +
@@ -86,7 +86,7 @@ namespace System.Net.Tests
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {utcNow:R}\r\n" +
                         "Content-Type: application/json;charset=UTF-8\r\n" +
@@ -121,7 +121,7 @@ namespace System.Net.Tests
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {utcNow:R}\r\n" +
                         "Content-Length: 0\r\n" +

--- a/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -32,13 +32,7 @@ namespace System.Net.Tests
                 request.ContinueDelegate = continueDelegate;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK\r\n" +
-                        $"Date: {utcNow:R}\r\n" +
-                        "Content-Type: application/json;charset=UTF-8\r\n" +
-                        "Content-Length: 5\r\n" +
-                        "\r\n" +
-                        "12345");
+                await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, "Content-Type: application/json;charset=UTF-8\r\n", "12345");
                 Assert.Equal(continueDelegate, request.ContinueDelegate);
             });
         }
@@ -53,13 +47,7 @@ namespace System.Net.Tests
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK\r\n" +
-                        $"Date: {utcNow:R}\r\n" +
-                        "Content-Type: application/json;charset=UTF-8\r\n" +
-                        "Content-Length: 5\r\n" +
-                        "\r\n" +
-                        "12345");
+                await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, "Content-Type: application/json;charset=UTF-8\r\n", "12345");
 
                 using (WebResponse response = await getResponse)
                 {
@@ -86,13 +74,7 @@ namespace System.Net.Tests
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK\r\n" +
-                        $"Date: {utcNow:R}\r\n" +
-                        "Content-Type: application/json;charset=UTF-8\r\n" +
-                        "Content-Length: 5\r\n" +
-                        "\r\n" +
-                        "12345");
+                await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, "Content-Type: application/json;charset=UTF-8\r\n", "12345");
                 WebResponse response = await getResponse;
                 HttpWebResponse httpResponse = (HttpWebResponse)response;
                 httpResponse.Close();
@@ -121,11 +103,7 @@ namespace System.Net.Tests
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK\r\n" +
-                        $"Date: {utcNow:R}\r\n" +
-                        "Content-Length: 0\r\n" +
-                        "\r\n");
+                await server.AcceptConnectionSendResponseAndCloseAsync();
 
                 using (WebResponse response = await getResponse)
                 {

--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -23,13 +23,7 @@ namespace System.Net.Tests
                 HttpWebRequest request = WebRequest.CreateHttp(url);
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        $"Content-Type: {expectedContentType}\r\n" +
-                        "Content-Length: 5\r\n" +
-                        "\r\n" +
-                        "12345");
+                await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, $"Content-Type: {expectedContentType}\r\n", "12345");
 
                 using (WebResponse response = await getResponse)
                 {
@@ -46,12 +40,7 @@ namespace System.Net.Tests
                 HttpWebRequest request = WebRequest.CreateHttp(url);
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        "Content-Length: 5\r\n" +
-                        "\r\n" +
-                        "12345");
+                await server.AcceptConnectionSendResponseAndCloseAsync(content: "12345");
 
                 using (WebResponse response = await getResponse)
                 {

--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -23,7 +23,7 @@ namespace System.Net.Tests
                 HttpWebRequest request = WebRequest.CreateHttp(url);
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Type: {expectedContentType}\r\n" +
@@ -46,7 +46,7 @@ namespace System.Net.Tests
                 HttpWebRequest request = WebRequest.CreateHttp(url);
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         "Content-Length: 5\r\n" +

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -374,7 +374,7 @@ namespace System.Net.Tests
             {
                 Task<string> download = wc.DownloadStringTaskAsync(url.ToString());
                 Assert.Null(wc.ResponseHeaders);
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         "HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Length: 0\r\n" +
@@ -430,7 +430,7 @@ namespace System.Net.Tests
             {
                 Task<string> download = wc.DownloadStringTaskAsync(url.ToString());
                 Assert.Null(wc.ResponseHeaders);
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         "HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Length: 0\r\n" +
@@ -522,7 +522,7 @@ namespace System.Net.Tests
                 }
 
                 Task<string> download = DownloadStringAsync(wc, url.ToString());
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         "HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Length: {ExpectedText.Length}\r\n" +
@@ -543,7 +543,7 @@ namespace System.Net.Tests
                 wc.DownloadProgressChanged += (s, e) => downloadProgressInvoked.TrySetResult(true);
 
                 Task<byte[]> download = DownloadDataAsync(wc, url.ToString());
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         "HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Length: {ExpectedText.Length}\r\n" +
@@ -576,7 +576,7 @@ namespace System.Net.Tests
                 };
 
                 Task<byte[]> download = DownloadDataAsync(wc, url.ToString());
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         "HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Length: {largeText.Length}\r\n" +
@@ -601,7 +601,7 @@ namespace System.Net.Tests
                 {
                     var wc = new WebClient();
                     Task download = DownloadFileAsync(wc, url.ToString(), tempPath);
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    await server.AcceptConnectionSendResponseAndCloseAsync(
                             "HTTP/1.1 200 OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             $"Content-Length: {ExpectedText.Length}\r\n" +
@@ -625,7 +625,7 @@ namespace System.Net.Tests
             {
                 var wc = new WebClient();
                 Task<Stream> download = OpenReadAsync(wc, url.ToString());
-                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                await server.AcceptConnectionSendResponseAndCloseAsync(
                         "HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Length: {ExpectedText.Length}\r\n" +

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -374,12 +374,7 @@ namespace System.Net.Tests
             {
                 Task<string> download = wc.DownloadStringTaskAsync(url.ToString());
                 Assert.Null(wc.ResponseHeaders);
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        "HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        $"Content-Length: 0\r\n" +
-                        "ArbitraryHeader: ArbitraryValue\r\n" +
-                        "\r\n");
+                await server.AcceptConnectionSendResponseAndCloseAsync(additionalHeaders: "ArbitraryHeader: ArbitraryValue\r\n");
                 await download;
             });
 
@@ -430,7 +425,7 @@ namespace System.Net.Tests
             {
                 Task<string> download = wc.DownloadStringTaskAsync(url.ToString());
                 Assert.Null(wc.ResponseHeaders);
-                await server.AcceptConnectionSendDefaultResponseAndCloseAsync();
+                await server.AcceptConnectionSendResponseAndCloseAsync();
                 await download;
             });
         }
@@ -518,12 +513,7 @@ namespace System.Net.Tests
                 }
 
                 Task<string> download = DownloadStringAsync(wc, url.ToString());
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        "HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        $"Content-Length: {ExpectedText.Length}\r\n" +
-                        "\r\n" +
-                        $"{ExpectedText}");
+                await server.AcceptConnectionSendResponseAndCloseAsync(content: ExpectedText);
                 Assert.Equal(ExpectedText, await download);
             });
         }
@@ -539,12 +529,7 @@ namespace System.Net.Tests
                 wc.DownloadProgressChanged += (s, e) => downloadProgressInvoked.TrySetResult(true);
 
                 Task<byte[]> download = DownloadDataAsync(wc, url.ToString());
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        "HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        $"Content-Length: {ExpectedText.Length}\r\n" +
-                        "\r\n" +
-                        $"{ExpectedText}");
+                await server.AcceptConnectionSendResponseAndCloseAsync(content: ExpectedText);
                 Assert.Equal(ExpectedText, Encoding.ASCII.GetString(await download));
 
                 if (IsAsync)
@@ -572,12 +557,7 @@ namespace System.Net.Tests
                 };
 
                 Task<byte[]> download = DownloadDataAsync(wc, url.ToString());
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        "HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        $"Content-Length: {largeText.Length}\r\n" +
-                        "\r\n" +
-                        $"{largeText}");
+                await server.AcceptConnectionSendResponseAndCloseAsync(content: largeText);
                 Assert.Equal(largeText, Encoding.ASCII.GetString(await download));
 
                 if (IsAsync)
@@ -597,12 +577,7 @@ namespace System.Net.Tests
                 {
                     var wc = new WebClient();
                     Task download = DownloadFileAsync(wc, url.ToString(), tempPath);
-                    await server.AcceptConnectionSendResponseAndCloseAsync(
-                            "HTTP/1.1 200 OK\r\n" +
-                            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                            $"Content-Length: {ExpectedText.Length}\r\n" +
-                            "\r\n" +
-                            $"{ExpectedText}");
+                    await server.AcceptConnectionSendResponseAndCloseAsync(content: ExpectedText);
 
                     await download;
                     Assert.Equal(ExpectedText, File.ReadAllText(tempPath));
@@ -621,12 +596,7 @@ namespace System.Net.Tests
             {
                 var wc = new WebClient();
                 Task<Stream> download = OpenReadAsync(wc, url.ToString());
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        "HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        $"Content-Length: {ExpectedText.Length}\r\n" +
-                        "\r\n" +
-                        $"{ExpectedText}");
+                await server.AcceptConnectionSendResponseAndCloseAsync(content: ExpectedText);
 
                 using (var reader = new StreamReader(await download))
                 {

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -430,11 +430,7 @@ namespace System.Net.Tests
             {
                 Task<string> download = wc.DownloadStringTaskAsync(url.ToString());
                 Assert.Null(wc.ResponseHeaders);
-                await server.AcceptConnectionSendResponseAndCloseAsync(
-                        "HTTP/1.1 200 OK\r\n" +
-                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                        $"Content-Length: 0\r\n" +
-                        "\r\n");
+                await server.AcceptConnectionSendDefaultResponseAndCloseAsync();
                 await download;
             });
         }

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -89,22 +89,21 @@ namespace System.Net.WebSockets.Client.Tests
         {
             var options = new LoopbackServer.Options { UseSsl = true, WebSocketEndpoint = true };
 
-            Func<ClientWebSocket, Socket, Uri, X509Certificate2, Task> connectToServerWithClientCert = async (clientSocket, server, url, clientCert) =>
+            Func<ClientWebSocket, LoopbackServer, Uri, X509Certificate2, Task> connectToServerWithClientCert = async (clientSocket, server, url, clientCert) =>
             {
                 // Start listening for incoming connections on the server side.
-                Task<List<string>> acceptTask = LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
+                Task acceptTask = server.AcceptConnectionAsync(async connection =>
                     {
                         // Validate that the client certificate received by the server matches the one configured on
                         // the client-side socket.
-                        SslStream sslStream = Assert.IsType<SslStream>(stream);
+                        SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);
                         Assert.NotNull(sslStream.RemoteCertificate);
                         Assert.Equal(clientCert, new X509Certificate2(sslStream.RemoteCertificate));
 
                         // Complete the WebSocket upgrade over the secure channel. After this is done, the client-side
                         // ConnectAsync should complete.
-                        Assert.True(await LoopbackServer.WebSocketHandshakeAsync(socket, reader, writer));
-                        return null;
-                    }, options);
+                        Assert.True(await LoopbackHelper.WebSocketHandshakeAsync(connection));
+                    });
 
                 // Initiate a connection attempt with a client certificate configured on the socket.
                 clientSocket.Options.ClientCertificates.Add(clientCert);

--- a/src/System.Net.WebSockets.Client/tests/LoopbackHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/LoopbackHelper.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Test.Common;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Net.WebSockets.Client.Tests
+{
+    public static class LoopbackHelper
+    {
+        public static async Task<bool> WebSocketHandshakeAsync(LoopbackServer.Connection connection)
+        {
+            string serverResponse = null;
+            string currentRequestLine;
+            while (!string.IsNullOrEmpty(currentRequestLine = await connection.Reader.ReadLineAsync().ConfigureAwait(false)))
+            {
+                string[] tokens = currentRequestLine.Split(new char[] { ':' }, 2);
+                if (tokens.Length == 2)
+                {
+                    string headerName = tokens[0];
+                    if (headerName == "Sec-WebSocket-Key")
+                    {
+                        string headerValue = tokens[1].Trim();
+                        string responseSecurityAcceptValue = ComputeWebSocketHandshakeSecurityAcceptValue(headerValue);
+                        serverResponse =
+                            "HTTP/1.1 101 Switching Protocols\r\n" +
+                            "Upgrade: websocket\r\n" +
+                            "Connection: Upgrade\r\n" +
+                            "Sec-WebSocket-Accept: " + responseSecurityAcceptValue + "\r\n\r\n";
+                    }
+                }
+            }
+
+            if (serverResponse != null)
+            {
+                // We received a valid WebSocket opening handshake. Send the appropriate response.
+                await connection.Writer.WriteAsync(serverResponse).ConfigureAwait(false);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string ComputeWebSocketHandshakeSecurityAcceptValue(string secWebSocketKey)
+        {
+            // GUID specified by RFC 6455.
+            const string Rfc6455Guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+            string combinedKey = secWebSocketKey + Rfc6455Guid;
+
+            // Use of SHA1 hash is required by RFC 6455.
+            SHA1 sha1Provider = new SHA1CryptoServiceProvider();
+            byte[] sha1Hash = sha1Provider.ComputeHash(Encoding.UTF8.GetBytes(combinedKey));
+            return Convert.ToBase64String(sha1Hash);
+        }
+    }
+}

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -381,25 +381,23 @@ namespace System.Net.WebSockets.Client.Tests
         {
             var options = new LoopbackServer.Options { WebSocketEndpoint = true };
 
-            Func<ClientWebSocket, Socket, Uri, Task> connectToServerThatAbortsConnection = async (clientSocket, server, url) =>
+            Func<ClientWebSocket, LoopbackServer, Uri, Task> connectToServerThatAbortsConnection = async (clientSocket, server, url) =>
             {
                 AutoResetEvent pendingReceiveAsyncPosted =  new AutoResetEvent(false);
 
                 // Start listening for incoming connections on the server side.
-                Task<List<string>> acceptTask = LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
+                Task acceptTask = server.AcceptConnectionAsync(async connection =>
                 {
                     // Complete the WebSocket upgrade. After this is done, the client-side ConnectAsync should complete.
-                    Assert.True(await LoopbackServer.WebSocketHandshakeAsync(socket, reader, writer));
+                    Assert.True(await LoopbackHelper.WebSocketHandshakeAsync(connection));
 
                     // Wait for client-side ConnectAsync to complete and for a pending ReceiveAsync to be posted.
                     pendingReceiveAsyncPosted.WaitOne(TimeOutMilliseconds);
 
                     // Close the underlying connection prematurely (without sending a WebSocket Close frame).
-                    socket.Shutdown(SocketShutdown.Both);
-                    socket.Close();
-
-                    return null;
-                }, options);
+                    connection.Socket.Shutdown(SocketShutdown.Both);
+                    connection.Socket.Close();
+                });
 
                 // Initiate a connection attempt.
                 var cts = new CancellationTokenSource(TimeOutMilliseconds);

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ConnectTest.cs" />
     <Compile Include="LoggingTest.cs" />
     <Compile Include="KeepAliveTest.cs" />
+    <Compile Include="LoopbackHelper.cs" />
     <Compile Include="ResourceHelper.cs" />
     <Compile Include="SendReceiveTest.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="SendReceiveTest.cs" />


### PR DESCRIPTION
As we are writing more and more LoopbackServer based tests, seems like a good time to do a bit of refactoring and simplification.

Several related changes:
(1) Move nonessential code out of LoopbackServer itself. E.g. the websocket test code and the "transfer" code. These are only used by a couple very specific tests, and don't actually need to be in LoopbackServer.
(2) Simplify a few things that are awkward today. For example, the Options object gets passed in to several different places and used in different ways. I changed it to only be passed in to CreateServerAsync. Another example: the callback you pass to AcceptSocketAsync always has to return a Task<List>, even though many uses don't care about this and just pass null.
(3) Add the Connection object, which makes the callback from AcceptSocketAsync (now AcceptConnectionAsync) cleaner. Today you have to have four params on the callback, even though you often only care about one or two. Connection just encapsulates these args into a single object, and allows you to easily discover and call instance methods on this object.
(4) Rename some core methods to make them more descriptive.
(5) Fix usage in tests to reflect the updates.

@stephentoub @davidsh @Priya91 @wfurt 

