### PR TITLE
Several perf improvements/tweaks for SocketsHttpHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -31,6 +31,7 @@ namespace System.Net.Http.Headers
         public string Name => _headerName;
         public HttpHeaderParser Parser => _knownHeader?.Parser;
         public HttpHeaderType HeaderType => _knownHeader == null ? HttpHeaderType.Custom : _knownHeader.HeaderType;
+        public KnownHeader KnownHeader => _knownHeader;
 
         public bool Equals(HeaderDescriptor other) =>
             _knownHeader == null ?

--- a/src/System.Net.Http/src/System/Net/Http/Headers/KnownHeader.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/KnownHeader.cs
@@ -26,6 +26,7 @@ namespace System.Net.Http.Headers
             Debug.Assert(!string.IsNullOrEmpty(name));
             Debug.Assert(HttpRuleParser.GetTokenLength(name, 0) == name.Length);
             Debug.Assert((headerType == HttpHeaderType.Custom) == (parser == null));
+            Debug.Assert(knownValues == null || headerType != HttpHeaderType.Custom);
 
             _name = name;
             _headerType = headerType;

--- a/src/System.Net.Http/src/System/Net/Http/Headers/KnownHeader.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/KnownHeader.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Text;
 
 namespace System.Net.Http.Headers
 {
@@ -12,34 +13,37 @@ namespace System.Net.Http.Headers
         private readonly HttpHeaderType _headerType;
         private readonly HttpHeaderParser _parser;
         private readonly string[] _knownValues;
+        private readonly byte[] _asciiBytesWithColonSpace;
+
+        public KnownHeader(string name) : this(name, HttpHeaderType.Custom, null)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(name));
+            Debug.Assert(HttpRuleParser.GetTokenLength(name, 0) == name.Length);
+        }
 
         public KnownHeader(string name, HttpHeaderType headerType, HttpHeaderParser parser, string[] knownValues = null)
         {
             Debug.Assert(!string.IsNullOrEmpty(name));
             Debug.Assert(HttpRuleParser.GetTokenLength(name, 0) == name.Length);
-            Debug.Assert(headerType != HttpHeaderType.Custom);
-            Debug.Assert(parser != null);
+            Debug.Assert((headerType == HttpHeaderType.Custom) == (parser == null));
 
             _name = name;
             _headerType = headerType;
             _parser = parser;
             _knownValues = knownValues;
-        }
 
-        public KnownHeader(string name)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(name));
-            Debug.Assert(HttpRuleParser.GetTokenLength(name, 0) == name.Length);
-
-            _name = name;
-            _headerType = HttpHeaderType.Custom;
-            _parser = null;
+            _asciiBytesWithColonSpace = new byte[name.Length + 2]; // + 2 for ':' and ' '
+            int asciiBytes = Encoding.ASCII.GetBytes(name, _asciiBytesWithColonSpace);
+            Debug.Assert(asciiBytes == name.Length);
+            _asciiBytesWithColonSpace[_asciiBytesWithColonSpace.Length - 2] = (byte)':';
+            _asciiBytesWithColonSpace[_asciiBytesWithColonSpace.Length - 1] = (byte)' ';
         }
 
         public string Name => _name;
         public HttpHeaderParser Parser => _parser;
         public HttpHeaderType HeaderType => _headerType;
         public string[] KnownValues => _knownValues;
+        public byte[] AsciiBytesWithColonSpace => _asciiBytesWithColonSpace;
         public HeaderDescriptor Descriptor => new HeaderDescriptor(this);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -25,121 +25,66 @@ namespace System.Net.Http
             private const int MaxTrailingHeaderLength = 16*1024;
             /// <summary>The number of bytes remaining in the chunk.</summary>
             private ulong _chunkBytesRemaining;
+            /// <summary>The current state of the parsing state machine for the chunked response.</summary>
+            private ParsingState _state = ParsingState.ExpectChunkHeader;
 
