### PR TITLE
Normalize names of span inputs in crypto API

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/DSACng.SignVerify.cs
@@ -45,21 +45,21 @@ namespace System.Security.Cryptography
                 }
             }
 
-            public override unsafe bool TryCreateSignature(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+            public override unsafe bool TryCreateSignature(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten)
             {
-                byte[] arrayToReturnToArrayPool = AdjustHashSizeIfNecessaryWithArrayPool(ref source);
+                byte[] arrayToReturnToArrayPool = AdjustHashSizeIfNecessaryWithArrayPool(ref hash);
                 try
                 {
                     using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
                     {
-                        return CngCommon.TrySignHash(keyHandle, source, destination, AsymmetricPaddingMode.None, null, out bytesWritten);
+                        return CngCommon.TrySignHash(keyHandle, hash, destination, AsymmetricPaddingMode.None, null, out bytesWritten);
                     }
                 }
                 finally
                 {
                     if (arrayToReturnToArrayPool != null)
                     {
-                        Array.Clear(arrayToReturnToArrayPool, 0, source.Length);
+                        Array.Clear(arrayToReturnToArrayPool, 0, hash.Length);
                         ArrayPool<byte>.Shared.Return(arrayToReturnToArrayPool);
                     }
                 }
@@ -79,16 +79,16 @@ namespace System.Security.Cryptography
                 return VerifySignature((ReadOnlySpan<byte>)rgbHash, (ReadOnlySpan<byte>)rgbSignature);
             }
 
-            public override bool VerifySignature(ReadOnlySpan<byte> rgbHash, ReadOnlySpan<byte> rgbSignature)
+            public override bool VerifySignature(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature)
             {
-                byte[] arrayToReturnToArrayPool = AdjustHashSizeIfNecessaryWithArrayPool(ref rgbHash);
+                byte[] arrayToReturnToArrayPool = AdjustHashSizeIfNecessaryWithArrayPool(ref hash);
                 try
                 {
                     using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
                     {
                         unsafe
                         {
-                            return CngCommon.VerifyHash(keyHandle, rgbHash, rgbSignature, AsymmetricPaddingMode.None, null);
+                            return CngCommon.VerifyHash(keyHandle, hash, signature, AsymmetricPaddingMode.None, null);
                         }
                     }
                 }
@@ -96,7 +96,7 @@ namespace System.Security.Cryptography
                 {
                     if (arrayToReturnToArrayPool != null)
                     {
-                        Array.Clear(arrayToReturnToArrayPool, 0, rgbHash.Length);
+                        Array.Clear(arrayToReturnToArrayPool, 0, hash.Length);
                         ArrayPool<byte>.Shared.Return(arrayToReturnToArrayPool);
                     }
                 }

--- a/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -235,8 +235,8 @@ namespace System.Security.Cryptography
                 protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
                     AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
 
-                protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
-                    AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+                protected override bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+                    AsymmetricAlgorithmHelpers.TryHashData(data, destination, hashAlgorithm, out bytesWritten);
 
                 protected override void Dispose(bool disposing)
                 {

--- a/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography
                 return converted;
             }
 
-            public override bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+            public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten)
             {
                 SafeEcKeyHandle key = _key.Value;
 
@@ -98,7 +98,7 @@ namespace System.Security.Cryptography
                 byte[] signature = ArrayPool<byte>.Shared.Rent(signatureLength);
                 try
                 {
-                    if (!Interop.Crypto.EcDsaSign(source, source.Length, new Span<byte>(signature, 0, signatureLength), ref signatureLength, key))
+                    if (!Interop.Crypto.EcDsaSign(hash, hash.Length, new Span<byte>(signature, 0, signatureLength), ref signatureLength, key))
                     {
                         throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
@@ -159,8 +159,8 @@ namespace System.Security.Cryptography
             protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
                 AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
 
-            protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
-                AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+            protected override bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+                AsymmetricAlgorithmHelpers.TryHashData(data, destination, hashAlgorithm, out bytesWritten);
 
             protected override void Dispose(bool disposing)
             {

--- a/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -27,12 +27,12 @@ namespace System.Security.Cryptography
             EncryptOrDecrypt(data, padding, encrypt: false);
 
         /// <summary>Encrypts data using the public key.</summary>
-        public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
-            TryEncryptOrDecrypt(source, destination, padding, encrypt: true, bytesWritten: out bytesWritten);
+        public override bool TryEncrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
+            TryEncryptOrDecrypt(data, destination, padding, encrypt: true, bytesWritten: out bytesWritten);
 
         /// <summary>Decrypts data using the private key.</summary>
-        public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
-            TryEncryptOrDecrypt(source, destination, padding, encrypt: false, bytesWritten: out bytesWritten);
+        public override bool TryDecrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
+            TryEncryptOrDecrypt(data, destination, padding, encrypt: false, bytesWritten: out bytesWritten);
 
         // Conveniently, Encrypt() and Decrypt() are identical save for the actual P/Invoke call to CNG. Thus, both
         // array-based APIs invoke this common helper with the "encrypt" parameter determining whether encryption or decryption is done.
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography
 
         // Conveniently, Encrypt() and Decrypt() are identical save for the actual P/Invoke call to CNG. Thus, both
         // span-based APIs invoke this common helper with the "encrypt" parameter determining whether encryption or decryption is done.
-        private unsafe bool TryEncryptOrDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, bool encrypt, out int bytesWritten)
+        private unsafe bool TryEncryptOrDecrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, bool encrypt, out int bytesWritten)
         {
             if (padding == null)
             {
@@ -93,7 +93,7 @@ namespace System.Security.Cryptography
                 switch (padding.Mode)
                 {
                     case RSAEncryptionPaddingMode.Pkcs1:
-                        return TryEncryptOrDecrypt(keyHandle, source, destination, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, null, encrypt, out bytesWritten);
+                        return TryEncryptOrDecrypt(keyHandle, data, destination, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, null, encrypt, out bytesWritten);
 
                     case RSAEncryptionPaddingMode.Oaep:
                         IntPtr namePtr = Marshal.StringToHGlobalUni(padding.OaepHashAlgorithm.Name);
@@ -105,7 +105,7 @@ namespace System.Security.Cryptography
                                 pbLabel = IntPtr.Zero, // It would nice to put randomized data here but RSAEncryptionPadding does not at this point provide support for this.
                                 cbLabel = 0,
                             };
-                            return TryEncryptOrDecrypt(keyHandle, source, destination, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encrypt, out bytesWritten);
+                            return TryEncryptOrDecrypt(keyHandle, data, destination, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encrypt, out bytesWritten);
                         }
                         finally
                         {

--- a/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -68,7 +68,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        public override unsafe bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        public override unsafe bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
         {
             string hashAlgorithmName = hashAlgorithm.Name;
             if (string.IsNullOrEmpty(hashAlgorithmName))
@@ -89,11 +89,11 @@ namespace System.Security.Cryptography
                     {
                         case RSASignaturePaddingMode.Pkcs1:
                             var pkcs1PaddingInfo = new BCRYPT_PKCS1_PADDING_INFO() { pszAlgId = namePtr };
-                            return keyHandle.TrySignHash(source, destination, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, &pkcs1PaddingInfo, out bytesWritten);
+                            return keyHandle.TrySignHash(hash, destination, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, &pkcs1PaddingInfo, out bytesWritten);
 
                         case RSASignaturePaddingMode.Pss:
-                            var pssPaddingInfo = new BCRYPT_PSS_PADDING_INFO() { pszAlgId = namePtr, cbSalt = source.Length };
-                            return keyHandle.TrySignHash(source, destination, AsymmetricPaddingMode.NCRYPT_PAD_PSS_FLAG, &pssPaddingInfo, out bytesWritten);
+                            var pssPaddingInfo = new BCRYPT_PSS_PADDING_INFO() { pszAlgId = namePtr, cbSalt = hash.Length };
+                            return keyHandle.TrySignHash(hash, destination, AsymmetricPaddingMode.NCRYPT_PAD_PSS_FLAG, &pssPaddingInfo, out bytesWritten);
 
                         default:
                             throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);

--- a/src/Common/src/System/Security/Cryptography/RSACng.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.cs
@@ -50,8 +50,8 @@ namespace System.Security.Cryptography
         protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
             CngCommon.HashData(data, offset, count, hashAlgorithm);
 
-        protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
-            CngCommon.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+        protected override bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+            CngCommon.TryHashData(data, destination, hashAlgorithm, out bytesWritten);
 
         protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
             CngCommon.HashData(data, hashAlgorithm);

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -120,7 +120,7 @@ namespace System.Security.Cryptography
             return plainBytes;
         }
 
-        public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        public override bool TryDecrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
             if (padding == null)
             {
@@ -137,7 +137,7 @@ namespace System.Security.Cryptography
                 return false;
             }
 
-            int returnValue = Interop.Crypto.RsaPrivateDecrypt(source.Length, source, destination, key, rsaPadding);
+            int returnValue = Interop.Crypto.RsaPrivateDecrypt(data.Length, data, destination, key, rsaPadding);
             CheckReturn(returnValue);
 
             // If the padding mode is RSA_NO_PADDING then the size of the decrypted block
@@ -174,7 +174,7 @@ namespace System.Security.Cryptography
             return buf;
         }
 
-        public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        public override bool TryEncrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
             if (padding == null)
             {
@@ -191,7 +191,7 @@ namespace System.Security.Cryptography
                 return false;
             }
 
-            int returnValue = Interop.Crypto.RsaPublicEncrypt(source.Length, source, destination, key, rsaPadding);
+            int returnValue = Interop.Crypto.RsaPublicEncrypt(data.Length, data, destination, key, rsaPadding);
             CheckReturn(returnValue);
 
             bytesWritten = returnValue;
@@ -389,8 +389,8 @@ namespace System.Security.Cryptography
         protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
             AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
 
-        protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
-            AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+        protected override bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+            AsymmetricAlgorithmHelpers.TryHashData(data, destination, hashAlgorithm, out bytesWritten);
 
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
@@ -436,7 +436,7 @@ namespace System.Security.Cryptography
             return signature;
         }
 
-        public override bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
         {
             if (string.IsNullOrEmpty(hashAlgorithm.Name))
             {
@@ -462,7 +462,7 @@ namespace System.Security.Cryptography
             }
 
             int signatureSize;
-            if (!Interop.Crypto.RsaSign(algorithmNid, source, source.Length, destination, out signatureSize, rsa))
+            if (!Interop.Crypto.RsaSign(algorithmNid, hash, hash.Length, destination, out signatureSize, rsa))
             {
                 throw Interop.Crypto.CreateOpenSslCryptographicException();
             }

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -169,14 +169,14 @@ namespace System.Security.Cryptography
                 return Interop.AppleCrypto.RsaEncrypt(GetKeys().PublicKey, data, padding);
             }
 
-            public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+            public override bool TryEncrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
             {
                 if (padding == null)
                 {
                     throw new ArgumentNullException(nameof(padding));
                 }
 
-                return Interop.AppleCrypto.TryRsaEncrypt(GetKeys().PublicKey, source, destination, padding, out bytesWritten);
+                return Interop.AppleCrypto.TryRsaEncrypt(GetKeys().PublicKey, data, destination, padding, out bytesWritten);
             }
 
             public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
@@ -200,7 +200,7 @@ namespace System.Security.Cryptography
                 return Interop.AppleCrypto.RsaDecrypt(keys.PrivateKey, data, padding);
             }
 
-            public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+            public override bool TryDecrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
             {
                 if (padding == null)
                 {
@@ -214,7 +214,7 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
                 }
 
-                return Interop.AppleCrypto.TryRsaDecrypt(keys.PrivateKey, source, destination, padding, out bytesWritten);
+                return Interop.AppleCrypto.TryRsaDecrypt(keys.PrivateKey, data, destination, padding, out bytesWritten);
             }
 
             public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
@@ -257,7 +257,7 @@ namespace System.Security.Cryptography
                     palAlgId);
             }
 
