### PR TITLE
Enable RSA-OAEP(SHA-2) and RSA-PSS on Unix systems

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
+++ b/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
@@ -27,7 +27,14 @@ internal static partial class Interop
             try
             {
                 cfData.DangerousAddRef(ref addedRef);
-                byte[] bytes = new byte[CFDataGetLength(cfData).ToInt64()];
+                long length = CFDataGetLength(cfData).ToInt64();
+
+                if (length == 0)
+                {
+                    return Array.Empty<byte>();
+                }
+
+                byte[] bytes = new byte[length];
 
                 unsafe
                 {
@@ -61,10 +68,13 @@ internal static partial class Interop
                     return false;
                 }
 
-                byte* dataBytes = CFDataGetBytePtr(cfData);
-                fixed (byte* destinationPtr = &MemoryMarshal.GetReference(destination))
+                if (length > 0)
                 {
-                    Buffer.MemoryCopy(dataBytes, destinationPtr, destination.Length, length);
+                    byte* dataBytes = CFDataGetBytePtr(cfData);
+                    fixed (byte* destinationPtr = &MemoryMarshal.GetReference(destination))
+                    {
+                        Buffer.MemoryCopy(dataBytes, destinationPtr, destination.Length, length);
+                    }
                 }
 
                 bytesWritten = (int)length;

--- a/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
+++ b/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
@@ -62,14 +62,15 @@ internal static partial class Interop
                 cfData.DangerousAddRef(ref addedRef);
 
                 long length = CFDataGetLength(cfData).ToInt64();
-                if (destination.Length < length)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
 
                 if (length > 0)
                 {
+                    if (destination.Length < length)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
                     byte* dataBytes = CFDataGetBytePtr(cfData);
                     fixed (byte* destinationPtr = &MemoryMarshal.GetReference(destination))
                     {

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -21,6 +21,38 @@ internal static partial class Interop
             out SafeSecKeyRefHandle pPrivateKey,
             out int pOSStatus);
 
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_RsaSignaturePrimitive(
+            SafeSecKeyRefHandle privateKey,
+            ref byte pbData,
+            int cbData,
+            out SafeCFDataHandle pDataOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_RsaVerificationPrimitive(
+            SafeSecKeyRefHandle publicKey,
+            ref byte pbData,
+            int cbData,
+            out SafeCFDataHandle pDataOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_RsaDecryptionPrimitive(
+            SafeSecKeyRefHandle privateKey,
+            ref byte pbData,
+            int cbData,
+            out SafeCFDataHandle pDataOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_RsaEncryptionPrimitive(
+            SafeSecKeyRefHandle publicKey,
+            ref byte pbData,
+            int cbData,
+            out SafeCFDataHandle pDataOut,
+            out SafeCFErrorHandle pErrorOut);
+
         private static int RsaEncryptOaep(
             SafeSecKeyRefHandle publicKey,
             ReadOnlySpan<byte> pbData,
@@ -218,6 +250,94 @@ internal static partial class Interop
                         RsaDecryptPkcs(privateKey, innerSource, innerSource.Length, out outputHandle, out errorHandle) :
                         RsaDecryptOaep(privateKey, innerSource, innerSource.Length, PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm), out outputHandle, out errorHandle);
                 });
+        }
+
+        private static bool ProcessPrimitiveResponse(
+            int returnValue,
+            SafeCFDataHandle cfData,
+            SafeCFErrorHandle cfError,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            const int kErrorSeeError = -2;
+            const int kSuccess = 1;
+
+            if (returnValue == kErrorSeeError)
+            {
+                throw CreateExceptionForCFError(cfError);
+            }
+
+            if (returnValue == kSuccess && !cfData.IsInvalid)
+            {
+                return CoreFoundation.TryCFWriteData(cfData, destination, out bytesWritten);
+            }
+
+            Debug.Fail($"Unknown return value ({returnValue}) or no data object returned");
+            throw new CryptographicException();
+        }
+
+        internal static bool TryRsaDecryptionPrimitive(
+            SafeSecKeyRefHandle privateKey,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            int returnValue = AppleCryptoNative_RsaDecryptionPrimitive(
+                privateKey,
+                ref MemoryMarshal.GetReference(source),
+                source.Length,
+                out SafeCFDataHandle cfData,
+                out SafeCFErrorHandle cfError);
+
+            return ProcessPrimitiveResponse(returnValue, cfData, cfError, destination, out bytesWritten);
+        }
+
+        internal static bool TryRsaEncryptionPrimitive(
+            SafeSecKeyRefHandle publicKey,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            int returnValue = AppleCryptoNative_RsaEncryptionPrimitive(
+                publicKey,
+                ref MemoryMarshal.GetReference(source),
+                source.Length,
+                out SafeCFDataHandle cfData,
+                out SafeCFErrorHandle cfError);
+
+            return ProcessPrimitiveResponse(returnValue, cfData, cfError, destination, out bytesWritten);
+        }
+
+        internal static bool TryRsaSignaturePrimitive(
+            SafeSecKeyRefHandle privateKey,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            int returnValue = AppleCryptoNative_RsaSignaturePrimitive(
+                privateKey,
+                ref MemoryMarshal.GetReference(source),
+                source.Length,
+                out SafeCFDataHandle cfData,
+                out SafeCFErrorHandle cfError);
+
+            return ProcessPrimitiveResponse(returnValue, cfData, cfError, destination, out bytesWritten);
+        }
+
+        internal static bool TryRsaVerificationPrimitive(
+            SafeSecKeyRefHandle publicKey,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            int returnValue = AppleCryptoNative_RsaVerificationPrimitive(
+                publicKey,
+                ref MemoryMarshal.GetReference(source),
+                source.Length,
+                out SafeCFDataHandle cfData,
+                out SafeCFErrorHandle cfError);
+
+            return ProcessPrimitiveResponse(returnValue, cfData, cfError, destination, out bytesWritten);
         }
 
         private static PAL_HashAlgorithm PalAlgorithmFromAlgorithmName(HashAlgorithmName hashAlgorithmName) =>

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
@@ -57,6 +57,32 @@ internal static partial class Interop
             SafeRsaHandle rsa,
             RsaPadding padding);
 
+        internal static int RsaSignPrimitive(
+            ReadOnlySpan<byte> from,
+            Span<byte> to,
+            SafeRsaHandle rsa) =>
+            RsaSignPrimitive(from.Length, ref MemoryMarshal.GetReference(from), ref MemoryMarshal.GetReference(to), rsa);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaSignPrimitive")]
+        private static extern int RsaSignPrimitive(
+            int flen,
+            ref byte from,
+            ref byte to,
+            SafeRsaHandle rsa);
+
+        internal static int RsaVerificationPrimitive(
+            ReadOnlySpan<byte> from,
+            Span<byte> to,
+            SafeRsaHandle rsa) =>
+            RsaVerificationPrimitive(from.Length, ref MemoryMarshal.GetReference(from), ref MemoryMarshal.GetReference(to), rsa);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaVerificationPrimitive")]
+        private static extern int RsaVerificationPrimitive(
+            int flen,
+            ref byte from,
+            ref byte to,
+            SafeRsaHandle rsa);
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaSize")]
         internal static extern int RsaSize(SafeRsaHandle rsa);
 
@@ -168,6 +194,7 @@ internal static partial class Interop
         {
             Pkcs1 = 0,
             OaepSHA1 = 1,
+            NoPadding = 2,
         }
     }
 }

--- a/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography
             {
                 if (encrypt && data.Length == 0)
                 {
-                    int bufSize = (KeySize + 7) / 8;
+                    int bufSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
                     byte[] rented = ArrayPool<byte>.Shared.Rent(bufSize);
                     Span<byte> paddedMessage = new Span<byte>(rented, 0, bufSize);
 
@@ -126,7 +126,7 @@ namespace System.Security.Cryptography
             {
                 if (encrypt && data.Length == 0)
                 {
-                    int bufSize = (KeySize + 7) / 8;
+                    int bufSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
                     byte[] rented = ArrayPool<byte>.Shared.Rent(bufSize);
                     Span<byte> paddedMessage = new Span<byte>(rented, 0, bufSize);
 

--- a/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -62,13 +62,13 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(padding));
             }
 
+            if (hash.Length != GetHashSizeInBytes(hashAlgorithm))
+            {
+                throw new CryptographicException(SR.Cryptography_SignHash_WrongSize);
+            }
+
             using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
             {
-                if (hash.Length != GetHashSizeInBytes(hashAlgorithm))
-                {
-                    throw new CryptographicException(SR.Cryptography_SignHash_WrongSize);
-                }
-
                 IntPtr namePtr = Marshal.StringToHGlobalUni(hashAlgorithmName);
                 try
                 {

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 
@@ -88,65 +89,117 @@ namespace System.Security.Cryptography
             if (padding == null)
                 throw new ArgumentNullException(nameof(padding));
 
-            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding);
+            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor oaepProcessor);
             SafeRsaHandle key = _key.Value;
             CheckInvalidKey(key);
 
-            byte[] buf = new byte[Interop.Crypto.RsaSize(key)];
+            int rsaSize = Interop.Crypto.RsaSize(key);
+            byte[] buf = null;
 
-            int returnValue = Interop.Crypto.RsaPrivateDecrypt(
-                data.Length,
-                data,
-                buf,
-                key,
-                rsaPadding);
-
-            CheckReturn(returnValue);
-
-            // If the padding mode is RSA_NO_PADDING then the size of the decrypted block
-            // will be RSA_size, so let's just return buf.
-            //
-            // If any padding was used, then some amount (determined by the padding algorithm)
-            // will have been reduced, and only returnValue bytes were part of the decrypted
-            // body, so copy the decrypted bytes to an appropriately sized array before
-            // returning it.
-            if (returnValue == buf.Length)
+            try
             {
-                return buf;
-            }
+                buf = ArrayPool<byte>.Shared.Rent(rsaSize);
+                Span<byte> destination = new Span<byte>(buf, 0, rsaSize);
 
-            byte[] plainBytes = new byte[returnValue];
-            Buffer.BlockCopy(buf, 0, plainBytes, 0, returnValue);
-            return plainBytes;
+                if (!TryDecrypt(key, data, destination, rsaPadding, oaepProcessor, out int bytesWritten))
+                {
+                    Debug.Fail($"{nameof(TryDecrypt)} should not return false for RSA_size buffer");
+                    throw new CryptographicException();
+                }
+
+                return destination.Slice(0, bytesWritten).ToArray();
+            }
+            finally
+            {
+                if (buf != null)
+                {
+                    Array.Clear(buf, 0, rsaSize);
+                    ArrayPool<byte>.Shared.Return(buf);
+                }
+            }
         }
 
-        public override bool TryDecrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        public override bool TryDecrypt(
+            ReadOnlySpan<byte> data,
+            Span<byte> destination,
+            RSAEncryptionPadding padding,
+            out int bytesWritten)
         {
             if (padding == null)
             {
                 throw new ArgumentNullException(nameof(padding));
             }
 
-            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding);
+            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor oaepProcessor);
             SafeRsaHandle key = _key.Value;
             CheckInvalidKey(key);
 
-            if (destination.Length < Interop.Crypto.RsaSize(key))
+            return TryDecrypt(key, data, destination, rsaPadding, oaepProcessor, out bytesWritten);
+        }
+
+        private static bool TryDecrypt(
+            SafeRsaHandle key,
+            ReadOnlySpan<byte> data,
+            Span<byte> destination,
+            Interop.Crypto.RsaPadding rsaPadding,
+            RsaPaddingProcessor rsaPaddingProcessor,
+            out int bytesWritten)
+        {
+            // If rsaPadding is PKCS1 or OAEP-SHA1 then no depadding method should be present.
+            // If rsaPadding is NoPadding then a depadding method should be present.
+            Debug.Assert(
+                (rsaPadding == Interop.Crypto.RsaPadding.NoPadding) ==
+                (rsaPaddingProcessor != null));
+
+            // Caller should have already checked this.
+            Debug.Assert(!key.IsInvalid);
+
+            int rsaSize = Interop.Crypto.RsaSize(key);
+
+            if (destination.Length < rsaSize)
             {
                 bytesWritten = 0;
                 return false;
             }
 
-            int returnValue = Interop.Crypto.RsaPrivateDecrypt(data.Length, data, destination, key, rsaPadding);
-            CheckReturn(returnValue);
+            Span<byte> decryptBuf = destination;
+            byte[] paddingBuf = null;
 
-            // If the padding mode is RSA_NO_PADDING then the size of the decrypted block
-            // will be RSA_size. If any padding was used, then some amount (determined by the padding algorithm)
-            // will have been reduced, and only returnValue bytes were part of the decrypted
-            // body.  Either way, we can just use returnValue, but some additional bytes may have been overwritten
-            // in the destination span.
-            bytesWritten = returnValue;
-            return true;
+            if (rsaPaddingProcessor != null)
+            {
+                paddingBuf = ArrayPool<byte>.Shared.Rent(rsaSize);
+                decryptBuf = paddingBuf;
+            }
+
+            try
+            {
+                int returnValue = Interop.Crypto.RsaPrivateDecrypt(data.Length, data, decryptBuf, key, rsaPadding);
+                CheckReturn(returnValue);
+
+                if (rsaPaddingProcessor != null)
+                {
+                    return rsaPaddingProcessor.DepadOaep(paddingBuf, destination, out bytesWritten);
+                }
+                else
+                {
+                    // If the padding mode is RSA_NO_PADDING then the size of the decrypted block
+                    // will be RSA_size. If any padding was used, then some amount (determined by the padding algorithm)
+                    // will have been reduced, and only returnValue bytes were part of the decrypted
+                    // body.  Either way, we can just use returnValue, but some additional bytes may have been overwritten
+                    // in the destination span.
+                    bytesWritten = returnValue;
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (paddingBuf != null)
+                {
+                    Array.Clear(paddingBuf, 0, rsaSize);
+                    ArrayPool<byte>.Shared.Return(paddingBuf);
+                }
+            }
         }
 
         public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
@@ -156,20 +209,25 @@ namespace System.Security.Cryptography
             if (padding == null)
                 throw new ArgumentNullException(nameof(padding));
 
-            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding);
+            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor oaepProcessor);
             SafeRsaHandle key = _key.Value;
             CheckInvalidKey(key);
 
             byte[] buf = new byte[Interop.Crypto.RsaSize(key)];
 
-            int returnValue = Interop.Crypto.RsaPublicEncrypt(
-                data.Length,
+            bool encrypted = TryEncrypt(
+                key,
                 data,
                 buf,
-                key,
-                rsaPadding);
+                rsaPadding,
+                oaepProcessor,
+                out int bytesWritten);
 
-            CheckReturn(returnValue);
+            if (!encrypted || bytesWritten != buf.Length)
+            {
+                Debug.Fail("TryEncrypt behaved unexpectedly");
+                throw new CryptographicException();
+            }
 
             return buf;
         }
@@ -181,27 +239,87 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(padding));
             }
 
-            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding);
+            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor oaepProcessor);
             SafeRsaHandle key = _key.Value;
             CheckInvalidKey(key);
 
