### PR TITLE
Rename string-slicing extension methods

### DIFF
--- a/src/Common/src/CoreLib/System/Text/ValueStringBuilder.cs
+++ b/src/Common/src/CoreLib/System/Text/ValueStringBuilder.cs
@@ -106,7 +106,7 @@ namespace System.Text
                 Grow(s.Length);
             }
 
-            s.AsReadOnlySpan().CopyTo(_chars.Slice(pos));
+            s.AsSpan().CopyTo(_chars.Slice(pos));
             _pos += s.Length;
         }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
@@ -23,7 +23,7 @@ internal static partial class Interop
                     const string OpenSSL = "OpenSSL ";
 
                     // Skip OpenSSL part, and get the version string of format x.y.z
-                    if (!Version.TryParse(OpenSslVersionDescription().AsReadOnlySpan().Slice(OpenSSL.Length, 5), out s_opensslVersion))
+                    if (!Version.TryParse(OpenSslVersionDescription().AsSpan().Slice(OpenSSL.Length, 5), out s_opensslVersion))
                     {
                         s_opensslVersion = new Version(0, 0, 0);
                     }

--- a/src/Common/src/System/Security/Cryptography/Asn1V2.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1V2.cs
@@ -395,7 +395,7 @@ namespace System.Security.Cryptography.Asn1
 
         public override int GetByteCount(string s)
         {
-            return GetByteCount(s.AsReadOnlySpan());
+            return GetByteCount(s.AsSpan());
         }
 
         public

--- a/src/Common/src/System/Security/Cryptography/AsnWriter.cs
+++ b/src/Common/src/System/Security/Cryptography/AsnWriter.cs
@@ -759,7 +759,7 @@ namespace System.Security.Cryptography.Asn1
             if (oidValue == null)
                 throw new ArgumentNullException(nameof(oidValue));
 
-            WriteObjectIdentifier(oidValue.AsReadOnlySpan());
+            WriteObjectIdentifier(oidValue.AsSpan());
         }
 
         public void WriteObjectIdentifier(ReadOnlySpan<char> oidValue)
@@ -780,7 +780,7 @@ namespace System.Security.Cryptography.Asn1
             if (oidValue == null)
                 throw new ArgumentNullException(nameof(oidValue));
 
-            WriteObjectIdentifier(tag, oidValue.AsReadOnlySpan());
+            WriteObjectIdentifier(tag, oidValue.AsSpan());
         }
 
         public void WriteObjectIdentifier(Asn1Tag tag, ReadOnlySpan<char> oidValue)
@@ -1408,7 +1408,7 @@ namespace System.Security.Cryptography.Asn1
             if (str == null)
                 throw new ArgumentNullException(nameof(str));
 
-            WriteCharacterString(encodingType, str.AsReadOnlySpan());
+            WriteCharacterString(encodingType, str.AsSpan());
         }
 
         public void WriteCharacterString(UniversalTagNumber encodingType, ReadOnlySpan<char> str)
@@ -1423,7 +1423,7 @@ namespace System.Security.Cryptography.Asn1
             if (str == null)
                 throw new ArgumentNullException(nameof(str));
 
-            WriteCharacterString(tag, encodingType, str.AsReadOnlySpan());
+            WriteCharacterString(tag, encodingType, str.AsSpan());
         }
 
         public void WriteCharacterString(Asn1Tag tag, UniversalTagNumber encodingType, ReadOnlySpan<char> str)

--- a/src/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
+++ b/src/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
@@ -127,7 +127,7 @@ namespace System.Text.Tests
                 Span<char> span = vsb.AppendSpan(s.Length);
                 Assert.Equal(sb.Length, vsb.Length);
 
-                s.AsReadOnlySpan().CopyTo(span);
+                s.AsSpan().CopyTo(span);
             }
 
             Assert.Equal(sb.Length, vsb.Length);

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -88,7 +88,7 @@ namespace System.Diagnostics
                 int length = text.IndexOf(' ');
                 if (length != -1)
                 {
-                    Double.TryParse(text.AsReadOnlySpan().Slice(0, length), NumberStyles.AllowDecimalPoint, NumberFormatInfo.InvariantInfo, out uptimeSeconds);
+                    Double.TryParse(text.AsSpan().Slice(0, length), NumberStyles.AllowDecimalPoint, NumberFormatInfo.InvariantInfo, out uptimeSeconds);
                 }
 
                 return TimeSpan.FromSeconds(uptimeSeconds);

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
@@ -26,7 +26,7 @@ namespace System.IO.Enumeration
             //
             // We also allowed for expression to be "foo\" which would translate to "foo\*".
 
-            ReadOnlySpan<char> directoryName = PathHelpers.GetDirectoryNameNoChecks(expression.AsReadOnlySpan());
+            ReadOnlySpan<char> directoryName = PathHelpers.GetDirectoryNameNoChecks(expression.AsSpan());
 
             if (directoryName.Length != 0)
             {

--- a/src/System.IO.FileSystem/tests/Enumeration/DosMatcherTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/DosMatcherTests.netcoreapp.cs
@@ -12,7 +12,7 @@ namespace System.IO.Tests
         [Theory, MemberData(nameof(DosMatchData)), MemberData(nameof(EscapedDosMatchData))]
         public static void DosMatch(string expression, string name, bool ignoreCase, bool expected)
         {
-            Assert.Equal(expected, FileSystemName.MatchesDosExpression(expression, name.AsReadOnlySpan(), ignoreCase));
+            Assert.Equal(expected, FileSystemName.MatchesDosExpression(expression, name.AsSpan(), ignoreCase));
         }
 
         public static TheoryData<string, string, bool, bool> EscapedDosMatchData => new TheoryData<string, string, bool, bool>

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -11,13 +11,13 @@ namespace System
     {
         public static System.ReadOnlySpan<byte> AsBytes<T>(this System.ReadOnlySpan<T> source) where T : struct { throw null; }
         public static System.Span<byte> AsBytes<T>(this System.Span<T> source) where T : struct { throw null; }
-        public static System.ReadOnlyMemory<char> AsReadOnlyMemory(this string text) { throw null; }
-        public static System.ReadOnlyMemory<char> AsReadOnlyMemory(this string text, int start) { throw null; }
-        public static System.ReadOnlyMemory<char> AsReadOnlyMemory(this string text, int start, int length) { throw null; }
+        public static System.ReadOnlyMemory<char> AsMemory(this string text) { throw null; }
+        public static System.ReadOnlyMemory<char> AsMemory(this string text, int start) { throw null; }
+        public static System.ReadOnlyMemory<char> AsMemory(this string text, int start, int length) { throw null; }
         public static System.ReadOnlyMemory<T> AsReadOnlyMemory<T>(this System.Memory<T> memory) { throw null; }
-        public static System.ReadOnlySpan<char> AsReadOnlySpan(this string text) { throw null; }
-        public static System.ReadOnlySpan<char> AsReadOnlySpan(this string text, int start) { throw null; }
-        public static System.ReadOnlySpan<char> AsReadOnlySpan(this string text, int start, int length) { throw null; }
+        public static System.ReadOnlySpan<char> AsSpan(this string text) { throw null; }
+        public static System.ReadOnlySpan<char> AsSpan(this string text, int start) { throw null; }
+        public static System.ReadOnlySpan<char> AsSpan(this string text, int start, int length) { throw null; }
         public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this System.ArraySegment<T> arraySegment) { throw null; }
         public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this System.Span<T> span) { throw null; }
         public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) { throw null; }

--- a/src/System.Memory/src/System/Buffers/StandardFormat.cs
+++ b/src/System.Memory/src/System/Buffers/StandardFormat.cs
@@ -103,7 +103,7 @@ namespace System.Buffers
         /// <summary>
         /// Converts a classic .NET format string into a StandardFormat
         /// </summary>
-        public static StandardFormat Parse(string format) => format == null ? default : Parse(MemoryExtensions.AsReadOnlySpan(format));  //@todo: Change back to extension syntax once the ambiguous reference with CoreLib is eliminated.
+        public static StandardFormat Parse(string format) => format == null ? default : Parse(MemoryExtensions.AsSpan(format));  //@todo: Change back to extension syntax once the ambiguous reference with CoreLib is eliminated.
 
         /// <summary>
         /// Returns true if both the Symbol and Precision are equal.

--- a/src/System.Memory/src/System/MemoryExtensions.Fast.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.Fast.cs
@@ -44,7 +44,7 @@ namespace System
         /// </summary>
         /// <param name="text">The target string.</param>
         /// <remarks>Returns default when <paramref name="text"/> is null.</remarks>
-        public static ReadOnlySpan<char> AsReadOnlySpan(this string text) => Span.AsReadOnlySpan(text);
+        public static ReadOnlySpan<char> AsSpan(this string text) => Span.AsReadOnlySpan(text);
 
         /// <summary>
         /// Creates a new readonly span over the portion of the target string.
@@ -55,7 +55,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;text.Length).
         /// </exception>
-        public static ReadOnlySpan<char> AsReadOnlySpan(this string text, int start) => Span.AsReadOnlySpan(text, start);
+        public static ReadOnlySpan<char> AsSpan(this string text, int start) => Span.AsReadOnlySpan(text, start);
 
         /// <summary>
         /// Creates a new readonly span over the portion of the target string.
@@ -67,12 +67,12 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> index or <paramref name="length"/> is not in range.
         /// </exception>
-        public static ReadOnlySpan<char> AsReadOnlySpan(this string text, int start, int length) => Span.AsReadOnlySpan(text, start, length);
+        public static ReadOnlySpan<char> AsSpan(this string text, int start, int length) => Span.AsReadOnlySpan(text, start, length);
 
         /// <summary>Creates a new <see cref="ReadOnlyMemory{T}"/> over the portion of the target string.</summary>
         /// <param name="text">The target string.</param>
         /// <remarks>Returns default when <paramref name="text"/> is null.</remarks>
-        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text) => Span.AsReadOnlyMemory(text);
+        public static ReadOnlyMemory<char> AsMemory(this string text) => Span.AsReadOnlyMemory(text);
 
         /// <summary>Creates a new <see cref="ReadOnlyMemory{T}"/> over the portion of the target string.</summary>
         /// <param name="text">The target string.</param>
@@ -81,7 +81,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;text.Length).
         /// </exception>
