### PR TITLE
Adding missing typeforward for Lazy<T,TMetadata> to S.CM.Composition

### DIFF
--- a/external/netcoreapp/netcoreapp.depproj
+++ b/external/netcoreapp/netcoreapp.depproj
@@ -21,6 +21,8 @@
     <BinPlaceConfiguration Include="$(Configuration)">
       <RefPath>$(RefPath)</RefPath>
     </BinPlaceConfiguration>
+
+    <FileToExclude Include="System.ComponentModel.Composition" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -55,8 +55,16 @@
     <PropertyGroup>
       <_NETStandardRefFolder>$(PackagesDir)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\$(_NETStandardTFMFolder)\ref</_NETStandardRefFolder>
     </PropertyGroup>
+
     <ItemGroup>
-      <Reference Include="$(_NETStandardRefFolder)\*.dll">
+      <ExcludeNetStandardRefs Include="System.ComponentModel.Composition" />
+      <NetStandardRefs
+        Include="$(_NETStandardRefFolder)\*.dll"
+        Exclude="@(ExcludeNetStandardRefs -> '$(_NETStandardRefFolder)\%(Identity).dll')" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="@(NetStandardRefs)">
         <Private>False</Private>
         <NuGetPackageId>$(NETStandardLibraryPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>

--- a/src/System.ComponentModel.Composition/dir.props
+++ b/src/System.ComponentModel.Composition/dir.props
@@ -3,6 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyKey>MSFT</AssemblyKey>
+    <AssemblyKey>ECMA</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Composition/pkg/System.ComponentModel.Composition.pkgproj
+++ b/src/System.ComponentModel.Composition/pkg/System.ComponentModel.Composition.pkgproj
@@ -10,9 +10,6 @@
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
-    <File Include="$(PlaceHolderFile)">
-      <TargetPath>runtimes/win/lib/net45</TargetPath>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.Composition/ref/Configurations.props
+++ b/src/System.ComponentModel.Composition/ref/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      _netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.cs
+++ b/src/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.cs
@@ -5,6 +5,8 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(destination: typeof(System.Lazy<,>))]
+
 namespace System.ComponentModel.Composition
 {
     public static partial class AdaptationConstants

--- a/src/System.ComponentModel.Composition/src/Configurations.props
+++ b/src/System.ComponentModel.Composition/src/Configurations.props
@@ -7,6 +7,7 @@
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      _netfx;
       netcoreapp;
       uap;
     </BuildConfigurations>

--- a/src/System.ComponentModel.Composition/src/System.ComponentModel.Composition.csproj
+++ b/src/System.ComponentModel.Composition/src/System.ComponentModel.Composition.csproj
@@ -15,6 +15,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="TypeForwards.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
     <Compile Include="Microsoft\Internal\AdaptationHelpers.cs" />
     <Compile Include="Microsoft\Internal\AttributeServices.cs" />

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionContainer.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionContainer.cs
@@ -11,8 +11,6 @@ using System.Diagnostics.Contracts;
 using System.Threading;
 using Microsoft.Internal;
 
-[assembly: System.Runtime.CompilerServices.TypeForwardedTo(destination: typeof(System.Lazy<,>))]
-
 namespace System.ComponentModel.Composition.Hosting
 {
     public partial class CompositionContainer : ExportProvider, ICompositionService, IDisposable

--- a/src/System.ComponentModel.Composition/src/TypeForwards.cs
+++ b/src/System.ComponentModel.Composition/src/TypeForwards.cs
@@ -1,0 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(destination: typeof(System.Lazy<,>))]

--- a/src/System.ComponentModel.Composition/tests/Configurations.props
+++ b/src/System.ComponentModel.Composition/tests/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp;
       uap;
+      _netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adding missing typeforward for Lazy<T,TMetadata> to System.ComponentModel.Composition

Fixes #27299