### PR TITLE
Light up prodcon tests with correct helix source

### DIFF
--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -61,6 +61,8 @@
 
     <HelixJobType Condition="'$(HelixJobType)'==''">test/functional/cli/</HelixJobType>
 
+    <!-- Detect whether we are on a product construction build via ProductBuildId. If so, set source appropriately -->
+    <HelixSource Condition="'$(HelixSource)'=='' And '$(IsOfficial)'!='' And '$(TestProduct)'!='' And '$(Branch)'!='' And '$(ProductBuildId)'!=''">prodcon/$(TestProduct)/$(Branch)/</HelixSource>
     <HelixSource Condition="'$(HelixSource)'=='' And '$(IsOfficial)'!='' And '$(TestProduct)'!='' And '$(Branch)'!=''">official/$(TestProduct)/$(Branch)/</HelixSource>
     <HelixSource Condition="'$(HelixSource)'=='' And '$(IsOfficial)'=='' And '$(TestProduct)'!='' And '$(Branch)'!=''">pr/$(TestProduct)/$(Branch)/</HelixSource>
     <HelixSource Condition="'$(HelixSource)'==''">pr/unknown/</HelixSource>


### PR DESCRIPTION
ProductBuildId != '' is used to detect a prodcon build and send the correct testing helix source.

This is non-ideal but cleanup of the general build reporting infrastructure is part of an upcoming epic.