### PR TITLE
Modify StreamContent to use default CopyToAsync buffer size when no size is provided

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -18,12 +18,21 @@ namespace System.Net.Http
 
         public StreamContent(Stream content)
         {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
             // Indicate that we should use default buffer size by setting size to 0.
             InitializeContent(content, 0);
         }
 
         public StreamContent(Stream content, int bufferSize)
         {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
             if (bufferSize <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(bufferSize));
@@ -34,11 +43,6 @@ namespace System.Net.Http
 
         private void InitializeContent(Stream content, int bufferSize)
         {
-            if (content == null)
-            {
-                throw new ArgumentNullException(nameof(content));
-            }
-
             _content = content;
             _bufferSize = bufferSize;
             if (content.CanSeek)

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -34,7 +34,7 @@ namespace System.Net.Http
             InitializeContent(content, bufferSize);
         }
 
-        private void InitializeContent(stream content, int bufferSize)
+        private void InitializeContent(Stream content, int bufferSize)
         {
             if (content == null)
             {

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -19,19 +19,26 @@ namespace System.Net.Http
         private long _start;
 
         public StreamContent(Stream content)
-            : this(content, DefaultBufferSize)
         {
+            // Indicate that we should use default buffer size by setting size to 0.
+            InitializeContent(content, 0);
         }
 
         public StreamContent(Stream content, int bufferSize)
         {
-            if (content == null)
-            {
-                throw new ArgumentNullException(nameof(content));
-            }
             if (bufferSize <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(bufferSize));
+            }
+
+            InitializeContent(content, bufferSize);
+        }
+
+        private void InitializeContent(stream content, int bufferSize)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
             }
 
             _content = content;

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -11,8 +11,6 @@ namespace System.Net.Http
 {
     public class StreamContent : HttpContent
     {
-        private const int DefaultBufferSize = 4096;
-
         private Stream _content;
         private int _bufferSize;
         private bool _contentConsumed;

--- a/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
@@ -19,18 +19,20 @@ namespace System.Net.Http
         /// <summary>Copies the source stream from its current position to the destination stream at its current position.</summary>
         /// <param name="source">The source stream from which to copy.</param>
         /// <param name="destination">The destination stream to which to copy.</param>
-        /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
+        /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated. If zero, use the default buffer size.</param>
         /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
         /// <param name="cancellationToken">CancellationToken used to cancel the copy operation.</param>
         public static Task CopyAsync(Stream source, Stream destination, int bufferSize, bool disposeSource, CancellationToken cancellationToken = default(CancellationToken))
         {
             Debug.Assert(source != null);
             Debug.Assert(destination != null);
-            Debug.Assert(bufferSize > 0);
+            Debug.Assert(bufferSize >= 0);
 
             try
             {
-                Task copyTask = source.CopyToAsync(destination, bufferSize, cancellationToken);
+                Task copyTask = bufferSize == 0 ?
+                    source.CopyToAsync(destination, cancellationToken) :
+                    source.CopyToAsync(destination, bufferSize, cancellationToken);
                 return disposeSource ?
                     DisposeSourceWhenCompleteAsync(copyTask, source) :
                     copyTask;

--- a/src/System.Net.Http/tests/FunctionalTests/StreamContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/StreamContentTest.cs
@@ -33,6 +33,12 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        public void Ctor_NullStreamAndZeroBufferSize_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StreamContent(null, 0));
+        }
+
+        [Fact]
         public void ContentLength_SetStreamSupportingSeeking_StreamLengthMatchesHeaderValue()
         {
             var source = new MockStream(new byte[10], true, true); // Supports seeking.


### PR DESCRIPTION
When creating `StreamContent`, users have the option to provide a buffer size or to use our default. This change attempts to improve performance by deferring to the default buffer size chosen in CopyToAsync rather than selecting the default ourselves.

The default buffer size in CopyToAsync is much larger than the default we chose in StreamContent. Deferring to that default greatly improves performance for uploads from slow stream sources like the file system. While it does add some cost for the initial allocation, the larger buffers are then pooled. Users are also still able to specify their own buffer size if they prefer not to use the default.

Some rough performance testing on my machine showed a ~20% decrease in the time it took HttpClient to upload a 20 MB file. That performance testing was based off the code in [this article](http://weblogs.thinktecture.com/pawel/2017/03/aspnet-core-webapi-performance.html), which was the source for the original issue.

Fixes: #24495