-            public override bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+            public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
             {
                 if (string.IsNullOrEmpty(hashAlgorithm.Name))
                 {
@@ -280,19 +280,19 @@ namespace System.Security.Cryptography
                 }
 
                 Interop.AppleCrypto.PAL_HashAlgorithm palAlgId = PalAlgorithmFromAlgorithmName(hashAlgorithm, out int expectedSize);
-                if (source.Length != expectedSize)
+                if (hash.Length != expectedSize)
                 {
                     // Windows: NTE_BAD_DATA ("Bad Data.")
                     // OpenSSL: RSA_R_INVALID_MESSAGE_LENGTH ("invalid message length")
                     throw new CryptographicException(
                         SR.Format(
                             SR.Cryptography_BadHashSize_ForAlgorithm,
-                            source.Length,
+                            hash.Length,
                             expectedSize,
                             hashAlgorithm.Name));
                 }
 
-                return Interop.AppleCrypto.TryGenerateSignature(keys.PrivateKey, source, destination, palAlgId, out bytesWritten);
+                return Interop.AppleCrypto.TryGenerateSignature(keys.PrivateKey, hash, destination, palAlgId, out bytesWritten);
             }
 
             public override bool VerifyHash(
@@ -338,8 +338,8 @@ namespace System.Security.Cryptography
             protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
                 AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
 
-            protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
-                AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+            protected override bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+                AsymmetricAlgorithmHelpers.TryHashData(data, destination, hashAlgorithm, out bytesWritten);
 
             protected override void Dispose(bool disposing)
             {

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
@@ -10,17 +10,17 @@ namespace System.Security.Cryptography
 {
     public abstract partial class DSA : System.Security.Cryptography.AsymmetricAlgorithm
     {
-        public virtual bool TryCreateSignature(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) { throw null; }
-        protected virtual bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
-        public virtual bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
+        public virtual bool TryCreateSignature(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
+        public virtual bool TrySignData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
         public virtual bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm) { throw null; }
-        public virtual bool VerifySignature(ReadOnlySpan<byte> rgbHash, ReadOnlySpan<byte> rgbSignature) { throw null; }
+        public virtual bool VerifySignature(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature) { throw null; }
     }
     public abstract partial class ECDsa : System.Security.Cryptography.AsymmetricAlgorithm
     {
-        protected virtual bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
-        public virtual bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
-        public virtual bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
+        public virtual bool TrySignData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
+        public virtual bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten) { throw null; }
         public virtual bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm) { throw null; }
         public virtual bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature) { throw null; }
     }
