### PR TITLE
Updated contract, exposed SqlMetaData ctors

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -158,7 +158,11 @@ namespace Microsoft.SqlServer.Server
         public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, long locale, System.Data.SqlTypes.SqlCompareOptions compareOptions, bool useServerDefault, bool isUniqueKey, System.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
         public SqlMetaData(string name, System.Data.SqlDbType dbType, string database, string owningSchema, string objectName) { }
         public SqlMetaData(string name, System.Data.SqlDbType dbType, string database, string owningSchema, string objectName, bool useServerDefault, bool isUniqueKey, System.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
+        public SqlMetaData(string name, System.Data.SqlDbType dbType, System.Type userDefinedType, string serverTypeName) { }
+        public SqlMetaData(string name, System.Data.SqlDbType dbType, System.Type userDefinedType, string serverTypeName, bool useServerDefault, bool isUniqueKey, System.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
+
         public System.Data.SqlTypes.SqlCompareOptions CompareOptions { get { throw null; } }
+        public System.Data.DbType DbType { get { throw null; } }
         public bool IsUniqueKey { get { throw null; } }
         public long LocaleId { get { throw null; } }
         public static long Max { get { throw null; } }
@@ -169,6 +173,7 @@ namespace Microsoft.SqlServer.Server
         public System.Data.SqlClient.SortOrder SortOrder { get { throw null; } }
         public int SortOrdinal { get { throw null; } }
         public System.Data.SqlDbType SqlDbType { get { throw null; } }
+        public System.Type Type{ get { throw null; } }
         public string TypeName { get { throw null; } }
         public bool UseServerDefault { get { throw null; } }
         public string XmlSchemaCollectionDatabase { get { throw null; } }
@@ -693,6 +698,7 @@ namespace System.Data.SqlClient
         public override int GetValues(object[] values) { throw null; }
         public virtual System.Xml.XmlReader GetXmlReader(int i) { throw null; }
         public override bool IsDBNull(int i) { throw null; }
+        protected internal bool IsCommandBehavior(System.Data.CommandBehavior condition) { throw null; }
         public override System.Threading.Tasks.Task<bool> IsDBNullAsync(int i, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override bool NextResult() { throw null; }
         public override System.Threading.Tasks.Task<bool> NextResultAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -786,6 +792,8 @@ namespace System.Data.SqlClient
     {
         internal SqlParameterCollection() { }
         public override int Count { get { throw null; } }
+        public override bool IsFixedSize { get { throw null; } }
+        public override bool IsReadOnly { get { throw null; } }
         public new System.Data.SqlClient.SqlParameter this[int index] { get { throw null; } set { } }
         public new System.Data.SqlClient.SqlParameter this[string parameterName] { get { throw null; } set { } }
         public override object SyncRoot { get { throw null; } }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterCollection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterCollection.cs
@@ -30,6 +30,21 @@ namespace System.Data.SqlClient
                 _isDirty = value;
             }
         }
+        override public bool IsFixedSize
+        {
+            get
+            {
+                return ((System.Collections.IList)InnerList).IsFixedSize;
+            }
+        }
+
+        override public bool IsReadOnly
+        {
+            get
+            {
+                return ((System.Collections.IList)InnerList).IsReadOnly;
+            }
+        }
 
         new public SqlParameter this[int index]
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterCollection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterCollection.cs
@@ -30,22 +30,8 @@ namespace System.Data.SqlClient
                 _isDirty = value;
             }
         }
