### PR TITLE
Remove unsafe from Uri.HexEscape in favor of string.Create

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -1409,14 +1409,12 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(character));
             }
 
-            unsafe
+            return string.Create(3, character, (Span<char> chars, char c) =>
             {
-                char* chars = stackalloc char[3];
                 chars[0] = '%';
-                chars[1] = UriHelper.s_hexUpperChars[(character & 0xf0) >> 4];
-                chars[2] = UriHelper.s_hexUpperChars[character & 0xf];
-                return new string(chars, 0, 3);
-            }
+                chars[1] = UriHelper.s_hexUpperChars[(c & 0xf0) >> 4];
+                chars[2] = UriHelper.s_hexUpperChars[c & 0xf];
+            });
         }
 
         //


### PR DESCRIPTION
Remove unsafe, avoid allocation and write directly into the string's memory. Benchmarking with 200k * 100 samples.

Relates to https://github.com/dotnet/corefx/pull/22872
Benchmark-Code: https://gist.github.com/ViktorHofer/43a61de5cd7d3e45b29e36e7a40f21c2

``` ini

BenchmarkDotNet=v0.10.12.431-nightly, OS=Windows 10.0.17101
Intel Core i7-6600U CPU 2.60GHz (Skylake), 1 CPU, 4 logical cores and 2 physical cores
Frequency=2742189 Hz, Resolution=364.6722 ns, Timer=TSC
  [Host] : .NET Core ? (Framework 4.6.26214.07), 64bit RyuJIT

Job=.NET Core 2.1 uri Runtime=Core  Toolchain=InProcessToolchain  

```

Before:

|    Method |     Mean |    Error |   StdDev |       Gen 0 | Allocated |
|---------- |---------:|---------:|---------:|------------:|----------:|
| HexEscape | 345.2 ms | 3.552 ms | 3.322 ms | 384500.0000 | 769.04 MB |

After:

|    Method |     Mean |    Error |   StdDev |       Gen 0 | Allocated |
|---------- |---------:|---------:|---------:|------------:|----------:|
| HexEscape | 328.6 ms | 5.602 ms | 4.966 ms | 384500.0000 | 769.04 MB |

cc @CIPop, @davidsh @danmosemsft 