-        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text, int start) => Span.AsReadOnlyMemory(text, start);
+        public static ReadOnlyMemory<char> AsMemory(this string text, int start) => Span.AsReadOnlyMemory(text, start);
 
         /// <summary>Creates a new <see cref="ReadOnlyMemory{T}"/> over the portion of the target string.</summary>
         /// <param name="text">The target string.</param>
@@ -91,7 +91,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> index or <paramref name="length"/> is not in range.
         /// </exception>
-        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text, int start, int length) => Span.AsReadOnlyMemory(text, start, length);
+        public static ReadOnlyMemory<char> AsMemory(this string text, int start, int length) => Span.AsReadOnlyMemory(text, start, length);
 
         /// <summary>Attempts to get the underlying <see cref="string"/> from a <see cref="ReadOnlyMemory{T}"/>.</summary>
         /// <param name="readOnlyMemory">The memory that may be wrapping a <see cref="string"/> object.</param>

--- a/src/System.Memory/src/System/MemoryExtensions.Portable.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.Portable.cs
@@ -62,7 +62,7 @@ namespace System
         /// <param name="text">The target string.</param>
         /// <remarks>Returns default when <paramref name="text"/> is null.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<char> AsReadOnlySpan(this string text)
+        public static ReadOnlySpan<char> AsSpan(this string text)
         {
             if (text == null)
                 return default;
@@ -80,7 +80,7 @@ namespace System
         /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;text.Length).
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<char> AsReadOnlySpan(this string text, int start)
+        public static ReadOnlySpan<char> AsSpan(this string text, int start)
         {
             if (text == null)
             {
@@ -105,7 +105,7 @@ namespace System
         /// Thrown when the specified <paramref name="start"/> index or <paramref name="length"/> is not in range.
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<char> AsReadOnlySpan(this string text, int start, int length)
+        public static ReadOnlySpan<char> AsSpan(this string text, int start, int length)
         {
             if (text == null)
             {
@@ -122,7 +122,7 @@ namespace System
         /// <summary>Creates a new <see cref="ReadOnlyMemory{T}"/> over the portion of the target string.</summary>
         /// <param name="text">The target string.</param>
         /// <remarks>Returns default when <paramref name="text"/> is null.</remarks>
-        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text)
+        public static ReadOnlyMemory<char> AsMemory(this string text)
         {
             if (text == null)
                 return default;
@@ -137,7 +137,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;text.Length).
         /// </exception>
-        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text, int start)
+        public static ReadOnlyMemory<char> AsMemory(this string text, int start)
         {
             if (text == null)
             {
@@ -159,7 +159,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> index or <paramref name="length"/> is not in range.
         /// </exception>
-        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text, int start, int length)
+        public static ReadOnlyMemory<char> AsMemory(this string text, int start, int length)
         {
             if (text == null)
             {

--- a/src/System.Memory/tests/Memory/Strings.cs
+++ b/src/System.Memory/tests/Memory/Strings.cs
@@ -22,7 +22,7 @@ namespace System.MemoryTests
         [MemberData(nameof(StringInputs))]
         public static void Memory_ToArray_Roundtrips(string input)
         {
-            ReadOnlyMemory<char> readonlyMemory = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> readonlyMemory = input.AsMemory();
             Memory<char> m = MemoryMarshal.AsMemory(readonlyMemory);
             Assert.Equal(input, new string(m.ToArray()));
         }
@@ -31,7 +31,7 @@ namespace System.MemoryTests
         [MemberData(nameof(StringInputs))]
         public static void Memory_Span_Roundtrips(string input)
         {
-            ReadOnlyMemory<char> readonlyMemory = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> readonlyMemory = input.AsMemory();
             Memory<char> m = MemoryMarshal.AsMemory(readonlyMemory);
             ReadOnlySpan<char> s = m.Span;
             Assert.Equal(input, new string(s.ToArray()));
@@ -49,7 +49,7 @@ namespace System.MemoryTests
         [InlineData("0123456789", 5, 3)]
         public static void Memory_Slice_MatchesSubstring(string input, int offset, int count)
         {
-            ReadOnlyMemory<char> readonlyMemory = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> readonlyMemory = input.AsMemory();
             Memory<char> m = MemoryMarshal.AsMemory(readonlyMemory);
             Assert.Equal(input.Substring(offset, count), new string(m.Slice(offset, count).ToArray()));
             Assert.Equal(input.Substring(offset, count), new string(m.Slice(offset, count).Span.ToArray()));
@@ -60,7 +60,7 @@ namespace System.MemoryTests
         public static unsafe void Memory_Retain_ExpectedPointerValue()
         {
             string input = "0123456789";
-            ReadOnlyMemory<char> readonlyMemory = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> readonlyMemory = input.AsMemory();
             Memory<char> m = MemoryMarshal.AsMemory(readonlyMemory);
 
             using (MemoryHandle h = m.Retain(pin: false))
@@ -81,8 +81,8 @@ namespace System.MemoryTests
         [Fact]
         public static void Memory_EqualsAndGetHashCode_ExpectedResults()
         {
-            ReadOnlyMemory<char> readonlyMemory1 = new string('a', 4).AsReadOnlyMemory();
-            ReadOnlyMemory<char> readonlyMemory2 = new string('a', 4).AsReadOnlyMemory();
+            ReadOnlyMemory<char> readonlyMemory1 = new string('a', 4).AsMemory();
+            ReadOnlyMemory<char> readonlyMemory2 = new string('a', 4).AsMemory();
 
             Memory<char> m1 = MemoryMarshal.AsMemory(readonlyMemory1);
             Memory<char> m2 = MemoryMarshal.AsMemory(readonlyMemory2);

--- a/src/System.Memory/tests/MemoryMarshal/AsMemory.cs
+++ b/src/System.Memory/tests/MemoryMarshal/AsMemory.cs
@@ -34,7 +34,7 @@ namespace System.MemoryTests
             yield return new object[] { ReadOnlyMemory<char>.Empty };
             yield return new object[] { new ReadOnlyMemory<char>(new char[10], 1, 3) };
             yield return new object[] { (ReadOnlyMemory<char>)new CustomMemoryForTest<char>(new char[10]).Memory };
-            yield return new object[] { "12345".AsReadOnlyMemory() };
+            yield return new object[] { "12345".AsMemory() };
         }
 
         [Theory]

--- a/src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs
@@ -39,7 +39,7 @@ namespace System.Buffers.Text.Tests
         [InlineData("", default(char), default(byte))]
         public static void StandardFormatParseSpan(string formatString, char expectedSymbol, byte expectedPrecision)
         {
-            ReadOnlySpan<char> span = formatString.AsReadOnlySpan();
+            ReadOnlySpan<char> span = formatString.AsSpan();
             StandardFormat format = StandardFormat.Parse(span);
             Assert.Equal(expectedSymbol, format.Symbol);
             Assert.Equal(expectedPrecision, format.Precision);

--- a/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
@@ -22,7 +22,7 @@ namespace System.MemoryTests
         [MemberData(nameof(StringInputs))]
         public static void AsReadOnlyMemory_ToArray_Roundtrips(string input)
         {
-            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> m = input.AsMemory();
             Assert.Equal(input, new string(m.ToArray()));
         }
 
@@ -30,7 +30,7 @@ namespace System.MemoryTests
         [MemberData(nameof(StringInputs))]
         public static void AsReadOnlyMemory_Span_Roundtrips(string input)
         {
-            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> m = input.AsMemory();
             ReadOnlySpan<char> s = m.Span;
             Assert.Equal(input, new string(s.ToArray()));
         }
@@ -47,7 +47,7 @@ namespace System.MemoryTests
         [InlineData("0123456789", 5, 3)]
         public static void AsReadOnlyMemory_Slice_MatchesSubstring(string input, int offset, int count)
         {
-            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> m = input.AsMemory();
             Assert.Equal(input.Substring(offset, count), new string(m.Slice(offset, count).ToArray()));
             Assert.Equal(input.Substring(offset, count), new string(m.Slice(offset, count).Span.ToArray()));
             Assert.Equal(input.Substring(offset), new string(m.Slice(offset).ToArray()));
@@ -56,15 +56,15 @@ namespace System.MemoryTests
         [Fact]
         public static void AsReadOnlyMemory_NullString_Default()
         {
-            ReadOnlyMemory<char> m = ((string)null).AsReadOnlyMemory();
+            ReadOnlyMemory<char> m = ((string)null).AsMemory();
             m.Validate();
             Assert.Equal(default, m);
 
-            m = ((string)null).AsReadOnlyMemory(0);
+            m = ((string)null).AsMemory(0);
             m.Validate();
             Assert.Equal(default, m);
 
-            m = ((string)null).AsReadOnlyMemory(0, 0);
+            m = ((string)null).AsMemory(0, 0);
             m.Validate();
             Assert.Equal(default, m);
         }
@@ -74,20 +74,20 @@ namespace System.MemoryTests
         {
             string str = null;
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsMemory(1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsMemory(-1));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(0, 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(1, 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(-1, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsMemory(0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsMemory(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsMemory(1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsMemory(-1, -1));
         }
 
         [Fact]
         public static void AsReadOnlyMemory_TryGetString_Roundtrips()
         {
             string input = "0123456789";
-            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> m = input.AsMemory();
             Assert.False(m.IsEmpty);
 
             Assert.True(m.TryGetString(out string text, out int start, out int length));
@@ -147,7 +147,7 @@ namespace System.MemoryTests
         [Fact]
         public static void AsReadOnlyMemory_TryGetArray_ReturnsFalse()
         {
-            ReadOnlyMemory<char> m = "0123456789".AsReadOnlyMemory();
+            ReadOnlyMemory<char> m = "0123456789".AsMemory();
             Assert.False(MemoryMarshal.TryGetArray(m, out ArraySegment<char> array));
             Assert.Null(array.Array);
             Assert.Equal(0, array.Offset);
@@ -158,7 +158,7 @@ namespace System.MemoryTests
         public static unsafe void AsReadOnlyMemory_Retain_ExpectedPointerValue()
         {
             string input = "0123456789";
-            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            ReadOnlyMemory<char> m = input.AsMemory();
 
             using (MemoryHandle h = m.Retain(pin: false))
             {
@@ -184,16 +184,16 @@ namespace System.MemoryTests
             {
                 start = 0;
                 length = text.Length;
-                m = text.AsReadOnlyMemory();
+                m = text.AsMemory();
             }
             else if (length == -1)
             {
                 length = text.Length - start;
-                m = text.AsReadOnlyMemory(start);
+                m = text.AsMemory(start);
             }
             else
             {
-                m = text.AsReadOnlyMemory(start, length);
+                m = text.AsMemory(start, length);
             }
 
             Assert.Equal(length, m.Length);
@@ -213,21 +213,21 @@ namespace System.MemoryTests
         [MemberData(nameof(TestHelpers.StringSlice2ArgTestOutOfRangeData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsReadOnlyMemory_2Arg_OutOfRange(string text, int start)
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsReadOnlyMemory(start));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsMemory(start));
         }
 
         [Theory]
         [MemberData(nameof(TestHelpers.StringSlice3ArgTestOutOfRangeData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsReadOnlyMemory_3Arg_OutOfRange(string text, int start, int length)
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsReadOnlyMemory(start, length));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsMemory(start, length));
         }
 
         [Fact]
         public static void AsReadOnlyMemory_EqualsAndGetHashCode_ExpectedResults()
         {
-            ReadOnlyMemory<char> m1 = new string('a', 4).AsReadOnlyMemory();
-            ReadOnlyMemory<char> m2 = new string('a', 4).AsReadOnlyMemory();
+            ReadOnlyMemory<char> m1 = new string('a', 4).AsMemory();
+            ReadOnlyMemory<char> m2 = new string('a', 4).AsMemory();
 
             Assert.True(m1.Span.SequenceEqual(m2.Span));
             Assert.True(m1.Equals(m1));

--- a/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
@@ -102,7 +102,7 @@ namespace System.SpanTests
         public static void StringAsReadOnlySpanNullary()
         {
             string s = "Hello";
-            ReadOnlySpan<char> span = s.AsReadOnlySpan();
+            ReadOnlySpan<char> span = s.AsSpan();
             char[] expected = s.ToCharArray();
             span.Validate(expected);
         }
@@ -111,7 +111,7 @@ namespace System.SpanTests
         public static void StringAsReadOnlySpanEmptyString()
         {
             string s = "";
-            ReadOnlySpan<char> span = s.AsReadOnlySpan();
+            ReadOnlySpan<char> span = s.AsSpan();
             span.ValidateNonNullEmpty();
         }
 
@@ -119,15 +119,15 @@ namespace System.SpanTests
         public static void StringAsReadOnlySpanNullChecked()
         {
             string s = null;
-            ReadOnlySpan<char> span = s.AsReadOnlySpan();
+            ReadOnlySpan<char> span = s.AsSpan();
             span.Validate();
             Assert.True(span == default);
 
-            span = s.AsReadOnlySpan(0);
+            span = s.AsSpan(0);
             span.Validate();
             Assert.True(span == default);
 
-            span = s.AsReadOnlySpan(0, 0);
+            span = s.AsSpan(0, 0);
             span.Validate();
             Assert.True(span == default);
         }
@@ -137,13 +137,13 @@ namespace System.SpanTests
         {
             string str = null;
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(1).DontBox());
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(-1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsSpan(1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsSpan(-1).DontBox());
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(0, 1).DontBox());
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(1, 0).DontBox());
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(1, 1).DontBox());
-            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(-1, -1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsSpan(0, 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsSpan(1, 0).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsSpan(1, 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsSpan(-1, -1).DontBox());
         }
 
         [Fact]
@@ -172,16 +172,16 @@ namespace System.SpanTests
             {
                 start = 0;
                 length = text.Length;
-                span = text.AsReadOnlySpan();
+                span = text.AsSpan();
             }
             else if (length == -1)
             {
                 length = text.Length - start;
-                span = text.AsReadOnlySpan(start);
+                span = text.AsSpan(start);
             }
             else
             {
-                span = text.AsReadOnlySpan(start, length);
+                span = text.AsSpan(start, length);
             }
 
             Assert.Equal(length, span.Length);
@@ -198,14 +198,14 @@ namespace System.SpanTests
         [MemberData(nameof(TestHelpers.StringSlice2ArgTestOutOfRangeData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsReadOnlySpan_2Arg_OutOfRange(string text, int start)
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsReadOnlySpan(start).DontBox());
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsSpan(start).DontBox());
         }
 
         [Theory]
         [MemberData(nameof(TestHelpers.StringSlice3ArgTestOutOfRangeData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsReadOnlySpan_3Arg_OutOfRange(string text, int start, int length)
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsReadOnlySpan(start, length).DontBox());
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsSpan(start, length).DontBox());
         }
     }
 }

--- a/src/System.Memory/tests/ReadOnlySpan/ToString.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/ToString.cs
@@ -31,7 +31,7 @@ namespace System.SpanTests
             Assert.Equal("abc", span.ToString());
 
             string testString = "abcdefg";
-            ReadOnlySpan<char> readOnlySpan = testString.AsReadOnlySpan();
+            ReadOnlySpan<char> readOnlySpan = testString.AsSpan();
             Assert.Equal(testString, readOnlySpan.ToString());
         }
 

--- a/src/System.Memory/tests/ReadOnlySpan/TrimManyCharacters.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/TrimManyCharacters.cs
@@ -23,8 +23,8 @@ namespace System.SpanTests
             Assert.True(span.SequenceEqual(span.TrimStart(trimChars)));
             Assert.True(span.SequenceEqual(span.TrimEnd(trimChars)));
 
-            ReadOnlySpan<char> stringSpan = "".AsReadOnlySpan();
-            ReadOnlySpan<char> trimCharsFromString = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = "".AsSpan();
+            ReadOnlySpan<char> trimCharsFromString = "abcde".AsSpan();
             Assert.True(stringSpan.SequenceEqual(stringSpan.Trim(trimCharsFromString)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimStart(trimCharsFromString)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimEnd(trimCharsFromString)));
@@ -61,8 +61,8 @@ namespace System.SpanTests
                 Assert.True(span.SequenceEqual(span.TrimEnd(chars)));
             }
 
-            ReadOnlySpan<char> stringSpan = "ffghifhig".AsReadOnlySpan();
-            ReadOnlySpan<char> trimCharsFromString = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = "ffghifhig".AsSpan();
+            ReadOnlySpan<char> trimCharsFromString = "abcde".AsSpan();
             Assert.True(stringSpan.SequenceEqual(stringSpan.Trim(trimCharsFromString)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimStart(trimCharsFromString)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimEnd(trimCharsFromString)));
@@ -85,8 +85,8 @@ namespace System.SpanTests
                 Assert.True(ReadOnlySpan<char>.Empty.SequenceEqual(span.TrimEnd(chars)), "I: " + length);
             }
 
-            ReadOnlySpan<char> stringSpan = "babedebcabba".AsReadOnlySpan();
-            ReadOnlySpan<char> trimChars = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = "babedebcabba".AsSpan();
+            ReadOnlySpan<char> trimChars = "abcde".AsSpan();
             Assert.True(ReadOnlySpan<char>.Empty.SequenceEqual(stringSpan.Trim(trimChars)), "J");
             Assert.True(ReadOnlySpan<char>.Empty.SequenceEqual(stringSpan.TrimStart(trimChars)), "K");
             Assert.True(ReadOnlySpan<char>.Empty.SequenceEqual(stringSpan.TrimEnd(trimChars)), "L");
@@ -110,8 +110,8 @@ namespace System.SpanTests
                 Assert.True(span.SequenceEqual(span.TrimEnd(chars)), "C: " + length);
             }
 
-            ReadOnlySpan<char> stringSpan = "babffffff".AsReadOnlySpan();
-            ReadOnlySpan<char> trimChars = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = "babffffff".AsSpan();
+            ReadOnlySpan<char> trimChars = "abcde".AsSpan();
             Assert.True(stringSpan.Slice(3).SequenceEqual(stringSpan.Trim(trimChars)), "D");
             Assert.True(stringSpan.Slice(3).SequenceEqual(stringSpan.TrimStart(trimChars)), "E");
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimEnd(trimChars)), "F");
@@ -135,8 +135,8 @@ namespace System.SpanTests
                 Assert.True(span.Slice(0, length - 1).SequenceEqual(span.TrimEnd(chars)));
             }
 
-            ReadOnlySpan<char> stringSpan = "fffffcced".AsReadOnlySpan();
-            ReadOnlySpan<char> trimChars = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = "fffffcced".AsSpan();
+            ReadOnlySpan<char> trimChars = "abcde".AsSpan();
             Assert.True(stringSpan.Slice(0, 5).SequenceEqual(stringSpan.Trim(trimChars)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimStart(trimChars)));
             Assert.True(stringSpan.Slice(0, 5).SequenceEqual(stringSpan.TrimEnd(trimChars)));
@@ -161,8 +161,8 @@ namespace System.SpanTests
                 Assert.True(span.Slice(0, length - 1).SequenceEqual(span.TrimEnd(chars)));
             }
 
-            ReadOnlySpan<char> stringSpan = "ccedafffffbdaa".AsReadOnlySpan();
-            ReadOnlySpan<char> trimChars = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = "ccedafffffbdaa".AsSpan();
+            ReadOnlySpan<char> trimChars = "abcde".AsSpan();
             Assert.True(stringSpan.Slice(5, 5).SequenceEqual(stringSpan.Trim(trimChars)));
             Assert.True(stringSpan.Slice(5).SequenceEqual(stringSpan.TrimStart(trimChars)));
             Assert.True(stringSpan.Slice(0, 10).SequenceEqual(stringSpan.TrimEnd(trimChars)));
@@ -186,8 +186,8 @@ namespace System.SpanTests
                 Assert.True(span.SequenceEqual(span.TrimEnd(chars)));
             }
 
-            ReadOnlySpan<char> stringSpan = "fabbacddeeddef".AsReadOnlySpan();
-            ReadOnlySpan<char> trimChars = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = "fabbacddeeddef".AsSpan();
+            ReadOnlySpan<char> trimChars = "abcde".AsSpan();
             Assert.True(stringSpan.SequenceEqual(stringSpan.Trim(trimChars)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimStart(trimChars)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimEnd(trimChars)));
@@ -220,8 +220,8 @@ namespace System.SpanTests
                 Assert.True(trimEndResult.SequenceEqual(trimEndResult.TrimEnd(chars)));
             }
 
-            ReadOnlySpan<char> stringSpan = "ccedafffffbdaa".AsReadOnlySpan();
-            ReadOnlySpan<char> trimChars = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = "ccedafffffbdaa".AsSpan();
+            ReadOnlySpan<char> trimChars = "abcde".AsSpan();
 
             ReadOnlySpan<char> trimStringResult = stringSpan.Trim(trimChars);
             ReadOnlySpan<char> trimStartStringResult = stringSpan.TrimStart(trimChars);
@@ -253,8 +253,8 @@ namespace System.SpanTests
             }
 
             string testString = "afghijklmnopqrstfe";
-            ReadOnlySpan<char> stringSpan = testString.AsReadOnlySpan().Slice(1, testString.Length - 2);
-            ReadOnlySpan<char> trimChars = "abcde".AsReadOnlySpan();
+            ReadOnlySpan<char> stringSpan = testString.AsSpan().Slice(1, testString.Length - 2);
+            ReadOnlySpan<char> trimChars = "abcde".AsSpan();
             Assert.True(stringSpan.SequenceEqual(stringSpan.Trim(trimChars)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimStart(trimChars)));
             Assert.True(stringSpan.SequenceEqual(stringSpan.TrimEnd(trimChars)));

--- a/src/System.Memory/tests/Span/ToString.cs
+++ b/src/System.Memory/tests/Span/ToString.cs
@@ -32,7 +32,7 @@ namespace System.SpanTests
             Assert.Equal("abc", span.ToString());
 
             string testString = "abcdefg";
-            ReadOnlySpan<char> readOnlySpan = testString.AsReadOnlySpan();
+            ReadOnlySpan<char> readOnlySpan = testString.AsSpan();
 
             fixed (void* ptr = &MemoryMarshal.GetReference(readOnlySpan))
             {

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -231,7 +231,7 @@ namespace System.Net
                 return false;
             }
 
-            address = IPAddressParser.Parse(ipString.AsReadOnlySpan(), tryParse: true);
+            address = IPAddressParser.Parse(ipString.AsSpan(), tryParse: true);
             return (address != null);
         }
 
@@ -248,7 +248,7 @@ namespace System.Net
                 throw new ArgumentNullException(nameof(ipString));
             }
 
-            return IPAddressParser.Parse(ipString.AsReadOnlySpan(), tryParse: false);
+            return IPAddressParser.Parse(ipString.AsSpan(), tryParse: false);
         }
 
         public static IPAddress Parse(ReadOnlySpan<char> ipSpan)

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsingSpan.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsingSpan.cs
@@ -9,8 +9,8 @@ namespace System.Net.Primitives.Functional.Tests
 {
     public sealed class IPAddressParsing_Span : IPAddressParsing
     {
-        public override IPAddress Parse(string ipString) => IPAddress.Parse(ipString.AsReadOnlySpan());
-        public override bool TryParse(string ipString, out IPAddress address) => IPAddress.TryParse(ipString.AsReadOnlySpan(), out address);
+        public override IPAddress Parse(string ipString) => IPAddress.Parse(ipString.AsSpan());
+        public override bool TryParse(string ipString, out IPAddress address) => IPAddress.TryParse(ipString.AsSpan(), out address);
 
 
         [Theory]

--- a/src/System.Private.Xml/src/System/Xml/NameTable.cs
+++ b/src/System.Private.Xml/src/System/Xml/NameTable.cs
@@ -234,7 +234,7 @@ namespace System.Xml
 
         private static int ComputeHash32(string key)
         {
-            ReadOnlySpan<byte> bytes = key.AsReadOnlySpan().AsBytes();
+            ReadOnlySpan<byte> bytes = key.AsSpan().AsBytes();
             return Marvin.ComputeHash32(bytes, Marvin.DefaultSeed);
         }
 

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.IsPathFullyQualified.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.IsPathFullyQualified.cs
@@ -67,7 +67,7 @@ namespace System.IO.Tests
         public static void IsPathFullyQualified_Unix_Invalid(string path)
         {
             Assert.False(Path.IsPathFullyQualified(path));
-            Assert.False(Path.IsPathFullyQualified(path.AsReadOnlySpan()));
+            Assert.False(Path.IsPathFullyQualified(path.AsSpan()));
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
@@ -81,7 +81,7 @@ namespace System.IO.Tests
         public static void IsPathFullyQualified_Unix_Valid(string path)
         {
             Assert.True(Path.IsPathFullyQualified(path));
-            Assert.True(Path.IsPathFullyQualified(path.AsReadOnlySpan()));
+            Assert.True(Path.IsPathFullyQualified(path.AsSpan()));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.IsPathFullyQualified.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.IsPathFullyQualified.netcoreapp.cs
@@ -23,7 +23,7 @@ namespace System.IO.Tests
         [InlineData("C:foo.txt")]
         public static void IsPathFullyQualified_Windows_Invalid(string path)
         {
-            Assert.False(Path.IsPathFullyQualified(path.AsReadOnlySpan()));
+            Assert.False(Path.IsPathFullyQualified(path.AsSpan()));
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]
@@ -44,7 +44,7 @@ namespace System.IO.Tests
         [InlineData(@"C://foo2")]
         public static void IsPathFullyQualified_Windows_Valid(string path)
         {
-            Assert.True(Path.IsPathFullyQualified(path.AsReadOnlySpan()));
+            Assert.True(Path.IsPathFullyQualified(path.AsSpan()));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.netcoreapp.cs
@@ -12,35 +12,35 @@ namespace System.IO.Tests
         [Theory, MemberData(nameof(GetDirectoryName_NonControl_Test_Data))]
         public static void GetDirectoryName_NonControl_Span(string path)
         {
-            Assert.Equal(string.Empty, new string(Path.GetDirectoryName(path.AsReadOnlySpan())));
+            Assert.Equal(string.Empty, new string(Path.GetDirectoryName(path.AsSpan())));
         }
 
         [Theory, MemberData(nameof(GetDirectoryName_NonControl_Test_Data))]
         public static void GetDirectoryName_NonControlWithSeparator_Span(string path)
         {
-            Assert.Equal(path, new string(Path.GetDirectoryName(Path.Combine(path, path).AsReadOnlySpan())));
+            Assert.Equal(path, new string(Path.GetDirectoryName(Path.Combine(path, path).AsSpan())));
         }
 
         [Theory, MemberData(nameof(GetDirectoryName_Test_Data))]
         public static void GetDirectoryName_Span(string path, string expected)
         {
             if (path != null)
-                Assert.Equal(expected, new string(Path.GetDirectoryName(path.AsReadOnlySpan())));
+                Assert.Equal(expected, new string(Path.GetDirectoryName(path.AsSpan())));
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific paths
         [Theory, MemberData(nameof(GetDirectoryName_Windows_Test_Data))]
         public static void GetDirectoryName_Windows_Span(string path, string expected)
         {
-            Assert.Equal(expected ?? string.Empty, new string(Path.GetDirectoryName(path.AsReadOnlySpan())));
+            Assert.Equal(expected ?? string.Empty, new string(Path.GetDirectoryName(path.AsSpan())));
         }
 
         [Fact]
         public static void GetDirectoryName_CurrentDirectory_Span()
         {
             string curDir = Directory.GetCurrentDirectory();
-            Assert.Equal(curDir, new string(Path.GetDirectoryName(Path.Combine(curDir, "baz").AsReadOnlySpan())));
-            Assert.Equal(string.Empty, new string(Path.GetDirectoryName(Path.GetPathRoot(curDir).AsReadOnlySpan())));
+            Assert.Equal(curDir, new string(Path.GetDirectoryName(Path.Combine(curDir, "baz").AsSpan())));
+            Assert.Equal(string.Empty, new string(Path.GetDirectoryName(Path.GetPathRoot(curDir).AsSpan())));
         }
 
 
@@ -53,8 +53,8 @@ namespace System.IO.Tests
             {
                 path = path.Replace('/', Path.DirectorySeparatorChar);
 
-                Assert.Equal(expected, new string(Path.GetExtension(path.AsReadOnlySpan())));
-                Assert.Equal(!string.IsNullOrEmpty(expected), Path.HasExtension(path.AsReadOnlySpan()));
+                Assert.Equal(expected, new string(Path.GetExtension(path.AsSpan())));
+                Assert.Equal(!string.IsNullOrEmpty(expected), Path.HasExtension(path.AsSpan()));
             }
         }
 
@@ -78,7 +78,7 @@ namespace System.IO.Tests
             // We used to break on ':' on Windows. This is a valid file name character for alternate data streams.
             // Additionally the character can show up on unix volumes mounted to Windows.
             Assert.Equal(expected, Path.GetFileName(path));
-            Assert.Equal(expected, new string(Path.GetFileName(path.AsReadOnlySpan())));
+            Assert.Equal(expected, new string(Path.GetFileName(path.AsSpan())));
         }
 
         [ActiveIssue(27269)]
@@ -90,7 +90,7 @@ namespace System.IO.Tests
         {
             // With a valid drive letter followed by a colon, we have a root, but only on Windows.
             Assert.Equal(expected, Path.GetFileName(path));
-            Assert.Equal(expected, new string(Path.GetFileName(path.AsReadOnlySpan())));
+            Assert.Equal(expected, new string(Path.GetFileName(path.AsSpan())));
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace System.IO.Tests
         {
             // No such thing as a drive relative path on Unix.
             Assert.Equal(expected, Path.GetFileName(path));
-            Assert.Equal(expected, new string(Path.GetFileName(path.AsReadOnlySpan())));
+            Assert.Equal(expected, new string(Path.GetFileName(path.AsSpan())));
         }
 
         [Theory]
@@ -109,7 +109,7 @@ namespace System.IO.Tests
         public static void GetFileName_Span(string path, string expected)
         {
             if (path != null)
-                Assert.Equal(expected, new string(Path.GetFileName(path.AsReadOnlySpan())));
+                Assert.Equal(expected, new string(Path.GetFileName(path.AsSpan())));
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace System.IO.Tests
         public static void GetFileNameWithoutExtension_Span(string path, string expected)
         {
             if(path != null)
-                Assert.Equal(expected, new string(Path.GetFileNameWithoutExtension(path.AsReadOnlySpan())));
+                Assert.Equal(expected, new string(Path.GetFileNameWithoutExtension(path.AsSpan())));
         }
 
         [Fact]
@@ -130,26 +130,26 @@ namespace System.IO.Tests
         [Theory, MemberData(nameof(GetPathRoot_Windows_UncAndExtended_Test_Data))]
         public static void GetPathRoot_Windows_UncAndExtended_Span(string value, string expected)
         {
-            Assert.True(Path.IsPathRooted(value.AsReadOnlySpan()));
-            Assert.Equal(expected, new string(Path.GetPathRoot(value.AsReadOnlySpan())));
+            Assert.True(Path.IsPathRooted(value.AsSpan()));
+            Assert.Equal(expected, new string(Path.GetPathRoot(value.AsSpan())));
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]
         [Theory, MemberData(nameof(GetPathRoot_Windows_UncAndExtended_WithLegacySupport_Test_Data))]
         public static void GetPathRoot_Windows_UncAndExtended_WithLegacySupport_Span(string normalExpected, string legacyExpected, string value)
         {
-            Assert.True(Path.IsPathRooted(value.AsReadOnlySpan()));
+            Assert.True(Path.IsPathRooted(value.AsSpan()));
 
             string expected = PathFeatures.IsUsingLegacyPathNormalization() ? legacyExpected : normalExpected;
-            Assert.Equal(expected, new string(Path.GetPathRoot(value.AsReadOnlySpan())));
+            Assert.Equal(expected, new string(Path.GetPathRoot(value.AsSpan())));
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific path convention
         [Theory, MemberData(nameof(GetPathRoot_Windows_Test_Data))]
         public static void GetPathRoot_Windows_Span(string value, string expected)
         {
-            Assert.True(Path.IsPathRooted(value.AsReadOnlySpan()));
-            Assert.Equal(expected, new string(Path.GetPathRoot(value.AsReadOnlySpan())));
+            Assert.True(Path.IsPathRooted(value.AsSpan()));
+            Assert.Equal(expected, new string(Path.GetPathRoot(value.AsSpan())));
         }
 
         [Theory]
@@ -157,7 +157,7 @@ namespace System.IO.Tests
         [InlineData(" ")]
         public static void IsPathRooted_Span(string path)
         {
-            Assert.False(Path.IsPathRooted(path.AsReadOnlySpan()));
+            Assert.False(Path.IsPathRooted(path.AsSpan()));
         }
 
         // Testing invalid drive letters !(a-zA-Z)
@@ -166,7 +166,7 @@ namespace System.IO.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Bug fixed on Core where it would return true if the first char is not a drive letter followed by a VolumeSeparatorChar coreclr/10297")]
         public static void IsPathRooted_Windows_Invalid_Span(string value)
         {
-            Assert.False(Path.IsPathRooted(value.AsReadOnlySpan()));
+            Assert.False(Path.IsPathRooted(value.AsSpan()));
         }
 
         [Fact]
@@ -175,12 +175,12 @@ namespace System.IO.Tests
             Assert.All(Path.GetInvalidPathChars(), c =>
             {
                 string bad = c.ToString();
-                Assert.Equal(string.Empty, new string(Path.GetDirectoryName(bad.AsReadOnlySpan())));
-                Assert.Equal(string.Empty, new string(Path.GetExtension(bad.AsReadOnlySpan())));
-                Assert.Equal(bad, new string(Path.GetFileName(bad.AsReadOnlySpan())));
-                Assert.Equal(bad, new string(Path.GetFileNameWithoutExtension(bad.AsReadOnlySpan())));
-                Assert.Equal(string.Empty, new string(Path.GetPathRoot(bad.AsReadOnlySpan())));
-                Assert.False(Path.IsPathRooted(bad.AsReadOnlySpan()));
+                Assert.Equal(string.Empty, new string(Path.GetDirectoryName(bad.AsSpan())));
+                Assert.Equal(string.Empty, new string(Path.GetExtension(bad.AsSpan())));
+                Assert.Equal(bad, new string(Path.GetFileName(bad.AsSpan())));
+                Assert.Equal(bad, new string(Path.GetFileNameWithoutExtension(bad.AsSpan())));
+                Assert.Equal(string.Empty, new string(Path.GetPathRoot(bad.AsSpan())));
+                Assert.False(Path.IsPathRooted(bad.AsSpan()));
             });
         }
 
@@ -188,35 +188,35 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Tests Unix-specific paths
         public static void GetDirectoryName_Unix_Span(string path, string expected)
         {
-            Assert.Equal(expected ?? string.Empty, new string(Path.GetDirectoryName(path.AsReadOnlySpan())));
+            Assert.Equal(expected ?? string.Empty, new string(Path.GetDirectoryName(path.AsSpan())));
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Checks Unix-specific special characters in directory path
         [Theory, MemberData(nameof(GetDirectoryName_ControlCharacters_Unix_Test_Data))]
         public static void GetDirectoryName_ControlCharacters_Unix_Span(char ch, int count, string file)
         {
-            Assert.Equal(new string(ch, count), new string(Path.GetDirectoryName(Path.Combine(new string(ch, count), file).AsReadOnlySpan())));
+            Assert.Equal(new string(ch, count), new string(Path.GetDirectoryName(Path.Combine(new string(ch, count), file).AsSpan())));
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Checks file extension behavior on Unix
         [Theory, MemberData(nameof(GetExtension_Unix_Test_Data))]
         public static void GetExtension_Unix_Span(string path, string expected)
         {
-            Assert.Equal(expected, new string(Path.GetExtension(path.AsReadOnlySpan())));
-            Assert.Equal(!string.IsNullOrEmpty(expected), Path.HasExtension(path.AsReadOnlySpan()));
+            Assert.Equal(expected, new string(Path.GetExtension(path.AsSpan())));
+            Assert.Equal(!string.IsNullOrEmpty(expected), Path.HasExtension(path.AsSpan()));
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Tests Unix-specific valid file names
         [Theory, MemberData(nameof(GetFileName_Unix_Test_Data))]
         public static void GetFileName_Unix_Span(string file)
         {
-            Assert.Equal(file, new string(Path.GetFileName(file).AsReadOnlySpan()));
+            Assert.Equal(file, new string(Path.GetFileName(file).AsSpan()));
         }
 
         [Fact]
         public static void GetFileNameWithSpaces_Unix_Span()
         {
-            Assert.Equal("fi  le", new string(Path.GetFileName(Path.Combine("b \r\n ar", "fi  le").AsReadOnlySpan())));
+            Assert.Equal("fi  le", new string(Path.GetFileName(Path.Combine("b \r\n ar", "fi  le").AsSpan())));
         }
     }
 }

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -330,7 +330,7 @@ namespace System.Numerics
                 return false;
             }
 
-            return TryParseBigInteger(value.AsReadOnlySpan(), style, info, out result);
+            return TryParseBigInteger(value.AsSpan(), style, info, out result);
         }
 
         internal static bool TryParseBigInteger(ReadOnlySpan<char> value, NumberStyles style, NumberFormatInfo info, out BigInteger result)
@@ -371,7 +371,7 @@ namespace System.Numerics
                 throw new ArgumentNullException(nameof(value));
             }
 
-            return ParseBigInteger(value.AsReadOnlySpan(), style, info);
+            return ParseBigInteger(value.AsSpan(), style, info);
         }
 
         internal static BigInteger ParseBigInteger(ReadOnlySpan<char> value, NumberStyles style, NumberFormatInfo info)

--- a/src/System.Runtime.Numerics/tests/BigInteger/parse.netcoreapp.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/parse.netcoreapp.cs
@@ -13,26 +13,26 @@ namespace System.Numerics.Tests
         {
             if (failureNotExpected)
             {
-                Eval(BigInteger.Parse(num1.AsReadOnlySpan(), ns), expected);
+                Eval(BigInteger.Parse(num1.AsSpan(), ns), expected);
 
-                Assert.True(BigInteger.TryParse(num1.AsReadOnlySpan(), ns, provider: null, out BigInteger test));
+                Assert.True(BigInteger.TryParse(num1.AsSpan(), ns, provider: null, out BigInteger test));
                 Eval(test, expected);
 
                 if (ns == NumberStyles.Integer)
                 {
-                    Assert.True(BigInteger.TryParse(num1.AsReadOnlySpan(), out test));
+                    Assert.True(BigInteger.TryParse(num1.AsSpan(), out test));
                     Eval(test, expected);
                 }
             }
             else
             {
-                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1.AsReadOnlySpan(), ns); });
+                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1.AsSpan(), ns); });
 
-                Assert.False(BigInteger.TryParse(num1.AsReadOnlySpan(), ns, provider: null, out BigInteger test));
+                Assert.False(BigInteger.TryParse(num1.AsSpan(), ns, provider: null, out BigInteger test));
 
                 if (ns == NumberStyles.Integer)
                 {
-                    Assert.False(BigInteger.TryParse(num1.AsReadOnlySpan(), out test));
+                    Assert.False(BigInteger.TryParse(num1.AsSpan(), out test));
                 }
             }
         }
