### PR TITLE
[release/2.1] Fix build on clang 5 (#27178)

### DIFF
--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -247,6 +247,9 @@ add_subdirectory(System.IO.Compression.Native)
 
 add_compile_options(-Weverything)
 add_compile_options(-Wno-c++98-compat-pedantic)
+if (HAVE_ZERO_AS_NULL_POINTER_CONSTANT_FLAG)
+    add_compile_options(-Wno-zero-as-null-pointer-constant)
+endif()
 
 add_subdirectory(System.Native)
 add_subdirectory(System.Net.Http.Native)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -609,6 +609,6 @@ extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const uint8_t** proto
 
 extern "C" int32_t CryptoNative_SslSetTlsExtHostName(SSL* ssl, const uint8_t* name)
 {
-    return static_cast<int32_t>(SSL_set_tlsext_host_name(ssl, name));
+    return static_cast<int32_t>(SSL_set_tlsext_host_name(ssl, const_cast<unsigned char*>(name)));
 }
 

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -1,3 +1,4 @@
+include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 include(CheckCXXSourceRuns)
 include(CheckCSourceCompiles)
@@ -28,6 +29,13 @@ endif ()
 
 # We compile with -Werror, so we need to make sure these code fragments compile without warnings.
 set(CMAKE_REQUIRED_FLAGS -Werror)
+
+# This compiler warning will fail code as innocuous as:
+# static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+# Check if the compiler knows about this warning so we can disable it
+check_cxx_compiler_flag(
+    -Wzero-as-null-pointer-constant
+    HAVE_ZERO_AS_NULL_POINTER_CONSTANT_FLAG)
 
 # in_pktinfo: Find whether this struct exists
 check_include_files(


### PR DESCRIPTION
This is a port of https://github.com/dotnet/corefx/pull/27178 to the `release/2.1` branch. It lets us build corefx with clang 5.

clang 5 is the default on some platforms supported by .NET Core 2.1, such as Fedora 27.