### PR TITLE
Improve test coverage of SocketsHttpHandler

### DIFF
--- a/src/Common/src/System/Net/HttpStatusDescription.cs
+++ b/src/Common/src/System/Net/HttpStatusDescription.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Net
 {
     internal static class HttpStatusDescription
@@ -20,6 +18,7 @@ namespace System.Net
                 case 100: return "Continue";
                 case 101: return "Switching Protocols";
                 case 102: return "Processing";
+                case 103: return "Early Hints";
 
                 case 200: return "OK";
                 case 201: return "Created";
@@ -29,6 +28,8 @@ namespace System.Net
                 case 205: return "Reset Content";
                 case 206: return "Partial Content";
                 case 207: return "Multi-Status";
+                case 208: return "Already Reported";
+                case 226: return "IM Used";
 
                 case 300: return "Multiple Choices";
                 case 301: return "Moved Permanently";
@@ -37,6 +38,7 @@ namespace System.Net
                 case 304: return "Not Modified";
                 case 305: return "Use Proxy";
                 case 307: return "Temporary Redirect";
+                case 308: return "Permanent Redirect";
 
                 case 400: return "Bad Request";
                 case 401: return "Unauthorized";
@@ -56,10 +58,15 @@ namespace System.Net
                 case 415: return "Unsupported Media Type";
                 case 416: return "Requested Range Not Satisfiable";
                 case 417: return "Expectation Failed";
+                case 421: return "Misdirected Request";
                 case 422: return "Unprocessable Entity";
                 case 423: return "Locked";
                 case 424: return "Failed Dependency";
                 case 426: return "Upgrade Required"; // RFC 2817
+                case 428: return "Precondition Required";
+                case 429: return "Too Many Requests";
+                case 431: return "Request Header Fields Too Large";
+                case 451: return "Unavailable For Legal Reasons";
 
                 case 500: return "Internal Server Error";
                 case 501: return "Not Implemented";
@@ -67,7 +74,11 @@ namespace System.Net
                 case 503: return "Service Unavailable";
                 case 504: return "Gateway Timeout";
                 case 505: return "Http Version Not Supported";
+                case 506: return "Variant Also Negotiates";
                 case 507: return "Insufficient Storage";
+                case 508: return "Loop Detected";
+                case 510: return "Not Extended";
+                case 511: return "Network Authentication Required";
             }
             return null;
         }