@@ -41,14 +41,14 @@ namespace System.Numerics.Tests
         {
             if (!failureExpected)
             {
-                Assert.Equal(expected, BigInteger.Parse(num1.AsReadOnlySpan(), provider: nfi));
-                Assert.True(BigInteger.TryParse(num1.AsReadOnlySpan(), NumberStyles.Any, nfi, out BigInteger test));
+                Assert.Equal(expected, BigInteger.Parse(num1.AsSpan(), provider: nfi));
+                Assert.True(BigInteger.TryParse(num1.AsSpan(), NumberStyles.Any, nfi, out BigInteger test));
                 Assert.Equal(expected, test);
             }
             else
             {
-                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1.AsReadOnlySpan(), provider: nfi); });
-                Assert.False(BigInteger.TryParse(num1.AsReadOnlySpan(), NumberStyles.Any, nfi, out BigInteger test), String.Format("Expected TryParse to fail on {0}", num1));
+                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1.AsSpan(), provider: nfi); });
+                Assert.False(BigInteger.TryParse(num1.AsSpan(), NumberStyles.Any, nfi, out BigInteger test), String.Format("Expected TryParse to fail on {0}", num1));
             }
         }
 
@@ -56,14 +56,14 @@ namespace System.Numerics.Tests
         {
             if (!failureExpected)
             {
-                Assert.Equal(expected, BigInteger.Parse(num1.AsReadOnlySpan(), ns, nfi));
-                Assert.True(BigInteger.TryParse(num1.AsReadOnlySpan(), NumberStyles.Any, nfi, out BigInteger test));
+                Assert.Equal(expected, BigInteger.Parse(num1.AsSpan(), ns, nfi));
+                Assert.True(BigInteger.TryParse(num1.AsSpan(), NumberStyles.Any, nfi, out BigInteger test));
                 Assert.Equal(expected, test);
             }
             else
             {
-                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1.AsReadOnlySpan(), ns, nfi); });
-                Assert.False(BigInteger.TryParse(num1.AsReadOnlySpan(), ns, nfi, out BigInteger test), String.Format("Expected TryParse to fail on {0}", num1));
+                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1.AsSpan(), ns, nfi); });
+                Assert.False(BigInteger.TryParse(num1.AsSpan(), ns, nfi, out BigInteger test), String.Format("Expected TryParse to fail on {0}", num1));
             }
         }
     }

