### PR TITLE
Change RootDirectory properties to span

### DIFF
--- a/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
+++ b/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
@@ -251,8 +251,8 @@ namespace System.IO.Enumeration
     public ref struct FileSystemEntry
     {
         public ReadOnlySpan<char> Directory { get { throw null; } }
-        public string RootDirectory { get { throw null; } }
-        public string OriginalRootDirectory { get { throw null; } }
+        public ReadOnlySpan<char> RootDirectory { get { throw null; } }
+        public ReadOnlySpan<char> OriginalRootDirectory { get { throw null; } }
         public ReadOnlySpan<char> FileName { get { throw null; } }
         public FileAttributes Attributes { get { throw null; } }
         public long Length { get { throw null; } }

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -21,8 +21,8 @@ namespace System.IO.Enumeration
             ref FileSystemEntry entry,
             Interop.Sys.DirectoryEntry directoryEntry,
             ReadOnlySpan<char> directory,
-            string rootDirectory,
-            string originalRootDirectory,
+            ReadOnlySpan<char> rootDirectory,
+            ReadOnlySpan<char> originalRootDirectory,
             Span<char> pathBuffer)
         {
             entry._directoryEntry = directoryEntry;
@@ -54,7 +54,6 @@ namespace System.IO.Enumeration
             FileStatus.Initialize(ref entry._status, isDirectory);
             return isDirectory;
         }
-
 
         private ReadOnlySpan<char> FullPath
         {
@@ -99,12 +98,12 @@ namespace System.IO.Enumeration
         /// <summary>
         /// The full path of the root directory used for the enumeration.
         /// </summary>
-        public string RootDirectory { get; private set; }
+        public ReadOnlySpan<char> RootDirectory { get; private set; }
 
         /// <summary>
         /// The root directory for the enumeration as specified in the constructor.
         /// </summary>
-        public string OriginalRootDirectory { get; private set; }
+        public ReadOnlySpan<char> OriginalRootDirectory { get; private set; }
 
         public FileAttributes Attributes => _status.GetAttributes(FullPath, FileName);
         public long Length => _status.GetLength(FullPath);

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Windows.cs
@@ -13,8 +13,8 @@ namespace System.IO.Enumeration
             ref FileSystemEntry entry,
             Interop.NtDll.FILE_FULL_DIR_INFORMATION* info,
             ReadOnlySpan<char> directory,
-            string rootDirectory,
-            string originalRootDirectory)
+            ReadOnlySpan<char> rootDirectory,
+            ReadOnlySpan<char> originalRootDirectory)
         {
             entry._info = info;
             entry.Directory = directory;
@@ -32,12 +32,12 @@ namespace System.IO.Enumeration
         /// <summary>
         /// The full path of the root directory used for the enumeration.
         /// </summary>
-        public string RootDirectory { get; private set; }
+        public ReadOnlySpan<char> RootDirectory { get; private set; }
 
         /// <summary>
         /// The root directory for the enumeration as specified in the constructor.
         /// </summary>
-        public string OriginalRootDirectory { get; private set; }
+        public ReadOnlySpan<char> OriginalRootDirectory { get; private set; }
 
         /// <summary>
         /// The file name for this entry.

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -4,7 +4,6 @@
 
 using System.Buffers;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -47,23 +47,6 @@ namespace System.IO
         /// Combines two paths. Does no validation of paths, only concatenates the paths
         /// and places a directory separator between them if needed.
         /// </summary>
-        internal static string CombineNoChecks(string first, ReadOnlySpan<char> second)
-        {
-            if (string.IsNullOrEmpty(first))
-                return second.Length == 0
-                    ? string.Empty
-                    : new string(second);
-
-            if (second.Length == 0)
-                return first;
-
-            return CombineNoChecksInternal(first.AsReadOnlySpan(), second);
-        }
-
-        /// <summary>
-        /// Combines two paths. Does no validation of paths, only concatenates the paths
-        /// and places a directory separator between them if needed.
-        /// </summary>
         internal static string CombineNoChecks(ReadOnlySpan<char> first, ReadOnlySpan<char> second)
         {
             if (first.Length == 0)
@@ -81,9 +64,9 @@ namespace System.IO
         /// Combines three paths. Does no validation of paths, only concatenates the paths
         /// and places a directory separator between them if needed.
         /// </summary>
-        internal static string CombineNoChecks(string first, ReadOnlySpan<char> second, ReadOnlySpan<char> third)
+        internal static string CombineNoChecks(ReadOnlySpan<char> first, ReadOnlySpan<char> second, ReadOnlySpan<char> third)
         {
-            if (string.IsNullOrEmpty(first))
+            if (first.Length == 0)
                 return CombineNoChecks(second, third);
 
             if (second.Length == 0)
@@ -92,7 +75,7 @@ namespace System.IO
             if (third.Length == 0)
                 return CombineNoChecks(first, second);
 
-            return CombineNoChecksInternal(first.AsReadOnlySpan(), second, third);
+            return CombineNoChecksInternal(first, second, third);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Exposing string restricts the ability to change internals without introducing unnecessary allocations.