-            public ChunkedEncodingReadStream(HttpConnection connection) : base(connection)
+            public ChunkedEncodingReadStream(HttpConnection connection) : base(connection) { }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
             {
-            }
-
-            private async Task<bool> TryGetNextChunkAsync()
-            {
-                Debug.Assert(_chunkBytesRemaining == 0);
-
-                // Read the start of the chunk line.
-                _connection._allowedReadLineBytes = MaxChunkBytesAllowed;
-                ArraySegment<byte> line = await _connection.ReadNextLineAsync().ConfigureAwait(false);
-
-                // Parse the hex value.
-                if (!Utf8Parser.TryParse(line.AsReadOnlySpan(), out ulong chunkSize, out int bytesConsumed, 'X'))
+                if (cancellationToken.IsCancellationRequested)
                 {
-                    throw new IOException(SR.net_http_invalid_response);
+                    // Cancellation requested.
+                    return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
                 }
-                else if (bytesConsumed != line.Count)
-                {
-                    // There was data after the chunk size, presumably a "chunk extension".
-                    // Allow tabs and spaces and then stop validating once we get to an extension.
-                    int offset = line.Offset + bytesConsumed, end = line.Count - bytesConsumed + line.Offset;
-                    for (int i = offset; i < end; i++)
-                    {
-                        char c = (char)line.Array[i];
-                        if (c == ';')
-                        {
-                            break;
-                        }
-                        else if (c != ' ' && c != '\t') // not called out in the RFC, but WinHTTP allows it
-                        {
-                            throw new IOException(SR.net_http_invalid_response);
-                        }
-                    }
-                }
-
-                _chunkBytesRemaining = chunkSize;
-                if (chunkSize > 0)
-                {
-                    return true;
-                }
-
-                // We received a chunk size of 0, which indicates end of response body. 
-                // Read and discard any trailing headers, until we see an empty line.
-                while (true)
-                {
-                    _connection._allowedReadLineBytes = MaxTrailingHeaderLength;
-                    if (LineIsEmpty(await _connection.ReadNextLineAsync().ConfigureAwait(false)))
-                    {
-                        break;
-                    }
-                }
-
-                _connection.ReturnConnectionToPool();
-                _connection = null;
-                return false;
-            }
-
-            private Task ConsumeChunkBytesAsync(ulong bytesConsumed)
-            {
-                Debug.Assert(bytesConsumed <= _chunkBytesRemaining);
-                _chunkBytesRemaining -= bytesConsumed;
-                return _chunkBytesRemaining != 0 ?
-                    Task.CompletedTask :
-                    ReadNextLineAndThrowIfNotEmptyAsync();
-            }
-
-            private async Task ReadNextLineAndThrowIfNotEmptyAsync()
-            {
-                _connection._allowedReadLineBytes = 2; // \r\n
-                if (!LineIsEmpty(await _connection.ReadNextLineAsync().ConfigureAwait(false)))
-                {
-                    ThrowInvalidHttpResponse();
-                }
-            }
-
-            public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
 
                 if (_connection == null || destination.Length == 0)
                 {
-                    // Response body fully consumed or the caller didn't ask for any data
-                    return 0;
+                    // Response body fully consumed or the caller didn't ask for any data.
+                    return new ValueTask<int>(0);
                 }
+
+                // Try to consume from data we already have in the buffer.
+                int bytesRead = ReadChunksFromConnectionBuffer(destination.Span);
+                if (bytesRead > 0)
+                {
+                    return new ValueTask<int>(bytesRead);
+                }
+
+                // Nothing available to consume.  Fall back to I/O.
+                return ReadAsyncCore(destination, cancellationToken);
+            }
+
+            private async ValueTask<int> ReadAsyncCore(Memory<byte> destination, CancellationToken cancellationToken)
+            {
+                // Should only be called if ReadChunksFromConnectionBuffer returned 0.
+
+                Debug.Assert(_connection != null);
+                Debug.Assert(destination.Length > 0);
 
                 CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
                 try
                 {
-                    if (_chunkBytesRemaining == 0)
+                    while (true)
                     {
-                        if (!await TryGetNextChunkAsync().ConfigureAwait(false))
+                        if (_state == ParsingState.Ending)
                         {
-                            // End of response body
+                            await ConsumeTrailingHeaders().ConfigureAwait(false);
+                            Finish();
                             return 0;
                         }
+
+                        // We're only here if we need more data to make forward progress.
+                        await _connection.FillAsync();
+
+                        // Now that we have more, see if we can get any response data, and if
+                        // we can we're done.
+                        int bytesCopied = ReadChunksFromConnectionBuffer(destination.Span);
+                        if (bytesCopied > 0)
+                        {
+                            return bytesCopied;
+                        }
                     }
-
-                    if (_chunkBytesRemaining < (ulong)destination.Length)
-                    {
-                        destination = destination.Slice(0, (int)_chunkBytesRemaining);
-                    }
-
-                    int bytesRead = await _connection.ReadAsync(destination).ConfigureAwait(false);
-
-                    if (bytesRead <= 0)
-                    {
-                        // Unexpected end of response stream
-                        throw new IOException(SR.net_http_invalid_response);
-                    }
-
-                    await ConsumeChunkBytesAsync((ulong)bytesRead).ConfigureAwait(false);
-
-                    return bytesRead;
                 }
                 catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
                 {
@@ -155,36 +100,193 @@ namespace System.Net.Http
             {
                 ValidateCopyToArgs(this, destination, bufferSize);
 
-                return cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) :
-                    _connection != null ? CopyToAsyncCore(destination, bufferSize, cancellationToken) :
-                    Task.CompletedTask;
+                return
+                    cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) :
+                    _connection == null ? Task.CompletedTask :
+                    CopyToAsyncCore(destination, cancellationToken);
             }
 
