### PR TITLE
Increase jobTimeoutInMinutes from 60 to 90.

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -511,7 +511,7 @@
   ],
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
-  "jobTimeoutInMinutes": 60,
+  "jobTimeoutInMinutes": 90,
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {


### PR DESCRIPTION
As per #27510, some build perf regressions have been causing builds to time out. Current theory is that the Spectre/Meltdown patching of the build agents is responsible for this.