### PR TITLE
Fix build on clang 5

### DIFF
--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -259,6 +259,9 @@ add_subdirectory(System.IO.Compression.Native)
 
 add_compile_options(-Weverything)
 add_compile_options(-Wno-c++98-compat-pedantic)
+if (HAVE_ZERO_AS_NULL_POINTER_CONSTANT_FLAG)
+    add_compile_options(-Wno-zero-as-null-pointer-constant)
+endif()
 
 add_subdirectory(System.Native)
 add_subdirectory(System.Net.Http.Native)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -609,6 +609,6 @@ extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const uint8_t** proto
 
 extern "C" int32_t CryptoNative_SslSetTlsExtHostName(SSL* ssl, const uint8_t* name)
 {
-    return static_cast<int32_t>(SSL_set_tlsext_host_name(ssl, name));
+    return static_cast<int32_t>(SSL_set_tlsext_host_name(ssl, const_cast<unsigned char*>(name)));
 }
 

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -1,3 +1,4 @@
+include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 include(CheckCXXSourceRuns)
 include(CheckCSourceCompiles)
@@ -28,6 +29,13 @@ endif ()
 
 # We compile with -Werror, so we need to make sure these code fragments compile without warnings.
 set(CMAKE_REQUIRED_FLAGS -Werror)
+
+# This compiler warning will fail code as innocuous as:
+# static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+# Check if the compiler knows about this warning so we can disable it
+check_cxx_compiler_flag(
+    -Wzero-as-null-pointer-constant
+    HAVE_ZERO_AS_NULL_POINTER_CONSTANT_FLAG)
 
 # in_pktinfo: Find whether this struct exists
 check_include_files(


### PR DESCRIPTION
This contains two fixes, both related to new warnings introduced with clang 5: http://releases.llvm.org/5.0.0/tools/clang/docs/ReleaseNotes.html

1. clang 5 [introduces](https://stackoverflow.com/a/43810077/3561275) a `-Wzero-as-null-pointer-constant` warning, which becomes an error with `-Werror`. This warning is not known by older versions of clang. It also affects code we pick up from our dependency libraries. Lets check if the compiler knows about this warning and disable it if so. Example of code it affects includes things like:

```
     static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
```

2. clang 5 introduces checks for casts. The [library expects a `char *`](https://github.com/openssl/openssl/blob/773da093b1b9a63ae9c94cae756848011686caa0/ssl/tls1.h#L333-L334), so lets cast our pointer to the expected type so it will continue working.


Btw, an alternative for `-Wzero-as-null-pointer-constant` would be to do something like `-Wno-error=zero-as-null-pointer-constant`. This makes it a warning (instead of an error) but keeps it, instead of disabling that warning entirely. This style is not used elsewhere in our cmake files, so I didn't do it that way.

cc @crummel @Priya91 @justinvp @bartonjs @stephentoub @mikem8361 @danmosemsft 