-            if (destination.Length < Interop.Crypto.RsaSize(key))
+            return TryEncrypt(key, data, destination, rsaPadding, oaepProcessor, out bytesWritten);
+        }
+
+        private static bool TryEncrypt(
+            SafeRsaHandle key,
+            ReadOnlySpan<byte> data,
+            Span<byte> destination,
+            Interop.Crypto.RsaPadding rsaPadding,
+            RsaPaddingProcessor rsaPaddingProcessor,
+            out int bytesWritten)
+        {
+            int rsaSize = Interop.Crypto.RsaSize(key);
+
+            if (destination.Length < rsaSize)
             {
                 bytesWritten = 0;
                 return false;
             }
 
-            int returnValue = Interop.Crypto.RsaPublicEncrypt(data.Length, data, destination, key, rsaPadding);
+            int returnValue;
+
+            if (rsaPaddingProcessor != null)
+            {
+                Debug.Assert(rsaPadding == Interop.Crypto.RsaPadding.NoPadding);
+                byte[] rented = ArrayPool<byte>.Shared.Rent(rsaSize);
+                Span<byte> tmp = new Span<byte>(rented, 0, rsaSize);
+
+                try
+                {
+                    rsaPaddingProcessor.PadOaep(data, tmp);
+                    returnValue = Interop.Crypto.RsaPublicEncrypt(tmp.Length, tmp, destination, key, rsaPadding);
+                }
+                finally
+                {
+                    tmp.Clear();
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
+            }
+            else
+            {
+                Debug.Assert(rsaPadding != Interop.Crypto.RsaPadding.NoPadding);
+
+                returnValue = Interop.Crypto.RsaPublicEncrypt(data.Length, data, destination, key, rsaPadding);
+            }
+
             CheckReturn(returnValue);
 
             bytesWritten = returnValue;
+            Debug.Assert(returnValue == rsaSize);
             return true;
+
         }
 
-        private static Interop.Crypto.RsaPadding GetInteropPadding(RSAEncryptionPadding padding) =>
-            padding == RSAEncryptionPadding.Pkcs1 ? Interop.Crypto.RsaPadding.Pkcs1 :
-            padding == RSAEncryptionPadding.OaepSHA1 ? Interop.Crypto.RsaPadding.OaepSHA1 :
+        private static Interop.Crypto.RsaPadding GetInteropPadding(
+            RSAEncryptionPadding padding,
+            out RsaPaddingProcessor rsaPaddingProcessor)
+        {
+            if (padding == RSAEncryptionPadding.Pkcs1)
+            {
+                rsaPaddingProcessor = null;
+                return Interop.Crypto.RsaPadding.Pkcs1;
+            }
+
+            if (padding == RSAEncryptionPadding.OaepSHA1)
+            {
+                rsaPaddingProcessor = null;
+                return Interop.Crypto.RsaPadding.OaepSHA1;
+            }
+
+            if (padding.Mode == RSAEncryptionPaddingMode.Oaep)
+            {
+                rsaPaddingProcessor = RsaPaddingProcessor.OpenProcessor(padding.OaepHashAlgorithm);
+                return Interop.Crypto.RsaPadding.NoPadding;
+            }
+
             throw PaddingModeNotSupported();
+        }
 
         public override RSAParameters ExportParameters(bool includePrivateParameters)
         {
@@ -400,43 +518,29 @@ namespace System.Security.Cryptography
                 throw HashAlgorithmNameNullOrEmpty();
             if (padding == null)
                 throw new ArgumentNullException(nameof(padding));
-            if (padding != RSASignaturePadding.Pkcs1)
-                throw PaddingModeNotSupported();
 
-            return SignHash(hash, hashAlgorithm);
-        }
-
-        private byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithmName)
-        {
-            int algorithmNid = GetAlgorithmNid(hashAlgorithmName);
-            SafeRsaHandle rsa = _key.Value;
-            byte[] signature = new byte[Interop.Crypto.RsaSize(rsa)];
-            int signatureSize;
-
-            bool success = Interop.Crypto.RsaSign(
-                algorithmNid,
+            if (!TrySignHash(
                 hash,
-                hash.Length,
-                signature,
-                out signatureSize,
-                rsa);
-
-            if (!success)
+                Span<byte>.Empty,
+                hashAlgorithm, padding,
+                true,
+                out int bytesWritten,
+                out byte[] signature))
             {
-                throw Interop.Crypto.CreateOpenSslCryptographicException();
+                Debug.Fail("TrySignHash should not return false in allocation mode");
+                throw new CryptographicException();
             }
 
-            Debug.Assert(
-                signatureSize == signature.Length,
-                "RSA_sign reported an unexpected signature size",
-                "RSA_sign reported signatureSize was {0}, when {1} was expected",
-                signatureSize,
-                signature.Length);
-
+            Debug.Assert(signature != null);
             return signature;
         }
 
-        public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        public override bool TrySignHash(
+            ReadOnlySpan<byte> hash,
+            Span<byte> destination,
+            HashAlgorithmName hashAlgorithm,
+            RSASignaturePadding padding,
+            out int bytesWritten)
         {
             if (string.IsNullOrEmpty(hashAlgorithm.Name))
             {
@@ -446,30 +550,110 @@ namespace System.Security.Cryptography
             {
                 throw new ArgumentNullException(nameof(padding));
             }
-            if (padding != RSASignaturePadding.Pkcs1)
+
+            bool ret = TrySignHash(
+                hash,
+                destination,
+                hashAlgorithm,
+                padding,
+                false,
+                out bytesWritten,
+                out byte[] alloced);
+
+            Debug.Assert(alloced == null);
+            return ret;
+        }
+
+        private bool TrySignHash(
+            ReadOnlySpan<byte> hash,
+            Span<byte> destination,
+            HashAlgorithmName hashAlgorithm,
+            RSASignaturePadding padding,
+            bool allocateSignature,
+            out int bytesWritten,
+            out byte[] signature)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+            Debug.Assert(padding != null);
+
+            signature = null;
+
+            // Do not factor out getting _key.Value, since the key creation should not happen on
+            // invalid padding modes.
+
+            if (padding.Mode == RSASignaturePaddingMode.Pkcs1)
             {
-                throw PaddingModeNotSupported();
+                int algorithmNid = GetAlgorithmNid(hashAlgorithm);
+                SafeRsaHandle rsa = _key.Value;
+
+                int bytesRequired = Interop.Crypto.RsaSize(rsa);
+
+                if (allocateSignature)
+                {
+                    Debug.Assert(destination.Length == 0);
+                    signature = new byte[bytesRequired];
+                    destination = signature;
+                }
+
+                if (destination.Length < bytesRequired)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                if (!Interop.Crypto.RsaSign(algorithmNid, hash, hash.Length, destination, out int signatureSize, rsa))
+                {
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
+                }
+
+                Debug.Assert(
+                    signatureSize == bytesRequired,
+                    $"RSA_sign reported signatureSize was {signatureSize}, when {bytesRequired} was expected");
+
+                bytesWritten = signatureSize;
+                return true;
+            }
+            else if (padding.Mode == RSASignaturePaddingMode.Pss)
+            {
+                RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(hashAlgorithm);
+                SafeRsaHandle rsa = _key.Value;
+
+                int bytesRequired = Interop.Crypto.RsaSize(rsa);
+
+                if (allocateSignature)
+                {
+                    Debug.Assert(destination.Length == 0);
+                    signature = new byte[bytesRequired];
+                    destination = signature;
+                }
+
+                if (destination.Length < bytesRequired)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                byte[] pssRented = ArrayPool<byte>.Shared.Rent(bytesRequired);
+                Span<byte> pssBytes = new Span<byte>(pssRented, 0, bytesRequired);
+
+                processor.EncodePss(hash, pssBytes, KeySize);
+
+                int ret = Interop.Crypto.RsaSignPrimitive(pssBytes, destination, rsa);
+
+                pssBytes.Clear();
+                ArrayPool<byte>.Shared.Return(pssRented);
+
+                CheckReturn(ret);
+
+                Debug.Assert(
+                    ret == signature.Length,
+                    $"RSA_private_encrypt returned {ret} when {signature.Length} was expected");
+
+                bytesWritten = ret;
+                return true;
             }
 
-            int algorithmNid = GetAlgorithmNid(hashAlgorithm);
-            SafeRsaHandle rsa = _key.Value;
-
-            int bytesRequired = Interop.Crypto.RsaSize(rsa);
-            if (destination.Length < bytesRequired)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            int signatureSize;
-            if (!Interop.Crypto.RsaSign(algorithmNid, hash, hash.Length, destination, out signatureSize, rsa))
-            {
-                throw Interop.Crypto.CreateOpenSslCryptographicException();
-            }
-
-            Debug.Assert(signatureSize == bytesRequired, $"RSA_sign reported signatureSize was {signatureSize}, when {bytesRequired} was expected");
-            bytesWritten = signatureSize;
-            return true;
+            throw PaddingModeNotSupported();
         }
 
         public override bool VerifyHash(
@@ -500,14 +684,53 @@ namespace System.Security.Cryptography
             {
                 throw new ArgumentNullException(nameof(padding));
             }
-            if (padding != RSASignaturePadding.Pkcs1)
+
+            if (padding == RSASignaturePadding.Pkcs1)
             {
-                throw PaddingModeNotSupported();
+                int algorithmNid = GetAlgorithmNid(hashAlgorithm);
+                SafeRsaHandle rsa = _key.Value;
+                return Interop.Crypto.RsaVerify(algorithmNid, hash, hash.Length, signature, signature.Length, rsa);
+            }
+            else if (padding == RSASignaturePadding.Pss)
+            {
+                RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(hashAlgorithm);
+                SafeRsaHandle rsa = _key.Value;
+
+                int requiredBytes = Interop.Crypto.RsaSize(rsa);
+
+                if (signature.Length != requiredBytes)
+                {
+                    return false;
+                }
+
+                if (hash.Length != processor.HashLength)
+                {
+                    return false;
+                }
+
+                byte[] rented = ArrayPool<byte>.Shared.Rent(requiredBytes);
+                Span<byte> unwrapped = new Span<byte>(rented, 0, requiredBytes);
+
+                try
+                {
+                    int ret = Interop.Crypto.RsaVerificationPrimitive(signature, unwrapped, rsa);
+
+                    CheckReturn(ret);
+
+                    Debug.Assert(
+                        ret == requiredBytes,
+                        $"RSA_private_encrypt returned {ret} when {requiredBytes} was expected");
+
+                    return processor.VerifyPss(hash, unwrapped, KeySize);
+                }
+                finally
+                {
+                    unwrapped.Clear();
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
             }
 
-            int algorithmNid = GetAlgorithmNid(hashAlgorithm);
-            SafeRsaHandle rsa = _key.Value;
-            return Interop.Crypto.RsaVerify(algorithmNid, hash, hash.Length, signature, signature.Length, rsa);
+            throw PaddingModeNotSupported();
         }
 
         private static int GetAlgorithmNid(HashAlgorithmName hashAlgorithmName)

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -277,7 +277,7 @@ namespace System.Security.Cryptography
                 }
                 finally
                 {
-                    tmp.Clear();
+                    CryptographicOperations.ZeroMemory(tmp);
                     ArrayPool<byte>.Shared.Return(rented);
                 }
             }

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -646,8 +646,8 @@ namespace System.Security.Cryptography
                 CheckReturn(ret);
 
                 Debug.Assert(
-                    ret == signature.Length,
-                    $"RSA_private_encrypt returned {ret} when {signature.Length} was expected");
+                    ret == bytesRequired,
+                    $"RSA_private_encrypt returned {ret} when {bytesRequired} was expected");
 
                 bytesWritten = ret;
                 return true;

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography.Apple;
@@ -166,7 +167,17 @@ namespace System.Security.Cryptography
                     throw new ArgumentNullException(nameof(padding));
                 }
 
-                return Interop.AppleCrypto.RsaEncrypt(GetKeys().PublicKey, data, padding);
+                // The size of encrypt is always the keysize (in ceiling-bytes)
+                byte[] output = new byte[(KeySize + 7) / 8];
+
+                if (!TryEncrypt(data, output, padding, out int bytesWritten))
+                {
+                    Debug.Fail($"TryEncrypt with a preallocated buffer should not fail");
+                    throw new CryptographicException();
+                }
+
+                Debug.Assert(bytesWritten == output.Length);
+                return output;
             }
 
             public override bool TryEncrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
@@ -176,7 +187,64 @@ namespace System.Security.Cryptography
                     throw new ArgumentNullException(nameof(padding));
                 }
 
-                return Interop.AppleCrypto.TryRsaEncrypt(GetKeys().PublicKey, data, destination, padding, out bytesWritten);
+                int rsaSize = (KeySize + 7) / 8;
+
+                if (destination.Length < rsaSize)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                if (padding == RSAEncryptionPadding.Pkcs1 && data.Length > 0)
+                {
+                    return Interop.AppleCrypto.TryRsaEncrypt(
+                        GetKeys().PublicKey,
+                        data,
+                        destination,
+                        padding,
+                        out bytesWritten);
+                }
+
+                RsaPaddingProcessor processor;
+
+                switch (padding.Mode)
+                {
+                    case RSAEncryptionPaddingMode.Pkcs1:
+                        processor = null;
+                        break;
+                    case RSAEncryptionPaddingMode.Oaep:
+                        processor = RsaPaddingProcessor.OpenProcessor(padding.OaepHashAlgorithm);
+                        break;
+                    default:
+                        throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
+                }
+
+                byte[] rented = ArrayPool<byte>.Shared.Rent(rsaSize);
+                Span<byte> tmp = new Span<byte>(rented, 0, rsaSize);
+
+                try
+                {
+                    if (processor != null)
+                    {
+                        processor.PadOaep(data, tmp);
+                    }
+                    else
+                    {
+                        Debug.Assert(padding.Mode == RSAEncryptionPaddingMode.Pkcs1);
+                        RsaPaddingProcessor.PadPkcs1Encryption(data, tmp);
+                    }
+
+                    return Interop.AppleCrypto.TryRsaEncryptionPrimitive(
+                        GetKeys().PublicKey,
+                        tmp,
+                        destination,
+                        out bytesWritten);
+                }
+                finally
+                {
+                    tmp.Clear();
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
             }
 
             public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
@@ -197,7 +265,31 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
                 }
 
-                return Interop.AppleCrypto.RsaDecrypt(keys.PrivateKey, data, padding);
+                if (padding.Mode == RSAEncryptionPaddingMode.Pkcs1)
+                {
+                    return Interop.AppleCrypto.RsaDecrypt(keys.PrivateKey, data, padding);
+                }
+
+                int maxOutputSize = (KeySize + 7) / 8;
+                byte[] rented = ArrayPool<byte>.Shared.Rent(maxOutputSize);
+                Span<byte> contentsSpan = Span<byte>.Empty;
+
+                try
+                {
+                    if (!TryDecrypt(keys.PrivateKey, data, rented, padding, out int bytesWritten))
+                    {
+                        Debug.Fail($"TryDecrypt returned false with a modulus-sized destination");
+                        throw new CryptographicException();
+                    }
+
+                    contentsSpan = new Span<byte>(rented, 0, bytesWritten);
+                    return contentsSpan.ToArray();
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(contentsSpan);
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
             }
 
             public override bool TryDecrypt(ReadOnlySpan<byte> data, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
@@ -214,7 +306,52 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
                 }
 
