### PR TITLE
Ported System.Data.SqlCredential Class 

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -837,6 +837,13 @@ namespace System.Data.SqlClient
         public void Rollback(string transactionName) { }
         public void Save(string savePointName) { }
     }
+
+    public sealed class SqlCredential
+    {
+        public SqlCredential(string userId, System.Security.SecureString password) { }
+        public string UserId { get { throw null; } }
+        public System.Security.SecureString Password { get { throw null; } }
+    }
 }
 namespace System.Data
 {

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1165,32 +1165,32 @@
   <data name="SqlProvider_InvalidDataColumnMaxLength" xml:space="preserve">
     <value>The size of column '{0}' is not supported. The size is {1}.</value>
   </data>
-  <data name="MDF_InvalidXmlInvalidValue" xml:space="preserve"> 
+  <data name="MDF_InvalidXmlInvalidValue" xml:space="preserve">
     <value>The metadata XML is invalid. The {1} column of the {0} collection must contain a non-empty string.</value>
   </data>
-  <data name="MDF_CollectionNameISNotUnique" xml:space="preserve"> 
+  <data name="MDF_CollectionNameISNotUnique" xml:space="preserve">
     <value>There are multiple collections named '{0}'.</value>
   </data>
-  <data name="MDF_InvalidXmlMissingColumn" xml:space="preserve"> 
+  <data name="MDF_InvalidXmlMissingColumn" xml:space="preserve">
     <value>The metadata XML is invalid. The {0} collection must contain a {1} column and it must be a string column.</value>
   </data>
-  <data name="MDF_InvalidXml" xml:space="preserve"> 
+  <data name="MDF_InvalidXml" xml:space="preserve">
     <value>The metadata XML is invalid.</value>
   </data>
-  <data name="MDF_NoColumns" xml:space="preserve"> 
+  <data name="MDF_NoColumns" xml:space="preserve">
     <value>The schema table contains no columns.</value>
   </data>
-  <data name="MDF_QueryFailed" xml:space="preserve"> 
+  <data name="MDF_QueryFailed" xml:space="preserve">
     <value>Unable to build the '{0}' collection because execution of the SQL query failed. See the inner exception for details.</value>
   </data>
-  <data name="MDF_TooManyRestrictions" xml:space="preserve"> 
+  <data name="MDF_TooManyRestrictions" xml:space="preserve">
     <value>More restrictions were provided than the requested schema ('{0}') supports.</value>
   </data>
-  <data name="MDF_DataTableDoesNotExist" xml:space="preserve"> 
+  <data name="MDF_DataTableDoesNotExist" xml:space="preserve">
     <value>The collection '{0}' is missing from the metadata XML.</value>
   </data>
-  <data name="MDF_UndefinedCollection" xml:space="preserve"> 
-    <value>The requested collection ({0}) is not defined.</value> 
+  <data name="MDF_UndefinedCollection" xml:space="preserve">
+    <value>The requested collection ({0}) is not defined.</value>
   </data>
   <data name="MDF_UnsupportedVersion" xml:space="preserve">
     <value> requested collection ({0}) is not supported by this version of the provider.</value>
@@ -1212,5 +1212,11 @@
   </data>
   <data name="MDF_UnableToBuildCollection" xml:space="preserve">
     <value>Unable to build schema collection '{0}';</value>
+  </data>
+  <data name="ADP_InvalidArgumentLength" xml:space="preserve">
+    <value>The length of argument '{0}' exceeds its limit of '{1}'.</value>
+  </data>
+  <data name="ADP_MustBeReadOnly" xml:space="preserve">
+    <value>{0} must be marked as read only.</value>
   </data>
 </root>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -201,6 +201,7 @@
     <Compile Include="System\Data\SqlClient\SNI\SSRP.cs" />
     <Compile Include="System\Data\SqlClient\TdsParserStateObjectManaged.cs" />
     <Compile Include="Interop\SNINativeMethodWrapper.Common.cs" />
+    <Compile Include="System\Data\SqlClient\SqlCredential.cs" />
   </ItemGroup>
   <!-- Manage the SNI toggle for Windows netstandard and UWP -->
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' AND '$(TargetsWindows)' == 'true'">
@@ -465,9 +466,6 @@
     <EmbeddedResource Include="Resources\System.Data.SqlClient.SqlMetaData.xml">
       <LogicalName>System.Data.SqlClient.SqlMetaData.xml</LogicalName>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="System\Data\SqlClient\SqlCredential.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Import Project=".\GenerateThisAssemblyCs.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -466,6 +466,9 @@
       <LogicalName>System.Data.SqlClient.SqlMetaData.xml</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Data\SqlClient\SqlCredential.cs" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Import Project=".\GenerateThisAssemblyCs.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />
 </Project>

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
@@ -880,5 +880,16 @@ namespace System.Data.Common
             TraceExceptionAsReturnValue(e);
             return e;
         }