-        override public bool IsFixedSize
-        {
-            get
-            {
-                return ((System.Collections.IList)InnerList).IsFixedSize;
-            }
-        }
-
-        override public bool IsReadOnly
-        {
-            get
-            {
-                return ((System.Collections.IList)InnerList).IsReadOnly;
-            }
-        }
-
+        public override bool IsFixedSize => ((System.Collections.IList)InnerList).IsFixedSize;
+        public override bool IsReadOnly => ((System.Collections.IList)InnerList).IsReadOnly;
         new public SqlParameter this[int index]
         {
             get

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlMetaDataTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlMetaDataTest.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.SqlServer.Server;
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class SqlMetaDataTest
+    {
+
+        // Test UDT constrtuctor without tvp extended properties
+        [Fact]
+        public void UdtConstructorTest()
+        {
+            Address address = Address.Parse("123 baker st || Redmond");
+            SqlMetaData metaData = new SqlMetaData("col1", SqlDbType.Udt, typeof(Address), "UdtTestDb.dbo.Address");
+            Assert.Equal("col1", metaData.Name);
+            Assert.Equal(SqlDbType.Udt, metaData.SqlDbType);
+            Assert.Equal(address.GetType(), metaData.Type);
+            Assert.Equal("UdtTestDb.dbo.Address", metaData.TypeName);
+            Assert.False(metaData.UseServerDefault);
+            Assert.False(metaData.IsUniqueKey);
+            Assert.Equal(SortOrder.Unspecified, metaData.SortOrder);
+            Assert.Equal(-1, metaData.SortOrdinal);
+        }
+
+
+        // Test UDT constrtuctor with tvp extended properties
+        [Fact]
+        public void UdtConstructorWithTvpTest()
+        {
+            Address address = Address.Parse("123 baker st || Redmond");
+            SqlMetaData metaData = new SqlMetaData("col2", SqlDbType.Udt, typeof(Address), "UdtTestDb.dbo.Address", true, true, SortOrder.Ascending, 0);
+            Assert.Equal("col2", metaData.Name);
+            Assert.Equal(SqlDbType.Udt, metaData.SqlDbType);
+            Assert.Equal(address.GetType(), metaData.Type);
+            Assert.Equal("UdtTestDb.dbo.Address", metaData.TypeName);
+            Assert.True(metaData.UseServerDefault);
+            Assert.True(metaData.IsUniqueKey);
+            Assert.Equal(SortOrder.Ascending, metaData.SortOrder);
+            Assert.Equal(0, metaData.SortOrdinal);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="FakeDiagnosticListenerObserver.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
     <Compile Include="SqlDataRecordTest.cs" />
+    <Compile Include="SqlMetaDataTest.cs" />
     <Compile Include="SqlParameterTest.cs" />
     <Compile Include="SqlClientFactoryTest.cs" />
     <Compile Include="SqlConnectionTest.RetrieveStatistics.cs" />
@@ -30,6 +31,10 @@
     <Compile Include="..\ManualTests\DataCommon\DataTestUtility.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\ManualTests\SQL\UdtTest\UDTs\Address\Address.csproj">
+      <Project>{d1392b54-998a-4f27-bc17-4ce149117bcc}</Project>
+      <Name>Address</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Tools\TDS\TDS.Servers\TDS.Servers.csproj">
       <Name>TDS.Servers</Name>
     </ProjectReference>


### PR DESCRIPTION
Updated contract, exposed SqlMetaData ctors and added SqlParameterCollection properties.

Completed the following types:
M:Microsoft.SqlServer.Server.SqlMetaData..ctor(System.String, System.Data.SqlDbType, System.Type, System.String) 
M:Microsoft.SqlServer.Server.SqlMetaData..ctor(System.String, System.Data.SqlDbType, System.Type, System.String, System.Boolean, System.Boolean, System.Data.SqlClient.SortOrder, System.Int32)
P:Microsoft.SqlServer.Server.SqlMetaData.DbType {get;}
P:Microsoft.SqlServer.Server.SqlMetaData.Type {get;}
P:System.Data.SqlClient.SqlParameterCollection.IsFixedSize
P:System.Data.SqlClient.SqlParameterCollection.IsReadOnly M:System.Data.SqlClient.SqlDataReader.IsCommandBehavior(System.Data.CommandBehavior) 



Adding reviewers:
@saurabh500 @corivera @geleems 