-                return Interop.AppleCrypto.TryRsaDecrypt(keys.PrivateKey, data, destination, padding, out bytesWritten);
+                return TryDecrypt(keys.PrivateKey, data, destination, padding, out bytesWritten);
+            }
+
+            private bool TryDecrypt(
+                SafeSecKeyRefHandle privateKey,
+                ReadOnlySpan<byte> data,
+                Span<byte> destination,
+                RSAEncryptionPadding padding,
+                out int bytesWritten)
+            {
+                Debug.Assert(privateKey != null);
+
+                if (padding.Mode == RSAEncryptionPaddingMode.Pkcs1 ||
+                    padding == RSAEncryptionPadding.OaepSHA1)
+                {
+                    return Interop.AppleCrypto.TryRsaDecrypt(privateKey, data, destination, padding, out bytesWritten);
+                }
+
+                if (padding.Mode != RSAEncryptionPaddingMode.Oaep)
+                {
+                    throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
+                }
+
+                RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(padding.OaepHashAlgorithm);
+
+                int bytesRequired = (KeySize + 7) / 8;
+                byte[] rented = ArrayPool<byte>.Shared.Rent(bytesRequired);
+                Span<byte> unpaddedData = Span<byte>.Empty;
+
+                try
+                {
+                    if (!Interop.AppleCrypto.TryRsaDecryptionPrimitive(privateKey, data, rented, out int paddedSize))
+                    {
+                        Debug.Fail($"Raw decryption failed with KeySize={KeySize} and a buffer length {rented.Length}");
+                        throw new CryptographicException();
+                    }
+
+                    Debug.Assert(bytesRequired == paddedSize);
+                    unpaddedData = new Span<byte>(rented, 0, paddedSize);
+                    return processor.DepadOaep(unpaddedData, destination, out bytesWritten);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(unpaddedData);
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
             }
 
             public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
@@ -225,36 +362,49 @@ namespace System.Security.Cryptography
                     throw HashAlgorithmNameNullOrEmpty();
                 if (padding == null)
                     throw new ArgumentNullException(nameof(padding));
-                if (padding != RSASignaturePadding.Pkcs1)
-                    throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
 
-                SecKeyPair keys = GetKeys();
-
-                if (keys.PrivateKey == null)
+                if (padding == RSASignaturePadding.Pkcs1)
                 {
-                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                    SecKeyPair keys = GetKeys();
+
+                    if (keys.PrivateKey == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                    }
+
+                    int expectedSize;
+                    Interop.AppleCrypto.PAL_HashAlgorithm palAlgId =
+                        PalAlgorithmFromAlgorithmName(hashAlgorithm, out expectedSize);
+
+                    if (hash.Length != expectedSize)
+                    {
+                        // Windows: NTE_BAD_DATA ("Bad Data.")
+                        // OpenSSL: RSA_R_INVALID_MESSAGE_LENGTH ("invalid message length")
+                        throw new CryptographicException(
+                            SR.Format(
+                                SR.Cryptography_BadHashSize_ForAlgorithm,
+                                hash.Length,
+                                expectedSize,
+                                hashAlgorithm.Name));
+                    }
+
+                    return Interop.AppleCrypto.GenerateSignature(
+                        keys.PrivateKey,
+                        hash,
+                        palAlgId);
                 }
 
-                int expectedSize;
-                Interop.AppleCrypto.PAL_HashAlgorithm palAlgId =
-                    PalAlgorithmFromAlgorithmName(hashAlgorithm, out expectedSize);
+                // A signature will always be the keysize (in ceiling-bytes) in length.
+                byte[] output = new byte[(KeySize + 7) / 8];
 
-                if (hash.Length != expectedSize)
+                if (!TrySignHash(hash, output, hashAlgorithm, padding, out int bytesWritten))
                 {
-                    // Windows: NTE_BAD_DATA ("Bad Data.")
-                    // OpenSSL: RSA_R_INVALID_MESSAGE_LENGTH ("invalid message length")
-                    throw new CryptographicException(
-                        SR.Format(
-                            SR.Cryptography_BadHashSize_ForAlgorithm,
-                            hash.Length,
-                            expectedSize,
-                            hashAlgorithm.Name));
+                    Debug.Fail("TrySignHash failed with a pre-allocated buffer");
+                    throw new CryptographicException();
                 }
 
-                return Interop.AppleCrypto.GenerateSignature(
-                    keys.PrivateKey,
-                    hash,
-                    palAlgId);
+                Debug.Assert(bytesWritten == output.Length);
+                return output;
             }
 
             public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
@@ -267,7 +417,14 @@ namespace System.Security.Cryptography
                 {
                     throw new ArgumentNullException(nameof(padding));
                 }
-                if (padding != RSASignaturePadding.Pkcs1)
+
+                RsaPaddingProcessor processor = null;
+
+                if (padding.Mode == RSASignaturePaddingMode.Pss)
+                {
+                    processor = RsaPaddingProcessor.OpenProcessor(hashAlgorithm);
+                }
+                else if (padding != RSASignaturePadding.Pkcs1)
                 {
                     throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
                 }
@@ -279,20 +436,61 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
                 }
 
-                Interop.AppleCrypto.PAL_HashAlgorithm palAlgId = PalAlgorithmFromAlgorithmName(hashAlgorithm, out int expectedSize);
-                if (hash.Length != expectedSize)
+                int keySize = KeySize;
+                int rsaSize = (keySize + 7) / 8;
+
+                if (processor == null)
                 {
-                    // Windows: NTE_BAD_DATA ("Bad Data.")
-                    // OpenSSL: RSA_R_INVALID_MESSAGE_LENGTH ("invalid message length")
-                    throw new CryptographicException(
-                        SR.Format(
-                            SR.Cryptography_BadHashSize_ForAlgorithm,
-                            hash.Length,
-                            expectedSize,
-                            hashAlgorithm.Name));
+                    Interop.AppleCrypto.PAL_HashAlgorithm palAlgId =
+                        PalAlgorithmFromAlgorithmName(hashAlgorithm, out int expectedSize);
+
+                    if (hash.Length != expectedSize)
+                    {
+                        // Windows: NTE_BAD_DATA ("Bad Data.")
+                        // OpenSSL: RSA_R_INVALID_MESSAGE_LENGTH ("invalid message length")
+                        throw new CryptographicException(
+                            SR.Format(
+                                SR.Cryptography_BadHashSize_ForAlgorithm,
+                                hash.Length,
+                                expectedSize,
+                                hashAlgorithm.Name));
+                    }
+
+                    if (destination.Length < rsaSize)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    return Interop.AppleCrypto.TryGenerateSignature(
+                        keys.PrivateKey,
+                        hash,
+                        destination,
+                        palAlgId,
+                        out bytesWritten);
                 }
 
-                return Interop.AppleCrypto.TryGenerateSignature(keys.PrivateKey, hash, destination, palAlgId, out bytesWritten);
+                Debug.Assert(padding.Mode == RSASignaturePaddingMode.Pss);
+
+                if (destination.Length < rsaSize)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                byte[] rented = ArrayPool<byte>.Shared.Rent(rsaSize);
+                Span<byte> buf = new Span<byte>(rented, 0, rsaSize);
+                processor.EncodePss(hash, buf, keySize);
+
+                try
+                {
+                    return Interop.AppleCrypto.TryRsaSignaturePrimitive(keys.PrivateKey, buf, destination, out bytesWritten);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(buf);
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
             }
 
             public override bool VerifyHash(
@@ -323,13 +521,57 @@ namespace System.Security.Cryptography
                 {
                     throw new ArgumentNullException(nameof(padding));
                 }
-                if (padding != RSASignaturePadding.Pkcs1)
+
+                if (padding == RSASignaturePadding.Pkcs1)
                 {
-                    throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
+                    Interop.AppleCrypto.PAL_HashAlgorithm palAlgId =
+                        PalAlgorithmFromAlgorithmName(hashAlgorithm, out int expectedSize);
+                    return Interop.AppleCrypto.VerifySignature(GetKeys().PublicKey, hash, signature, palAlgId);
+                }
+                else if (padding.Mode == RSASignaturePaddingMode.Pss)
+                {
+                    RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(hashAlgorithm);
+                    SafeSecKeyRefHandle publicKey = GetKeys().PublicKey;
+
+                    int keySize = KeySize;
+                    int rsaSize = (keySize + 7) / 8;
+
+                    if (signature.Length != rsaSize)
+                    {
+                        return false;
+                    }
+
+                    if (hash.Length != processor.HashLength)
+                    {
+                        return false;
+                    }
+
+                    byte[] rented = ArrayPool<byte>.Shared.Rent(rsaSize);
+                    Span<byte> unwrapped = new Span<byte>(rented, 0, rsaSize);
+
+                    try
+                    {
+                        if (!Interop.AppleCrypto.TryRsaVerificationPrimitive(
+                            publicKey,
+                            signature,
+                            unwrapped,
+                            out int bytesWritten))
+                        {
+                            Debug.Fail($"TryRsaVerificationPrimitive with a pre-allocated buffer");
+                            throw new CryptographicException();
+                        }
+
+                        Debug.Assert(bytesWritten == rsaSize);
+                        return processor.VerifyPss(hash, unwrapped, keySize);
+                    }
+                    finally
+                    {
+                        unwrapped.Clear();
+                        ArrayPool<byte>.Shared.Return(rented);
+                    }
                 }
 
-                Interop.AppleCrypto.PAL_HashAlgorithm palAlgId = PalAlgorithmFromAlgorithmName(hashAlgorithm, out int expectedSize);
-                return Interop.AppleCrypto.VerifySignature(GetKeys().PublicKey, hash, signature, palAlgId);
+                throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
             }
 
             protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -168,7 +168,8 @@ namespace System.Security.Cryptography
                 }
 
                 // The size of encrypt is always the keysize (in ceiling-bytes)
-                byte[] output = new byte[(KeySize + 7) / 8];
+                int outputSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
+                byte[] output = new byte[outputSize];
 
                 if (!TryEncrypt(data, output, padding, out int bytesWritten))
                 {
@@ -176,7 +177,7 @@ namespace System.Security.Cryptography
                     throw new CryptographicException();
                 }
 
-                Debug.Assert(bytesWritten == output.Length);
+                Debug.Assert(bytesWritten == outputSize);
                 return output;
             }
 
@@ -187,7 +188,7 @@ namespace System.Security.Cryptography
                     throw new ArgumentNullException(nameof(padding));
                 }
 
-                int rsaSize = (KeySize + 7) / 8;
+                int rsaSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
 
                 if (destination.Length < rsaSize)
                 {
@@ -270,7 +271,7 @@ namespace System.Security.Cryptography
                     return Interop.AppleCrypto.RsaDecrypt(keys.PrivateKey, data, padding);
                 }
 
-                int maxOutputSize = (KeySize + 7) / 8;
+                int maxOutputSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
                 byte[] rented = ArrayPool<byte>.Shared.Rent(maxOutputSize);
                 Span<byte> contentsSpan = Span<byte>.Empty;
 
@@ -331,7 +332,7 @@ namespace System.Security.Cryptography
 
                 RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(padding.OaepHashAlgorithm);
 
-                int bytesRequired = (KeySize + 7) / 8;
+                int bytesRequired = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
                 byte[] rented = ArrayPool<byte>.Shared.Rent(bytesRequired);
                 Span<byte> unpaddedData = Span<byte>.Empty;
 
@@ -395,7 +396,8 @@ namespace System.Security.Cryptography
                 }
 
                 // A signature will always be the keysize (in ceiling-bytes) in length.
-                byte[] output = new byte[(KeySize + 7) / 8];
+                int outputSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
+                byte[] output = new byte[outputSize];
 
                 if (!TrySignHash(hash, output, hashAlgorithm, padding, out int bytesWritten))
                 {
@@ -403,7 +405,7 @@ namespace System.Security.Cryptography
                     throw new CryptographicException();
                 }
 
-                Debug.Assert(bytesWritten == output.Length);
+                Debug.Assert(bytesWritten == outputSize);
                 return output;
             }
 
@@ -437,7 +439,7 @@ namespace System.Security.Cryptography
                 }
 
                 int keySize = KeySize;
