### PR TITLE
Fix NullReferenceException on exception cascade when CEK doesn't decrypt

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
@@ -82,7 +82,10 @@ namespace Internal.Cryptography.Pal.AnyOS
                     }
                     finally
                     {
-                        Array.Clear(cek, 0, cek.Length);
+                        if (cek != null)
+                        {
+                            Array.Clear(cek, 0, cek.Length);
+                        }
                     }
                 }
 


### PR DESCRIPTION
A late change caused a test which only runs in outer-loop to fail with a NullReferenceException instead of a CryptographicException.  This is caused by the "return now if decryption failed" path.