### PR TITLE
Add tests against corelib shared IO internals

### DIFF
--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Tests\Interop\procfsTests.cs" />
     <Compile Include="Tests\System\AssertExtensionTests.cs" />
     <Compile Include="Tests\System\CharArrayHelpersTests.cs" />
+    <Compile Include="Tests\System\IO\PathInternal.Tests.cs" />
     <Compile Include="Tests\System\IO\StringParserTests.cs" />
     <Compile Include="Tests\System\MarvinTests.cs" />
     <Compile Include="Tests\System\PasteArgumentsTests.cs" />
@@ -95,10 +96,13 @@
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
       <Link>ProductionCode\Common\System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\System\IO\PathInternal.cs">
+      <Link>Common\CoreLib\System\IO\PathInternal.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
-      <Link>Common\System\IO\PathInternal.Windows.cs</Link>
+    <Compile Include="$(CommonPath)\CoreLib\System\IO\PathInternal.Windows.cs">
+      <Link>Common\CoreLib\System\IO\PathInternal.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
@@ -122,8 +126,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
-    <Compile Include="..\src\System\IO\PathInternal.Unix.cs">
-      <Link>Common\System\IO\PathInternal.Unix.cs</Link>
+    <Compile Include="Tests\System\IO\PathInternal.Unix.Tests.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\System\IO\PathInternal.Unix.cs">
+      <Link>Common\CoreLib\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PathConf.cs">
       <Link>Common\Interop\Unix\Interop.PathConf.cs</Link>

--- a/src/Common/tests/Resources/Strings.resx
+++ b/src/Common/tests/Resources/Strings.resx
@@ -156,4 +156,7 @@
   <data name="IO_PathTooLong_Path" xml:space="preserve">
     <value>IO_PathTooLong_Path {0}</value>
   </data>
+  <data name="Arg_InvalidSearchPattern" xml:space="preserve">
+    <value>Arg_InvalidSearchPattern {0}</value>
+  </data>
 </root>

--- a/src/Common/tests/Tests/System/IO/PathInternal.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Tests.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Tests.System.IO
+{
+    public class PathInternal_Windows_Tests
+    {
+        [Theory,
+            InlineData("", "", true, 0),
+            InlineData("", "", false, 0),
+            InlineData("a", "", true, 0),
+            InlineData("a", "", false, 0),
+            InlineData("", "b", true, 0),
+            InlineData("", "b", false, 0),
+            InlineData("\0", "\0", true, 1),
+            InlineData("\0", "\0", false, 1),
+            InlineData("ABcd", "ABCD", true, 4),
+            InlineData("ABCD", "ABcd", true, 4),
+            InlineData("ABcd", "ABCD", false, 2),
+            InlineData("ABCD", "ABcd", false, 2),
+            InlineData("AB\0cd", "AB\0CD", true, 5),
+            InlineData("AB\0CD", "AB\0cd", true, 5),
+            InlineData("AB\0cd", "AB\0CD", false, 3),
+            InlineData("AB\0CD", "AB\0cd", false, 3),
+            InlineData("ABc\0", "ABC\0", true, 4),
+            InlineData("ABC\0", "ABc\0", true, 4),
+            InlineData("ABc\0", "ABC\0", false, 2),
+            InlineData("ABC\0", "ABc\0", false, 2),
+            InlineData("ABcdxyzl", "ABCDpdq", true, 4),
+            InlineData("ABCDxyz", "ABcdpdql", true, 4),
+            InlineData("ABcdxyz", "ABCDpdq", false, 2),
+            InlineData("ABCDxyzoo", "ABcdpdq", false, 2)]
+        public void EqualStartingCharacterCount(string first, string second, bool ignoreCase, int expected)
+        {
+            Assert.Equal(expected, PathInternal.EqualStartingCharacterCount(first, second, ignoreCase));
+        }
+
+
+        [Theory,
+            InlineData(@"", @"", true, 0),
+            InlineData(@"", @"", false, 0),
+            InlineData(@"a", @"A", true, 1),
+            InlineData(@"A", @"a", true, 1),
+            InlineData(@"a", @"A", false, 0),
+            InlineData(@"A", @"a", false, 0),
+            InlineData(@"foo", @"foobar", true, 0),
+            InlineData(@"foo", @"foobar", false, 0),
+            InlineData(@"foo", @"foo/bar", true, 3),
+            InlineData(@"foo", @"foo/bar", false, 3),
+            InlineData(@"foo/", @"foo/bar", true, 4),
+            InlineData(@"foo/", @"foo/bar", false, 4),
+            InlineData(@"foo/bar", @"foo/bar", true, 7),
+            InlineData(@"foo/bar", @"foo/bar", false, 7),
+            InlineData(@"foo/bar", @"foo/BAR", true, 7),
+            InlineData(@"foo/bar", @"foo/BAR", false, 4),
+            InlineData(@"foo/bar", @"foo/barb", true, 4),
+            InlineData(@"foo/bar", @"foo/barb", false, 4)]
+        public void GetCommonPathLength(string first, string second, bool ignoreCase, int expected)
+        {
+            Assert.Equal(expected, PathInternal.GetCommonPathLength(first, second, ignoreCase));
+        }
+    }
+}

