### PR TITLE
Activity for HttpClient calls not stopped if inner handler does not use async/await

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -92,9 +92,9 @@ namespace System.Net.Http
                 }
             }
 
-            Task<HttpResponseMessage> responseTask = base.SendAsync(request, cancellationToken);
             try
             {
+                Task<HttpResponseMessage> responseTask = base.SendAsync(request, cancellationToken);
                 await responseTask.ConfigureAwait(false);
             }
             catch (TaskCanceledException)


### PR DESCRIPTION
I've been writing some `DiagnosticSource`/`Activity` based instrumentation for HttpClient. [In my unit tests](https://github.com/cwe1ss/opentracing-contrib-dotnet/blob/ba20de4ba57e43cb685083e3c0b2b19022ce067e/test/OpenTracing.Contrib.AspNetCore.Tests/HttpOut/HttpOutInterceptorTest.cs) I've created a HttpMessageHandler and wrapped it with the existing `DiagnosticsHandler` (by using reflection, so in an unsupported way) to test the different scenarios.

However, I noticed that if my handler doesn't use `async/await`, the `DiagnosticsHandler` does NOT raise the Diagnostics-events for `System.Net.Http.Exception` and `System.Net.Http.HttpRequestOut.Stop` because the invocation is outside of the try...catch block.

E.g. if DiagnosticsHandler is using an inner handler that looks like this, it does NOT raise the events:
```csharp
public class FailingHttpMessageHandler : HttpMessageHandler
{
    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
    {
        throw new InvalidOperationException("foo");
    }
}
```

It only works, if I change the code as follows:
```csharp
public class FailingHttpMessageHandler : HttpMessageHandler
{
    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
    {
        await Task.CompletedTask;
        throw new InvalidOperationException("foo");
    }
}
```

My direct usage of DiagnosticsHandler is obviously a hack as it is internal and AFAIU in a regular application `DiagnosticsHandler` is an internal feature of `HttpClientHandler` so there shouldn't be any user code after it but nevertheless, I think that it would make sense to move the call from this PR into the try..catch block.

/cc @lmolkova @vancem