-                int rsaSize = (keySize + 7) / 8;
+                int rsaSize = RsaPaddingProcessor.BytesRequiredForBitCount(keySize);
 
                 if (processor == null)
                 {
@@ -534,7 +536,7 @@ namespace System.Security.Cryptography
                     SafeSecKeyRefHandle publicKey = GetKeys().PublicKey;
 
                     int keySize = KeySize;
-                    int rsaSize = (keySize + 7) / 8;
+                    int rsaSize = RsaPaddingProcessor.BytesRequiredForBitCount(keySize);
 
                     if (signature.Length != rsaSize)
                     {

--- a/src/Common/src/System/Security/Cryptography/RsaPaddingProcessor.cs
+++ b/src/Common/src/System/Security/Cryptography/RsaPaddingProcessor.cs
@@ -1,0 +1,560 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography
+{
+    internal sealed class RsaPaddingProcessor
+    {
+        private static readonly byte[] s_eightZeros = new byte[8];
+
+        private static readonly Dictionary<HashAlgorithmName, RsaPaddingProcessor> s_lookup =
+            new Dictionary<HashAlgorithmName, RsaPaddingProcessor>();
+
+        private readonly HashAlgorithmName _hashAlgorithmName;
+        private readonly int _hLen;
+
+        private RsaPaddingProcessor(HashAlgorithmName hashAlgorithmName, int hLen)
+        {
+            _hashAlgorithmName = hashAlgorithmName;
+            _hLen = hLen;
+        }
+
+        internal int HashLength => _hLen;
+
+        internal static RsaPaddingProcessor OpenProcessor(HashAlgorithmName hashAlgorithmName)
+        {
+            lock (s_lookup)
+            {
+                if (s_lookup.TryGetValue(hashAlgorithmName, out RsaPaddingProcessor processor))
+                {
+                    return processor;
+                }
+
+                using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName))
+                {
+                    // SHA-2-512 is the biggest we expect
+                    Span<byte> stackDest = stackalloc byte[512 / 8];
+
+                    if (hasher.TryGetHashAndReset(stackDest, out int bytesWritten))
+                    {
+                        processor = new RsaPaddingProcessor(hashAlgorithmName, bytesWritten);
+                    }
+                    else
+                    {
+                        byte[] big = hasher.GetHashAndReset();
+                        processor = new RsaPaddingProcessor(hashAlgorithmName, big.Length);
+                    }
+                }
+
+                s_lookup[hashAlgorithmName] = processor;
+                return processor;
+            }
+        }
+
+        internal static void PadPkcs1Encryption(
+            ReadOnlySpan<byte> source,
+            Span<byte> destination)
+        {
+            // https://tools.ietf.org/html/rfc3447#section-7.2.1
+
+            int mLen = source.Length;
+            int k = destination.Length;
+
+            // 1. If mLen > k - 11, fail
+            if (mLen > k - 11)
+            {
+                throw new CryptographicException(SR.Cryptography_KeyTooSmall);
+            }
+
+            // 2(b). EM is composed of 00 02 [PS] 00 [M]
+            Span<byte> mInEM = destination.Slice(destination.Length - source.Length);
+            Span<byte> ps = destination.Slice(2, destination.Length - source.Length - 3);
+            destination[0] = 0;
+            destination[1] = 2;
+            destination[ps.Length + 2] = 0;
+
+            // 2(a). Fill PS with random data from a CSPRNG, but no zero-values.
+            FillNonZeroBytes(ps);
+
+            source.CopyTo(mInEM);
+        }
+
+        internal void PadOaep(
+            ReadOnlySpan<byte> source,
+            Span<byte> destination)
+        {
+            // https://tools.ietf.org/html/rfc3447#section-7.1.2
+
+            byte[] dbMask = null;
+            Span<byte> dbMaskSpan = Span<byte>.Empty;
+
+            try
+            {
+                // Since the biggest known _hLen is 512/8 (64) and destination.Length is 0 or more,
+                // this shouldn't underflow without something having severely gone wrong.
+                int maxInput = checked(destination.Length - _hLen - _hLen - 2);
+
+                // 1(a) does not apply, we do not allow custom label values.
+
+                // 1(b)
+                if (source.Length > maxInput)
+                {
+                    throw new CryptographicException(
+                        SR.Format(SR.Cryptography_Encryption_MessageTooLong, maxInput));
+                }
+
+                // The final message (step 2(i)) will be
+                // 0x00 || maskedSeed (hLen long) || maskedDB (rest of the buffer)
+                Span<byte> seed = destination.Slice(1, _hLen);
+                Span<byte> db = destination.Slice(1 + _hLen);
+
+                using (IncrementalHash hasher = IncrementalHash.CreateHash(_hashAlgorithmName))
+                {
+                    // DB = lHash || PS || 0x01 || M
+                    Span<byte> lHash = db.Slice(0, _hLen);
+                    Span<byte> mDest = db.Slice(db.Length - source.Length);
+                    Span<byte> ps = db.Slice(_hLen, db.Length - _hLen - 1 - mDest.Length);
+                    Span<byte> psEnd = db.Slice(_hLen + ps.Length, 1);
+
+                    // 2(a) lHash = Hash(L), where L is the empty string.
+                    if (!hasher.TryGetHashAndReset(lHash, out int hLen2) || hLen2 != _hLen)
+                    {
+                        Debug.Fail("TryGetHashAndReset failed with exact-size destination");
+                        throw new CryptographicException();
+                    }
+
+                    // 2(b) generate a padding string of all zeros equal to the amount of unused space.
+                    ps.Clear();
+
+                    // 2(c)
+                    psEnd[0] = 0x01;
+
+                    // still 2(c)
+                    source.CopyTo(mDest);
+
+                    // 2(d)
+                    RandomNumberGenerator.Fill(seed);
+
+                    // 2(e)
+                    dbMask = ArrayPool<byte>.Shared.Rent(db.Length);
+                    dbMaskSpan = new Span<byte>(dbMask, 0, db.Length);
+                    Mgf1(hasher, seed, dbMaskSpan);
+
+                    // 2(f)
+                    for (int i = 0; i < dbMaskSpan.Length; i++)
+                    {
+                        db[i] ^= dbMaskSpan[i];
+                    }
+
+                    // 2(g)
+                    Span<byte> seedMask = stackalloc byte[_hLen];
+                    Mgf1(hasher, db, seedMask);
+
+                    // 2(h)
+                    for (int i = 0; i < seedMask.Length; i++)
+                    {
+                        seed[i] ^= seedMask[i];
+                    }
+
+                    // 2(i)
+                    destination[0] = 0;
+                }
+            }
+            catch (Exception e) when (!(e is CryptographicException))
+            {
+                Debug.Fail("Bad exception produced from OAEP padding: " + e);
+                throw new CryptographicException();
+            }
+            finally
+            {
+                if (dbMask != null)
+                {
+                    dbMaskSpan.Clear();
+                    ArrayPool<byte>.Shared.Return(dbMask);
+                }
+            }
+        }
+
+        internal bool DepadOaep(
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            // https://tools.ietf.org/html/rfc3447#section-7.1.2
+            using (IncrementalHash hasher = IncrementalHash.CreateHash(_hashAlgorithmName))
+            {
+                Span<byte> lHash = stackalloc byte[_hLen];
+
+                if (!hasher.TryGetHashAndReset(lHash, out int hLen2) || hLen2 != _hLen)
+                {
+                    Debug.Fail("TryGetHashAndReset failed with exact-size destination");
+                    throw new CryptographicException();
+                }
+
+                int y = source[0];
+                ReadOnlySpan<byte> maskedSeed = source.Slice(1, _hLen);
+                ReadOnlySpan<byte> maskedDB = source.Slice(1 + _hLen);
+
+                Span<byte> seed = stackalloc byte[_hLen];
+                // seedMask = MGF(maskedDB, hLen)
+                Mgf1(hasher, maskedDB, seed);
+
+                // seed = seedMask XOR maskedSeed
+                for (int i = 0; i < seed.Length; i++)
+                {
+                    seed[i] ^= maskedSeed[i];
+                }
+
+                byte[] tmp = ArrayPool<byte>.Shared.Rent(source.Length);
+
+                try
+                {
+                    Span<byte> dbMask = new Span<byte>(tmp, 0, maskedDB.Length);
+                    // dbMask = MGF(seed, k - hLen - 1)
+                    Mgf1(hasher, seed, dbMask);
+
+                    // DB = dbMask XOR maskedDB
+                    for (int i = 0; i < dbMask.Length; i++)
+                    {
+                        dbMask[i] ^= maskedDB[i];
+                    }
+
+                    ReadOnlySpan<byte> lHashPrime = dbMask.Slice(0, _hLen);
+
+                    int separatorPos = int.MaxValue;
+
+                    for (int i = dbMask.Length - 1; i >= _hLen; i--)
+                    {
+                        // if dbMask[i] is 1, val is 0. otherwise val is [01,FF]
+                        byte dbMinus1 = (byte)(dbMask[i] - 1);
+                        int val = dbMinus1;
+
+                        // if val is 0: FFFFFFFF & FFFFFFFF => FFFFFFFF
+                        // if val is any other byte value, val-1 will be in the range 00000000 to 000000FE,
+                        // and so the high bit will not be set.
+                        val = (~val & (val - 1)) >> 31;
+
+                        // if val is 0: separator = (0 & i) | (~0 & separator) => separator
+                        // else: separator = (~0 & i) | (0 & separator) => i
+                        //
+                        // Net result: non-branching "if (dbMask[i] == 1) separatorPos = i;"
+                        separatorPos = (val & i) | (~val & separatorPos);
+                    }
+
+                    bool lHashMatches = CryptographicOperations.FixedTimeEquals(lHash, lHashPrime);
+                    bool yIsZero = y == 0;
+                    bool separatorMadeSense = separatorPos < dbMask.Length;
+
+                    bool shouldContinue = lHashMatches & yIsZero & separatorMadeSense;
+
+                    if (!shouldContinue)
+                    {
+                        throw new CryptographicException(SR.Cryptography_OAEP_Decryption_Failed);
+                    }
+
+                    Span<byte> message = dbMask.Slice(separatorPos + 1);
+
+                    if (message.Length <= destination.Length)
+                    {
+                        message.CopyTo(destination);
+                        bytesWritten = message.Length;
+                        return true;
+                    }
+                    else
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+                }
+                finally
+                {
+                    Array.Clear(tmp, 0, source.Length);
+                    ArrayPool<byte>.Shared.Return(tmp);
+                }
+            }
+        }
+
+        internal void EncodePss(ReadOnlySpan<byte> mHash, Span<byte> destination, int keySize)
+        {
+            // https://tools.ietf.org/html/rfc3447#section-9.1.1
+            int emBits = keySize - 1;
+            int emLen = (emBits + 7) / 8;
+
+            if (mHash.Length != _hLen)
+            {
+                throw new CryptographicException(SR.Cryptography_SignHash_WrongSize);
+            }
+
+            // In this implementation, sLen is restricted to the length of the input hash.
+            int sLen = _hLen;
+
+            // 3.  if emLen < hLen + sLen + 2, encoding error.
+            //
+            // sLen = hLen in this implementation.
+
+            if (emLen < 2 + _hLen + sLen)
+            {
+                throw new CryptographicException(SR.Cryptography_KeyTooSmall);
+            }
+
+            // Set any leading bytes to zero, since that will be required for the pending
+            // RSA operation.
+            destination.Slice(0, destination.Length - emLen).Clear();
+
+            // 12. Let EM = maskedDB || H || 0xbc (H has length hLen)
+            Span<byte> em = destination.Slice(destination.Length - emLen, emLen);
+
+            int dbLen = emLen - _hLen - 1;
+
+            Span<byte> db = em.Slice(0, dbLen);
+            Span<byte> hDest = em.Slice(dbLen, _hLen);
+            em[emLen - 1] = 0xBC;
+
+            byte[] dbMaskRented = ArrayPool<byte>.Shared.Rent(dbLen);
+            Span<byte> dbMask = new Span<byte>(dbMaskRented, 0, dbLen);
+
+            using (IncrementalHash hasher = IncrementalHash.CreateHash(_hashAlgorithmName))
+            {
+                // 4. Generate a random salt of length sLen
+                Span<byte> salt = stackalloc byte[sLen];
+                RandomNumberGenerator.Fill(salt);
+
+                // 5. Let M' = an octet string of 8 zeros concat mHash concat salt
+                // 6. Let H = Hash(M')
+
+                hasher.AppendData(s_eightZeros);
+                hasher.AppendData(mHash);
+                hasher.AppendData(salt);
+
+                if (!hasher.TryGetHashAndReset(hDest, out int hLen2) || hLen2 != _hLen)
+                {
+                    Debug.Fail("TryGetHashAndReset failed with exact-size destination");
+                    throw new CryptographicException();
+                }
+
+                // 7. Generate PS as zero-valued bytes of length emLen - sLen - hLen - 2.
+                // 8. Let DB = PS || 0x01 || salt
+                int psLen = emLen - sLen - _hLen - 2;
+                db.Slice(0, psLen).Clear();
+                db[psLen] = 0x01;
+                salt.CopyTo(db.Slice(psLen + 1));
+
+                // 9. Let dbMask = MGF(H, emLen - hLen - 1)
+                Mgf1(hasher, hDest, dbMask);
+
+                // 10. Let maskedDB = DB XOR dbMask
+                for (int i = 0; i < dbMask.Length; i++)
+                {
+                    db[i] ^= dbMask[i];
+                }
+
+                // 11. Set the "unused" bits in the leftmost byte of maskedDB to 0.
+                int unusedBits = 8 * emLen - emBits;
+
+                if (unusedBits != 0)
+                {
+                    byte mask = (byte)(0xFF >> unusedBits);
+                    db[0] &= mask;
+                }
+            }
+
+            dbMask.Clear();
+            ArrayPool<byte>.Shared.Return(dbMaskRented);
+        }
+
+        internal bool VerifyPss(ReadOnlySpan<byte> mHash, ReadOnlySpan<byte> em, int keySize)
+        {
+            int emBits = keySize - 1;
+            int emLen = (emBits + 7) / 8;
+
+            if (mHash.Length != _hLen)
+            {
+                return false;
+            }
+
+            Debug.Assert(em.Length >= emLen);
+
+            // In this implementation, sLen is restricted to hLen.
+            int sLen = _hLen;
+
+            // 3. If emLen < hLen + sLen + 2, output "inconsistent" and stop.
+            if (emLen < _hLen + sLen + 2)
+            {
+                return false;
+            }
+
+            // 4. If the last byte is not 0xBC, output "inconsistent" and stop.
+            if (em[em.Length - 1] != 0xBC)
+            {
+                return false;
+            }
+
+            // 5. maskedDB is the leftmost emLen - hLen -1 bytes, H is the next hLen bytes.
+            int dbLen = emLen - _hLen - 1;
+
+            ReadOnlySpan<byte> maskedDb = em.Slice(0, dbLen);
+            ReadOnlySpan<byte> h = em.Slice(dbLen, _hLen);
+
+            // 6. If the unused bits aren't zero, output "inconsistent" and stop.
+            int unusedBits = 8 * emLen - emBits;
+            byte usedBitsMask = (byte)(0xFF >> unusedBits);
+
+            if ((maskedDb[0] & usedBitsMask) != maskedDb[0])
+            {
+                return false;
+            }
+
+            // 7. dbMask = MGF(H, emLen - hLen - 1)
+            byte[] dbMaskRented = ArrayPool<byte>.Shared.Rent(maskedDb.Length);
+            Span<byte> dbMask = new Span<byte>(dbMaskRented, 0, maskedDb.Length);
+
+            try
+            {
+                using (IncrementalHash hasher = IncrementalHash.CreateHash(_hashAlgorithmName))
+                {
+                    Mgf1(hasher, h, dbMask);
+
+                    // 8. DB = maskedDB XOR dbMask
+                    for (int i = 0; i < dbMask.Length; i++)
+                    {
+                        dbMask[i] ^= maskedDb[i];
+                    }
+
+                    // 9. Set the unused bits of DB to 0
+                    dbMask[0] &= usedBitsMask;
+
+                    // 10 ("a"): If the emLen - hLen - sLen - 2 leftmost bytes are not 0,
+                    // output "inconsistent" and stop.
+                    //
+                    // Since signature verification is a public key operation there's no need to
+                    // use fixed time equality checking here.
+                    for (int i = emLen - _hLen - sLen - 2 - 1; i >= 0; --i)
+                    {
+                        if (dbMask[i] != 0)
+                        {
+                            return false;
+                        }
+                    }
+
+                    // 10 ("b") If the octet at position emLen - hLen - sLen - 1 (under a 1-indexed scheme)
+                    // is not 0x01, output "inconsistent" and stop.
+                    if (dbMask[emLen - _hLen - sLen - 2] != 0x01)
+                    {
+                        return false;
+                    }
+
+                    // 11. Let salt be the last sLen octets of DB.
+                    ReadOnlySpan<byte> salt = dbMask.Slice(dbMask.Length - sLen);
+
+                    // 12/13. Let H' = Hash(eight zeros || mHash || salt)
+                    hasher.AppendData(s_eightZeros);
+                    hasher.AppendData(mHash);
+                    hasher.AppendData(salt);
+
+                    Span<byte> hPrime = stackalloc byte[_hLen];
+
+                    if (!hasher.TryGetHashAndReset(hPrime, out int hLen2) || hLen2 != _hLen)
+                    {
+                        Debug.Fail("TryGetHashAndReset failed with exact-size destination");
+                        throw new CryptographicException();
+                    }
+
+                    // 14. If H = H' output "consistent". Otherwise, output "inconsistent"
+                    //
+                    // Since this is a public key operation, no need to provide fixed time
+                    // checking.
+                    return h.SequenceEqual(hPrime);
+                }
+            }
+            finally
+            {
+                dbMask.Clear();
+                ArrayPool<byte>.Shared.Return(dbMaskRented);
+            }
+        }
+
+        // https://tools.ietf.org/html/rfc3447#appendix-B.2.1
+        private void Mgf1(IncrementalHash hasher, ReadOnlySpan<byte> mgfSeed, Span<byte> mask)
+        {
+            Span<byte> writePtr = mask;
+            int count = 0;
+            Span<byte> bigEndianCount = stackalloc byte[sizeof(int)];
+
+            while (writePtr.Length > 0)
+            {
+                hasher.AppendData(mgfSeed);
+                BinaryPrimitives.WriteInt32BigEndian(bigEndianCount, count);
+                hasher.AppendData(bigEndianCount);
+
+                if (writePtr.Length >= _hLen)
+                {
+                    if (!hasher.TryGetHashAndReset(writePtr, out int bytesWritten))
+                    {
+                        Debug.Fail($"TryGetHashAndReset failed with sufficient space");
+                        throw new CryptographicException();
+                    }
+
+                    Debug.Assert(bytesWritten == _hLen);
+                    writePtr = writePtr.Slice(bytesWritten);
+                }
+                else
+                {
+                    Span<byte> tmp = stackalloc byte[_hLen];
+
+                    if (!hasher.TryGetHashAndReset(tmp, out int bytesWritten))
+                    {
+                        Debug.Fail($"TryGetHashAndReset failed with sufficient space");
+                        throw new CryptographicException();
+                    }
+
+                    Debug.Assert(bytesWritten == _hLen);
+                    tmp.Slice(0, writePtr.Length).CopyTo(writePtr);
+                    break;
+                }
+
+                count++;
+            }
+        }
+
+        // This is a copy of RandomNumberGeneratorImplementation.GetNonZeroBytes, but adapted
+        // to the object-less RandomNumberGenerator.Fill.
+        private static void FillNonZeroBytes(Span<byte> data)
+        {
+            while (data.Length > 0)
+            {
+                // Fill the remaining portion of the span with random bytes.
+                RandomNumberGenerator.Fill(data);
+
+                // Find the first zero in the remaining portion.
+                int indexOfFirst0Byte = data.Length;
+                for (int i = 0; i < data.Length; i++)
+                {
+                    if (data[i] == 0)
+                    {
+                        indexOfFirst0Byte = i;
+                        break;
+                    }
+                }
+
+                // If there were any zeros, shift down all non-zeros.
+                for (int i = indexOfFirst0Byte + 1; i < data.Length; i++)
+                {
+                    if (data[i] != 0)
+                    {
+                        data[indexOfFirst0Byte++] = data[i];
+                    }
+                }
+
+                // Request new random bytes if necessary; dont re-use
+                // existing bytes since they were shifted down.
+                data = data.Slice(indexOfFirst0Byte);
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.Rsa.Tests
@@ -26,6 +27,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
     public abstract class EncryptDecrypt
     {
+        public static bool SupportsSha2Oaep => RSAFactory.SupportsSha2Oaep;
         private static bool EphemeralKeysAreExportable => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer;
 
         protected abstract byte[] Encrypt(RSA rsa, byte[] data, RSAEncryptionPadding padding);
@@ -36,8 +38,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             using (RSA rsa = RSAFactory.Create())
             {
-                AssertExtensions.Throws<ArgumentNullException>("padding", () => Encrypt(rsa, new byte[1], null));
-                AssertExtensions.Throws<ArgumentNullException>("padding", () => Decrypt(rsa, new byte[1], null));
+                AssertExtensions.Throws<ArgumentNullException>("padding", () => Encrypt(rsa, TestData.HelloBytes, null));
+                AssertExtensions.Throws<ArgumentNullException>("padding", () => Decrypt(rsa, TestData.HelloBytes, null));
             }
         }
 
@@ -115,6 +117,41 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        public void DecryptSavedAnswer_OaepSHA256()
+        {
+            byte[] cipherBytes = (
+                "3ED1D2DCFBD1778D1B1F20C2CC4FD364D7236ACB6DBD7109CE9C44F6DA8D47A4" +
+                "53C36A3D4E8E87168CD1E5427A6C261F87CDC5A62507AF6127D1C5D274D5EECD" +
+                "50DC53C559FC85624D9FB999ADDD9BE5652926440A3DE32CA27554F524C30A7A" +
+                "E66215FE725F5998FB2AFD2E1E5F06F2944B61502A27272660A21363F35C3DC8" +
+                "8ED072096391B27D27BE5E1775F949A3A5C9C2903794090CE8D9DFE7003A4745" +
+                "E7029B0D4C0F6FD28E9886227E05B56D6BB0BA2933126C808EE0D972054A26DB" +
+                "2CA97B09967B2B6D7592F2563302111DE2FC42ED442522CD83A1AE9E8C3F0B1A" +
+                "9D50A4A89008D2135E0D8BC859F81CEF76166834432B4AE9BAAD1FC08E4C2C70").HexToByteArray();
+
+            byte[] output;
+
+            using (RSA rsa = RSAFactory.Create())
+            {
+                rsa.ImportParameters(TestData.RSA2048Params);
+
+                if (RSAFactory.SupportsSha2Oaep)
+                {
+                    output = Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA256);
+                }
+                else
+                {
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA256));
+
+                    return;
+                }
+            }
+
+            Assert.Equal(TestData.RSA2048Params.InverseQ, output);
+        }
+
+        [Fact]
         public void DecryptSavedAnswer_OaepSHA384()
         {
             byte[] cipherBytes =
@@ -176,6 +213,41 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        public void DecryptSavedAnswer_OaepSHA512()
+        {
+            byte[] cipherBytes = (
+                "7F0598C7257433FCDEF3F6C0AE69517D3AA6B4FD67D7F4C25F9A5996D20843AF" +
+                "E14C21D35D4D289CE4E720A1C9D998C9F95AFB73E523F5EA4B54D0BAE9B5665C" +
+                "B0A5F5719F5466A491FDB5B323F6B741CF7E0C263D1274959AD87B64B789F7EC" +
+                "6E52085954B59F7A3EBE6295EB7F168E8DADB49F166B4CB753F0D2774370D3E2" +
+                "D5B9F6493D7EEA65AA7BD8867313C13850CB2F2D7CCF46E553BEBDADA6060C14" +
+                "CC43AE238410167BC42FDE9DA07D135C0D2DB48537299DC067A808CCBA2B0B0A" +
+                "7A741705DA98872A7416610939DE4E2D4C387662ABD74D80E33502AFF1D571DB" +
+                "B874CA25CC54CEE69B6252B33BA92119873E0F8B5CCE0496324904A7847D73FB").HexToByteArray();
+
+            byte[] output;
+
+            using (RSA rsa = RSAFactory.Create())
+            {
+                rsa.ImportParameters(TestData.RSA2048Params);
+
+                if (RSAFactory.SupportsSha2Oaep)
+                {
+                    output = Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA512);
+                }
+                else
+                {
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA512));
+
+                    return;
+                }
+            }
+
+            Assert.Equal(TestData.RSA1032Parameters.DQ, output);
+        }
+
+        [Fact]
         public void DecryptSavedAnswerUnusualExponent()
         {
             byte[] cipherBytes =
@@ -210,19 +282,195 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        public void RsaCryptRoundtrip()
+        public void RsaCryptRoundtrip_OaepSHA1() => RsaCryptRoundtrip(RSAEncryptionPadding.OaepSHA1);
+
+        [Fact]
+        public void RsaCryptRoundtrip_OaepSHA256() =>
+            RsaCryptRoundtrip(RSAEncryptionPadding.OaepSHA256, RSAFactory.SupportsSha2Oaep);
+
+        [Fact]
+        public void RsaCryptRoundtrip_OaepSHA384() =>
+            RsaCryptRoundtrip(RSAEncryptionPadding.OaepSHA384, RSAFactory.SupportsSha2Oaep);
+
+        [Fact]
+        public void RsaCryptRoundtrip_OaepSHA512() =>
+            RsaCryptRoundtrip(RSAEncryptionPadding.OaepSHA512, RSAFactory.SupportsSha2Oaep);
+
+        private void RsaCryptRoundtrip(RSAEncryptionPadding paddingMode, bool expectSuccess=true)
         {
             byte[] crypt;
             byte[] output;
 
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(2048))
             {
-                crypt = Encrypt(rsa, TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
-                output = Decrypt(rsa, crypt, RSAEncryptionPadding.OaepSHA1);
+                if (!expectSuccess)
+                {
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => Encrypt(rsa, TestData.HelloBytes, paddingMode));
+
+                    return;
+                }
+
+                crypt = Encrypt(rsa, TestData.HelloBytes, paddingMode);
+                output = Decrypt(rsa, crypt, paddingMode);
             }
 
             Assert.NotEqual(crypt, output);
             Assert.Equal(TestData.HelloBytes, output);
+        }
+
+        [Fact]
+        public void RoundtripEmptyArray()
+        {
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                void RoundtripEmpty(RSAEncryptionPadding paddingMode)
+                {
+                    byte[] encrypted = Encrypt(rsa, Array.Empty<byte>(), paddingMode);
+                    byte[] decrypted = Decrypt(rsa, encrypted, paddingMode);
+
+                    Assert.Equal(Array.Empty<byte>(), decrypted);
+                }
+
+                RoundtripEmpty(RSAEncryptionPadding.Pkcs1);
+                RoundtripEmpty(RSAEncryptionPadding.OaepSHA1);
+
+                if (RSAFactory.SupportsSha2Oaep)
+                {
+                    RoundtripEmpty(RSAEncryptionPadding.OaepSHA256);
+                    RoundtripEmpty(RSAEncryptionPadding.OaepSHA384);
+                    RoundtripEmpty(RSAEncryptionPadding.OaepSHA512);
+                }
+            }
+        }
+
+        [Fact]
+        public void RsaOaepMaxSize()
+        {
+            RSAParameters rsaParameters = TestData.RSA2048Params;
+
+            using (RSA rsa = RSAFactory.Create(rsaParameters))
+            {
+                void Test(RSAEncryptionPadding paddingMode, int hashSizeInBits)
+                {
+                    // The overhead required is hLen + hLen + 2.
+                    int hLen = (hashSizeInBits + 7) / 8;
+                    int overhead = hLen + hLen + 2;
+                    int maxSize = rsaParameters.Modulus.Length - overhead;
+
+                    byte[] data = new byte[maxSize];
+                    byte[] encrypted = Encrypt(rsa, data, paddingMode);
+                    byte[] decrypted = Decrypt(rsa, encrypted, paddingMode);
+
+                    Assert.Equal(data.ByteArrayToHex(), decrypted.ByteArrayToHex());
+
+                    data = new byte[maxSize + 1];
+
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => Encrypt(rsa, data, paddingMode));
+                }
+
+                Test(RSAEncryptionPadding.OaepSHA1, 160);
+
+                if (RSAFactory.SupportsSha2Oaep)
+                {
+                    Test(RSAEncryptionPadding.OaepSHA256, 256);
+                    Test(RSAEncryptionPadding.OaepSHA384, 384);
+                    Test(RSAEncryptionPadding.OaepSHA512, 512);
+                }
+            }
+        }
+
+        [Fact]
+        public void RsaDecryptOaep_ExpectFailure()
+        {
+            // This particular byte pattern, when decrypting under OAEP-SHA-2-384 has
+            // an 0x01 in the correct range, and y=0, but lHash and lHashPrime do not agree
+            byte[] encrypted = (
+                "2A1914D11E2F6B9E286DAC9D76F32A008EC31457522CEA058D7C48C85085899F" +
+                "E9C2DBD4FCA5FAD936F2B747E0BEF131217F8521FA921DF807A83C1B34DB1547" +
+                "8D637EDFED222B6411C80D465332B2EE5208F87D4F8D1736FEBC291E14E77C4B" +
+                "75A1F06B5124F225F310BFFA83BCA9F11101BA67A64109C37F52BF00B84FFD9A" +
+                "D39282AD2BA9EEADADA0FE38998755B556B152EE8974F2C8158ACFA5F509DD4A" +
+                "BFE72218C0DF596DFF02C332F45ECC04280455F5D2666E93A3522BB8B41FC92E" +
+                "0176AFB1D3A5AE474B708B882ACA88447046E13D44E5EA8D66421DFC177A683B" +
+                "7B395F18886AAFD9CED072079739ED1D390354976D188C50A29AAD58784886E6").HexToByteArray();
+
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                Assert.ThrowsAny<CryptographicException>(
+                    () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA384));
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsSha2Oaep))]
+        public void RsaDecryptOaepWrongAlgorithm()
+        {
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] data = TestData.HelloBytes;
+                byte[] encrypted = Encrypt(rsa, data, RSAEncryptionPadding.OaepSHA256);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA384));
+            }
+        }
+
+        [Fact]
+        public void RsaDecryptOaepWrongData()
+        {
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] data = TestData.HelloBytes;
+                byte[] encrypted = Encrypt(rsa, data, RSAEncryptionPadding.OaepSHA1);
+                encrypted[1] ^= 0xFF;
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA1));
+
+                if (RSAFactory.SupportsSha2Oaep)
+                {
+                    encrypted = Encrypt(rsa, data, RSAEncryptionPadding.OaepSHA256);
+                    encrypted[1] ^= 0xFF;
+
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA256));
+                }
+            }
+        }
+
+        [Fact]
+        public void RsaDecryptOaepWrongDataLength()
+        {
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] data = TestData.HelloBytes;
+
+                byte[] encrypted = Encrypt(rsa, data, RSAEncryptionPadding.OaepSHA1);
+                Array.Resize(ref encrypted, encrypted.Length + 1);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA1));
+
+                Array.Resize(ref encrypted, encrypted.Length - 2);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA1));
+
+                if (RSAFactory.SupportsSha2Oaep)
+                {
+                    encrypted = Encrypt(rsa, data, RSAEncryptionPadding.OaepSHA256);
+                    Array.Resize(ref encrypted, encrypted.Length + 1);
+
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA1));
+
+                    Array.Resize(ref encrypted, encrypted.Length - 2);
+
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA1));
+                }
+            }
         }
 
         [ConditionalFact(nameof(EphemeralKeysAreExportable))]

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -320,6 +320,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void RoundtripEmptyArray()
         {
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -10,6 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         RSA Create(int keySize);
         bool Supports384PrivateKey { get; }
         bool SupportsSha2Oaep { get; }
+        bool SupportsPss { get; }
         bool SupportsDecryptingIntoExactSpaceRequired { get; }
     }
 