--- a/src/System.Runtime/tests/System/BooleanTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/BooleanTests.netcoreapp.cs
@@ -12,9 +12,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, bool expected)
         {
-            Assert.Equal(expected, bool.Parse(value.AsReadOnlySpan()));
+            Assert.Equal(expected, bool.Parse(value.AsSpan()));
 
-            Assert.True(bool.TryParse(value.AsReadOnlySpan(), out bool result));
+            Assert.True(bool.TryParse(value.AsSpan(), out bool result));
             Assert.Equal(expected, result);
         }
 
@@ -24,9 +24,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => bool.Parse(value.AsReadOnlySpan()));
+                Assert.Throws(exceptionType, () => bool.Parse(value.AsSpan()));
 
-                Assert.False(bool.TryParse(value.AsReadOnlySpan(), out bool result));
+                Assert.False(bool.TryParse(value.AsSpan(), out bool result));
                 Assert.Equal(false, result);
             }
         }

--- a/src/System.Runtime/tests/System/ByteTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ByteTests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, byte expected)
         {
-            Assert.Equal(expected, byte.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, byte.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(byte.TryParse(value.AsReadOnlySpan(), style, provider, out byte result));
+            Assert.True(byte.TryParse(value.AsSpan(), style, provider, out byte result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => byte.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => byte.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(byte.TryParse(value.AsReadOnlySpan(), style, provider, out byte result));
+                Assert.False(byte.TryParse(value.AsSpan(), style, provider, out byte result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/System.Runtime/tests/System/DateTimeOffsetTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffsetTests.netcoreapp.cs
@@ -15,13 +15,13 @@ namespace System.Tests
             DateTimeOffset expected = DateTimeOffset.MaxValue;
             string expectedString = expected.ToString();
 
-            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsReadOnlySpan()).ToString());
-            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsReadOnlySpan(), null).ToString());
-            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsReadOnlySpan(), null, DateTimeStyles.None).ToString());
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsSpan()).ToString());
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsSpan(), null).ToString());
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsSpan(), null, DateTimeStyles.None).ToString());
 
