### PR TITLE
Add MaxResponseDrainSize, and fix a few draining bugs

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -13,6 +13,7 @@ namespace System.Net.Http
     {
         public const int DefaultMaxAutomaticRedirections = 50;
         public const int DefaultMaxConnectionsPerServer = int.MaxValue;
+        public const int DefaultMaxResponseDrainSize = 1024 * 1024;
         public const int DefaultMaxResponseHeadersLength = 64; // Units in K (1024) bytes.
         public const DecompressionMethods DefaultAutomaticDecompression = DecompressionMethods.None;
         public const bool DefaultAutomaticRedirection = true;

--- a/src/System.Net.Http/src/ILLinkTrim.xml
+++ b/src/System.Net.Http/src/ILLinkTrim.xml
@@ -2,5 +2,6 @@
   <assembly fullname="System.Net.Http">
     <!-- Anonymous types are used with DiagnosticSource logging and subscribers reflect over those, calling their public getters. -->
     <type fullname="*f__AnonymousType*" />
+    <type fullname="System.Net.Http.SocketsHttpHandler" /> <!-- TODO #27329: Remove this once MaxResponseDrainSize is exposed -->
   </assembly>
 </linker>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -336,6 +336,9 @@
   <data name="net_http_response_headers_exceeded_length" xml:space="preserve">
     <value>The HTTP response headers length exceeded the set limit of {0} bytes.</value>
   </data>
+  <data name="ArgumentOutOfRange_NeedNonNegativeNum" xml:space="preserve">
+    <value>Non-negative number required.</value>
+  </data>
   <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
     <value>Positive number required.</value>
   </data>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
@@ -14,25 +14,26 @@ namespace System.Net.Http
         private sealed class HttpConnectionResponseContent : HttpContent
         {
             private HttpContentStream _stream;
+            private bool _consumedStream;
 
             public void SetStream(HttpContentStream stream)
             {
                 Debug.Assert(stream != null);
                 Debug.Assert(stream.CanRead);
+                Debug.Assert(!_consumedStream);
 
                 _stream = stream;
             }
 
             private HttpContentStream ConsumeStream()
             {
-                if (_stream == null)
+                if (_consumedStream || _stream == null)
                 {
                     throw new InvalidOperationException(SR.net_http_content_stream_already_read);
                 }
+                _consumedStream = true;
 
-                HttpContentStream stream = _stream;
-                _stream = null;
-                return stream;
+                return _stream;
             }
 
             protected sealed override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -26,6 +26,7 @@ namespace System.Net.Http
         internal int _maxAutomaticRedirections = HttpHandlerDefaults.DefaultMaxAutomaticRedirections;
 
         internal int _maxConnectionsPerServer = HttpHandlerDefaults.DefaultMaxConnectionsPerServer;
+        internal int _maxResponseDrainSize = HttpHandlerDefaults.DefaultMaxResponseDrainSize;
         internal int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
 
         internal TimeSpan _pooledConnectionLifetime = HttpHandlerDefaults.DefaultPooledConnectionLifetime;
@@ -56,6 +57,7 @@ namespace System.Net.Http
                 _expect100ContinueTimeout = _expect100ContinueTimeout,
                 _maxAutomaticRedirections = _maxAutomaticRedirections,
                 _maxConnectionsPerServer = _maxConnectionsPerServer,
+                _maxResponseDrainSize = _maxResponseDrainSize,
                 _maxResponseHeadersLength = _maxResponseHeadersLength,
                 _pooledConnectionLifetime = _pooledConnectionLifetime,
                 _pooledConnectionIdleTimeout = _pooledConnectionIdleTimeout,

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
     {
         internal abstract class HttpContentReadStream : HttpContentStream
         {
-            private bool _disposed;
+            private int _disposed; // 0==no, 1==yes
 
             public HttpContentReadStream(HttpConnection connection) : base(connection)
             {
@@ -64,11 +64,10 @@ namespace System.Net.Http
                 // response stream and response content) will kick off multiple concurrent draining
                 // operations. Also don't delegate to the base if Dispose has already been called,
                 // as doing so will end up disposing of the connection before we're done draining.
-                if (_disposed)
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
                 {
                     return;
                 }
-                _disposed = true;
 
                 if (disposing && NeedsDrain)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -9,94 +9,106 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal abstract class HttpContentReadStream : HttpContentStream
+    internal partial class HttpConnection
     {
-        public HttpContentReadStream(HttpConnection connection) : base(connection)
+        internal abstract class HttpContentReadStream : HttpContentStream
         {
-        }
+            private bool _disposed;
 
-        public sealed override bool CanRead => true;
-        public sealed override bool CanWrite => false;
-
-        public sealed override void Flush() { }
-        public sealed override Task FlushAsync(CancellationToken cancellationToken) =>
-            cancellationToken.IsCancellationRequested ?
-                Task.FromCanceled(cancellationToken) :
-                Task.CompletedTask;
-
-        public sealed override void WriteByte(byte value) => throw new NotSupportedException();
-        public sealed override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-        public sealed override void Write(ReadOnlySpan<byte> source) => throw new NotSupportedException();
-        public sealed override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
-        public sealed override Task WriteAsync(ReadOnlyMemory<byte> destination, CancellationToken cancellationToken) => throw new NotSupportedException();
-
-        public sealed override int Read(byte[] buffer, int offset, int count)
-        {
-            ValidateBufferArgs(buffer, offset, count);
-            return ReadAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).GetAwaiter().GetResult();
-        }
-
-        public sealed override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            ValidateBufferArgs(buffer, offset, count);
-            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
-        }
-
-        public sealed override void CopyTo(Stream destination, int bufferSize) =>
-            CopyToAsync(destination, bufferSize, CancellationToken.None).GetAwaiter().GetResult();
-
-        public virtual bool NeedsDrain => false;
-
-        public virtual Task<bool> DrainAsync(int maxDrainBytes)
-        {
-            Debug.Assert(false, "DrainAsync should not be called for this response stream");
-            return Task.FromResult(false);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
+            public HttpContentReadStream(HttpConnection connection) : base(connection)
             {
-                if (NeedsDrain)
+            }
+
+            public sealed override bool CanRead => true;
+            public sealed override bool CanWrite => false;
+
+            public sealed override void Flush() { }
+            public sealed override Task FlushAsync(CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ?
+                    Task.FromCanceled(cancellationToken) :
+                    Task.CompletedTask;
+
+            public sealed override void WriteByte(byte value) => throw new NotSupportedException();
+            public sealed override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public sealed override void Write(ReadOnlySpan<byte> source) => throw new NotSupportedException();
+            public sealed override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
+            public sealed override Task WriteAsync(ReadOnlyMemory<byte> destination, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+            public sealed override int Read(byte[] buffer, int offset, int count)
+            {
+                ValidateBufferArgs(buffer, offset, count);
+                return ReadAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).GetAwaiter().GetResult();
+            }
+
+            public sealed override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                ValidateBufferArgs(buffer, offset, count);
+                return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            }
+
+            public sealed override void CopyTo(Stream destination, int bufferSize) =>
+                CopyToAsync(destination, bufferSize, CancellationToken.None).GetAwaiter().GetResult();
+
+            public virtual bool NeedsDrain => false;
+
+            public virtual Task<bool> DrainAsync(int maxDrainBytes)
+            {
+                Debug.Fail($"DrainAsync should not be called for this response stream: {GetType()}");
+                return Task.FromResult(false);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                // Only attempt draining if we haven't started draining due to disposal; otherwise
+                // multiple calls to Dispose (which happens frequently when someone disposes of the
+                // response stream and response content) will kick off multiple concurrent draining
+                // operations. Also don't delegate to the base if Dispose has already been called,
+                // as doing so will end up disposing of the connection before we're done draining.
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+
+                if (disposing && NeedsDrain)
                 {
                     // Start the asynchronous drain.
                     // It may complete synchronously, in which case the connection will be put back in the pool synchronously.
-                    // Skip the call to base.Dispose -- it will be deferred until DrainOnDispose finishes.
-                    DrainOnDispose();
+                    // Skip the call to base.Dispose -- it will be deferred until DrainOnDisposeAsync finishes.
+                    DrainOnDisposeAsync();
                     return;
                 }
+
+                base.Dispose(disposing);
             }
 
-            base.Dispose(disposing);
-        }
-
-        // Maximum request drain size, 1MB.
-        private const int MaxDrainBytes = 1024 * 1024;
-
-        private async void DrainOnDispose()
-        {
-            HttpConnection connection = _connection;        // Will be null after drain succeeds
-
-            try
+            private async void DrainOnDisposeAsync()
             {
-                bool drained = await DrainAsync(MaxDrainBytes).ConfigureAwait(false);
+                HttpConnection connection = _connection;        // Will be null after drain succeeds
 
-                if (NetEventSource.IsEnabled)
+                try
                 {
-                    connection.Trace(drained ? "Connection drain succeeded" : "Connection drain failed because MaxDrainSize was exceeded");
+                    bool drained = await DrainAsync(connection._pool.Settings._maxResponseDrainSize).ConfigureAwait(false);
+
+                    if (NetEventSource.IsEnabled)
+                    {
+                        connection.Trace(drained ?
+                            "Connection drain succeeded" :
+                            $"Connection drain failed because MaxResponseDrainSize of {connection._pool.Settings._maxResponseDrainSize} bytes was exceeded");
+                    }
                 }
-            }
-            catch (Exception e)
-            {
-                if (NetEventSource.IsEnabled)
+                catch (Exception e)
                 {
-                    connection.Trace($"Connection drain failed due to exception: {e}");
+                    if (NetEventSource.IsEnabled)
+                    {
+                        connection.Trace($"Connection drain failed due to exception: {e}");
+                    }
+
+                    // Eat any exceptions and just Dispose.
                 }
 
-                // Eat any exceptions and just Dispose.
+                base.Dispose(true);
             }
-
-            base.Dispose(true);
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -152,6 +152,21 @@ namespace System.Net.Http
             }
         }
 
+        internal int MaxResponseDrainSize // TODO #27329: Expose publicly.
+        {
+            get => _settings._maxResponseDrainSize;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, SR.ArgumentOutOfRange_NeedNonNegativeNum);
+                }
+
+                CheckDisposedOrStarted();
+                _settings._maxResponseDrainSize = value;
+            }
+        }
+
         public int MaxResponseHeadersLength
         {
             get => _settings._maxResponseHeadersLength;


### PR DESCRIPTION
I've added MaxResponseDrainSize to make the setting configurable rather than a const; I left it internal until the API is approved.

In adding tests for it, I found a few existing bugs in draining that I fixed:
- HttpConnectionResponseContent nulls out its Stream when the Stream is consumed.  Then when the response content is disposed, the Stream is null, so it's not disposed, so it's not drained.
- HttpContentReadStream's Dispose wasn't checking whether it was already called, and would kick off a new draining operation if the connection was still associated.  So if the stream was disposed multiple times, which happens if the response content and stream are both disposed (since the content disposes of the stream), we end up corrupting the response due to multiple threads concurrently accessing and draining it.

cc: @geoffkizer, @davidsh, @wfurt
Contributes to https://github.com/dotnet/corefx/issues/27329