@@ -36,8 +37,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         public static bool SupportsSha2Oaep => s_provider.SupportsSha2Oaep;
 
-        // It's currently true on all our platforms that supporting PSS is equivalent to supporting OAEP-SHA-2.
-        public static bool SupportsPss => s_provider.SupportsSha2Oaep;
+        public static bool SupportsPss => s_provider.SupportsPss;
 
         public static bool SupportsDecryptingIntoExactSpaceRequired => s_provider.SupportsDecryptingIntoExactSpaceRequired;
     }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -25,9 +25,19 @@ namespace System.Security.Cryptography.Rsa.Tests
             return s_provider.Create(keySize);
         }
 
+        public static RSA Create(RSAParameters rsaParameters)
+        {
+            RSA rsa = Create();
+            rsa.ImportParameters(rsaParameters);
+            return rsa;
+        }
+
         public static bool Supports384PrivateKey => s_provider.Supports384PrivateKey;
 
         public static bool SupportsSha2Oaep => s_provider.SupportsSha2Oaep;
+
+        // It's currently true on all our platforms that supporting PSS is equivalent to supporting OAEP-SHA-2.
+        public static bool SupportsPss => s_provider.SupportsSha2Oaep;
 
         public static bool SupportsDecryptingIntoExactSpaceRequired => s_provider.SupportsDecryptingIntoExactSpaceRequired;
     }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using Test.Cryptography;
 using Test.IO.Streams;
 using Xunit;
 
