### PR TITLE
make sure socket is blocking after accept() on macOS and BSD

### DIFF
--- a/src/System.IO.FileSystem/tests/Enumeration/RootTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/RootTests.netcoreapp.cs
@@ -19,6 +19,9 @@ namespace System.IO.Tests.Enumeration
             {
             }
 
+            protected override bool ShouldIncludeEntry(ref FileSystemEntry entry)
+                => !entry.IsDirectory;
+
             protected override string TransformEntry(ref FileSystemEntry entry)
                 => entry.ToFullPath();
 
@@ -29,7 +32,6 @@ namespace System.IO.Tests.Enumeration
             }
         }
 
-        [ActiveIssue(27244)]
         [Fact]
         public void CanRecurseFromRoot()
         {
@@ -45,7 +47,8 @@ namespace System.IO.Tests.Enumeration
                     }
 
                     // Should not get back a full path without a single separator (C:\foo.txt or /foo.txt)
-                    Assert.Equal(Path.DirectorySeparatorChar, recursed.Current.SingleOrDefault(c => c == Path.DirectorySeparatorChar));
+                    int count = recursed.Current.Count(c => c == Path.DirectorySeparatorChar);
+                    Assert.True(count <= 1, $"expected to find just one separator in '{recursed.Current}'");
                 }
 
                 Assert.NotNull(recursed.LastDirectory);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1013,10 +1013,7 @@ namespace System.Net.Sockets
 
         private void Register()
         {
-            // Note, on OSX, this is not always true because in certain cases, 
-            // the socket can already be in non-blocking mode even though we didn't set that ourselves.
-            // TODO: Track down exactly why this is
-            // Debug.Assert(_nonBlockingSet);
+            Debug.Assert(_nonBlockingSet);
             lock (_registerLock)
             {
                 if (!_registered)


### PR DESCRIPTION
This change will make sure new sockets after Accept() are in blocking mode on macOS. 
See the notes from #27210. 

It will also make them auto-close after exec to match Linux behavior.
I have no direct evidence that it is causing problems but now remote exec xUnit tests will inherit sockets from main process. 