### PR TITLE
Null value in string array in DataRow causes DataRowComparer to throw NRE, but only if it is the first parameter

### DIFF
--- a/src/System.Data.DataSetExtensions/src/System/Data/DataRowComparer.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/DataRowComparer.cs
@@ -101,7 +101,7 @@ namespace System.Data
 
             for (int i = 0; i < a.Length; ++i)
             {
-                if (!Equals(a[i], b[i]))
+                if (!a[i]?.Equals(b[i]) ?? b[i] != null)
                 {
                     return false;
                 }

--- a/src/System.Data.DataSetExtensions/src/System/Data/DataRowComparer.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/DataRowComparer.cs
@@ -101,7 +101,7 @@ namespace System.Data
 
             for (int i = 0; i < a.Length; ++i)
             {
-                if (!a[i].Equals(b[i]))
+                if (!Equals(a[i], b[i]))
                 {
                     return false;
                 }

--- a/src/System.Data.DataSetExtensions/tests/System/Data/DataRowComparerTests.cs
+++ b/src/System.Data.DataSetExtensions/tests/System/Data/DataRowComparerTests.cs
@@ -288,7 +288,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void Equals_NullStringValueInStringArrayInRightColumn_ThrowsNullReferenceException()
+        public void Equals_NullStringValueInStringArray_CanBeCompared()
         {
             var table = new DataTable("Table");
             DataColumn column = table.Columns.Add("Column");
@@ -298,11 +298,14 @@ namespace System.Data.Tests
             DataRow row2 = table.Rows.Add(new object[] { new string[] { null } });
             DataRow row3 = table.Rows.Add(new object[] { new string[] { "abc" } });
 
-            Assert.Throws<NullReferenceException>(() => DataRowComparer.Default.Equals(row1, row2));
-            Assert.Throws<NullReferenceException>(() => DataRowComparer.Default.Equals(row2, row1));
-            Assert.Throws<NullReferenceException>(() => DataRowComparer.Default.Equals(row1, row3));
+            Assert.True(DataRowComparer.Default.Equals(row1, row2));
+            Assert.True(DataRowComparer.Default.Equals(row2, row1));
 
+            Assert.False(DataRowComparer.Default.Equals(row1, row3));
             Assert.False(DataRowComparer.Default.Equals(row3, row1));
+
+            Assert.False(DataRowComparer.Default.Equals(row2, row3));
+            Assert.False(DataRowComparer.Default.Equals(row3, row2));
         }
 
         [Fact]

--- a/src/System.Data.DataSetExtensions/tests/System/Data/DataRowComparerTests.cs
+++ b/src/System.Data.DataSetExtensions/tests/System/Data/DataRowComparerTests.cs
@@ -288,6 +288,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fix applied only for dotnet Core, full framework throws NullReferenceException")]
         public void Equals_NullStringValueInStringArray_CanBeCompared()
         {
             var table = new DataTable("Table");


### PR DESCRIPTION
Use object.Equals() to compare array elements and avoid NRE