### PR TITLE
Dont allow exceptions to emerge on the threadpool

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -1381,10 +1381,12 @@ namespace System.Data.ProviderBase
                                             // Don't specify any user options because there is no outer connection associated with the new connection
                                             newObj = CreateObject(owningObject: null, userOptions: null, oldConnection: null);
                                         }
-                                        catch(Exception)
+                                        catch
                                         {
                                             // Catch all the exceptions occuring during CreateObject so that they 
                                             // don't emerge as unhandled on the thread pool and don't crash applications
+                                            // The error is handled in CreateObject and surfaced to the caller of the Connection Pool
+                                            // using the ErrorEvent. Hence it is OK to swallow all exceptions here.
                                             break;
                                         }
                                         // We do not need to check error flag here, since we know if

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -1376,9 +1376,17 @@ namespace System.Data.ProviderBase
                                 {
                                     while (NeedToReplenish)
                                     {
-                                        // Don't specify any user options because there is no outer connection associated with the new connection
-                                        newObj = CreateObject(owningObject: null, userOptions: null, oldConnection: null);
-
+                                        try
+                                        {
+                                            // Don't specify any user options because there is no outer connection associated with the new connection
+                                            newObj = CreateObject(owningObject: null, userOptions: null, oldConnection: null);
+                                        }
+                                        catch(Exception)
+                                        {
+                                            // Catch all the exceptions occuring during CreateObject so that they 
+                                            // don't emerge as unhandled on the thread pool and don't crash applications
+                                            break;
+                                        }
                                         // We do not need to check error flag here, since we know if
                                         // CreateObject returned null, we are in error case.
                                         if (null != newObj)

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -135,6 +135,29 @@ namespace System.Data.SqlClient.Tests
             Console.WriteLine($"ConnectionTimeoutTestWithThread: Elapsed Time {theMax} and threshold {threshold}");
         }
 
+        [Fact]
+        public void ExceptionsWithMinPoolSizeCanBeHandled()
+        {
+            int count = 0;
+            int expected = 3;
+            string connectionString = $"Data Source={Guid.NewGuid().ToString()};uid=random;pwd=asd;Connect Timeout=2; Min Pool Size=3";
+            while (count < expected)
+            {
+                using (SqlConnection connection = new SqlConnection(connectionString))
+                {
+                    try
+                    {
+                        connection.Open();
+                    }
+                    catch (Exception)
+                    {
+                        count++;
+                    }
+                }
+            }
+            Assert.Equal(expected, count);
+        }
+
         public class ConnectionWorker
         {
             private static ManualResetEventSlim startEvent = new ManualResetEventSlim(false);

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -144,7 +144,8 @@ namespace System.Data.SqlClient.Tests
             {
                 using (SqlConnection connection = new SqlConnection(connectionString))
                 {
-                    Assert.ThrowsAny<Exception>(() => connection.Open());
+                    Exception exception = Record.Exception(() => connection.Open());
+                    Assert.True(exception is InvalidOperationException || exception is SqlException, $"Unexpected exception: {exception}");
                 }
             }
         }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -135,27 +135,18 @@ namespace System.Data.SqlClient.Tests
             Console.WriteLine($"ConnectionTimeoutTestWithThread: Elapsed Time {theMax} and threshold {threshold}");
         }
 
+        [OuterLoop("Can take up to 4 seconds")]
         [Fact]
         public void ExceptionsWithMinPoolSizeCanBeHandled()
         {
-            int count = 0;
-            int expected = 3;
             string connectionString = $"Data Source={Guid.NewGuid().ToString()};uid=random;pwd=asd;Connect Timeout=2; Min Pool Size=3";
-            while (count < expected)
+            for (int i = 0; i < 2; i++)
             {
                 using (SqlConnection connection = new SqlConnection(connectionString))
                 {
-                    try
-                    {
-                        connection.Open();
-                    }
-                    catch (Exception)
-                    {
-                        count++;
-                    }
+                    Assert.ThrowsAny<Exception>(() => connection.Open());
                 }
             }
-            Assert.Equal(expected, count);
         }
 
         public class ConnectionWorker


### PR DESCRIPTION
PoolCreateRequest handles creation of new connections on the thread pool. However when an exception occurs, it is bubbled up to the thread pool. This is a regression from .Net Framework and causes applications using Min Pool Size to crash. 

The solution is to catch all exceptions during connection open and to swallow them. This will not change the exception that app sees from Connection Pool, as the error is bubbled up from another code path where the errorWaitHandle is set during connection Open. 

The test added, makes sure that we can open 3 bad connections using MinPoolSize. Before the fix, the test would crash after the first exception. 

Fixes https://github.com/dotnet/corefx/issues/14615