### PR TITLE
Do not clear service name before deleting it by name

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
@@ -182,10 +182,10 @@ namespace System.ServiceProcess.Tests
                     ServiceName, Interop.Advapi32.ServiceOptions.STANDARD_RIGHTS_DELETE);
 
                 if (serviceHandle == IntPtr.Zero)
-                    throw new Win32Exception($"Could not find service {ServiceName}");
+                    throw new Win32Exception($"Could not find service '{ServiceName}'");
 
                 if (!Interop.Advapi32.DeleteService(serviceHandle))
-                    throw new Win32Exception($"Could not delete service {ServiceName}");
+                    throw new Win32Exception($"Could not delete service '{ServiceName}'");
             }
             finally
             {

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
@@ -161,7 +161,6 @@ namespace System.ServiceProcess.Tests
                     catch (InvalidOperationException)
                     {
                         // Already stopped
-                        ServiceName = null;
                         return;
                     }
 


### PR DESCRIPTION
#27054 introduced a bug wherein if our call to ControlService to stop a running service failed (possibly because it raced and stopped already) we would clear the field holding the service name before proceeding to try to delete it using its name.

This causes the output below I see on the NETFX test run. There is still the hang on one configuration in the netcoreapp run.

```
2018-02-17 01:17:12,653: INFO: proc(54): run_and_log_output: Output:   Starting:    System.ServiceProcess.ServiceController.Tests
2018-02-17 01:17:55,865: INFO: proc(54): run_and_log_output: Output:     System.ServiceProcess.Tests.ServiceControllerTests.PauseAndContinue [FAIL]
2018-02-17 01:17:55,865: INFO: proc(54): run_and_log_output: Output:       System.ComponentModel.Win32Exception : Could not find service 
2018-02-17 01:17:55,865: INFO: proc(54): run_and_log_output: Output:       Stack Trace:
2018-02-17 01:17:55,865: INFO: proc(54): run_and_log_output: Output:            at System.ServiceProcess.Tests.TestServiceInstaller.DeleteService()
2018-02-17 01:17:55,865: INFO: proc(54): run_and_log_output: Output:            at System.ServiceProcess.Tests.TestServiceInstaller.RemoveService()
2018-02-17 01:17:55,865: INFO: proc(54): run_and_log_output: Output:            at System.ServiceProcess.Tests.TestServiceProvider.DeleteTestServices()
2018-02-17 01:17:55,865: INFO: proc(54): run_and_log_output: Output:            at System.ServiceProcess.Tests.TestServiceProvider.DeleteTestServices()
2018-02-17 01:17:55,865: INFO: proc(54): run_and_log_output: Output:            at System.ServiceProcess.Tests.ServiceControllerTests.Dispose()

```