### PR TITLE
Expose Path.Join and tests

### DIFF
--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1226,7 +1226,8 @@ namespace System.IO
         public static string GetRelativePath(string relativeTo, string path) { throw null; }
         public static string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2) { throw null; }
         public static string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2, ReadOnlySpan<char> path3) { throw null; }
-        public static bool TryJoin(Span<char> destination, out int charsWritten, ReadOnlySpan<char> path1, ReadOnlySpan<char> path2) { throw null; }
+        public static bool TryJoin(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2, Span<char> destination, out int charsWritten) { throw null; }
+        public static bool TryJoin(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2, ReadOnlySpan<char> path3, Span<char> destination, out int charsWritten) { throw null; }
     }
 
     public partial class BinaryReader : System.IDisposable

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1224,6 +1224,9 @@ namespace System.IO
         public static bool IsPathFullyQualified(string path) { throw null; }
         public static bool IsPathFullyQualified(ReadOnlySpan<char> path) { throw null; }
         public static string GetRelativePath(string relativeTo, string path) { throw null; }
+        public static string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2) { throw null; }
+        public static string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2, ReadOnlySpan<char> path3) { throw null; }
+        public static bool TryJoin(Span<char> destination, out int charsWritten, ReadOnlySpan<char> path1, ReadOnlySpan<char> path2) { throw null; }
     }
 
     public partial class BinaryReader : System.IDisposable

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="System\IO\PathTests_Windows.netcoreapp.cs" />
     <Compile Include="System\IO\PathTests.netcoreapp.cs" />
     <Compile Include="System\IO\PathTests_Unix.cs" />
