### PR TITLE
Enable clearing initlocals when running dotnet msbuild.

### DIFF
--- a/illink.targets
+++ b/illink.targets
@@ -72,8 +72,8 @@
       <!-- reflection heuristics to apply -->
       <ILLinkArgs>$(ILLinkArgs) -h LdtokenTypeMethods,InstanceConstructors</ILLinkArgs>
       <!-- add a linker step to clear initlocals flag on all assemblies before the output step -->
-      <!-- TODO Issue #27045: Remove the OS-specific condition once the custom step runs on Unix -->
-      <ILLinkArgs Condition="'$(ILLinkClearInitLocals)' == 'true' AND '$(OS)' == 'Windows_NT'">$(ILLinkArgs) -s ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps:OutputStep</ILLinkArgs>
+      <!-- version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016 -->
+      <ILLinkArgs Condition="'$(ILLinkClearInitLocals)' == 'true'">$(ILLinkArgs) -s ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep</ILLinkArgs>
     </PropertyGroup>
 
     <MakeDir Directories="$(ILLinkTrimInputPath)" />

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(TargetGroup)' == 'netfx'">true</OmitResources>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
+    <ILLinkClearInitLocals Condition="'$(OS)' == 'Windows_NT'">true</ILLinkClearInitLocals>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />


### PR DESCRIPTION
Linker step to clear initlocals was only enabled in Windows builds that use
desktop msbuild. dotnet msbuild has a bug in assembly loading: https://github.com/Microsoft/msbuild/issues/3016
that was preventing ILLink.CustomSteps from loading by a Type.GetType() call. This PR adds a workaround by appending ILLink.CustomSteps version to the string that is eventually passed to Type.GetType().

Fixes #27045.

@ericstj  @stephentoub PTAL