### PR TITLE
Add CU\My to the search path for resolving cert chains on Linux

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -380,16 +380,19 @@ namespace Internal.Cryptography.Pal
             using (var systemIntermediateStore = new X509Store(StoreName.CertificateAuthority, StoreLocation.LocalMachine))
             using (var userRootStore = new X509Store(StoreName.Root, StoreLocation.CurrentUser))
             using (var userIntermediateStore = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser))
+            using (var userMyStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
             {
                 systemRootStore.Open(OpenFlags.ReadOnly);
                 systemIntermediateStore.Open(OpenFlags.ReadOnly);
                 userRootStore.Open(OpenFlags.ReadOnly);
                 userIntermediateStore.Open(OpenFlags.ReadOnly);
+                userMyStore.Open(OpenFlags.ReadOnly);
 
                 X509Certificate2Collection systemRootCerts = systemRootStore.Certificates;
                 X509Certificate2Collection systemIntermediateCerts = systemIntermediateStore.Certificates;
                 X509Certificate2Collection userRootCerts = userRootStore.Certificates;
                 X509Certificate2Collection userIntermediateCerts = userIntermediateStore.Certificates;
+                X509Certificate2Collection userMyCerts = userMyStore.Certificates;
 
                 // fill the system trusted collection
                 foreach (X509Certificate2 userRootCert in userRootCerts)
@@ -416,6 +419,7 @@ namespace Internal.Cryptography.Pal
                 X509Certificate2Collection[] storesToCheck =
                 {
                     extraStore,
+                    userMyCerts,
                     userIntermediateCerts,
                     systemIntermediateCerts,
                     userRootCerts,
@@ -452,7 +456,7 @@ namespace Internal.Cryptography.Pal
                     candidates,
                     ReferenceEqualityComparer<X509Certificate2>.Instance);
 
-                // Certificates come from 5 sources:
+                // Certificates come from 6 sources:
                 //  1) extraStore.
                 //     These are cert objects that are provided by the user, we shouldn't dispose them.
                 //  2) the machine root store
@@ -463,8 +467,11 @@ namespace Internal.Cryptography.Pal
                 //     These certs were either path candidates, or not. If they were, don't dispose them. Otherwise do.
                 //  5) the user intermediate store
                 //     These certs were either path candidates, or not. If they were, don't dispose them. Otherwise do.
+                //  6) the user my store
+                //     These certs were either path candidates, or not. If they were, don't dispose them. Otherwise do.
                 DisposeUnreferenced(candidatesByReference, systemIntermediateCerts);
                 DisposeUnreferenced(candidatesByReference, userIntermediateCerts);
+                DisposeUnreferenced(candidatesByReference, userMyCerts);
             }
 
             return candidates;


### PR DESCRIPTION
No test is being committed because it requires editing the user's CU\My store, which doesn't make me happy.  This was tested by taking the CertificateRequest chain tests, saving the created intermediate to CU\My, removing the intermediate from ExtraStore, and then removing them at the end of the test.

After the test succeeded on Windows (and failed on Linux), the fix was made on the Linux chain builder driver.

Fixes #26020.