### PR TITLE
Add msbuild.binlog to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bld/
 msbuild.log
 msbuild.err
 msbuild.wrn
+msbuild.binlog
 
 # Cross building rootfs
 cross/rootfs/


### PR DESCRIPTION
Very useful to debug build related issues adding to .gitignore