### PR TITLE
Fix/Update System.Diagnostics.Tests.ProcessTests/ProcessStart_UseShellExecuteTrue_OpenMissingFile_Throw

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -18,7 +18,7 @@ namespace System
         // do it in a way that failures don't cascade.
         //
 
-        public static bool HasWindowsShell => IsNotWindowsServerCore && IsNotWindowsNanoServer && IsNotWindowsIoTCore;
+        public static bool HasWindowsShell => IsWindows && IsNotWindowsServerCore && IsNotWindowsNanoServer && IsNotWindowsIoTCore;
         public static bool IsUap => IsInAppContainer || IsNetNative;
         public static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
         public static bool IsNetNative => RuntimeInformation.FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -346,7 +346,7 @@ namespace System.Diagnostics.Tests
         public void TestWorkingDirectoryProperty()
         {
             CreateDefaultProcess();
-            
+
             // check defaults
             Assert.Equal(string.Empty, _process.StartInfo.WorkingDirectory);
 
@@ -498,7 +498,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("NewValue", kvpaOrdered[2].Value);
 
             psi.EnvironmentVariables.Remove("NewKey3");
-            Assert.False(psi.Environment.Contains(new KeyValuePair<string,string>("NewKey3", "NewValue3")));
+            Assert.False(psi.Environment.Contains(new KeyValuePair<string, string>("NewKey3", "NewValue3")));
         }
 
         [Fact]
@@ -603,7 +603,7 @@ namespace System.Diagnostics.Tests
                     // modify the registry.
                     return;
                 }
-                
+
                 tempKey.Key.SetValue("", 123);
 
                 var info = new ProcessStartInfo { FileName = FileName };
@@ -626,7 +626,7 @@ namespace System.Diagnostics.Tests
                     // modify the registry.
                     return;
                 }
-                
+
                 tempKey.Key.SetValue("", "nosuchshell");
 
                 var info = new ProcessStartInfo { FileName = FileName };
@@ -653,7 +653,7 @@ namespace System.Diagnostics.Tests
                 }
 
                 extensionKey.Key.SetValue("", SubKeyValue);
-                
+
                 shellKey.Key.CreateSubKey("verb1");
                 shellKey.Key.CreateSubKey("NEW");
                 shellKey.Key.CreateSubKey("new");
@@ -746,7 +746,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<KeyNotFoundException>(() =>
             {
                 string stringout = environmentVariables["NewKey99"];
-            });            
+            });
 
             //Exception not thrown with invalid key
             Assert.Throws<ArgumentNullException>(() =>
@@ -943,8 +943,8 @@ namespace System.Diagnostics.Tests
                 UseShellExecute = true,
                 FileName = @"http://www.microsoft.com"
             };
-
-            Process.Start(info); // Returns null after navigating browser
+            // Returns null after navigating browser
+            using (var p = Process.Start(info)) { }
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // No Notepad on Nano
@@ -1088,7 +1088,7 @@ namespace System.Diagnostics.Tests
                 FileName = tempFile
             };
 
-            Assert.Throws<PlatformNotSupportedException>(() => Process.Start(info));
+            Assert.Throws<PlatformNotSupportedException>(() => { using (var p = Process.Start(info)) { } });
         }
 
         public static TheoryData<bool> UseShellExecute
@@ -1119,7 +1119,8 @@ namespace System.Diagnostics.Tests
                 Verb = "Zlorp"
             };
 
-            Assert.Equal(ERROR_FILE_NOT_FOUND, Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode);
+            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(info)) { } });
+            Assert.Equal(ERROR_FILE_NOT_FOUND, e.NativeErrorCode);
         }
 
         [MemberData(nameof(UseShellExecute))]
@@ -1141,7 +1142,8 @@ namespace System.Diagnostics.Tests
             if (PlatformDetection.IsWindowsNanoServer)
                 expected = ERROR_SUCCESS;
 
-            Assert.Equal(expected, Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode);
+            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(info)) { } });
+            Assert.Equal(expected, e.NativeErrorCode);
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -944,7 +944,10 @@ namespace System.Diagnostics.Tests
                 FileName = @"http://www.microsoft.com"
             };
 
