### PR TITLE
Fix enumerating the root directory.

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
@@ -41,7 +41,7 @@ namespace System.IO.Enumeration
         public FileSystemEnumerator(string directory, EnumerationOptions options = null)
         {
             _originalRootDirectory = directory ?? throw new ArgumentNullException(nameof(directory));
-            _rootDirectory = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar);
+            _rootDirectory = PathHelpers.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
             _options = options ?? EnumerationOptions.Default;
 
             // We need to initialize the directory handle up front to ensure

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -42,7 +42,7 @@ namespace System.IO.Enumeration
         public FileSystemEnumerator(string directory, EnumerationOptions options = null)
         {
             _originalRootDirectory = directory ?? throw new ArgumentNullException(nameof(directory));
-            _rootDirectory = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar);
+            _rootDirectory = PathHelpers.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
             _options = options ?? EnumerationOptions.Default;
 
             // We'll only suppress the media insertion prompt on the topmost directory as that is the

--- a/src/System.IO.FileSystem/tests/Enumeration/RootTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/RootTests.netcoreapp.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Enumeration;
+using System.Linq;
+using Xunit;
+
+namespace System.IO.Tests.Enumeration
+{
+    public class RootTests
+    {
+        private class DirectoryRecursed : FileSystemEnumerator<string>
+        {
+            public string LastDirectory { get; private set; }
+
+            public DirectoryRecursed(string directory, EnumerationOptions options)
+                : base(directory, options)
+            {
+            }
+
+            protected override string TransformEntry(ref FileSystemEntry entry)
+                => entry.ToFullPath();
+
+            protected override bool ShouldRecurseIntoEntry(ref FileSystemEntry entry)
+            {
+                LastDirectory = new string(entry.Directory); 
+                return false;
+            }
+        }
+
+        [Fact]
+        public void CanRecurseFromRoot()
+        {
+            string root = Path.GetPathRoot(Path.GetTempPath());
+            using (var recursed = new DirectoryRecursed(root, new EnumerationOptions { AttributesToSkip = FileAttributes.System, RecurseSubdirectories = true }))
+            {
+                while (recursed.MoveNext())
+                {
+                    if (recursed.LastDirectory != null)
+                    {
+                        Assert.Equal(root, recursed.LastDirectory);
+                        return;
+                    }
+
+                    // Should not get back a full path without a single separator (C:\foo.txt or /foo.txt)
+                    Assert.Equal(Path.DirectorySeparatorChar, recursed.Current.SingleOrDefault(c => c == Path.DirectorySeparatorChar));
+                }
+
+                Assert.NotNull(recursed.LastDirectory);
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Enumeration\ErrorHandlingTests.netcoreapp.cs" />
     <Compile Include="Enumeration\IncludePredicateTests.netcoreapp.cs" />
     <Compile Include="Enumeration\PatternTransformTests.netcoreapp.cs" />
+    <Compile Include="Enumeration\RootTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Rewritten -->


### PR DESCRIPTION
Shouldn't trim the trailing separator when at the root. On Windows that makes
the path drive relative- which breaks most of the logic.

Add a test to catch this case.