### PR TITLE
fallback to IPv4 if AF is not specified and OS does not support IPv6

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -72,9 +72,12 @@ namespace System.Net.Sockets
 
         #region Constructors
         public Socket(SocketType socketType, ProtocolType protocolType)
-            : this(AddressFamily.InterNetworkV6, socketType, protocolType)
+            : this(OSSupportsIPv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork, socketType, protocolType)
         {
-            DualMode = true;
+            if (OSSupportsIPv6)
+            {
+                DualMode = true;
+            }
         }
 
         // Initializes a new instance of the Sockets.Socket class.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -316,8 +316,18 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
 
-            TcpListener listener = new TcpListener(IPAddress.IPv6Any, port);
-            listener.Server.DualMode = true;
+            TcpListener listener;
+            if (Socket.OSSupportsIPv6)
+            {
+                // If OS supports IPv6 use dual mode so both address families work.
+                listener = new TcpListener(IPAddress.IPv6Any, port);
+                listener.Server.DualMode = true;
+            }
+            else
+            {
+                // If not, fall-back to old IPv4.
+                listener = new TcpListener(IPAddress.Any , port);
+            }
 
             if (NetEventSource.IsEnabled) NetEventSource.Exit(null, port);
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -134,7 +134,7 @@ namespace System.Net.Sockets.Tests
                 return; 
             }
 
-            // This should not thorowm e.g. default to IPv6.
+            // This should not throw e.g. default to IPv6.
             TcpListener  l = TcpListener.Create(0);
             l.Stop();
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -124,6 +124,24 @@ namespace System.Net.Sockets.Tests
             listener.Stop();
         }
 
+        [Fact]
+        // This verify that basic constructs do work when IPv6 is NOT available.
+        public void IPv6_Only_Works()
+        {
+            if (Socket.OSSupportsIPv6 || !Socket.OSSupportsIPv4)
+            {
+                // TBD we should figure out better way how to execute this in IPv4 only environment.
+                return; 
+            }
+
+            // This should not thorowm e.g. default to IPv6.
+            TcpListener  l = TcpListener.Create(0);
+            l.Stop();
+
+            Socket s = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            s.Close();
+        }
+
         private sealed class DerivedTcpListener : TcpListener
         {
 #pragma warning disable 0618


### PR DESCRIPTION
fixes #26664

Following code does not throw any more when IPv6 is not available on given system:
TcpListener  l = TcpListener.Create(5666);
var s = new Socket(SocketType.Stream, ProtocolType.Tcp)

I did not craft any test for this as it is unlikely we will ever have such situation in CI. 
I'm open to suggestions how to test this. 