### PR TITLE
Fix calling convention gap in ILGenerator.EmitCalli

### DIFF
--- a/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
+++ b/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
@@ -48,6 +48,7 @@ namespace System.Reflection.Emit
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Type cls) { }
         public virtual void EmitCall(System.Reflection.Emit.OpCode opcode, System.Reflection.MethodInfo methodInfo, System.Type[] optionalParameterTypes) { }
         public virtual void EmitCalli(System.Reflection.Emit.OpCode opcode, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Type[] optionalParameterTypes) { }
+        public virtual void EmitCalli(System.Reflection.Emit.OpCode opcode, System.Runtime.InteropServices.CallingConvention unmanagedCallConv, Type returnType, Type[] parameterTypes) { }
         public virtual void EmitWriteLine(System.Reflection.Emit.LocalBuilder localBuilder) { }
         public virtual void EmitWriteLine(System.Reflection.FieldInfo fld) { }
         public virtual void EmitWriteLine(string value) { }

--- a/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.csproj
+++ b/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.InteropServices\ref\System.Runtime.InteropServices.csproj" />
     <ProjectReference Include="..\..\System.Reflection\ref\System.Reflection.csproj" />
     <ProjectReference Include="..\..\System.Reflection.Primitives\ref\System.Reflection.Primitives.csproj" />
   </ItemGroup>

--- a/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -9,31 +9,42 @@ namespace System.Reflection.Emit.Tests
 {
     public class ILGeneratorEmit4
     {
-        [Fact]
-        public void TestEmitCalliWithNullReturnType()
+        [Theory]
+        [InlineData(1, 1, 2)]
+        public void TestEmitCalliStdCall(int a, int b, int result)
         {
             ModuleBuilder moduleBuilder = Helpers.DynamicModule();
             TypeBuilder typeBuilder = moduleBuilder.DefineType("T", TypeAttributes.Public);
+            Type returnType = typeof(int);
 
             MethodBuilder methodBuilder = typeBuilder.DefineMethod("F",
-                MethodAttributes.Public | MethodAttributes.Static, null, new Type[] { typeof(IntPtr) });
+                MethodAttributes.Public | MethodAttributes.Static, returnType, new Type[] { typeof(IntPtr), typeof(int), typeof(int) });
             methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
 
             ILGenerator il = methodBuilder.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_2);
             il.Emit(OpCodes.Ldarg_0);
-            il.EmitCalli(OpCodes.Calli, CallingConvention.StdCall, null, Type.EmptyTypes);
+            il.EmitCalli(OpCodes.Calli, CallingConvention.StdCall, returnType, new Type[] { typeof(int), typeof(int) });
             il.Emit(OpCodes.Ret);
 
             Type dynamicType = typeBuilder.CreateType();
-            dynamicType
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFoo(Foo));
+
+            object resultValue = dynamicType
                 .GetMethod("F", BindingFlags.Public | BindingFlags.Static)
-                .Invoke(null, new object[] { Marshal.GetFunctionPointerForDelegate(new FooFoo(Foo)) });
+                .Invoke(null, new object[] { funcPtr, a, b });
+
+            Assert.IsType(returnType, resultValue);
+            Assert.Equal(result, resultValue);
         }
 
-        delegate void FooFoo();
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        public delegate int FooFoo(int a, int b);
 
-        static void Foo()
+        public static int Foo(int a, int b)
         {
+            return a + b;
         }
     }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -11,7 +11,7 @@ namespace System.Reflection.Emit.Tests
     public class ILGeneratorEmit4
     {
         [Fact]
-        public void TestEmitCalliStdCall()
+        public void TestEmitCalliBlittable()
         {
             int a = 1, b = 1, result = 2;
 
@@ -31,7 +31,7 @@ namespace System.Reflection.Emit.Tests
             il.Emit(OpCodes.Ret);
 
             Type dynamicType = typeBuilder.CreateType();
-            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFooStdCall(Foo));
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new Int32SumStdCall(Int32Sum));
 
             object resultValue = dynamicType
                 .GetMethod("F", BindingFlags.Public | BindingFlags.Static)
