### PR TITLE
Scrub error messages for missing arguments

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -1916,7 +1916,7 @@ namespace System.ComponentModel
                         }
                         catch (InvalidCastException)
                         {
-                            throw new ArgumentException(SR.GetResourceString(SR.TypeDescriptorExpectedElementType, typeof(Attribute).FullName));
+                            throw new ArgumentException(SR.Format(SR.TypeDescriptorExpectedElementType, typeof(Attribute).FullName));
                         }
                         cacheValue = new AttributeCollection(attrArray);
                         break;
@@ -1929,7 +1929,7 @@ namespace System.ComponentModel
                         }
                         catch (InvalidCastException)
                         {
-                            throw new ArgumentException(SR.GetResourceString(SR.TypeDescriptorExpectedElementType, typeof(PropertyDescriptor).FullName));
+                            throw new ArgumentException(SR.Format(SR.TypeDescriptorExpectedElementType, typeof(PropertyDescriptor).FullName));
                         }
                         cacheValue = new PropertyDescriptorCollection(propArray, true);
                         break;
@@ -1942,7 +1942,7 @@ namespace System.ComponentModel
                         }
                         catch (InvalidCastException)
                         {
-                            throw new ArgumentException(SR.GetResourceString(SR.TypeDescriptorExpectedElementType, typeof(EventDescriptor).FullName));
+                            throw new ArgumentException(SR.Format(SR.TypeDescriptorExpectedElementType, typeof(EventDescriptor).FullName));
                         }
                         cacheValue = new EventDescriptorCollection(eventArray, true);
                         break;

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/SectionInformation.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/SectionInformation.cs
@@ -584,7 +584,7 @@ namespace System.Configuration
                 // fail silently so that app code can easily loop through sections
                 // and declare all of them?
                 if (force && BaseConfigurationRecord.IsImplicitSection(SectionName))
-                    throw new ConfigurationErrorsException(SR.Cannot_declare_or_remove_implicit_section);
+                    throw new ConfigurationErrorsException(SR.Format(SR.Cannot_declare_or_remove_implicit_section,SectionName));
 
                 if (force && _flags[FlagIsUndeclared])
                 {

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -963,14 +963,14 @@ namespace System
             if (csbi.dwSize.X < csbi.srWindow.Left + width)
             {
                 if (csbi.srWindow.Left >= short.MaxValue - width)
-                    throw new ArgumentOutOfRangeException(nameof(width), SR.ArgumentOutOfRange_ConsoleWindowBufferSize);
+                    throw new ArgumentOutOfRangeException(nameof(width), SR.Format(SR.ArgumentOutOfRange_ConsoleWindowBufferSize, short.MaxValue - width));
                 size.X = (short)(csbi.srWindow.Left + width);
                 resizeBuffer = true;
             }
             if (csbi.dwSize.Y < csbi.srWindow.Top + height)
             {
                 if (csbi.srWindow.Top >= short.MaxValue - height)
-                    throw new ArgumentOutOfRangeException(nameof(height), SR.ArgumentOutOfRange_ConsoleWindowBufferSize);
+                    throw new ArgumentOutOfRangeException(nameof(height), SR.Format(SR.ArgumentOutOfRange_ConsoleWindowBufferSize, short.MaxValue - height));
                 size.Y = (short)(csbi.srWindow.Top + height);
                 resizeBuffer = true;
             }

--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -374,7 +374,7 @@ namespace System.Diagnostics
         public static void Delete(string logName, string machineName)
         {
             if (!SyntaxCheck.CheckMachineName(machineName))
-                throw new ArgumentException(SR.InvalidParameterFormat, nameof(machineName));
+                throw new ArgumentException(SR.Format(SR.InvalidParameterFormat, nameof(machineName)), nameof(machineName));
             if (logName == null || logName.Length == 0)
                 throw new ArgumentException(SR.NoLogName);
             if (!ValidLogName(logName, false))

--- a/src/System.Net.Mail/src/System/Net/Mime/SmtpDateTime.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/SmtpDateTime.cs
@@ -230,7 +230,7 @@ namespace System.Net.Mime
             {
                 if (!Char.IsLetter(value, i))
                 {
-                    throw new FormatException(SR.MailHeaderFieldInvalidCharacter);
+                    throw new FormatException(SR.Format(SR.MailHeaderFieldInvalidCharacter, value));
                 }
             }
         }
@@ -258,7 +258,7 @@ namespace System.Net.Mime
             // no ':' means invalid value
             if (indexOfHourSeparator == -1)
             {
-                throw new FormatException(SR.MailHeaderFieldInvalidCharacter);
+                throw new FormatException(SR.Format(SR.MailHeaderFieldInvalidCharacter, data));
             }
 
             // now we know where hours and minutes are separated.  The first whitespace after 
@@ -269,7 +269,7 @@ namespace System.Net.Mime
 
             if (indexOfTimeZoneSeparator == -1)
             {
-                throw new FormatException(SR.MailHeaderFieldInvalidCharacter);
+                throw new FormatException(SR.Format(SR.MailHeaderFieldInvalidCharacter, data));
             }
 
             // extract the time portion and remove all leading and trailing whitespace

--- a/src/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -274,7 +274,7 @@ namespace System.Net
                     maxProtocolId = SslProtocols.Tls11;
                     break;
                 default:
-                    throw new PlatformNotSupportedException(SR.net_security_sslprotocol_contiguous);
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_security_sslprotocol_contiguous, protocols));
             }
 
             Interop.AppleCrypto.SslSetMinProtocolVersion(sslContext, minProtocolId);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -60,7 +60,7 @@ namespace System.Net.Sockets
             // Validate the address family.
             if (family != AddressFamily.InterNetwork && family != AddressFamily.InterNetworkV6)
             {
-                throw new ArgumentException(SR.net_protocol_invalid_family, nameof(family));
+                throw new ArgumentException(SR.Format(SR.net_protocol_invalid_family, family), nameof(family));
             }
 
             IPEndPoint localEP;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataReaderExtensions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataReaderExtensions.cs
