### PR TITLE
SNIPacket performance improvement

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -207,7 +207,7 @@ namespace System.Data.SqlClient.SNI
                         };
 
                         _dataBytesLeft = (int)_currentHeader.length;
-                        _currentPacket = new SNIPacket(null);
+                        _currentPacket = new SNIPacket();
                         _currentPacket.Allocate((int)_currentHeader.length);
                     }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -100,7 +100,7 @@ namespace System.Data.SqlClient.SNI
                 GetSMUXHeaderBytes(0, (byte)flags, ref headerBytes);
             }
 
-            SNIPacket packet = new SNIPacket(null);
+            SNIPacket packet = new SNIPacket();
             packet.SetData(headerBytes, SNISMUXHeader.HEADER_LENGTH);
             
             _connection.Send(packet);
@@ -143,7 +143,7 @@ namespace System.Data.SqlClient.SNI
             byte[] headerBytes = null;
             GetSMUXHeaderBytes(packet.Length, (byte)SNISMUXFlags.SMUX_DATA, ref headerBytes);
 
-            SNIPacket smuxPacket = new SNIPacket(null);
+            SNIPacket smuxPacket = new SNIPacket();
             smuxPacket.Description = string.Format("({0}) SMUX packet {1}", packet.Description == null ? "" : packet.Description, xSequenceNumber);
             smuxPacket.Allocate(16 + packet.Length);
             smuxPacket.AppendData(headerBytes, 16);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -154,7 +154,7 @@ namespace System.Data.SqlClient.SNI
                 packet = null;
                 try
                 {
-                    packet = new SNIPacket(null);
+                    packet = new SNIPacket();
                     packet.Allocate(_bufferSize);
                     packet.ReadFromStream(_stream);
 
@@ -181,7 +181,7 @@ namespace System.Data.SqlClient.SNI
         {
             lock (this)
             {
-                packet = new SNIPacket(null);
+                packet = new SNIPacket();
                 packet.Allocate(_bufferSize);
 
                 try

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -189,11 +189,11 @@ namespace System.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Get packet data
+        /// Copies data packets in SNIPacket object to given byte array parameter
         /// </summary>
-        /// <param name="packet">SNI packet</param>
-        /// <param name="inBuff">Buffer</param>
-        /// <param name="dataSize">Data size</param>
+        /// <param name="packet">SNIPacket object containing data packets</param>
+        /// <param name="inBuff">Destination byte array where data packets are copied to</param>
+        /// <param name="dataSize">Length of data packets</param>
         /// <returns>SNI error status</returns>
         public uint PacketGetData(SNIPacket packet, byte[] inBuff, ref uint dataSize)
         {
@@ -240,11 +240,11 @@ namespace System.Data.SqlClient.SNI
         {
             if (sync)
             {
-                return handle.Send(packet.Clone());
+                return handle.Send(packet);
             }
             else
             {
-                return handle.SendAsync(packet.Clone());
+                return handle.SendAsync(packet);
             }
         }
 
@@ -426,8 +426,7 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error status</returns>
         public uint ReadAsync(SNIHandle handle, out SNIPacket packet, bool isMars = false)
         {
-            packet = new SNIPacket(null);
-
+            packet = null;
             return handle.ReceiveAsync(ref packet);
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -168,10 +168,10 @@ namespace System.Data.SqlClient.SNI
         {
             if (_sniAsyncAttnPacket == null)
             {
-                _sniAsyncAttnPacket = new SNIPacket();
-                SetPacketData(_sniAsyncAttnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN);
+                SNIPacket attnPacket = new SNIPacket();
+                SetPacketData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN);
+                _sniAsyncAttnPacket = attnPacket;
             }
-            
             return _sniAsyncAttnPacket;
         }
 
@@ -208,7 +208,8 @@ namespace System.Data.SqlClient.SNI
         {
             if (_sniPacket != null)
             {
-                _sniPacket.Release();
+                _sniPacket.Dispose();
+                _sniPacket = null;
             }
             lock (_writePacketLockObject)
             {


### PR DESCRIPTION
 In `SNIPacket`, memory for `_data` byte array is allocated and released everytime `SqlClient` receives packets from server. I made it to reuse existing byte array if new allocation size is the same as existing byte array length. In `TdsParserStateObjectManaged`, `SNIPacket` object is newly created everytime it sends packets to server. I made it to reuse existing `SNIPacket` object if it is already created previously. 
This fix improves SqlClient (managedSNI) by around 1000 tps both in sync and async in TechEmpower benchmark testing.(https://github.com/aspnet/benchmarks)