-            Assert.True(DateTimeOffset.TryParse(expectedString.AsReadOnlySpan(), out DateTimeOffset actual));
+            Assert.True(DateTimeOffset.TryParse(expectedString.AsSpan(), out DateTimeOffset actual));
             Assert.Equal(expectedString, actual.ToString());
-            Assert.True(DateTimeOffset.TryParse(expectedString.AsReadOnlySpan(), null, DateTimeStyles.None, out actual));
+            Assert.True(DateTimeOffset.TryParse(expectedString.AsSpan(), null, DateTimeStyles.None, out actual));
             Assert.Equal(expectedString, actual.ToString());
         }
 

--- a/src/System.Runtime/tests/System/DateTimeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DateTimeTests.netcoreapp.cs
@@ -39,18 +39,18 @@ namespace System.Tests
         [MemberData(nameof(Parse_ValidInput_Suceeds_MemberData))]
         public static void Parse_Span_ValidInput_Suceeds(string input, CultureInfo culture, DateTime? expected)
         {
-            Assert.Equal(expected, DateTime.Parse(input.AsReadOnlySpan(), culture));
+            Assert.Equal(expected, DateTime.Parse(input.AsSpan(), culture));
         }
 
         [Theory]
         [MemberData(nameof(ParseExact_ValidInput_Succeeds_MemberData))]
         public static void ParseExact_Span_ValidInput_Succeeds(string input, string format, CultureInfo culture, DateTimeStyles style, DateTime? expected)
         {
-            DateTime result1 = DateTime.ParseExact(input.AsReadOnlySpan(), format, culture, style);
-            DateTime result2 = DateTime.ParseExact(input.AsReadOnlySpan(), new[] { format }, culture, style);
+            DateTime result1 = DateTime.ParseExact(input.AsSpan(), format, culture, style);
+            DateTime result2 = DateTime.ParseExact(input.AsSpan(), new[] { format }, culture, style);
 
-            Assert.True(DateTime.TryParseExact(input.AsReadOnlySpan(), format, culture, style, out DateTime result3));
-            Assert.True(DateTime.TryParseExact(input.AsReadOnlySpan(), new[] { format }, culture, style, out DateTime result4));
+            Assert.True(DateTime.TryParseExact(input.AsSpan(), format, culture, style, out DateTime result3));
+            Assert.True(DateTime.TryParseExact(input.AsSpan(), new[] { format }, culture, style, out DateTime result4));
 
             Assert.Equal(result1, result2);
             Assert.Equal(result1, result3);
@@ -76,11 +76,11 @@ namespace System.Tests
         [MemberData(nameof(ParseExact_InvalidInputs_Fail_MemberData))]
         public static void ParseExact_Span_InvalidInputs_Fail(string input, string format, CultureInfo culture, DateTimeStyles style)
         {
-            Assert.Throws<FormatException>(() => DateTime.ParseExact(input.AsReadOnlySpan(), format, culture, style));
-            Assert.Throws<FormatException>(() => DateTime.ParseExact(input.AsReadOnlySpan(), new[] { format }, culture, style));
+            Assert.Throws<FormatException>(() => DateTime.ParseExact(input.AsSpan(), format, culture, style));
+            Assert.Throws<FormatException>(() => DateTime.ParseExact(input.AsSpan(), new[] { format }, culture, style));
 
-            Assert.False(DateTime.TryParseExact(input.AsReadOnlySpan(), format, culture, style, out DateTime result));
-            Assert.False(DateTime.TryParseExact(input.AsReadOnlySpan(), new[] { format }, culture, style, out result));
+            Assert.False(DateTime.TryParseExact(input.AsSpan(), format, culture, style, out DateTime result));
+            Assert.False(DateTime.TryParseExact(input.AsSpan(), new[] { format }, culture, style, out result));
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/DecimalTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DecimalTests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, decimal expected)
         {
-            Assert.Equal(expected, decimal.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, decimal.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(decimal.TryParse(value.AsReadOnlySpan(), style, provider, out decimal result));
+            Assert.True(decimal.TryParse(value.AsSpan(), style, provider, out decimal result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => decimal.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => decimal.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(decimal.TryParse(value.AsReadOnlySpan(), style, provider, out decimal result));
+                Assert.False(decimal.TryParse(value.AsSpan(), style, provider, out decimal result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/System.Runtime/tests/System/DoubleTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DoubleTests.netcoreapp.cs
@@ -91,9 +91,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, double expected)
         {
-            Assert.Equal(expected, double.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, double.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(double.TryParse(value.AsReadOnlySpan(), style, provider, out double result));
+            Assert.True(double.TryParse(value.AsSpan(), style, provider, out double result));
             Assert.Equal(expected, result);
         }
 
@@ -103,9 +103,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => double.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => double.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(double.TryParse(value.AsReadOnlySpan(), style, provider, out double result));
+                Assert.False(double.TryParse(value.AsSpan(), style, provider, out double result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/System.Runtime/tests/System/GuidTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GuidTests.netcoreapp.cs
@@ -77,19 +77,19 @@ namespace System.Tests
         [MemberData(nameof(GuidStrings_Valid_TestData))]
         public static void Parse_Span_ValidInput_Success(string input, string format, Guid expected)
         {
-            Assert.Equal(expected, Guid.Parse(input.AsReadOnlySpan()));
-            Assert.Equal(expected, Guid.ParseExact(input.AsReadOnlySpan(), format.ToUpperInvariant()));
-            Assert.Equal(expected, Guid.ParseExact(input.AsReadOnlySpan(), format.ToLowerInvariant())); // Format should be case insensitive
+            Assert.Equal(expected, Guid.Parse(input.AsSpan()));
+            Assert.Equal(expected, Guid.ParseExact(input.AsSpan(), format.ToUpperInvariant()));
+            Assert.Equal(expected, Guid.ParseExact(input.AsSpan(), format.ToLowerInvariant())); // Format should be case insensitive
 
             Guid result;
 
-            Assert.True(Guid.TryParse(input.AsReadOnlySpan(), out result));
+            Assert.True(Guid.TryParse(input.AsSpan(), out result));
             Assert.Equal(expected, result);
 
-            Assert.True(Guid.TryParseExact(input.AsReadOnlySpan(), format.ToUpperInvariant(), out result));
+            Assert.True(Guid.TryParseExact(input.AsSpan(), format.ToUpperInvariant(), out result));
             Assert.Equal(expected, result);
 
-            Assert.True(Guid.TryParseExact(input.AsReadOnlySpan(), format.ToLowerInvariant(), out result)); // Format should be case insensitive
+            Assert.True(Guid.TryParseExact(input.AsSpan(), format.ToLowerInvariant(), out result)); // Format should be case insensitive
             Assert.Equal(expected, result);
         }
 
@@ -107,16 +107,16 @@ namespace System.Tests
             {
                 exceptionType = typeof(FormatException);
             }
-            Assert.Throws(exceptionType, () => Guid.Parse(input.AsReadOnlySpan()));
+            Assert.Throws(exceptionType, () => Guid.Parse(input.AsSpan()));
 
-            Assert.False(Guid.TryParse(input.AsReadOnlySpan(), out Guid result));
+            Assert.False(Guid.TryParse(input.AsSpan(), out Guid result));
             Assert.Equal(Guid.Empty, result);
 
             foreach (string format in new[] { "N", "D", "B", "P", "X" })
             {
-                Assert.Throws(exceptionType, () => Guid.ParseExact(input.AsReadOnlySpan(), format));
+                Assert.Throws(exceptionType, () => Guid.ParseExact(input.AsSpan(), format));
 
-                Assert.False(Guid.TryParseExact(input.AsReadOnlySpan(), format, out result));
+                Assert.False(Guid.TryParseExact(input.AsSpan(), format, out result));
                 Assert.Equal(Guid.Empty, result);
             }
         }

--- a/src/System.Runtime/tests/System/Int16Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Int16Tests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, short expected)
         {
-            Assert.Equal(expected, short.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, short.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(short.TryParse(value.AsReadOnlySpan(), style, provider, out short result));
+            Assert.True(short.TryParse(value.AsSpan(), style, provider, out short result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => short.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => short.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(short.TryParse(value.AsReadOnlySpan(), style, provider, out short result));
+                Assert.False(short.TryParse(value.AsSpan(), style, provider, out short result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/System.Runtime/tests/System/Int32Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Int32Tests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, int expected)
         {
-            Assert.Equal(expected, int.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, int.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(int.TryParse(value.AsReadOnlySpan(), style, provider, out int result));
+            Assert.True(int.TryParse(value.AsSpan(), style, provider, out int result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => int.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => int.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(int.TryParse(value.AsReadOnlySpan(), style, provider, out int result));
+                Assert.False(int.TryParse(value.AsSpan(), style, provider, out int result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/System.Runtime/tests/System/Int64Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Int64Tests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, long expected)
         {
-            Assert.Equal(expected, long.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, long.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(long.TryParse(value.AsReadOnlySpan(), style, provider, out long result));
+            Assert.True(long.TryParse(value.AsSpan(), style, provider, out long result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => long.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => long.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(long.TryParse(value.AsReadOnlySpan(), style, provider, out long result));
+                Assert.False(long.TryParse(value.AsSpan(), style, provider, out long result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/System.Runtime/tests/System/SByteTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/SByteTests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, sbyte expected)
         {
-            Assert.Equal(expected, sbyte.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, sbyte.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(sbyte.TryParse(value.AsReadOnlySpan(), style, provider, out sbyte result));
+            Assert.True(sbyte.TryParse(value.AsSpan(), style, provider, out sbyte result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => sbyte.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => sbyte.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(sbyte.TryParse(value.AsReadOnlySpan(), style, provider, out sbyte result));
+                Assert.False(sbyte.TryParse(value.AsSpan(), style, provider, out sbyte result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/System.Runtime/tests/System/SingleTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/SingleTests.netcoreapp.cs
@@ -91,9 +91,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, float expected)
         {
-            Assert.Equal(expected, float.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, float.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(float.TryParse(value.AsReadOnlySpan(), style, provider, out float result));
+            Assert.True(float.TryParse(value.AsSpan(), style, provider, out float result));
             Assert.Equal(expected, result);
         }
 
@@ -103,9 +103,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => float.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => float.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(float.TryParse(value.AsReadOnlySpan(), style, provider, out float result));
+                Assert.False(float.TryParse(value.AsSpan(), style, provider, out float result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -325,7 +325,7 @@ namespace System.Text.Tests
         [MemberData(nameof(Equals_String_TestData))]
         public static void Equals(StringBuilder sb1, string value, bool expected)
         {
-            Assert.Equal(expected, sb1.Equals(value.AsReadOnlySpan()));
+            Assert.Equal(expected, sb1.Equals(value.AsSpan()));
         }
     }
 }

--- a/src/System.Runtime/tests/System/TimeSpanTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TimeSpanTests.netcoreapp.cs
@@ -115,7 +115,7 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span(string inputString, IFormatProvider provider, TimeSpan expected)
         {
-            ReadOnlySpan<char> input = inputString.AsReadOnlySpan();
+            ReadOnlySpan<char> input = inputString.AsSpan();
             TimeSpan result;
 
             Assert.Equal(expected, TimeSpan.Parse(input, provider));
@@ -125,7 +125,7 @@ namespace System.Tests
             // Also negate
             if (!char.IsWhiteSpace(input[0]))
             {
-                input = ("-" + inputString).AsReadOnlySpan();
+                input = ("-" + inputString).AsSpan();
                 expected = -expected;
 
                 Assert.Equal(expected, TimeSpan.Parse(input, provider));
@@ -140,8 +140,8 @@ namespace System.Tests
         {
             if (inputString != null)
             {
-                Assert.Throws(exceptionType, () => TimeSpan.Parse(inputString.AsReadOnlySpan(), provider));
-                Assert.False(TimeSpan.TryParse(inputString.AsReadOnlySpan(), provider, out TimeSpan result));
+                Assert.Throws(exceptionType, () => TimeSpan.Parse(inputString.AsSpan(), provider));
+                Assert.False(TimeSpan.TryParse(inputString.AsSpan(), provider, out TimeSpan result));
                 Assert.Equal(TimeSpan.Zero, result);
             }
         }
@@ -152,7 +152,7 @@ namespace System.Tests
         [MemberData(nameof(ParseExact_Valid_TestData))]
         public static void ParseExact_Span_Valid(string inputString, string format, TimeSpan expected)
         {
-            ReadOnlySpan<char> input = inputString.AsReadOnlySpan();
+            ReadOnlySpan<char> input = inputString.AsSpan();
 
             TimeSpan result;
             Assert.Equal(expected, TimeSpan.ParseExact(input, format, new CultureInfo("en-US")));
@@ -188,13 +188,13 @@ namespace System.Tests
         {
             if (inputString != null && format != null)
             {
-                Assert.Throws(exceptionType, () => TimeSpan.ParseExact(inputString.AsReadOnlySpan(), format, new CultureInfo("en-US")));
+                Assert.Throws(exceptionType, () => TimeSpan.ParseExact(inputString.AsSpan(), format, new CultureInfo("en-US")));
 
                 TimeSpan result;
-                Assert.False(TimeSpan.TryParseExact(inputString.AsReadOnlySpan(), format, new CultureInfo("en-US"), out result));
+                Assert.False(TimeSpan.TryParseExact(inputString.AsSpan(), format, new CultureInfo("en-US"), out result));
                 Assert.Equal(TimeSpan.Zero, result);
 
-                Assert.False(TimeSpan.TryParseExact(inputString.AsReadOnlySpan(), new[] { format }, new CultureInfo("en-US"), out result));
+                Assert.False(TimeSpan.TryParseExact(inputString.AsSpan(), new[] { format }, new CultureInfo("en-US"), out result));
                 Assert.Equal(TimeSpan.Zero, result);
             }
         }
@@ -204,11 +204,11 @@ namespace System.Tests
         {
             TimeSpan result;
 
-            AssertExtensions.Throws<ArgumentNullException>("formats", () => TimeSpan.ParseExact("12:34:56".AsReadOnlySpan(), (string[])null, null));
-            Assert.False(TimeSpan.TryParseExact("12:34:56".AsReadOnlySpan(), (string[])null, null, out result));
+            AssertExtensions.Throws<ArgumentNullException>("formats", () => TimeSpan.ParseExact("12:34:56".AsSpan(), (string[])null, null));
+            Assert.False(TimeSpan.TryParseExact("12:34:56".AsSpan(), (string[])null, null, out result));
 
-            Assert.Throws<FormatException>(() => TimeSpan.ParseExact("12:34:56".AsReadOnlySpan(), new string[0], null));
-            Assert.False(TimeSpan.TryParseExact("12:34:56".AsReadOnlySpan(), new string[0], null, out result));
+            Assert.Throws<FormatException>(() => TimeSpan.ParseExact("12:34:56".AsSpan(), new string[0], null));
+            Assert.False(TimeSpan.TryParseExact("12:34:56".AsSpan(), new string[0], null, out result));
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/UInt16Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/UInt16Tests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, ushort expected)
         {
-            Assert.Equal(expected, ushort.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, ushort.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(ushort.TryParse(value.AsReadOnlySpan(), style, provider, out ushort result));
+            Assert.True(ushort.TryParse(value.AsSpan(), style, provider, out ushort result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => ushort.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => ushort.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(ushort.TryParse(value.AsReadOnlySpan(), style, provider, out ushort result));
+                Assert.False(ushort.TryParse(value.AsSpan(), style, provider, out ushort result));
                 Assert.Equal(0, (short)result);
             }
         }

--- a/src/System.Runtime/tests/System/UInt32Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/UInt32Tests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, uint expected)
         {
-            Assert.Equal(expected, uint.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, uint.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(uint.TryParse(value.AsReadOnlySpan(), style, provider, out uint result));
+            Assert.True(uint.TryParse(value.AsSpan(), style, provider, out uint result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => uint.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => uint.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(uint.TryParse(value.AsReadOnlySpan(), style, provider, out uint result));
+                Assert.False(uint.TryParse(value.AsSpan(), style, provider, out uint result));
                 Assert.Equal(0, (int)result);
             }
         }

--- a/src/System.Runtime/tests/System/UInt64Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/UInt64Tests.netcoreapp.cs
@@ -13,9 +13,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, ulong expected)
         {
-            Assert.Equal(expected, ulong.Parse(value.AsReadOnlySpan(), style, provider));
+            Assert.Equal(expected, ulong.Parse(value.AsSpan(), style, provider));
 
-            Assert.True(ulong.TryParse(value.AsReadOnlySpan(), style, provider, out ulong result));
+            Assert.True(ulong.TryParse(value.AsSpan(), style, provider, out ulong result));
             Assert.Equal(expected, result);
         }
 
@@ -25,9 +25,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => ulong.Parse(value.AsReadOnlySpan(), style, provider));
+                Assert.Throws(exceptionType, () => ulong.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(ulong.TryParse(value.AsReadOnlySpan(), style, provider, out ulong result));
+                Assert.False(ulong.TryParse(value.AsSpan(), style, provider, out ulong result));
                 Assert.Equal(0, (long)result);
             }
         }

--- a/src/System.Runtime/tests/System/VersionTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/VersionTests.netcoreapp.cs
@@ -17,9 +17,9 @@ namespace System.Tests
                 return;
             }
 
-            Assert.Equal(expected, Version.Parse(input.AsReadOnlySpan()));
+            Assert.Equal(expected, Version.Parse(input.AsSpan()));
 
-            Assert.True(Version.TryParse(input.AsReadOnlySpan(), out Version version));
+            Assert.True(Version.TryParse(input.AsSpan(), out Version version));
             Assert.Equal(expected, version);
         }
 
@@ -32,9 +32,9 @@ namespace System.Tests
                 return;
             }
 
-            Assert.Throws(exceptionType, () => Version.Parse(input.AsReadOnlySpan()));
+            Assert.Throws(exceptionType, () => Version.Parse(input.AsSpan()));
 
-            Assert.False(Version.TryParse(input.AsReadOnlySpan(), out Version version));
+            Assert.False(Version.TryParse(input.AsSpan(), out Version version));
             Assert.Null(version);
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
@@ -107,7 +107,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
-                WriteSpan(writer, input.AsReadOnlySpan());
+                WriteSpan(writer, input.AsSpan());
 
                 Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
             }
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
                 Asn1Tag tag = new Asn1Tag(TagClass.Private, int.MaxValue >> 1);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(tag) + expectedPayloadHex);
             }
@@ -128,7 +128,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
-                WriteSpan(writer, input.AsReadOnlySpan());
+                WriteSpan(writer, input.AsSpan());
 
                 Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
             }
@@ -139,7 +139,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
                 Asn1Tag tag = new Asn1Tag(TagClass.Application, 30);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(tag) + expectedPayloadHex);
             }
@@ -149,7 +149,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
-                WriteSpan(writer, input.AsReadOnlySpan());
+                WriteSpan(writer, input.AsSpan());
 
                 Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
             }
@@ -160,7 +160,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
                 Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 31);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(tag) + expectedPayloadHex);
             }
@@ -196,7 +196,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             {
                 Asn1Tag standard = StandardTag;
                 Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(standard) + expectedPayloadHex);
             }
@@ -208,7 +208,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             {
                 Asn1Tag tag = new Asn1Tag(TagClass.Private, 24601, isConstructed: true);
                 Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(expected) + expectedPayloadHex);
             }
@@ -244,7 +244,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             {
                 Asn1Tag standard = StandardTag;
                 Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(standard) + expectedPayloadHex);
             }
@@ -256,7 +256,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             {
                 Asn1Tag tag = new Asn1Tag(TagClass.Application, 11, isConstructed: true);
                 Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(expected) + expectedPayloadHex);
             }
@@ -292,7 +292,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             {
                 Asn1Tag standard = StandardTag;
                 Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(standard) + expectedPayloadHex);
             }
@@ -304,7 +304,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             {
                 Asn1Tag tag = new Asn1Tag(TagClass.Private, 24601, isConstructed: true);
                 Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
 
                 Verify(writer, Stringify(expected) + expectedPayloadHex);
             }
@@ -346,7 +346,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             {
                 AssertExtensions.Throws<ArgumentException>(
                     "tag",
-                    () => WriteSpan(writer, Asn1Tag.EndOfContents, "hi".AsReadOnlySpan()));
+                    () => WriteSpan(writer, Asn1Tag.EndOfContents, "hi".AsSpan()));
             }
         }
 
@@ -436,7 +436,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
                 string tagHex = Stringify(tag);
 
-                WriteSpan(writer, input.AsReadOnlySpan());
+                WriteSpan(writer, input.AsSpan());
                 VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
             }
         }
@@ -448,7 +448,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Asn1Tag tag = new Asn1Tag(TagClass.Private, 7, true);
                 string tagHex = Stringify(tag);
 
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
                 VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
             }
         }
@@ -461,7 +461,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
                 string tagHex = Stringify(tag);
 
-                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                WriteSpan(writer, tag, input.AsSpan());
                 VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
             }
         }
@@ -474,7 +474,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Asn1Tag constr = new Asn1Tag(prim.TagClass, prim.TagValue, true);
                 string tagHex = Stringify(constr);
 
-                WriteSpan(writer, prim, input.AsReadOnlySpan());
+                WriteSpan(writer, prim, input.AsSpan());
                 VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
             }
         }
@@ -491,7 +491,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
-                Assert.Throws<EncoderFallbackException>(() => WriteSpan(writer, input.AsReadOnlySpan()));
+                Assert.Throws<EncoderFallbackException>(() => WriteSpan(writer, input.AsSpan()));
             }
         }
     }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteObjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteObjectIdentifier.cs
