### PR TITLE
Fix the name of the schema queue

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNotificationTest/SqlNotificationTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNotificationTest/SqlNotificationTest.cs
@@ -13,9 +13,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private const int CALLBACK_TIMEOUT = 5000; // milliseconds
 
         // Database schema
-        private readonly string _tableName = "dbo.[SQLDEP_" + Guid.NewGuid().ToString() + "]";
-        private readonly string _queueName = "SQLDEP_" + Guid.NewGuid().ToString();
-        private readonly string _serviceName = "SQLDEP_" + Guid.NewGuid().ToString();
+        private readonly string _tableName   = $"dbo.[SQLDEP_{Guid.NewGuid().ToString()}]";
+        private readonly string _queueName   = $"SQLDEP_{Guid.NewGuid().ToString()}";
+        private readonly string _serviceName = $"SQLDEP_{Guid.NewGuid().ToString()}";
         private readonly string _schemaQueue;
 
         // Connection information used by all tests
@@ -27,15 +27,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             _startConnectionString = DataTestUtility.TcpConnStr;
             _execConnectionString = DataTestUtility.TcpConnStr;
 
-            var startBuilder = new SqlConnectionStringBuilder(_startConnectionString);
-            if (startBuilder.IntegratedSecurity)
-            {
-                _schemaQueue = string.Format("[{0}]", _queueName);
-            }
-            else
-            {
-                _schemaQueue = string.Format("[{0}].[{1}]", startBuilder.UserID, _queueName);
-            }
+            _schemaQueue = $"[{_queueName}]";
 
             Setup();
         }


### PR DESCRIPTION
Allow Schema queue to be detected from the database schema instead of assuming that the schema name is user name.
This approach is more portable, especially while running tests in a SQL docker installation. 