@@ -38,6 +39,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
     public abstract class SignVerify
     {
+        public static bool SupportsPss => RSAFactory.SupportsPss;
         public static bool BadKeyFormatDoesntThrow => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer;
         public static bool InvalidKeySizeDoesntThrow => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer;
 
@@ -546,6 +548,32 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        public void PkcsSignHash_MismatchedHashSize()
+        {
+            RSASignaturePadding padding = RSASignaturePadding.Pkcs1;
+
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] data152 = new byte[152 / 8];
+                byte[] data168 = new byte[168 / 8];
+                RandomNumberGenerator.Fill(data152);
+                RandomNumberGenerator.Fill(data168);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => SignHash(rsa, data152, HashAlgorithmName.SHA1, padding));
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => SignHash(rsa, data168, HashAlgorithmName.SHA1, padding));
+
+                byte[] data160 = new byte[160 / 8];
+                RandomNumberGenerator.Fill(data160);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => SignHash(rsa, data160, HashAlgorithmName.SHA256, padding));
+            }
+        }
+
+        [Fact]
         public void ExpectedHashSignature_SHA1_2048()
         {
             byte[] expectedHashSignature = new byte[]
@@ -805,6 +833,341 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
 
             VerifyHashSignature(hashSignature, dataHash, "SHA256", TestData.RSA2048Params);
+        }
+
+        [Theory]
+        [InlineData("SHA256")]
+        [InlineData("SHA384")]
+        [InlineData("SHA512")]
+        [InlineData("MD5")]
+        [InlineData("SHA1")]
+        public void PssRoundtrip(string hashAlgorithmName)
+        {
+            RSAParameters privateParameters = TestData.RSA2048Params;
+            RSAParameters publicParameters = new RSAParameters
+            {
+                Modulus = privateParameters.Modulus,
+                Exponent = privateParameters.Exponent,
+            };
+
+            using (RSA privateKey = RSAFactory.Create())
+            using (RSA publicKey = RSAFactory.Create())
+            {
+                privateKey.ImportParameters(privateParameters);
+                publicKey.ImportParameters(publicParameters);
+
+                byte[] data = TestData.RsaBigExponentParams.Modulus;
+                HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
+                RSASignaturePadding padding = RSASignaturePadding.Pss;
+
+                if (RSAFactory.SupportsPss)
+                {
+                    byte[] signature = SignData(privateKey, data, hashAlgorithm, padding);
+
+                    Assert.NotNull(signature);
+                    Assert.Equal(publicParameters.Modulus.Length, signature.Length);
+
+                    Assert.True(VerifyData(publicKey, data, signature, hashAlgorithm, padding));
+                }
+                else
+                {
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => SignData(privateKey, data, hashAlgorithm, padding));
+
+                    byte[] signature = new byte[privateParameters.Modulus.Length];
+
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => VerifyData(privateKey, data, signature, hashAlgorithm, padding));
+                }
+            }
+        }
+
+        [Fact]
+        public void VerifyExpectedSignature_PssSha256_RSA2048()
+        {
+            byte[] modulus2048Signature = (
+                "460CA7273FF6CC02DD57F07CB18E65E5AF23B0285E26122B810EC6D2F4EE7E1A" +
+                "1B01A203623E800C9940CE827614B2F1DC7C7B1CC3A976D27F82517EB64AC90B" +
+                "9A97D1CC17FB4731C63CA02C9F46B57A4A03981D73265CDB36E28EF08FCA77ED" +
+                "FAB34EE91FE6AABF00045489ACEB631FB004438344EA7997ADE2191C1A70E9F9" +
+                "2BA809FEFB4EFA0DBC1075A7EBBBCF57747DA8D0B3467BD3DAC5EA8B47F76F07" +
+                "7043497E7459A83349FE74320E77D471008CB7B43707561FA8DC9251F8EAE531" +
+                "5AC1894C4F9E6B7BECF993C146C5D6CF0DB60992A297F358A0895831965887C4" +
+                "B9153B96771C998CD61DA0C487D63555AE66F917F1BFDF509BFFEB21440F6A3C").HexToByteArray();
+
+            VerifyExpectedSignature_Pss(
+                TestData.RSA2048Params,
+                HashAlgorithmName.SHA256,
+                TestData.RSA2048Params.Modulus,
+                modulus2048Signature);
+        }
+
+        [Fact]
+        public void VerifyExpectedSignature_PssSha256_RSA16384()
+        {
+            byte[] modulus2048Signature = (
+                "1D92D529567F6922866FFDE4BF44C427FA511BF5EDF163ED51A0D14ADECD98FB" +
+                "C6A61A61532404AF74C3AB65119BB1358855A68362FBABAED7D8E56403EE9AFA" +
+                "33C8D73E35880066556A7304F8E8A3EBF981C8318958AC867B32F3A01F085F53" +
+                "B0885781DFCF4DE4183805B7B26C4718E58031FF8D0B82B38D958BF0147C263F" +
+                "A4012FE29E8B3D7EA18780C3A6B01E15D81387C4367AFB35FF4868309928C112" +
+                "86F030AFED02B2C8CED24C527B8EAA126076B268F469427E70D0ACFC4C3E007D" +
+                "05F84E2F3D3DC3028674DA38026F9054F54636FBED099CD528782F60F1882045" +
+                "E2F297B467496F01AE566EC80C384A5E775481EECEA713D0F35C75CBFDB33F52" +
+                "FC4699EDBEB1F938368AA2B261402634BEE548F38821E6FCBFE7C26C0C44EB1D" +
+                "58D215500E11EA400AE44B349727BE28A62188770393863B0F9BCC6C82717C35" +
+                "34334205B931BDD6FEA4FDCC681566BCB2AF80266D692007E027682535BFD265" +
+                "3E8D906D3531575975F2BB77457378FA84A34F2F064F6E5B986D48FBFD9F8BF8" +
+                "BD3CDFDA21C624A315C8246764841C811939B60BC73AB4CD15B141A1C3D063B6" +
+                "9529FB4B4342B1064650272CECE2B0A398A5F9B5FD2D107A9FE84781CA11D29F" +
+                "00986BEE1850BC5E46570FDFD54DBD15C6C8BA12AC0CA7825765009346AB7E95" +
+                "848F95928368E65AFDCB8AA058B0EE31320584248327F4D22017480BAB38BA47" +
+                "4FFCBBE68C5A24582AB9594EAD26ACE67170319B1BA9FB514070A5051744EAB3" +
+                "BDC1C131A8AF580CE5B11B23B50FF66D4DC6F6064C7FBA88D8CB74A3A85A51EB" +
+                "C344F7226871286109B0B9D33B7137B223FDC152EDD1BA0641D906A22F91D146" +
+                "8B39EAC8261EB05CA7757AEA46051599087CE92A9962D1DEF8DAF910F10169E0" +
+                "A0F8F864C0E4B29DC12958B06E8E4225C90CFEB6D7367DFEB7F8DF2891D50DCC" +
+                "89F435466A3D25B676BD06C69D39EDE7EDD639703C262B7C0257C88BD197542F" +
+                "0CE25F8E317037C1DC4380E2AA43CB4FBBA078AF83CDCA8DD8A8545267E3F853" +
+                "8DE7A897269E492A1400715FC3BABF2E30D2696216F51FD30FC3BE67FB9813CA" +
+                "DAEE3E4CB779A5F8A10DBCA11927CBC50721A5412680E490A68CA3DFF74B9E2A" +
+                "774DCC32B84B9D5B253268465A911A6CF3D189F51D21DDEF30006F929C151402" +
+                "E821F4097A8514192F95CA8B9ABFD0B7C7C86AAC5B0FDAECB02EABBC3B1F8442" +
+                "2A1921AE0B4BC01B6C037038DF382DC130843B15F5F042A98053578248E8DB02" +
+                "A1B5FC702B59FEAD99C32F6DAF15308A53CA139E408CE0F45DEC48FF1E5DB77B" +
+                "0305196F16598A21AF92603F77BA061A2A12B5D6F69B19F2EBDDE47578DD3895" +
+                "8D36D15D88015F5E51AA818669B6A65DE40C264CAD22B8E25D4866E8BBC0A64E" +
+                "59E0D95C69DF925BB9B9C88AB0542E53C6034DDE4FB5763D21C62765FA7A39AA" +
+                "B50652F20D464652710162EBBE7ECFEFF255864B459A0DD83DD3E7DD88EA1271" +
+                "442D70A944106A47EF22ADF67AD9D7CC24FC47C66B5D9B15E3D0104491D8C060" +
+                "A6E46F96A8E0C11A7D25211E2206B1CE272143B4B369D7B07645CB1E94668C43" +
+                "3D412A4600364122F22D7EC6B79227FA215CD230E3D09D0AA5BE3B291C4BE343" +
+                "808582C7F6EE20D7457DE1955F9E7E40A4C9EF55C5A5A0D3D125D8F53E69477B" +
+                "F0D91BD8B3401ECEEFE9D94382F836ACFB81814DFEF86F614406B02B6001E90E" +
+                "E84DA2BD0441BB943A6295F530AA7B7F375CD91EBA4CA83A0CF35FCBCA9F9915" +
+                "3BA0C28D1DA762D6257C99378F21FD6D890C31B9606BB6238CD3B0DBD4012649" +
+                "602E5352D20DA067576A94DB21E323B7902885F8892C844411027C3F4ED1F28B" +
+                "DBFB929E986DA6AF15F552975705C9C2C5500CE52F90903EF4BD53B145FB713B" +
+                "8A62FA292E608438A1CBF663FCCCEC99489CE9D709BF92AA9260F3950B058618" +
+                "B4EED63DD02376057460AF3854976C6A9C605148B0882F337253AD8AE8FA3AA6" +
+                "4194EF462A403D8198F1FBEFCC2ECAAE6B3C3A52AC79F5311F60B3EF2B281FE1" +
+                "C22E2C820570C687A1B5C7A1BB5013844DEE5AD720BE9D186B14EF38EA2FCB12" +
+                "4358CF552BEB3B9A0B36FB298FE527EEE2CD428680C4D6C55CCBFCE6F8E81162" +
+                "32198584267DF41CF50BDDBA22C601ADCA005A2187FC0097DC0B6AF0552B3034" +
+                "BA6E432DD0D7D6F3D58DDA91AC4756D2CFFC28DCF0A7EEE2D2A6CC23C77A2E2F" +
+                "9DD26143AAD7062093D7592C282A02FABC3815DD285064F6F5F0848294D781B3" +
+                "20C3F2DA3C26E1CCF6DB171908D5AFABA1A7BABC6D3F31FD7B566B7321AF6297" +
+                "F3EE652ABD11DD4FFF39D77B4FE06A838412B85C4877534369D115C65FA36BA3" +
+                "DDFF9B50C95B2AD649A5C814C9183ED743FA5CB23F65C5216C0F61B16CB73409" +
+                "D105EE6321C7D210C4DABC7A80C63B383178669FA9E79DCDD3DB1C175EED5199" +
+                "9F51BBAC06C90794B77491D0BC2FED10199EE322B7B23DB5B63B6C6B85E39ED3" +
+                "D145BC070EA912820C2E59FE9ED3670D8FBC44B9B2D6FAEEF95154972BA509CC" +
+                "96F83328DD7243DB11F9CDD5D8013DB8C7DD5ED58DEEFAC7FD282085715A063E" +
+                "320B167C904A65761233361B8232DAE539A8B5B38D9506ABBA9844E24D64E2DA" +
+                "ACD1E4F22546959282B721ACDA8289AE92C5FE0775F59A4EA10C732EE22FA01C" +
+                "E6556E8CCA94E6DD87F3A50EDF6FFDC4D10B07B3FBC55111DF62088A1AFCE2B6" +
+                "C6CF4C18CAA3BA05E7117368546B241236DDE91DF9CE30AE691C6044F30EA85A" +
+                "F169F0B64C353A40BC4AFF467C4B304B70751248B1B09F3781DDB84087B972FD" +
+                "0C92C6ABE141D38327BD810F87F0E058098B6E8A538E236C40955005AC4A232D" +
+                "22F7F9B479D0C093F18C4C4756B06F80132980E30716A3282306D1352CBBCD31").HexToByteArray();
+
+            VerifyExpectedSignature_Pss(
+                TestData.RSA16384Params,
+                HashAlgorithmName.SHA256,
+                TestData.RSA2048Params.Modulus,
+                modulus2048Signature);
+        }
+
+        [Fact]
+        public void VerifyExpectedSignature_PssSha384()
+        {
+            byte[] bigModulusSignature = (
+                "70F48CA4E8640701369DB986C4D09C91E4C197DB1BE4F32C3F37A67AEC4BA95D" +
+                "733EAACAE139B7B9C8E66C5BC82629971C3BEBF93A949CB81763FECDF96B73DA" +
+                "7D5929A15DFEF58B51E6D43F46238FC1121AAA3A5F3DF6B56E0FE2B6205192AB" +
+                "BA9752FC9CFD3000B08E3A823514A93FD90871FD09A005DA191431487DAF6364" +
+                "22").HexToByteArray();
+
+            VerifyExpectedSignature_Pss(
+                TestData.RSA1032Parameters,
+                HashAlgorithmName.SHA384,
+                TestData.RSA16384Params.Modulus,
+                bigModulusSignature);
+        }
+
+        [Fact]
+        public void VerifyExpectedSignature_PssSha512()
+        {
+            byte[] helloSignature = (
+                "60678D68816149206AD33F7153FFBAA1043FF7ABC539D6C88E5D2C94BCC10CF4" +
+                "E66A6F0F08DEA15781B8FA06F9E27D0B01347DAAA4B760D8978EC2EF87B508A2" +
+                "680FBE59F8BCC8A6AF413A1CB2373DFF32C4217542A9EE86179083DD316485FB" +
+                "E496EEF0EBE3E4A2793C888E988962C5EAF35136172E74B02724770863D10B19" +
+                "AACDE7D31CE77BE96EA54DE7A2409648AB3105FAC1003B00E32FAE4527284352" +
+                "A859C17F4C7D611DE4C451291A3096A0D6230EE2699B79CD571DE6D441CB372A" +
+                "9D6E46080AB8041D45D4B9475CBE6B48D10F4332910869D8C3931133224475D9" +
+                "BA1E0B92161BB2C17A96F92432F2BA1AEBAD8C7CD33D79F5C6EFB9BF6F192205").HexToByteArray();
+
+            VerifyExpectedSignature_Pss(
+                TestData.RSA2048Params,
+                HashAlgorithmName.SHA512,
+                TestData.HelloBytes,
+                helloSignature);
+        }
+
+        private void VerifyExpectedSignature_Pss(
+            RSAParameters keyParameters,
+            HashAlgorithmName hashAlgorithm,
+            byte[] data,
+            byte[] signature,
+            [System.Runtime.CompilerServices.CallerMemberName] string callerName = null)
+        {
+            RSAParameters publicParameters = new RSAParameters
+            {
+                Modulus = keyParameters.Modulus,
+                Exponent = keyParameters.Exponent,
+            };
+
+            RSASignaturePadding padding = RSASignaturePadding.Pss;
+
+            using (RSA rsaPublic = RSAFactory.Create())
+            using (RSA rsaPrivate = RSAFactory.Create())
+            {
+                try
+                {
+                    rsaPublic.ImportParameters(publicParameters);
+                }
+                catch (CryptographicException)
+                {
+                    // The key didn't load, not anything else this test can do.
+                    return;
+                }
+
+                rsaPrivate.ImportParameters(keyParameters);
+
+                // Generator for new tests.
+                if (signature == null)
+                {
+                    signature = SignData(rsaPrivate, data, hashAlgorithm, padding);
+                    Console.WriteLine($"{callerName}: {signature.ByteArrayToHex()}");
+                }
+
+                if (RSAFactory.SupportsPss)
+                {
+                    Assert.True(
+                        VerifyData(rsaPublic, data, signature, hashAlgorithm, padding),
+                        "Public key verified the signature");
+
+                    Assert.True(
+                        VerifyData(rsaPrivate, data, signature, hashAlgorithm, padding),
+                        "Private key verified the signature");
+                }
+                else
+                {
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => VerifyData(rsaPublic, data, signature, hashAlgorithm, padding));
+
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => VerifyData(rsaPrivate, data, signature, hashAlgorithm, padding));
+                }
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsPss))]
+        public void PssSignature_WrongHashAlgorithm()
+        {
+            RSASignaturePadding padding = RSASignaturePadding.Pss;
+            byte[] data = TestData.HelloBytes;
+
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] signature = SignData(rsa, data, HashAlgorithmName.SHA256, padding);
+                Assert.False(VerifyData(rsa, data, signature, HashAlgorithmName.SHA384, padding));
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsPss))]
+        public void PssVerifyHash_MismatchedHashSize()
+        {
+            // This is a legal SHA-1 value, which we're going to use with SHA-2-256 instead.
+            byte[] hash = "75ED7E627DB9AECBD870E27EED49ED7D9AEB2F52".HexToByteArray();
+
+            byte[] sig = (
+                "837A17C13618030A6C0C17551D8A34CA5AE4BB1D45A5DAD091F4016C630E0838" +
+                "5F9D9F1F75EF4CCBBE723C0630AC699C43587D81BD16AFBD2F797215F68F8062" +
+                "87A352BB269FB9D042DA4D9D664172E4B3B39FC3457879C8DBDD56FAB44F2515" +
+                "71E2E607A964CB548CB36198004ACD8D3E3B80D10917CE582710BB65513C0310" +
+                "4A0A82C63D2B8898F5BAF97618B5EBE5F3B0824561C059FD7FC949B12837E8B1" +
+                "E86380E9A68F6D7E8E8BD5C57B04E831DBBDBDCA20403EC988635F62D4B48382" +
+                "56E2AF4213FDCA6BF801C06AF6381DAC61288C13B08806A323B3E956A13BCB29" +
+                "680F62CCA9880A8A1FD1A2CA61DCFE008AC7FC55E98ACCE9B7BE010E5BCB836A").HexToByteArray();
+
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                Assert.False(VerifyHash(rsa, hash, sig, HashAlgorithmName.SHA256, RSASignaturePadding.Pss));
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsPss))]
+        public void PssSignHash_MismatchedHashSize()
+        {
+            RSASignaturePadding padding = RSASignaturePadding.Pss;
+
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] data152 = new byte[152 / 8];
+                byte[] data168 = new byte[168 / 8];
+                RandomNumberGenerator.Fill(data152);
+                RandomNumberGenerator.Fill(data168);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => SignHash(rsa, data152, HashAlgorithmName.SHA1, padding));
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => SignHash(rsa, data168, HashAlgorithmName.SHA1, padding));
+
+                byte[] data160 = new byte[160 / 8];
+                RandomNumberGenerator.Fill(data160);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => SignHash(rsa, data160, HashAlgorithmName.SHA256, padding));
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsPss))]
+        public void PssSignature_WrongData()
+        {
+            RSASignaturePadding padding = RSASignaturePadding.Pss;
+            byte[] dataCopy = (byte[])TestData.HelloBytes.Clone();
+            HashAlgorithmName hashAlgorithmName = HashAlgorithmName.SHA256;
+
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] signature = SignData(rsa, dataCopy, hashAlgorithmName, padding);
+                dataCopy[0] ^= 0xFF;
+                Assert.False(VerifyData(rsa, dataCopy, signature, hashAlgorithmName, padding));
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsPss))]
+        public void PssSignature_WrongLength()
+        {
+            RSASignaturePadding padding = RSASignaturePadding.Pss;
+            byte[] data = TestData.HelloBytes;
+            HashAlgorithmName hashAlgorithmName = HashAlgorithmName.SHA256;
+
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] signature = SignData(rsa, data, hashAlgorithmName, padding);
+
+                // Too long by a byte
+                Array.Resize(ref signature, signature.Length + 1);
+                Assert.False(VerifyData(rsa, data, signature, hashAlgorithmName, padding));
+
+                // Net too short by a byte
+                Array.Resize(ref signature, signature.Length - 2);
+                Assert.False(VerifyData(rsa, data, signature, hashAlgorithmName, padding));
+            }
         }
 
         private void ExpectSignature(

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -1084,6 +1084,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsPss))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void PssVerifyHash_MismatchedHashSize()
         {
             // This is a legal SHA-1 value, which we're going to use with SHA-2-256 instead.
@@ -1106,6 +1107,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsPss))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void PssSignHash_MismatchedHashSize()
         {
             RSASignaturePadding padding = RSASignaturePadding.Pss;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -556,8 +556,6 @@ namespace System.Security.Cryptography.Rsa.Tests
             {
                 byte[] data152 = new byte[152 / 8];
                 byte[] data168 = new byte[168 / 8];
-                RandomNumberGenerator.Fill(data152);
-                RandomNumberGenerator.Fill(data168);
 
                 Assert.ThrowsAny<CryptographicException>(
                     () => SignHash(rsa, data152, HashAlgorithmName.SHA1, padding));
@@ -566,7 +564,6 @@ namespace System.Security.Cryptography.Rsa.Tests
                     () => SignHash(rsa, data168, HashAlgorithmName.SHA1, padding));
 
                 byte[] data160 = new byte[160 / 8];
-                RandomNumberGenerator.Fill(data160);
 
                 Assert.ThrowsAny<CryptographicException>(
                     () => SignHash(rsa, data160, HashAlgorithmName.SHA256, padding));
@@ -1117,8 +1114,6 @@ namespace System.Security.Cryptography.Rsa.Tests
             {
                 byte[] data152 = new byte[152 / 8];
                 byte[] data168 = new byte[168 / 8];
-                RandomNumberGenerator.Fill(data152);
-                RandomNumberGenerator.Fill(data168);
 
                 Assert.ThrowsAny<CryptographicException>(
                     () => SignHash(rsa, data152, HashAlgorithmName.SHA1, padding));
@@ -1127,7 +1122,6 @@ namespace System.Security.Cryptography.Rsa.Tests
                     () => SignHash(rsa, data168, HashAlgorithmName.SHA1, padding));
 
                 byte[] data160 = new byte[160 / 8];
-                RandomNumberGenerator.Fill(data160);
 
                 Assert.ThrowsAny<CryptographicException>(
                     () => SignHash(rsa, data160, HashAlgorithmName.SHA256, padding));

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
@@ -267,3 +267,76 @@ cleanup:
 
     return ret;
 }
