### PR TITLE
Set Microsoft.Diagnostics.Tracing.EventSource.Redist Package Version to 2.0.1

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -103,7 +103,8 @@
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "2.0.0.0": "2.0.0"
+        "2.0.0.0": "2.0.0",
+        "2.0.1.0": "2.0.1"
       }
     },
     "Microsoft.JScript": {
@@ -2903,6 +2904,7 @@
       }
     },
     "System.Net.WebSockets.WebSocketProtocol": {
+      "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0"
       }
@@ -4887,7 +4889,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.1.1.0",
         "netcoreapp2.1": "4.1.2.0",
-        "uap10.0.16300": "4.1.2.0",
+        "uap10.0.16300": "4.1.2.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/dir.props
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/dir.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <PackageVersion>2.0.1</PackageVersion>
+    <AssemblyVersion>2.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Set Microsoft.Diagnostics.Tracing.EventSource.Redist package version to 2.0.1 after marking 2.0.0 as stable.