@@ -34,7 +34,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteObjectIdentifier(oidValue.AsReadOnlySpan());
+                writer.WriteObjectIdentifier(oidValue.AsSpan());
 
                 Verify(writer, expectedHex);
             }
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
                 Assert.Throws<CryptographicException>(
-                    () => writer.WriteObjectIdentifier(nonOidValue.AsReadOnlySpan()));
+                    () => writer.WriteObjectIdentifier(nonOidValue.AsSpan()));
             }
         }
 
@@ -123,7 +123,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteObjectIdentifier(new Asn1Tag(TagClass.Application, 2), "1.3.14.3.2.26".AsReadOnlySpan());
+                writer.WriteObjectIdentifier(new Asn1Tag(TagClass.Application, 2), "1.3.14.3.2.26".AsSpan());
 
                 Verify(writer, "42052B0E03021A");
             }
@@ -206,7 +206,7 @@ namespace System.Security.Cryptography.Tests.Asn1
 
                 AssertExtensions.Throws<ArgumentException>(
                     "tag",
-                    () => writer.WriteObjectIdentifier(Asn1Tag.EndOfContents, "1.1".AsReadOnlySpan()));
+                    () => writer.WriteObjectIdentifier(Asn1Tag.EndOfContents, "1.1".AsSpan()));
 
                 AssertExtensions.Throws<ArgumentException>(
                     "tag",
@@ -228,8 +228,8 @@ namespace System.Security.Cryptography.Tests.Asn1
 
                 writer.WriteObjectIdentifier(constructedOid, OidValue);
                 writer.WriteObjectIdentifier(constructedContext0, OidValue);
-                writer.WriteObjectIdentifier(constructedOid, OidValue.AsReadOnlySpan());
-                writer.WriteObjectIdentifier(constructedContext0, OidValue.AsReadOnlySpan());
+                writer.WriteObjectIdentifier(constructedOid, OidValue.AsSpan());
+                writer.WriteObjectIdentifier(constructedContext0, OidValue.AsSpan());
                 writer.WriteObjectIdentifier(constructedOid, new Oid(OidValue, OidValue));
                 writer.WriteObjectIdentifier(constructedContext0, new Oid(OidValue, OidValue));
 

--- a/src/System.Text.Encoding/tests/Encoder/EncoderSpanTests.netcoreapp.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderSpanTests.netcoreapp.cs
@@ -13,7 +13,7 @@ namespace System.Text.Encodings.Tests
         {
             const string TextString = "hello world";
             Encoding e = Encoding.UTF8;
-            Assert.Equal(e.GetByteCount(TextString), e.GetEncoder().GetByteCount(TextString.AsReadOnlySpan(), flush: true));
+            Assert.Equal(e.GetByteCount(TextString), e.GetEncoder().GetByteCount(TextString.AsSpan(), flush: true));
         }
 
         [Fact]
@@ -23,7 +23,7 @@ namespace System.Text.Encodings.Tests
             Encoding e = Encoding.UTF8;
 
             byte[] bytes = new byte[e.GetByteCount(TextString)];
-            Assert.Equal(bytes.Length, e.GetEncoder().GetBytes(TextString.AsReadOnlySpan(), bytes, flush: true));
+            Assert.Equal(bytes.Length, e.GetEncoder().GetBytes(TextString.AsSpan(), bytes, flush: true));
             Assert.Equal(e.GetBytes(TextString), bytes);
         }
 
