### PR TITLE
Disable servicebase tests

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 /// </summary>
 namespace System.ServiceProcess.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/27071")]
     [OuterLoop(/* Modifies machine state */)]
     public class ServiceBaseTests : IDisposable
     {

--- a/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace System.ServiceProcess.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/27071")]
     [OuterLoop(/* Modifies machine state */)]
     public class ServiceControllerTests : IDisposable
     {

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests.csproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests.csproj
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{F7D9984B-02EB-4573-84EF-00FFFBFB872C}</ProjectGuid>
+      <XunitShowProgress>true</XunitShowProgress>
+      <XunitMaxThreads>1</XunitMaxThreads>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/issues/27071

After the change to PauseAndContinue, the tests are now consistently failing, but not necessarily in PauseAndContinue. Sometimes in TestOnExecuteCustomCommand. If I comment those out, it's randomly elsewhere. Breaking in, the tests are waiting for a byte sent on the pipe from the service. 

There may be a flaw in how the pipe communication is set up. I notice that there doesn't seem to be protection against the connect not having completed by the time that WriteStreamAsync is first called. If connect has not completed, it just does nothing (since some tests never connect). Perhaps it needs a scheme such that tests wait for a "Connected" byte - or always connect.

Disabling to get test runs clean. 