@@ -37,11 +37,11 @@ namespace System.Security.Cryptography
     }
     public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
     {
-        public virtual bool TryDecrypt(System.ReadOnlySpan<byte> source, System.Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) { throw null; }
-        public virtual bool TryEncrypt(System.ReadOnlySpan<byte> source, System.Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) { throw null; }
-        protected virtual bool TryHashData(System.ReadOnlySpan<byte> source, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
-        public virtual bool TrySignData(System.ReadOnlySpan<byte> source, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) { throw null; }
-        public virtual bool TrySignHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) { throw null; }
+        public virtual bool TryDecrypt(System.ReadOnlySpan<byte> data, System.Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) { throw null; }
+        public virtual bool TryEncrypt(System.ReadOnlySpan<byte> data, System.Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) { throw null; }
+        protected virtual bool TryHashData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
+        public virtual bool TrySignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) { throw null; }
+        public virtual bool TrySignHash(System.ReadOnlySpan<byte> hash, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) { throw null; }
         public virtual bool VerifyData(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) { throw null; }
         public virtual bool VerifyHash(System.ReadOnlySpan<byte> hash, System.ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) { throw null; }
     }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsa.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsa.cs
@@ -83,14 +83,14 @@ namespace System.Security.Cryptography
             return SignHash(hash);
         }
 
