### PR TITLE
Tweak Socket.InitializeSockets

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4373,14 +4373,16 @@ namespace System.Net.Sockets
         {
             if (!s_initialized)
             {
+                InitializeSocketsCore();
+            }
+
+            void InitializeSocketsCore()
+            {
                 lock (InternalSyncObject)
                 {
                     if (!s_initialized)
                     {
                         SocketPal.Initialize();
-
-                        // Cache some settings locally.
-                        // s_perfCountersEnabled = SocketPerfCounter.Instance.Enabled; // TODO (#7833): Implement socket perf counters.
                         s_initialized = true;
                     }
                 }


### PR DESCRIPTION
Scratching an itch; it's called in a bunch of places to ensure sockets have been initialized, but it's not inlineable.  Make it so.

cc: @geoffkizer 