@@ -42,7 +42,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        public void TestDynamicMethodEmitCalliStdCall()
+        public void TestDynamicMethodEmitCalliBlittable()
         {
             int a = 1, b = 1, result = 2;
 
@@ -57,7 +57,7 @@ namespace System.Reflection.Emit.Tests
             il.EmitCalli(OpCodes.Calli, CallingConvention.StdCall, returnType, new Type[] { typeof(int), typeof(int) });
             il.Emit(OpCodes.Ret);
 
-            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFooStdCall(Foo));
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new Int32SumStdCall(Int32Sum));
 
             object resultValue = dynamicMethod
                 .Invoke(null, new object[] { funcPtr, a, b });
@@ -67,7 +67,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        public void TestEmitCalliCdeclCall()
+        public void TestEmitCalliNonBlittable()
         {
             string input = "Test string!", result = "!gnirts tseT";
 
@@ -86,7 +86,7 @@ namespace System.Reflection.Emit.Tests
             il.Emit(OpCodes.Ret);
 
             Type dynamicType = typeBuilder.CreateType();
-            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFooCdecl(Foo));
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new StringReverseCdecl(StringReverse));
 
             object resultValue = dynamicType
                 .GetMethod("F", BindingFlags.Public | BindingFlags.Static)
@@ -97,7 +97,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        public void TestDynamicMethodEmitCalliCdeclCall()
+        public void TestDynamicMethodTestEmitCalliNonBlittable()
         {
             string input = "Test string!", result = "!gnirts tseT";
 
@@ -111,7 +111,7 @@ namespace System.Reflection.Emit.Tests
             il.EmitCalli(OpCodes.Calli, CallingConvention.Cdecl, returnType, new Type[] { typeof(string) });
             il.Emit(OpCodes.Ret);
 
-            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFooCdecl(Foo));
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new StringReverseCdecl(StringReverse));
 
             object resultValue = dynamicMethod
                 .Invoke(null, new object[] { funcPtr, input });
@@ -121,19 +121,13 @@ namespace System.Reflection.Emit.Tests
         }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        public delegate int FooFooStdCall(int a, int b);
+        private delegate int Int32SumStdCall(int a, int b);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate string FooFooCdecl(string a);
+        private delegate string StringReverseCdecl(string a);
 
-        public static int Foo(int a, int b)
-        {
-            return a + b;
-        }
+        private static int Int32Sum(int a, int b) => a + b;
 
