### PR TITLE
Temporarily Disable EventSource ETW Tests and Revert TraceEvent Package Version

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -47,7 +47,7 @@
 
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0015</XunitPerfAnalysisPackageVersion>
-    <TraceEventPackageVersion>2.0.4</TraceEventPackageVersion>
+    <TraceEventPackageVersion>1.0.3-alpha-experimental</TraceEventPackageVersion>
     <XunitNetcoreExtensionsVersion>2.1.0-preview2-02513-01</XunitNetcoreExtensionsVersion>
   </PropertyGroup>
 

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
@@ -5,7 +5,6 @@
 #if USE_ETW
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Session;
-using Microsoft.Diagnostics.Tracing.Etlx;
 #endif
 using System;
 using System.Collections.Generic;

--- a/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_ETLEVENTS</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_EVENTCOUNTER_DISPOSE</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp' And '$(TargetsWindows)' == 'true'">$(DefineConstants);USE_ETW</DefineConstants>
+<!--    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp' And '$(TargetsWindows)' == 'true'">$(DefineConstants);USE_ETW</DefineConstants> -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />


### PR DESCRIPTION
The upgrade to TraceEvent has broken the performance tests and there isn't a clean way to make the ETW tests run under this version of TraceEvent.