+
+        internal static ArgumentException InvalidArgumentLength(string argumentName, int limit)
+        {
+            return Argument(SR.GetString(SR.ADP_InvalidArgumentLength, argumentName, limit));
+        }
+
+        internal static ArgumentException MustBeReadOnly(string argumentName)
+        {
+            return Argument(SR.GetString(SR.ADP_MustBeReadOnly, argumentName));
+        }
+
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCredential.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCredential.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data.Common;
+using System.Security;
+
+namespace System.Data.SqlClient
+{
+    public sealed class SqlCredential
+    {
+        string _userId;
+        SecureString _password;
+
+        public SqlCredential(string userId, SecureString password)
+        {
+            if (userId == null)
+            {
+                throw ADP.ArgumentNull("userId");
+            }
+
+            if (userId.Length > TdsEnums.MAXLEN_USERNAME)
+            {
+                throw ADP.InvalidArgumentLength("userId", TdsEnums.MAXLEN_USERNAME);
+            }
+
+            if (password == null)
+            {
+                throw ADP.ArgumentNull("password");
+            }
+
+            if (password.Length > TdsEnums.MAXLEN_PASSWORD)
+            {
+                throw ADP.InvalidArgumentLength("password", TdsEnums.MAXLEN_PASSWORD);
+            }
+
+            if (!password.IsReadOnly())
+            {
+                throw ADP.MustBeReadOnly("password");
+            }
+
+            _userId = userId;
+            _password = password;
+        }
+
+        public string UserId
+        {
+            get
+            {
+                return _userId;
+            }
+        }
+
+        public SecureString Password
+        {
+            get
+            {
+                return _password;
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCredential.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCredential.cs
@@ -16,47 +16,36 @@ namespace System.Data.SqlClient
         {
             if (userId == null)
             {
-                throw ADP.ArgumentNull("userId");
+                throw ADP.ArgumentNull(nameof(userId));
             }
 
             if (userId.Length > TdsEnums.MAXLEN_USERNAME)
             {
-                throw ADP.InvalidArgumentLength("userId", TdsEnums.MAXLEN_USERNAME);
+                throw ADP.InvalidArgumentLength(nameof(userId), TdsEnums.MAXLEN_USERNAME);
             }
 
             if (password == null)
             {
-                throw ADP.ArgumentNull("password");
+                throw ADP.ArgumentNull(nameof(password));
             }
 
             if (password.Length > TdsEnums.MAXLEN_PASSWORD)
             {
-                throw ADP.InvalidArgumentLength("password", TdsEnums.MAXLEN_PASSWORD);
+                throw ADP.InvalidArgumentLength(nameof(password), TdsEnums.MAXLEN_PASSWORD);
             }
 
             if (!password.IsReadOnly())
             {
-                throw ADP.MustBeReadOnly("password");
+                throw ADP.MustBeReadOnly(nameof(password));
             }
 
             _userId = userId;
             _password = password;
         }
 
-        public string UserId
-        {
-            get
-            {
-                return _userId;
-            }
-        }
+        public string UserId => _userId;
 
-        public SecureString Password
-        {
-            get
-            {
-                return _password;
-            }
-        }
+        public SecureString Password => _password;
+
     }
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlCredentialTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlCredentialTest.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
@@ -48,6 +52,21 @@ namespace System.Data.SqlClient.Tests
 
             // Verify non-null userId requirement
             Assert.Throws<ArgumentNullException>(() => new SqlCredential(null, password));
+
+        }
+
+        [Fact]
+        public static void Test_SqlCredential_Properties()
+        {
+            var userId = "user";
+            var password = new SecureString();
+            password.AppendChar('0');
+            password.MakeReadOnly();
+
+            var credential = new SqlCredential(userId, password);
+
+            Assert.Equal(userId, credential.UserId);
+            Assert.Equal(password, credential.Password);
 
         }
 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlCredentialTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlCredentialTest.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Security;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public static class SqlCredentialTest
+    {
+        [Fact]
+        public static void Test_SqlCredential_Password_Requirements()
+        {
+            var userId = "user";
+
+            // Create password with value longer than max allowed length
+            var longPassword = new SecureString();
+
+            var genPassword = string.Empty.PadLeft(129, '0');
+            genPassword.ToCharArray().ToList().ForEach(c => longPassword.AppendChar(c));
+            longPassword.MakeReadOnly();
+
+            // Verify non-null password requirement
+            Assert.Throws<ArgumentNullException>(() => new SqlCredential(userId, null));
+
+            // Verify max length requirement
+            Assert.Throws<ArgumentException>(() => new SqlCredential(userId, longPassword));
+
+            // Verify read only password requirement
+            Assert.Throws<ArgumentException>(() => new SqlCredential(userId, new SecureString()));
+
+        }
+
+        [Fact]
+        public static void Test_SqlCredential_UserId_Requirements()
+        {
+            var password = new SecureString();
+            password.MakeReadOnly();
+
+            // Create userId longer than max allowed length
+            var userId = string.Empty.PadLeft(129, '0');
+
+            // Verify max length requirement
+            Assert.Throws<ArgumentException>(() => new SqlCredential(userId, password));
+
+            // Verify non-null userId requirement
+            Assert.Throws<ArgumentNullException>(() => new SqlCredential(null, password));
+
+        }
+
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="BaseProviderAsyncTest\MockCommand.cs" />
     <Compile Include="BaseProviderAsyncTest\MockConnection.cs" />
     <Compile Include="BaseProviderAsyncTest\MockDataReader.cs" />
+    <Compile Include="SqlCredentialTest.cs" />
     <Compile Include="DiagnosticTest.cs" />
     <Compile Include="AmbientTransactionFailureTest.cs" />
     <Compile Include="ExceptionTest.cs" />


### PR DESCRIPTION
This PR adds the SqlCredential class to System.Data.SqlClient per issue #11542.  As discussed in #17126 this is the first phase of two, adding the type itself back in. I'll follow up with a change that integrates SqlCredential with portions of the SqlClient API that have not yet been ported.

Also added as part of this PR are tests for SqlCredential's constructor parameters. This set of tests seemed to fit best alongside the items in the System.Data.SqlClient.Tests project, but I can move them elsewhere if preferred. 

