### PR TITLE
In ImmutableArray.ToDictionary, presize Dictionary

### DIFF
--- a/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -608,7 +608,7 @@ namespace System.Linq
         {
             Requires.NotNull(keySelector, nameof(keySelector));
 
-            var result = new Dictionary<TKey, T>(comparer);
+            var result = new Dictionary<TKey, T>(immutableArray.Length, comparer);
             foreach (var v in immutableArray)
             {
                 result.Add(keySelector(v), v);


### PR DESCRIPTION
Seems like an oversight. Also showed up in profile of major Azure service.