### PR TITLE
ReadOnlySequence Performance Improvements

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -7,10 +7,10 @@ using System.Diagnostics;
 
 namespace System.IO.Pipelines
 {
-    internal sealed class BufferSegment : IMemoryList<byte>
+    internal sealed class BufferSegment : ReadOnlySequenceSegment<byte>
     {
         private OwnedMemory<byte> _ownedMemory;
-
+        private BufferSegment _next;
         private int _end;
 
         /// <summary>
@@ -43,12 +43,15 @@ namespace System.IO.Pipelines
         /// working memory. The "active" memory is grown when bytes are copied in, End is increased, and Next is assigned. The "active"
         /// memory is shrunk when bytes are consumed, Start is increased, and blocks are returned to the pool.
         /// </summary>
-        public BufferSegment NextSegment { get; set; }
-
-        /// <summary>
-        /// Combined length of all segments before this
-        /// </summary>
-        public long RunningIndex { get; private set; }
+        public BufferSegment NextSegment
+        {
+            get => _next;
+            set
+            {
+                _next = value;
+                Next = value;
+            }
+        }
 
         public void SetMemory(OwnedMemory<byte> buffer)
         {
@@ -78,11 +81,7 @@ namespace System.IO.Pipelines
 
         public Memory<byte> AvailableMemory { get; private set; }
 
-        public Memory<byte> Memory { get; private set; }
-
         public int Length => End - Start;
-
-        public IMemoryList<byte> Next => NextSegment;
 
         /// <summary>
         /// If true, data should not be written into the backing block after the End offset. Data between start and end should never be modified

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -224,11 +224,11 @@ namespace System.Buffers
         System.Memory<T> GetMemory(int sizeHint = 0);
         System.Span<T> GetSpan(int sizeHint = 0);
     }
-    public partial interface IMemoryList<T>
+    public abstract partial class ReadOnlySequenceSegment<T>
     {
-        System.Memory<T> Memory { get; }
-        System.Buffers.IMemoryList<T> Next { get; }
-        long RunningIndex { get; }
+        public System.ReadOnlyMemory<T> Memory { get; protected set; }
+        public System.Buffers.ReadOnlySequenceSegment<T> Next { get; protected set; }
+        public long RunningIndex { get; protected set; }
     }
     public partial interface IRetainable
     {
@@ -287,7 +287,7 @@ namespace System.Buffers
     {
         private readonly object _dummy;
         public static readonly System.Buffers.ReadOnlySequence<T> Empty;
-        public ReadOnlySequence(System.Buffers.IMemoryList<T> startSegment, int startIndex, System.Buffers.IMemoryList<T> endSegment, int endIndex) { throw null; }
+        public ReadOnlySequence(System.Buffers.ReadOnlySequenceSegment<T> startSegment, int startIndex, System.Buffers.ReadOnlySequenceSegment<T> endSegment, int endIndex) { throw null; }
         public ReadOnlySequence(T[] array) { throw null; }
         public ReadOnlySequence(T[] array, int start, int length) { throw null; }
         public ReadOnlySequence(System.ReadOnlyMemory<T> memory) { throw null; }
@@ -517,7 +517,7 @@ namespace System.Runtime.InteropServices
     public static partial class SequenceMarshal
     {
         public static bool TryGetArray<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ArraySegment<T> arraySegment) { throw null; }
-        public static bool TryGetMemoryList<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.Buffers.IMemoryList<T> startSegment, out int startIndex, out System.Buffers.IMemoryList<T> endSegment, out int endIndex) { throw null; }
+        public static bool TryGetReadOnlySequenceSegment<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.Buffers.ReadOnlySequenceSegment<T> startSegment, out int startIndex, out System.Buffers.ReadOnlySequenceSegment<T> endSegment, out int endIndex) { throw null; }
         public static bool TryGetOwnedMemory<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.Buffers.OwnedMemory<T> ownedMemory, out int start, out int length) { throw null; }
         public static bool TryGetReadOnlyMemory<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ReadOnlyMemory<T> readOnlyMemory) { throw null; }
     }

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -32,7 +32,7 @@
     <Compile Include="System\Buffers\ArrayMemoryPool.ArrayMemoryPoolBuffer.cs" />
     <Compile Include="System\Buffers\BuffersExtensions.cs" />
     <Compile Include="System\Buffers\IBufferWriter.cs" />