-        public static string Foo(string a)
-        {
-            return string.Join("", a.Reverse());
-        }
+        private static string StringReverse(string a) => string.Join("", a.Reverse());
     }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -10,10 +10,11 @@ namespace System.Reflection.Emit.Tests
 {
     public class ILGeneratorEmit4
     {
-        [Theory]
-        [InlineData(1, 1, 2)]
-        public void TestEmitCalliStdCall(int a, int b, int result)
+        [Fact]
+        public void TestEmitCalliStdCall()
         {
+            int a = 1, b = 1, result = 2;
+
             ModuleBuilder moduleBuilder = Helpers.DynamicModule();
             TypeBuilder typeBuilder = moduleBuilder.DefineType("T", TypeAttributes.Public);
             Type returnType = typeof(int);
@@ -40,10 +41,11 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(result, resultValue);
         }
 
-        [Theory]
-        [InlineData(1, 1, 2)]
-        public void TestDynamicMethodEmitCalliStdCall(int a, int b, int result)
+        [Fact]
+        public void TestDynamicMethodEmitCalliStdCall()
         {
+            int a = 1, b = 1, result = 2;
+
             Type returnType = typeof(int);
 
             var dynamicMethod = new DynamicMethod("F", returnType, new Type[] { typeof(IntPtr), typeof(int), typeof(int) });
@@ -64,10 +66,11 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(result, resultValue);
         }
 
-        [Theory]
-        [InlineData("Test string!", "!gnirts tseT")]
-        public void TestEmitCalliCdeclCall(string input, string result)
+        [Fact]
+        public void TestEmitCalliCdeclCall()
         {
+            string input = "Test string!", result = "!gnirts tseT";
+
             ModuleBuilder moduleBuilder = Helpers.DynamicModule();
             TypeBuilder typeBuilder = moduleBuilder.DefineType("T", TypeAttributes.Public);
             Type returnType = typeof(string);
@@ -93,10 +96,11 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(result, resultValue);
         }
 
-        [Theory]
-        [InlineData("Test string!", "!gnirts tseT")]
-        public void TestDynamicMethodEmitCalliCdeclCall(string input, string result)
+        [Fact]
+        public void TestDynamicMethodEmitCalliCdeclCall()
         {
+            string input = "Test string!", result = "!gnirts tseT";
+
             Type returnType = typeof(string);
 
             var dynamicMethod = new DynamicMethod("F", returnType, new Type[] { typeof(IntPtr), typeof(string) });

--- a/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Reflection.Emit.Tests
+{
+    public class ILGeneratorEmit4
+    {
+        [Fact]
+        public void TestEmitCalliWithNullReturnType()
+        {
+            ModuleBuilder moduleBuilder = Helpers.DynamicModule();
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("T", TypeAttributes.Public);
+
+            MethodBuilder methodBuilder = typeBuilder.DefineMethod("F",
+                MethodAttributes.Public | MethodAttributes.Static, null, new Type[] { typeof(IntPtr) });
+            methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
+
+            ILGenerator il = methodBuilder.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.EmitCalli(OpCodes.Calli, CallingConvention.StdCall, null, Type.EmptyTypes);
+            il.Emit(OpCodes.Ret);
+
+            Type dynamicType = typeBuilder.CreateType();
+            dynamicType
+                .GetMethod("F", BindingFlags.Public | BindingFlags.Static)
+                .Invoke(null, new object[] { Marshal.GetFunctionPointerForDelegate(new FooFoo(Foo)) });
+        }
+
+        delegate void FooFoo();
+
+        static void Foo()
+        {
+        }
+    }
+}

--- a/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -39,6 +39,30 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(result, resultValue);
         }
 
+        [Theory]
+        [InlineData(1, 1, 2)]
+        public void TestDynamicMethodEmitCalliStdCall(int a, int b, int result)
+        {
+            Type returnType = typeof(int);
+
+            var dynamicMethod = new DynamicMethod("F", returnType, new Type[] { typeof(IntPtr), typeof(int), typeof(int) });
+
+            ILGenerator il = dynamicMethod.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldarg_0);
+            il.EmitCalli(OpCodes.Calli, CallingConvention.StdCall, returnType, new Type[] { typeof(int), typeof(int) });
+            il.Emit(OpCodes.Ret);
+
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFoo(Foo));
+
+            object resultValue = dynamicMethod
+                .Invoke(null, new object[] { funcPtr, a, b });
+
+            Assert.IsType(returnType, resultValue);
+            Assert.Equal(result, resultValue);
+        }
+
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         public delegate int FooFoo(int a, int b);
 

--- a/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -97,7 +97,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        public void TestDynamicMethodTestEmitCalliNonBlittable()
+        public void TestDynamicMethodEmitCalliNonBlittable()
         {
             string input = "Test string!", result = "!gnirts tseT";
 

--- a/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -29,7 +30,7 @@ namespace System.Reflection.Emit.Tests
             il.Emit(OpCodes.Ret);
 
             Type dynamicType = typeBuilder.CreateType();
-            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFoo(Foo));
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFooStdCall(Foo));
 
             object resultValue = dynamicType
                 .GetMethod("F", BindingFlags.Public | BindingFlags.Static)
@@ -54,7 +55,7 @@ namespace System.Reflection.Emit.Tests
             il.EmitCalli(OpCodes.Calli, CallingConvention.StdCall, returnType, new Type[] { typeof(int), typeof(int) });
             il.Emit(OpCodes.Ret);
 
