### PR TITLE
Split up cookie headers that are added via HttpListenerResponse.WebHeaders.Add

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -313,7 +313,7 @@ namespace System.Net
                     string value = values[j];
                     if (!string.IsNullOrWhiteSpace(value))
                     {
-                        if(anyValues)
+                        if (anyValues)
                         {
                             if (key.Equals(HttpKnownHeaderNames.SetCookie, StringComparison.InvariantCultureIgnoreCase) ||
                                 key.Equals(HttpKnownHeaderNames.SetCookie2, StringComparison.InvariantCultureIgnoreCase))

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -315,8 +315,8 @@ namespace System.Net
                     {
                         if (anyValues)
                         {
-                            if (key.Equals(HttpKnownHeaderNames.SetCookie, StringComparison.InvariantCultureIgnoreCase) ||
-                                key.Equals(HttpKnownHeaderNames.SetCookie2, StringComparison.InvariantCultureIgnoreCase))
+                            if (key.Equals(HttpKnownHeaderNames.SetCookie, StringComparison.OrdinalIgnoreCase) ||
+                                key.Equals(HttpKnownHeaderNames.SetCookie2, StringComparison.OrdinalIgnoreCase))
                             {
                                 sb.Append("\r\n").Append(key).Append(": ");
                             }

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -313,9 +313,16 @@ namespace System.Net
                     string value = values[j];
                     if (!string.IsNullOrWhiteSpace(value))
                     {
-                        if (anyValues)
+                        if(anyValues)
                         {
-                            sb.Append(", ");
+                            if (key.Equals("Set-Cookie", StringComparison.InvariantCultureIgnoreCase) || key.Equals("Set-Cookie2", StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                sb.Append("\r\n").Append(key).Append(": ");
+                            }
+                            else
+                            {
+                                sb.Append(", ");
+                            }
                         }
                         sb.Append(value);
                         anyValues = true;

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -315,7 +315,8 @@ namespace System.Net
                     {
                         if(anyValues)
                         {
-                            if (key.Equals("Set-Cookie", StringComparison.InvariantCultureIgnoreCase) || key.Equals("Set-Cookie2", StringComparison.InvariantCultureIgnoreCase))
+                            if (key.Equals(HttpKnownHeaderNames.SetCookie, StringComparison.InvariantCultureIgnoreCase) ||
+                                key.Equals(HttpKnownHeaderNames.SetCookie2, StringComparison.InvariantCultureIgnoreCase))
                             {
                                 sb.Append("\r\n").Append(key).Append(": ");
                             }

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -128,7 +128,7 @@ namespace System.Net.Tests
 
             response.Close();
 
-            string clientResponse = GetClientResponse(173);
+            string clientResponse = GetClientResponse(expectedLength:173);
             Assert.Contains($"\r\nSet-Cookie: name1=value1\r\n", clientResponse);
             Assert.Contains($"\r\nSet-Cookie2: name2=value2\r\n", clientResponse);
         }
@@ -147,7 +147,7 @@ namespace System.Net.Tests
             Assert.Null(response.Headers["Set-Cookie"]);
             Assert.Equal("name3=value3; Port=\"200\"; Version=1", response.Headers["Set-Cookie2"]);
 
-            string clientResponse = GetClientResponse(170);
+            string clientResponse = GetClientResponse(expectedLength:170);
             Assert.DoesNotContain("Set-Cookie:", clientResponse);
             Assert.Contains($"\r\nSet-Cookie2: name3=value3; Port=\"200\"; Version=1\r\n", clientResponse);
         }
@@ -166,7 +166,7 @@ namespace System.Net.Tests
             Assert.Equal("name3=value3", response.Headers["Set-Cookie"]);
             Assert.Null(response.Headers["Set-Cookie2"]);
 
-            string clientResponse = GetClientResponse(146);
+            string clientResponse = GetClientResponse(expectedLength:146);
             Assert.Contains($"\r\nSet-Cookie: name3=value3\r\n", clientResponse);
             Assert.DoesNotContain("Set-Cookie2", clientResponse);
         }
@@ -182,7 +182,7 @@ namespace System.Net.Tests
 
             response.Close();
 
-            string clientResponse = GetClientResponse(224);
+            string clientResponse = GetClientResponse(expectedLength:224);
             Assert.Contains($"\r\nSet-Cookie: name1=value1\r\n", clientResponse);
             Assert.Contains($"\r\nSet-Cookie: name2=value2\r\n", clientResponse);
             Assert.Contains($"\r\nSet-Cookie: name3=value3\r\n", clientResponse);

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -177,12 +177,16 @@ namespace System.Net.Tests
             HttpListenerResponse response = await GetResponse();
             response.Headers.Add("Set-Cookie", "name1=value1");
             response.Headers.Add("Set-Cookie", "name2=value2");
+            response.Headers.Add("Set-Cookie", "name3=value3");
+            response.Headers.Add("Set-Cookie", "name4=value4");
 
             response.Close();
 
-            string clientResponse = GetClientResponse(172);
+            string clientResponse = GetClientResponse(224);
             Assert.Contains($"\r\nSet-Cookie: name1=value1\r\n", clientResponse);
             Assert.Contains($"\r\nSet-Cookie: name2=value2\r\n", clientResponse);
+            Assert.Contains($"\r\nSet-Cookie: name3=value3\r\n", clientResponse);
+            Assert.Contains($"\r\nSet-Cookie: name4=value4\r\n", clientResponse);
         }
 
         [Fact]

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -170,6 +170,21 @@ namespace System.Net.Tests
             Assert.Contains($"\r\nSet-Cookie: name3=value3\r\n", clientResponse);
             Assert.DoesNotContain("Set-Cookie2", clientResponse);
         }
+  
+        [Fact]
+        public async Task Cookies_AddMultipleInHeader_ClientReceivesExpectedHeaders()
+        {
+            HttpListenerResponse response = await GetResponse();
+            response.Headers.Add("Set-Cookie", "name1=value1");
+             response.Headers.Add("Set-Cookie", "name2=value2");
+
+            response.Close();
+
+            string clientResponse = GetClientResponse(174);
+            Assert.Contains($"\r\nSet-Cookie: name1=value1\r\n", clientResponse);
+            Assert.Contains($"\r\nSet-Cookie: name2=value2\r\n", clientResponse);
+        }
+
 
         [Fact]
         public async Task AppendCookie_ValidCookie_AddsCookieToCollection()

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -180,7 +180,7 @@ namespace System.Net.Tests
 
             response.Close();
 
-            string clientResponse = GetClientResponse(174);
+            string clientResponse = GetClientResponse(172);
             Assert.Contains($"\r\nSet-Cookie: name1=value1\r\n", clientResponse);
             Assert.Contains($"\r\nSet-Cookie: name2=value2\r\n", clientResponse);
         }

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -129,8 +129,8 @@ namespace System.Net.Tests
             response.Close();
 
             string clientResponse = GetClientResponse(expectedLength:173);
-            Assert.Contains($"\r\nSet-Cookie: name1=value1\r\n", clientResponse);
-            Assert.Contains($"\r\nSet-Cookie2: name2=value2\r\n", clientResponse);
+            Assert.Contains("\r\nSet-Cookie: name1=value1\r\n", clientResponse);
+            Assert.Contains("\r\nSet-Cookie2: name2=value2\r\n", clientResponse);
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace System.Net.Tests
 
             string clientResponse = GetClientResponse(expectedLength:170);
             Assert.DoesNotContain("Set-Cookie:", clientResponse);
-            Assert.Contains($"\r\nSet-Cookie2: name3=value3; Port=\"200\"; Version=1\r\n", clientResponse);
+            Assert.Contains("\r\nSet-Cookie2: name3=value3; Port=\"200\"; Version=1\r\n", clientResponse);
         }
 
         [Fact]
@@ -167,7 +167,7 @@ namespace System.Net.Tests
             Assert.Null(response.Headers["Set-Cookie2"]);
 
             string clientResponse = GetClientResponse(expectedLength:146);
-            Assert.Contains($"\r\nSet-Cookie: name3=value3\r\n", clientResponse);
+            Assert.Contains("\r\nSet-Cookie: name3=value3\r\n", clientResponse);
             Assert.DoesNotContain("Set-Cookie2", clientResponse);
         }
   