-        public virtual bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        public virtual bool TrySignData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
         {
             if (string.IsNullOrEmpty(hashAlgorithm.Name))
             {
                 throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
             }
 
-            if (TryHashData(source, destination, hashAlgorithm, out int hashLength) &&
+            if (TryHashData(data, destination, hashAlgorithm, out int hashLength) &&
                 TrySignHash(destination.Slice(0, hashLength), destination, out bytesWritten))
             {
                 return true;
@@ -191,13 +191,13 @@ namespace System.Security.Cryptography
             throw new NotSupportedException(SR.NotSupported_SubclassOverride);
         }
 
-        protected virtual bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        protected virtual bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
         {
-            byte[] array = ArrayPool<byte>.Shared.Rent(source.Length);
+            byte[] array = ArrayPool<byte>.Shared.Rent(data.Length);
             try
             {
-                source.CopyTo(array);
-                byte[] hash = HashData(array, 0, source.Length, hashAlgorithm);
+                data.CopyTo(array);
+                byte[] hash = HashData(array, 0, data.Length, hashAlgorithm);
                 if (hash.Length <= destination.Length)
                 {
                     new ReadOnlySpan<byte>(hash).CopyTo(destination);
@@ -212,14 +212,14 @@ namespace System.Security.Cryptography
             }
             finally
             {
-                Array.Clear(array, 0, source.Length);
+                Array.Clear(array, 0, data.Length);
                 ArrayPool<byte>.Shared.Return(array);
             }
         }
 
-        public virtual bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+        public virtual bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten)
         {
-            byte[] result = SignHash(source.ToArray());
+            byte[] result = SignHash(hash.ToArray());
             if (result.Length <= destination.Length)
             {
                 new ReadOnlySpan<byte>(result).CopyTo(destination);

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -56,9 +56,9 @@ namespace System.Security.Cryptography
         protected virtual byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) => throw DerivedClassMustOverride();
         protected virtual byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) => throw DerivedClassMustOverride();
 
-        public virtual bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        public virtual bool TryDecrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
-            byte[] result = Decrypt(source.ToArray(), padding);
+            byte[] result = Decrypt(data.ToArray(), padding);
 
             if (destination.Length >= result.Length)
             {
@@ -71,9 +71,9 @@ namespace System.Security.Cryptography
             return false;
         }
 
-        public virtual bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        public virtual bool TryEncrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
-            byte[] result = Encrypt(source.ToArray(), padding);
+            byte[] result = Encrypt(data.ToArray(), padding);
 
             if (destination.Length >= result.Length)
             {
@@ -86,18 +86,18 @@ namespace System.Security.Cryptography
             return false;
         }
 
-        protected virtual bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        protected virtual bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
         {
             byte[] result;
-            byte[] array = ArrayPool<byte>.Shared.Rent(source.Length);
+            byte[] array = ArrayPool<byte>.Shared.Rent(data.Length);
             try
             {
-                source.CopyTo(array);
-                result = HashData(array, 0, source.Length, hashAlgorithm);
+                data.CopyTo(array);
+                result = HashData(array, 0, data.Length, hashAlgorithm);
             }
             finally
             {
-                Array.Clear(array, 0, source.Length);
+                Array.Clear(array, 0, data.Length);
                 ArrayPool<byte>.Shared.Return(array);
             }
 
@@ -112,9 +112,9 @@ namespace System.Security.Cryptography
             return false;
         }
 
-        public virtual bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        public virtual bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
         {
-            byte[] result = SignHash(source.ToArray(), hashAlgorithm, padding);
+            byte[] result = SignHash(hash.ToArray(), hashAlgorithm, padding);
 
             if (destination.Length >= result.Length)
             {
@@ -184,7 +184,7 @@ namespace System.Security.Cryptography
             return SignHash(hash, hashAlgorithm, padding);
         }
 
-        public virtual bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        public virtual bool TrySignData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
         {
             if (string.IsNullOrEmpty(hashAlgorithm.Name))
             {
@@ -195,7 +195,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(padding));
             }
 
-            if (TryHashData(source, destination, hashAlgorithm, out int hashLength) &&
+            if (TryHashData(data, destination, hashAlgorithm, out int hashLength) &&
                 TrySignHash(destination.Slice(0, hashLength), destination, hashAlgorithm, padding, out bytesWritten))
             {
                 return true;

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
@@ -50,8 +50,8 @@ namespace System.Security.Cryptography
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "This is the implementation of DSACryptoServiceProvider")]
         public override byte[] CreateSignature(byte[] rgbHash) => _impl.CreateSignature(rgbHash);
 
-        public override bool TryCreateSignature(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
-            _impl.TryCreateSignature(source, destination, out bytesWritten);
+        public override bool TryCreateSignature(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten) =>
+            _impl.TryCreateSignature(hash, destination, out bytesWritten);
 
         public CspKeyContainerInfo CspKeyContainerInfo
         {
@@ -94,12 +94,12 @@ namespace System.Security.Cryptography
             return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
         }
 
-        protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        protected override bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
         {
             if (hashAlgorithm != HashAlgorithmName.SHA1)
                 throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
 
-            return AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+            return AsymmetricAlgorithmHelpers.TryHashData(data, destination, hashAlgorithm, out bytesWritten);
         }
 
         public void ImportCspBlob(byte[] keyBlob)
@@ -180,12 +180,12 @@ namespace System.Security.Cryptography
             return _impl.SignData(data, hashAlgorithm);
         }
 
-        public override bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        public override bool TrySignData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
         {
             if (hashAlgorithm != HashAlgorithmName.SHA1)
                 throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
 
-            return _impl.TrySignData(source, destination, hashAlgorithm, out bytesWritten);
+            return _impl.TrySignData(data, destination, hashAlgorithm, out bytesWritten);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "This is the implementation of DSACryptoServiceProvider")]
@@ -251,8 +251,8 @@ namespace System.Security.Cryptography
         public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) =>
             _impl.VerifySignature(rgbHash, rgbSignature);
 
-        public override bool VerifySignature(ReadOnlySpan<byte> rgbHash, ReadOnlySpan<byte> rgbSignature) =>
-            _impl.VerifySignature(rgbHash, rgbSignature);
+        public override bool VerifySignature(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature) =>
+            _impl.VerifySignature(hash, signature);
 
         // UseMachineKeyStore has no effect in Unix
         public static bool UseMachineKeyStore { get; set; }

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -61,16 +61,16 @@ namespace System.Security.Cryptography
                 throw PaddingModeNotSupported();
         }
 
