### PR TITLE
Increase timeout on ConnectTimeout_TimesOutSSLAuth_Throws test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -232,7 +232,7 @@ namespace System.Net.Http.Functional.Tests
                             new UriBuilder(uri) { Scheme = "https" }.ToString()), default));
                     sw.Stop();
 
-                    Assert.InRange(sw.ElapsedMilliseconds, 500, 10_000);
+                    Assert.InRange(sw.ElapsedMilliseconds, 500, 30_000);
                     releaseServer.SetResult(true);
                 }
             }, server => releaseServer.Task); // doesn't establish SSL connection


### PR DESCRIPTION
Fixes #27291 (hopefully).  If it fails again, we'll need to look for a deeper reason than just CI hammering the server and causing things to take longer.