### PR TITLE
Fix Span Debugger Display String to correctly show the string contents

### DIFF
--- a/src/Common/src/CoreLib/System/ReadOnlySpan.Fast.cs
+++ b/src/Common/src/CoreLib/System/ReadOnlySpan.Fast.cs
@@ -23,7 +23,7 @@ namespace System
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebugView<>))]
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{ToString(),raw}")]
     [NonVersionable]
     public readonly ref partial struct ReadOnlySpan<T>
     {

--- a/src/Common/src/CoreLib/System/ReadOnlySpan.cs
+++ b/src/Common/src/CoreLib/System/ReadOnlySpan.cs
@@ -18,7 +18,7 @@ namespace System
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebugView<>))]
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{ToString(),raw}")]
     public readonly ref partial struct ReadOnlySpan<T>
     {
         /// <summary>

--- a/src/Common/src/CoreLib/System/Span.Fast.cs
+++ b/src/Common/src/CoreLib/System/Span.Fast.cs
@@ -23,7 +23,7 @@ namespace System
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebugView<>))]
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{ToString(),raw}")]
     [NonVersionable]
     public readonly ref partial struct Span<T>
     {

--- a/src/Common/src/CoreLib/System/Span.cs
+++ b/src/Common/src/CoreLib/System/Span.cs
@@ -18,7 +18,7 @@ namespace System
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebugView<>))]
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{ToString(),raw}")]
     public readonly ref partial struct Span<T>
     {
         /// <summary>

--- a/src/System.Memory/src/System/ReadOnlySpan.Portable.cs
+++ b/src/System.Memory/src/System/ReadOnlySpan.Portable.cs
@@ -16,7 +16,7 @@ namespace System
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebugView<>))]
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{ToString(),raw}")]
     public readonly ref partial struct ReadOnlySpan<T>
     {
         /// <summary>
@@ -107,9 +107,6 @@ namespace System
             _pinnable = pinnable;
             _byteOffset = byteOffset;
         }
-
-        //Debugger Display = System.ReadOnlySpan<T>[length]
-        private string DebuggerDisplay => string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, Length);
 
         /// <summary>
         /// Returns the specified element of the read-only span.

--- a/src/System.Memory/src/System/Span.Portable.cs
+++ b/src/System.Memory/src/System/Span.Portable.cs
@@ -16,7 +16,7 @@ namespace System
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebugView<>))]
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{ToString(),raw}")]
     public readonly ref partial struct Span<T>
     {
         /// <summary>
@@ -111,9 +111,6 @@ namespace System
             _pinnable = pinnable;
             _byteOffset = byteOffset;
         }
-
-        //Debugger Display = System.Span<T>[length]
-        private string DebuggerDisplay => string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
 
         /// <summary>
         /// Returns a reference to specified element of the Span.


### PR DESCRIPTION
Resolves https://github.com/dotnet/coreclr/issues/16450

Leftover from https://github.com/dotnet/corefx/pull/26726#issuecomment-362522270

cc @stephentoub, @khellang, @pakrym, @KrzysztofCwalina 

