### PR TITLE
Fix some compression tests

### DIFF
--- a/src/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
+++ b/src/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
@@ -34,10 +34,6 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        [OuterLoop("Test takes ~12 seconds to run")]
-        public override void Dispose_WithUnfinishedWriteAsync() { base.Dispose_WithUnfinishedWriteAsync(); }
-
-        [Fact]
         [OuterLoop("Test takes ~6 seconds to run")]
         public override void FlushAsync_DuringWriteAsync() { base.FlushAsync_DuringWriteAsync(); }
 

--- a/src/System.IO.Compression.Brotli/tests/Performance/System.IO.Compression.Brotli.Performance.Tests.csproj
+++ b/src/System.IO.Compression.Brotli/tests/Performance/System.IO.Compression.Brotli.Performance.Tests.csproj
@@ -11,7 +11,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
-<!-- [ActiveIssue(26566)]
     <Compile Include="BrotliPerfTests.cs" />
     <Compile Include="CompressionStreamPerfTests.Brotli.cs" />
     <Compile Include="$(CommonTestPath)\System\IO\Compression\CompressionStreamTestBase.cs">
@@ -20,7 +19,6 @@
     <Compile Include="$(CommonTestPath)\System\IO\Compression\CompressionStreamPerfTestBase.cs">
       <Link>Common\System\IO\Compression\CompressionStreamPerfTestBase.cs</Link>
     </Compile>
--->
   </ItemGroup>
   <ItemGroup>
     <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.6-prerelease\content\**\*.*">


### PR DESCRIPTION
- Remove an unnecessary, flaky compression test
- Reduce brotli performance test time down to ~13 minutes. The problem looks to be that since i was using custom inneriterations the perf runner was going to the max time clock length each time, regardless of max iteration count. I switched my tests to use the Benchmark InnerIterations field and also artificially limited the max Compression iteration count to 100 instead of the usual 1000.

resolves https://github.com/dotnet/corefx/issues/26089
resolves https://github.com/dotnet/corefx/issues/26566

