### PR TITLE
Use TrailingZeroCount rather than LocateLastFoundByte

### DIFF
--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 
 #if !netstandard
 using Internal.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 #endif
 
 #if !netstandard11
@@ -1042,8 +1043,15 @@ namespace System
                 }
             }
 
-            // Single LEA instruction with jitted const (using function result)
-            return i * 8 + LocateLastFoundByte(candidate);
+            if (IntPtr.Size == 8 && Bmi1.IsSupported)
+            {
+                return i * 8 + (int)Bmi1.TrailingZeroCount(candidate) >> 3;
+            }
+            else
+            {
+                // Single LEA instruction with jitted const (using function result)
+                return i * 8 + LocateLastFoundByte(candidate);
+            }
         }
 #endif
 


### PR DESCRIPTION
`Bmi1.TrailingZeroCount` isn't currently supported; so can't test, so this is mostly for feedback
```csharp
return i * 8 + (int)Bmi1.TrailingZeroCount(candidate) >> 3;
```
Using `LeadingZeroCount` ended up more instructions than the current flow
```csharp
return i * 8 + (int)(((match ^ (match - 1)) * XorPowerOfTwoToHighByte) >> 57)
```
Changing multiply to Lzcnt and subtraction
```csharp
return i * 8 + (63 - (int)Lzcnt.LeadingZeroCount((candidate ^ (candidate - 1)))) >> 3;
```

/cc @fiigii @tannergooding