--- a/src/Common/tests/System/Net/Configuration.Certificates.cs
+++ b/src/Common/tests/System/Net/Configuration.Certificates.cs
@@ -57,7 +57,7 @@ namespace System.Net.Test.Common
 
             private static X509Certificate2Collection GetCertificateCollection(string certificateFileName)
             {
-                // On Windows, .Net Core applications should not import PFX files in parallel to avoid a known system-level race condition.
+                // On Windows, .NET Core applications should not import PFX files in parallel to avoid a known system-level race condition.
                 // This bug results in corrupting the X509Certificate2 certificate state.
                 try
                 {

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -138,6 +138,7 @@ namespace System.Diagnostics
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, string, string, string, string, int> method, string arg1, string arg2, string arg3, string arg4, string arg5, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<System.Threading.Tasks.Task<int>> method, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, System.Threading.Tasks.Task<int>> method, string arg, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
+        public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, string, System.Threading.Tasks.Task<int>> method, string arg1, string arg2, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvokeRaw(System.Delegate method, string unparsedArg, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public sealed partial class RemoteInvokeHandle : System.IDisposable
         {

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -58,6 +58,7 @@ namespace System.Diagnostics
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
+        /// <param name="arg">The argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
             Func<string, Task<int>> method,
@@ -70,6 +71,19 @@ namespace System.Diagnostics
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle RemoteInvoke(
+            Func<string, string, Task<int>> method,
+            string arg1, string arg2,
+            RemoteInvokeOptions options = null)
+        {
+            return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg">The argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
             Func<string, int> method,

--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CrossProcess.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CrossProcess.cs
@@ -17,7 +17,7 @@ namespace System.IO.Pipes.Tests
             // Then spawn another process to communicate with.
             using (var outbound = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.Inheritable))
             using (var inbound = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable))
-            using (var remote = RemoteInvoke(PingPong_OtherProcess, outbound.GetClientHandleAsString(), inbound.GetClientHandleAsString()))
+            using (var remote = RemoteInvoke(new Func<string, string, int>(PingPong_OtherProcess), outbound.GetClientHandleAsString(), inbound.GetClientHandleAsString()))
             {
                 // Close our local copies of the handles now that we've passed them of to the other process
                 outbound.DisposeLocalCopyOfClientHandle();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
@@ -22,7 +22,7 @@ namespace System.IO.Pipes.Tests
             // another process with which to communicate
             using (var outbound = new NamedPipeServerStream(outName, PipeDirection.Out))
             using (var inbound = new NamedPipeClientStream(".", inName, PipeDirection.In))
-            using (RemoteInvoke(PingPong_OtherProcess, outName, inName))
+            using (RemoteInvoke(new Func<string, string, int>(PingPong_OtherProcess), outName, inName))
             {
                 // Wait for both pipes to be connected
                 Task.WaitAll(outbound.WaitForConnectionAsync(), inbound.ConnectAsync());
@@ -48,7 +48,7 @@ namespace System.IO.Pipes.Tests
             // another process with which to communicate
             using (var outbound = new NamedPipeServerStream(outName, PipeDirection.Out))
             using (var inbound = new NamedPipeClientStream(".", inName, PipeDirection.In))
-            using (RemoteInvoke(PingPong_OtherProcess, outName, inName))
+            using (RemoteInvoke(new Func<string, string, int>(PingPong_OtherProcess), outName, inName))
             {
                 // Wait for both pipes to be connected
                 await Task.WhenAll(outbound.WaitForConnectionAsync(), inbound.ConnectAsync());

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Unix.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Unix.cs
@@ -31,7 +31,7 @@ namespace System.IO.Pipes.Tests
         {
             string pipeName = Path.GetRandomFileName();
             uint pairID = (uint)(Math.Abs(new Random(5125123).Next()));
-            RemoteInvoke(ServerConnectAsId, pipeName, pairID.ToString()).Dispose();
+            RemoteInvoke(new Func<string, string, int>(ServerConnectAsId), pipeName, pairID.ToString()).Dispose();
         }
 
         private static int ServerConnectAsId(string pipeName, string pairIDString)
@@ -39,7 +39,7 @@ namespace System.IO.Pipes.Tests
             uint pairID = uint.Parse(pairIDString);
             Assert.NotEqual(-1, seteuid(pairID));
             using (var outbound = new NamedPipeServerStream(pipeName, PipeDirection.Out))
-            using (var handle = RemoteInvoke(ClientConnectAsID, pipeName, pairIDString))
+            using (var handle = RemoteInvoke(new Func<string, string, int>(ClientConnectAsID), pipeName, pairIDString))
             {
                 // Connect as the unpriveleged user, but RunAsClient as the superuser
                 outbound.WaitForConnection();

--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
@@ -3,13 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Text;
 
 namespace System
 {
     internal static class ByteArrayHelpers
     {
+        // TODO #21395:
+        // Replace with the MemoryExtensions implementation of Equals once it's available
         internal static bool EqualsOrdinalAsciiIgnoreCase(string left, ReadOnlySpan<byte> right)
         {
             Debug.Assert(left != null, "Expected non-null string");

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderParser.cs
@@ -8,9 +8,6 @@ using System.Diagnostics.Contracts;
 
 namespace System.Net.Http.Headers
 {
-#if DEBUG
-    [ContractClass(typeof(HttpHeaderParserContract))]
-#endif
     internal abstract class HttpHeaderParser
     {
         internal const string DefaultSeparator = ", ";
@@ -91,25 +88,4 @@ namespace System.Net.Http.Headers
             return value.ToString();
         }
     }
-
-#if DEBUG
-    [ContractClassFor(typeof(HttpHeaderParser))]
-    internal abstract class HttpHeaderParserContract : HttpHeaderParser
-    {
-        public HttpHeaderParserContract()
-            : base(false)
-        {
-        }
-
-        public override bool TryParseValue(string value, object storeValue, ref int index, out object parsedValue)
-        {
-            // Index may be value.Length (e.g. both 0). This may be allowed for some headers (e.g. Accept but not
-            // allowed by others (e.g. Content-Length). The parser has to decide if this is valid or not.
-            Debug.Assert((value == null) || ((index >= 0) && (index <= value.Length)));
-
-            parsedValue = null;
-            return false;
-        }
-    }
-#endif
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -102,12 +102,6 @@ namespace System.Net.Http
                 }
             }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                ValidateBufferArgs(buffer, offset, count);
-                return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
-            }
-
             public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -157,25 +151,18 @@ namespace System.Net.Http
                 }
             }
 
-            public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             {
-                if (destination == null)
-                {
-                    throw new ArgumentNullException(nameof(destination));
-                }
-                if (bufferSize <= 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(bufferSize));
-                }
+                ValidateCopyToArgs(this, destination, bufferSize);
 
-                cancellationToken.ThrowIfCancellationRequested();
+                return
+                    cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) :
+                    _connection != null ? CopyToAsyncCore(destination, bufferSize, cancellationToken) :
+                    Task.CompletedTask;
+            }
 
-                if (_connection == null)
-                {
-                    // Response body fully consumed
-                    return;
-                }
-
+            private async Task CopyToAsyncCore(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            {
                 CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
                 try
                 {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -155,8 +155,7 @@ namespace System.Net.Http
             {
                 ValidateCopyToArgs(this, destination, bufferSize);
 
-                return
-                    cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) :
+                return cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) :
                     _connection != null ? CopyToAsyncCore(destination, bufferSize, cancellationToken) :
                     Task.CompletedTask;
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,12 +15,6 @@ namespace System.Net.Http
 
             public ChunkedEncodingWriteStream(HttpConnection connection) : base(connection)
             {
-            }
-
-            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ignored)
-            {
-                ValidateBufferArgs(buffer, offset, count);
-                return WriteAsync(new Memory<byte>(buffer, offset, count), ignored);
             }
 
             public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken ignored)
@@ -78,10 +71,7 @@ namespace System.Net.Http
                 // and if all of the headers and content fit in the write buffer that we've actually sent the request.
                 await _connection.FlushAsync().ConfigureAwait(false);
             }
-
-            public override Task FlushAsync(CancellationToken ignored) => // see comment on WriteAsync about "ignored"
-                _connection.FlushAsync();
-
+            
             public override async Task FinishAsync()
             {
                 // Send 0 byte chunk to indicate end, then final CrLf

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
@@ -15,12 +15,6 @@ namespace System.Net.Http
             {
             }
 
-            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ignored) // token ignored as it comes from SendAsync
-            {
-                ValidateBufferArgs(buffer, offset, count);
-                return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), ignored);
-            }
-
             public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken ignored) // token ignored as it comes from SendAsync
             {
                 if (_connection._currentRequest == null)
@@ -35,9 +29,6 @@ namespace System.Net.Http
                 // that are still buffered.
                 return _connection.WriteWithoutBufferingAsync(source);
             }