@@ -36,14 +36,14 @@ namespace System.Text.Encodings.Tests
             byte[] bytes;
 
             bytes = new byte[encoding.GetByteCount(TextString)];
-            encoder.Convert(TextString.AsReadOnlySpan(), bytes.AsSpan().Slice(0, 2), true, out int charsUsed, out int bytesUsed, out bool completed);
+            encoder.Convert(TextString.AsSpan(), bytes.AsSpan().Slice(0, 2), true, out int charsUsed, out int bytesUsed, out bool completed);
             Assert.Equal(encoding.GetBytes(TextString).AsSpan().Slice(0, 2).ToArray(), bytes.AsSpan().Slice(0, 2).ToArray());
             Assert.Equal(2, charsUsed);
             Assert.Equal(2, bytesUsed);
             Assert.False(completed);
 
             bytes = new byte[encoding.GetByteCount(TextString)];
-            encoder.Convert(TextString.AsReadOnlySpan(), bytes, true, out charsUsed, out bytesUsed, out completed);
+            encoder.Convert(TextString.AsSpan(), bytes, true, out charsUsed, out bytesUsed, out completed);
             Assert.Equal(encoding.GetBytes(TextString), bytes);
             Assert.Equal(TextString.Length, charsUsed);
             Assert.Equal(bytes.Length, bytesUsed);

