### PR TITLE
Mark Microsoft.Diagnostics.Tracing.EventSource.Redist Package as Stable with Version 2.0

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -98,6 +98,9 @@
       }
     },
     "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+      "StableVersions": [
+        "2.0.0"
+      ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "2.0.0.0": "2.0.0"

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/pkg/Microsoft.Diagnostics.Tracing.EventSource.Redist.pkgproj
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/pkg/Microsoft.Diagnostics.Tracing.EventSource.Redist.pkgproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <HarvestStablePackage>false</HarvestStablePackage>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
   </PropertyGroup>
 


### PR DESCRIPTION
Mark the current version of the EventSource.Redist package version 2.0.0 as stable to produce a 2.0.0 package for publication.

cc: @vancem 