### PR TITLE
Use SCH_USE_STRONG_CRYPTO with SystemDefaults

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -153,7 +153,8 @@ namespace System.Net.Security
                     Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_SEND_AUX_RECORD;
 
                 // CoreFX: always opt-in SCH_USE_STRONG_CRYPTO except for SSL3.
-                if (((protocolFlags & (Interop.SChannel.SP_PROT_TLS1_0 | Interop.SChannel.SP_PROT_TLS1_1 | Interop.SChannel.SP_PROT_TLS1_2)) != 0)
+                if (((protocolFlags == 0) ||
+                        (protocolFlags & (Interop.SChannel.SP_PROT_TLS1_0 | Interop.SChannel.SP_PROT_TLS1_1 | Interop.SChannel.SP_PROT_TLS1_2)) != 0)
                      && (policy != EncryptionPolicy.AllowNoEncryption) && (policy != EncryptionPolicy.NoEncryption))
                 {
                     flags |= Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_USE_STRONG_CRYPTO;
@@ -165,6 +166,7 @@ namespace System.Net.Security
                 flags = Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_SEND_AUX_RECORD;
             }
 
+            if (NetEventSource.IsEnabled) NetEventSource.Info($"flags=({flags}), ProtocolFlags=({protocolFlags}), EncryptionPolicy={policy}");
             Interop.SspiCli.SCHANNEL_CRED secureCredential = CreateSecureCredential(
                 Interop.SspiCli.SCHANNEL_CRED.CurrentVersion,
                 certificate,

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -25,7 +25,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "CI uses old Framework version, which doesn't support SystemDefault")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "CI uses old Framework version, which doesn't support using SslProtocols.None for SystemDefaultTlsVersions behavior")]
         public async Task ClientAsyncAuthenticate_SslStreamClientServerNone_UseStrongCryptoSet()
         {
             SslProtocols protocol = SslProtocols.None;

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -25,6 +25,16 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        public async Task ClientAsyncAuthenticate_SslStreamClientServerNone_UseStrongCryptoSet()
+        {
+            SslProtocols protocol = SslProtocols.None;
+            await ClientAsyncSslHelper(protocol, protocol);
+
+            // Additional manual verification.
+            // Step into the code and verify that the 'UseStrongCrypto' flag is being set.
+        }
+
+        [Fact]
         public async Task ClientAsyncAuthenticate_ServerRequireEncryption_ConnectWithEncryption()
         {
             await ClientAsyncSslHelper(EncryptionPolicy.RequireEncryption);

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -25,13 +25,14 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "CI uses old Framework version, which doesn't support SystemDefault")]
         public async Task ClientAsyncAuthenticate_SslStreamClientServerNone_UseStrongCryptoSet()
         {
             SslProtocols protocol = SslProtocols.None;
             await ClientAsyncSslHelper(protocol, protocol);
 
             // Additional manual verification.
-            // Step into the code and verify that the 'UseStrongCrypto' flag is being set.
+            // Step into the code and verify that the 'SCH_USE_STRONG_CRYPTO' flag is being set.
         }
 
         [Fact]


### PR DESCRIPTION
The current SslStream implementation was applying SCH_USE_STRONG_CRYPTO only when TLS1.2, TLS1.1 and/or TLS1.0 flags were set. 
In .NET Core 2.0, we introduced a new TLS option (#13075), called 'SystemDefault', which means to use the best (strongest) TLS security 
protocol available in the operating system. But since SystemDefault (equal to all flag bits set to zero) doesn't match any of the TLS bit 
masks, we weren't passing in the SCH_USE_STRONG_CRYPTO flag.

This fix adds a check for SystemDefault and makes sure that the SCH_USE_STRONG_CRYPTO flag is passed to SCHANNEL.
According to the SCHANNEL experts, the current "SystemDefault' will actually use strong crypto settings on current Windows OS's. 
But they advised us that we should always pass in the SCH_USE_STRONG_CRYPTO flag when using 'SystemDefault'.

This is related to internal bug 458042.