### PR TITLE
Use user-scope chains when doing Find with validOnly=true

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/FindPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/FindPal.cs
@@ -360,7 +360,7 @@ namespace Internal.Cryptography.Pal
             // This needs to be kept in sync with IsCertValid in the
             // Unix/OpenSSL PAL version (and potentially any other PALs that come about)
             ChainPal chainPal = ChainPal.BuildChain(
-                true,
+                false,
                 CertificatePal.FromHandle(pCertContext.DangerousGetHandle()),
                 null, //extraStore
                 null, //applicationPolicy


### PR DESCRIPTION
.NET Framework's version passes new IntPtr(CAPI.HCCE_CURRENT_USER), so
we need to also pass that same value (eventually) which we control by setting
useMachineContext to false (which is the default for `new X509Chain()`).

Fixes #27405.

No test is added with this because adding trust to CU\Root gives a blocking modal dialog ("are you sure?").  Turns out, removing something from CU\Root also gives one.

This was verified, however, by splicing a test into the CertificateRequest chains tests:

* Verify that Find(validOnly=false) matched 1 thing
* Verify that FInd(validOnly=true) matched 0 things
* Add the new root to CU\Root (and accept the consent popup)
* Add the new intermediate to CU\CA
* Verify that FInd(validOnly=true) matched 1 thing
* Remove the new intermediate from CU\CA
* Remove the new root from CU\Root (and accept the consent popup)

Given that that test runs 3 times per run (RSA, ECDSA, Hybrid) and I didn't think about the intermediate on the first attempt, many consent dialogs were seen in the making of this fix.