### PR TITLE
ReadOnlySequence efficiency+inlines+string

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -278,9 +278,9 @@ namespace System.Buffers
     }
     public static partial class BuffersExtensions
     {
-        public static void CopyTo<T>(this System.Buffers.ReadOnlySequence<T> sequence, System.Span<T> destination) { }
-        public static System.Nullable<System.SequencePosition> PositionOf<T>(this System.Buffers.ReadOnlySequence<T> sequence, T value) where T : System.IEquatable<T> { throw null; }
-        public static T[] ToArray<T>(this System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
+        public static void CopyTo<T>(in this System.Buffers.ReadOnlySequence<T> sequence, System.Span<T> destination) { }
+        public static System.Nullable<System.SequencePosition> PositionOf<T>(in this System.Buffers.ReadOnlySequence<T> sequence, T value) where T : System.IEquatable<T> { throw null; }
+        public static T[] ToArray<T>(in this System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
         public static void Write<T>(this System.Buffers.IBufferWriter<T> bufferWriter, ReadOnlySpan<T> source) { }
     }
     public readonly partial struct ReadOnlySequence<T>
@@ -315,7 +315,7 @@ namespace System.Buffers
         public partial struct Enumerator
         {
             private object _dummy;
-            public Enumerator(System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
+            public Enumerator(in System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
             public System.ReadOnlyMemory<T> Current { get { throw null; } }
             public bool MoveNext() { throw null; }
         }

--- a/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
+++ b/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
@@ -12,19 +12,43 @@ namespace System.Buffers
         /// <summary>
         /// Returns position of first occurrence of item in the <see cref="ReadOnlySequence{T}"/>
         /// </summary>
-        public static SequencePosition? PositionOf<T>(this ReadOnlySequence<T> sequence, T value) where T : IEquatable<T>
+        public static SequencePosition? PositionOf<T>(in this ReadOnlySequence<T> sequence, T value) where T : IEquatable<T>
+        {
+            if (sequence.IsSingleSegment)
+            {
+                int index = sequence.First.Span.IndexOf(value);
+                if (index != -1)
+                {
+                    return sequence.GetPosition(sequence.Start, index);
+                }
+
+                return null;
+            }
+            else
+            {
+                return PositionOfMultiSegement(sequence, value);
+            }
+        }
+
+        private static SequencePosition? PositionOfMultiSegement<T>(in ReadOnlySequence<T> sequence, T value) where T : IEquatable<T>
         {
             SequencePosition position = sequence.Start;
             SequencePosition result = position;
-            while (sequence.TryGet(ref position, out var memory))
+            while (sequence.TryGet(ref position, out ReadOnlyMemory<T> memory))
             {
-                var index = memory.Span.IndexOf(value);
+                int index = memory.Span.IndexOf(value);
                 if (index != -1)
                 {
                     return sequence.GetPosition(result, index);
                 }
+                else if (position.GetObject() == null)
+                {
+                    break;
+                }
+
                 result = position;
             }
+
             return null;
         }
 
@@ -33,22 +57,43 @@ namespace System.Buffers
         /// </summary>
         /// <param name="sequence">The source <see cref="ReadOnlySequence{T}"/>.</param>
         /// <param name="destination">The destination <see cref="Span{Byte}"/>.</param>
-        public static void CopyTo<T>(this ReadOnlySequence<T> sequence, Span<T> destination)
+        public static void CopyTo<T>(in this ReadOnlySequence<T> sequence, Span<T> destination)
         {
             if (sequence.Length > destination.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
 
-            foreach (var segment in sequence)
+            if (sequence.IsSingleSegment)
             {
-                segment.Span.CopyTo(destination);
-                destination = destination.Slice(segment.Length);
+                sequence.First.Span.CopyTo(destination);
+            }
+            else
+            {
+                CopyToMultiSegement(sequence, destination);
+            }
+        }
+
+        private static void CopyToMultiSegement<T>(in ReadOnlySequence<T> sequence, Span<T> destination)
+        {
+            SequencePosition position = sequence.Start;
+            while (sequence.TryGet(ref position, out ReadOnlyMemory<T> memory))
+            {
+                ReadOnlySpan<T> span = memory.Span;
+                span.CopyTo(destination);
+                if (position.GetObject() != null)
+                {
+                    destination = destination.Slice(span.Length);
+                }
+                else
+                {
+                    break;
+                }
             }
         }
 
         /// <summary>
         /// Converts the <see cref="ReadOnlySequence{T}"/> to an array
         /// </summary>
-        public static T[] ToArray<T>(this ReadOnlySequence<T> sequence)
+        public static T[] ToArray<T>(in this ReadOnlySequence<T> sequence)
         {
             var array = new T[sequence.Length];
             sequence.CopyTo(array);
@@ -67,23 +112,25 @@ namespace System.Buffers
             {
                 source.CopyTo(destination);
                 bufferWriter.Advance(source.Length);
-                return;
             }
-
-            WriteMultiSegment(bufferWriter, source, destination);
+            else
+            {
+                WriteMultiSegment(bufferWriter, source, destination);
+            }
         }
 
-        private static void WriteMultiSegment<T>(IBufferWriter<T> bufferWriter, ReadOnlySpan<T> source, Span<T> destination)
+        private static void WriteMultiSegment<T>(IBufferWriter<T> bufferWriter, in ReadOnlySpan<T> source, Span<T> destination)
         {
+            ReadOnlySpan<T> input = source;
             while (true)
             {
-                int writeSize = Math.Min(destination.Length, source.Length);
-                source.Slice(0, writeSize).CopyTo(destination);
+                int writeSize = Math.Min(destination.Length, input.Length);
+                input.Slice(0, writeSize).CopyTo(destination);
                 bufferWriter.Advance(writeSize);
-                source = source.Slice(writeSize);
-                if (source.Length > 0)
+                input = input.Slice(writeSize);
+                if (input.Length > 0)
                 {
-                    destination = bufferWriter.GetSpan(source.Length);
+                    destination = bufferWriter.GetSpan(input.Length);
                     continue;
                 }
 

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -13,25 +13,17 @@ namespace System.Buffers
     /// </summary>
     public readonly partial struct ReadOnlySequence<T>
     {
-        private const int IndexBitMask = 0x7FFFFFFF;
-
-        private const int MemoryListStartMask = 0;
-        private const int MemoryListEndMask = 0;
-
-        private const int ArrayStartMask = 0;
-        private const int ArrayEndMask = 1 << 31;
-
-        private const int OwnedMemoryStartMask = 1 << 31;
-        private const int OwnedMemoryEndMask = 0;
-
         private readonly SequencePosition _sequenceStart;
         private readonly SequencePosition _sequenceEnd;
 
         /// <summary>
         /// Returns empty <see cref="ReadOnlySequence{T}"/>
         /// </summary>
-        public static readonly ReadOnlySequence<T> Empty = new ReadOnlySequence<T>(new T[0]);
-
+#if FEATURE_PORTABLE_SPAN
+        public static readonly ReadOnlySequence<T> Empty = new ReadOnlySequence<T>(SpanHelpers.PerTypeValues<T>.EmptyArray); 
+#else
+        public static readonly ReadOnlySequence<T> Empty = new ReadOnlySequence<T>(Array.Empty<T>()); 
+#endif // FEATURE_PORTABLE_SPAN 
         /// <summary>
         /// Length of the <see cref="ReadOnlySequence{T}"/>.
         /// </summary>
@@ -69,13 +61,15 @@ namespace System.Buffers
         /// </summary>
         public SequencePosition End => _sequenceEnd;
 
-        private ReadOnlySequence(object startSegment, int startIndex, object endSegment, int endIndex)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ReadOnlySequence(object startSegment, int startIndexAndFlags, object endSegment, int endIndexAndFlags)
         {
+            // Used by SliceImpl to create new ReadOnlySequence
             Debug.Assert(startSegment != null);
             Debug.Assert(endSegment != null);
 
-            _sequenceStart = new SequencePosition(startSegment, startIndex);
-            _sequenceEnd = new SequencePosition(endSegment, endIndex);
+            _sequenceStart = new SequencePosition(startSegment, startIndexAndFlags);
+            _sequenceEnd = new SequencePosition(endSegment, endIndexAndFlags);
         }
 
         /// <summary>
@@ -84,26 +78,27 @@ namespace System.Buffers
         /// </summary>
         public ReadOnlySequence(IMemoryList<T> startSegment, int startIndex, IMemoryList<T> endSegment, int endIndex)
         {
-            if (startSegment == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.startSegment);
-            if (endSegment == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.endSegment);
-            if (startIndex < 0 || startSegment.Memory.Length < startIndex)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex);
-            if (endIndex < 0 || endSegment.Memory.Length < endIndex)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.endIndex);
-            if (startSegment == endSegment && endIndex < startIndex)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.endIndex);
+            if (startSegment == null ||
+                endSegment == null ||
+                (uint)startSegment.Memory.Length < (uint)startIndex ||
+                (uint)endSegment.Memory.Length < (uint)endIndex ||
+                (startSegment == endSegment && endIndex < startIndex))
+                ThrowHelper.ThrowArgumentValidationException(startSegment, startIndex, endSegment);
 
-            _sequenceStart = new SequencePosition(startSegment, startIndex | MemoryListStartMask);
-            _sequenceEnd = new SequencePosition(endSegment, endIndex | MemoryListEndMask);
+            _sequenceStart = new SequencePosition(startSegment, ReadOnlySequence.MemoryListToSequenceStart(startIndex));
+            _sequenceEnd = new SequencePosition(endSegment, ReadOnlySequence.MemoryListToSequenceEnd(endIndex));
         }
 
         /// <summary>
         /// Creates an instance of <see cref="ReadOnlySequence{T}"/> from the <see cref="T:T[]"/>.
         /// </summary>
-        public ReadOnlySequence(T[] array) : this(array, 0, array.Length)
+        public ReadOnlySequence(T[] array)
         {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
+            _sequenceStart = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceStart(0));
+            _sequenceEnd = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceEnd(array.Length));
         }
 
         /// <summary>
@@ -111,15 +106,13 @@ namespace System.Buffers
         /// </summary>
         public ReadOnlySequence(T[] array, int start, int length)
         {
-            if (array == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if (start < 0 || start > array.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-            if (length < 0 || length > array.Length - start)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+            if (array == null ||
+                (uint)start > (uint)array.Length ||
+                (uint)length > (uint)(array.Length - start))
+                ThrowHelper.ThrowArgumentValidationException(array, start);
 
-            _sequenceStart = new SequencePosition(array, start | ArrayStartMask);
-            _sequenceEnd = new SequencePosition(array, start + length | ArrayEndMask);
+            _sequenceStart = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceStart(start));
+            _sequenceEnd = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceEnd(start + length));
         }
 
         /// <summary>
@@ -128,20 +121,46 @@ namespace System.Buffers
         /// </summary>
         public ReadOnlySequence(ReadOnlyMemory<T> readOnlyMemory)
         {
-            ReadOnlySequenceSegment segment = new ReadOnlySequenceSegment
+            if (MemoryMarshal.TryGetOwnedMemory(readOnlyMemory, out OwnedMemory<T> ownedMemory, out int index, out int length))
             {
-                Memory = MemoryMarshal.AsMemory(readOnlyMemory)
-            };
-            _sequenceStart = new SequencePosition(segment, 0 | MemoryListStartMask);
-            _sequenceEnd = new SequencePosition(segment, readOnlyMemory.Length | MemoryListEndMask);
+                _sequenceStart = new SequencePosition(ownedMemory, ReadOnlySequence.OwnedMemoryToSequenceStart(index));
+                _sequenceEnd = new SequencePosition(ownedMemory, ReadOnlySequence.OwnedMemoryToSequenceEnd(length));
+            }
+            else if (MemoryMarshal.TryGetArray(readOnlyMemory, out ArraySegment<T> arraySegment))
+            {
+                T[] array = arraySegment.Array;
+                int start = arraySegment.Offset;
+                _sequenceStart = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceStart(start));
+                _sequenceEnd = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceEnd(start + arraySegment.Count));
+            }
+            else if (typeof(T) == typeof(char))
+            {
+                // TODO: MemoryMarshal.TryGetString -- doesn't exist?
+                // https://github.com/dotnet/corefx/issues/27451
+                MemoryExtensions.TryGetString(((ReadOnlyMemory<char>)(object)readOnlyMemory), out string text, out int start, out length);
+                _sequenceStart = new SequencePosition(text, ReadOnlySequence.StringToSequenceStart(start));
+                _sequenceEnd = new SequencePosition(text, ReadOnlySequence.StringToSequenceEnd(start + length));
+            }
+            else
+            {
+                // Should never be reached
+                ThrowHelper.ThrowInvalidOperationException();
+                _sequenceStart = default;
+                _sequenceEnd = default;
+            }
         }
 
         /// <summary>
         /// Creates an instance of <see cref="ReadOnlySequence{T}"/> from the <see cref="OwnedMemory{T}"/>.
         /// Consumer is expected to manage lifetime of memory until <see cref="ReadOnlySequence{T}"/> is not used anymore.
         /// </summary>
