### PR TITLE
Fix fragment handling in HttpClient

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -278,7 +278,7 @@ namespace System.Net.Http
                     await WriteAsciiStringAsync(request.RequestUri.IdnHost).ConfigureAwait(false);
                 }
 
-                await WriteStringAsync(request.RequestUri.PathAndQuery).ConfigureAwait(false);
+                await WriteStringAsync(request.RequestUri.GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.UriEscaped)).ConfigureAwait(false);
 
                 // Fall back to 1.1 for all versions other than 1.0
                 Debug.Assert(request.Version.Major >= 0 && request.Version.Minor >= 0); // guaranteed by Version class

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -912,40 +912,77 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ConditionalTheory(nameof(IsNotWindows7))] // Skip test on Win7 since WinHTTP has bugs w/ fragments.
+        [Theory]
         [InlineData("#origFragment", "", "#origFragment", false)]
         [InlineData("#origFragment", "", "#origFragment", true)]
         [InlineData("", "#redirFragment", "#redirFragment", false)]
         [InlineData("", "#redirFragment", "#redirFragment", true)]
         [InlineData("#origFragment", "#redirFragment", "#redirFragment", false)]
         [InlineData("#origFragment", "#redirFragment", "#redirFragment", true)]
-        [ActiveIssue(27217)]
         public async Task GetAsync_AllowAutoRedirectTrue_RetainsOriginalFragmentIfAppropriate(
             string origFragment, string redirFragment, string expectedFragment, bool useRelativeRedirect)
         {
+            if (IsCurlHandler)
+            {
+                // Starting with libcurl 7.20, "fragment part of URLs are no longer sent to the server".
+                // So CurlHandler doesn't send fragments.
+                return;
+            }
+
+            if (IsNetfxHandler)
+            {
+                // Similarly, netfx doesn't send fragments at all.
+                return;
+            }
+
+            if (IsWinHttpHandler &&
+                (PlatformDetection.IsWindows7 || (!string.IsNullOrEmpty(origFragment) && string.IsNullOrEmpty(redirFragment))))
+            {
+                // According to https://tools.ietf.org/html/rfc7231#section-7.1.2,
+                // "If the Location value provided in a 3xx (Redirection) response does
+                //  not have a fragment component, a user agent MUST process the
+                //  redirection as if the value inherits the fragment component of the
+                //  URI reference used to generate the request target(i.e., the
+                //  redirection inherits the original reference's fragment, if any)."
+                // WINHTTP is not doing this, and thus neither is WinHttpHandler.
+                // It also has issues with fragments on Windows 7.
+                return;
+            }
+
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.AllowAutoRedirect = true;
             using (var client = new HttpClient(handler))
             {
                 await LoopbackServer.CreateServerAsync(async (origServer, origUrl) =>
                 {
-                    origUrl = new Uri(origUrl.ToString() + origFragment);
-                    Uri redirectUrl = useRelativeRedirect ?
-                        new Uri(origUrl.PathAndQuery + redirFragment, UriKind.Relative) :
-                        new Uri(origUrl.ToString() + redirFragment);
-                    Uri expectedUrl = new Uri(origUrl.ToString() + expectedFragment);
+                    origUrl = new UriBuilder(origUrl) { Fragment = origFragment }.Uri;
+                    Uri redirectUrl = new UriBuilder(origUrl) { Fragment = redirFragment }.Uri;
+                    if (useRelativeRedirect)
+                    {
+                        redirectUrl = new Uri(redirectUrl.GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.SafeUnescaped), UriKind.Relative);
+                    }
+                    Uri expectedUrl = new UriBuilder(origUrl) { Fragment = expectedFragment }.Uri;
 
+                    // Make and receive the first request that'll be redirected.
                     Task<HttpResponseMessage> getResponse = client.GetAsync(origUrl);
                     Task firstRequest = origServer.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.Found, $"Location: {redirectUrl}\r\n");
                     Assert.Equal(firstRequest, await Task.WhenAny(firstRequest, getResponse));
 
-                    Task secondRequest = origServer.AcceptConnectionSendResponseAndCloseAsync();
+                    // Receive the second request.
+                    Task<List<string>> secondRequest = origServer.AcceptConnectionSendResponseAndCloseAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(secondRequest, getResponse);
 
+                    // Make sure the server received the second request for the right Uri.
+                    Assert.NotEmpty(secondRequest.Result);
+                    string[] statusLineParts = secondRequest.Result[0].Split(' ');
+                    Assert.Equal(3, statusLineParts.Length);
+                    Assert.Equal(expectedUrl.GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.SafeUnescaped), statusLineParts[1]);
+
+                    // Make sure the request message was updated with the correct redirected location.
                     using (HttpResponseMessage response = await getResponse)
                     {
                         Assert.Equal(200, (int)response.StatusCode);
-                        Assert.Equal(expectedUrl, response.RequestMessage.RequestUri);
+                        Assert.Equal(expectedUrl.ToString(), response.RequestMessage.RequestUri.ToString());
                     }
                 });
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -935,8 +935,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            if (IsWinHttpHandler &&
-                (PlatformDetection.IsWindows7 || (!string.IsNullOrEmpty(origFragment) && string.IsNullOrEmpty(redirFragment))))
+            if (IsWinHttpHandler)
             {
                 // According to https://tools.ietf.org/html/rfc7231#section-7.1.2,
                 // "If the Location value provided in a 3xx (Redirection) response does
@@ -945,7 +944,8 @@ namespace System.Net.Http.Functional.Tests
                 //  URI reference used to generate the request target(i.e., the
                 //  redirection inherits the original reference's fragment, if any)."
                 // WINHTTP is not doing this, and thus neither is WinHttpHandler.
-                // It also has issues with fragments on Windows 7.
+                // It also sometimes doesn't include the fragments for redirects
+                // even in other cases.
                 return;
             }
 


### PR DESCRIPTION
SocketsHttpHandler isn't sending fragments, nor is it properly inheriting the fragment from the original request URI into the redirect location URI when the original URI had one and the redirect URI did not, even though RFC 7231 says it must.  This commit fixes that for SocketsHttpHandler.

WinHttpHandler also isn't handling this inheritance according to the RFC. It appears that the logic for WinHttpHandler would actually need to be changed in WINHTTP itself, or else WinHttpHandler would need to be changed to do the redirects itself.

Neither CurlHandler or NetFxHandler send fragments at all.

This commit also fixes the test to correctly compare the expected and actual Uris... apparently Uri equality doesn't factor in fragments, so they're first converted to strings.  It also updates the test to also validate that the server received the URI with the fragment included.

Closes https://github.com/dotnet/corefx/issues/27305
cc: @geoffkizer, @davidsh, @wfurt, @rmkerr 