-
-            public override Task FlushAsync(CancellationToken ignored) => // token ignored as it comes from SendAsync
-                _connection.FlushAsync();
 
             public override Task FinishAsync()
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http.Headers;
@@ -23,12 +24,11 @@ namespace System.Net.Http
 
         public DecompressionHandler(DecompressionMethods decompressionMethods, HttpMessageHandler innerHandler)
         {
-            _innerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
-            if (decompressionMethods == DecompressionMethods.None)
-            {
-                throw new ArgumentOutOfRangeException(nameof(decompressionMethods));
-            }
+            Debug.Assert(decompressionMethods != DecompressionMethods.None);
+            Debug.Assert(innerHandler != null);
+
             _decompressionMethods = decompressionMethods;
+            _innerHandler = innerHandler;
         }
 
         internal bool GZipEnabled => (_decompressionMethods & DecompressionMethods.GZip) != 0;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/EmptyReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/EmptyReadStream.cs
@@ -20,13 +20,9 @@ namespace System.Net.Http
             protected override void Dispose(bool disposing) {  /* nop */ }
             public override void Close() { /* nop */ }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                ValidateBufferArgs(buffer, offset, count);
-                return cancellationToken.IsCancellationRequested ?
-                    Task.FromCanceled<int>(cancellationToken) :
-                    s_zeroTask;
-            }
+            public override int ReadByte() => -1;
+
+            public override int Read(Span<byte> destination) => 0;
 
             public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken) =>
                 cancellationToken.IsCancellationRequested ? new ValueTask<int>(Task.FromCanceled<int>(cancellationToken)) :

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -731,21 +731,21 @@ namespace System.Net.Http
                 pos++;
                 if (pos == line.Length)
                 {
-                    // Ignore invalid header line that doesn't contain ':'.
-                    return;
+                    // Invalid header line that doesn't contain ':'.
+                    ThrowInvalidHttpResponse();
                 }
             }
 
             if (pos == 0)
             {
-                // Ignore invalid empty header name.
-                return;
+                // Invalid empty header name.
+                ThrowInvalidHttpResponse();
             }
 
             if (!HeaderDescriptor.TryGet(line.Slice(0, pos), out HeaderDescriptor descriptor))
             {
-                // Ignore invalid header name
-                return;
+                // Invalid header name
+                ThrowInvalidHttpResponse();
             }
 
             // Eat any trailing whitespace
