### PR TITLE
Inline RegexCharClass code

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.RegularExpressions
 {
@@ -739,22 +740,17 @@ namespace System.Text.RegularExpressions
         /// </summary>
         internal static bool IsSingleton(string set)
         {
-            if (set[FLAGS] == 0 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
-                (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]))
-                return true;
-            else
-                return false;
+            return (set[FLAGS] == 0 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
+                (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]));
         }
 
         internal static bool IsSingletonInverse(string set)
         {
-            if (set[FLAGS] == 1 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
-                (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]))
-                return true;
-            else
-                return false;
+            return (set[FLAGS] == 1 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
+                (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsSubtraction(string charClass)
         {
             return (charClass.Length > SETSTART + charClass[SETLENGTH] + charClass[CATEGORYLENGTH]);


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/issues/27124

Code wasn't inlined before because the JIT function size exceeds threshold. IL size is 26 bytes.
Is there an easier way to tell for sure if a method is inlined? Currently I'm more or less guessing by looking at the generated JIT code and then I set a break point inside the function and if it not hit the code must be  inlined. (in Release mode of course)

cc @danmosemsft 