-        public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        public override bool TryDecrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
             if (padding == null)
                 throw new ArgumentNullException(nameof(padding));
-            if (source.Length > (KeySize / 8))
+            if (data.Length > (KeySize / 8))
                 throw new CryptographicException(SR.Format(SR.Cryptography_Padding_DecDataTooBig, Convert.ToString(KeySize / 8)));
             if (padding != RSAEncryptionPadding.Pkcs1 && padding != RSAEncryptionPadding.OaepSHA1)
                 throw PaddingModeNotSupported();
 
-            return _impl.TryDecrypt(source, destination, padding, out bytesWritten);
+            return _impl.TryDecrypt(data, destination, padding, out bytesWritten);
         }
 
         protected override void Dispose(bool disposing)
@@ -103,14 +103,14 @@ namespace System.Security.Cryptography
                 throw PaddingModeNotSupported();
         }
 
-        public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        public override bool TryEncrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
             if (padding == null)
                 throw new ArgumentNullException(nameof(padding));
             if (padding != RSAEncryptionPadding.Pkcs1 && padding != RSAEncryptionPadding.OaepSHA1)
                 throw PaddingModeNotSupported();
 
-            return _impl.TryEncrypt(source, destination, padding, out bytesWritten);
+            return _impl.TryEncrypt(data, destination, padding, out bytesWritten);
         }
 
         public byte[] ExportCspBlob(bool includePrivateParameters)