@@ -754,15 +754,15 @@ namespace System.Net.Http
                 pos++;
                 if (pos == line.Length)
                 {
-                    // Ignore invalid header line that doesn't contain ':'.
-                    return;
+                    // Invalid header line that doesn't contain ':'.
+                    ThrowInvalidHttpResponse();
                 }
             }
 
             if (line[pos++] != ':')
             {
-                // Ignore invalid header line that doesn't contain ':'.
-                return;
+                // Invalid header line that doesn't contain ':'.
+                ThrowInvalidHttpResponse();
             }
 
             // Skip whitespace after colon

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentDuplexStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentDuplexStream.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
@@ -24,8 +25,23 @@ namespace System.Net.Http
             return ReadAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).GetAwaiter().GetResult();
         }
 
-        public sealed override void Write(byte[] buffer, int offset, int count) =>
-            WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+        public sealed override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateBufferArgs(buffer, offset, count);
+            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+        }
+
+        public sealed override void Write(byte[] buffer, int offset, int count)
+        {
+            ValidateBufferArgs(buffer, offset, count);
+            WriteAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        public sealed override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateBufferArgs(buffer, offset, count);
+            return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
+        }
 
         public sealed override void CopyTo(Stream destination, int bufferSize) =>
             CopyToAsync(destination, bufferSize, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
@@ -17,13 +18,22 @@ namespace System.Net.Http
         public sealed override bool CanWrite => false;
 
         public sealed override void Flush() { }
-
+        public sealed override void WriteByte(byte value) => throw new NotSupportedException();
         public sealed override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public sealed override void Write(ReadOnlySpan<byte> source) => throw new NotSupportedException();
+        public sealed override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public sealed override Task WriteAsync(ReadOnlyMemory<byte> destination, CancellationToken cancellationToken) => throw new NotSupportedException();
 
         public sealed override int Read(byte[] buffer, int offset, int count)
         {
             ValidateBufferArgs(buffer, offset, count);
             return ReadAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        public sealed override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateBufferArgs(buffer, offset, count);
+            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
         public sealed override void CopyTo(Stream destination, int bufferSize) =>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
@@ -8,21 +8,37 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal abstract class HttpContentWriteStream : HttpContentStream
+    internal partial class HttpConnection : IDisposable
     {
-        public HttpContentWriteStream(HttpConnection connection) : base(connection) =>
-            Debug.Assert(connection != null);
+        private abstract class HttpContentWriteStream : HttpContentStream
+        {
+            public HttpContentWriteStream(HttpConnection connection) : base(connection) =>
+                Debug.Assert(connection != null);
 
-        public sealed override bool CanRead => false;
-        public sealed override bool CanWrite => true;
+            public sealed override bool CanRead => false;
+            public sealed override bool CanWrite => true;
 
-        public sealed override void Flush() => FlushAsync().GetAwaiter().GetResult();
+            public sealed override void Flush() => FlushAsync().GetAwaiter().GetResult();
 
-        public sealed override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public sealed override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
-        public sealed override void Write(byte[] buffer, int offset, int count) =>
-            WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+            public sealed override void Write(byte[] buffer, int offset, int count) =>
+                WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
 
-        public abstract Task FinishAsync();
+            // The token here is ignored because it's coming from SendAsync and the only operations
+            // here are those that are already covered by the token having been registered with
+            // to close the connection.
+
+            public sealed override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ignored)
+            {
+                ValidateBufferArgs(buffer, offset, count);
+                return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), ignored);
+            }
+
+            public sealed override Task FlushAsync(CancellationToken ignored) =>
+                _connection.FlushAsync();
+
+            public abstract Task FinishAsync();
+        }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpProxyConnectionHandler.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.IO;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,7 +63,7 @@ namespace System.Net.Http
         {
             if (proxyUri.Scheme != UriScheme.Http)
             {
-                throw new InvalidOperationException(SR.net_http_invalid_proxy_scheme);
+                throw new NotSupportedException(SR.net_http_invalid_proxy_scheme);
             }
 
             if (!HttpUtilities.IsSupportedNonSecureScheme(request.RequestUri.Scheme))

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Net.Http;
-using System.Net;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -16,12 +16,6 @@ namespace System.Net.Http
             {
             }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                ValidateBufferArgs(buffer, offset, count);
-                return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
-            }
-
             public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -69,25 +63,17 @@ namespace System.Net.Http
                 return bytesRead;
             }
 
