### PR TITLE
Log libc version in our "OS info logging test"

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -103,6 +103,8 @@ namespace System
         public static bool IsInAppContainer { get { throw null; } }
         public static bool IsWinRTSupported { get { throw null; } }
         public static bool IsXmlDsigXsltTransformSupported { get { throw null; } }
+        public static string LibcRelease { get { throw null; } }
+        public static string LibcVersion { get { throw null; } }
         public static System.Version OSXVersion { get { throw null; } }
         public static int WindowsVersion { get { throw null; } }
         public static string GetDistroVersionString() { throw null; }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NetFx.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NetFx.cs
@@ -24,6 +24,9 @@ namespace System
 
         public static bool IsNetfx471OrNewer => GetFrameworkVersion() >= new Version(4, 7, 1);
 
+        public static string LibcRelease { get { return ""; } }
+        public static string LibcVersion { get { return ""; } }
+
         // To get the framework version we can do it throught the registry key and getting the Release value under the .NET Framework key.
         // the mapping to each version can be found in: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
         // everytime we ship a new version this method should be updated to include the new framework version.

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NetFx.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NetFx.cs
@@ -24,8 +24,8 @@ namespace System
 
         public static bool IsNetfx471OrNewer => GetFrameworkVersion() >= new Version(4, 7, 1);
 
-        public static string LibcRelease { get { return ""; } }
-        public static string LibcVersion { get { return ""; } }
+        public static string LibcRelease => "";
+        public static string LibcVersion => "";
 
         // To get the framework version we can do it throught the registry key and getting the Release value under the .NET Framework key.
         // the mapping to each version can be found in: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NonNetFx.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NonNetFx.cs
@@ -24,8 +24,7 @@ namespace System
 
         /// <summary>
         /// If gnulibc is available, returns the release, such as "stable".
-        /// If the libc is musl, currently returns empty string.
-        /// Otherwise returns "Glibc not found".
+        /// Otherwise (eg., Windows, musl) returns "glibc_not_found".
         /// </summary>
         public static string LibcRelease
         {
@@ -37,15 +36,14 @@ namespace System
                 }
                 catch (Exception e) when (e is DllNotFoundException || e is EntryPointNotFoundException)
                 {
-                    return "Glibc not found";
+                    return "glibc_not_found";
                 }
             }
         }
 
         /// <summary>
         /// If gnulibc is available, returns the version, such as "2.22".
-        /// If the libc is musl, currently returns empty string. (In future could run "ldd -version".)
-        /// Otherwise returns "Glibc not found".
+        /// Otherwise (eg., Windows, musl) returns "glibc_not_found". (In future could run "ldd -version" for musl)
         /// </summary>
         public static string LibcVersion
         {
@@ -57,7 +55,7 @@ namespace System
                 }
                 catch (Exception e) when (e is DllNotFoundException || e is EntryPointNotFoundException)
                 {
-                    return "Glibc not found";
+                    return "glibc_not_found";
                 }
             }
         }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NonNetFx.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NonNetFx.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System
@@ -12,5 +14,52 @@ namespace System
         public static bool IsNetfx462OrNewer => false;
         public static bool IsNetfx470OrNewer => false;
         public static bool IsNetfx471OrNewer => false;
+
+
+        [DllImport("libc", ExactSpelling = true, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr gnu_get_libc_release();
+
+        [DllImport("libc", ExactSpelling = true, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr gnu_get_libc_version();
+
+        /// <summary>
+        /// If gnulibc is available, returns the release, such as "stable".
+        /// If the libc is musl, currently returns empty string.
+        /// Otherwise returns "Glibc not found".
+        /// </summary>
+        public static string LibcRelease
+        {
+            get
+            {
+                try
+                {
+                    return Marshal.PtrToStringUTF8(gnu_get_libc_release());
+                }
+                catch (Exception e) when (e is DllNotFoundException || e is EntryPointNotFoundException)
+                {
+                    return "Glibc not found";
+                }
+            }
+        }
+
+        /// <summary>
+        /// If gnulibc is available, returns the version, such as "2.22".
+        /// If the libc is musl, currently returns empty string. (In future could run "ldd -version".)
+        /// Otherwise returns "Glibc not found".
+        /// </summary>
+        public static string LibcVersion
+        {
+            get
+            {
+                try
+                {
+                    return Marshal.PtrToStringUTF8(gnu_get_libc_version());
+                }
+                catch (Exception e) when (e is DllNotFoundException || e is EntryPointNotFoundException)
+                {
+                    return "Glibc not found";
+                }
+            }
+        }
     }
 }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -71,7 +71,7 @@ namespace System
         public static bool IsWindows7 => GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
         public static bool IsWindows8x => GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);
 
-        public static string GetDistroVersionString() { return "ProductType=" + GetWindowsProductType() + "InstallationType=" + GetInstallationType(); }
+        public static string GetDistroVersionString() { return "WindowsProductType=" + GetWindowsProductType() + " WindowsInstallationType=" + GetInstallationType(); }
 
         private static int s_isInAppContainer = -1;
 

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -26,6 +26,19 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Unix interop")]
+        public void DumpRuntimeInformationToConsole2()
+        {
+            // Not really a test, but useful to dump to the log to
+            // sanity check that the test run or CI job
+            // was actually run on the OS that it claims to be on
+            string lcr = PlatformDetection.LibcRelease;
+            string lcv = PlatformDetection.LibcVersion;
+
+            Console.WriteLine($@"LibcRelease={lcr} LibcVersion={lcv}");
+        }
+
+        [Fact]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.Netcoreapp)]
         public void VerifyRuntimeDebugNameOnNetCoreApp()
         {

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -21,21 +21,10 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             string osa = RuntimeInformation.OSArchitecture.ToString();
             string pra = RuntimeInformation.ProcessArchitecture.ToString();
             string frd = RuntimeInformation.FrameworkDescription.Trim();
-
-            Console.WriteLine($@"{dvs} OS={osd} OSVer={osv} OSArch={osa} Arch={pra} Framework={frd}");
-        }
-
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Unix interop")]
-        public void DumpRuntimeInformationToConsole2()
-        {
-            // Not really a test, but useful to dump to the log to
-            // sanity check that the test run or CI job
-            // was actually run on the OS that it claims to be on
             string lcr = PlatformDetection.LibcRelease;
             string lcv = PlatformDetection.LibcVersion;
 
-            Console.WriteLine($@"LibcRelease={lcr} LibcVersion={lcv}");
+            Console.WriteLine($@"{dvs} OS={osd} OSVer={osv} OSArch={osa} Arch={pra} Framework={frd} LibcRelease={lcr} LibcVersion={lcv}");
         }
 
         [Fact]


### PR DESCRIPTION
Add logging of glibc version to our special test that logs the configuration of the machines it runs on.

Note I'm putting the code in PlatformDetection.NonNetfx.cs so it runs on Windows as well -- this will help demonstrate it's safe on all platforms CoreFX tests on, to help the case for adding it to the CLI as telemetry (see https://github.com/dotnet/corefx/issues/24522)