### PR TITLE
disable drain test variation for CurlHandler

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
@@ -42,11 +42,9 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(ContentMode.BytePerChunk)]
         public async Task GetAsync_DisposeBeforeReadingToEnd_DrainsRequestsAndReusesConnection(ContentMode mode)
         {
-            if (IsWinHttpHandler && mode == ContentMode.BytePerChunk)
+            if ((IsWinHttpHandler || IsCurlHandler) && mode == ContentMode.BytePerChunk)
             {
-                // WinHttpHandler seems to only do a limited amount of draining when chunking is used;
-                // I *think* it's not draining anything beyond the current chunk being processed.
-                // So, these cases won't pass.
+                // These handlers' behavior with multiple chunks is inconsistent, so disable the test.
                 return;
             }
 


### PR DESCRIPTION
Fixes #27528 

@stephentoub @davidsh @dotnet/ncl 