### PR TITLE
Fix race condition in PostAsyncExpect100Continue_RetryOnConnectionClosed_Success test

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -47,6 +47,7 @@ namespace System.Net.Test.Common
             }
         }
 
+        public Socket ListenSocket => _listenSocket;
         public Uri Uri => _uri;
 
         public static async Task CreateServerAsync(Func<LoopbackServer, Task> funcAsync, Options options = null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/26760

cc: @geoffkizer 