### PR TITLE
Add fast-path optimization to slow ReadOnlySpan<char>'s ToString

### DIFF
--- a/src/System.Memory/src/System/ReadOnlySpan.Portable.cs
+++ b/src/System.Memory/src/System/ReadOnlySpan.Portable.cs
@@ -193,6 +193,17 @@ namespace System
         {
             if (typeof(T) == typeof(char))
             {
+                // If this wraps a string and represents the full length of the string, just return the wrapped string.
+                if (_byteOffset == MemoryExtensions.StringAdjustment)
+                {
+                    object obj = Unsafe.As<object>(_pinnable); // minimize chances the compilers will optimize away the 'is' check
+                    if (obj is string s && _length == s.Length)
+                    {
+                        return s;
+                    }
+                }
+
+                // Otherwise, copy the data to a new string.
                 unsafe
                 {
                     fixed (char* src = &Unsafe.As<T, char>(ref DangerousGetPinnableReference()))

--- a/src/System.Memory/tests/ReadOnlySpan/ToString.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/ToString.cs
@@ -49,5 +49,23 @@ namespace System.SpanTests
             var span = new ReadOnlySpan<string>(a);
             Assert.Equal("System.ReadOnlySpan<String>[3]", span.ToString());
         }
+
+        [Fact]
+        public static void ToString_SpanOverString()
+        {
+            string orig = "hello world";
+            Assert.Equal(orig, orig.AsReadOnlySpan().ToString());
+            Assert.Equal(orig.Substring(0, 5), orig.AsReadOnlySpan(0, 5).ToString());
+            Assert.Equal(orig.Substring(5), orig.AsReadOnlySpan(5).ToString());
+            Assert.Equal(orig.Substring(1, 3), orig.AsReadOnlySpan(1, 3).ToString());
+        }
+
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Optimization only applies to portable span.")]
+        [Fact]
+        public static void ToString_SpanOverFullString_ReturnsOriginal()
+        {
+            string orig = "hello world";
+            Assert.Same(orig, orig.AsReadOnlySpan().ToString());
+        }
     }
 }


### PR DESCRIPTION
If the span wraps a string and represents its full length, just return the original string rather than allocating/copying a new one.

cc: @ahsonkhan, @jkotas 