### PR TITLE
Force inlining CheckTimeout in RegexRunner

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -206,15 +206,16 @@ namespace System.Text.RegularExpressions
             if (_ignoreTimeout)
                 return;
 
-            if (--_timeoutChecksToSkip != 0)
-                return;
-
-            _timeoutChecksToSkip = TimeoutCheckFrequency;
             DoCheckTimeout();
         }
 
         private void DoCheckTimeout()
         {
+            if (--_timeoutChecksToSkip != 0)
+                return;
+
+            _timeoutChecksToSkip = TimeoutCheckFrequency;
+
             // Note that both, Environment.TickCount and timeoutOccursAt are ints and can overflow and become negative.
             // See the comment in StartTimeoutWatch().
 


### PR DESCRIPTION
I can't get any valuable measurements with BDN here. I tried multiple times but it seems either my benchmarks are bad or the absolute costs of the CheckTimeout native calls are to small.

@AndyAyersMS Perfview tells me that without AggresiveInlining it won't inline the method with reason "unprofitable inline". Any idea why it doesn't inline a simple boolean check here (it doesn't inline either without the OR condition). Has it do with the state of inliner here (huge switch)?

Perfview before:

Name | Exc %
-- | --
system.text.regularexpressions!RegexInterpreter.Go | 35.8
system.text.regularexpressions!RegexCharClass.CharInClassInternal | 12.1
system.text.regularexpressions!RegexCharClass.CharInClassRecursive | 7.1
system.text.regularexpressions!RegexInterpreter.Backtrack | 7.0
system.text.regularexpressions!RegexInterpreter.Stringmatch | 6.1
system.text.regularexpressions!RegexInterpreter.SetOperator | 5.4
system.text.regularexpressions!RegexInterpreter.FindFirstChar | 5.3
system.text.regularexpressions!RegexInterpreter.Forwardcharnext | 3.5
system.text.regularexpressions!RegexRunner.Scan | 3.1
system.text.regularexpressions!RegexRunner.CheckTimeout | 2.9
system.text.regularexpressions!RegexInterpreter.Goto | 2.5

Perfview after:


Name | Exc %
-- | --
system.text.regularexpressions!RegexInterpreter.Go | 35.3
system.text.regularexpressions!RegexCharClass.CharInClassInternal | 13.8
system.text.regularexpressions!RegexCharClass.CharInClassRecursive | 8.0
system.text.regularexpressions!RegexInterpreter.Backtrack | 7.3
system.text.regularexpressions!RegexInterpreter.Stringmatch | 6.0
system.text.regularexpressions!RegexInterpreter.SetOperator | 5.3
system.text.regularexpressions!RegexInterpreter.FindFirstChar | 5.0
system.text.regularexpressions!RegexInterpreter.Forwardcharnext | 3.8
system.text.regularexpressions!RegexRunner.Scan | 3.1
system.text.regularexpressions!RegexInterpreter.Goto | 2.5



cc @danmosemsft @stephentoub