-            private async Task CopyToAsyncCore(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            private async Task CopyToAsyncCore(Stream destination, CancellationToken cancellationToken)
             {
                 CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
                 try
                 {
-                    if (_chunkBytesRemaining > 0)
+                    while (true)
                     {
-                        await _connection.CopyToAsync(destination, _chunkBytesRemaining).ConfigureAwait(false);
-                        await ConsumeChunkBytesAsync(_chunkBytesRemaining).ConfigureAwait(false);
-                    }
+                        while (true)
+                        {
+                            ReadOnlyMemory<byte> bytesRead = ReadChunkFromConnectionBuffer(int.MaxValue);
+                            if (bytesRead.Length == 0)
+                            {
+                                break;
+                            }
+                            await destination.WriteAsync(bytesRead, cancellationToken).ConfigureAwait(false);
+                        }
 
-                    while (await TryGetNextChunkAsync().ConfigureAwait(false))
-                    {
-                        await _connection.CopyToAsync(destination, _chunkBytesRemaining).ConfigureAwait(false);
-                        await ConsumeChunkBytesAsync(_chunkBytesRemaining).ConfigureAwait(false);
+                        if (_state == ParsingState.Ending)
+                        {
+                            await ConsumeTrailingHeaders().ConfigureAwait(false);
+                            Finish();
+                            return;
+                        }
+
+                        await _connection.FillAsync().ConfigureAwait(false);
                     }
                 }
                 catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
                 {
-                    throw CreateOperationCanceledException(exc, cancellationToken);
+                    throw new OperationCanceledException(s_cancellationMessage, exc, cancellationToken);
                 }
                 finally
                 {
                     ctr.Dispose();
                 }
+            }
+
+            private async Task ConsumeTrailingHeaders()
+            {
+                while (true)
+                {
+                    _connection._allowedReadLineBytes = MaxTrailingHeaderLength;
+                    if (LineIsEmpty(await _connection.ReadNextLineAsync().ConfigureAwait(false)))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            private void Finish()
+            {
+                _connection.ReturnConnectionToPool();
+                _connection = null;
+            }
+
+            private int ReadChunksFromConnectionBuffer(Span<byte> destination)
+            {
+                int totalBytesRead = 0;
+                while (destination.Length > 0)
+                {
+                    ReadOnlyMemory<byte> bytesRead = ReadChunkFromConnectionBuffer(destination.Length);
+                    Debug.Assert(bytesRead.Length <= destination.Length);
+                    if (bytesRead.Length == 0)
+                    {
+                        break;
+                    }
+
+                    totalBytesRead += bytesRead.Length;
+                    bytesRead.Span.CopyTo(destination);
+                    destination = destination.Slice(bytesRead.Length);
+                }
+                return totalBytesRead;
+            }
+
+            private ReadOnlyMemory<byte> ReadChunkFromConnectionBuffer(int maxBytesToRead)
+            {
+                ReadOnlySpan<byte> currentLine;
+                switch (_state)
+                {
+                    case ParsingState.ExpectChunkHeader:
+                        // Read the chunk header line.
+                        _connection._allowedReadLineBytes = MaxChunkBytesAllowed;
+                        if (!_connection.TryReadNextLine(out currentLine))
+                        {
+                            // Could not get a whole line, so we can't parse the chunk header.
+                            return default;
+                        }
+
+                        // Parse the hex value from it.
+                        if (!Utf8Parser.TryParse(currentLine, out ulong chunkSize, out int bytesConsumed, 'X'))
+                        {
+                            throw new IOException(SR.net_http_invalid_response);
+                        }
+                        _chunkBytesRemaining = chunkSize;
+
+                        // If there's a chunk extension after the chunk size, validate it.
+                        if (bytesConsumed != currentLine.Length)
+                        {
+                            ValidateChunkExtension(currentLine.Slice(bytesConsumed));
+                        }
+
+                        // Proceed to handle the chunk.  If there's data in it, go read it.
+                        // Otherwise, finish handling the response.
+                        if (chunkSize > 0)
+                        {
+                            _state = ParsingState.ExpectChunkData;
+                            goto case ParsingState.ExpectChunkData;
+                        }
+                        else
+                        {
+                            _state = ParsingState.Ending;
+                            return default;
+                        }
+
+                    case ParsingState.ExpectChunkData:
+                        Debug.Assert(_chunkBytesRemaining > 0);
+                        ReadOnlyMemory<byte> connectionBuffer = _connection.RemainingBuffer;
+                        if (connectionBuffer.Length == 0 || maxBytesToRead == 0)
+                        {
+                            return default;
+                        }
+
+                        int bytesToConsume = Math.Min(maxBytesToRead, (int)Math.Min((ulong)connectionBuffer.Length, _chunkBytesRemaining));
+                        Debug.Assert(bytesToConsume > 0);
+
+                        _connection.ConsumeFromRemainingBuffer(bytesToConsume);
+                        _chunkBytesRemaining -= (ulong)bytesToConsume;
+                        if (_chunkBytesRemaining == 0)
+                        {
+                            _state = ParsingState.ExpectChunkTerminator;
+                        }
+
+                        return connectionBuffer.Slice(0, bytesToConsume);
+
+                    case ParsingState.ExpectChunkTerminator:
+                        _connection._allowedReadLineBytes = MaxChunkBytesAllowed;
+                        if (!_connection.TryReadNextLine(out currentLine))
+                        {
+                            return default;
+                        }
+
+                        if (currentLine.Length != 0)
+                        {
+                            ThrowInvalidHttpResponse();
+                        }
+
+                        _state = ParsingState.ExpectChunkHeader;
+                        goto case ParsingState.ExpectChunkHeader;
+
+                    // Done processing all data.
+                    default:
+                    case ParsingState.Ending:
+                        Debug.Assert(_state == ParsingState.Ending, $"Unknown state: {_state}");
+                        return default;
+                }
+            }
+
+            private static void ValidateChunkExtension(ReadOnlySpan<byte> lineAfterChunkSize)
+            {
+                // Until we see the ';' denoting the extension, the line after the chunk size
+                // must contain only tabs and spaces.  After the ';', anything goes.
+                for (int i = 0; i < lineAfterChunkSize.Length; i++)
+                {
+                    byte c = lineAfterChunkSize[i];
+                    if (c == ';')
+                    {
+                        break;
+                    }
+                    else if (c != ' ' && c != '\t') // not called out in the RFC, but WinHTTP allows it
+                    {
+                        throw new IOException(SR.net_http_invalid_response);
+                    }
+                }
+            }
+
+            private enum ParsingState : byte
+            {
+                ExpectChunkHeader,
+                ExpectChunkData,
+                ExpectChunkTerminator,
+                Ending
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -57,7 +57,7 @@ namespace System.Net.Http
                                 break;
                             case SocketError.OperationAborted:
                             case SocketError.ConnectionAborted:
-                                if (cancellationToken.IsCancellationRequested)
+                                if (csaea.CancellationToken.IsCancellationRequested)
                                 {
                                     csaea.Builder.SetException(new OperationCanceledException(csaea.CancellationToken));
                                     break;
@@ -116,7 +116,7 @@ namespace System.Net.Http
             }
         }
 
-        public static async ValueTask<SslStream> EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Stream stream, CancellationToken cancellationToken)
+        public static ValueTask<SslStream> EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Stream stream, CancellationToken cancellationToken)
         {
             // If there's a cert validation callback, and if it came from HttpClientHandler,
             // wrap the original delegate in order to change the sender to be the request message (expected by HttpClientHandler's delegate).
@@ -131,17 +131,21 @@ namespace System.Net.Http
             }
 
             // Create the SslStream, authenticate, and return it.
-            var sslStream = new SslStream(stream);
+            return EstablishSslConnectionAsyncCore(new SslStream(stream), sslOptions, cancellationToken);
+        }
+
+        private static async ValueTask<SslStream> EstablishSslConnectionAsyncCore(SslStream sslStream, SslClientAuthenticationOptions sslOptions, CancellationToken cancellationToken)
+        {
             try
             {
                 await sslStream.AuthenticateAsClientAsync(sslOptions, cancellationToken).ConfigureAwait(false);
+                return sslStream;
             }
             catch (Exception e)
             {
                 sslStream.Dispose();
                 throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
             }
-            return sslStream;
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -72,38 +72,54 @@ namespace System.Net.Http
             {
                 ValidateCopyToArgs(this, destination, bufferSize);
 
-                return
-                    cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) :
-                    _connection != null ? CopyToAsyncCore(destination, bufferSize, cancellationToken) :
-                    Task.CompletedTask; // null if response body fully consumed
-            }
-
-            private async Task CopyToAsyncCore(Stream destination, int bufferSize, CancellationToken cancellationToken)
-            {
-                Task copyTask = _connection.CopyToAsync(destination);
-                if (!copyTask.IsCompletedSuccessfully)
+                if (cancellationToken.IsCancellationRequested)
                 {
-                    CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
-                    try
-                    {
-                        await copyTask.ConfigureAwait(false);
-                    }
-                    catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
-                    {
-                        throw CreateOperationCanceledException(exc, cancellationToken);
-                    }
-                    finally
-                    {
-                        ctr.Dispose();
-                    }
-
-                    // If cancellation is requested and tears down the connection, it could cause the copy
-                    // to end early but think it ended successfully. So we prioritize cancellation in this
-                    // race condition, and if we find after the copy has completed that cancellation has
-                    // been requested, we assume the copy completed due to cancellation and throw.
-                    cancellationToken.ThrowIfCancellationRequested();
+                    return Task.FromCanceled(cancellationToken);
                 }
 
+                if (_connection == null)
+                {
+                    // null if response body fully consumed
+                    return Task.CompletedTask;
+                }
+
+                Task copyTask = _connection.CopyToUntilEofAsync(destination, bufferSize, cancellationToken);
+                if (copyTask.IsCompletedSuccessfully)
+                {
+                    Finish();
+                    return Task.CompletedTask;
+                }
+
+                return CompleteCopyToAsync(copyTask, cancellationToken);
+            }
+
+            private async Task CompleteCopyToAsync(Task copyTask, CancellationToken cancellationToken)
+            {
+                CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
+                try
+                {
+                    await copyTask.ConfigureAwait(false);
+                }
+                catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                {
+                    throw CreateOperationCanceledException(exc, cancellationToken);
+                }
+                finally
+                {
+                    ctr.Dispose();
+                }
+
+                // If cancellation is requested and tears down the connection, it could cause the copy
+                // to end early but think it ended successfully. So we prioritize cancellation in this
+                // race condition, and if we find after the copy has completed that cancellation has
+                // been requested, we assume the copy completed due to cancellation and throw.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Finish();
+            }
+
+            private void Finish()
+            {
                 // We cannot reuse this connection, so close it.
                 _connection.Dispose();
                 _connection = null;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -153,7 +153,9 @@ namespace System.Net.Http
 
         public DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
 
-        private Memory<byte> RemainingBuffer => new Memory<byte>(_readBuffer, _readOffset, _readLength - _readOffset);
+        private int ReadBufferSize => _readBuffer.Length;
+
+        private ReadOnlyMemory<byte> RemainingBuffer => new ReadOnlyMemory<byte>(_readBuffer, _readOffset, _readLength - _readOffset);
 
         private void ConsumeFromRemainingBuffer(int bytesToConsume)
         {
@@ -656,9 +658,8 @@ namespace System.Net.Http
             }
         }
 