@@ -125,8 +125,8 @@ namespace System.Security.Cryptography
         protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
             AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
 
-        protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
-            AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+        protected override bool TryHashData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+            AsymmetricAlgorithmHelpers.TryHashData(data, destination, hashAlgorithm, out bytesWritten);
 
         protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
             AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
@@ -175,8 +175,8 @@ namespace System.Security.Cryptography
         public override byte[] SignData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
             _impl.SignData(data, offset, count, hashAlgorithm, padding);
 
-        public override bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) =>
-            _impl.TrySignData(source, destination, hashAlgorithm, padding, out bytesWritten);
+        public override bool TrySignData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) =>
+            _impl.TrySignData(data, destination, hashAlgorithm, padding, out bytesWritten);
 
         public byte[] SignData(byte[] buffer, int offset, int count, object halg) =>
             _impl.SignData(buffer, offset, count, HashAlgorithmNames.ObjToHashAlgorithmName(halg), RSASignaturePadding.Pkcs1);
@@ -190,8 +190,8 @@ namespace System.Security.Cryptography
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
             _impl.SignHash(hash, hashAlgorithm, padding);
 
-        public override bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) =>
-            _impl.TrySignHash(source, destination, hashAlgorithm, padding, out bytesWritten);
+        public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) =>
+            _impl.TrySignHash(hash, destination, hashAlgorithm, padding, out bytesWritten);
 
         public byte[] SignHash(byte[] rgbHash, string str)
         {


### PR DESCRIPTION
The asymmetric types operate on either hashed input, or unprocessed input.
The existing API tends to call hashed input "hash" (or "rgbHash" for older API),
and unprocessed input "data" (or "rgbData").

This change modifies the new (ReadOnly)Span-based methods to use "data"
and "hash" (as appropriate) instead of "source".  Particularly because the
hash-based methods in DSA do not contain the word Hash, making "source"
for CreateSignature ambiguous.

In the cases where the existing parameter was named "rgbHash" (et al) the
"rgb" was dropped in the (ReadOnly)Span variant, including in the cases
where the (ReadOnly)Span variant is a proper overload.