### PR TITLE
Fix PauseAndContinue failure?

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -43,11 +43,11 @@ namespace System.ServiceProcess.Tests
             Assert.True(testServiceController.CanShutdown);
         }
 
-        //[Fact]
+        // [Fact]
         // To cleanup lingering Test Services uncomment the Fact attribute and run the following command
-        //   msbuild /t:rebuildandtest /p:XunitMethodName=System.ServiceProcess.Tests.ServiceBaseTests.Cleanup
+        //   msbuild /t:rebuildandtest /p:XunitMethodName=System.ServiceProcess.Tests.ServiceBaseTests.Cleanup /p:OuterLoop=true
         // Remember to comment out the Fact again before running tests otherwise it will cleanup tests running in parallel
-        // and casue them to fail.
+        // and cause them to fail.
         public void Cleanup()
         {
             string currentService = "";

--- a/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
@@ -125,6 +125,11 @@ namespace System.ServiceProcess.Tests
                 controller.WaitForStatus(ServiceControllerStatus.Running, _testService.ControlTimeout);
                 Assert.Equal(ServiceControllerStatus.Running, controller.Status);
             }
+
+            controller.Stop();
+            Assert.Equal((int)PipeMessageByteCode.Stop, _testService.GetByte());
+            controller.WaitForStatus(ServiceControllerStatus.Stopped, _testService.ControlTimeout);
+            Assert.Equal(ServiceControllerStatus.Stopped, controller.Status);
         }
 
         [ConditionalFact(nameof(IsProcessElevated))]

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
@@ -165,7 +165,13 @@ namespace System.ServiceProcess.Tests
                         return;
                     }
 
-                    svc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(30));
+                    // var sw = Stopwatch.StartNew();
+                    svc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(120));
+                    // sw.Stop();
+                    // if (sw.Elapsed > TimeSpan.FromSeconds(30))
+                    // {
+                    //    Console.WriteLine($"Took unexpectedly long to stop a service: {sw.Elapsed.TotalSeconds}");
+                    // }
                 }
             }
         }


### PR DESCRIPTION
Attempt to fix #27071

I cannot repro, at least when I run the test library (or test) individually, on the repro machine, even looping. Nor can I come up with a good theory why this particular test sporadically fails in cleanup.

I increased the time we wait for the service to stop from 30 sec to 120 sec in case it is machine slowness. (On the repro machine, it usually takes less than 1 sec)

I also added explicit verification of the state of the test service in this test.