### PR TITLE
add basic and digest authentication for tunnel/https proxy in SocketHttpHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHandler.cs
@@ -91,7 +91,7 @@ namespace System.Net.Http
             return response;
         }
 
-        private static AuthenticationHeaderValue GetSupportedAuthScheme(HttpHeaderValueCollection<AuthenticationHeaderValue> authenticateValues)
+        public static AuthenticationHeaderValue GetSupportedAuthScheme(HttpHeaderValueCollection<AuthenticationHeaderValue> authenticateValues)
         {
             AuthenticationHeaderValue basicAuthenticationHeaderValue = null;
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionHandler.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http
 
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return _poolManager.SendAsync(request, null, cancellationToken);
+            return _poolManager.SendAsync(request, null, null, cancellationToken);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -139,14 +139,14 @@ namespace System.Net.Http
             }
         }
 
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, Uri proxyUri, CancellationToken cancellationToken)
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, Uri proxyUri, ICredentials proxyCredentials, CancellationToken cancellationToken)
         {
             HttpConnectionKey key = GetConnectionKey(request, proxyUri);
 
             HttpConnectionPool pool;
             while (!_pools.TryGetValue(key, out pool))
             {
-                pool = new HttpConnectionPool(this, key.Host, key.Port, key.SslHostName, key.ProxyUri, _maxConnectionsPerServer);
+                pool = new HttpConnectionPool(this, key.Host, key.Port, key.SslHostName, key.ProxyUri, proxyCredentials, _maxConnectionsPerServer);
                 if (_pools.TryAdd(key, pool))
                 {
                     // We need to ensure the cleanup timer is running if it isn't

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpProxyConnectionHandler.cs
@@ -50,7 +50,7 @@ namespace System.Net.Http
 
         private Task<HttpResponseMessage> GetConnectionAndSendAsync(HttpRequestMessage request, Uri proxyUri, CancellationToken cancellationToken)
         {
-            return _poolManager.SendAsync(request, proxyUri, cancellationToken);
+            return _poolManager.SendAsync(request, proxyUri, _proxy.Credentials ?? _defaultCredentials, cancellationToken);
         }
 
         private async Task<HttpResponseMessage> SendWithProxyAsync(


### PR DESCRIPTION
this allows https request to go through proxy requiring basic or digest authentication. 
Note, that this builds on top of some pending changes and it will not work on its own.
There is now unit test yet as that also depending PR. I'm going to add more tests as follow-op PR.

If preferable I think I can refactor this more and get more sharing with AuthenticationHandler code and existing proxy. But this change works and I wanted to get more feedback. 

Also note, that we will throw if authentication to proxy fails. That is different from existing handlers. 
At least curl will return failed response to the caller. 