-            using (var p = Process.Start(info)) { }
+            using (var p = Process.Start(info))
+            {
+                Assert.NotNull(p);
+            }
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // No Notepad on Nano

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -943,6 +943,7 @@ namespace System.Diagnostics.Tests
                 UseShellExecute = true,
                 FileName = @"http://www.microsoft.com"
             };
+
             using (var p = Process.Start(info)) { }
         }
 
@@ -1074,7 +1075,6 @@ namespace System.Diagnostics.Tests
             return sb.ToString();
         }
 
-
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsNanoServer))] 
         public void ShellExecute_Nano_Fails_Start()
         {
@@ -1087,7 +1087,7 @@ namespace System.Diagnostics.Tests
                 FileName = tempFile
             };
 
-            Assert.Throws<PlatformNotSupportedException>(() => { using (var p = Process.Start(info)) { } });
+            Assert.Throws<PlatformNotSupportedException>(() => Process.Start(info));
         }
 
         public static TheoryData<bool> UseShellExecute
@@ -1107,6 +1107,7 @@ namespace System.Diagnostics.Tests
         private const int ERROR_FILE_NOT_FOUND = 0x2;
         private const int ERROR_BAD_EXE_FORMAT = 0xC1;
 
+        [Theory]
         [MemberData(nameof(UseShellExecute))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void StartInfo_BadVerb(bool useShellExecute)
@@ -1118,10 +1119,10 @@ namespace System.Diagnostics.Tests
                 Verb = "Zlorp"
             };
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(info)) { } });
-            Assert.Equal(ERROR_FILE_NOT_FOUND, e.NativeErrorCode);
+            Assert.Equal(ERROR_FILE_NOT_FOUND, Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode);
         }
 
+        [Theory]
         [MemberData(nameof(UseShellExecute))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void StartInfo_BadExe(bool useShellExecute)
@@ -1141,8 +1142,7 @@ namespace System.Diagnostics.Tests
             if (PlatformDetection.IsWindowsNanoServer)
                 expected = ERROR_SUCCESS;
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(info)) { } });
-            Assert.Equal(expected, e.NativeErrorCode);
+            Assert.Equal(expected, Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode);
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -943,7 +943,6 @@ namespace System.Diagnostics.Tests
                 UseShellExecute = true,
                 FileName = @"http://www.microsoft.com"
             };
-            // Returns null after navigating browser
             using (var p = Process.Start(info)) { }
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -103,6 +103,25 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Fact]
+        [OuterLoop]
+        public void ProcessStart_UseShellExecute_OnUnix_OpenMissingFile_DoesNotThrow()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && 
+                s_allowedProgramsToRun.FirstOrDefault(program => IsProgramInstalled(program)) == null)
+            {
+                return;
+            }
+            string fileToOpen = Path.Combine(Environment.CurrentDirectory, "_no_such_file.TXT");
+            using (var px = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }))
+            {
+                Assert.NotNull(px);
+                px.Kill();
+                px.WaitForExit();
+                Assert.True(px.HasExited);
+            }
+        }
+
         [Theory, InlineData(true), InlineData(false)]
         [OuterLoop("Opens program")]
         public void ProcessStart_UseShellExecute_OnUnix_SuccessWhenProgramInstalled(bool isFolder)

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -70,7 +70,7 @@ namespace System.Diagnostics.Tests
             if (!s_allowedProgramsToRun.Any(program => IsProgramInstalled(program)))
             {
                 Console.WriteLine($"None of the following programs were installed on this machine: {string.Join(",", s_allowedProgramsToRun)}.");
-                Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = Environment.CurrentDirectory }));
+                Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = Environment.CurrentDirectory })) { } });
             }
         }
 
@@ -271,7 +271,7 @@ namespace System.Diagnostics.Tests
 
             Assert.Equal(0, chmod(path, mode));
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
+            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(path)) { } });
             Assert.NotEqual(0, e.NativeErrorCode);
         }
 
