### PR TITLE
Remove EOL OS's from Jenkins

### DIFF
--- a/buildpipeline/pipelinejobs.groovy
+++ b/buildpipeline/pipelinejobs.groovy
@@ -57,6 +57,7 @@ configurations.each { config ->
     // Add optional PR trigger for Outerloop test runs
     params.TestOuter = true
     pipeline.triggerPipelineOnGithubPRComment("Outerloop ${triggerName}", params)
+    pipeline.triggerPipelinePeriodically('@daily', params)
 }}}
 
 JobReport.Report.generateJobReport(out)

--- a/netci.groovy
+++ b/netci.groovy
@@ -17,9 +17,7 @@ def osGroupMap = ['Windows 7':'Windows_NT',
                   'Windows_NT':'Windows_NT',
                   'Ubuntu14.04':'Linux',
                   'Ubuntu16.04':'Linux',
-                  'Ubuntu16.10':'Linux',
                   'Debian8.4':'Linux',
-                  'Fedora24':'Linux',
                   'OSX10.12':'OSX',
                   'CentOS7.1': 'Linux',
                   'RHEL7.2': 'Linux',
@@ -29,9 +27,7 @@ def osShortName = ['Windows 7' : 'win7',
                    'Windows_NT' : 'windows_nt',
                    'Ubuntu14.04' : 'ubuntu14.04',
                    'Ubuntu16.04' : 'ubuntu16.04',
-                   'Ubuntu16.10' : 'ubuntu16.10',
                    'Debian8.4' : 'debian8.4',
-                   'Fedora24' : 'fedora24',
                    'OSX10.12' : 'osx',
                    'CentOS7.1' : 'centos7.1',
                    'RHEL7.2' : 'rhel7.2',
@@ -40,11 +36,11 @@ def osShortName = ['Windows 7' : 'win7',
 def buildArchConfiguration = ['Debug': 'x86',
                               'Release': 'x64']
 
-def targetGroupOsMapOuterloop = ['netcoreapp': ['Windows 7', 'Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'Ubuntu16.10', 'CentOS7.1',
-                                        'RHEL7.2', 'Fedora24', 'Debian8.4', 'OSX10.12', 'PortableLinux']]
+def targetGroupOsMapOuterloop = ['netcoreapp': ['Windows 7', 'Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'CentOS7.1',
+                                        'RHEL7.2', 'Debian8.4', 'OSX10.12', 'PortableLinux']]
 
-def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'Ubuntu16.10', 'CentOS7.1',
-                                        'RHEL7.2', 'Fedora24', 'Debian8.4', 'OSX10.12', 'PortableLinux']]
+def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'CentOS7.1',
+                                        'RHEL7.2', 'Debian8.4', 'OSX10.12', 'PortableLinux']]
 
 // **************************
 // Define code coverage build


### PR DESCRIPTION
- Removes some EOL OS's from our Jenkins Innerloop and Outerloop tests. These test definitions are triggerable on PR's but are not run by default. They are primarily used for daily/onPush runs that the badges on the corefx ReadMe.md can point to. By removing the definitions, we aren't losing any OS coverage since we run them on Helix. We are, however, losing the badge runs, so until we point the badges to the helix runs those are going to be outdated.
- Add a daily trigger to helix outerloop runs to replace the outerloop runs I'm removing from the Jenkins build/test.

resolves https://github.com/dotnet/corefx/issues/27095 for corefx/master.
resolves https://github.com/dotnet/corefx/issues/25252 for corefx/master

@mmitche @MattGal 