-            public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             {
-                if (destination == null)
-                {
-                    throw new ArgumentNullException(nameof(destination));
-                }
-                if (bufferSize <= 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(bufferSize));
-                }
+                ValidateCopyToArgs(this, destination, bufferSize);
+                return
+                    cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) :
+                    _connection != null ? CopyToAsyncCore(destination, bufferSize, cancellationToken) :
+                    Task.CompletedTask; // null if response body fully consumed
+            }
 
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (_connection == null)
-                {
-                    // Response body fully consumed
-                    return;
-                }
-
+            private async Task CopyToAsyncCore(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            {
                 Task copyTask = _connection.CopyToAsync(destination);
                 if (!copyTask.IsCompletedSuccessfully)
                 {
@@ -104,17 +90,17 @@ namespace System.Net.Http
                     {
                         ctr.Dispose();
                     }
+
+                    // If cancellation is requested and tears down the connection, it could cause the copy
+                    // to end early but think it ended successfully. So we prioritize cancellation in this
+                    // race condition, and if we find after the copy has completed that cancellation has
+                    // been requested, we assume the copy completed due to cancellation and throw.
+                    cancellationToken.ThrowIfCancellationRequested();
                 }
 
                 // We cannot reuse this connection, so close it.
                 _connection.Dispose();
                 _connection = null;
-            }
-
-            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                ValidateBufferArgs(buffer, offset, count);
-                return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
             }
 
             public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -191,11 +191,14 @@ namespace System.Net.Http.Functional.Tests
 
                             // Do a post to a remote server
                             byte[] expectedData = Enumerable.Range(0, 20000).Select(i => unchecked((byte)i)).ToArray();
