### PR TITLE
Remove intrinsic from Vector4:op_Division(struct,float)

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector2_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector2_Intrinsics.cs
@@ -248,14 +248,10 @@ namespace System.Numerics
         /// <param name="value1">The source vector.</param>
         /// <param name="value2">The scalar value.</param>
         /// <returns>The result of the division.</returns>
-        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 operator /(Vector2 value1, float value2)
         {
-            float invDiv = 1.0f / value2;
-            return new Vector2(
-                value1.X * invDiv,
-                value1.Y * invDiv);
+            return value1 / new Vector2(value2);
         }
 
         /// <summary>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector3_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector3_Intrinsics.cs
@@ -267,16 +267,10 @@ namespace System.Numerics
         /// <param name="value1">The source vector.</param>
         /// <param name="value2">The scalar value.</param>
         /// <returns>The result of the division.</returns>
-        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 operator /(Vector3 value1, float value2)
         {
-            float invDiv = 1.0f / value2;
-
-            return new Vector3(
-                value1.X * invDiv,
-                value1.Y * invDiv,
-                value1.Z * invDiv);
+            return value1 / new Vector3(value2);
         }
 
         /// <summary>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector4_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector4_Intrinsics.cs
@@ -301,17 +301,24 @@ namespace System.Numerics
         /// <param name="value1">The source vector.</param>
         /// <param name="value2">The scalar value.</param>
         /// <returns>The result of the division.</returns>
-        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector4 operator /(Vector4 value1, float value2)
         {
-            float invDiv = 1.0f / value2;
+            if (Vector.IsHardwareAccelerated)
+            {
+                return value1 / new Vector4(value2);
+            }
+            else
+            {
+                float invDiv = 1.0f / value2;
 
-            return new Vector4(
-                value1.X * invDiv,
-                value1.Y * invDiv,
-                value1.Z * invDiv,
-                value1.W * invDiv);
+                return new Vector4(
+                    value1.X * invDiv,
+                    value1.Y * invDiv,
+                    value1.Z * invDiv,
+                    value1.W * invDiv);
+            }
+
         }
 
         /// <summary>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector4_Intrinsics.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector4_Intrinsics.cs
@@ -304,21 +304,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector4 operator /(Vector4 value1, float value2)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                return value1 / new Vector4(value2);
-            }
-            else
-            {
-                float invDiv = 1.0f / value2;
-
-                return new Vector4(
-                    value1.X * invDiv,
-                    value1.Y * invDiv,
-                    value1.Z * invDiv,
-                    value1.W * invDiv);
-            }
-
+            return value1 / new Vector4(value2);
         }
 
         /// <summary>


### PR DESCRIPTION
Also divide by vector if hardware accelerated 

Issue: https://github.com/dotnet/coreclr/issues/16385

/cc @mikedn @CarolEidt 