-    <Compile Include="System\Buffers\IMemoryList.cs" />
+    <Compile Include="System\Buffers\ReadOnlySequenceSegment.cs" />
     <Compile Include="System\Buffers\MemoryPool.cs" />
     <Compile Include="System\Buffers\OperationStatus.cs" />
     <Compile Include="System\Buffers\ReadOnlySequence.cs" />

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -32,10 +32,10 @@
     <Compile Include="System\Buffers\ArrayMemoryPool.ArrayMemoryPoolBuffer.cs" />
     <Compile Include="System\Buffers\BuffersExtensions.cs" />
     <Compile Include="System\Buffers\IBufferWriter.cs" />
-    <Compile Include="System\Buffers\ReadOnlySequenceSegment.cs" />
     <Compile Include="System\Buffers\MemoryPool.cs" />
     <Compile Include="System\Buffers\OperationStatus.cs" />
     <Compile Include="System\Buffers\ReadOnlySequence.cs" />
+    <Compile Include="System\Buffers\ReadOnlySequenceSegment.cs" />
     <Compile Include="System\Buffers\ReadOnlySequence_helpers.cs" />
     <Compile Include="System\Buffers\Binary\Reader.cs" />
     <Compile Include="System\Buffers\Binary\ReaderBigEndian.cs" />

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -398,7 +398,7 @@ namespace System.Buffers
 
         private enum SequenceType
         {
-            Segment = 0x00,
+            MultiSegment = 0x00,
             Array = 0x1,
             OwnedMemory = 0x2,
             String = 0x3,

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -189,8 +189,8 @@ namespace System.Buffers
         /// <param name="length">The length of the slice</param>
         public ReadOnlySequence<T> Slice(long start, long length)
         {
-            SequencePosition begin = Seek(_sequenceStart, _sequenceEnd, start, false);
-            SequencePosition end = Seek(begin, _sequenceEnd, length, false);
+            SequencePosition begin = Seek(_sequenceStart, _sequenceEnd, start);
+            SequencePosition end = Seek(begin, _sequenceEnd, length);
             return SliceImpl(begin, end);
         }
 
@@ -204,6 +204,12 @@ namespace System.Buffers
             BoundsCheck(end, _sequenceEnd);
 
             SequencePosition begin = Seek(_sequenceStart, end, start);
+            object beginObject = begin.GetObject();
+            object endObject = end.GetObject();
+            if (beginObject != endObject)
+            {
+                CheckEndReachable(beginObject, endObject);
+            }
             return SliceImpl(begin, end);
         }
 
@@ -216,7 +222,7 @@ namespace System.Buffers
         {
             BoundsCheck(start, _sequenceEnd);
 
-            SequencePosition end = Seek(start, _sequenceEnd, length, false);
+            SequencePosition end = Seek(start, _sequenceEnd, length);
             return SliceImpl(start, end);
         }
 
@@ -227,8 +233,8 @@ namespace System.Buffers
         /// <param name="length">The length of the slice</param>
         public ReadOnlySequence<T> Slice(int start, int length)
         {
-            SequencePosition begin = Seek(_sequenceStart, _sequenceEnd, start, false);
-            SequencePosition end = Seek(begin, _sequenceEnd, length, false);
+            SequencePosition begin = Seek(_sequenceStart, _sequenceEnd, start);
+            SequencePosition end = Seek(begin, _sequenceEnd, length);
             return SliceImpl(begin, end);
         }
 
@@ -242,6 +248,12 @@ namespace System.Buffers
             BoundsCheck(end, _sequenceEnd);
 
             SequencePosition begin = Seek(_sequenceStart, end, start);
