### PR TITLE
PipeOptions.CurrentUserOnly: remove dir on Unix and add negative tests for Windows

### DIFF
--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -182,9 +182,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
       <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ChMod.cs">
-      <Link>Common\Interop\Unix\Interop.ChMod.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Common\Interop\Unix\Interop.Close.cs</Link>
     </Compile>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -90,7 +90,7 @@ namespace System.IO.Pipes
                 IsCurrentUserOnly = true;
             }
 
-            _normalizedPipePath = GetPipePath(serverName, pipeName, IsCurrentUserOnly);
+            _normalizedPipePath = GetPipePath(serverName, pipeName);
             _direction = direction;
             _inheritability = inheritability;
             _impersonationLevel = impersonationLevel;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -41,7 +41,7 @@ namespace System.IO.Pipes
             // We don't have a good way to enforce maxNumberOfServerInstances across processes; we only factor it in
             // for streams created in this process.  Between processes, we behave similarly to maxNumberOfServerInstances == 1,
             // in that the second process to come along and create a stream will find the pipe already in existence and will fail.
-            _instance = SharedServer.Get(GetPipePath(".", pipeName, IsCurrentUserOnly), maxNumberOfServerInstances);
+            _instance = SharedServer.Get(GetPipePath(".", pipeName), maxNumberOfServerInstances);
 
             _direction = direction;
             _options = options;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -29,7 +29,7 @@ namespace System.IO.Pipes
         /// <summary>Prefix to prepend to all pipe names.</summary>
         private static readonly string s_pipePrefix = Path.Combine(Path.GetTempPath(), "CoreFxPipe_");
 
-        internal static string GetPipePath(string serverName, string pipeName, bool isCurrentUserOnly)
+        internal static string GetPipePath(string serverName, string pipeName)
         {
             if (serverName != "." && serverName != Interop.Sys.GetHostName())
             {
@@ -59,18 +59,6 @@ namespace System.IO.Pipes
             // naming scheme used as that breaks the ability for code running on an older
             // runtime to connect to code running on the newer runtime.  That means we're stuck
             // with a tmp file for the lifetime of the server stream.
-            if (isCurrentUserOnly)
-            {
-                string directory = Path.Combine(Path.GetTempPath(), ".NET" + Interop.Sys.GetEUid());
-                Directory.CreateDirectory(directory);
-                if (Interop.Sys.ChMod(directory, (int)Interop.Sys.Permissions.S_IRWXU) == -1)
-                {
-                    throw CreateExceptionForLastError();
-                }
-
-                return Path.Combine(directory, pipeName);
-            }
-
             return s_pipePrefix + pipeName;
         }
 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -17,8 +17,7 @@ namespace System.IO.Pipes
         internal const bool CheckOperationsRequiresSetHandle = true;
         internal ThreadPoolBoundHandle _threadPoolBinding;
 
-        // In Windows we don't use isCurrentUserOnly flag for the path because we set an ACL to the pipe.
-        internal static string GetPipePath(string serverName, string pipeName, bool isCurrentUserOnly)
+        internal static string GetPipePath(string serverName, string pipeName)
         {
             string normalizedPipePath = Path.GetFullPath(@"\\" + serverName + @"\pipe\" + pipeName);
             if (String.Equals(normalizedPipePath, @"\\.\pipe\" + AnonymousPipeName, StringComparison.OrdinalIgnoreCase))

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
@@ -1,0 +1,151 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
+using System.DirectoryServices.AccountManagement;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    // Class to be used as xUnit fixture to avoid creating the user, an relatively slow operation (couple of seconds), multiple times.
+    public class TestAccountImpersonator : IDisposable
+    {
+        private const string TestAccountName = "CorFxTst0uZa"; // Extra random suffix to avoid matching any other account by accident, but const to avoid leaking it.
+        private SafeAccessTokenHandle _testAccountTokenHandle;
+
+        public TestAccountImpersonator()
+        {
+            string testAccountPassword = Guid.NewGuid().ToString() + "_^-As@!%*(1)4#2";  // Add special chars to ensure it satisfies password requirements.
+            DateTime accountExpirationDate = DateTime.UtcNow + TimeSpan.FromMinutes(5);
+            using (var principalCtx = new PrincipalContext(ContextType.Machine))
+            {
+                bool needToCreate = false;
+                using (var foundUserPrincipal = UserPrincipal.FindByIdentity(principalCtx, TestAccountName))
+                {
+                    if (foundUserPrincipal == null)
+                    {
+                        needToCreate = true;
+                    }
+                    else
+                    {
+                        // Somehow the account leaked from previous runs, however, password is lost, reset it.
+                        foundUserPrincipal.SetPassword(testAccountPassword);
+                        foundUserPrincipal.AccountExpirationDate = accountExpirationDate;
+                        foundUserPrincipal.Save();
+                    }
+                }
+
+                if (needToCreate)
+                {
+                    using (var userPrincipal = new UserPrincipal(principalCtx))
+                    {
+                        userPrincipal.SetPassword(testAccountPassword);
+                        userPrincipal.AccountExpirationDate = accountExpirationDate;
+                        userPrincipal.Name = TestAccountName;
+                        userPrincipal.DisplayName = TestAccountName;
+                        userPrincipal.Description = TestAccountName;
+                        userPrincipal.Save();
+                    }
+                }
+            }
+
+            const int LOGON32_PROVIDER_DEFAULT = 0;
+            const int LOGON32_LOGON_INTERACTIVE = 2;
+
+            if (!LogonUser(TestAccountName, ".", testAccountPassword, LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT, out _testAccountTokenHandle))
+            {
+                _testAccountTokenHandle = null;
+                throw new Exception($"Failed to get SafeAccessTokenHandle for test account {TestAccountName}", new Win32Exception());
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_testAccountTokenHandle == null)
+                return;
+
+            _testAccountTokenHandle.Dispose();
+            _testAccountTokenHandle = null;
+
+            using (var principalCtx = new PrincipalContext(ContextType.Machine))
+            using (var userPrincipal = UserPrincipal.FindByIdentity(principalCtx, TestAccountName))
+            {
+                if (userPrincipal == null)
+                    throw new Exception($"Failed to get user principal to delete test account {TestAccountName}");
+
+                try
+                {
+                    userPrincipal.Delete();
+                }
+                catch (InvalidOperationException)
+                {
+                    // TODO: Investigate, it always throw this exception with "Can't delete object already deleted", but it actually deletes it.
+                }
+            }
+        }
+
+        // This method asserts if it impersonates the current identity, i.e.: it ensures that an actual impersonation happens
+        public void RunImpersonated(Action action)
+        {
+            using (WindowsIdentity serverIdentity = WindowsIdentity.GetCurrent())
+            {
+                WindowsIdentity.RunImpersonated(_testAccountTokenHandle, () =>
+                {
+                    using (WindowsIdentity clientIdentity = WindowsIdentity.GetCurrent())
+                        Assert.NotEqual(serverIdentity.Name, clientIdentity.Name);
+
+                    action();
+                });
+            }
+        }
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool LogonUser(string userName, string domain, string password, int logonType, int logonProvider, out SafeAccessTokenHandle safeAccessTokenHandle);
+    }
+
+    /// <summary>
+    /// Tests for the constructors for NamedPipeClientStream
+    /// </summary>
+    public class NamedPipeTest_CurrentUserOnly_Windows : NamedPipeTestBase, IClassFixture<TestAccountImpersonator>
+    {
+        private TestAccountImpersonator _testAccountImpersonator;
+
+        public NamedPipeTest_CurrentUserOnly_Windows(TestAccountImpersonator testAccountImpersonator)
+        {
+            _testAccountImpersonator = testAccountImpersonator;
+        }
+
+        [OuterLoop]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsAndElevated))]
+        [InlineData(PipeOptions.None, PipeOptions.CurrentUserOnly)]
+        [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.None)]
+        public void Connection_UnderDifferentUser_SingleSide_CurrentUserOnly_Fails(PipeOptions serverPipeOptions, PipeOptions clientPipeOptions)
+        {
+            string name = GetUniquePipeName();
+            using (var cts = new CancellationTokenSource())
+            using (var server = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, serverPipeOptions | PipeOptions.Asynchronous))
+            {
+                Task serverTask = server.WaitForConnectionAsync(cts.Token);
+
+                _testAccountImpersonator.RunImpersonated(() =>
+                {
+                    using (var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, clientPipeOptions))
+                    {
+                        Assert.Throws<UnauthorizedAccessException>(() => client.Connect());
+                    }
+                });
+
+                // Server is expected to not have received any request.
+                cts.Cancel();
+                var e = Assert.Throws<AggregateException>(() => serverTask.Wait(10_000));
+                Assert.IsType(typeof(TaskCanceledException), e.InnerException);
+            }
+        }
+    }
+}

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -42,9 +42,11 @@
     <Compile Include="PipeTest.Read.netcoreapp.cs" />
     <Compile Include="PipeTest.Write.netcoreapp.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' and '$(TargetsWindows)' == 'true'">