@@ -183,10 +183,10 @@ namespace System.Net.Tests
             response.Close();
 
             string clientResponse = GetClientResponse(expectedLength:224);
-            Assert.Contains($"\r\nSet-Cookie: name1=value1\r\n", clientResponse);
-            Assert.Contains($"\r\nSet-Cookie: name2=value2\r\n", clientResponse);
-            Assert.Contains($"\r\nSet-Cookie: name3=value3\r\n", clientResponse);
-            Assert.Contains($"\r\nSet-Cookie: name4=value4\r\n", clientResponse);
+            Assert.Contains("\r\nSet-Cookie: name1=value1\r\n", clientResponse);
+            Assert.Contains("\r\nSet-Cookie: name2=value2\r\n", clientResponse);
+            Assert.Contains("\r\nSet-Cookie: name3=value3\r\n", clientResponse);
+            Assert.Contains("\r\nSet-Cookie: name4=value4\r\n", clientResponse);
         }
 
         [Fact]

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -176,7 +176,7 @@ namespace System.Net.Tests
         {
             HttpListenerResponse response = await GetResponse();
             response.Headers.Add("Set-Cookie", "name1=value1");
-             response.Headers.Add("Set-Cookie", "name2=value2");
+            response.Headers.Add("Set-Cookie", "name2=value2");
 
             response.Close();
 
@@ -184,7 +184,6 @@ namespace System.Net.Tests
             Assert.Contains($"\r\nSet-Cookie: name1=value1\r\n", clientResponse);
             Assert.Contains($"\r\nSet-Cookie: name2=value2\r\n", clientResponse);
         }
-
 
         [Fact]
         public async Task AppendCookie_ValidCookie_AddsCookieToCollection()


### PR DESCRIPTION
This fixes an inconsistency between the Windows and Managed implementation of  HttpListenerResponse.

Basically, there are two ways to add cookies to an HttpListenerResponse. The 'usual' way is to add them to the cookie collection:
```
response.Cookies = cookies;
```
On Unix and on Windows that yields the following Set-Cookie header:
```
Set-Cookie: name1=value1, name2=value2
```
In this case though the user is setting the headers by adding them directly:
```
foreach (var c in cookies)
{
    HttpListenerResponse.Headers.Add("Set-Cookie",c);
}
```
According to the relevant documentation for WebHeaderCollection.Add headers added more than once will be added in a comma separated list. So, even adding the headers directly, we expect the same result. That is true on Unix, and we get the following header:
```
Set-Cookie: name1=value1,name2=value2
```
However, on Windows we see an unexpected result:
```
Set-Cookie: name1=value1
Set-Cookie: name2=value2
```
While both behaviors are acceptable, I think that the Windows behavior was intentionally added. That is based off of this comment in the relevant code:
https://github.com/dotnet/corefx/blob/3db29b721a45fb4f300e27c5df5750f57b38ec45/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs#L460-L482
This PR ensures that the managed implementation follows the same behavior as the Windows version. I think that should also update the documentation to reflect this behavior, since it seems to be by design.

Fixes: #22910 