+            object beginObject = begin.GetObject();
+            object endObject = end.GetObject();
+            if (beginObject != endObject)
+            {
+                CheckEndReachable(beginObject, endObject);
+            }
             return SliceImpl(begin, end);
         }
 
@@ -254,7 +266,7 @@ namespace System.Buffers
         {
             BoundsCheck(start, _sequenceEnd);
 
-            SequencePosition end = Seek(start, _sequenceEnd, length, false);
+            SequencePosition end = Seek(start, _sequenceEnd, length);
             return SliceImpl(start, end);
         }
 
@@ -293,7 +305,7 @@ namespace System.Buffers
                 return this;
             }
 
-            SequencePosition begin = Seek(_sequenceStart, _sequenceEnd, start, false);
+            SequencePosition begin = Seek(_sequenceStart, _sequenceEnd, start);
             return SliceImpl(begin, _sequenceEnd);
         }
 
@@ -313,7 +325,7 @@ namespace System.Buffers
             if (offset < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
 
-            return Seek(origin, _sequenceEnd, offset, false);
+            return Seek(origin, _sequenceEnd, offset);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -46,14 +46,7 @@ namespace System.Buffers
         /// <summary>
         /// Gets <see cref="ReadOnlyMemory{T}"/> from the first segment.
         /// </summary>
-        public ReadOnlyMemory<T> First
-        {
-            get
-            {
-                TryGetBuffer(_sequenceStart, _sequenceEnd, out ReadOnlyMemory<T> first, out _);
-                return first;
-            }
-        }
+        public ReadOnlyMemory<T> First => GetFirstBuffer(_sequenceStart, _sequenceEnd);
 
         /// <summary>
         /// A position to the start of the <see cref="ReadOnlySequence{T}"/>.

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -37,7 +37,11 @@ namespace System.Buffers
         /// <summary>
         /// Determines if the <see cref="ReadOnlySequence{T}"/> contains a single <see cref="ReadOnlyMemory{T}"/> segment.
         /// </summary>
-        public bool IsSingleSegment => _sequenceStart.GetObject() == _sequenceEnd.GetObject();
+        public bool IsSingleSegment
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _sequenceStart.GetObject() == _sequenceEnd.GetObject();
+        }
 
         /// <summary>
         /// Gets <see cref="ReadOnlyMemory{T}"/> from the first segment.
@@ -76,7 +80,7 @@ namespace System.Buffers
         /// Creates an instance of <see cref="ReadOnlySequence{T}"/> from linked memory list represented by start and end segments
         /// and corresponding indexes in them.
         /// </summary>
-        public ReadOnlySequence(IMemoryList<T> startSegment, int startIndex, IMemoryList<T> endSegment, int endIndex)
+        public ReadOnlySequence(ReadOnlySequenceSegment<T> startSegment, int startIndex, ReadOnlySequenceSegment<T> endSegment, int endIndex)
         {
             if (startSegment == null ||
                 endSegment == null ||
@@ -85,8 +89,8 @@ namespace System.Buffers
                 (startSegment == endSegment && endIndex < startIndex))
                 ThrowHelper.ThrowArgumentValidationException(startSegment, startIndex, endSegment);
 
-            _sequenceStart = new SequencePosition(startSegment, ReadOnlySequence.MemoryListToSequenceStart(startIndex));
-            _sequenceEnd = new SequencePosition(endSegment, ReadOnlySequence.MemoryListToSequenceEnd(endIndex));
+            _sequenceStart = new SequencePosition(startSegment, ReadOnlySequence.SegmentToSequenceStart(startIndex));
+            _sequenceEnd = new SequencePosition(endSegment, ReadOnlySequence.SegmentToSequenceEnd(endIndex));
         }
 
         /// <summary>