-        // TODO: Remove this overload once https://github.com/dotnet/roslyn/issues/17287 is addressed
-        // and the compiler doesn't lift the span temporary from the call site into the async state
-        // machine in debug builds.
+        // TODO: Remove this overload once https://github.com/dotnet/csharplang/issues/1331 is addressed
+        // and the compiler doesn't prevent using spans in async methods.
         private static void ParseStatusLine(ArraySegment<byte> line, HttpResponseMessage response) =>
             ParseStatusLine((Span<byte>)line, response);
 
@@ -736,9 +737,8 @@ namespace System.Net.Http
             }
         }
 
-        // TODO: Remove this overload once https://github.com/dotnet/roslyn/issues/17287 is addressed
-        // and the compiler doesn't lift the span temporary from the call site into the async state
-        // machine in debug builds.
+        // TODO: Remove this overload once https://github.com/dotnet/csharplang/issues/1331 is addressed
+        // and the compiler doesn't prevent using spans in async methods.
         private static void ParseHeaderNameValue(ArraySegment<byte> line, HttpResponseMessage response) =>
             ParseHeaderNameValue((Span<byte>)line, response);
 
@@ -1149,7 +1149,7 @@ namespace System.Net.Http
 
         private async ValueTask<int> ReadAsync(Memory<byte> destination)
         {
-            // This is called when reading the response body
+            // This is called when reading the response body.
 
             int remaining = _readLength - _readOffset;
             if (remaining > 0)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -36,7 +36,6 @@ namespace System.Net.Http
         private static readonly byte[] s_contentLength0NewlineAsciiBytes = Encoding.ASCII.GetBytes("Content-Length: 0\r\n");
         private static readonly byte[] s_spaceHttp10NewlineAsciiBytes = Encoding.ASCII.GetBytes(" HTTP/1.0\r\n");
         private static readonly byte[] s_spaceHttp11NewlineAsciiBytes = Encoding.ASCII.GetBytes(" HTTP/1.1\r\n");
-        private static readonly byte[] s_hostKeyAndSeparator = Encoding.ASCII.GetBytes(HttpKnownHeaderNames.Host + ": ");
         private static readonly byte[] s_httpSchemeAndDelimiter = Encoding.ASCII.GetBytes(Uri.UriSchemeHttp + Uri.SchemeDelimiter);
         private static readonly byte[] s_http1DotBytes = Encoding.ASCII.GetBytes("HTTP/1.");
         private static readonly ulong s_http10Bytes = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("HTTP/1.0"));
