### PR TITLE
IOControl_SIOCATMARK_Success test improvements

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -81,7 +81,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue(25639)]
+        //[ActiveIssue(25639)]
         [Fact]
         public void IOControl_SIOCATMARK_Success()
         {
@@ -112,14 +112,14 @@ namespace System.Net.Sockets.Tests
                         Assert.Equal(1, client.Receive(received));
                         Assert.Equal(42, received[0]);
 
-                        Assert.Equal(1, client.Receive(received, SocketFlags.OutOfBand));
-                        Assert.Equal(43, received[0]);
-
                         Assert.True(SpinWait.SpinUntil(() =>
                         {
                             Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
                             return BitConverter.ToInt32(siocatmarkResult, 0) == 1;
                         }, 10_000));
+
+                        Assert.Equal(1, client.Receive(received, SocketFlags.OutOfBand));
+                        Assert.Equal(43, received[0]);
                     }
                 }
             }

--- a/src/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -81,9 +81,9 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        //[ActiveIssue(25639)]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [Fact]
-        public void IOControl_SIOCATMARK_Success()
+        public void IOControl_SIOCATMARK_Unix_Success()
         {
             using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
@@ -101,9 +101,14 @@ namespace System.Net.Sockets.Tests
                     {
                         byte[] siocatmarkResult = new byte[sizeof(int)];
 
+                        // Socket connected but no data sent.
+                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                        Assert.Equal(0, BitConverter.ToInt32(siocatmarkResult, 0));
+
                         server.Send(new byte[] { 42 }, SocketFlags.None);
                         server.Send(new byte[] { 43 }, SocketFlags.OutOfBand);
 
+                        // OOB data recieved, but read pointer not at mark.
                         Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
                         Assert.Equal(0, BitConverter.ToInt32(siocatmarkResult, 0));
 
@@ -112,14 +117,73 @@ namespace System.Net.Sockets.Tests
                         Assert.Equal(1, client.Receive(received));
                         Assert.Equal(42, received[0]);
 
+                        // OOB data recieved, read pointer at mark.
+                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                        Assert.Equal(1, BitConverter.ToInt32(siocatmarkResult, 0));
+
+                        Assert.Equal(1, client.Receive(received, SocketFlags.OutOfBand));
+                        Assert.Equal(43, received[0]);
+
+                        // OOB data read, read pointer at mark.
+                        Assert.True(SpinWait.SpinUntil(() =>
+                        {
+                            Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                            return BitConverter.ToInt32(siocatmarkResult, 0) == (PlatformDetection.IsOSX ? 0 : 1);
+                        }, 10_000));
+                    }
+                }
+            }
+        }
+
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [Fact]
+        public void IOControl_SIOCATMARK_Windows_Success()
+        {
+            using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<SocketException>(() => client.IOControl(IOControlCode.OobDataRead, null, null));
+                Assert.Throws<SocketException>(() => client.IOControl(IOControlCode.OobDataRead, null, new byte[0]));
+                Assert.Throws<SocketException>(() => client.IOControl(IOControlCode.OobDataRead, null, new byte[sizeof(int) - 1]));
+
+                using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                    listener.Listen(1);
+
+                    client.Connect(listener.LocalEndPoint);
+                    using (Socket server = listener.Accept())
+                    {
+                        byte[] siocatmarkResult = new byte[sizeof(int)];
+
+                        // Socket connected but no data sent.
+                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                        Assert.Equal(1, BitConverter.ToInt32(siocatmarkResult, 0));
+
+                        server.Send(new byte[] { 42 }, SocketFlags.None);
+                        server.Send(new byte[] { 43 }, SocketFlags.OutOfBand);
+
+                        // OOB data recieved, but read pointer not at mark.
+                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                        Assert.Equal(0, BitConverter.ToInt32(siocatmarkResult, 0));
+
+                        var received = new byte[1];
+
+                        Assert.Equal(1, client.Receive(received));
+                        Assert.Equal(42, received[0]);
+
+                        // OOB data recieved, read pointer at mark.
+                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                        Assert.Equal(0, BitConverter.ToInt32(siocatmarkResult, 0));
+
+                        Assert.Equal(1, client.Receive(received, SocketFlags.OutOfBand));
+                        Assert.Equal(43, received[0]);
+
+                        // OOB data read, read pointer at mark.
                         Assert.True(SpinWait.SpinUntil(() =>
                         {
                             Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
                             return BitConverter.ToInt32(siocatmarkResult, 0) == 1;
                         }, 10_000));
-
-                        Assert.Equal(1, client.Receive(received, SocketFlags.OutOfBand));
-                        Assert.Equal(43, received[0]);
                     }
                 }
             }


### PR DESCRIPTION
The behavior of SIOCATMARK varies significantly between different socket implementations. This test ensures that the expected behavior occurs on Windows, Linux, and OSX.

Here's a table with the state on different platforms during the modified test:

  | SIOCATMARK(Win) | SIOCATMARK(Unix)
-- | -- | --
Before Data   Received: | 1 | 0
After Non-OOB Data   Received | 1 | 0
After OOB Data   Received (Read pointer not at OOB Mark) | 0 | 0
After OOB Data   Received (Read pointer at OOB Mark) | 0 | 1
OOB Data Read   (Read pointer at OOB Mark) | 1 | (1/0)
OOB Data Read   (Read pointer not at OOB Mark) | 1 | 0

Note: When the OOB data has been read but the read pointer is still at the OOB mark, behavior varies on Linux and OSX.

For more details check out issue #25639. 