### PR TITLE
[release/2.1] Replace EOL Linux OSes in CI with new ones

### DIFF
--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -52,11 +52,11 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      'Debian.87.Amd64.Open',
                                      'Ubuntu.1404.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
-                                     'opensuse.422.amd64.open',
-                                     'fedora.25.amd64.Open',]
+                                     'OpenSuse.423.Amd64.Open',
+                                     'Fedora.26.Amd64.Open',]
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.90.Amd64.Open',
-                                      'Fedora.26.Amd64.Open',
+                                      'Fedora.27.Amd64.Open',
                                       'SLES.12.Amd64.Open',]
             }
 


### PR DESCRIPTION
This should fix the hang I saw in https://github.com/dotnet/corefx/pull/27180 by using the new Helix queues.

Port of https://github.com/dotnet/corefx/pull/26723 from master, only including CI changes. The other changes are merge-conflicting (and may affect product construction).