@@ -154,20 +153,34 @@ namespace System.Net.Http
 
         public DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
 
+        private Memory<byte> RemainingBuffer => new Memory<byte>(_readBuffer, _readOffset, _readLength - _readOffset);
+
+        private void ConsumeFromRemainingBuffer(int bytesToConsume)
+        {
+            Debug.Assert(bytesToConsume <= _readLength - _readOffset, $"{bytesToConsume} > {_readLength} - {_readOffset}");
+            _readOffset += bytesToConsume;
+        }
+
         private async Task WriteHeadersAsync(HttpHeaders headers, string cookiesFromContainer)
         {
-            foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
+            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValues())
             {
-                await WriteAsciiStringAsync(header.Key).ConfigureAwait(false);
-                await WriteTwoBytesAsync((byte)':', (byte)' ').ConfigureAwait(false);
-
-                var values = (string[])header.Value; // typed as IEnumerable<string>, but always a string[]
-                Debug.Assert(values.Length > 0, "No values for header??");
-                if (values.Length > 0)
+                if (header.Key.KnownHeader != null)
                 {
-                    await WriteStringAsync(values[0]).ConfigureAwait(false);
+                    await WriteBytesAsync(header.Key.KnownHeader.AsciiBytesWithColonSpace).ConfigureAwait(false);
+                }
+                else
+                {
+                    await WriteAsciiStringAsync(header.Key.Name).ConfigureAwait(false);
+                    await WriteTwoBytesAsync((byte)':', (byte)' ').ConfigureAwait(false);
+                }
 
-                    if (cookiesFromContainer != null && header.Key == HttpKnownHeaderNames.Cookie)
+                Debug.Assert(header.Value.Length > 0, "No values for header??");
+                if (header.Value.Length > 0)
+                {
+                    await WriteStringAsync(header.Value[0]).ConfigureAwait(false);
+
+                    if (cookiesFromContainer != null && header.Key.KnownHeader == KnownHeaders.Cookie)
                     {
                         await WriteTwoBytesAsync((byte)';', (byte)' ').ConfigureAwait(false);
                         await WriteStringAsync(cookiesFromContainer).ConfigureAwait(false);
@@ -175,10 +188,10 @@ namespace System.Net.Http
                         cookiesFromContainer = null;
                     }
 
-                    for (int i = 1; i < values.Length; i++)
+                    for (int i = 1; i < header.Value.Length; i++)
                     {
                         await WriteTwoBytesAsync((byte)',', (byte)' ').ConfigureAwait(false);
-                        await WriteStringAsync(values[i]).ConfigureAwait(false);
+                        await WriteStringAsync(header.Value[i]).ConfigureAwait(false);
                     }
                 }
 
@@ -196,7 +209,7 @@ namespace System.Net.Http
 
         private async Task WriteHostHeaderAsync(Uri uri)
         {
-            await WriteBytesAsync(s_hostKeyAndSeparator).ConfigureAwait(false);
+            await WriteBytesAsync(KnownHeaders.Host.AsciiBytesWithColonSpace).ConfigureAwait(false);
 
             await (_idnHostAsciiBytes != null ?
                 WriteBytesAsync(_idnHostAsciiBytes) :
@@ -205,13 +218,13 @@ namespace System.Net.Http
             if (!uri.IsDefaultPort)
             {
                 await WriteByteAsync((byte)':').ConfigureAwait(false);
-                await WriteFormattedInt32Async(uri.Port).ConfigureAwait(false);
+                await WriteDecimalInt32Async(uri.Port).ConfigureAwait(false);
             }
 
             await WriteTwoBytesAsync((byte)'\r', (byte)'\n').ConfigureAwait(false);
         }
 
-        private Task WriteFormattedInt32Async(int value)
+        private Task WriteDecimalInt32Async(int value)
         {
             // Try to format into our output buffer directly.
             if (Utf8Formatter.TryFormat(value, new Span<byte>(_writeBuffer, _writeOffset, _writeBuffer.Length - _writeOffset), out int bytesWritten))
@@ -221,7 +234,20 @@ namespace System.Net.Http
             }
 
             // If we don't have enough room, do it the slow way.
-            return WriteAsciiStringAsync(value.ToString(CultureInfo.InvariantCulture));
+            return WriteAsciiStringAsync(value.ToString());
+        }
+
+        private Task WriteHexInt32Async(int value)
+        {
+            // Try to format into our output buffer directly.
+            if (Utf8Formatter.TryFormat(value, new Span<byte>(_writeBuffer, _writeOffset, _writeBuffer.Length - _writeOffset), out int bytesWritten, 'X'))
+            {
+                _writeOffset += bytesWritten;
+                return Task.CompletedTask;
+            }
+
+            // If we don't have enough room, do it the slow way.
+            return WriteAsciiStringAsync(value.ToString("X", CultureInfo.InvariantCulture));
         }
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -464,7 +490,7 @@ namespace System.Net.Http
 
                 // Create the response stream.
                 HttpContentStream responseStream;
-                if (request.Method == HttpMethod.Head || (int)response.StatusCode == 204 || (int)response.StatusCode == 304)
+                if (request.Method == HttpMethod.Head || response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.NotModified)
                 {
                     responseStream = EmptyReadStream.Instance;
                     ReturnConnectionToPool();
@@ -1000,6 +1026,33 @@ namespace System.Net.Http
             return _stream.WriteAsync(source);
         }
 
+        private bool TryReadNextLine(out ReadOnlySpan<byte> line)
+        {
+            var buffer = new ReadOnlySpan<byte>(_readBuffer, _readOffset, _readLength - _readOffset);
+            int length = buffer.IndexOf((byte)'\n');
+            if (length < 0)
+            {
+                if (_allowedReadLineBytes < buffer.Length)
+                {
+                    ThrowInvalidHttpResponse();
+                }
+
+                line = default;
+                return false;
+            }
+
+            int bytesConsumed = length + 1;
+            _readOffset += bytesConsumed;
+            _allowedReadLineBytes -= bytesConsumed;
+            if (_allowedReadLineBytes < 0)
+            {
+                ThrowInvalidHttpResponse();
+            }
+
+            line = buffer.Slice(0, length > 0 && buffer[length - 1] == '\r' ? length - 1 : length);
+            return true;
+        }
+
         private async ValueTask<ArraySegment<byte>> ReadNextLineAsync()
         {
             int previouslyScannedBytes = 0;
@@ -1122,44 +1175,38 @@ namespace System.Net.Http
             return count;
         }
 
-        private async Task CopyFromBufferAsync(Stream destination, int count)
+        private async Task CopyFromBufferAsync(Stream destination, int count, CancellationToken cancellationToken)
         {
             Debug.Assert(count <= _readLength - _readOffset);
 
             if (NetEventSource.IsEnabled) Trace($"Copying {count} bytes to stream.");
-            await destination.WriteAsync(_readBuffer, _readOffset, count).ConfigureAwait(false);
+            await destination.WriteAsync(_readBuffer, _readOffset, count, cancellationToken).ConfigureAwait(false);
             _readOffset += count;
         }
 
-        private async Task CopyToAsync(Stream destination)
+        private Task CopyToUntilEofAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             Debug.Assert(destination != null);
 
             int remaining = _readLength - _readOffset;
-            if (remaining > 0)
-            {
-                await CopyFromBufferAsync(destination, remaining).ConfigureAwait(false);
-            }
+            return remaining > 0 ?
+                CopyToUntilEofWithExistingBufferedDataAsync(destination, cancellationToken) :
+                _stream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
 
-            while (true)
-            {
-                _readOffset = 0;
+        private async Task CopyToUntilEofWithExistingBufferedDataAsync(Stream destination, CancellationToken cancellationToken)
+        {
+            int remaining = _readLength - _readOffset;
+            Debug.Assert(remaining > 0);
 
-                // Don't use FillAsync here as it will throw on EOF.
-                Debug.Assert(_readAheadTask == null);
-                _readLength = await _stream.ReadAsync(_readBuffer).ConfigureAwait(false);
-                if (_readLength == 0)
-                {
-                    // End of stream
-                    break;
-                }
+            await CopyFromBufferAsync(destination, remaining, cancellationToken).ConfigureAwait(false);
+            _readLength = _readOffset = 0;
 
-                await CopyFromBufferAsync(destination, _readLength).ConfigureAwait(false);
-            }
+            await _stream.CopyToAsync(destination).ConfigureAwait(false);
         }
 
         // Copy *exactly* [length] bytes into destination; throws on end of stream.
-        private async Task CopyToAsync(Stream destination, ulong length)
+        private async Task CopyToExactLengthAsync(Stream destination, ulong length, CancellationToken cancellationToken)
         {
             Debug.Assert(destination != null);
             Debug.Assert(length > 0);
@@ -1171,7 +1218,7 @@ namespace System.Net.Http
                 {
                     remaining = (int)length;
                 }
-                await CopyFromBufferAsync(destination, remaining).ConfigureAwait(false);
+                await CopyFromBufferAsync(destination, remaining, cancellationToken).ConfigureAwait(false);
 
                 length -= (ulong)remaining;
                 if (length == 0)
@@ -1185,7 +1232,7 @@ namespace System.Net.Http
                 await FillAsync().ConfigureAwait(false);
 
                 remaining = (ulong)_readLength < length ? _readLength : (int)length;
-                await CopyFromBufferAsync(destination, remaining).ConfigureAwait(false);
+                await CopyFromBufferAsync(destination, remaining, cancellationToken).ConfigureAwait(false);
 
                 length -= (ulong)remaining;
                 if (length == 0)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -541,6 +541,12 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(GetAsync_Chunked_VaryingSizeChunks_ReceivedCorrectly_MemberData))]
         public async Task GetAsync_Chunked_VaryingSizeChunks_ReceivedCorrectly(int maxChunkSize, string lineEnding, bool useCopyToAsync)
         {
+            if (!UseSocketsHttpHandler && lineEnding != "\r\n")
+            {
+                // Some handlers don't deal well with "\n" alone as the line ending
+                return;
+            }
+
             var rand = new Random(42);
             byte[] expectedData = new byte[100_000];
             rand.NextBytes(expectedData);


### PR DESCRIPTION
- Chunked reads from buffer.  We now process as much of the buffer as we can synchronously during ReadAsync, rather than returning once we hit the end of a chunk.  For very small chunks that arrive quickly, this results in a huge perf increase, e.g. best case for the optimization, with lots of 1-byte chunks getting buffered together, it's now 10x faster.  With 100-byte chunks buffered together, it's 2x faster.

- Blitting byte[] to output for known headers.  Rather than using WriteStringAsync to output all header names, we now use WriteBytesAsync for known headers, with the headers precomputed into byte[]s and cached.

- Cached `Task<int>`s for ReadAsync.  Hopefully consumers start moving to the new `ReadAsync(Memory<byte>, CancellationToken)` overload on Stream, but for those who consume via `ReadAsync(byte[], int, int)`, we need to allocate a task even for synchronously completing values, which will be common when reading from a buffer.  We now cache `Task<int>`s for values < 1024, to account for small reads.

- Removed delegate/closure allocation from connection.  We were accidentally closing over a cancellation token, resulting in an extra delegate and closure allocation in ConnectHelper.  Also reduced the size of the EstablishSslConnectionAsync state machine by splitting the method in order to remove several arguments from being included.

- Use Utf8Formatter for hex values.  Switched from custom formatting of hex values to just use Utf8Formatter.TryFormat.

- Avoid buffering in HttpConnection.CopyToAsync(Stream).  This is used when we want to copy the whole source stream until EOF (e.g. for a Connection: close response), and thus we can skip the buffer and use the source stream's CopyToAsync directly.

- Added a test to exercise various size chunks, line endings, ReadAsync vs CopyToAsync, etc.

- Fix CopyToAsync cancellation handling.  Even though we'll abort the connection when cancellation is requested, we still need to pass the token to the destination stream's WriteAsync to give it the opportunity to cancel.  Also properly pass the buffer size through to the underlying stream's CopyToAsync where appropriate.

- Small miscellaneous cleanup, like removing a few unused arguments from methods, fixing an assert to validate the right thing, etc.

Fixes https://github.com/dotnet/corefx/issues/27198
cc: @geoffkizer, @davidsh, @wfurt, @Priya91 