### PR TITLE
Remove Commit from PipeWriter

### DIFF
--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
@@ -78,7 +78,6 @@ namespace System.IO.Pipelines
         protected PipeWriter() { }
         public abstract void Advance(int bytes);
         public abstract void CancelPendingFlush();
-        public abstract void Commit();
         public abstract void Complete(System.Exception exception = null);
         public abstract System.IO.Pipelines.PipeAwaiter<System.IO.Pipelines.FlushResult> FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         public abstract System.Memory<byte> GetMemory(int minimumLength = 0);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.DefaultPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.DefaultPipeWriter.cs
@@ -28,8 +28,6 @@ namespace System.IO.Pipelines
 
             public override PipeAwaiter<FlushResult> FlushAsync(CancellationToken cancellationToken = default) => _pipe.FlushAsync(cancellationToken);
 
-            public override void Commit() => _pipe.Commit();
-
             public override void Advance(int bytes) => _pipe.Advance(bytes);
 
             public override Memory<byte> GetMemory(int minimumLength = 0) => _pipe.GetMemory(minimumLength);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -206,15 +206,6 @@ namespace System.IO.Pipelines
             }
         }
 
-        internal void Commit()
-        {
-            // Changing commit head shared with Reader
-            lock (_sync)
-            {
-                CommitUnsynchronized();
-            }
-        }
-
         internal void CommitUnsynchronized()
         {
             if (_writingHead == null)
@@ -312,10 +303,8 @@ namespace System.IO.Pipelines
 
             lock (_sync)
             {
-                if (_currentWriteLength > 0)
-                {
-                    ThrowHelper.ThrowInvalidOperationException_CompleteWriterActiveWriter();
-                }
+                // Commit any pending buffers
+                CommitUnsynchronized();
 
                 completionCallbacks = _writerCompletion.TryComplete(exception);
                 awaitable = _readerAwaitable.Complete();

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
@@ -33,11 +33,6 @@ namespace System.IO.Pipelines
         /// </summary>
         public abstract PipeAwaiter<FlushResult> FlushAsync(CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// Makes bytes written available to <see cref="PipeReader"/> without running <see cref="PipeReader.ReadAsync"/> continuation.
-        /// </summary>
-        public abstract void Commit();
-
         /// <inheritdoc />
         public abstract void Advance(int bytes);
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
@@ -45,10 +45,6 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static Exception CreateInvalidOperationException_NoReadingAllowed() => new InvalidOperationException(SR.WritingAfterCompleted);
 
-        public static void ThrowInvalidOperationException_CompleteWriterActiveWriter() => throw CreateInvalidOperationException_CompleteWriterActiveWriter();
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Exception CreateInvalidOperationException_CompleteWriterActiveWriter() => new InvalidOperationException(SR.CannotCompleteWhiteWriting);
-
         public static void ThrowInvalidOperationException_CompleteReaderActiveReader() => throw CreateInvalidOperationException_CompleteReaderActiveReader();
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static Exception CreateInvalidOperationException_CompleteReaderActiveReader() => new InvalidOperationException(SR.CannotCompleteWhileReading);

--- a/src/System.IO.Pipelines/tests/PipeLengthTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeLengthTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Pipelines.Tests
@@ -26,22 +27,22 @@ namespace System.IO.Pipelines.Tests
         private readonly Pipe _pipe;
 
         [Fact]
-        public void ByteByByteTest()
+        public async Task ByteByByteTest()
         {
             for (var i = 1; i <= 1024 * 1024; i++)
             {
                 _pipe.Writer.GetMemory(100);
                 _pipe.Writer.Advance(1);
-                _pipe.Writer.Commit();
+                await _pipe.Writer.FlushAsync();
 
                 Assert.Equal(i, _pipe.Length);
             }
 
-            _pipe.Writer.FlushAsync();
+            await _pipe.Writer.FlushAsync();
 
             for (int i = 1024 * 1024 - 1; i >= 0; i--)
             {
-                ReadResult result = _pipe.Reader.ReadAsync().GetResult();
+                ReadResult result = await _pipe.Reader.ReadAsync();
                 SequencePosition consumed = result.Buffer.Slice(1).Start;
 
                 Assert.Equal(i + 1, result.Buffer.Length);
@@ -53,33 +54,32 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public void LengthCorrectAfterAlloc0AdvanceCommit()
+        public async Task LengthCorrectAfterAlloc0AdvanceFlush()
         {
             _pipe.Writer.GetMemory(0);
             _pipe.Writer.WriteEmpty(10);
-            _pipe.Writer.Commit();
+            await _pipe.Writer.FlushAsync();
 
             Assert.Equal(10, _pipe.Length);
         }
 
         [Fact]
-        public void LengthCorrectAfterAllocAdvanceCommit()
+        public async Task LengthCorrectAfterAllocAdvanceFlush()
         {
             PipeWriter writableBuffer = _pipe.Writer.WriteEmpty(10);
-            writableBuffer.Commit();
+            await writableBuffer.FlushAsync();
 
             Assert.Equal(10, _pipe.Length);
         }
 
         [Fact]
-        public void LengthDecreasedAfterReadAdvanceConsume()
+        public async Task LengthDecreasedAfterReadAdvanceConsume()
         {
             _pipe.Writer.GetMemory(100);
             _pipe.Writer.Advance(10);
-            _pipe.Writer.Commit();
-            _pipe.Writer.FlushAsync();
+            await _pipe.Writer.FlushAsync();
 
-            ReadResult result = _pipe.Reader.ReadAsync().GetResult();
+            ReadResult result = await _pipe.Reader.ReadAsync();
             SequencePosition consumed = result.Buffer.Slice(5).Start;
             _pipe.Reader.AdvanceTo(consumed, consumed);
 
@@ -87,13 +87,12 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public void LengthNotChangeAfterReadAdvanceExamine()
+        public async Task LengthNotChangeAfterReadAdvanceExamine()
         {
             PipeWriter writableBuffer = _pipe.Writer.WriteEmpty(10);
-            writableBuffer.Commit();
-            writableBuffer.FlushAsync();
+            await writableBuffer.FlushAsync();
 
-            ReadResult result = _pipe.Reader.ReadAsync().GetResult();
+            ReadResult result = await _pipe.Reader.ReadAsync();
             _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
 
             Assert.Equal(10, _pipe.Length);

--- a/src/System.IO.Pipelines/tests/PipePoolTests.cs
+++ b/src/System.IO.Pipelines/tests/PipePoolTests.cs
@@ -208,7 +208,7 @@ namespace System.IO.Pipelines.Tests
             ReadResult readResult = await pipe.Reader.ReadAsync();
             pipe.Reader.AdvanceTo(readResult.Buffer.End);
             pipe.Writer.Write(new byte[writeSize]);
-            pipe.Writer.Commit();
+            await pipe.Writer.FlushAsync();
 
             Assert.Equal(1, pool.CurrentlyRentedBlocks);
         }


### PR DESCRIPTION
- PipeWriter.Complete now commits any uncommitted data instead of throwing.
- Updated the tests

Fixes #27162