@@ -394,7 +398,7 @@ namespace System.Buffers
 
         private enum SequenceType
         {
-            IMemoryList = 0x00,
+            Segment = 0x00,
             Array = 0x1,
             OwnedMemory = 0x2,
             String = 0x3,
@@ -407,8 +411,8 @@ namespace System.Buffers
         public const int FlagBitMask = 1 << 31;
         public const int IndexBitMask = ~FlagBitMask;
 
-        public const int MemoryListStartMask = 0;
-        public const int MemoryListEndMask = 0;
+        public const int SegmentStartMask = 0;
+        public const int SegmentEndMask = 0;
 
         public const int ArrayStartMask = 0;
         public const int ArrayEndMask = FlagBitMask;
@@ -420,9 +424,9 @@ namespace System.Buffers
         public const int StringEndMask = FlagBitMask;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int MemoryListToSequenceStart(int startIndex) => startIndex | MemoryListStartMask;
+        public static int SegmentToSequenceStart(int startIndex) => startIndex | SegmentStartMask;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int MemoryListToSequenceEnd(int endIndex) => endIndex | MemoryListEndMask;
+        public static int SegmentToSequenceEnd(int endIndex) => endIndex | SegmentEndMask;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ArrayToSequenceStart(int startIndex) => startIndex | ArrayStartMask;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequenceSegment.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequenceSegment.cs
@@ -5,7 +5,7 @@
 namespace System.Buffers
 {
     /// <summary>
-    /// Represents a linked list of <see cref="Memory{T}"/> nodes.
+    /// Represents a linked list of <see cref="ReadOnlyMemory{T}"/> nodes.
     /// </summary>
     public abstract class ReadOnlySequenceSegment<T>
     {

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequenceSegment.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequenceSegment.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Represents a linked list of <see cref="Memory{T}"/> nodes.
+    /// </summary>
+    public abstract class ReadOnlySequenceSegment<T>
+    {
+        /// <summary>
+        /// The <see cref="ReadOnlyMemory{T}"/> value for current node.
+        /// </summary>
+        public ReadOnlyMemory<T> Memory { get; protected set; }
+
+        /// <summary>
+        /// The next node.
+        /// </summary>
+        public ReadOnlySequenceSegment<T> Next { get; protected set; }
+
+        /// <summary>
+        /// The sum of node length before current.
+        /// </summary>
+        public long RunningIndex { get; protected set; }
+    }
+}

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -4,7 +4,10 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+
+#if !netstandard
 using Internal.Runtime.CompilerServices;
+#endif
 
 namespace System.Buffers
 {
@@ -55,7 +58,8 @@ namespace System.Buffers
             {
                 Debug.Assert(startObject is string);
 
-                data = (ReadOnlyMemory<T>)(object)(Unsafe.As<string>(startObject)).AsMemory(startIndex, length);
+                var text = Unsafe.As<string>(startObject);
+                data = (ReadOnlyMemory<T>)(object)text.AsMemory(startIndex, length);
             }
             else
             {
@@ -188,7 +192,7 @@ namespace System.Buffers
 
                     if (memoryLength > count || (memoryLength == count && isCurrentAtEnd))
                     {
-                        // Fully contained in this segment; or at end of segment but isn't a next one to move to
+                        // Fully contained in this segment; or at end of segment but there isn't a next one to move to
                         break;
                     }
 
@@ -377,7 +381,8 @@ namespace System.Buffers
             {
                 Debug.Assert(startObject is string);
 
-                memory = (ReadOnlyMemory<T>)(object)Unsafe.As<string>(startObject).AsMemory(startIndex, length);
+                var text = Unsafe.As<string>(startObject);
+                memory = (ReadOnlyMemory<T>)(object)text.AsMemory(startIndex, length);
             }
             else // ReadOnlySequenceSegment
             {

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -171,14 +171,12 @@ namespace System.Buffers
         private static SequencePosition SeekMultiSegment(ReadOnlySequenceSegment<T> currentSegment, int startIndex, object endObject, int endPosition, long count)
         {
             Debug.Assert(currentSegment != null);
+            Debug.Assert(currentSegment.Next != null);
 
             if (count == 0)
             {
-                // End of segment. Move to start of next, if one exists
-                if (currentSegment.Next != null)
-                {
-                    currentSegment = currentSegment.Next;
-                }
+                // End of segment. Move to start of next.
+                currentSegment = currentSegment.Next;
             }
             else
             {

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -40,33 +40,34 @@ namespace System.Buffers
                     next = GetBufferCrossSegment(startIndex, end, ref startSegment, ref length);
                 }
 
-                data = startSegment.Memory.Slice(startIndex, length);
+                data = startSegment.Memory;
             }
             else if (type == SequenceType.Array)
             {
                 Debug.Assert(startObject is T[]);
 
-                data = new ReadOnlyMemory<T>(Unsafe.As<T[]>(startObject), startIndex, length);
+                data = new ReadOnlyMemory<T>(Unsafe.As<T[]>(startObject));
             }
             else if (type == SequenceType.OwnedMemory)
             {
                 Debug.Assert(startObject is OwnedMemory<T>);
 
-                data = (Unsafe.As<OwnedMemory<T>>(startObject)).Memory.Slice(startIndex, length);
+                data = (Unsafe.As<OwnedMemory<T>>(startObject)).Memory;
             }
             else if (typeof(T) == typeof(char) && type == SequenceType.String)
             {
                 Debug.Assert(startObject is string);
 
-                var text = Unsafe.As<string>(startObject);
-                data = (ReadOnlyMemory<T>)(object)text.AsMemory(startIndex, length);
+                data = (ReadOnlyMemory<T>)(object)(Unsafe.As<string>(startObject)).AsMemory();
             }
             else
             {
                 data = default;
+                return false;
             }
 
-            return type != SequenceType.Empty;
+            data = data.Slice(startIndex, length);
+            return true;
         }
 
         private static SequencePosition GetBufferCrossSegment(int startIndex, in SequencePosition end, ref ReadOnlySequenceSegment<T> startSegment, ref int length)
@@ -367,28 +368,29 @@ namespace System.Buffers
             {
                 Debug.Assert(startObject is T[]);
 
-                memory = new ReadOnlyMemory<T>(Unsafe.As<T[]>(startObject), startIndex, length);
+                memory = new ReadOnlyMemory<T>(Unsafe.As<T[]>(startObject));
             }
             else if (type == SequenceType.OwnedMemory)
             {
                 Debug.Assert(startObject is OwnedMemory<T>);
 
-                memory = Unsafe.As<OwnedMemory<T>>(startObject).Memory.Slice(startIndex, length);
+                memory = Unsafe.As<OwnedMemory<T>>(startObject).Memory;
             }
             else if (typeof(T) == typeof(char) && type == SequenceType.String)
             {
                 Debug.Assert(startObject is string);
 
                 var text = Unsafe.As<string>(startObject);
-                memory = (ReadOnlyMemory<T>)(object)text.AsMemory(startIndex, length);
+                memory = (ReadOnlyMemory<T>)(object)text.AsMemory();
             }
             else // ReadOnlySequenceSegment
             {
                 Debug.Assert(startObject is ReadOnlySequenceSegment<T>);
 
-                memory = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject).Memory.Slice(startIndex, length);
+                memory = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject).Memory;
             }
 
+            memory = memory.Slice(startIndex, length);
             return true;
         }
 

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -83,7 +83,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, int count, bool checkEndReachable = true)
+        internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, int count)
         {
             GetTypeAndIndices(start.GetInteger(), end.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);
 
@@ -94,14 +94,7 @@ namespace System.Buffers
                 object endSegment = end.GetObject();
                 if (notInRange || startSegment != endSegment)
                 {
-                    SequencePosition result = SeekMultiSegment(startSegment, startIndex, endSegment, endIndex, count);
-
-                    if (checkEndReachable)
-                    {
-                        CheckEndReachable(result.GetObject(), endSegment);
-                    }
-
-                    return result;
+                    return SeekMultiSegment(startSegment, startIndex, endSegment, endIndex, count);
                 }
             }
             else if (notInRange)
