### PR TITLE
[System.Runtime.InteropServices] Introduce broader platform definitions.

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -1,3 +1,4 @@
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -8,11 +9,42 @@ namespace System.Runtime.InteropServices
     {
         private readonly string _osPlatform;
 
+        public static OSPlatform Android { get; } = new OSPlatform("ANDROID");
+
+        public static OSPlatform iOS { get; } = new OSPlatform("IOS");
+
+	// Returns true for Linux, Tizen and Android systems
         public static OSPlatform Linux { get; } = new OSPlatform("LINUX");
 
+        public static OSPlatform macOS { get; } = new OSPlatform("MACOS");
+
+        public static OSPlatform N3DS { get; } = new OSPlatform("3DS");
+	
+	// This one has historically been used as "Apple platforms", so it returns true
+	// on iOS, tvOS, macOS, watchOS.
         public static OSPlatform OSX { get; } = new OSPlatform("OSX");
 
+        public static OSPlatform PlayStation4 { get; } = new OSPlatform("PS4");
+
+        public static OSPlatform PlayStationPortable2 { get; } = new OSPlatform("PSP2");
+
+        public static OSPlatform PlayStationVita { get; } = new OSPlatform("PSVITA");
+
+        public static OSPlatform Switch { get; } = new OSPlatform("SWITCH");
+	
+        public static OSPlatform Tizen { get; } = new OSPlatform("TIZEN");
+
+        public static OSPlatform tvOS { get; } = new OSPlatform("TVOS");
+
+        public static OSPlatform watchOS { get; } = new OSPlatform("WATCHOS");
+
+        public static OSPlatform WebAssembly { get; } = new OSPlatform("WEBASSEMBLY");
+
+        public static OSPlatform WiiU { get; } = new OSPlatform("WIIU");
+
         public static OSPlatform Windows { get; } = new OSPlatform("WINDOWS");
+
+        public static OSPlatform XboxOne { get; } = new OSPlatform("XBOXONE");
 
         private OSPlatform(string osPlatform)
         {

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -19,7 +19,19 @@ namespace System.Runtime.InteropServices
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {
             string name = s_osPlatformName ?? (s_osPlatformName = Interop.Sys.GetUnixName());
-            return osPlatform.Equals(name);
+            if (osPlatform.Equals(name))
+		    return true;
+	    if (osPlatform.Equals (OSPlatform.OSX)){
+		    return OSPlatform.tvOS.Equals (name) ||
+			    OSPlatform.watchOS.Equals (name) ||
+			    OSPlatform.iOS.Equals (name) ||
+			    OSPlatform.macOS.Equals (name);
+	    }
+	    if (osPlatform.Equals (OSPlatform.Linux)){
+		    return OSPlatform.Tizen.Equals (name) ||
+			    OSPlatform.Android.Equals (name);
+	    }
+	    return false;
         }
 
         public static string OSDescription


### PR DESCRIPTION
Unity, Xamarin and Mono users suffers from a historic problem with
platform detection.  This patch introduces definitions for all the
existing platforms that .NET supports beyond .NET Core via Unity and
Xamarin.

To cope with the historical setting that OSX has been used in existing
code to probe for an Apple OS (iOS, tvOS, watchOS), we introduce new
values for all four apple platforms (macOS, iOS, tvOS, watchOS) and
also return true when probed for the legacy OSX setting.

The same principle is applied to Linux, we will continue to return
true, but the more specific versions of Tizen and Android are
supported.

The list has been expanded to all the platforms currently supported by
Mono and Unity.