### PR TITLE
Stop FileSystem WriteAsync test from writing too much data to disk

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -389,7 +389,6 @@ namespace System.IO.Tests
             do
             {
 
-                CancellationTokenSource tokenSource = new CancellationTokenSource();
                 int totalBytesWritten = 0;
 
                 using (var stream = new FileStream(writeFileName, FileMode.Create, FileAccess.Write))
@@ -407,7 +406,7 @@ namespace System.IO.Tests
                         else
                         {
                             // 90%: Async write
-                            await WriteAsync(stream, dataToWrite, 0, bytesToWrite, tokenSource.Token);
+                            await WriteAsync(stream, dataToWrite, 0, bytesToWrite);
                         }
 
                         totalBytesWritten += bytesToWrite;

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -418,7 +418,7 @@ namespace System.IO.Tests
                         }
                     } while (!tokenSource.Token.IsCancellationRequested);
                 }
-            } while (DateTime.UtcNow - testStartTime <= testRunTime);
+            } while (DateTime.UtcNow - testStartTime <= testRunTime && totalBytesWritten < 10000000);
         }
     }
 

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -385,6 +385,8 @@ namespace System.IO.Tests
             byte[] dataToWrite = new byte[MaximumWriteSize];
             rand.NextBytes(dataToWrite);
 
+            int totalBytesWritten = 0;
+
             string writeFileName = GetTestFilePath();
             do
             {
@@ -411,6 +413,8 @@ namespace System.IO.Tests
                                 // 90%: Async write
                                 await WriteAsync(stream, dataToWrite, 0, bytesToWrite, tokenSource.Token);
                             }
+
+                            totalBytesWritten += bytesToWrite;
                         }
                         catch (TaskCanceledException)
                         {


### PR DESCRIPTION
For https://github.com/dotnet/corefx/issues/24505

@danmosemsft PTAL