+    <Compile Include="System\IO\PathTests_Join.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'!='netstandard'">
     <Compile Include="System\BitConverterSpan.cs" />

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTestsBase.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTestsBase.cs
@@ -8,6 +8,9 @@ namespace System.IO.Tests
 {
     public partial class PathTestsBase
     {
+        protected static string Sep = Path.DirectorySeparatorChar.ToString();
+        protected static string AltSep = Path.AltDirectorySeparatorChar.ToString();
+
         public static TheoryData<string> TestData_EmbeddedNull => new TheoryData<string>
         {
             "a\0b"

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class PathTests_Join : PathTestsBase
+    {
+        public static TheoryData<string, string, string> TestData_JoinTwoPaths = new TheoryData<string, string, string>
+        {
+            { "", "", "" },
+            { Sep, "", Sep },
+            { AltSep, "", AltSep },
+            { "", Sep, Sep },
+            { "", AltSep, AltSep },
+            { Sep, Sep, new string(Path.DirectorySeparatorChar, 2) },
+            { AltSep, AltSep, new string(Path.AltDirectorySeparatorChar, 2) },
+            { "a", "", "a" },
+            { "", "a", "a" },
+            { "a", "a", $"a{Sep}a" },
+            { $"a{Sep}", "a", $"a{Sep}a" },
+            { "a", $"{Sep}a", $"a{Sep}a" },
+            { $"a{Sep}", $"{Sep}a", $"a{Sep}{Sep}a" },
+            { "a", $"a{Sep}", $"a{Sep}a{Sep}" },
+            { $"a{AltSep}", "a", $"a{AltSep}a" },
+            { "a", $"{AltSep}a", $"a{AltSep}a" },
+            { $"a{Sep}", $"{AltSep}a", $"a{Sep}{AltSep}a" },
+            { $"a{AltSep}", $"{AltSep}a", $"a{AltSep}{AltSep}a" },
+            { "a", $"a{AltSep}", $"a{Sep}a{AltSep}" },
+        };
+
+        [Theory, MemberData(nameof(TestData_JoinTwoPaths))]
+        public void JoinTwoPaths(string path1, string path2, string expected)
+        {
+            Assert.Equal(expected, Path.Join(path1, path2));
+        }
+
+        [Theory, MemberData(nameof(TestData_JoinTwoPaths))]
+        public unsafe void TryJoinTwoPaths(string path1, string path2, string expected)
+        {
+            string output = new string('\0', expected.Length);
+
+            fixed (char* c = output)
+            {
+                Assert.True(Path.TryJoin(new Span<char>(c, output.Length), out int written, path1, path2));
+                if (expected.Length > 0)
+                {
+                    Assert.False(Path.TryJoin(Span<char>.Empty, out _, path1, path2));
+                }
+                Assert.Equal(expected, output);
+                Assert.Equal(expected.Length, written);
+            }
+        }
+
+        public static TheoryData<string, string, string, string> TestData_JoinThreePaths = new TheoryData<string, string, string, string>
+        {
+            { "", "", "", "" },
+            { Sep, Sep, Sep, new string(Path.DirectorySeparatorChar, 3) },
+            { AltSep, AltSep, AltSep, new string(Path.AltDirectorySeparatorChar, 3) },
+            { "a", "", "", "a" },
+            { "", "a", "", "a" },
+            { "", "", "a", "a" },
+            { "a", "", "a", $"a{Sep}a" },
+            { "a", "a", "", $"a{Sep}a" },
+            { "", "a", "a", $"a{Sep}a" },
+            { "a", "a", "a", $"a{Sep}a{Sep}a" },
+            { "a", Sep, "a", $"a{Sep}a" },
+            { $"a{Sep}", "", "a", $"a{Sep}a" },
+            { $"a{Sep}", "a", "", $"a{Sep}a" },
+            { "", $"a{Sep}", "a", $"a{Sep}a" },
+            { "a", "", $"{Sep}a", $"a{Sep}a" },
+            { $"a{AltSep}", "", "a", $"a{AltSep}a" },
+            { $"a{AltSep}", "a", "", $"a{AltSep}a" },
+            { "", $"a{AltSep}", "a", $"a{AltSep}a" },
+            { "a", "", $"{AltSep}a", $"a{AltSep}a" },
+        };
+
+        [Theory, MemberData(nameof(TestData_JoinThreePaths))]
+        public void JoinThreePaths(string path1, string path2, string path3, string expected)
+        {
+            Assert.Equal(expected, Path.Join(path1, path2, path3));
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -40,18 +40,18 @@ namespace System.IO.Tests
         [Theory, MemberData(nameof(TestData_JoinTwoPaths))]
         public unsafe void TryJoinTwoPaths(string path1, string path2, string expected)
         {
-            string output = new string('\0', expected.Length);
+            char[] output = new char[expected.Length];
 
-            fixed (char* c = output)
+            Assert.True(Path.TryJoin(path1, path2, new Span<char>(output), out int written));
+            Assert.Equal(expected.Length, written);
+            if (expected.Length > 0)
             {
-                Assert.True(Path.TryJoin(path1, path2, new Span<char>(c, output.Length), out int written));
-                if (expected.Length > 0)
-                {
-                    Assert.False(Path.TryJoin(path1, path2, Span<char>.Empty, out _));
-                }
-                Assert.Equal(expected, output);
-                Assert.Equal(expected.Length, written);
+                Assert.False(Path.TryJoin(path1, path2, Span<char>.Empty, out written));
+                Assert.Equal(0, written);
+                Assert.False(Path.TryJoin(path1, path2, new Span<char>(output, 0, output.Length - 1), out written));
+                Assert.Equal(0, written);
             }
+            Assert.Equal(expected, new string(output));
         }
 
         public static TheoryData<string, string, string, string> TestData_JoinThreePaths = new TheoryData<string, string, string, string>
@@ -86,18 +86,18 @@ namespace System.IO.Tests
         [Theory, MemberData(nameof(TestData_JoinThreePaths))]
         public unsafe void TryJoinThreePaths(string path1, string path2, string path3, string expected)
         {
-            string output = new string('\0', expected.Length);
+            char[] output = new char[expected.Length];
 
-            fixed (char* c = output)
+            Assert.True(Path.TryJoin(path1, path2, path3, new Span<char>(output), out int written));
+            Assert.Equal(expected.Length, written);
+            if (expected.Length > 0)
             {
-                Assert.True(Path.TryJoin(path1, path2, path3, new Span<char>(c, output.Length), out int written));
-                if (expected.Length > 0)
-                {
-                    Assert.False(Path.TryJoin(path1, path2, path3, Span<char>.Empty, out _));
-                }
-                Assert.Equal(expected, output);
-                Assert.Equal(expected.Length, written);
+                Assert.False(Path.TryJoin(path1, path2, path3, Span<char>.Empty, out written));
+                Assert.Equal(0, written);
+                Assert.False(Path.TryJoin(path1, path2, path3, new Span<char>(output, 0, output.Length - 1), out written));
+                Assert.Equal(0, written);
             }
+            Assert.Equal(expected, new string(output));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -15,8 +15,8 @@ namespace System.IO.Tests
             { AltSep, "", AltSep },
             { "", Sep, Sep },
             { "", AltSep, AltSep },
-            { Sep, Sep, new string(Path.DirectorySeparatorChar, 2) },
-            { AltSep, AltSep, new string(Path.AltDirectorySeparatorChar, 2) },
+            { Sep, Sep, $"{Sep}{Sep}" },
+            { AltSep, AltSep, $"{AltSep}{AltSep}" },
             { "a", "", "a" },
             { "", "a", "a" },
             { "a", "a", $"a{Sep}a" },
@@ -38,27 +38,31 @@ namespace System.IO.Tests
         }
 
         [Theory, MemberData(nameof(TestData_JoinTwoPaths))]
-        public unsafe void TryJoinTwoPaths(string path1, string path2, string expected)
+        public void TryJoinTwoPaths(string path1, string path2, string expected)
         {
             char[] output = new char[expected.Length];
 
-            Assert.True(Path.TryJoin(path1, path2, new Span<char>(output), out int written));
+            Assert.True(Path.TryJoin(path1, path2, output, out int written));
             Assert.Equal(expected.Length, written);
+            Assert.Equal(expected, new string(output));
+
             if (expected.Length > 0)
             {
                 Assert.False(Path.TryJoin(path1, path2, Span<char>.Empty, out written));
                 Assert.Equal(0, written);
-                Assert.False(Path.TryJoin(path1, path2, new Span<char>(output, 0, output.Length - 1), out written));
+
+                output = new char[expected.Length - 1];
+                Assert.False(Path.TryJoin(path1, path2, output, out written));
                 Assert.Equal(0, written);
+                Assert.Equal(output, new char[output.Length]);
             }
-            Assert.Equal(expected, new string(output));
         }
 
         public static TheoryData<string, string, string, string> TestData_JoinThreePaths = new TheoryData<string, string, string, string>
         {
             { "", "", "", "" },
-            { Sep, Sep, Sep, new string(Path.DirectorySeparatorChar, 3) },
-            { AltSep, AltSep, AltSep, new string(Path.AltDirectorySeparatorChar, 3) },
+            { Sep, Sep, Sep, $"{Sep}{Sep}{Sep}" },
+            { AltSep, AltSep, AltSep, $"{AltSep}{AltSep}{AltSep}" },
             { "a", "", "", "a" },
             { "", "a", "", "a" },
             { "", "", "a", "a" },
@@ -84,20 +88,24 @@ namespace System.IO.Tests
         }
 
         [Theory, MemberData(nameof(TestData_JoinThreePaths))]
-        public unsafe void TryJoinThreePaths(string path1, string path2, string path3, string expected)
+        public void TryJoinThreePaths(string path1, string path2, string path3, string expected)
         {
             char[] output = new char[expected.Length];
 
-            Assert.True(Path.TryJoin(path1, path2, path3, new Span<char>(output), out int written));
+            Assert.True(Path.TryJoin(path1, path2, path3, output, out int written));
             Assert.Equal(expected.Length, written);
+            Assert.Equal(expected, new string(output));
+
             if (expected.Length > 0)
             {
                 Assert.False(Path.TryJoin(path1, path2, path3, Span<char>.Empty, out written));
                 Assert.Equal(0, written);
-                Assert.False(Path.TryJoin(path1, path2, path3, new Span<char>(output, 0, output.Length - 1), out written));
+
+                output = new char[expected.Length - 1];
+                Assert.False(Path.TryJoin(path1, path2, path3, output, out written));
                 Assert.Equal(0, written);
+                Assert.Equal(output, new char[output.Length]);
             }
-            Assert.Equal(expected, new string(output));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -44,10 +44,10 @@ namespace System.IO.Tests
 
             fixed (char* c = output)
             {
-                Assert.True(Path.TryJoin(new Span<char>(c, output.Length), out int written, path1, path2));
+                Assert.True(Path.TryJoin(path1, path2, new Span<char>(c, output.Length), out int written));
                 if (expected.Length > 0)
                 {
-                    Assert.False(Path.TryJoin(Span<char>.Empty, out _, path1, path2));
+                    Assert.False(Path.TryJoin(path1, path2, Span<char>.Empty, out _));
                 }
                 Assert.Equal(expected, output);
                 Assert.Equal(expected.Length, written);
@@ -81,6 +81,23 @@ namespace System.IO.Tests
         public void JoinThreePaths(string path1, string path2, string path3, string expected)
         {
             Assert.Equal(expected, Path.Join(path1, path2, path3));
+        }
+
+        [Theory, MemberData(nameof(TestData_JoinThreePaths))]
+        public unsafe void TryJoinThreePaths(string path1, string path2, string path3, string expected)
+        {
+            string output = new string('\0', expected.Length);
+
+            fixed (char* c = output)
+            {
+                Assert.True(Path.TryJoin(path1, path2, path3, new Span<char>(c, output.Length), out int written));
+                if (expected.Length > 0)
+                {
+                    Assert.False(Path.TryJoin(path1, path2, path3, Span<char>.Empty, out _));
+                }
+                Assert.Equal(expected, output);
+                Assert.Equal(expected.Length, written);
+            }
         }
     }
 }


### PR DESCRIPTION
Goes with https://github.com/dotnet/coreclr/pull/16561. Will need an updated CoreCLR with those bits. Will fail until that point.

cc: @pjanotti, @danmosemsft, @Anipik 