### PR TITLE
SocketsHttpHandler: add response stream drain

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
@@ -261,6 +262,28 @@ namespace System.Net.Test.Common
             "\r\n" +
             content;
 
+        public static string GetSingleChunkHttpResponse(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null) =>
+            $"HTTP/1.1 {(int)statusCode} {GetStatusDescription(statusCode)}\r\n" +
+            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+            "Transfer-Encoding: chunked\r\n" +
+            additionalHeaders +
+            "\r\n" +
+            (string.IsNullOrEmpty(content) ? "" :
+                $"{content.Length:X}\r\n" +
+                $"{content}\r\n") +
+            $"0\r\n" +
+            $"\r\n";
+
+        public static string GetBytePerChunkHttpResponse(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null) =>
+            $"HTTP/1.1 {(int)statusCode} {GetStatusDescription(statusCode)}\r\n" +
+            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+            "Transfer-Encoding: chunked\r\n" +
+            additionalHeaders +
+            "\r\n" +
+            (string.IsNullOrEmpty(content) ? "" : string.Join("", content.Select(c => $"1\r\n{c}\r\n"))) + 
+            $"0\r\n" +
+            $"\r\n";
+
         public class Options
         {
             public IPAddress Address { get; set; } = IPAddress.Loopback;
@@ -320,6 +343,11 @@ namespace System.Net.Test.Common
                 while (!string.IsNullOrEmpty(line = await _reader.ReadLineAsync().ConfigureAwait(false)))
                 {
                     lines.Add(line);
+                }
+
+                if (line == null)
+                {
+                    throw new Exception("Unexpected EOF trying to read request header");
                 }
 
                 return lines;

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -280,7 +280,7 @@ namespace System.Net.Test.Common
             "Transfer-Encoding: chunked\r\n" +
             additionalHeaders +
             "\r\n" +
-            (string.IsNullOrEmpty(content) ? "" : string.Join("", content.Select(c => $"1\r\n{c}\r\n"))) + 
+            (string.IsNullOrEmpty(content) ? "" : string.Concat(content.Select(c => $"1\r\n{c}\r\n"))) + 
             $"0\r\n" +
             $"\r\n";
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -194,110 +194,120 @@ namespace System.Net.Http
             {
                 Debug.Assert(maxBytesToRead > 0);
 
-                ReadOnlySpan<byte> currentLine;
-                switch (_state)
+                try
                 {
-                    case ParsingState.ExpectChunkHeader:
-                        Debug.Assert(_chunkBytesRemaining == 0, $"Expected {nameof(_chunkBytesRemaining)} == 0, got {_chunkBytesRemaining}");
+                    ReadOnlySpan<byte> currentLine;
+                    switch (_state)
+                    {
+                        case ParsingState.ExpectChunkHeader:
+                            Debug.Assert(_chunkBytesRemaining == 0, $"Expected {nameof(_chunkBytesRemaining)} == 0, got {_chunkBytesRemaining}");
 
-                        // Read the chunk header line.
-                        _connection._allowedReadLineBytes = MaxChunkBytesAllowed;
-                        if (!_connection.TryReadNextLine(out currentLine))
-                        {
-                            // Could not get a whole line, so we can't parse the chunk header.
-                            return default;
-                        }
-
-                        // Parse the hex value from it.
-                        if (!Utf8Parser.TryParse(currentLine, out ulong chunkSize, out int bytesConsumed, 'X'))
-                        {
-                            throw new IOException(SR.net_http_invalid_response);
-                        }
-                        _chunkBytesRemaining = chunkSize;
-
-                        // If there's a chunk extension after the chunk size, validate it.
-                        if (bytesConsumed != currentLine.Length)
-                        {
-                            ValidateChunkExtension(currentLine.Slice(bytesConsumed));
-                        }
-
-                        // Proceed to handle the chunk.  If there's data in it, go read it.
-                        // Otherwise, finish handling the response.
-                        if (chunkSize > 0)
-                        {
-                            _state = ParsingState.ExpectChunkData;
-                            goto case ParsingState.ExpectChunkData;
-                        }
-                        else
-                        {
-                            _state = ParsingState.ConsumeTrailers;
-                            goto case ParsingState.ConsumeTrailers;
-                        }
-
-                    case ParsingState.ExpectChunkData:
-                        Debug.Assert(_chunkBytesRemaining > 0);
-
-                        ReadOnlyMemory<byte> connectionBuffer = _connection.RemainingBuffer;
-                        if (connectionBuffer.Length == 0)
-                        {
-                            return default;
-                        }
-
-                        int bytesToConsume = Math.Min(maxBytesToRead, (int)Math.Min((ulong)connectionBuffer.Length, _chunkBytesRemaining));
-                        Debug.Assert(bytesToConsume > 0);
-
-                        _connection.ConsumeFromRemainingBuffer(bytesToConsume);
-                        _chunkBytesRemaining -= (ulong)bytesToConsume;
-                        if (_chunkBytesRemaining == 0)
-                        {
-                            _state = ParsingState.ExpectChunkTerminator;
-                        }
-
-                        return connectionBuffer.Slice(0, bytesToConsume);
-
-                    case ParsingState.ExpectChunkTerminator:
-                        Debug.Assert(_chunkBytesRemaining == 0, $"Expected {nameof(_chunkBytesRemaining)} == 0, got {_chunkBytesRemaining}");
-
-                        _connection._allowedReadLineBytes = MaxChunkBytesAllowed;
-                        if (!_connection.TryReadNextLine(out currentLine))
-                        {
-                            return default;
-                        }
-
-                        if (currentLine.Length != 0)
-                        {
-                            ThrowInvalidHttpResponse();
-                        }
-
-                        _state = ParsingState.ExpectChunkHeader;
-                        goto case ParsingState.ExpectChunkHeader;
-
-                    case ParsingState.ConsumeTrailers:
-                        Debug.Assert(_chunkBytesRemaining == 0, $"Expected {nameof(_chunkBytesRemaining)} == 0, got {_chunkBytesRemaining}");
-
-                        while (true)
-                        {
-                            _connection._allowedReadLineBytes = MaxTrailingHeaderLength;
+                            // Read the chunk header line.
+                            _connection._allowedReadLineBytes = MaxChunkBytesAllowed;
                             if (!_connection.TryReadNextLine(out currentLine))
                             {
-                                break;
+                                // Could not get a whole line, so we can't parse the chunk header.
+                                return default;
                             }
 
-                            if (currentLine.IsEmpty)
+                            // Parse the hex value from it.
+                            if (!Utf8Parser.TryParse(currentLine, out ulong chunkSize, out int bytesConsumed, 'X'))
                             {
-                                _state = ParsingState.Done;
-                                _connection.ReturnConnectionToPool();
-                                _connection = null;
-                                break;
+                                throw new IOException(SR.net_http_invalid_response);
                             }
-                        }
+                            _chunkBytesRemaining = chunkSize;
 
-                        return default;
+                            // If there's a chunk extension after the chunk size, validate it.
+                            if (bytesConsumed != currentLine.Length)
+                            {
+                                ValidateChunkExtension(currentLine.Slice(bytesConsumed));
+                            }
 
-                    default:
-                    case ParsingState.Done: // shouldn't be called once we're done
-                        Debug.Fail($"Unexpected state: {_state}");
-                        return default;
+                            // Proceed to handle the chunk.  If there's data in it, go read it.
+                            // Otherwise, finish handling the response.
+                            if (chunkSize > 0)
+                            {
+                                _state = ParsingState.ExpectChunkData;
+                                goto case ParsingState.ExpectChunkData;
+                            }
+                            else
+                            {
+                                _state = ParsingState.ConsumeTrailers;
+                                goto case ParsingState.ConsumeTrailers;
+                            }
+
+                        case ParsingState.ExpectChunkData:
+                            Debug.Assert(_chunkBytesRemaining > 0);
+
+                            ReadOnlyMemory<byte> connectionBuffer = _connection.RemainingBuffer;
+                            if (connectionBuffer.Length == 0)
+                            {
+                                return default;
+                            }
+
+                            int bytesToConsume = Math.Min(maxBytesToRead, (int)Math.Min((ulong)connectionBuffer.Length, _chunkBytesRemaining));
+                            Debug.Assert(bytesToConsume > 0);
+
+                            _connection.ConsumeFromRemainingBuffer(bytesToConsume);
+                            _chunkBytesRemaining -= (ulong)bytesToConsume;
+                            if (_chunkBytesRemaining == 0)
+                            {
+                                _state = ParsingState.ExpectChunkTerminator;
+                            }
+
+                            return connectionBuffer.Slice(0, bytesToConsume);
+
+                        case ParsingState.ExpectChunkTerminator:
+                            Debug.Assert(_chunkBytesRemaining == 0, $"Expected {nameof(_chunkBytesRemaining)} == 0, got {_chunkBytesRemaining}");
+
+                            _connection._allowedReadLineBytes = MaxChunkBytesAllowed;
+                            if (!_connection.TryReadNextLine(out currentLine))
+                            {
+                                return default;
+                            }
+
+                            if (currentLine.Length != 0)
+                            {
+                                ThrowInvalidHttpResponse();
+                            }
+
+                            _state = ParsingState.ExpectChunkHeader;
+                            goto case ParsingState.ExpectChunkHeader;
+
+                        case ParsingState.ConsumeTrailers:
+                            Debug.Assert(_chunkBytesRemaining == 0, $"Expected {nameof(_chunkBytesRemaining)} == 0, got {_chunkBytesRemaining}");
+
+                            while (true)
+                            {
+                                _connection._allowedReadLineBytes = MaxTrailingHeaderLength;
+                                if (!_connection.TryReadNextLine(out currentLine))
+                                {
+                                    break;
+                                }
+
+                                if (currentLine.IsEmpty)
+                                {
+                                    _state = ParsingState.Done;
+                                    _connection.ReturnConnectionToPool();
+                                    _connection = null;
+                                    break;
+                                }
+                            }
+
+                            return default;
+
+                        default:
+                        case ParsingState.Done: // shouldn't be called once we're done
+                            Debug.Fail($"Unexpected state: {_state}");
+                            return default;
+                    }
+                }
+                catch (Exception)
+                {
+                    // Ensure we don't try to read from the connection again (in particular, for draining)
+                    _connection.Dispose();
+                    _connection = null;
+                    throw;
                 }
             }
 
@@ -326,6 +336,38 @@ namespace System.Net.Http
                 ExpectChunkTerminator,
                 ConsumeTrailers,
                 Done
+            }
+
+            public override async Task DrainAsync(int maxDrainBytes)
+            {
+                Debug.Assert(_connection != null);
+
+                int drainedBytes = 0;
+                while (true)
+                {
+                    drainedBytes += _connection.RemainingBuffer.Length;
+                    while (true)
+                    {
+                        ReadOnlyMemory<byte> bytesRead = ReadChunkFromConnectionBuffer(int.MaxValue);
+                        if (bytesRead.Length == 0)
+                        {
+                            break;
+                        }
+                    }
+
+                    if (_connection == null)
+                    {
+                        // Fully consumed the response, and the connection has been released back to the pool.
+                        return;
+                    }
+
+                    if (drainedBytes >= maxDrainBytes)
+                    {
+                        break;
+                    }
+
+                    await _connection.FillAsync().ConfigureAwait(false);
+                }
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -156,7 +156,7 @@ namespace System.Net.Http
                     _contentBytesRemaining -= (ulong)_connection.RemainingBuffer.Length;
                     _connection.ConsumeFromRemainingBuffer(_connection.RemainingBuffer.Length);
 
-                    await _connection.FillAsync();
+                    await _connection.FillAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -155,7 +155,9 @@ namespace System.Net.Http
                 return connectionBuffer.Slice(0, bytesToConsume);
             }
 