+    <Compile Include="NamedPipeTests\NamedPipeTest.CurrentUserOnly.netcoreapp.Windows.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="Interop.Windows.cs" />
-    <Compile Include="NamedPipeTests\NamedPipeTest.CurrentUserOnly.Windows.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.RunAsClient.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -15,8 +15,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="NamedPipeTests\NamedPipeTest.cs" />
-    <Compile Include="PipeTest.cs" />
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.CreateServer.cs" />
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.CreateClient.cs" />
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.CrossProcess.cs" />
@@ -24,6 +22,7 @@
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.Read.cs" />
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.Specific.cs" />
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.Write.cs" />
+    <Compile Include="NamedPipeTests\NamedPipeTest.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.CreateServer.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.CreateClient.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.CrossProcess.cs" />
@@ -32,6 +31,7 @@
     <Compile Include="NamedPipeTests\NamedPipeTest.Write.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.Specific.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.Simple.cs" />
+    <Compile Include="PipeTest.cs" />
     <Compile Include="PipeTestBase.cs" />
     <Compile Include="PipeTest.Read.cs" />
     <Compile Include="PipeTest.Write.cs" />
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="Interop.Windows.cs" />
+    <Compile Include="NamedPipeTests\NamedPipeTest.CurrentUserOnly.Windows.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.RunAsClient.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">


### PR DESCRIPTION
The directory is being removed on Unix due to the following reasons:

* Ensure compatibility between servers/clients when only one side is on 2.1 and specifying `PipeOptions.CurrentUserOnly` (migration case).
* Bring the behavior in Unix and Windows closer when only one side is specifying the flag.
* Since it is advisable to use `getpeerid` on server and client sides, and we are now doing that, the directory becomes redundant and bring the two problems described above.