@@ -425,7 +425,7 @@ namespace System.Reflection.Metadata.Ecma335
                     return SignatureTypeKind.Unknown;
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(typeHandle), SR.UnexpectedHandleKind);
+                    throw new ArgumentOutOfRangeException(nameof(typeHandle), SR.Format(SR.UnexpectedHandleKind, typeHandle.Kind));
             }
         }
     }

--- a/src/System.Runtime.Extensions/src/System/OperatingSystem.cs
+++ b/src/System.Runtime.Extensions/src/System/OperatingSystem.cs
@@ -22,7 +22,7 @@ namespace System
         {
             if (platform < PlatformID.Win32S || platform > PlatformID.MacOSX)
             {
-                throw new ArgumentOutOfRangeException(nameof(platform), platform, SR.Arg_EnumIllegalVal);
+                throw new ArgumentOutOfRangeException(nameof(platform), platform, SR.Format(SR.Arg_EnumIllegalVal, platform));
             }
 
             if (version == null)

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SurrogateSelector.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SurrogateSelector.cs
@@ -67,7 +67,7 @@ namespace System.Runtime.Serialization
             // Verify that we don't try and add ourself twice.
             if (selector == this)
             {
-                throw new SerializationException(SR.Serialization_DuplicateSelector);
+                throw new SerializationException(SR.Format(SR.Serialization_DuplicateSelector, this, selector));
             }
 
             // Verify that the argument doesn't contain a cycle.

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
@@ -78,7 +78,7 @@ namespace System.Security.Permissions
             }
             else if (!VerifyType(target))
             {
-                throw new ArgumentException(SR.Argument_WrongType, GetType().FullName);
+                throw new ArgumentException(SR.Format(SR.Argument_WrongType, GetType().FullName), GetType().FullName);
             }
 
             PrincipalPermission operand = (PrincipalPermission)target;
@@ -121,7 +121,7 @@ namespace System.Security.Permissions
             }
             else if (!VerifyType(target))
             {
-                throw new ArgumentException(SR.Argument_WrongType, GetType().FullName);
+                throw new ArgumentException(SR.Format(SR.Argument_WrongType, GetType().FullName), GetType().FullName);
             }
             else if (IsUnrestricted())
             {
@@ -178,7 +178,7 @@ namespace System.Security.Permissions
             }
             else if (!VerifyType(other))
             {
-                throw new ArgumentException(SR.Argument_WrongType, GetType().FullName);
+                throw new ArgumentException(SR.Format(SR.Argument_WrongType, GetType().FullName), GetType().FullName);
             }
 
             PrincipalPermission operand = (PrincipalPermission)other;


### PR DESCRIPTION
fixes #27206 

where:

```csharp
Regex.IsMatch(line, @"\bthrow[ ]*new\b") &&
Regex.IsMatch(line, string.Format(@"\b{0}\b", Regex.Escape(data.Item1))) &&
!Regex.IsMatch(line, @"\bSR.Format\b") &&
!Regex.IsMatch(line, @"\bstring.Format\b") &&
!Regex.IsMatch(line, @"\bRH.Format\b") &&
!Regex.IsMatch(line, @"\bSR.GetString\b") &&
!Regex.IsMatch(line, @"\bString.Format\b") &&
!line.Trim().StartsWith(@"//") &&
!Regex.IsMatch(line, @"\bXslTransformException\b") &&
!Regex.IsMatch(line, @"\bXmlException\b") &&
!Regex.IsMatch(line, @"\bXmlSchemaException\b") &&
!Regex.IsMatch(line, @"\bCryptographicException\b") &&
!Regex.IsMatch(line, @"\bXslLoadException\b") &&
!Regex.IsMatch(line, @"\bXsltException\b") &&
!Regex.IsMatch(line, @"\bXPathCompileException\b") &&
!Regex.IsMatch(line, @"\bXmlSchemaInferenceException\b"
```
cc: @stephentoub 