-            public override async Task DrainAsync(int maxDrainBytes)
+            public override bool NeedsDrain => (_connection != null);
+
+            public override async Task<bool> DrainAsync(int maxDrainBytes)
             {
                 Debug.Assert(_connection != null);
                 Debug.Assert(_contentBytesRemaining > 0);
@@ -164,12 +166,12 @@ namespace System.Net.Http
                 if (_contentBytesRemaining == 0)
                 {
                     Finish();
-                    return;
+                    return true;
                 }
 
                 if (_contentBytesRemaining > (ulong)maxDrainBytes)
                 {
-                    return;
+                    return false;
                 }
 
                 while (true)
@@ -179,7 +181,7 @@ namespace System.Net.Http
                     if (_contentBytesRemaining == 0)
                     {
                         Finish();
-                        return;
+                        return true;
                     }
                 }
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -58,14 +58,14 @@ namespace System.Net.Http
             base.Dispose(disposing);
         }
 
-        // Maximum request drain size, 16K.
-        private const int s_maxDrainBytes = 16 * 1024;
+        // Maximum request drain size, 1MB.
+        private const int MaxDrainBytes = 1024 * 1024;
 
         private async void DrainOnDispose()
         {
             try
             {
-                await DrainAsync(s_maxDrainBytes);
+                await DrainAsync(MaxDrainBytes).ConfigureAwait(false);
             }
             catch (Exception)
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
@@ -1,0 +1,269 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Net.Test.Common;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpClientHandler_ResponseDrain_Test : HttpClientTestBase
+    {
+        public enum ContentMode
+        {
+            ContentLength,
+            SingleChunk,
+            BytePerChunk
+        }
+
+        private static string GetResponseForContentMode(string content, ContentMode mode)
+        {
+            switch (mode)
+            {
+                case ContentMode.ContentLength:
+                    return LoopbackServer.GetHttpResponse(content: content);
+                case ContentMode.SingleChunk:
+                    return LoopbackServer.GetSingleChunkHttpResponse(content: content);
+                case ContentMode.BytePerChunk:
+                    return LoopbackServer.GetBytePerChunkHttpResponse(content: content);
+                default:
+                    Assert.True(false);
+                    return null;
+            }
+        }
+
+        [OuterLoop]
+        [Theory]
+        [InlineData(ContentMode.ContentLength)]
+        [InlineData(ContentMode.SingleChunk)]
+        [InlineData(ContentMode.BytePerChunk)]
+        public async Task GetAsync_DisposeBeforeReadingToEnd_DrainsRequestsAndReusesConnection(ContentMode mode)
+        {
+            if (IsWinHttpHandler && mode == ContentMode.BytePerChunk)
+            {
+                // WinHttpHandler seems to only do a limited amount of draining when chunking is used;
+                // I *think* it's not draining anything beyond the current chunk being processed.
+                // So, these cases won't pass.
+                return;
+            }
+
+            const string simpleContent = "Hello world!";
+
+            await LoopbackServer.CreateClientAndServerAsync(
+                async url =>
+                {
+                    using (var client = CreateHttpClient())
+                    {
+                        HttpResponseMessage response1 = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                        ValidateResponseHeaders(response1, simpleContent.Length, mode);
+
+                        // Read up to exactly 1 byte before the end of the response
+                        Stream responseStream = await response1.Content.ReadAsStreamAsync();
+                        byte[] bytes = await ReadToByteCount(responseStream, simpleContent.Length - 1);
+                        Assert.Equal(simpleContent.Substring(0, simpleContent.Length - 1), Encoding.ASCII.GetString(bytes));
+
+                        // Introduce a short delay to try to ensure that when we dispose the response,
+                        // all response data is available and we can drain synchronously and reuse the connection.
+                        await Task.Delay(100);
+
+                        response1.Dispose();
+
+                        // Issue another request.  We'll confirm that it comes on the same connection.
+                        HttpResponseMessage response2 = await client.GetAsync(url);
+                        ValidateResponseHeaders(response2, simpleContent.Length, mode);
+                        Assert.Equal(simpleContent, await response2.Content.ReadAsStringAsync());
+                    }
+                },
+                async server =>
+                {
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        string response = GetResponseForContentMode(simpleContent, mode);
+                        await connection.ReadRequestHeaderAndSendCustomResponseAsync(response);
+                        await connection.ReadRequestHeaderAndSendCustomResponseAsync(response);
+                    });
+                });
+        }
+
+        // The actual amount of drain that's supported is handler and timing dependent, apparently.
+        // These cases are an attempt to provide a "min bar" for draining behavior.
+
+        [OuterLoop]
+        [Theory]
+        [InlineData(0, 0, ContentMode.ContentLength)]
+        [InlineData(0, 0, ContentMode.SingleChunk)]
+        [InlineData(1, 0, ContentMode.ContentLength)]
+        [InlineData(1, 0, ContentMode.SingleChunk)]
+        [InlineData(1, 0, ContentMode.BytePerChunk)]
+        [InlineData(2, 1, ContentMode.ContentLength)]
+        [InlineData(2, 1, ContentMode.SingleChunk)]
+        [InlineData(2, 1, ContentMode.BytePerChunk)]
+        [InlineData(10, 1, ContentMode.ContentLength)]
+        [InlineData(10, 1, ContentMode.SingleChunk)]
+        [InlineData(10, 1, ContentMode.BytePerChunk)]
+        [InlineData(100, 10, ContentMode.ContentLength)]
+        [InlineData(100, 10, ContentMode.SingleChunk)]
+        [InlineData(100, 10, ContentMode.BytePerChunk)]
+        [InlineData(1000, 950, ContentMode.ContentLength)]
+        [InlineData(1000, 950, ContentMode.SingleChunk)]
+        [InlineData(1000, 950, ContentMode.BytePerChunk)]
+        [InlineData(10000, 9500, ContentMode.ContentLength)]
+        [InlineData(10000, 9500, ContentMode.SingleChunk)]
+        [InlineData(10000, 9500, ContentMode.BytePerChunk)]
+        public async Task GetAsyncWithMaxConnections_DisposeBeforeReadingToEnd_DrainsRequestsAndReusesConnection(int totalSize, int readSize, ContentMode mode)
+        {
+            if (IsWinHttpHandler && 
+                ((mode == ContentMode.SingleChunk && readSize == 0) ||
+                 (mode == ContentMode.BytePerChunk)))
+            {
+                // WinHttpHandler seems to only do a limited amount of draining when TE is used;
+                // I *think* it's not draining anything beyond the current chunk being processed.
+                // So, these cases won't pass.
+                return;
+            }
+
+            if (IsCurlHandler && (mode != ContentMode.ContentLength || readSize == 0))
+            {
+                // CurlHandler behaves inconsistently when TE is used -- seems to be timing dependent.
+                // Also, it doesn't try to drain when no body is read.
+                return;
+            }
+
+            await LoopbackServer.CreateClientAndServerAsync(
+                async url =>
+                {
+                    HttpClientHandler handler = CreateHttpClientHandler();
+
+                    // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
+                    handler.MaxConnectionsPerServer = 1;
+
+                    using (var client = new HttpClient(handler))
+                    { 
+                        HttpResponseMessage response1 = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                        ValidateResponseHeaders(response1, totalSize, mode);
+
+                        // Read part but not all of response
+                        Stream responseStream = await response1.Content.ReadAsStreamAsync();
+                        await ReadToByteCount(responseStream, readSize);
+
+                        response1.Dispose();
+
+                        // Issue another request.  We'll confirm that it comes on the same connection.
+                        HttpResponseMessage response2 = await client.GetAsync(url);
+                        ValidateResponseHeaders(response2, totalSize, mode);
+                        Assert.Equal(totalSize, (await response2.Content.ReadAsStringAsync()).Length);
+                    }
+                },
+                async server =>
+                {
+                    string content = new string('a', totalSize);
+                    string response = GetResponseForContentMode(content, mode);
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        await connection.ReadRequestHeaderAndSendCustomResponseAsync(response);
+                        await connection.ReadRequestHeaderAndSendCustomResponseAsync(response);
+                    });
+                });
+        }
+
+        // Similar to above, these are semi-extreme cases where the response should never drain for any handler.
+
+        [OuterLoop]
+        [Theory]
+        [InlineData(20000, 0, ContentMode.ContentLength)]
+        [InlineData(20000, 0, ContentMode.SingleChunk)]
+        [InlineData(20000, 0, ContentMode.BytePerChunk)]
+        [InlineData(40000, 10000, ContentMode.ContentLength)]
+        [InlineData(40000, 10000, ContentMode.SingleChunk)]
+        [InlineData(40000, 10000, ContentMode.BytePerChunk)]
+        [InlineData(100000, 50000, ContentMode.ContentLength)]
+        [InlineData(100000, 50000, ContentMode.SingleChunk)]
+        [InlineData(100000, 50000, ContentMode.BytePerChunk)]
+        public async Task GetAsyncWithMaxConnections_DisposeBeforeReadingToEnd_KillsConnection(int totalSize, int readSize, ContentMode mode)
+        {
+            await LoopbackServer.CreateClientAndServerAsync(
+                async url =>
+                {
+                    HttpClientHandler handler = CreateHttpClientHandler();
+
+                    // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
+                    handler.MaxConnectionsPerServer = 1;
+
+                    using (var client = new HttpClient(handler))
+                    {
+                        HttpResponseMessage response1 = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                        ValidateResponseHeaders(response1, totalSize, mode);
+
+                        // Read part but not all of response
+                        Stream responseStream = await response1.Content.ReadAsStreamAsync();
+                        await ReadToByteCount(responseStream, readSize);
+
+                        response1.Dispose();
+
+                        // Issue another request.  We'll confirm that it comes on a new connection.
+                        HttpResponseMessage response2 = await client.GetAsync(url);
+                        ValidateResponseHeaders(response2, totalSize, mode);
+                        Assert.Equal(totalSize, (await response2.Content.ReadAsStringAsync()).Length);
+                    }
+                },
+                async server =>
+                {
+                    string content = new string('a', totalSize);
+                    string response = GetResponseForContentMode(content, mode);
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        await connection.ReadRequestHeaderAsync();
+                        try
+                        {
+                            await connection.Writer.WriteAsync(response);
+                        }
+                        catch (Exception) { }     // Eat errors from client disconnect.
+                    });
+                    await server.AcceptConnectionSendCustomResponseAndCloseAsync(response);
+                });
+        }
+
+        private static void ValidateResponseHeaders(HttpResponseMessage response, int contentLength, ContentMode mode)
+        {
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            switch (mode)
+            {
+                case ContentMode.ContentLength:
+                    Assert.Equal(contentLength, response.Content.Headers.ContentLength);
+                    break;
+
+                case ContentMode.SingleChunk:
+                case ContentMode.BytePerChunk:
+                    Assert.True(response.Headers.TransferEncodingChunked);
+                    break;
+            }
+        }
+
+        private static async Task<byte[]> ReadToByteCount(Stream stream, int byteCount)
+        {
+            byte[] buffer = new byte[byteCount];
+            int totalBytesRead = 0;
+
+            while (totalBytesRead < byteCount)
+            {
+                int bytesRead = await stream.ReadAsync(buffer, totalBytesRead, (byteCount - totalBytesRead));
+                if (bytesRead == 0)
+                {
+                    throw new Exception("Unexpected EOF");
+                }
+
+                totalBytesRead += bytesRead;
+                if (totalBytesRead > byteCount)
+                {
+                    throw new Exception("Read more bytes than requested???");
+                }
+            }
+
+            return buffer;
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
@@ -125,10 +125,9 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            if (IsCurlHandler && (mode != ContentMode.ContentLength || readSize == 0))
+            if (IsCurlHandler)
             {
-                // CurlHandler behaves inconsistently when TE is used -- seems to be timing dependent.
-                // Also, it doesn't try to drain when no body is read.
+                // CurlHandler drain behavior is very inconsistent, so just skip these tests.
                 return;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -72,6 +72,11 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => true;
     }
 
+    public sealed class SocketsHttpHandler_HttpClientHandler_ResponseDrain_Test : HttpClientHandler_ResponseDrain_Test
+    {
+        protected override bool UseSocketsHttpHandler => true;
+    }
+
     public sealed class SocketsHttpHandler_PostScenarioTest : PostScenarioTest
     {
         public SocketsHttpHandler_PostScenarioTest(ITestOutputHelper output) : base(output) { }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="HttpClientHandlerTest.Cancellation.cs" />
     <Compile Include="HttpClientHandlerTest.ClientCertificates.cs" />
     <Compile Include="HttpClientHandlerTest.DefaultProxyCredentials.cs" />
+    <Compile Include="HttpClientHandlerTest.ResponseDrain.cs" />
     <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
     <Compile Include="HttpClientHandlerTest.MaxResponseHeadersLength.cs" />
     <Compile Include="HttpClientHandlerTest.ServerCertificates.cs" />


### PR DESCRIPTION
When an HttpResponseMessage is disposed before the entire response stream is read, we are currently just killing the connection.

Instead, try to drain the connection (up to a limit) so that it can be reused.

@stephentoub @davidsh @dotnet/ncl 
