### PR TITLE
Use stackalloc for longer SystemDirectory paths

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Environment.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Windows.cs
@@ -11,8 +11,6 @@ namespace System
 {
     public static partial class Environment
     {
-        const int SystemDirectoryAllocLimit = 260;
-
         private static string CurrentDirectoryCore
         {
             get
@@ -151,16 +149,12 @@ namespace System
         {
             get
             {
-                // The path will likely be under 32 characters, e.g. C:\Windows\system32
-                Span<char> buffer = stackalloc char[32];
+                Span<char> buffer = stackalloc char[260];
                 int requiredSize = Interop.Kernel32.GetSystemDirectoryW(buffer);
 
                 if (requiredSize > buffer.Length)
                 {
-                    if (requiredSize < SystemDirectoryAllocLimit)
-                        buffer = stackalloc char[requiredSize];
-                    else
-                        buffer = new char[requiredSize];
+                    buffer = new char[requiredSize];
                     requiredSize = Interop.Kernel32.GetSystemDirectoryW(buffer);
                 }
 

--- a/src/System.Runtime.Extensions/src/System/Environment.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Windows.cs
@@ -11,6 +11,8 @@ namespace System
 {
     public static partial class Environment
     {
+        const int SystemDirectoryAllocLimit = 260;
+
         private static string CurrentDirectoryCore
         {
             get
@@ -155,7 +157,10 @@ namespace System
 
                 if (requiredSize > buffer.Length)
                 {
-                    buffer = new char[requiredSize];
+                    if (requiredSize < SystemDirectoryAllocLimit)
+                        buffer = stackalloc char[requiredSize];
+                    else
+                        buffer = new char[requiredSize];
                     requiredSize = Interop.Kernel32.GetSystemDirectoryW(buffer);
                 }
 


### PR DESCRIPTION
nit change, use stackalloc for longer SystemDirectory path < 260 chars.