@@ -111,7 +104,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, long count, bool checkEndReachable = true)
+        internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, long count)
         {
             GetTypeAndIndices(start.GetInteger(), end.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);
 
@@ -122,14 +115,7 @@ namespace System.Buffers
                 object endSegment = end.GetObject();
                 if (notInRange || startSegment != endSegment)
                 {
-                    SequencePosition result = SeekMultiSegment(startSegment, startIndex, endSegment, endIndex, count);
-
-                    if (checkEndReachable)
-                    {
-                        CheckEndReachable(result.GetObject(), endSegment);
-                    }
-
-                    return result;
+                    return SeekMultiSegment(startSegment, startIndex, endSegment, endIndex, count);
                 }
             }
             else if (notInRange)
@@ -188,7 +174,6 @@ namespace System.Buffers
             return new SequencePosition(current, (int)count);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CheckEndReachable(object startSegment, object endSegment)
         {
             var current = (ReadOnlySequenceSegment<T>)startSegment;

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -323,6 +323,7 @@ namespace System.Buffers
                 return endSegment.RunningIndex - startSegment.RunningIndex - startIndex + endIndex; // Rearranged to avoid overflow
             }
 
+            Debug.Assert(startObject == endObject);
             // Single segment length
             return endIndex - startIndex;
         }