@@ -285,7 +285,7 @@ namespace System.Diagnostics.Tests
 
             Assert.Equal(0, chmod(path, mode)); // execute permissions
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
+            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(path)) { } });
             Assert.NotEqual(0, e.NativeErrorCode);
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -70,7 +70,7 @@ namespace System.Diagnostics.Tests
             if (!s_allowedProgramsToRun.Any(program => IsProgramInstalled(program)))
             {
                 Console.WriteLine($"None of the following programs were installed on this machine: {string.Join(",", s_allowedProgramsToRun)}.");
-                Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = Environment.CurrentDirectory })) { } });
+                Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = Environment.CurrentDirectory }));
             }
         }
 
@@ -271,7 +271,7 @@ namespace System.Diagnostics.Tests
 
             Assert.Equal(0, chmod(path, mode));
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(path)) { } });
+            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
             Assert.NotEqual(0, e.NativeErrorCode);
         }
 
@@ -285,7 +285,7 @@ namespace System.Diagnostics.Tests
 
             Assert.Equal(0, chmod(path, mode)); // execute permissions
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(path)) { } });
+            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
             Assert.NotEqual(0, e.NativeErrorCode);
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -925,7 +925,7 @@ namespace System.Diagnostics.Tests
         public void GetProcesses_InvalidMachineName_ThrowsInvalidOperationException()
         {
             Type exceptionType = PlatformDetection.IsWindows ? typeof(InvalidOperationException) : typeof(PlatformNotSupportedException);
-            var exception = Assert.Throws(exceptionType, () => Process.GetProcesses(Guid.NewGuid().ToString()));
+            Assert.Throws(exceptionType, () => Process.GetProcesses(Guid.NewGuid().ToString()));
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -176,13 +176,12 @@ namespace System.Diagnostics.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasWindowsShell))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "not supported on UAP")]
         [OuterLoop("Launches File Explorer")]
-        public void ProcessStart_UseShellExecuteTrue_OpenMissingFile_Throws()
+        public void ProcessStart_UseShellExecute_OnWindows_OpenMissingFile_Throws()
         {
             string fileToOpen = Path.Combine(Environment.CurrentDirectory, "_no_such_file.TXT");
             Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }));
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.HasWindowsShell))]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -122,19 +122,19 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void ProcessStart_TryExitCommandAsFileName_ThrowsWin32Exception()
         {
-            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = "exit", Arguments = "42" })) { } });
+            Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = "exit", Arguments = "42" }));
         }
 
         [Fact]
         public void ProcessStart_UseShellExecuteFalse_FilenameIsUrl_ThrowsWin32Exception()
         {
-            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = "https://www.github.com/corefx" })) { } });
+            Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = "https://www.github.com/corefx" }));
         }
 
         [Fact]
         public void ProcessStart_TryOpenFolder_UseShellExecuteIsFalse_ThrowsWin32Exception()
         {
-            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = Path.GetTempPath() })) { } });
+            Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = Path.GetTempPath() }));
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace System.Diagnostics.Tests
                     WorkingDirectory = workingDirectory
                 };
 
-                Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(psi)) { } });
+                Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(psi));
                 Assert.NotEqual(0, e.NativeErrorCode);
             }
             else
@@ -179,7 +179,7 @@ namespace System.Diagnostics.Tests
         public void ProcessStart_UseShellExecuteTrue_OpenMissingFile_Throws()
         {
             string fileToOpen = Path.Combine(Environment.CurrentDirectory, "_no_such_file.TXT");
-            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen })) { } });
+            Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }));
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]
@@ -1201,14 +1201,14 @@ namespace System.Diagnostics.Tests
             }
             Assert.False(File.Exists(path));
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(path)) { } });
+            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
             Assert.NotEqual(0, e.NativeErrorCode);
         }
 
         [Fact]
         public void Start_NullStartInfo_ThrowsArgumentNullExceptionException()
         {
-            AssertExtensions.Throws<ArgumentNullException>("startInfo", () => { using (var p = Process.Start((ProcessStartInfo)null)) { } });
+            AssertExtensions.Throws<ArgumentNullException>("startInfo", () => Process.Start((ProcessStartInfo)null));
         }
 
         [Fact]