-                            HttpContent content = new ByteArrayContent(expectedData);
-                            content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(expectedData);
-                            using (HttpResponseMessage response = await client.PostAsync(Configuration.Http.RemoteEchoServer, content))
+                            foreach (Uri remoteServer in new[] { Configuration.Http.RemoteEchoServer, Configuration.Http.SecureRemoteEchoServer })
                             {
-                                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                                var content = new ByteArrayContent(expectedData);
+                                content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(expectedData);
+                                using (HttpResponseMessage response = await client.PostAsync(remoteServer, content))
+                                {
+                                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                                }
                             }
                         }
                     });

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -206,6 +206,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "dotnet/corefx #20010")]
+        [ActiveIssue(9543)] // fails sporadically with 'WinHttpException : The server returned an invalid or unrecognized response' or 'TaskCanceledException : A task was canceled'
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(6, false)]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -287,6 +287,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(ClientCertificateOption.Manual)]
         [InlineData(ClientCertificateOption.Automatic)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fails with \"Authentication failed\" error.")]
         public async Task AutomaticOrManual_DoesntFailRegardlessOfWhetherClientCertsAreAvailable(ClientCertificateOption mode)
         {
             if (!BackendSupportsCustomCertificateHandling) // can't use [Conditional*] right now as it's evaluated at the wrong time for SocketsHttpHandler

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -207,7 +207,6 @@ namespace System.Net.Http.Functional.Tests
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "dotnet/corefx #20010")]
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(9543)] // fails sporadically with 'WinHttpException : The server returned an invalid or unrecognized response' or 'TaskCanceledException : A task was canceled'
         [Theory]
         [InlineData(6, false)]
         [InlineData(3, true)]
@@ -221,6 +220,12 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
+            if (!UseSocketsHttpHandler)
+            {
+                // Issue #9543: fails sporadically on WinHttpHandler/CurlHandler
+                return;
+            }
+
             var options = new LoopbackServer.Options { UseSsl = true };
 
             Func<X509Certificate2, HttpClient> createClient = (cert) =>
@@ -228,6 +233,7 @@ namespace System.Net.Http.Functional.Tests
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.ServerCertificateCustomValidationCallback = delegate { return true; };
                 handler.ClientCertificates.Add(cert);
+                Assert.True(handler.ClientCertificates.Contains(cert));
                 return new HttpClient(handler);
             };
 
@@ -245,9 +251,9 @@ namespace System.Net.Http.Functional.Tests
 
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
-                if (reuseClient)
+                using (X509Certificate2 cert = Configuration.Certificates.GetClientCertificate())
                 {
-                    using (X509Certificate2 cert = Configuration.Certificates.GetClientCertificate())
+                    if (reuseClient)
                     {
                         using (HttpClient client = createClient(cert))
                         {
@@ -260,24 +266,53 @@ namespace System.Net.Http.Functional.Tests
                             }
                         }
                     }
-                }
-                else
-                {
-                    for (int i = 0; i < numberOfRequests; i++)
+                    else
                     {
-                        using (X509Certificate2 cert = Configuration.Certificates.GetClientCertificate())
+                        for (int i = 0; i < numberOfRequests; i++)
                         {
                             using (HttpClient client = createClient(cert))
                             {
                                 await makeAndValidateRequest(client, server, url, cert);
                             }
-                        }
 
-                        GC.Collect();
-                        GC.WaitForPendingFinalizers();
+                            GC.Collect();
+                            GC.WaitForPendingFinalizers();
+                        }
                     }
                 }
             }, options);
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [InlineData(ClientCertificateOption.Manual)]
+        [InlineData(ClientCertificateOption.Automatic)]
+        public async Task AutomaticOrManual_DoesntFailRegardlessOfWhetherClientCertsAreAvailable(ClientCertificateOption mode)
+        {
+            if (!BackendSupportsCustomCertificateHandling) // can't use [Conditional*] right now as it's evaluated at the wrong time for SocketsHttpHandler
+            {
+                _output.WriteLine($"Skipping {nameof(Manual_CertificateSentMatchesCertificateReceived_Success)}()");
+                return;
+            }
+
+            using (HttpClientHandler handler = CreateHttpClientHandler())
+            using (var client = new HttpClient(handler))
+            {
+                handler.ServerCertificateCustomValidationCallback = delegate { return true; };
+                handler.ClientCertificateOptions = mode;
+
+                await LoopbackServer.CreateServerAsync(async server =>
+                {
+                    Task clientTask = client.GetStringAsync(server.Uri);
+                    Task serverTask = server.AcceptConnectionAsync(async connection =>
+                    {
+                        SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);
+                        await connection.ReadRequestHeaderAndSendResponseAsync();
+                    });
+
+                    await new Task[] { clientTask, serverTask }.WhenAllOrAnyFailed();
+                }, new LoopbackServer.Options { UseSsl = true });
+            }
         }
 
         private bool BackendSupportsCustomCertificateHandling =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTestBase.cs
