### PR TITLE
Remove a SignalAndWait test so that relevant change in CoreCLR can be brought into CoreFX

### DIFF
--- a/src/System.Runtime/tests/System/Threading/WaitHandleTests.cs
+++ b/src/System.Runtime/tests/System/Threading/WaitHandleTests.cs
@@ -321,17 +321,6 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix doesn't support SignalAndWait
-        public static void SignalAndWait_PlatformNotSupported()
-        {
-            var toSignal = new ManualResetEvent(false);
-            var toWaitOn = new ManualResetEvent(true);
-            Assert.Throws<PlatformNotSupportedException>(() => WaitHandle.SignalAndWait(toSignal, toWaitOn));
-            Assert.Throws<PlatformNotSupportedException>(() => WaitHandle.SignalAndWait(toSignal, toWaitOn, 0, false));
-            Assert.Throws<PlatformNotSupportedException>(() => WaitHandle.SignalAndWait(toSignal, toWaitOn, TimeSpan.Zero, false));
-        }
-
-        [Fact]
         public static void Close()
         {
             var wh = new ManualResetEvent(false);


### PR DESCRIPTION
This test would fail after CoreCLR PR https://github.com/dotnet/coreclr/pull/16383, removing. https://github.com/dotnet/corefx/pull/27118 is the other part of this set of changes.