### PR TITLE
Recognize 'I' for idle in /proc/pid/stat

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -208,6 +208,8 @@ namespace System.Diagnostics
         /// <returns></returns>
         private static ThreadState ProcFsStateToThreadState(char c)
         {
+            // Information on these in fs/proc/array.c
+            // `man proc` does not document them all
             switch (c)
             {
                 case 'R': // Running
@@ -228,6 +230,9 @@ namespace System.Diagnostics
                 case 'W': // Paging or waking
                 case 'K': // Wakekill
                     return ThreadState.Transition;
+
+                case 'I': // Idle
+                    return ThreadState.Ready;
 
                 default:
                     Debug.Fail($"Unexpected status character: {c}");


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/27578

Judging by the [Linux commit](https://github.com/torvalds/linux/commit/06eb61844d841d0032a9950ce7f8e783ee49c0d0) this is distinct to an interruptible state. So "ThreadState.Ready" is my best guess at the appropriate .NET value.