-            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFoo(Foo));
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFooStdCall(Foo));
 
             object resultValue = dynamicMethod
                 .Invoke(null, new object[] { funcPtr, a, b });
@@ -63,12 +64,72 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(result, resultValue);
         }
 
+        [Theory]
+        [InlineData("Test string!", "!gnirts tseT")]
+        public void TestEmitCalliCdeclCall(string input, string result)
+        {
+            ModuleBuilder moduleBuilder = Helpers.DynamicModule();
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("T", TypeAttributes.Public);
+            Type returnType = typeof(string);
+
+            MethodBuilder methodBuilder = typeBuilder.DefineMethod("F",
+                MethodAttributes.Public | MethodAttributes.Static, returnType, new Type[] { typeof(IntPtr), typeof(string) });
+            methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
+
+            ILGenerator il = methodBuilder.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_0);
+            il.EmitCalli(OpCodes.Calli, CallingConvention.Cdecl, returnType, new Type[] { typeof(string) });
+            il.Emit(OpCodes.Ret);
+
+            Type dynamicType = typeBuilder.CreateType();
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFooCdecl(Foo));
+
+            object resultValue = dynamicType
+                .GetMethod("F", BindingFlags.Public | BindingFlags.Static)
+                .Invoke(null, new object[] { funcPtr, input });
+
+            Assert.IsType(returnType, resultValue);
+            Assert.Equal(result, resultValue);
+        }
+
+        [Theory]
+        [InlineData("Test string!", "!gnirts tseT")]
+        public void TestDynamicMethodEmitCalliCdeclCall(string input, string result)
+        {
+            Type returnType = typeof(string);
+
+            var dynamicMethod = new DynamicMethod("F", returnType, new Type[] { typeof(IntPtr), typeof(string) });
+
+            ILGenerator il = dynamicMethod.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_0);
+            il.EmitCalli(OpCodes.Calli, CallingConvention.Cdecl, returnType, new Type[] { typeof(string) });
+            il.Emit(OpCodes.Ret);
+
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(new FooFooCdecl(Foo));
+
+            object resultValue = dynamicMethod
+                .Invoke(null, new object[] { funcPtr, input });
+
+            Assert.IsType(returnType, resultValue);
+            Assert.Equal(result, resultValue);
+        }
+
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        public delegate int FooFoo(int a, int b);
+        public delegate int FooFooStdCall(int a, int b);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate string FooFooCdecl(string a);
 
         public static int Foo(int a, int b)
         {
             return a + b;
+        }
+
+        public static string Foo(string a)
+        {
+            return string.Join("", a.Reverse());
         }
     }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
+++ b/src/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="ILGenerator\DefineLabelTests.cs" />
     <Compile Include="ILGenerator\Emit1Tests.cs" />
     <Compile Include="ILGenerator\Emit2Tests.cs" />
+    <Compile Include="ILGenerator\Emit4Tests.cs" />
     <Compile Include="ILGenerator\Emit3Tests.cs" />
     <Compile Include="ILGenerator\EmitWriteLineTests.cs" />
     <Compile Include="ILGenerator\ExceptionEmitTests.cs" />

--- a/src/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
+++ b/src/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
@@ -11,8 +11,8 @@
     <Compile Include="ILGenerator\DefineLabelTests.cs" />
     <Compile Include="ILGenerator\Emit1Tests.cs" />
     <Compile Include="ILGenerator\Emit2Tests.cs" />
-    <Compile Include="ILGenerator\Emit4Tests.cs" />
     <Compile Include="ILGenerator\Emit3Tests.cs" />
+    <Compile Include="ILGenerator\Emit4Tests.cs" />
     <Compile Include="ILGenerator\EmitWriteLineTests.cs" />
     <Compile Include="ILGenerator\ExceptionEmitTests.cs" />
     <Compile Include="ILGenerator\ILOffsetTests.cs" />


### PR DESCRIPTION
This PR exposes the EmitCalli overload of the ILGenerator class and adds a test.

Fixes: dotnet/corefx#9800