-        public ReadOnlySequence(OwnedMemory<T> ownedMemory): this(ownedMemory, 0, ownedMemory.Length)
+        public ReadOnlySequence(OwnedMemory<T> ownedMemory)
         {
+            if (ownedMemory == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.ownedMemory);
+
+            _sequenceStart = new SequencePosition(ownedMemory, ReadOnlySequence.OwnedMemoryToSequenceStart(0));
+            _sequenceEnd = new SequencePosition(ownedMemory, ReadOnlySequence.OwnedMemoryToSequenceEnd(ownedMemory.Length));
         }
 
         /// <summary>
@@ -150,15 +169,13 @@ namespace System.Buffers
         /// </summary>
         public ReadOnlySequence(OwnedMemory<T> ownedMemory, int start, int length)
         {
-            if (ownedMemory == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.ownedMemory);
-            if (start < 0 || start > ownedMemory.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-            if (length < 0 || length > ownedMemory.Length - start)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+            if (ownedMemory == null ||
+                (uint)start > (uint)ownedMemory.Length ||
+                (uint)length > (uint)(ownedMemory.Length - start))
+                ThrowHelper.ThrowArgumentValidationException(ownedMemory, start);
 
-            _sequenceStart = new SequencePosition(ownedMemory, start | OwnedMemoryStartMask);
-            _sequenceEnd = new SequencePosition(ownedMemory, start + length | OwnedMemoryEndMask);
+            _sequenceStart = new SequencePosition(ownedMemory, ReadOnlySequence.OwnedMemoryToSequenceStart(start));
+            _sequenceEnd = new SequencePosition(ownedMemory, ReadOnlySequence.OwnedMemoryToSequenceEnd(start + length));
         }
 
         /// <summary>
@@ -180,7 +197,7 @@ namespace System.Buffers
         /// <param name="end">The end (inclusive) of the slice</param>
         public ReadOnlySequence<T> Slice(long start, SequencePosition end)
         {
-            BoundsCheck(_sequenceEnd, end);
+            BoundsCheck(end, _sequenceEnd);
 
             SequencePosition begin = Seek(_sequenceStart, end, start);
             return SliceImpl(begin, end);
@@ -193,7 +210,7 @@ namespace System.Buffers
         /// <param name="length">The length of the slice</param>
         public ReadOnlySequence<T> Slice(SequencePosition start, long length)
         {
-            BoundsCheck(_sequenceEnd, start);
+            BoundsCheck(start, _sequenceEnd);
 
             SequencePosition end = Seek(start, _sequenceEnd, length, false);
             return SliceImpl(start, end);
@@ -218,7 +235,7 @@ namespace System.Buffers
         /// <param name="end">The end (inclusive) of the slice</param>
         public ReadOnlySequence<T> Slice(int start, SequencePosition end)
         {
-            BoundsCheck(_sequenceEnd, end);
+            BoundsCheck(end, _sequenceEnd);
 
             SequencePosition begin = Seek(_sequenceStart, end, start);
             return SliceImpl(begin, end);
@@ -231,7 +248,7 @@ namespace System.Buffers
         /// <param name="length">The length of the slice</param>
         public ReadOnlySequence<T> Slice(SequencePosition start, int length)
         {
-            BoundsCheck(_sequenceEnd, start);
+            BoundsCheck(start, _sequenceEnd);
 
             SequencePosition end = Seek(start, _sequenceEnd, length, false);
             return SliceImpl(start, end);
@@ -244,8 +261,8 @@ namespace System.Buffers
         /// <param name="end">The ending (inclusive) <see cref="SequencePosition"/> of the slice</param>
         public ReadOnlySequence<T> Slice(SequencePosition start, SequencePosition end)
         {
-            BoundsCheck(_sequenceEnd, end);
-            BoundsCheck(end, start);
+            BoundsCheck(end, _sequenceEnd);
+            BoundsCheck(start, end);
 
             return SliceImpl(start, end);
         }
@@ -256,7 +273,7 @@ namespace System.Buffers
         /// <param name="start">The starting (inclusive) <see cref="SequencePosition"/> at which to begin this slice.</param>
         public ReadOnlySequence<T> Slice(SequencePosition start)
         {
-            BoundsCheck(_sequenceEnd, start);
+            BoundsCheck(start, _sequenceEnd);
 
             return SliceImpl(start, _sequenceEnd);
         }
@@ -267,7 +284,10 @@ namespace System.Buffers
         /// <param name="start">The start index at which to begin this slice.</param>
         public ReadOnlySequence<T> Slice(long start)
         {
-            if (start == 0) return this;
+            if (start == 0)
+            {
+                return this;
+            }
 
             SequencePosition begin = Seek(_sequenceStart, _sequenceEnd, start, false);
             return SliceImpl(begin, _sequenceEnd);
@@ -309,7 +329,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ReadOnlySequence<T> SliceImpl(SequencePosition begin, SequencePosition end)
+        private ReadOnlySequence<T> SliceImpl(in SequencePosition begin, in SequencePosition end)
         {
             // In this method we reset high order bits from indices
             // of positions that were passed in
@@ -317,29 +337,21 @@ namespace System.Buffers
 
             return new ReadOnlySequence<T>(
                 begin.GetObject(),
-                begin.GetInteger() & IndexBitMask | (Start.GetInteger() & ~IndexBitMask),
+                begin.GetInteger() & ReadOnlySequence.IndexBitMask | (Start.GetInteger() & ReadOnlySequence.FlagBitMask),
                 end.GetObject(),
-                end.GetInteger() & IndexBitMask | (End.GetInteger() & ~IndexBitMask)
+                end.GetInteger() & ReadOnlySequence.IndexBitMask | (End.GetInteger() & ReadOnlySequence.FlagBitMask)
             );
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private SequenceType GetSequenceType()
+        private void GetTypeAndIndices(int start, int end, out SequenceType sequenceType, out int startIndex, out int endIndex)
         {
+            startIndex = start & ReadOnlySequence.IndexBitMask;
+            endIndex = end & ReadOnlySequence.IndexBitMask;
             // We take high order bits of two indexes index and move them
             // to a first and second position to convert to BufferType
-            // Masking with 2 is required to only keep the second bit of Start.Index
-            return (SequenceType)((((uint)Start.GetInteger() >> 30) & 2) | (uint)End.GetInteger() >> 31);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetIndex(int index) => index & IndexBitMask;
-
-        private enum SequenceType
-        {
-            MemoryList = 0x00,
-            Array = 0x1,
-            OwnedMemory = 0x2
+            // Masking with 2 is required to only keep the second bit of Start.GetInteger()
+            sequenceType = Start.GetObject() == null ? SequenceType.Empty : (SequenceType)((((uint)Start.GetInteger() >> 30) & 2) | (uint)End.GetInteger() >> 31);
         }
 
         /// <summary>
@@ -353,11 +365,11 @@ namespace System.Buffers
 
             /// <summary>Initialize the enumerator.</summary>
             /// <param name="sequence">The <see cref="ReadOnlySequence{T}"/> to enumerate.</param>
-            public Enumerator(ReadOnlySequence<T> sequence)
+            public Enumerator(in ReadOnlySequence<T> sequence)
             {
-                _sequence = sequence;
                 _currentMemory = default;
                 _next = sequence.Start;
+                _sequence = sequence;
             }
 
             /// <summary>
@@ -379,5 +391,49 @@ namespace System.Buffers
                 return _sequence.TryGet(ref _next, out _currentMemory);
             }
         }
+
+        private enum SequenceType
+        {
+            IMemoryList = 0x00,
+            Array = 0x1,
+            OwnedMemory = 0x2,
+            String = 0x3,
+            Empty = 0x4
+        }
+    }
+
+    internal static class ReadOnlySequence
+    {
+        public const int FlagBitMask = 1 << 31;
+        public const int IndexBitMask = ~FlagBitMask;
+
+        public const int MemoryListStartMask = 0;
+        public const int MemoryListEndMask = 0;
+
+        public const int ArrayStartMask = 0;
+        public const int ArrayEndMask = FlagBitMask;
+
+        public const int OwnedMemoryStartMask = FlagBitMask;
+        public const int OwnedMemoryEndMask = 0;
+
+        public const int StringStartMask = FlagBitMask;
+        public const int StringEndMask = FlagBitMask;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int MemoryListToSequenceStart(int startIndex) => startIndex | MemoryListStartMask;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int MemoryListToSequenceEnd(int endIndex) => endIndex | MemoryListEndMask;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ArrayToSequenceStart(int startIndex) => startIndex | ArrayStartMask;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ArrayToSequenceEnd(int endIndex) => endIndex | ArrayEndMask;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int OwnedMemoryToSequenceStart(int startIndex) => startIndex | OwnedMemoryStartMask;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int OwnedMemoryToSequenceEnd(int endIndex) => endIndex | OwnedMemoryEndMask;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int StringToSequenceStart(int startIndex) => startIndex | StringStartMask;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int StringToSequenceEnd(int endIndex) => endIndex | StringEndMask;
     }
 }

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -339,17 +339,5 @@ namespace System.Buffers
 
             return true;
         }
-
-        private class ReadOnlySequenceSegment : IMemoryList<T>
-        {
-            public ReadOnlySequenceSegment(ReadOnlyMemory<T> readOnlyMemory)
-            {
-                Memory = MemoryMarshal.AsMemory(readOnlyMemory);
-            }
-
-            public Memory<T> Memory { get; set; }
-            public IMemoryList<T> Next { get; set; }
-            public long RunningIndex { get; set; }
-        }
     }
 }

--- a/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
+++ b/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
@@ -50,5 +50,14 @@ namespace System.Runtime.InteropServices
         {
             return sequence.TryGetReadOnlyMemory(out readOnlyMemory);
         }
+
+        /// <summary>
+        /// Get <see cref="string"/> from the underlying <see cref="ReadOnlySequence{T}"/>.
+        /// If unable to get the <see cref="string"/>, return false.
+        /// </summary>
+        internal static bool TryGetString(ReadOnlySequence<char> sequence, out string text, out int start, out int length)
+        {
+            return sequence.TryGetString(out text, out start, out length);
+        }
     }
 }