@@ -37,13 +37,26 @@ namespace System.Net.Http.Functional.Tests
             Debug.Assert(ctor != null, "Couldn't find test constructor on HttpClientHandler");
 
             HttpClientHandler handler = (HttpClientHandler)ctor.Invoke(new object[] { useSocketsHttpHandler });
-
-            FieldInfo field = typeof(HttpClientHandler).GetField("_socketsHttpHandler", BindingFlags.Instance | BindingFlags.NonPublic);
-            Debug.Assert(field != null, "Couldn't find _socketsHttpHandler field");
-            object socketsHttpHandler = field.GetValue(handler);
-            Debug.Assert((socketsHttpHandler != null) == useSocketsHttpHandler, $"{nameof(useSocketsHttpHandler)} was {useSocketsHttpHandler}, but _socketsHttpHandler field was {socketsHttpHandler}");
+            Debug.Assert(useSocketsHttpHandler == IsSocketsHttpHandler(handler), "Unexpected handler.");
 
             return handler;
+        }
+
+        protected static bool IsSocketsHttpHandler(HttpClientHandler handler)
+        {
+            FieldInfo field = typeof(HttpClientHandler).GetField("_socketsHttpHandler", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field == null)
+            {
+                return false;
+            }
+
+            object socketsHttpHandler = field.GetValue(handler);
+            if (socketsHttpHandler == null)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -459,18 +459,17 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_ReasonPhraseHasLF_BehaviorDifference()
         {
-            string responseString = "HTTP/1.1 200 O\nK";
+            string responseString = "HTTP/1.1 200 O\n";
             int expectedStatusCode = 200;
             string expectedReason = "O";
 
-            if (IsWinHttpHandler || IsNetfxHandler || IsCurlHandler)
+            if (IsNetfxHandler)
             {
-                // WinHttpHandler, .NET Framework, and CurlHandler will throw HttpRequestException.
+                // .NET Framework will throw HttpRequestException.
                 await GetAsyncThrowsExceptionHelper(responseString);
             }
             else
             {
-                // UAP and SocketsHttpHandler will allow LF ending.
                 await GetAsyncSuccessHelper(responseString, expectedStatusCode, expectedReason);
             }
         }

--- a/src/System.Threading/tests/SemaphoreTests.cs
+++ b/src/System.Threading/tests/SemaphoreTests.cs
@@ -290,7 +290,7 @@ namespace System.Threading.Tests
             // Create the two semaphores and the other process with which to synchronize
             using (var inbound = new Semaphore(1, 1, inboundName))
             using (var outbound = new Semaphore(0, 1, outboundName))
-            using (var remote = RemoteInvoke(PingPong_OtherProcess, outboundName, inboundName))
+            using (var remote = RemoteInvoke(new Func<string, string, int>(PingPong_OtherProcess), outboundName, inboundName))
             {
                 // Repeatedly wait for count in one semaphore and then release count into the other
                 for (int i = 0; i < 10; i++)


### PR DESCRIPTION
Used code coverage information to write targeted tests to cover various uncovered paths in SocketsHttpHandler.  Along the way fixed a variety of issues relating to throwing the wrong exception type, a stack overflow due to an unexpected recursive call, etc.

cc: @geoffkizer, @davidsh, @Priya91, @wfurt 