@@ -1591,9 +1591,9 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(TestPlatforms.Windows)]  // Starting process with authentication not supported on Unix
         public void Process_StartInvalidNamesTest()
         {
-            Assert.Throws<InvalidOperationException>(() => { using (var p = Process.Start(null, "userName", new SecureString(), "thisDomain")) { } });
-            Assert.Throws<InvalidOperationException>(() => { using (var p = Process.Start(string.Empty, "userName", new SecureString(), "thisDomain")) { } });
-            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start("exe", string.Empty, new SecureString(), "thisDomain")) { } });
+            Assert.Throws<InvalidOperationException>(() => Process.Start(null, "userName", new SecureString(), "thisDomain"));
+            Assert.Throws<InvalidOperationException>(() => Process.Start(string.Empty, "userName", new SecureString(), "thisDomain"));
+            Assert.Throws<Win32Exception>(() => Process.Start("exe", string.Empty, new SecureString(), "thisDomain"));
         }
 
         [Fact]
@@ -1602,8 +1602,8 @@ namespace System.Diagnostics.Tests
         public void Process_StartWithInvalidUserNamePassword()
         {
             SecureString password = AsSecureString("Value");
-            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(GetCurrentProcessName(), "userName", password, "thisDomain")) { } });
-            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(GetCurrentProcessName(), Environment.UserName, password, Environment.UserDomainName)) { } });
+            Assert.Throws<Win32Exception>(() => Process.Start(GetCurrentProcessName(), "userName", password, "thisDomain"));
+            Assert.Throws<Win32Exception>(() => Process.Start(GetCurrentProcessName(), Environment.UserName, password, Environment.UserDomainName));
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -122,19 +122,19 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void ProcessStart_TryExitCommandAsFileName_ThrowsWin32Exception()
         {
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = "exit", Arguments = "42" }));
+            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = "exit", Arguments = "42" })) { } });
         }
 
         [Fact]
         public void ProcessStart_UseShellExecuteFalse_FilenameIsUrl_ThrowsWin32Exception()
         {
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = "https://www.github.com/corefx" }));
+            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = "https://www.github.com/corefx" })) { } });
         }
 
         [Fact]
         public void ProcessStart_TryOpenFolder_UseShellExecuteIsFalse_ThrowsWin32Exception()
         {
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = Path.GetTempPath() }));
+            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = Path.GetTempPath() })) { } });
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace System.Diagnostics.Tests
                     WorkingDirectory = workingDirectory
                 };
 
-                Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(psi));
+                Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(psi)) { } });
                 Assert.NotEqual(0, e.NativeErrorCode);
             }
             else
@@ -179,7 +179,7 @@ namespace System.Diagnostics.Tests
         public void ProcessStart_UseShellExecuteTrue_OpenMissingFile_Throws()
         {
             string fileToOpen = Path.Combine(Environment.CurrentDirectory, "_no_such_file.TXT");
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }));
+            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen })) { } });
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]
@@ -1201,14 +1201,14 @@ namespace System.Diagnostics.Tests
             }
             Assert.False(File.Exists(path));
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
+            Win32Exception e = Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(path)) { } });
             Assert.NotEqual(0, e.NativeErrorCode);
         }
 
         [Fact]
         public void Start_NullStartInfo_ThrowsArgumentNullExceptionException()
         {
-            AssertExtensions.Throws<ArgumentNullException>("startInfo", () => Process.Start((ProcessStartInfo)null));
+            AssertExtensions.Throws<ArgumentNullException>("startInfo", () => { using (var p = Process.Start((ProcessStartInfo)null)) { } });
         }
 
         [Fact]
@@ -1591,9 +1591,9 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(TestPlatforms.Windows)]  // Starting process with authentication not supported on Unix
         public void Process_StartInvalidNamesTest()
         {
-            Assert.Throws<InvalidOperationException>(() => Process.Start(null, "userName", new SecureString(), "thisDomain"));
-            Assert.Throws<InvalidOperationException>(() => Process.Start(string.Empty, "userName", new SecureString(), "thisDomain"));
-            Assert.Throws<Win32Exception>(() => Process.Start("exe", string.Empty, new SecureString(), "thisDomain"));
+            Assert.Throws<InvalidOperationException>(() => { using (var p = Process.Start(null, "userName", new SecureString(), "thisDomain")) { } });
+            Assert.Throws<InvalidOperationException>(() => { using (var p = Process.Start(string.Empty, "userName", new SecureString(), "thisDomain")) { } });
+            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start("exe", string.Empty, new SecureString(), "thisDomain")) { } });
         }
 
         [Fact]
