### PR TITLE
Fix ConnectAsync not throwing exception for already connected Socket

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -789,6 +789,11 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
             }
 
+            if (_isConnected)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
+            }
+
             ValidateBlockingMode();
 
             if (NetEventSource.IsEnabled)
@@ -840,6 +845,11 @@ namespace System.Net.Sockets
             if (!TcpValidationHelpers.ValidatePortNumber(port))
             {
                 throw new ArgumentOutOfRangeException(nameof(port));
+            }
+
+            if (_isConnected)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
             }
 
             ValidateForMultiConnect(isMultiEndpoint: false); // needs to come before CanTryAddressFamily call
@@ -915,6 +925,11 @@ namespace System.Net.Sockets
             if (_addressFamily != AddressFamily.InterNetwork && _addressFamily != AddressFamily.InterNetworkV6)
             {
                 throw new NotSupportedException(SR.net_invalidversion);
+            }
+
+            if (_isConnected)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
             }
 
             ValidateForMultiConnect(isMultiEndpoint: true); // needs to come before CanTryAddressFamily call
@@ -2074,6 +2089,11 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
             }
 
+            if (_isConnected)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
+            }
+
 
             DnsEndPoint dnsEP = remoteEP as DnsEndPoint;
             if (dnsEP != null)
@@ -2154,6 +2174,11 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
             }
 
+            if (_isConnected)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
+            }
+
             IPAddress parsedAddress;
             if (IPAddress.TryParse(host, out parsedAddress))
             {
@@ -2201,6 +2226,11 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
 
+            if (_isConnected)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
+            }
+
             ValidateForMultiConnect(isMultiEndpoint: false); // needs to be called before CanTryAddressFamily
 
             if (!CanTryAddressFamily(address.AddressFamily))
@@ -2241,6 +2271,11 @@ namespace System.Net.Sockets
             if (_isListening)
             {
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
+            }
+
+            if (_isConnected)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
             }
 
             ValidateForMultiConnect(isMultiEndpoint: true);
@@ -3802,6 +3837,11 @@ namespace System.Net.Sockets
             if (_isListening)
             {
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
+            }
+
+            if (_isConnected)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
             }
 
             // Prepare SocketAddress.

--- a/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -44,9 +44,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Fact]
-        [ActiveIssue(22765, TestPlatforms.AnyUnix)]
         public async Task Connect_OnConnectedSocket_Fails()
         {
             int port;


### PR DESCRIPTION
For issue https://github.com/dotnet/corefx/issues/22765. @geoffkizer @wfurt PTAL

The previously failing tests are now passing for me locally, running a full test suite to make sure this doesn't regress anything else.