### PR TITLE
Update ILLink to version 0.1.4-preview-1421602

### DIFF
--- a/external/ILLink/ILLink.depproj
+++ b/external/ILLink/ILLink.depproj
@@ -9,7 +9,7 @@
     <NugetRuntimeIdentifier>$(ToolRuntimeRID)</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
     <ILLinkTasksPackageId>illink.tasks</ILLinkTasksPackageId>
-    <ILLinkTasksPackageVersion>0.1.4-preview-1222833</ILLinkTasksPackageVersion>
+    <ILLinkTasksPackageVersion>0.1.4-preview-1421602</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$(ILLinkTasksPackageId)">


### PR DESCRIPTION
This build has a support for SHA256 source checksum algorithm. Previously Mono.Cecil didn't write correct algorithm GUID into the PDBs, which resulted in bad PDBs.
See https://github.com/jbevain/cecil/pull/488