### PR TITLE
SocketsHttpHandler: remove Content-Length header if Transfer-Encoding: chunked is present

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -278,16 +278,19 @@ namespace System.Net.Http
             }
 
             // Add headers to define content transfer, if not present
-            bool transferEncodingChunkedSet = request.HasHeaders && request.Headers.TransferEncodingChunked.GetValueOrDefault();
-            if (request.Content == null)
+            if (request.HasHeaders && request.Headers.TransferEncodingChunked.GetValueOrDefault())
             {
-                if (transferEncodingChunkedSet)
+                if (request.Content == null)
                 {
                     return new HttpRequestException(SR.net_http_client_execution_error,
                         new InvalidOperationException(SR.net_http_chunked_not_allowed_with_empty_content));
                 }
+
+                // Since the user explicitly set TransferEncodingChunked to true, we need to remove
+                // the Content-Length header if present, as sending both is invalid.
+                request.Content.Headers.ContentLength = null;
             }
-            else if (!transferEncodingChunkedSet && request.Content.Headers.ContentLength == null)
+            else if (request.Content != null && request.Content.Headers.ContentLength == null)
             {
                 // We have content, but neither Transfer-Encoding nor Content-Length is set.
                 request.Headers.TransferEncodingChunked = true;

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -191,9 +191,17 @@ namespace System.Net.Http.Functional.Tests
         {
             using (HttpClient client = CreateHttpClient())
             {
-                if (!useContentLengthUpload && requestContent != null)
+                if (requestContent != null)
                 {
-                    requestContent.Headers.ContentLength = null;
+                    if (useContentLengthUpload)
+                    {
+                        // Ensure that Content-Length is populated (see issue #27245)
+                        requestContent.Headers.ContentLength = requestContent.Headers.ContentLength;
+                    }
+                    else
+                    {
+                        requestContent.Headers.ContentLength = null;
+                    }
                 }
                 
                 if (useChunkedEncodingUpload)


### PR DESCRIPTION
This matches behavior of other handlers.  We've been getting away with not doing this because #27245 would cause Content-Length to not appear in the enumeration in normal cases.

Contributes to #27245 

@stephentoub @davidsh 