### PR TITLE
NamedPipe: CurrentUserOnly, quick fixes for Unix

### DIFF
--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -285,4 +285,7 @@
   <data name="UnauthorizedAccess_NotOwnedByCurrentUser" xml:space="preserve">
     <value>Could not connect to the pipe because it was not owned by the current user.</value>
   </data>
+  <data name="UnauthorizedAccess_ClientIsNotCurrentUser" xml:space="preserve">
+    <value>Client connection refused because it was not owned by the current user.</value>
+  </data>
 </root>

--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -286,6 +286,6 @@
     <value>Could not connect to the pipe because it was not owned by the current user.</value>
   </data>
   <data name="UnauthorizedAccess_ClientIsNotCurrentUser" xml:space="preserve">
-    <value>Client connection refused because it was not owned by the current user.</value>
+    <value>Client connection (user id {0}) was refused because it was not owned by the current user (id {1}).</value>
   </data>
 </root>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -41,6 +41,8 @@ namespace System.IO.Pipes
             // We don't have a good way to enforce maxNumberOfServerInstances across processes; we only factor it in
             // for streams created in this process.  Between processes, we behave similarly to maxNumberOfServerInstances == 1,
             // in that the second process to come along and create a stream will find the pipe already in existence and will fail.
+            var pipeNameServer = GetPipePath(".", pipeName, IsCurrentUserOnly);
+            System.Console.WriteLine("PipeServerName: " + pipeNameServer + " IsCurrentUserOnly: " + IsCurrentUserOnly);
             _instance = SharedServer.Get(GetPipePath(".", pipeName, IsCurrentUserOnly), maxNumberOfServerInstances);
 
             _direction = direction;
@@ -83,8 +85,25 @@ namespace System.IO.Pipes
         private void HandleAcceptedSocket(Socket acceptedSocket)
         {
             var serverHandle = new SafePipeHandle(acceptedSocket);
+
             try
             {
+                if (IsCurrentUserOnly)
+                {
+                    uint serverEUID = Interop.Sys.GetEUid();
+
+                    uint peerID;
+                    if (Interop.Sys.GetPeerID(serverHandle, out peerID) == -1)
+                    {
+                        throw CreateExceptionForLastError(_instance?.PipeName);
+                    }
+                    
+                    if (serverEUID != peerID)
+                    {
+                        throw new UnauthorizedAccessException(SR.UnauthorizedAccess_ClientIsNotCurrentUser);
+                    }
+                }
+
                 ConfigureSocket(acceptedSocket, serverHandle, _direction, _inBufferSize, _outBufferSize, _inheritability);
             }
             catch

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -41,8 +41,6 @@ namespace System.IO.Pipes
             // We don't have a good way to enforce maxNumberOfServerInstances across processes; we only factor it in
             // for streams created in this process.  Between processes, we behave similarly to maxNumberOfServerInstances == 1,
             // in that the second process to come along and create a stream will find the pipe already in existence and will fail.
-            var pipeNameServer = GetPipePath(".", pipeName, IsCurrentUserOnly);
-            System.Console.WriteLine("PipeServerName: " + pipeNameServer + " IsCurrentUserOnly: " + IsCurrentUserOnly);
             _instance = SharedServer.Get(GetPipePath(".", pipeName, IsCurrentUserOnly), maxNumberOfServerInstances);
 
             _direction = direction;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -98,7 +98,7 @@ namespace System.IO.Pipes
                     
                     if (serverEUID != peerID)
                     {
-                        throw new UnauthorizedAccessException(SR.UnauthorizedAccess_ClientIsNotCurrentUser);
+                        throw new UnauthorizedAccessException(string.Format(SR.UnauthorizedAccess_ClientIsNotCurrentUser, peerID, serverEUID));
                     }
                 }
 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -68,7 +68,7 @@ namespace System.IO.Pipes
                     throw CreateExceptionForLastError();
                 }
 
-                return Path.Combine(directory, s_pipePrefix + pipeName);
+                return Path.Combine(directory, pipeName);
             }
 
             return s_pipePrefix + pipeName;

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.cs
@@ -30,7 +30,7 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void CreateServer_ConnectClient()
         {
-            var name = "test.named.pipe"; // GetUniquePipeName();
+            var name = GetUniquePipeName();
             using (var server = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
             {
                 using (var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.CurrentUserOnly))

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.cs
@@ -30,13 +30,27 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void CreateServer_ConnectClient()
         {
-            var name = GetUniquePipeName();
+            var name = "test.named.pipe"; // GetUniquePipeName();
             using (var server = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
             {
                 using (var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.CurrentUserOnly))
                 {
                     // Should not fail to connect since both, the server and client have the same owner.
                     client.Connect();
+                }
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)] // On Unix domain socket should have different location in this case.
+        public static void CreateServerNotCurrentUserOnly_ClientCurrentUserOnly_ThrowsTimeout_OnUnix()
+        {
+            var name = GetUniquePipeName();
+            using (var server = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
+            {
+                using (var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.CurrentUserOnly))
+                { 
+                    Assert.Throws<TimeoutException>(() => client.Connect(1));
                 }
             }
         }

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.cs
@@ -30,7 +30,7 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void CreateServer_ConnectClient()
         {
-            var name = GetUniquePipeName();
+            string name = GetUniquePipeName();
             using (var server = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
             {
                 using (var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.CurrentUserOnly))
@@ -45,7 +45,7 @@ namespace System.IO.Pipes.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)] // On Unix domain socket should have different location in this case.
         public static void CreateServerNotCurrentUserOnly_ClientCurrentUserOnly_ThrowsTimeout_OnUnix()
         {
-            var name = GetUniquePipeName();
+            string name = GetUniquePipeName();
             using (var server = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
             {
                 using (var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.CurrentUserOnly))
@@ -58,9 +58,9 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void CreateMultipleServers_ConnectMultipleClients()
         {
-            var name1 = GetUniquePipeName();
-            var name2 = GetUniquePipeName();
-            var name3 = GetUniquePipeName();
+            string name1 = GetUniquePipeName();
+            string name2 = GetUniquePipeName();
+            string name3 = GetUniquePipeName();
             using (var server1 = new NamedPipeServerStream(name1, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
             using (var server2 = new NamedPipeServerStream(name2, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
             using (var server3 = new NamedPipeServerStream(name3, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))


### PR DESCRIPTION
* The path for the directory when using current user only was wrong and not using the intended folder.
* Added getpeerid validation on the server side (see https://github.com/dotnet/corefx/pull/26395#discussion_r166484692)