@@ -353,6 +354,7 @@ namespace System.Buffers
             }
             else if (startIndex <= endIndex)
             {
+                Debug.Assert(startObject == endObject);
                 // Single segment in bounds
                 return;
             }

--- a/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
+++ b/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
@@ -12,16 +12,16 @@ namespace System.Runtime.InteropServices
     public static partial class SequenceMarshal
     {
         /// <summary>
-        /// Get <see cref="IMemoryList{T}"/> from the underlying <see cref="ReadOnlySequence{T}"/>.
-        /// If unable to get the <see cref="IMemoryList{T}"/>, return false.
+        /// Get <see cref="ReadOnlySequenceSegment{T}"/> from the underlying <see cref="ReadOnlySequence{T}"/>.
+        /// If unable to get the <see cref="ReadOnlySequenceSegment{T}"/>, return false.
         /// </summary>
-        public static bool TryGetMemoryList<T>(ReadOnlySequence<T> sequence,
-            out IMemoryList<T> startSegment,
+        public static bool TryGetReadOnlySequenceSegment<T>(ReadOnlySequence<T> sequence,
+            out ReadOnlySequenceSegment<T> startSegment,
             out int startIndex,
-            out IMemoryList<T> endSegment,
+            out ReadOnlySequenceSegment<T> endSegment,
             out int endIndex)
         {
-            return sequence.TryGetMemoryList(out startSegment, out startIndex, out endSegment, out endIndex);
+            return sequence.TryGetReadOnlySequenceSegment(out startSegment, out startIndex, out endSegment, out endIndex);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/ThrowHelper.cs
+++ b/src/System.Memory/src/System/ThrowHelper.cs
@@ -128,10 +128,10 @@ namespace System
         //
         // ReadOnlySequence .ctor validation Throws coalesced to enable inlining of the .ctor
         //
-        public static void ThrowArgumentValidationException<T>(IMemoryList<T> startSegment, int startIndex, IMemoryList<T> endSegment)
+        public static void ThrowArgumentValidationException<T>(ReadOnlySequenceSegment<T> startSegment, int startIndex, ReadOnlySequenceSegment<T> endSegment)
             => throw CreateArgumentValidationException(startSegment, startIndex, endSegment);
 
-        private static Exception CreateArgumentValidationException<T>(IMemoryList<T> startSegment, int startIndex, IMemoryList<T> endSegment)
+        private static Exception CreateArgumentValidationException<T>(ReadOnlySequenceSegment<T> startSegment, int startIndex, ReadOnlySequenceSegment<T> endSegment)
         {
             if (startSegment == null)
                 return CreateArgumentNullException(ExceptionArgument.startSegment);

--- a/src/System.Memory/tests/ReadOnlyBuffer/BufferSegment.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/BufferSegment.cs
@@ -6,21 +6,12 @@ using System.Buffers;
 
 namespace System.Memory.Tests
 {
-    internal class BufferSegment<T> : IMemoryList<T>
+    internal class BufferSegment<T> : ReadOnlySequenceSegment<T>
     {
         public BufferSegment(Memory<T> memory)
         {
             Memory = memory;
         }
-
-        /// <summary>
-        /// Combined length of all segments before this
-        /// </summary>
-        public long RunningIndex { get; private set; }
-
-        public Memory<T> Memory { get; set; }
-
-        public IMemoryList<T> Next { get; private set; }
 
         public BufferSegment<T> Append(Memory<T> memory)
         {

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Common.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Common.cs
@@ -136,7 +136,7 @@ namespace System.Memory.Tests
         }
 
         [Fact]
-        public void Ctor_MemoryList_ValidatesArguments()
+        public void Ctor_ReadOnlySequenceSegment_ValidatesArguments()
         {
             var segment = new BufferSegment<byte>(new byte[] { 1, 2, 3, 4, 5 });
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlySequence<byte>(segment, 6, segment, 0));


### PR DESCRIPTION
Change `IMemoryList` to POCO object; then inherit for Pipeline`s `BufferSegment`; this means all its properties inline in use rather than being interface dispatch.

Improve some of the code paths
    
Bottom numbers after the effect for 1, 100 and 1000 segments; top is current

```        
                           Method |    Categories |        Mean |         Op/s | Scaled |
--------------------------------- |-------------- |------------:|-------------:|-------:|
   ReadOnlySequence<T> (previous) |     1 segment |   104.86 ns |  9,536,378.9 |   1.00 |
    ReadOnlySequence<T> (current) |     1 segment |    85.64 ns | 11,677,040.0 |   0.82 |
    ReadOnlySequence<T> (this PR) |     1 segment |    70.79 ns | 14,125,877.7 |   0.68 |
                                  |               |             |              |        |
   ReadOnlySequence<T> (previous) |     2 segment |   188.92 ns |  5,293,250.6 |   1.00 |
    ReadOnlySequence<T> (current) |     2 segment |   181.64 ns |  5,505,269.8 |   0.96 |
    ReadOnlySequence<T> (this PR) |     2 segment |   111.34 ns |  8,981,178.5 |   0.59 |
                                  |               |             |              |        |
   ReadOnlySequence<T> (previous) |  100 segments | 1,297.69 ns |    770,599.7 |   1.00 |
    ReadOnlySequence<T> (current) |  100 segments |   966.50 ns |  1,034,659.7 |   0.74 |
    ReadOnlySequence<T> (this PR) |  100 segments |   233.30 ns |  4,286,286.4 |   0.18 |
                                  |               |             |              |        |
   ReadOnlySequence<T> (previous) | 1000 segments | 1,390.97 ns |    718,923.3 |   1.00 |
    ReadOnlySequence<T> (current) | 1000 segments | 1,095.54 ns |    912,790.8 |   0.79 |
    ReadOnlySequence<T> (this PR) | 1000 segments |   275.27 ns |  3,632,776.9 |   0.20 |
                                  |               |             |              |        |
                          Span<T> |       MM item |   147.34 ns |  6,787,204.7 |   0.54 |
                   BufferSlice<T> |       MM item |   152.70 ns |  6,548,884.8 |   0.56 |
   ReadOnlySequence<T> (previous) |       MM item |   272.44 ns |  3,670,500.0 |   1.00 |
    ReadOnlySequence<T> (current) |       MM item |   251.15 ns |  3,981,724.7 |   0.92 |
    ReadOnlySequence<T> (this PR) |       MM item |   200.79 ns |  4,980,437.7 |   0.74 |
```

Resolves https://github.com/dotnet/corefx/issues/27500