--- a/src/System.Memory/src/System/ThrowHelper.cs
+++ b/src/System.Memory/src/System/ThrowHelper.cs
@@ -124,6 +124,50 @@ namespace System
             ThrowHelper.ThrowFormatException_BadFormatSpecifier();
             return false;
         }
+
+        //
+        // ReadOnlySequence .ctor validation Throws coalesced to enable inlining of the .ctor
+        //
+        public static void ThrowArgumentValidationException<T>(IMemoryList<T> startSegment, int startIndex, IMemoryList<T> endSegment)
+            => throw CreateArgumentValidationException(startSegment, startIndex, endSegment);
+
+        private static Exception CreateArgumentValidationException<T>(IMemoryList<T> startSegment, int startIndex, IMemoryList<T> endSegment)
+        {
+            if (startSegment == null)
+                return CreateArgumentNullException(ExceptionArgument.startSegment);
+            else if (endSegment == null)
+                return CreateArgumentNullException(ExceptionArgument.endSegment);
+            else if ((uint)startSegment.Memory.Length < (uint)startIndex)
+                return CreateArgumentOutOfRangeException(ExceptionArgument.startIndex);
+            else
+                return CreateArgumentOutOfRangeException(ExceptionArgument.endIndex);
+        }
+
+        public static void ThrowArgumentValidationException(Array array, int start)
+            => throw CreateArgumentValidationException(array, start);
+
+        private static Exception CreateArgumentValidationException(Array array, int start)
+        {
+            if (array == null)
+                return CreateArgumentNullException(ExceptionArgument.array);
+            else if ((uint)start > (uint)array.Length)
+                return CreateArgumentOutOfRangeException(ExceptionArgument.start);
+            else
+                return CreateArgumentOutOfRangeException(ExceptionArgument.length);
+        }
+
+        public static void ThrowArgumentValidationException<T>(OwnedMemory<T> ownedMemory, int start)
+            => throw CreateArgumentValidationException(ownedMemory, start);
+
+        private static Exception CreateArgumentValidationException<T>(OwnedMemory<T> ownedMemory, int start)
+        {
+            if (ownedMemory == null)
+                return CreateArgumentNullException(ExceptionArgument.ownedMemory);
+            else if ((uint)start > (uint)ownedMemory.Length)
+                return CreateArgumentOutOfRangeException(ExceptionArgument.start);
+            else
+                return CreateArgumentOutOfRangeException(ExceptionArgument.length);
+        }
     }
 
     //