--- a/src/System.Text.Encoding/tests/EncodingTestHelpers.netcoreapp.cs
+++ b/src/System.Text.Encoding/tests/EncodingTestHelpers.netcoreapp.cs
@@ -14,7 +14,7 @@ namespace System.Text.Tests
             Assert.Equal(expected, encoding.GetByteCount(chars, index, count));
 
             // Use GetByteCount(ReadOnlySpan<char> chars)
-            Assert.Equal(expected, encoding.GetByteCount(chars.AsReadOnlySpan().Slice(index, count)));
+            Assert.Equal(expected, encoding.GetByteCount(chars.AsSpan().Slice(index, count)));
         }
 
         static partial void GetBytes_NetCoreApp(Encoding encoding, string chars, int index, int count, byte[] expected)
@@ -25,7 +25,7 @@ namespace System.Text.Tests
 
             // Use GetBytes(ReadOnlySpan<char>, Span<byte>)
             Array.Clear(stringResultAdvanced, 0, stringResultAdvanced.Length);
-            Assert.Equal(expected.Length, encoding.GetBytes(chars.AsReadOnlySpan().Slice(index, count), (Span<byte>)stringResultAdvanced));
+            Assert.Equal(expected.Length, encoding.GetBytes(chars.AsSpan().Slice(index, count), (Span<byte>)stringResultAdvanced));
             VerifyGetBytes(stringResultAdvanced, 0, stringResultAdvanced.Length, new byte[expected.Length], expected);
         }
 


### PR DESCRIPTION
As part of 

https://github.com/dotnet/corefx/issues/26894

the api folks have approved renaming AsROSpan and AsROMemory
on string instances to AsSpan and AsMemory (as the "readonly"
is obvious given the read-only nature of the input.)

This puts the renaming in effect. Basically a big search-replace
commit.