### PR TITLE
Prefer the generic IEnumerator over non-generic in regex MatchCollection and GroupCollection

### DIFF
--- a/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -28,8 +28,8 @@ namespace System.Text.RegularExpressions
         public object SyncRoot { get { throw null; } }
         public void CopyTo(System.Array array, int arrayIndex) { }
         public void CopyTo(System.Text.RegularExpressions.Capture[] array, int arrayIndex) { }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        System.Collections.Generic.IEnumerator<System.Text.RegularExpressions.Capture> System.Collections.Generic.IEnumerable<System.Text.RegularExpressions.Capture>.GetEnumerator() { throw null; }
+        public System.Collections.Generic.IEnumerator<System.Text.RegularExpressions.Capture> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         int System.Collections.Generic.IList<System.Text.RegularExpressions.Capture>.IndexOf(System.Text.RegularExpressions.Capture item) { throw null; }
         void System.Collections.Generic.IList<System.Text.RegularExpressions.Capture>.Insert(int index, System.Text.RegularExpressions.Capture item) { }
         void System.Collections.Generic.IList<System.Text.RegularExpressions.Capture>.RemoveAt(int index) { }

--- a/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -67,8 +67,8 @@ namespace System.Text.RegularExpressions
         public object SyncRoot { get { throw null; } }
         public void CopyTo(System.Array array, int arrayIndex) { }
         public void CopyTo(System.Text.RegularExpressions.Group[] array, int arrayIndex) { }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        System.Collections.Generic.IEnumerator<System.Text.RegularExpressions.Group> System.Collections.Generic.IEnumerable<System.Text.RegularExpressions.Group>.GetEnumerator() { throw null; }
+        public System.Collections.Generic.IEnumerator<System.Text.RegularExpressions.Group> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         int System.Collections.Generic.IList<System.Text.RegularExpressions.Group>.IndexOf(System.Text.RegularExpressions.Group item) { throw null; }
         void System.Collections.Generic.IList<System.Text.RegularExpressions.Group>.Insert(int index, System.Text.RegularExpressions.Group item) { }
         void System.Collections.Generic.IList<System.Text.RegularExpressions.Group>.RemoveAt(int index) { }
@@ -106,8 +106,8 @@ namespace System.Text.RegularExpressions
         public object SyncRoot { get { throw null; } }
         public void CopyTo(System.Array array, int arrayIndex) { }
         public void CopyTo(System.Text.RegularExpressions.Match[] array, int arrayIndex) { }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        System.Collections.Generic.IEnumerator<System.Text.RegularExpressions.Match> System.Collections.Generic.IEnumerable<System.Text.RegularExpressions.Match>.GetEnumerator() { throw null; }
+        public System.Collections.Generic.IEnumerator<System.Text.RegularExpressions.Match> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         int System.Collections.Generic.IList<System.Text.RegularExpressions.Match>.IndexOf(System.Text.RegularExpressions.Match item) { throw null; }
         void System.Collections.Generic.IList<System.Text.RegularExpressions.Match>.Insert(int index, System.Text.RegularExpressions.Match item) { }
         void System.Collections.Generic.IList<System.Text.RegularExpressions.Match>.RemoveAt(int index) { }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -49,9 +49,9 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Provides an enumerator in the same order as Item[].
         /// </summary>
-        public IEnumerator GetEnumerator() => new Enumerator(this);
+        public IEnumerator<Capture> GetEnumerator() => new Enumerator(this);
 
-        IEnumerator<Capture> IEnumerable<Capture>.GetEnumerator() => new Enumerator(this);
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
         /// Returns the set of captures for the group

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -47,9 +47,9 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Provides an enumerator in the same order as Item[].
         /// </summary>
-        public IEnumerator GetEnumerator() => new Enumerator(this);
+        public IEnumerator<Group> GetEnumerator() => new Enumerator(this);
 
-        IEnumerator<Group> IEnumerable<Group>.GetEnumerator() => new Enumerator(this);
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         private Group GetGroup(int groupnum)
         {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -84,9 +84,9 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Provides an enumerator in the same order as Item[i].
         /// </summary>
-        public IEnumerator GetEnumerator() => new Enumerator(this);
+        public IEnumerator<Match> GetEnumerator() => new Enumerator(this);
 
-        IEnumerator<Match> IEnumerable<Match>.GetEnumerator() => new Enumerator(this);
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         private Match GetMatch(int i)
         {


### PR DESCRIPTION
This allows the use of `var` in `foreach` loops as well as removing the `.Cast<Match>()` noise in LINQ queries.

A merge commit for this pull request to preserve the commit's GPG signature is appreciated.