+
+static int32_t RsaPrimitive(SecKeyRef key,
+                            uint8_t* pbData,
+                            int32_t cbData,
+                            CFDataRef* pDataOut,
+                            CFErrorRef* pErrorOut,
+                            SecKeyAlgorithm algorithm,
+                            CFDataRef func(SecKeyRef, SecKeyAlgorithm, CFDataRef, CFErrorRef*))
+{
+    if (pDataOut != nullptr)
+        *pDataOut = nullptr;
+    if (pErrorOut != nullptr)
+        *pErrorOut = nullptr;
+
+    if (key == nullptr || pbData == nullptr || cbData < 0 || pDataOut == nullptr || pErrorOut == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    assert(func != nullptr);
+
+    CFDataRef input = CFDataCreateWithBytesNoCopy(nullptr, pbData, cbData, kCFAllocatorNull);
+    CFDataRef output = func(key, algorithm, input, pErrorOut);
+
+    if (*pErrorOut != nullptr)
+    {
+        if (output != nullptr)
+        {
+            CFRelease(output);
+            output = nullptr;
+        }
+
+        return kErrorSeeError;
+    }
+
+    if (output == nullptr)
+    {
+        return kErrorUnknownState;
+    }
+
+    *pDataOut = output;
+    return 1;
+}
+
+extern "C" int32_t AppleCryptoNative_RsaSignaturePrimitive(
+    SecKeyRef privateKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut)
+{
+    return RsaPrimitive(
+        privateKey, pbData, cbData, pDataOut, pErrorOut, kSecKeyAlgorithmRSASignatureRaw, SecKeyCreateSignature);
+}
+
+extern "C" int32_t AppleCryptoNative_RsaDecryptionPrimitive(
+    SecKeyRef privateKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut)
+{
+    return RsaPrimitive(
+        privateKey, pbData, cbData, pDataOut, pErrorOut, kSecKeyAlgorithmRSAEncryptionRaw, SecKeyCreateDecryptedData);
+}
+
+extern "C" int32_t AppleCryptoNative_RsaEncryptionPrimitive(
+    SecKeyRef publicKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut)
+{
+    return RsaPrimitive(
+        publicKey, pbData, cbData, pDataOut, pErrorOut, kSecKeyAlgorithmRSAEncryptionRaw, SecKeyCreateEncryptedData);
+}
+
+extern "C" int32_t AppleCryptoNative_RsaVerificationPrimitive(
+    SecKeyRef publicKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut)
+{
+    // Since there's not an API which will give back the still-padded signature block with
+    // kSecAlgorithmRSASignatureRaw, use the encryption primitive to achieve the same result.
+    return RsaPrimitive(
+        publicKey, pbData, cbData, pDataOut, pErrorOut, kSecKeyAlgorithmRSAEncryptionRaw, SecKeyCreateDecryptedData);
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
@@ -338,5 +338,5 @@ extern "C" int32_t AppleCryptoNative_RsaVerificationPrimitive(
     // Since there's not an API which will give back the still-padded signature block with
     // kSecAlgorithmRSASignatureRaw, use the encryption primitive to achieve the same result.
     return RsaPrimitive(
-        publicKey, pbData, cbData, pDataOut, pErrorOut, kSecKeyAlgorithmRSAEncryptionRaw, SecKeyCreateDecryptedData);
+        publicKey, pbData, cbData, pDataOut, pErrorOut, kSecKeyAlgorithmRSAEncryptionRaw, SecKeyCreateEncryptedData);
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.h
@@ -59,3 +59,35 @@ Follows pal_seckey return conventions.
 */
 extern "C" int32_t AppleCryptoNative_RsaEncryptPkcs(
     SecKeyRef publicKey, uint8_t* pbData, int32_t cbData, CFDataRef* pEncryptedOut, CFErrorRef* pErrorOut);
+
+/*
+Apply an RSA private key to a signing operation on data which was already padded.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_RsaSignaturePrimitive(
+    SecKeyRef privateKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut);
+
+/*
+Apply an RSA private key to an encryption operation to emit data which is still padded.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_RsaDecryptionPrimitive(
+    SecKeyRef privateKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut);
+
+/*
+Apply an RSA public key to an encryption operation on data which was already padded.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_RsaEncryptionPrimitive(
+    SecKeyRef publicKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut);
+
+/*
+Apply an RSA public key to a signing operation to emit data which is still padded.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_RsaVerificationPrimitive(
+    SecKeyRef publicKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut);

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -248,6 +248,8 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(RSA_get_method, true) \
     PER_FUNCTION_BLOCK(RSA_new, true) \
     PER_FUNCTION_BLOCK(RSA_private_decrypt, true) \
+    PER_FUNCTION_BLOCK(RSA_private_encrypt, true) \
+    PER_FUNCTION_BLOCK(RSA_public_decrypt, true) \
     PER_FUNCTION_BLOCK(RSA_public_encrypt, true) \
     PER_FUNCTION_BLOCK(RSA_sign, true) \
     PER_FUNCTION_BLOCK(RSA_size, true) \
@@ -540,6 +542,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define RSA_get_method RSA_get_method_ptr
 #define RSA_new RSA_new_ptr
 #define RSA_private_decrypt RSA_private_decrypt_ptr
+#define RSA_private_encrypt RSA_private_encrypt_ptr
+#define RSA_public_decrypt RSA_public_decrypt_ptr
 #define RSA_public_encrypt RSA_public_encrypt_ptr
 #define RSA_sign RSA_sign_ptr
 #define RSA_size RSA_size_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.h
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#include "pal_types.h"
 #include "opensslshim.h"
+#include "pal_types.h"
 
 /*
 Padding options for RsaPublicEncrypt and RsaPrivateDecrypt.
@@ -13,6 +13,7 @@ enum RsaPadding : int32_t
 {
     Pkcs1 = 0,
     OaepSHA1 = 1,
+    NoPadding = 2,
 };
 
 /*
@@ -60,6 +61,22 @@ Returns the size of the signature, or -1 on error.
 */
 extern "C" int32_t
 CryptoNative_RsaPrivateDecrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding);
+
+/*
+Shims RSA_private_encrypt with a fixed value of RSA_NO_PADDING.
+
+Requires that the input be the size of the key.
+Returns the number of bytes written (which should be flen), or -1 on error.
+*/
+extern "C" int32_t CryptoNative_RsaSignPrimitive(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa);
+
+/*
+Shims RSA_public_decrypt with a fixed value of RSA_NO_PADDING.
+
+Requires that the input be the size of the key.
+Returns the number of bytes written (which should be flen), or -1 on error.
+*/
+extern "C" int32_t CryptoNative_RsaVerificationPrimitive(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa);
 
 /*
 Shims the RSA_size method.

--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -94,6 +94,9 @@
   <data name="Cryptography_DSA_KeyGenNotSupported" xml:space="preserve">
     <value>DSA keys can be imported, but new key generation is not supported on this platform.</value>
   </data>
+  <data name="Cryptography_Encryption_MessageTooLong" xml:space="preserve">
+    <value>The message exceeds the maximum allowable length for the chosen options ({0}).</value>
+  </data>
   <data name="Cryptography_ECXmlSerializationFormatRequired" xml:space="preserve">
     <value>XML serialization of an elliptic curve key requires using an overload which specifies the XML format to be used.</value>
   </data>
@@ -172,6 +175,9 @@
   <data name="Cryptography_Invalid_IA5String" xml:space="preserve">
     <value>The string contains a character not in the 7 bit ASCII character set.</value>
   </data>
+  <data name="Cryptography_KeyTooSmall" xml:space="preserve">
+    <value>The key is too small for the requested operation.</value>
+  </data>
   <data name="Cryptography_MissingIV" xml:space="preserve">
     <value>The cipher mode specified requires that an initialization vector (IV) be used.</value>
   </data>
@@ -189,6 +195,9 @@
   </data>
   <data name="Cryptography_NotValidPublicOrPrivateKey" xml:space="preserve">
     <value>Key is not a valid public or private key.</value>
+  </data>
+  <data name="Cryptography_OAEP_Decryption_Failed" xml:space="preserve">
+    <value>Error occurred while decoding OAEP padding.</value>
   </data>
   <data name="Cryptography_OpenInvalidHandle" xml:space="preserve">
     <value>Cannot open an invalid handle.</value>
@@ -210,6 +219,9 @@
   </data>
   <data name="Cryptography_Rijndael_BlockSize" xml:space="preserve">
     <value>BlockSize must be 128 in this implementation.</value>
+  </data>
+  <data name="Cryptography_SignHash_WrongSize" xml:space="preserve">
+    <value>The provided hash value is not the expected size for the specified hash algorithm.</value>
   </data>
   <data name="Cryptography_TransformBeyondEndOfBuffer" xml:space="preserve">
     <value>Attempt to transform beyond end of buffer.</value>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -481,6 +481,7 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Memory" />

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -104,6 +104,9 @@
     <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoDecryptor.cs">
       <Link>Internal\Cryptography\UniversalCryptoDecryptor.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\RsaPaddingProcessor.cs">
+      <Link>Common\System\Security\Cryptography\RsaPaddingProcessor.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' and '$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Security\Cryptography\CngKeyLite.cs" />

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -48,26 +48,11 @@ namespace System.Security.Cryptography.Rsa.Tests
         public bool SupportsSha2Oaep { get; } =
             !PlatformDetection.IsFullFramework || !(RSA.Create() is RSACryptoServiceProvider);
 
-        public bool SupportsPss { get; } = DeterminePssSupport();
+        public bool SupportsPss { get; } =
+            !PlatformDetection.IsFullFramework || !(RSA.Create() is RSACryptoServiceProvider);
 
         public bool SupportsDecryptingIntoExactSpaceRequired => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-        private static bool DeterminePssSupport()
-        {
-            if (PlatformDetection.IsFullFramework)
-            {
-                return !(RSA.Create() is RSACryptoServiceProvider);
-            }
-
-            //if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            //{
-            //    // Darwin Kernel 17 is macOS High Sierra (10.13)
-            //    // macOS Sierra (10.12) reports algorithm not supported for RSA raw sign.
-            //    return Environment.OSVersion.Version >= new Version(17, 0);
-            //}
-
-            return true;
-        }
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -59,12 +59,12 @@ namespace System.Security.Cryptography.Rsa.Tests
                 return !(RSA.Create() is RSACryptoServiceProvider);
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                // Darwin Kernel 17 is macOS High Sierra (10.13)
-                // macOS Sierra (10.12) reports algorithm not supported for RSA raw sign.
-                return Environment.OSVersion.Version >= new Version(17, 0);
-            }
+            //if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            //{
+            //    // Darwin Kernel 17 is macOS High Sierra (10.13)
+            //    // macOS Sierra (10.12) reports algorithm not supported for RSA raw sign.
+            //    return Environment.OSVersion.Version >= new Version(17, 0);
+            //}
 
             return true;
         }

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -45,11 +45,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
-        public bool SupportsSha2Oaep
-        {
-            // Currently only RSACng does, which is the default provider on Windows.
-            get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !(Create() is RSACryptoServiceProvider); }
-        }
+        public bool SupportsSha2Oaep { get; } = !(RSA.Create() is RSACryptoServiceProvider);
 
         public bool SupportsDecryptingIntoExactSpaceRequired => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -45,9 +45,29 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
-        public bool SupportsSha2Oaep { get; } = !(RSA.Create() is RSACryptoServiceProvider);
+        public bool SupportsSha2Oaep { get; } =
+            !PlatformDetection.IsFullFramework || !(RSA.Create() is RSACryptoServiceProvider);
+
+        public bool SupportsPss { get; } = DeterminePssSupport();
 
         public bool SupportsDecryptingIntoExactSpaceRequired => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        private static bool DeterminePssSupport()
+        {
+            if (PlatformDetection.IsFullFramework)
+            {
+                return !(RSA.Create() is RSACryptoServiceProvider);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // Darwin Kernel 17 is macOS High Sierra (10.13)
+                // macOS Sierra (10.12) reports algorithm not supported for RSA raw sign.
+                return Environment.OSVersion.Version >= new Version(17, 0);
+            }
+
+            return true;
+        }
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -82,6 +82,9 @@
   <data name="Cryptography_CngKeyWrongAlgorithm" xml:space="preserve">
     <value>This key is for algorithm '{0}'. Expected '{1}'.</value>
   </data>
+  <data name="Cryptography_Encryption_MessageTooLong" xml:space="preserve">
+    <value>The message exceeds the maximum allowable length for the chosen options ({0}).</value>
+  </data>
   <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
     <value>The hash algorithm name cannot be null or empty.</value>
   </data>
@@ -142,6 +145,9 @@
   <data name="Cryptography_KeyBlobParsingError" xml:space="preserve">
     <value>Key Blob not in expected format.</value>
   </data>
+  <data name="Cryptography_KeyTooSmall" xml:space="preserve">
+    <value>The key is too small for the requested operation.</value>
+  </data>
   <data name="Cryptography_OpenEphemeralKeyHandleWithoutEphemeralFlag" xml:space="preserve">
     <value>The CNG key handle being opened was detected to be ephemeral, but the EphemeralKey open option was not specified.</value>
   </data>
@@ -160,8 +166,14 @@
   <data name="Cryptography_NotValidPublicOrPrivateKey" xml:space="preserve">
     <value>Key is not a valid public or private key.</value>
   </data>
+  <data name="Cryptography_OAEP_Decryption_Failed" xml:space="preserve">
+    <value>Error occurred while decoding OAEP padding.</value>
+  </data>
   <data name="Cryptography_PartialBlock" xml:space="preserve">
     <value>The input data is not a complete block.</value>
+  </data>
+  <data name="Cryptography_SignHash_WrongSize" xml:space="preserve">
+    <value>The provided hash value is not the expected size for the specified hash algorithm.</value>
   </data>
   <data name="Cryptography_UnsupportedPaddingMode" xml:space="preserve">
     <value>The specified PaddingMode is not supported.</value>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -267,6 +267,9 @@
     <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.SignVerify.cs">
       <Link>Common\System\Security\Cryptography\RSACng.SignVerify.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\RsaPaddingProcessor.cs">
+      <Link>Common\System\Security\Cryptography\RsaPaddingProcessor.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="mscorlib" />
@@ -278,6 +281,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Reference Include="System.Buffers" />
+    <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Memory" />
@@ -289,6 +293,7 @@
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Encoding" />
     <Reference Include="System.Security.Cryptography.Primitives" />
+    <Reference Include="System.Threading" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -282,6 +282,7 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Memory" />

--- a/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
@@ -32,6 +32,8 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         public bool SupportsSha2Oaep => true;
 
+        public bool SupportsPss => true;
+
         public bool SupportsDecryptingIntoExactSpaceRequired => true;
     }
 

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -906,7 +906,9 @@ namespace Internal.NativeCrypto
             // parameter specifies the size of the plaintext to encrypt.
             if (!Interop.CryptEncrypt(safeKeyHandle, SafeHashHandle.InvalidHandle, true, dwEncryptFlags, pbEncryptedKey, ref cbKey, cbEncryptedKey))
             {
+                throw GetErrorCode().ToCryptographicException();
             }
+
             Debug.Assert(cbKey == cbEncryptedKey);
             Array.Reverse(pbEncryptedKey);
         }

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -170,12 +170,18 @@ namespace System.Security.Cryptography
         public override string SignatureAlgorithm => "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 
         public override byte[] SignData(Stream data, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding != RSASignaturePadding.Pkcs1 ? throw PaddingModeNotSupported() :
             _impl.SignData(data, hashAlgorithm, padding);
 
         public override byte[] SignData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding != RSASignaturePadding.Pkcs1 ? throw PaddingModeNotSupported() :
             _impl.SignData(data, offset, count, hashAlgorithm, padding);
 
         public override bool TrySignData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding != RSASignaturePadding.Pkcs1 ? throw PaddingModeNotSupported() :
             _impl.TrySignData(data, destination, hashAlgorithm, padding, out bytesWritten);
 
         public byte[] SignData(byte[] buffer, int offset, int count, object halg) =>
@@ -214,9 +220,13 @@ namespace System.Security.Cryptography
             _impl.VerifyData(buffer, signature, HashAlgorithmNames.ObjToHashAlgorithmName(halg), RSASignaturePadding.Pkcs1);
 
         public override bool VerifyData(byte[] data, int offset, int count, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding != RSASignaturePadding.Pkcs1 ? throw PaddingModeNotSupported() :
             _impl.VerifyData(data, offset, count, signature, hashAlgorithm, padding);
 
         public override bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding != RSASignaturePadding.Pkcs1 ? throw PaddingModeNotSupported() :
             _impl.VerifyData(data, signature, hashAlgorithm, padding);
 
         public override bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -188,9 +188,13 @@ namespace System.Security.Cryptography
             _impl.SignData(inputStream, HashAlgorithmNames.ObjToHashAlgorithmName(halg), RSASignaturePadding.Pkcs1);
 
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding != RSASignaturePadding.Pkcs1 ? throw PaddingModeNotSupported() : 
             _impl.SignHash(hash, hashAlgorithm, padding);
 
         public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding != RSASignaturePadding.Pkcs1 ? throw PaddingModeNotSupported() :
             _impl.TrySignHash(hash, destination, hashAlgorithm, padding, out bytesWritten);
 
         public byte[] SignHash(byte[] rgbHash, string str)

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using Internal.Cryptography;
 using Internal.NativeCrypto;
 using static Internal.NativeCrypto.CapiHelper;
 
@@ -314,6 +315,19 @@ namespace System.Security.Cryptography
             if (rgb == null)
             {
                 throw new ArgumentNullException(nameof(rgb));
+            }
+
+            if (fOAEP)
+            {
+                int rsaSize = (KeySize + 7) / 8;
+                const int OaepSha1Overhead = 20 + 20 + 2;
+
+                // Normalize the Windows 7 and Windows 8.1+ exception
+                if (rsaSize - OaepSha1Overhead < rgb.Length)
+                {
+                    const int NTE_BAD_LENGTH = unchecked((int)0x80090004);
+                    throw NTE_BAD_LENGTH.ToCryptographicException();
+                }
             }
 
             byte[] encryptedKey = null;

--- a/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
@@ -16,6 +16,8 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         public bool SupportsSha2Oaep => false;
 
+        public bool SupportsPss => false;
+
         public bool SupportsDecryptingIntoExactSpaceRequired => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 

--- a/src/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
@@ -129,6 +129,9 @@
   <data name="Cryptography_CSP_NoPrivateKey" xml:space="preserve">
     <value>Object contains only the public half of a key pair. A private key must also be provided.</value>
   </data>
+  <data name="Cryptography_Encryption_MessageTooLong" xml:space="preserve">
+    <value>The message exceeds the maximum allowable length for the chosen options ({0}).</value>
+  </data>
   <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
     <value>The hash algorithm name cannot be null or empty.</value>
   </data>
@@ -173,6 +176,15 @@
   </data>
   <data name="Cryptography_Invalid_IA5String" xml:space="preserve">
     <value>The string contains a character not in the 7 bit ASCII character set.</value>
+  </data>
+  <data name="Cryptography_KeyTooSmall" xml:space="preserve">
+    <value>The key is too small for the requested operation.</value>
+  </data>
+  <data name="Cryptography_OAEP_Decryption_Failed" xml:space="preserve">
+    <value>Error occurred while decoding OAEP padding.</value>
+  </data>
+  <data name="Cryptography_SignHash_WrongSize" xml:space="preserve">
+    <value>The provided hash value is not the expected size for the specified hash algorithm.</value>
   </data>
   <data name="PlatformNotSupported_CryptographyOpenSSL" xml:space="preserve">
     <value>OpenSSL is not supported on this platform.</value>

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -124,6 +124,7 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Memory" />

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -117,6 +117,9 @@
     <Compile Include="$(CommonPath)\System\Security\Cryptography\RSAOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\RSAOpenSsl.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\RsaPaddingProcessor.cs">
+      <Link>Common\System\Security\Cryptography\RsaPaddingProcessor.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Reference Include="System.Buffers" />

--- a/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         public bool Supports384PrivateKey => true;
 
-        public bool SupportsSha2Oaep => false;
+        public bool SupportsSha2Oaep => true;
 
         public bool SupportsDecryptingIntoExactSpaceRequired => false;
     }

--- a/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
@@ -14,6 +14,8 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         public bool SupportsSha2Oaep => true;
 
+        public bool SupportsPss => true;
+
         public bool SupportsDecryptingIntoExactSpaceRequired => false;
     }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -151,6 +151,9 @@
   <data name="Cryptography_ECC_NamedCurvesOnly" xml:space="preserve">
     <value>Only named curves are supported on this platform.</value>
   </data>
+  <data name="Cryptography_Encryption_MessageTooLong" xml:space="preserve">
+    <value>The message exceeds the maximum allowable length for the chosen options ({0}).</value>
+  </data>
   <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
     <value>ASN1 corrupted data.</value>
   </data>
@@ -178,6 +181,12 @@
   <data name="Cryptography_InvalidStoreHandle" xml:space="preserve">
     <value>The store handle is invalid.</value>
   </data>
+  <data name="Cryptography_KeyTooSmall" xml:space="preserve">
+    <value>The key is too small for the requested operation.</value>
+  </data>
+  <data name="Cryptography_OAEP_Decryption_Failed" xml:space="preserve">
+    <value>Error occurred while decoding OAEP padding.</value>
+  </data>
   <data name="Cryptography_OpenInvalidHandle" xml:space="preserve">
     <value>Cannot open an invalid handle.</value>
   </data>
@@ -186,6 +195,9 @@
   </data>
   <data name="Cryptography_PrivateKey_WrongAlgorithm" xml:space="preserve">
     <value>The provided key does not match the public key algorithm for this certificate.</value>
+  </data>
+  <data name="Cryptography_SignHash_WrongSize" xml:space="preserve">
+    <value>The provided hash value is not the expected size for the specified hash algorithm.</value>
   </data>
   <data name="Cryptography_Unix_X509_DisallowedStoreNotEmpty" xml:space="preserve">
    <value>The Disallowed store is not supported on this platform, but already has data. All files under '{0}' must be removed.</value>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -412,6 +412,7 @@
   <ItemGroup>
     <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -382,6 +382,9 @@
     <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyBlobHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeyBlobHelpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\RsaPaddingProcessor.cs">
+      <Link>Common\System\Security\Cryptography\RsaPaddingProcessor.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Security\Cryptography\RSASecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\RSASecurityTransforms.cs</Link>
     </Compile>
@@ -407,6 +410,7 @@
     <Compile Include="Internal\Cryptography\Pal.Unix\X500NameEncoder.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Diagnostics.Debug" />


### PR DESCRIPTION
This change provides an implementation of the OAEP padding algorithm and
the PSS encoding and verification routines in managed code. On the platforms
where we currently lack support for SHA-2-based OAEP and/or PSS the
managed implementation will be used in conjunction with the native layer in
a pre-padded operational context.

The suite of tests which were added uncovered other bugs which are being
addressed in this change, as well.  Mainly that RSACng and
RSASecurityTransforms both failed at encrypting zero-length data.  To solve
that problem the RSA padding class can build PKCS#1 encryption padding,
but since the native layers are capable of correctly decrypting the payloads
no unpadding code is needed at this time.

Fixes #2522
Fixes #2523
Fixes #27120