--- a/src/System.Memory/tests/ReadOnlyBuffer/BufferSegment.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/BufferSegment.cs
@@ -6,9 +6,9 @@ using System.Buffers;
 
 namespace System.Memory.Tests
 {
-    internal class BufferSegment : IMemoryList<byte>
+    internal class BufferSegment<T> : IMemoryList<T>
     {
-        public BufferSegment(Memory<byte> memory)
+        public BufferSegment(Memory<T> memory)
         {
             Memory = memory;
         }
@@ -18,13 +18,13 @@ namespace System.Memory.Tests
         /// </summary>
         public long RunningIndex { get; private set; }
 
-        public Memory<byte> Memory { get; set; }
+        public Memory<T> Memory { get; set; }
 
-        public IMemoryList<byte> Next { get; private set; }
+        public IMemoryList<T> Next { get; private set; }
 
-        public BufferSegment Append(Memory<byte> memory)
+        public BufferSegment<T> Append(Memory<T> memory)
         {
-            var segment = new BufferSegment(memory)
+            var segment = new BufferSegment<T>(memory)
             {
                 RunningIndex = RunningIndex + Memory.Length
             };

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceFactory.byte.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceFactory.byte.cs
@@ -9,13 +9,13 @@ using System.Text;
 
 namespace System.Memory.Tests
 {
-    public abstract class ReadOnlySequenceFactory
+    public abstract class ReadOnlySequenceFactoryByte
     {
-        public static ReadOnlySequenceFactory ArrayFactory { get; } = new ArrayTestSequenceFactory();
-        public static ReadOnlySequenceFactory MemoryFactory { get; } = new MemoryTestSequenceFactory();
-        public static ReadOnlySequenceFactory OwnedMemoryFactory { get; } = new OwnedMemoryTestSequenceFactory();
-        public static ReadOnlySequenceFactory SingleSegmentFactory { get; } = new SingleSegmentTestSequenceFactory();
-        public static ReadOnlySequenceFactory SegmentPerByteFactory { get; } = new BytePerSegmentTestSequenceFactory();
+        public static ReadOnlySequenceFactoryByte ArrayFactory { get; } = new ArrayTestSequenceFactoryByte();
+        public static ReadOnlySequenceFactoryByte MemoryFactory { get; } = new MemoryTestSequenceFactoryByte();
+        public static ReadOnlySequenceFactoryByte OwnedMemoryFactory { get; } = new OwnedMemoryTestSequenceFactoryByte();
+        public static ReadOnlySequenceFactoryByte SingleSegmentFactory { get; } = new SingleSegmentTestSequenceFactoryByte();
+        public static ReadOnlySequenceFactoryByte SegmentPerByteFactory { get; } = new BytePerSegmentTestSequenceFactoryByte();
 
         public abstract ReadOnlySequence<byte> CreateOfSize(int size);
         public abstract ReadOnlySequence<byte> CreateWithContent(byte[] data);
@@ -25,7 +25,7 @@ namespace System.Memory.Tests
             return CreateWithContent(Encoding.ASCII.GetBytes(data));
         }
 
-        internal class ArrayTestSequenceFactory : ReadOnlySequenceFactory
+        internal class ArrayTestSequenceFactoryByte : ReadOnlySequenceFactoryByte
         {
             public override ReadOnlySequence<byte> CreateOfSize(int size)
             {
@@ -40,7 +40,7 @@ namespace System.Memory.Tests
             }
         }
 
-        internal class MemoryTestSequenceFactory : ReadOnlySequenceFactory
+        internal class MemoryTestSequenceFactoryByte : ReadOnlySequenceFactoryByte
         {
             public override ReadOnlySequence<byte> CreateOfSize(int size)
             {
@@ -55,7 +55,7 @@ namespace System.Memory.Tests
             }
         }
 
-        internal class OwnedMemoryTestSequenceFactory : ReadOnlySequenceFactory
+        internal class OwnedMemoryTestSequenceFactoryByte : ReadOnlySequenceFactoryByte
         {
             public override ReadOnlySequence<byte> CreateOfSize(int size)
             {
@@ -70,7 +70,7 @@ namespace System.Memory.Tests
             }
         }
 
-        internal class SingleSegmentTestSequenceFactory : ReadOnlySequenceFactory
+        internal class SingleSegmentTestSequenceFactoryByte : ReadOnlySequenceFactoryByte
         {
             public override ReadOnlySequence<byte> CreateOfSize(int size)
             {
@@ -83,7 +83,7 @@ namespace System.Memory.Tests
             }
         }
 
-        internal class BytePerSegmentTestSequenceFactory : ReadOnlySequenceFactory
+        internal class BytePerSegmentTestSequenceFactoryByte : ReadOnlySequenceFactoryByte
         {
             public override ReadOnlySequence<byte> CreateOfSize(int size)
             {
@@ -114,8 +114,8 @@ namespace System.Memory.Tests
 
             int i = 0;
 
-            BufferSegment last = null;
-            BufferSegment first = null;
+            BufferSegment<byte> last = null;
+            BufferSegment<byte> first = null;
 
             do
             {
@@ -130,11 +130,11 @@ namespace System.Memory.Tests
                 }
 
                 // Create a segment that has offset relative to the OwnedMemory and OwnedMemory itself has offset relative to array
-                var memory = new Memory<byte>(chars).Slice(length, length);
+                Memory<byte> memory = new Memory<byte>(chars).Slice(length, length);
 
                 if (first == null)
                 {
-                    first = new BufferSegment(memory);
+                    first = new BufferSegment<byte>(memory);
                     last = first;
                 }
                 else

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceFactory.char.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceFactory.char.cs
@@ -1,0 +1,184 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.MemoryTests;
+using System.Text;
+
+namespace System.Memory.Tests
+{
+    public abstract class ReadOnlySequenceFactoryChar
+    {
+        public static ReadOnlySequenceFactoryChar ArrayFactory { get; } = new ArrayTestSequenceFactoryChar();
+        public static ReadOnlySequenceFactoryChar MemoryFactory { get; } = new MemoryTestSequenceFactoryChar();
+        public static ReadOnlySequenceFactoryChar StringFactory { get; } = new StringTestSequenceFactoryChar();
+        public static ReadOnlySequenceFactoryChar OwnedMemoryFactory { get; } = new OwnedMemoryTestSequenceFactoryChar();
+        public static ReadOnlySequenceFactoryChar SingleSegmentFactory { get; } = new SingleSegmentTestSequenceFactoryChar();
+        public static ReadOnlySequenceFactoryChar SegmentPerCharFactory { get; } = new CharPerSegmentTestSequenceFactoryChar();
+
+        public abstract ReadOnlySequence<char> CreateOfSize(int size);
+        public abstract ReadOnlySequence<char> CreateWithContent(char[] data);
+
+        public ReadOnlySequence<char> CreateWithContent(string data)
+        {
+            return CreateWithContent(data.ToCharArray());
+        }
+
+        internal class ArrayTestSequenceFactoryChar : ReadOnlySequenceFactoryChar
+        {
+            public override ReadOnlySequence<char> CreateOfSize(int size)
+            {
+                return new ReadOnlySequence<char>(new char[size + 20], 10, size);
+            }
+
+            public override ReadOnlySequence<char> CreateWithContent(char[] data)
+            {
+                var startSegment = new char[data.Length + 20];
+                Array.Copy(data, 0, startSegment, 10, data.Length);
+                return new ReadOnlySequence<char>(startSegment, 10, data.Length);
+            }
+        }
+
+        internal class StringTestSequenceFactoryChar : ReadOnlySequenceFactoryChar
+        {
+            static string s_stringData = InitalizeStringData();
+
+            static string InitalizeStringData()
+            {
+                IEnumerable<int> ascii = Enumerable.Range(' ', (char)0x7f - ' ');
+
+                return new string(ascii.Concat(ascii)
+                    .Concat(ascii)
+                    .Concat(ascii)
+                    .Concat(ascii)
+                    .Concat(ascii)
+                    .Concat(ascii)
+                    .Select(c => (char)c)
+                    .ToArray());
+            }
+
+            public override ReadOnlySequence<char> CreateOfSize(int size)
+            {
+                return new ReadOnlySequence<char>(s_stringData.AsMemory(10, size));
+            }
+
+            public override ReadOnlySequence<char> CreateWithContent(char[] data)
+            {
+                var startSegment = new char[data.Length + 20];
+                Array.Copy(data, 0, startSegment, 10, data.Length);
+                var text = new string(startSegment);
+                return new ReadOnlySequence<char>(text.AsMemory(10, data.Length));
+            }
+        }
+
+        internal class MemoryTestSequenceFactoryChar : ReadOnlySequenceFactoryChar
+        {
+            public override ReadOnlySequence<char> CreateOfSize(int size)
+            {
+                return CreateWithContent(new char[size]);
+            }
+
+            public override ReadOnlySequence<char> CreateWithContent(char[] data)
+            {
+                var startSegment = new char[data.Length + 20];
+                Array.Copy(data, 0, startSegment, 10, data.Length);
+                return new ReadOnlySequence<char>(new ReadOnlyMemory<char>(startSegment, 10, data.Length));
+            }
+        }
+
+        internal class OwnedMemoryTestSequenceFactoryChar : ReadOnlySequenceFactoryChar
+        {
+            public override ReadOnlySequence<char> CreateOfSize(int size)
+            {
+                return CreateWithContent(new char[size]);
+            }
+
+            public override ReadOnlySequence<char> CreateWithContent(char[] data)
+            {
+                var startSegment = new char[data.Length + 20];
+                Array.Copy(data, 0, startSegment, 10, data.Length);
+                return new ReadOnlySequence<char>(new CustomMemoryForTest<char>(startSegment, 10, data.Length));
+            }
+        }
+
+        internal class SingleSegmentTestSequenceFactoryChar : ReadOnlySequenceFactoryChar
+        {
+            public override ReadOnlySequence<char> CreateOfSize(int size)
+            {
+                return CreateWithContent(new char[size]);
+            }
+
+            public override ReadOnlySequence<char> CreateWithContent(char[] data)
+            {
+                return CreateSegments(data);
+            }
+        }
+
+        internal class CharPerSegmentTestSequenceFactoryChar : ReadOnlySequenceFactoryChar
+        {
+            public override ReadOnlySequence<char> CreateOfSize(int size)
+            {
+                return CreateWithContent(new char[size]);
+            }
+
+            public override ReadOnlySequence<char> CreateWithContent(char[] data)
+            {
+                var segments = new List<char[]>();
+
+                segments.Add(Array.Empty<char>());
+                foreach (var b in data)
+                {
+                    segments.Add(new[] { b });
+                    segments.Add(Array.Empty<char>());
+                }
+
+                return CreateSegments(segments.ToArray());
+            }
+        }
+
+        public static ReadOnlySequence<char> CreateSegments(params char[][] inputs)
+        {
+            if (inputs == null || inputs.Length == 0)
+            {
+                throw new InvalidOperationException();
+            }
+
+            int i = 0;
+
+            BufferSegment<char> last = null;
+            BufferSegment<char> first = null;
+
+            do
+            {
+                char[] s = inputs[i];
+                int length = s.Length;
+                int dataOffset = length;
+                var chars = new char[length * 2];
+
+                for (int j = 0; j < length; j++)
+                {
+                    chars[dataOffset + j] = s[j];
+                }
+
+                // Create a segment that has offset relative to the OwnedMemory and OwnedMemory itself has offset relative to array
+                Memory<char> memory = new Memory<char>(chars).Slice(length, length);
+
+                if (first == null)
+                {
+                    first = new BufferSegment<char>(memory);
+                    last = first;
+                }
+                else
+                {
+                    last = last.Append(memory);
+                }
+                i++;
+            } while (i < inputs.Length);
+
+            return new ReadOnlySequence<char>(first, 0, last, last.Memory.Length);
+        }
+    }
+}

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Common.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Common.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
 using System.MemoryTests;
+using System.Text;
 using Xunit;
 
 namespace System.Memory.Tests
@@ -16,8 +19,8 @@ namespace System.Memory.Tests
             // 0               50           100    0             50             100
             // [                ##############] -> [##############                ]
             //                         ^c1            ^c2
-            var bufferSegment1 = new BufferSegment(new byte[49]);
-            BufferSegment bufferSegment2 = bufferSegment1.Append(new byte[50]);
+            var bufferSegment1 = new BufferSegment<byte>(new byte[49]);
+            BufferSegment<byte> bufferSegment2 = bufferSegment1.Append(new byte[50]);
 
             var buffer = new ReadOnlySequence<byte>(bufferSegment1, 0, bufferSegment2, 50);
 
@@ -31,8 +34,8 @@ namespace System.Memory.Tests
         [Fact]
         public void GetPositionPrefersNextSegment()
         {
-            BufferSegment bufferSegment1 = new BufferSegment(new byte[50]);
-            BufferSegment bufferSegment2 = bufferSegment1.Append(new byte[0]);
+            BufferSegment<byte> bufferSegment1 = new BufferSegment<byte>(new byte[50]);
+            BufferSegment<byte> bufferSegment2 = bufferSegment1.Append(new byte[0]);
 
             ReadOnlySequence<byte> buffer = new ReadOnlySequence<byte>(bufferSegment1, 0, bufferSegment2, 0);
 
@@ -45,9 +48,9 @@ namespace System.Memory.Tests
         [Fact]
         public void GetPositionDoesNotCrossOutsideBuffer()
         {
-            var bufferSegment1 = new BufferSegment(new byte[100]);
-            BufferSegment bufferSegment2 = bufferSegment1.Append(new byte[100]);
-            BufferSegment bufferSegment3 = bufferSegment2.Append(new byte[0]);
+            var bufferSegment1 = new BufferSegment<byte>(new byte[100]);
+            BufferSegment<byte> bufferSegment2 = bufferSegment1.Append(new byte[100]);
+            BufferSegment<byte> bufferSegment3 = bufferSegment2.Append(new byte[0]);
 
             var buffer = new ReadOnlySequence<byte>(bufferSegment1, 0, bufferSegment2, 100);
 
@@ -135,7 +138,7 @@ namespace System.Memory.Tests
         [Fact]
         public void Ctor_MemoryList_ValidatesArguments()
         {
-            var segment = new BufferSegment(new byte[] { 1, 2, 3, 4, 5 });
+            var segment = new BufferSegment<byte>(new byte[] { 1, 2, 3, 4, 5 });
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlySequence<byte>(segment, 6, segment, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlySequence<byte>(segment, 0, segment, 6));
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlySequence<byte>(segment, 3, segment, 0));
@@ -145,7 +148,41 @@ namespace System.Memory.Tests
 
             Assert.Throws<ArgumentNullException>(() => new ReadOnlySequence<byte>(null, 5, segment, 0));
             Assert.Throws<ArgumentNullException>(() => new ReadOnlySequence<byte>(segment, 5, null, 0));
-        }
+        } 
 
+        [Fact]
+        public void HelloWorldAcrossTwoBlocks()
+        {
+            //     block 1       ->    block2
+            // [padding..hello]  ->  [  world   ]
+            const int blockSize = 4096;
+
+            byte[] bytes = Encoding.ASCII.GetBytes("Hello World");
+            byte[] firstBytes = Enumerable.Repeat((byte)'a', blockSize - 5).Concat(bytes.Take(5)).ToArray();
+            byte[] secondBytes = bytes.Skip(5).Concat( Enumerable.Repeat((byte)'a', blockSize - (bytes.Length - 5))).ToArray();
+
+            BufferSegment<byte> firstSegement = new BufferSegment<byte>(firstBytes);
+            BufferSegment<byte> secondSegement = firstSegement.Append(secondBytes);
+
+            ReadOnlySequence<byte> buffer = new ReadOnlySequence<byte>(firstSegement, 0, secondSegement, bytes.Length - 5);
+            Assert.False(buffer.IsSingleSegment);
+            ReadOnlySequence<byte> helloBuffer = buffer.Slice(blockSize - 5);
+            Assert.False(helloBuffer.IsSingleSegment);
+            var memory = new List<ReadOnlyMemory<byte>>();
+            foreach (ReadOnlyMemory<byte> m in helloBuffer)
+            {
+                memory.Add(m);
+            }
+
+            List<ReadOnlyMemory<byte>> spans = memory;
+
+            Assert.Equal(2, memory.Count);
+            var helloBytes = new byte[spans[0].Length];
+            spans[0].Span.CopyTo(helloBytes);
+            var worldBytes = new byte[spans[1].Length];
+            spans[1].Span.CopyTo(worldBytes);
+            Assert.Equal("Hello", Encoding.ASCII.GetString(helloBytes));
+            Assert.Equal(" World", Encoding.ASCII.GetString(worldBytes));
+        }
     }
 }

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
@@ -9,36 +9,36 @@ using Xunit;
 
 namespace System.Memory.Tests
 {
-    public abstract class ReadOnlySequenceTests
+    public abstract class ReadOnlySequenceTestsByte
     {
-        public class Array : ReadOnlySequenceTests
+        public class Array : ReadOnlySequenceTestsByte
         {
-            public Array() : base(ReadOnlySequenceFactory.ArrayFactory) { }
+            public Array() : base(ReadOnlySequenceFactoryByte.ArrayFactory) { }
         }
 
-        public class OwnedMemory : ReadOnlySequenceTests
+        public class OwnedMemory : ReadOnlySequenceTestsByte
         {
-            public OwnedMemory() : base(ReadOnlySequenceFactory.OwnedMemoryFactory) { }
+            public OwnedMemory() : base(ReadOnlySequenceFactoryByte.OwnedMemoryFactory) { }
         }
 
-        public class Memory : ReadOnlySequenceTests
+        public class Memory : ReadOnlySequenceTestsByte
         {
-            public Memory() : base(ReadOnlySequenceFactory.MemoryFactory) { }
+            public Memory() : base(ReadOnlySequenceFactoryByte.MemoryFactory) { }
         }
 
-        public class SingleSegment : ReadOnlySequenceTests
+        public class SingleSegment : ReadOnlySequenceTestsByte
         {
-            public SingleSegment() : base(ReadOnlySequenceFactory.SingleSegmentFactory) { }
+            public SingleSegment() : base(ReadOnlySequenceFactoryByte.SingleSegmentFactory) { }
         }
 
-        public class SegmentPerByte : ReadOnlySequenceTests
+        public class SegmentPerByte : ReadOnlySequenceTestsByte
         {
-            public SegmentPerByte() : base(ReadOnlySequenceFactory.SegmentPerByteFactory) { }
+            public SegmentPerByte() : base(ReadOnlySequenceFactoryByte.SegmentPerByteFactory) { }
         }
 
-        internal ReadOnlySequenceFactory Factory { get; }
+        internal ReadOnlySequenceFactoryByte Factory { get; }
 
-        internal ReadOnlySequenceTests(ReadOnlySequenceFactory factory)
+        internal ReadOnlySequenceTestsByte(ReadOnlySequenceFactoryByte factory)
         {
             Factory = factory;
         }
@@ -129,8 +129,8 @@ namespace System.Memory.Tests
             // 0               50           100    0             50             100
             // [                ##############] -> [##############                ]
             //                         ^c1            ^c2
-            var bufferSegment1 = new BufferSegment(new byte[49]);
-            BufferSegment bufferSegment2 = bufferSegment1.Append(new byte[50]);
+            var bufferSegment1 = new BufferSegment<byte>(new byte[49]);
+            BufferSegment<byte> bufferSegment2 = bufferSegment1.Append(new byte[50]);
 
             var buffer = new ReadOnlySequence<byte>(bufferSegment1, 0, bufferSegment2, 50);
 
@@ -144,8 +144,8 @@ namespace System.Memory.Tests
         [Fact]
         public void GetPositionPrefersNextSegment()
         {
-            BufferSegment bufferSegment1 = new BufferSegment(new byte[50]);
-            BufferSegment bufferSegment2 = bufferSegment1.Append(new byte[0]);
+            BufferSegment<byte> bufferSegment1 = new BufferSegment<byte>(new byte[50]);
+            BufferSegment<byte> bufferSegment2 = bufferSegment1.Append(new byte[0]);
 
             ReadOnlySequence<byte> buffer = new ReadOnlySequence<byte>(bufferSegment1, 0, bufferSegment2, 0);
 
@@ -158,9 +158,9 @@ namespace System.Memory.Tests
         [Fact]
         public void GetPositionDoesNotCrossOutsideBuffer()
         {
-            var bufferSegment1 = new BufferSegment(new byte[100]);
-            BufferSegment bufferSegment2 = bufferSegment1.Append(new byte[100]);
-            BufferSegment bufferSegment3 = bufferSegment2.Append(new byte[0]);
+            var bufferSegment1 = new BufferSegment<byte>(new byte[100]);
+            BufferSegment<byte> bufferSegment2 = bufferSegment1.Append(new byte[100]);
+            BufferSegment<byte> bufferSegment3 = bufferSegment2.Append(new byte[0]);
 
             var buffer = new ReadOnlySequence<byte>(bufferSegment1, 0, bufferSegment2, 100);
 

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.char.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.char.cs
@@ -1,0 +1,293 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.Memory.Tests
+{
+    public abstract class ReadOnlySequenceTestsChar
+    {
+        public class Array : ReadOnlySequenceTestsChar
+        {
+            public Array() : base(ReadOnlySequenceFactoryChar.ArrayFactory) { }
+        }
+
+        public class String : ReadOnlySequenceTestsChar
+        {
+            public String() : base(ReadOnlySequenceFactoryChar.StringFactory) { }
+        }
+
+        public class OwnedMemory : ReadOnlySequenceTestsChar
+        {
+            public OwnedMemory() : base(ReadOnlySequenceFactoryChar.OwnedMemoryFactory) { }
+        }
+
+        public class Memory : ReadOnlySequenceTestsChar
+        {
+            public Memory() : base(ReadOnlySequenceFactoryChar.MemoryFactory) { }
+        }
+
+        public class SingleSegment : ReadOnlySequenceTestsChar
+        {
+            public SingleSegment() : base(ReadOnlySequenceFactoryChar.SingleSegmentFactory) { }
+        }
+
+        public class SegmentPerChar : ReadOnlySequenceTestsChar
+        {
+            public SegmentPerChar() : base(ReadOnlySequenceFactoryChar.SegmentPerCharFactory) { }
+        }
+
+        internal ReadOnlySequenceFactoryChar Factory { get; }
+
+        internal ReadOnlySequenceTestsChar(ReadOnlySequenceFactoryChar factory)
+        {
+            Factory = factory;
+        }
+
+        [Fact]
+        public void EmptyIsCorrect()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(0);
+            Assert.Equal(0, buffer.Length);
+            Assert.True(buffer.IsEmpty);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(8)]
+        public void LengthIsCorrect(int length)
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(length);
+            Assert.Equal(length, buffer.Length);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(8)]
+        public void ToArrayIsCorrect(int length)
+        {
+            char[] data = Enumerable.Range(0, length).Select(i => (char)i).ToArray();
+            ReadOnlySequence<char> buffer = Factory.CreateWithContent(data);
+            Assert.Equal(length, buffer.Length);
+            Assert.Equal(data, buffer.ToArray());
+        }
+
+        [Fact]
+        public void ToStringIsCorrect()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateWithContent(Enumerable.Range(0, 255).Select(i => (char)i).ToArray());
+            Assert.Equal("System.Buffers.ReadOnlySequence<Char>[255]", buffer.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidSliceCases))]
+        public void Slice_Works(Func<ReadOnlySequence<char>, ReadOnlySequence<char>> func)
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateWithContent(new char[] { (char)0, (char)1, (char)2 , (char)3 , (char)4, (char)5, (char)6, (char)7, (char)8, (char)9 });
+            ReadOnlySequence<char> slice = func(buffer);
+            Assert.Equal(new char[] { (char)5, (char)6, (char)7, (char)8, (char)9 }, slice.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(OutOfRangeSliceCases))]
+        public void ReadOnlyBufferDoesNotAllowSlicingOutOfRange(Action<ReadOnlySequence<char>> fail)
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(100);
+            Assert.Throws<ArgumentOutOfRangeException>(() => fail(buffer));
+        }
+
+        [Fact]
+        public void ReadOnlyBufferGetPosition_MovesPosition()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(100);
+            SequencePosition position = buffer.GetPosition(buffer.Start, 65);
+            Assert.Equal(buffer.Slice(position).Length, 35);
+        }
+
+        [Fact]
+        public void ReadOnlyBufferGetPosition_ChecksBounds()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(100);
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(buffer.Start, 101));
+        }
+
+        [Fact]
+        public void ReadOnlyBufferGetPosition_DoesNotAlowNegative()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(20);
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(buffer.Start, -1));
+        }
+
+        public void ReadOnlyBufferSlice_ChecksEnd()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(100);
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Slice(70, buffer.Start));
+        }
+
+        [Fact]
+        public void SegmentStartIsConsideredInBoundsCheck()
+        {
+            // 0               50           100    0             50             100
+            // [                ##############] -> [##############                ]
+            //                         ^c1            ^c2
+            var bufferSegment1 = new BufferSegment<char>(new char[49]);
+            BufferSegment<char> bufferSegment2 = bufferSegment1.Append(new char[50]);
+
+            var buffer = new ReadOnlySequence<char>(bufferSegment1, 0, bufferSegment2, 50);
+
+            SequencePosition c1 = buffer.GetPosition(buffer.Start, 25); // segment 1 index 75
+            SequencePosition c2 = buffer.GetPosition(buffer.Start, 55); // segment 2 index 5
+
+            ReadOnlySequence<char> sliced = buffer.Slice(c1, c2);
+            Assert.Equal(30, sliced.Length);
+        }
+
+        [Fact]
+        public void GetPositionPrefersNextSegment()
+        {
+            BufferSegment<char> bufferSegment1 = new BufferSegment<char>(new char[50]);
+            BufferSegment<char> bufferSegment2 = bufferSegment1.Append(new char[0]);
+
+            ReadOnlySequence<char> buffer = new ReadOnlySequence<char>(bufferSegment1, 0, bufferSegment2, 0);
+
+            SequencePosition c1 = buffer.GetPosition(buffer.Start, 50);
+
+            Assert.Equal(0, c1.GetInteger());
+            Assert.Equal(bufferSegment2, c1.GetObject());
+        }
+
+        [Fact]
+        public void GetPositionDoesNotCrossOutsideBuffer()
+        {
+            var bufferSegment1 = new BufferSegment<char>(new char[100]);
+            BufferSegment<char> bufferSegment2 = bufferSegment1.Append(new char[100]);
+            BufferSegment<char> bufferSegment3 = bufferSegment2.Append(new char[0]);
+
+            var buffer = new ReadOnlySequence<char>(bufferSegment1, 0, bufferSegment2, 100);
+
+            SequencePosition c1 = buffer.GetPosition(buffer.Start, 200);
+
+            Assert.Equal(100, c1.GetInteger());
+            Assert.Equal(bufferSegment2, c1.GetObject());
+        }
+
+        [Fact]
+        public void Create_WorksWithArray()
+        {
+            var buffer = new ReadOnlySequence<char>(new char[] { (char)1, (char)2, (char)3, (char)4, (char)5 });
+            Assert.Equal(buffer.ToArray(), new char[] { (char)1, (char)2, (char)3, (char)4, (char)5 });
+        }
+
+        [Fact]
+        public void Empty_ReturnsLengthZeroBuffer()
+        {
+            var buffer = ReadOnlySequence<char>.Empty;
+            Assert.Equal(0, buffer.Length);
+            Assert.Equal(true, buffer.IsSingleSegment);
+            Assert.Equal(0, buffer.First.Length);
+        }
+
+        [Fact]
+        public void Create_WorksWithArrayWithOffset()
+        {
+            var buffer = new ReadOnlySequence<char>(new char[] { (char)1, (char)2, (char)3, (char)4, (char)5 }, 2, 3);
+            Assert.Equal(buffer.ToArray(), new char[] { (char)3, (char)4, (char)5 });
+        }
+
+        [Fact]
+        public void C_WorksWithArrayWithOffset()
+        {
+            var buffer = new ReadOnlySequence<char>(new char[] { (char)1, (char)2, (char)3, (char)4, (char)5 }, 2, 3);
+            Assert.Equal(buffer.ToArray(), new char[] { (char)3, (char)4, (char)5 });
+        }
+
+
+        [Fact]
+        public void Create_WorksWithMemory()
+        {
+            var memory = new ReadOnlyMemory<char>(new char[] { (char)1, (char)2, (char)3, (char)4, (char)5 });
+            var buffer = new ReadOnlySequence<char>(memory.Slice(2, 3));
+            Assert.Equal(new char[] { (char)3, (char)4, (char)5 }, buffer.ToArray());
+        }
+
+        [Fact]
+        public void SliceToTheEndWorks()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(10);
+            Assert.True(buffer.Slice(buffer.End).IsEmpty);
+        }
+
+        [Theory]
+        [InlineData("a", 'a', 0)]
+        [InlineData("ab", 'a', 0)]
+        [InlineData("aab", 'a', 0)]
+        [InlineData("acab", 'a', 0)]
+        [InlineData("acab", 'c', 1)]
+        [InlineData("abcdefghijklmnopqrstuvwxyz", 'l', 11)]
+        [InlineData("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", 'l', 11)]
+        [InlineData("aaaaaaaaaaacmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", 'm', 12)]
+        [InlineData("aaaaaaaaaaarmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", 'r', 11)]
+        [InlineData("/localhost:5000/PATH/%2FPATH2/ HTTP/1.1", '%', 21)]
+        [InlineData("/localhost:5000/PATH/%2FPATH2/?key=value HTTP/1.1", '%', 21)]
+        [InlineData("/localhost:5000/PATH/PATH2/?key=value HTTP/1.1", '?', 27)]
+        [InlineData("/localhost:5000/PATH/PATH2/ HTTP/1.1", ' ', 27)]
+        public void PositionOf_ReturnsPosition(string raw, char searchFor, int expectIndex)
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateWithContent(raw);
+            SequencePosition? result = buffer.PositionOf((char)searchFor);
+
+            Assert.NotNull(result);
+            Assert.Equal(buffer.Slice(result.Value).ToArray(), raw.Substring(expectIndex));
+        }
+
+        [Fact]
+        public void PositionOf_ReturnsNullIfNotFound()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateWithContent(new char[] { (char)1, (char)2, (char)3 });
+            SequencePosition? result = buffer.PositionOf((char)4);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CopyTo_ThrowsWhenSourceLargerThenDestination()
+        {
+            ReadOnlySequence<char> buffer = Factory.CreateOfSize(10);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Span<char> span = new char[5];
+                buffer.CopyTo(span);
+            });
+        }
+
+        public static TheoryData<Func<ReadOnlySequence<char>, ReadOnlySequence<char>>> ValidSliceCases => new TheoryData<Func<ReadOnlySequence<char>, ReadOnlySequence<char>>>
+        {
+            b => b.Slice(5),
+            b => b.Slice(0).Slice(5),
+            b => b.Slice(5, 5),
+            b => b.Slice(b.GetPosition(b.Start, 5), 5),
+            b => b.Slice(5, b.GetPosition(b.Start, 10)),
+            b => b.Slice(b.GetPosition(b.Start, 5), b.GetPosition(b.Start, 10)),
+
+            b => b.Slice((long)5),
+            b => b.Slice((long)5, 5),
+            b => b.Slice(b.GetPosition(b.Start, 5), (long)5),
+            b => b.Slice((long)5, b.GetPosition(b.Start, 10)),
+        };
+
+        public static TheoryData<Action<ReadOnlySequence<char>>> OutOfRangeSliceCases => new TheoryData<Action<ReadOnlySequence<char>>>
+        {
+            b => b.Slice(101),
+            b => b.Slice(0, 101),
+            b => b.Slice(b.Start, 101),
+            b => b.Slice(0, 70).Slice(b.End, b.End),
+            b => b.Slice(0, 70).Slice(b.Start, b.End),
+            b => b.Slice(0, 70).Slice(0, b.End)
+        };
+    }
+}

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -71,10 +71,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ReadOnlyBuffer\BufferSegment.cs" />
-    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.cs" />
-    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceFactory.cs" />
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceFactory.byte.cs" />
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceFactory.char.cs" />
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.byte.cs" />
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.char.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.cs" />
-    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.TryGet.cs" />
     <Compile Include="ReadOnlyBuffer\SequencePosition.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/26740

Also added handling for `string` backed `Memory<char>`

/cc @KrzysztofCwalina @davidfowl @ahsonkhan @pakrym