--- a/src/Common/tests/Tests/System/IO/PathInternal.Unix.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Unix.Tests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Tests.System.IO
+{
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public class PathInternalTests_Unix
+    {
+        [Theory,
+           InlineData(@"", @""),
+           InlineData(null, null),
+           InlineData(@"/", @"/"),
+           InlineData(@"//", @"/"),
+           InlineData(@"///", @"/"),
+           InlineData(@"\", @"\"),
+           InlineData(@"\\", @"\\"),
+           InlineData(@"\\\", @"\\\"),
+           InlineData(@"\/", @"\/"),
+           InlineData(@"\/\", @"\/\"),
+
+           InlineData(@"a/a", @"a/a"),
+           InlineData(@"a//a", @"a/a"),
+           InlineData(@"a\\a", @"a\\a"),
+           InlineData(@"/a", @"/a"),
+           InlineData(@"//a", @"/a"),
+           InlineData(@"\\a", @"\\a"),
+           InlineData(@"a/", @"a/"),
+           InlineData(@"a//", @"a/"),
+           InlineData(@"a\\", @"a\\"),
+           ]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void NormalizeDirectorySeparatorTests(string path, string expected)
+        {
+            string result = PathInternal.NormalizeDirectorySeparators(path);
+            Assert.Equal(expected, result);
+            if (string.Equals(path, expected, StringComparison.Ordinal))
+                Assert.Same(path, result);
+        }
+    }
+}

--- a/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
@@ -6,81 +6,139 @@ using System;
 using System.IO;
 using Xunit;
 
-public class PathInternal_Windows_Tests
+namespace Tests.System.IO
 {
-    [Theory,
-        InlineData(PathInternal.ExtendedDevicePathPrefix, PathInternal.ExtendedDevicePathPrefix),
-        InlineData(@"Foo", @"Foo"),
-        InlineData(@"C:\Foo", @"\\?\C:\Foo"),
-        InlineData(@"\\.\Foo", @"\\.\Foo"),
-        InlineData(@"\\?\Foo", @"\\?\Foo"),
-        InlineData(@"\??\Foo", @"\??\Foo"),
-        InlineData(@"//?/Foo", @"//?/Foo"),
-        InlineData(@"\\Server\Share", PathInternal.UncExtendedPathPrefix + @"Server\Share")
-        ]
     [PlatformSpecific(TestPlatforms.Windows)]
-    public void EnsureExtendedPrefixTest(string path, string expected)
+    public class PathInternalTests_Windows
     {
-        Assert.Equal(expected, PathInternal.EnsureExtendedPrefix(path));
-    }
+        [Theory,
+            InlineData(@"\\?\", @"\\?\"),
+            InlineData(@"Foo", @"Foo"),
+            InlineData(@"C:\Foo", @"\\?\C:\Foo"),
+            InlineData(@"\\.\Foo", @"\\.\Foo"),
+            InlineData(@"\\?\Foo", @"\\?\Foo"),
+            InlineData(@"\??\Foo", @"\??\Foo"),
+            InlineData(@"//?/Foo", @"//?/Foo"),
+            InlineData(@"\\Server\Share", PathInternal.UncExtendedPathPrefix + @"Server\Share")
+            ]
+        public void EnsureExtendedPrefixTest(string path, string expected)
+        {
+            Assert.Equal(expected, PathInternal.EnsureExtendedPrefix(path));
+        }
 
-    [Theory,
-        InlineData(@"", false),
-        InlineData(@"\\?\", true),
-        InlineData(@"\??\", true),
-        InlineData(@"\\.\", false),
-        InlineData(@"\\?", false),
-        InlineData(@"\??", false),
-        InlineData(@"//?/", false),
-        InlineData(@"/??/", false)
-        ]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void IsExtendedTest(string path, bool expected)
-    {
-        Assert.Equal(expected, PathInternal.IsExtended(path));
-    }
+        [Theory,
+            InlineData(@"", false),
+            InlineData(@"\\?\", true),
+            InlineData(@"\??\", true),
+            InlineData(@"\\.\", false),
+            InlineData(@"\\?", false),
+            InlineData(@"\??", false),
+            InlineData(@"//?/", false),
+            InlineData(@"/??/", false)
+            ]
+        public void IsExtendedTest(string path, bool expected)
+        {
+            Assert.Equal(expected, PathInternal.IsExtended(path));
+        }
 
-    [Theory,
-        InlineData(@"", false),
-        InlineData(@"\\?\", true),
-        InlineData(@"\??\", true),
-        InlineData(@"\\.\", true),
-        InlineData(@"\\?", false),
-        InlineData(@"\??", false),
-        InlineData(@"//?/", true),
-        InlineData(@"/??/", false)
-        ]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void IsDeviceTest(string path, bool expected)
-    {
-        Assert.Equal(expected, PathInternal.IsDevice(path));
-    }
+        [Theory,
+            InlineData(@"", false),
+            InlineData(@"\\?\", true),
+            InlineData(@"\??\", true),
+            InlineData(@"\\.\", true),
+            InlineData(@"\\?", false),
+            InlineData(@"\??", false),
+            InlineData(@"//?/", true),
+            InlineData(@"/??/", false)
+            ]
+        public void IsDeviceTest(string path, bool expected)
+        {
+            Assert.Equal(expected, PathInternal.IsDevice(path));
+        }
 
-    [Theory,
-        InlineData("", true),
-        InlineData("C:", true),
-        InlineData("**", true),
-        InlineData(@"\\.\path", false),
-        InlineData(@"\\?\path", false),
-        InlineData(@"\\.", false),
-        InlineData(@"\\?", false),
-        InlineData(@"\?", false),
-        InlineData(@"/?", false),
-        InlineData(@"\\", false),
-        InlineData(@"//", false),
-        InlineData(@"\a", true),
-        InlineData(@"/a", true),
-        InlineData(@"\", true),
-        InlineData(@"/", true),
-        InlineData(@"C:Path", true),
-        InlineData(@"C:\Path", false),
-        InlineData(@"\\?\C:\Path", false),
-        InlineData(@"Path", true),
-        InlineData(@"X", true)
-        ]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void IsPartiallyQualifiedTest(string path, bool expected)
-    {
-        Assert.Equal(expected, PathInternal.IsPartiallyQualified(path));
+        [Theory,
+            InlineData("", true),
+            InlineData("C:", true),
+            InlineData("**", true),
+            InlineData(@"\\.\path", false),
+            InlineData(@"\\?\path", false),
+            InlineData(@"\\.", false),
+            InlineData(@"\\?", false),
+            InlineData(@"\?", false),
+            InlineData(@"/?", false),
+            InlineData(@"\\", false),
+            InlineData(@"//", false),
+            InlineData(@"\a", true),
+            InlineData(@"/a", true),
+            InlineData(@"\", true),
+            InlineData(@"/", true),
+            InlineData(@"C:Path", true),
+            InlineData(@"C:\Path", false),
+            InlineData(@"\\?\C:\Path", false),
+            InlineData(@"Path", true),
+            InlineData(@"X", true)
+            ]
+        public void IsPartiallyQualifiedTest(string path, bool expected)
+        {
+            Assert.Equal(expected, PathInternal.IsPartiallyQualified(path));
+        }
+
+        [Theory,
+            InlineData(@"", @""),
+            InlineData(null, null),
+            InlineData(@"\", @"\"),
+            InlineData(@"/", @"\"),
+            InlineData(@"\\", @"\\"),
+            InlineData(@"\\\", @"\\"),
+            InlineData(@"//", @"\\"),
+            InlineData(@"///", @"\\"),
+            InlineData(@"\/", @"\\"),
+            InlineData(@"\/\", @"\\"),
+
+            InlineData(@"a\a", @"a\a"),
+            InlineData(@"a\\a", @"a\a"),
+            InlineData(@"a/a", @"a\a"),
+            InlineData(@"a//a", @"a\a"),
+            InlineData(@"a\", @"a\"),
+            InlineData(@"a\\", @"a\"),
+            InlineData(@"a/", @"a\"),
+            InlineData(@"a//", @"a\"),
+            InlineData(@"\a", @"\a"),
+            InlineData(@"\\a", @"\\a"),
+            InlineData(@"/a", @"\a"),
+            InlineData(@"//a", @"\\a"),
+
+            // Skip tests
+            InlineData(@"  :", @"  :"),
+            InlineData(@"  C:", @"C:"),
+            InlineData(@"   C:\", @"C:\"),
+            InlineData(@"   C:/", @"C:\"),
+            InlineData(@"  ", @"  "),
+            InlineData(@"  \", @"\"),
+            InlineData(@"  /", @"\"),
+            InlineData(@"  8:", @"  8:"),
+            InlineData(@"    \\", @"\\"),
+            InlineData(@"    //", @"\\")
+            ]
+        public void NormalizeDirectorySeparatorTests(string path, string expected)
+        {
+            string result = PathInternal.NormalizeDirectorySeparators(path);
+            Assert.Equal(expected, result);
+            if (string.Equals(path, expected, StringComparison.Ordinal))
+                Assert.Same(path, result);
+        }
+
+        [Theory,
+            InlineData(@"", @"", StringComparison.OrdinalIgnoreCase, true),
+            InlineData(@"", @"", StringComparison.Ordinal, true),
+            InlineData(@"A", @"a", StringComparison.OrdinalIgnoreCase, true),
+            InlineData(@"A", @"a", StringComparison.Ordinal, true),
+            InlineData(@"C:\", @"c:\", StringComparison.OrdinalIgnoreCase, true),
+            InlineData(@"C:\", @"c:\", StringComparison.Ordinal, false)
+            ]
+        public void AreRootsEqual(string first, string second, StringComparison comparisonType, bool expected)
+        {
+            Assert.Equal(expected, PathInternal.AreRootsEqual(first, second, comparisonType));
+        }
     }
 }


### PR DESCRIPTION
These were removed when we cleaned up unused code in CoreFX common. Next steps are to CoreFX PathInternal usages to CoreLib and remove existing CoreLib.