### PR TITLE
Skip CommandCancelTests [MultiThreadedCancel_NonAsync & MultiThreadedCancel_Async] on Unix

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -87,7 +87,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-
         [ActiveIssue(27574, TestPlatforms.AnyUnix)]
         [CheckConnStrSetupFact]
         public static void MultiThreadedCancel_NonAsync()

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -87,12 +87,15 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+
+        [ActiveIssue(27574, TestPlatforms.AnyUnix)]
         [CheckConnStrSetupFact]
         public static void MultiThreadedCancel_NonAsync()
         {
             MultiThreadedCancel(s_connStr, false);
         }
 
+        [ActiveIssue(27574, TestPlatforms.AnyUnix)]
         [CheckConnStrSetupFact]
         public static void MultiThreadedCancel_Async()
         {


### PR DESCRIPTION
Skipping the following CommandCancelTests on Unix due to #27574 :
MultiThreadedCancel_NonAsync
MultiThreadedCancel_Async

**Review:**
@saurabh500 @geleems @corivera 