### PR TITLE
Move from PRSS to ESRP signing

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -511,7 +511,7 @@
   ],
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
-  "jobTimeoutInMinutes": 60,
+  "jobTimeoutInMinutes": 90,
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
@@ -80,7 +80,8 @@
         "signType": "real",
         "zipSources": "false",
         "version": "",
-        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json",
+        "esrpSigning": "true"
       }
     },
     {

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -80,7 +80,8 @@
         "signType": "real",
         "zipSources": "false",
         "version": "",
-        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json",
+        "esrpSigning": "true"
       }
     },
     {

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -18,7 +18,8 @@
         "signType": "real",
         "zipSources": "true",
         "version": "",
-        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json",
+        "esrpSigning": "true"
       }
     },
     {


### PR DESCRIPTION
As seen in this VSTS build, we can now do all our signing jobs for CoreFX in the new ESRP system:
https://devdiv.visualstudio.com/DevDiv/_build?buildId=1425212 .  Performance is on par or better than PRSS for this specific build, i.e. the "build and sign product binaries" leg is < 15 minutes in all legs of this run.

We'll need to move over to this in order to support signed NuPkgs, so we should migrate ASAP.  There is some talk from Microbuild folks that this might be less reliable but I have no specific data on this.

As my test run hit some linux timeouts, I also bumped the non-Crossbuild linux's timeout to 90 minutes to accommodate this (it was very nearly done in 60)