@@ -1602,8 +1602,8 @@ namespace System.Diagnostics.Tests
         public void Process_StartWithInvalidUserNamePassword()
         {
             SecureString password = AsSecureString("Value");
-            Assert.Throws<Win32Exception>(() => Process.Start(GetCurrentProcessName(), "userName", password, "thisDomain"));
-            Assert.Throws<Win32Exception>(() => Process.Start(GetCurrentProcessName(), Environment.UserName, password, Environment.UserDomainName));
+            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(GetCurrentProcessName(), "userName", password, "thisDomain")) { } });
+            Assert.Throws<Win32Exception>(() => { using (var p = Process.Start(GetCurrentProcessName(), Environment.UserName, password, Environment.UserDomainName)) { } });
         }
 
         [Fact]
@@ -1616,14 +1616,15 @@ namespace System.Diagnostics.Tests
             string domain = "thisDomain";
             SecureString password = AsSecureString("Value");
 
-            Process p = Process.Start(currentProcessName, userName, password, domain); // This writes junk to the Console but with this overload, we can't prevent that.
-            Assert.NotNull(p);
-            Assert.Equal(currentProcessName, p.StartInfo.FileName);
-            Assert.Equal(userName, p.StartInfo.UserName);
-            Assert.Same(password, p.StartInfo.Password);
-            Assert.Equal(domain, p.StartInfo.Domain);
-
-            Assert.True(p.WaitForExit(WaitInMS));
+            using (Process p = Process.Start(currentProcessName, userName, password, domain)) // This writes junk to the Console but with this overload, we can't prevent that.
+            {
+                Assert.NotNull(p);
+                Assert.Equal(currentProcessName, p.StartInfo.FileName);
+                Assert.Equal(userName, p.StartInfo.UserName);
+                Assert.Same(password, p.StartInfo.Password);
+                Assert.Equal(domain, p.StartInfo.Domain);
+                Assert.True(p.WaitForExit(WaitInMS));
+            }
             password.Dispose();
         }
 
@@ -1637,15 +1638,16 @@ namespace System.Diagnostics.Tests
             string domain = Environment.UserDomainName;
             string arguments = "-xml testResults.xml";
             SecureString password = AsSecureString("Value");
-
-            Process p = Process.Start(currentProcessName, arguments, userName, password, domain);
-            Assert.NotNull(p);
-            Assert.Equal(currentProcessName, p.StartInfo.FileName);
-            Assert.Equal(arguments, p.StartInfo.Arguments);
-            Assert.Equal(userName, p.StartInfo.UserName);
-            Assert.Same(password, p.StartInfo.Password);
-            Assert.Equal(domain, p.StartInfo.Domain);
-            p.Kill();
+            using (Process p = Process.Start(currentProcessName, arguments, userName, password, domain))
+            {
+                Assert.NotNull(p);
+                Assert.Equal(currentProcessName, p.StartInfo.FileName);
+                Assert.Equal(arguments, p.StartInfo.Arguments);
+                Assert.Equal(userName, p.StartInfo.UserName);
+                Assert.Same(password, p.StartInfo.Password);
+                Assert.Equal(domain, p.StartInfo.Domain);
+                p.Kill();
+            }
             password.Dispose();
         }
 


### PR DESCRIPTION
Relates to #27547

I added this PR because I saw a failure in PR https://github.com/dotnet/corefx/pull/27415:
https://mc.dot.net/#/user/maryamariyan/pr~2Fjenkins~2Fdotnet~2Fcorefx~2Fmaster~2F/test~2Ffunctional~2Fcli~2F/103ec78a5875598ab5c876a9a7520615796dcbf4/workItem/System.Diagnostics.Process.Tests/analysis/xunit/System.Diagnostics.Tests.ProcessTests~2FProcessStart_UseShellExecuteTrue_OpenMissingFile_Throws

The test ```ProcessStart_UseShellExecuteTrue_OpenMissingFile_Throws``` had a Process.Start statement which wasn't wrapped with using statement so the Process is not disposed right away.

