### PR TITLE
Add API that allows the emitter to indicate presence of localloc

### DIFF
--- a/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -84,7 +84,7 @@ namespace System.Reflection.Metadata
 {
     public readonly partial struct ArrayShape
     {
-        private readonly int _dummy;
+        private readonly object _dummy;
         public ArrayShape(int rank, System.Collections.Immutable.ImmutableArray<int> sizes, System.Collections.Immutable.ImmutableArray<int> lowerBounds) { throw null; }
         public System.Collections.Immutable.ImmutableArray<int> LowerBounds { get { throw null; } }
         public int Rank { get { throw null; } }
@@ -99,9 +99,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle PublicKey { get { throw null; } }
         public System.Version Version { get { throw null; } }
-#if !NETSTANDARD11
         public System.Reflection.AssemblyName GetAssemblyName() { throw null; }
-#endif
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
         public System.Reflection.Metadata.DeclarativeSecurityAttributeHandleCollection GetDeclarativeSecurityAttributes() { throw null; }
     }
@@ -167,9 +165,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle PublicKeyOrToken { get { throw null; } }
         public System.Version Version { get { throw null; } }
-#if !NETSTANDARD11
         public System.Reflection.AssemblyName GetAssemblyName() { throw null; }
-#endif
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     public readonly partial struct AssemblyReferenceHandle : System.IEquatable<System.Reflection.Metadata.AssemblyReferenceHandle>
@@ -212,7 +208,7 @@ namespace System.Reflection.Metadata
     }
     public partial class BlobBuilder
     {
-        public BlobBuilder(int capacity=256) { }
+        public BlobBuilder(int capacity = 256) { }
         protected internal int ChunkCapacity { get { throw null; } }
         public int Count { get { throw null; } }
         protected int FreeBytes { get { throw null; } }
@@ -267,7 +263,7 @@ namespace System.Reflection.Metadata
         public void WriteUserString(string value) { }
         public void WriteUTF16(char[] value) { }
         public void WriteUTF16(string value) { }
-        public void WriteUTF8(string value, bool allowUnpairedSurrogates=true) { }
+        public void WriteUTF8(string value, bool allowUnpairedSurrogates = true) { }
         public partial struct Blobs : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Collections.Generic.IEnumerator<System.Reflection.Metadata.Blob>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
         {
             private object _dummy;
@@ -510,7 +506,7 @@ namespace System.Reflection.Metadata
     }
     public readonly partial struct CustomAttributeValue<TType>
     {
-        private readonly int _dummy;
+        private readonly object _dummy;
         public CustomAttributeValue(System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> fixedArguments, System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> namedArguments) { throw null; }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> FixedArguments { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> NamedArguments { get { throw null; } }
@@ -558,6 +554,7 @@ namespace System.Reflection.Metadata
         internal DebugMetadataHeader() { }
         public System.Reflection.Metadata.MethodDefinitionHandle EntryPoint { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<byte> Id { get { throw null; } }
+        public int IdStartOffset { get { throw null; } }
     }
     public readonly partial struct DeclarativeSecurityAttribute
     {
@@ -665,7 +662,7 @@ namespace System.Reflection.Metadata
     }
     public readonly partial struct EventAccessors
     {
-        private readonly int _dummy;
+        private readonly object _dummy;
         public System.Reflection.Metadata.MethodDefinitionHandle Adder { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle> Others { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Raiser { get { throw null; } }
@@ -1674,11 +1671,11 @@ namespace System.Reflection.Metadata
         public void Dispose() { }
         public unsafe static System.Reflection.Metadata.MetadataReaderProvider FromMetadataImage(byte* start, int size) { throw null; }
         public static System.Reflection.Metadata.MetadataReaderProvider FromMetadataImage(System.Collections.Immutable.ImmutableArray<byte> image) { throw null; }
-        public static System.Reflection.Metadata.MetadataReaderProvider FromMetadataStream(System.IO.Stream stream, System.Reflection.Metadata.MetadataStreamOptions options=(System.Reflection.Metadata.MetadataStreamOptions)(0), int size=0) { throw null; }
+        public static System.Reflection.Metadata.MetadataReaderProvider FromMetadataStream(System.IO.Stream stream, System.Reflection.Metadata.MetadataStreamOptions options = (System.Reflection.Metadata.MetadataStreamOptions)(0), int size = 0) { throw null; }
         public unsafe static System.Reflection.Metadata.MetadataReaderProvider FromPortablePdbImage(byte* start, int size) { throw null; }
         public static System.Reflection.Metadata.MetadataReaderProvider FromPortablePdbImage(System.Collections.Immutable.ImmutableArray<byte> image) { throw null; }
-        public static System.Reflection.Metadata.MetadataReaderProvider FromPortablePdbStream(System.IO.Stream stream, System.Reflection.Metadata.MetadataStreamOptions options=(System.Reflection.Metadata.MetadataStreamOptions)(0), int size=0) { throw null; }
-        public System.Reflection.Metadata.MetadataReader GetMetadataReader(System.Reflection.Metadata.MetadataReaderOptions options=(System.Reflection.Metadata.MetadataReaderOptions)(1), System.Reflection.Metadata.MetadataStringDecoder utf8Decoder=null) { throw null; }
+        public static System.Reflection.Metadata.MetadataReaderProvider FromPortablePdbStream(System.IO.Stream stream, System.Reflection.Metadata.MetadataStreamOptions options = (System.Reflection.Metadata.MetadataStreamOptions)(0), int size = 0) { throw null; }
+        public System.Reflection.Metadata.MetadataReader GetMetadataReader(System.Reflection.Metadata.MetadataReaderOptions options = (System.Reflection.Metadata.MetadataReaderOptions)(1), System.Reflection.Metadata.MetadataStringDecoder utf8Decoder = null) { throw null; }
     }
     [System.FlagsAttribute]
     public enum MetadataStreamOptions
@@ -2039,7 +2036,7 @@ namespace System.Reflection.Metadata
     }
     public readonly partial struct PropertyAccessors
     {
-        private readonly int _dummy;
+        private readonly object _dummy;
         public System.Reflection.Metadata.MethodDefinitionHandle Getter { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle> Others { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Setter { get { throw null; } }
@@ -2274,9 +2271,9 @@ namespace System.Reflection.Metadata
     public readonly partial struct TypeDefinition
     {
         private readonly object _dummy;
-        public bool IsNested { get { throw null; } }
         public System.Reflection.TypeAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle BaseType { get { throw null; } }
+        public bool IsNested { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Namespace { get { throw null; } }
         public System.Reflection.Metadata.NamespaceDefinitionHandle NamespaceDefinition { get { throw null; } }
@@ -2422,11 +2419,11 @@ namespace System.Reflection.Metadata.Ecma335
         public void CustomAttributeSignature(out System.Reflection.Metadata.Ecma335.FixedArgumentsEncoder fixedArguments, out System.Reflection.Metadata.Ecma335.CustomAttributeNamedArgumentsEncoder namedArguments) { throw null; }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder FieldSignature() { throw null; }
         public System.Reflection.Metadata.Ecma335.LocalVariablesEncoder LocalVariableSignature(int variableCount) { throw null; }
-        public System.Reflection.Metadata.Ecma335.MethodSignatureEncoder MethodSignature(System.Reflection.Metadata.SignatureCallingConvention convention=(System.Reflection.Metadata.SignatureCallingConvention)(0), int genericParameterCount=0, bool isInstanceMethod=false) { throw null; }
+        public System.Reflection.Metadata.Ecma335.MethodSignatureEncoder MethodSignature(System.Reflection.Metadata.SignatureCallingConvention convention = (System.Reflection.Metadata.SignatureCallingConvention)(0), int genericParameterCount = 0, bool isInstanceMethod = false) { throw null; }
         public System.Reflection.Metadata.Ecma335.GenericTypeArgumentsEncoder MethodSpecificationSignature(int genericArgumentCount) { throw null; }
         public System.Reflection.Metadata.Ecma335.NamedArgumentsEncoder PermissionSetArguments(int argumentCount) { throw null; }
         public System.Reflection.Metadata.Ecma335.PermissionSetEncoder PermissionSetBlob(int attributeCount) { throw null; }
-        public System.Reflection.Metadata.Ecma335.MethodSignatureEncoder PropertySignature(bool isInstanceProperty=false) { throw null; }
+        public System.Reflection.Metadata.Ecma335.MethodSignatureEncoder PropertySignature(bool isInstanceProperty = false) { throw null; }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder TypeSpecificationSignature() { throw null; }
     }
     public static partial class CodedIndex
@@ -2523,7 +2520,7 @@ namespace System.Reflection.Metadata.Ecma335
         private readonly object _dummy;
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public bool HasSmallFormat { get { throw null; } }
-        public System.Reflection.Metadata.Ecma335.ExceptionRegionEncoder Add(System.Reflection.Metadata.ExceptionRegionKind kind, int tryOffset, int tryLength, int handlerOffset, int handlerLength, System.Reflection.Metadata.EntityHandle catchType=default(System.Reflection.Metadata.EntityHandle), int filterOffset=0) { throw null; }
+        public System.Reflection.Metadata.Ecma335.ExceptionRegionEncoder Add(System.Reflection.Metadata.ExceptionRegionKind kind, int tryOffset, int tryLength, int handlerOffset, int handlerLength, System.Reflection.Metadata.EntityHandle catchType = default(System.Reflection.Metadata.EntityHandle), int filterOffset = 0) { throw null; }
         public System.Reflection.Metadata.Ecma335.ExceptionRegionEncoder AddCatch(int tryOffset, int tryLength, int handlerOffset, int handlerLength, System.Reflection.Metadata.EntityHandle catchType) { throw null; }
         public System.Reflection.Metadata.Ecma335.ExceptionRegionEncoder AddFault(int tryOffset, int tryLength, int handlerOffset, int handlerLength) { throw null; }
         public System.Reflection.Metadata.Ecma335.ExceptionRegionEncoder AddFilter(int tryOffset, int tryLength, int handlerOffset, int handlerLength, int filterOffset) { throw null; }
@@ -2565,7 +2562,7 @@ namespace System.Reflection.Metadata.Ecma335
     public readonly partial struct InstructionEncoder
     {
         private readonly object _dummy;
-        public InstructionEncoder(System.Reflection.Metadata.BlobBuilder codeBuilder, System.Reflection.Metadata.Ecma335.ControlFlowBuilder controlFlowBuilder=null) { throw null; }
+        public InstructionEncoder(System.Reflection.Metadata.BlobBuilder codeBuilder, System.Reflection.Metadata.Ecma335.ControlFlowBuilder controlFlowBuilder = null) { throw null; }
         public System.Reflection.Metadata.BlobBuilder CodeBuilder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.ControlFlowBuilder ControlFlowBuilder { get { throw null; } }
         public int Offset { get { throw null; } }
@@ -2635,7 +2632,7 @@ namespace System.Reflection.Metadata.Ecma335
         public LocalVariableTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
-        public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef=false, bool isPinned=false) { throw null; }
+        public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef = false, bool isPinned = false) { throw null; }
         public void TypedReference() { }
     }
     public sealed partial class MetadataAggregator
@@ -2646,7 +2643,7 @@ namespace System.Reflection.Metadata.Ecma335
     }
     public sealed partial class MetadataBuilder
     {
-        public MetadataBuilder(int userStringHeapStartOffset=0, int stringHeapStartOffset=0, int blobHeapStartOffset=0, int guidHeapStartOffset=0) { }
+        public MetadataBuilder(int userStringHeapStartOffset = 0, int stringHeapStartOffset = 0, int blobHeapStartOffset = 0, int guidHeapStartOffset = 0) { }
         public System.Reflection.Metadata.AssemblyDefinitionHandle AddAssembly(System.Reflection.Metadata.StringHandle name, System.Version version, System.Reflection.Metadata.StringHandle culture, System.Reflection.Metadata.BlobHandle publicKey, System.Reflection.AssemblyFlags flags, System.Reflection.AssemblyHashAlgorithm hashAlgorithm) { throw null; }
         public System.Reflection.Metadata.AssemblyFileHandle AddAssemblyFile(System.Reflection.Metadata.StringHandle name, System.Reflection.Metadata.BlobHandle hashValue, bool containsMetadata) { throw null; }
         public System.Reflection.Metadata.AssemblyReferenceHandle AddAssemblyReference(System.Reflection.Metadata.StringHandle name, System.Version version, System.Reflection.Metadata.StringHandle culture, System.Reflection.Metadata.BlobHandle publicKeyOrToken, System.Reflection.AssemblyFlags flags, System.Reflection.Metadata.BlobHandle hashValue) { throw null; }
@@ -2695,7 +2692,7 @@ namespace System.Reflection.Metadata.Ecma335
         public System.Reflection.Metadata.BlobHandle GetOrAddBlob(System.Collections.Immutable.ImmutableArray<byte> value) { throw null; }
         public System.Reflection.Metadata.BlobHandle GetOrAddBlob(System.Reflection.Metadata.BlobBuilder value) { throw null; }
         public System.Reflection.Metadata.BlobHandle GetOrAddBlobUTF16(string value) { throw null; }
-        public System.Reflection.Metadata.BlobHandle GetOrAddBlobUTF8(string value, bool allowUnpairedSurrogates=true) { throw null; }
+        public System.Reflection.Metadata.BlobHandle GetOrAddBlobUTF8(string value, bool allowUnpairedSurrogates = true) { throw null; }
         public System.Reflection.Metadata.BlobHandle GetOrAddConstantBlob(object value) { throw null; }
         public System.Reflection.Metadata.BlobHandle GetOrAddDocumentName(string value) { throw null; }
         public System.Reflection.Metadata.GuidHandle GetOrAddGuid(System.Guid guid) { throw null; }
@@ -2726,7 +2723,7 @@ namespace System.Reflection.Metadata.Ecma335
     }
     public sealed partial class MetadataRootBuilder
     {
-        public MetadataRootBuilder(System.Reflection.Metadata.Ecma335.MetadataBuilder tablesAndHeaps, string metadataVersion=null, bool suppressValidation=false) { }
+        public MetadataRootBuilder(System.Reflection.Metadata.Ecma335.MetadataBuilder tablesAndHeaps, string metadataVersion = null, bool suppressValidation = false) { }
         public string MetadataVersion { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.MetadataSizes Sizes { get { throw null; } }
         public bool SuppressValidation { get { throw null; } }
@@ -2809,8 +2806,10 @@ namespace System.Reflection.Metadata.Ecma335
         private readonly object _dummy;
         public MethodBodyStreamEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
-        public System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder.MethodBody AddMethodBody(int codeSize, int maxStack=8, int exceptionRegionCount=0, bool hasSmallExceptionRegions=true, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature=default(System.Reflection.Metadata.StandaloneSignatureHandle), System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes=(System.Reflection.Metadata.Ecma335.MethodBodyAttributes)(1)) { throw null; }
-        public int AddMethodBody(System.Reflection.Metadata.Ecma335.InstructionEncoder instructionEncoder, int maxStack=8, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature=default(System.Reflection.Metadata.StandaloneSignatureHandle), System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes=(System.Reflection.Metadata.Ecma335.MethodBodyAttributes)(1)) { throw null; }
+        public System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder.MethodBody AddMethodBody(int codeSize, int maxStack, int exceptionRegionCount, bool hasSmallExceptionRegions, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature, System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes) { throw null; }
+        public System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder.MethodBody AddMethodBody(int codeSize, int maxStack = 8, int exceptionRegionCount = 0, bool hasSmallExceptionRegions = true, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature = default(System.Reflection.Metadata.StandaloneSignatureHandle), System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes = (System.Reflection.Metadata.Ecma335.MethodBodyAttributes)(1), bool hasDynamicStackAllocation = false) { throw null; }
+        public int AddMethodBody(System.Reflection.Metadata.Ecma335.InstructionEncoder instructionEncoder, int maxStack, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature, System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes) { throw null; }
+        public int AddMethodBody(System.Reflection.Metadata.Ecma335.InstructionEncoder instructionEncoder, int maxStack = 8, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature = default(System.Reflection.Metadata.StandaloneSignatureHandle), System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes = (System.Reflection.Metadata.Ecma335.MethodBodyAttributes)(1), bool hasDynamicStackAllocation = false) { throw null; }
         public readonly partial struct MethodBody
         {
             private readonly object _dummy;
@@ -2855,7 +2854,7 @@ namespace System.Reflection.Metadata.Ecma335
     public readonly partial struct ParametersEncoder
     {
         private readonly object _dummy;
-        public ParametersEncoder(System.Reflection.Metadata.BlobBuilder builder, bool hasVarArgs=false) { throw null; }
+        public ParametersEncoder(System.Reflection.Metadata.BlobBuilder builder, bool hasVarArgs = false) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public bool HasVarArgs { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.ParameterTypeEncoder AddParameter() { throw null; }
@@ -2867,7 +2866,7 @@ namespace System.Reflection.Metadata.Ecma335
         public ParameterTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
-        public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef=false) { throw null; }
+        public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef = false) { throw null; }
         public void TypedReference() { }
     }
     public readonly partial struct PermissionSetEncoder
@@ -2880,7 +2879,7 @@ namespace System.Reflection.Metadata.Ecma335
     }
     public sealed partial class PortablePdbBuilder
     {
-        public PortablePdbBuilder(System.Reflection.Metadata.Ecma335.MetadataBuilder tablesAndHeaps, System.Collections.Immutable.ImmutableArray<int> typeSystemRowCounts, System.Reflection.Metadata.MethodDefinitionHandle entryPoint, System.Func<System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Reflection.Metadata.BlobContentId> idProvider=null) { }
+        public PortablePdbBuilder(System.Reflection.Metadata.Ecma335.MetadataBuilder tablesAndHeaps, System.Collections.Immutable.ImmutableArray<int> typeSystemRowCounts, System.Reflection.Metadata.MethodDefinitionHandle entryPoint, System.Func<System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Reflection.Metadata.BlobContentId> idProvider = null) { }
         public ushort FormatVersion { get { throw null; } }
         public System.Func<System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Reflection.Metadata.BlobContentId> IdProvider { get { throw null; } }
         public string MetadataVersion { get { throw null; } }
@@ -2892,7 +2891,7 @@ namespace System.Reflection.Metadata.Ecma335
         public ReturnTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
-        public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef=false) { throw null; }
+        public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef = false) { throw null; }
         public void TypedReference() { }
         public void Void() { }
     }
@@ -2913,7 +2912,7 @@ namespace System.Reflection.Metadata.Ecma335
         public System.Collections.Immutable.ImmutableArray<TType> DecodeLocalSignature(ref System.Reflection.Metadata.BlobReader blobReader) { throw null; }
         public System.Reflection.Metadata.MethodSignature<TType> DecodeMethodSignature(ref System.Reflection.Metadata.BlobReader blobReader) { throw null; }
         public System.Collections.Immutable.ImmutableArray<TType> DecodeMethodSpecificationSignature(ref System.Reflection.Metadata.BlobReader blobReader) { throw null; }
-        public TType DecodeType(ref System.Reflection.Metadata.BlobReader blobReader, bool allowTypeSpecifications=false) { throw null; }
+        public TType DecodeType(ref System.Reflection.Metadata.BlobReader blobReader, bool allowTypeSpecifications = false) { throw null; }
     }
     public readonly partial struct SignatureTypeEncoder
     {
@@ -2927,7 +2926,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void Char() { }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
         public void Double() { }
-        public System.Reflection.Metadata.Ecma335.MethodSignatureEncoder FunctionPointer(System.Reflection.Metadata.SignatureCallingConvention convention=(System.Reflection.Metadata.SignatureCallingConvention)(0), System.Reflection.Metadata.Ecma335.FunctionPointerAttributes attributes=(System.Reflection.Metadata.Ecma335.FunctionPointerAttributes)(0), int genericParameterCount=0) { throw null; }
+        public System.Reflection.Metadata.Ecma335.MethodSignatureEncoder FunctionPointer(System.Reflection.Metadata.SignatureCallingConvention convention = (System.Reflection.Metadata.SignatureCallingConvention)(0), System.Reflection.Metadata.Ecma335.FunctionPointerAttributes attributes = (System.Reflection.Metadata.Ecma335.FunctionPointerAttributes)(0), int genericParameterCount = 0) { throw null; }
         public System.Reflection.Metadata.Ecma335.GenericTypeArgumentsEncoder GenericInstantiation(System.Reflection.Metadata.EntityHandle genericType, int genericArgumentCount, bool isValueType) { throw null; }
         public void GenericMethodTypeParameter(int parameterIndex) { }
         public void GenericTypeParameter(int parameterIndex) { }
@@ -3082,6 +3081,9 @@ namespace System.Reflection.PortableExecutable
         public DebugDirectoryBuilder() { }
         public void AddCodeViewEntry(string pdbPath, System.Reflection.Metadata.BlobContentId pdbContentId, ushort portablePdbVersion) { }
         public void AddEmbeddedPortablePdbEntry(System.Reflection.Metadata.BlobBuilder debugMetadata, ushort portablePdbVersion) { }
+        public void AddEntry(System.Reflection.PortableExecutable.DebugDirectoryEntryType type, uint version, uint stamp) { }
+        public void AddEntry<TData>(System.Reflection.PortableExecutable.DebugDirectoryEntryType type, uint version, uint stamp, TData data, System.Action<System.Reflection.Metadata.BlobBuilder, TData> dataSerializer) { }
+        public void AddPdbChecksumEntry(string algorithmName, System.Collections.Immutable.ImmutableArray<byte> checksum) { }
         public void AddReproducibleEntry() { }
     }
     public readonly partial struct DebugDirectoryEntry
@@ -3102,6 +3104,7 @@ namespace System.Reflection.PortableExecutable
         CodeView = 2,
         Coff = 1,
         EmbeddedPortablePdb = 17,
+        PdbChecksum = 19,
         Reproducible = 16,
         Unknown = 0,
     }
@@ -3135,6 +3138,7 @@ namespace System.Reflection.PortableExecutable
         AM33 = (ushort)467,
         Amd64 = (ushort)34404,
         Arm = (ushort)448,
+        Arm64 = (ushort)43620,
         ArmThumb2 = (ushort)452,
         Ebc = (ushort)3772,
         I386 = (ushort)332,
@@ -3159,11 +3163,17 @@ namespace System.Reflection.PortableExecutable
     {
         public const int ManagedResourcesDataAlignment = 8;
         public const int MappedFieldDataAlignment = 8;
-        public ManagedPEBuilder(System.Reflection.PortableExecutable.PEHeaderBuilder header, System.Reflection.Metadata.Ecma335.MetadataRootBuilder metadataRootBuilder, System.Reflection.Metadata.BlobBuilder ilStream, System.Reflection.Metadata.BlobBuilder mappedFieldData=null, System.Reflection.Metadata.BlobBuilder managedResources=null, System.Reflection.PortableExecutable.ResourceSectionBuilder nativeResources=null, System.Reflection.PortableExecutable.DebugDirectoryBuilder debugDirectoryBuilder=null, int strongNameSignatureSize=128, System.Reflection.Metadata.MethodDefinitionHandle entryPoint=default(System.Reflection.Metadata.MethodDefinitionHandle), System.Reflection.PortableExecutable.CorFlags flags=(System.Reflection.PortableExecutable.CorFlags)(1), System.Func<System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Reflection.Metadata.BlobContentId> deterministicIdProvider=null) : base (default(System.Reflection.PortableExecutable.PEHeaderBuilder), default(System.Func<System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Reflection.Metadata.BlobContentId>)) { }
+        public ManagedPEBuilder(System.Reflection.PortableExecutable.PEHeaderBuilder header, System.Reflection.Metadata.Ecma335.MetadataRootBuilder metadataRootBuilder, System.Reflection.Metadata.BlobBuilder ilStream, System.Reflection.Metadata.BlobBuilder mappedFieldData = null, System.Reflection.Metadata.BlobBuilder managedResources = null, System.Reflection.PortableExecutable.ResourceSectionBuilder nativeResources = null, System.Reflection.PortableExecutable.DebugDirectoryBuilder debugDirectoryBuilder = null, int strongNameSignatureSize = 128, System.Reflection.Metadata.MethodDefinitionHandle entryPoint = default(System.Reflection.Metadata.MethodDefinitionHandle), System.Reflection.PortableExecutable.CorFlags flags = (System.Reflection.PortableExecutable.CorFlags)(1), System.Func<System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Reflection.Metadata.BlobContentId> deterministicIdProvider = null) : base (default(System.Reflection.PortableExecutable.PEHeaderBuilder), default(System.Func<System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Reflection.Metadata.BlobContentId>)) { }
         protected override System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.PEBuilder.Section> CreateSections() { throw null; }
         protected internal override System.Reflection.PortableExecutable.PEDirectoriesBuilder GetDirectories() { throw null; }
         protected override System.Reflection.Metadata.BlobBuilder SerializeSection(string name, System.Reflection.PortableExecutable.SectionLocation location) { throw null; }
         public void Sign(System.Reflection.Metadata.BlobBuilder peImage, System.Func<System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, byte[]> signatureProvider) { }
+    }
+    public readonly partial struct PdbChecksumDebugDirectoryData
+    {
+        private readonly object _dummy;
+        public string AlgorithmName { get { throw null; } }
+        public System.Collections.Immutable.ImmutableArray<byte> Checksum { get { throw null; } }
     }
     public abstract partial class PEBuilder
     {
@@ -3251,7 +3261,7 @@ namespace System.Reflection.PortableExecutable
     }
     public sealed partial class PEHeaderBuilder
     {
-        public PEHeaderBuilder(System.Reflection.PortableExecutable.Machine machine=(System.Reflection.PortableExecutable.Machine)(0), int sectionAlignment=8192, int fileAlignment=512, ulong imageBase=(ulong)4194304, byte majorLinkerVersion=(byte)48, byte minorLinkerVersion=(byte)0, ushort majorOperatingSystemVersion=(ushort)4, ushort minorOperatingSystemVersion=(ushort)0, ushort majorImageVersion=(ushort)0, ushort minorImageVersion=(ushort)0, ushort majorSubsystemVersion=(ushort)4, ushort minorSubsystemVersion=(ushort)0, System.Reflection.PortableExecutable.Subsystem subsystem=(System.Reflection.PortableExecutable.Subsystem)(3), System.Reflection.PortableExecutable.DllCharacteristics dllCharacteristics=(System.Reflection.PortableExecutable.DllCharacteristics)(34112), System.Reflection.PortableExecutable.Characteristics imageCharacteristics=(System.Reflection.PortableExecutable.Characteristics)(8192), ulong sizeOfStackReserve=(ulong)1048576, ulong sizeOfStackCommit=(ulong)4096, ulong sizeOfHeapReserve=(ulong)1048576, ulong sizeOfHeapCommit=(ulong)4096) { }
+        public PEHeaderBuilder(System.Reflection.PortableExecutable.Machine machine = (System.Reflection.PortableExecutable.Machine)(0), int sectionAlignment = 8192, int fileAlignment = 512, ulong imageBase = (ulong)4194304, byte majorLinkerVersion = (byte)48, byte minorLinkerVersion = (byte)0, ushort majorOperatingSystemVersion = (ushort)4, ushort minorOperatingSystemVersion = (ushort)0, ushort majorImageVersion = (ushort)0, ushort minorImageVersion = (ushort)0, ushort majorSubsystemVersion = (ushort)4, ushort minorSubsystemVersion = (ushort)0, System.Reflection.PortableExecutable.Subsystem subsystem = (System.Reflection.PortableExecutable.Subsystem)(3), System.Reflection.PortableExecutable.DllCharacteristics dllCharacteristics = (System.Reflection.PortableExecutable.DllCharacteristics)(34112), System.Reflection.PortableExecutable.Characteristics imageCharacteristics = (System.Reflection.PortableExecutable.Characteristics)(8192), ulong sizeOfStackReserve = (ulong)1048576, ulong sizeOfStackCommit = (ulong)4096, ulong sizeOfHeapReserve = (ulong)1048576, ulong sizeOfHeapCommit = (ulong)4096) { }
         public System.Reflection.PortableExecutable.DllCharacteristics DllCharacteristics { get { throw null; } }
         public int FileAlignment { get { throw null; } }
         public ulong ImageBase { get { throw null; } }
@@ -3330,6 +3340,7 @@ namespace System.Reflection.PortableExecutable
         public System.Reflection.PortableExecutable.CodeViewDebugDirectoryData ReadCodeViewDebugDirectoryData(System.Reflection.PortableExecutable.DebugDirectoryEntry entry) { throw null; }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.DebugDirectoryEntry> ReadDebugDirectory() { throw null; }
         public System.Reflection.Metadata.MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(System.Reflection.PortableExecutable.DebugDirectoryEntry entry) { throw null; }
+        public System.Reflection.PortableExecutable.PdbChecksumDebugDirectoryData ReadPdbChecksumDebugDirectoryData(System.Reflection.PortableExecutable.DebugDirectoryEntry entry) { throw null; }
         public bool TryOpenAssociatedPortablePdb(string peImagePath, System.Func<string, System.IO.Stream> pdbFileStreamProvider, out System.Reflection.Metadata.MetadataReaderProvider pdbReaderProvider, out string pdbPath) { throw null; }
     }
     [System.FlagsAttribute]

--- a/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -99,7 +99,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle PublicKey { get { throw null; } }
         public System.Version Version { get { throw null; } }
+#if !NETSTANDARD11
         public System.Reflection.AssemblyName GetAssemblyName() { throw null; }
+#endif
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
         public System.Reflection.Metadata.DeclarativeSecurityAttributeHandleCollection GetDeclarativeSecurityAttributes() { throw null; }
     }
@@ -165,7 +167,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle PublicKeyOrToken { get { throw null; } }
         public System.Version Version { get { throw null; } }
+#if !NETSTANDARD11
         public System.Reflection.AssemblyName GetAssemblyName() { throw null; }
+#endif
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     public readonly partial struct AssemblyReferenceHandle : System.IEquatable<System.Reflection.Metadata.AssemblyReferenceHandle>

--- a/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -84,7 +84,7 @@ namespace System.Reflection.Metadata
 {
     public readonly partial struct ArrayShape
     {
-        private readonly object _dummy;
+        private readonly int _dummy;
         public ArrayShape(int rank, System.Collections.Immutable.ImmutableArray<int> sizes, System.Collections.Immutable.ImmutableArray<int> lowerBounds) { throw null; }
         public System.Collections.Immutable.ImmutableArray<int> LowerBounds { get { throw null; } }
         public int Rank { get { throw null; } }
@@ -506,7 +506,7 @@ namespace System.Reflection.Metadata
     }
     public readonly partial struct CustomAttributeValue<TType>
     {
-        private readonly object _dummy;
+        private readonly int _dummy;
         public CustomAttributeValue(System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> fixedArguments, System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> namedArguments) { throw null; }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> FixedArguments { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> NamedArguments { get { throw null; } }
@@ -662,7 +662,7 @@ namespace System.Reflection.Metadata
     }
     public readonly partial struct EventAccessors
     {
-        private readonly object _dummy;
+        private readonly int _dummy;
         public System.Reflection.Metadata.MethodDefinitionHandle Adder { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle> Others { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Raiser { get { throw null; } }
@@ -2036,7 +2036,7 @@ namespace System.Reflection.Metadata
     }
     public readonly partial struct PropertyAccessors
     {
-        private readonly object _dummy;
+        private readonly int _dummy;
         public System.Reflection.Metadata.MethodDefinitionHandle Getter { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle> Others { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Setter { get { throw null; } }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyAttributes.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyAttributes.cs
@@ -4,10 +4,20 @@
 
 namespace System.Reflection.Metadata.Ecma335
 {
+    /// <summary>
+    /// Method body attributes.
+    /// </summary>
     [Flags]
     public enum MethodBodyAttributes
     {
+        /// <summary>
+        /// No local memory initialization is performed.
+        /// </summary>
         None = 0,
+
+        /// <summary>
+        /// Zero-initialize any locals the method defines and dynamically allocated local memory.
+        /// </summary>
         InitLocals = 1,
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyStreamEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyStreamEncoder.cs
@@ -136,7 +136,7 @@ namespace System.Reflection.Metadata.Ecma335
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxStack"/> is out of range [0, <see cref="ushort.MaxValue"/>].</exception>
         /// <exception cref="InvalidOperationException">
         /// A label targeted by a branch in the instruction stream has not been marked,
-        /// or the distance between a branch instruction and the target label is doesn't fit the size of the instruction operand.
+        /// or the distance between a branch instruction and the target label doesn't fit the size of the instruction operand.
         /// </exception>
         public int AddMethodBody(
             InstructionEncoder instructionEncoder,
@@ -159,7 +159,7 @@ namespace System.Reflection.Metadata.Ecma335
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxStack"/> is out of range [0, <see cref="ushort.MaxValue"/>].</exception>
         /// <exception cref="InvalidOperationException">
         /// A label targeted by a branch in the instruction stream has not been marked,
-        /// or the distance between a branch instruction and the target label is doesn't fit the size of the instruction operand.
+        /// or the distance between a branch instruction and the target label doesn't fit the size of the instruction operand.
         /// </exception>
         public int AddMethodBody(
             InstructionEncoder instructionEncoder, 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyStreamEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyStreamEncoder.cs
@@ -45,11 +45,35 @@ namespace System.Reflection.Metadata.Ecma335
         /// </exception>
         public MethodBody AddMethodBody(
             int codeSize,
+            int maxStack,
+            int exceptionRegionCount,
+            bool hasSmallExceptionRegions,
+            StandaloneSignatureHandle localVariablesSignature,
+            MethodBodyAttributes attributes)
+            => AddMethodBody(codeSize, maxStack, exceptionRegionCount, hasSmallExceptionRegions, localVariablesSignature, attributes, hasDynamicStackAllocation: false);
+
+        /// <summary>
+        /// Encodes a method body and adds it to the method body stream.
+        /// </summary>
+        /// <param name="codeSize">Number of bytes to be reserved for instructions.</param>
+        /// <param name="maxStack">Max stack.</param>
+        /// <param name="exceptionRegionCount">Number of exception regions.</param>
+        /// <param name="hasSmallExceptionRegions">True if the exception regions should be encoded in 'small' format.</param>
+        /// <param name="localVariablesSignature">Local variables signature handle.</param>
+        /// <param name="attributes">Attributes.</param>
+        /// <param name="hasDynamicStackAllocation">True if the method allocates from dynamic local memory pool (<c>localloc</c> instruction).</param>
+        /// <returns>The offset of the encoded body within the method body stream.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="codeSize"/>, <paramref name="exceptionRegionCount"/>, or <paramref name="maxStack"/> is out of allowed range.
+        /// </exception>
+        public MethodBody AddMethodBody(
+            int codeSize,
             int maxStack = 8,
             int exceptionRegionCount = 0,
             bool hasSmallExceptionRegions = true,
-            StandaloneSignatureHandle localVariablesSignature = default(StandaloneSignatureHandle),
-            MethodBodyAttributes attributes = MethodBodyAttributes.InitLocals)
+            StandaloneSignatureHandle localVariablesSignature = default,
+            MethodBodyAttributes attributes = MethodBodyAttributes.InitLocals,
+            bool hasDynamicStackAllocation = false)
         {
             if (codeSize < 0)
             {
@@ -66,11 +90,11 @@ namespace System.Reflection.Metadata.Ecma335
                 Throw.ArgumentOutOfRange(nameof(exceptionRegionCount));
             }
 
-            int bodyOffset = SerializeHeader(codeSize, (ushort)maxStack, exceptionRegionCount, attributes, localVariablesSignature);
+            int bodyOffset = SerializeHeader(codeSize, (ushort)maxStack, exceptionRegionCount, attributes, localVariablesSignature, hasDynamicStackAllocation);
             var instructions = Builder.ReserveBytes(codeSize);
 
             var regionEncoder = (exceptionRegionCount > 0) ? 
-                ExceptionRegionEncoder.SerializeTableHeader(Builder, exceptionRegionCount, hasSmallExceptionRegions) : default(ExceptionRegionEncoder);
+                ExceptionRegionEncoder.SerializeTableHeader(Builder, exceptionRegionCount, hasSmallExceptionRegions) : default;
 
             return new MethodBody(bodyOffset, instructions, regionEncoder);
         }
@@ -115,10 +139,34 @@ namespace System.Reflection.Metadata.Ecma335
         /// or the distance between a branch instruction and the target label is doesn't fit the size of the instruction operand.
         /// </exception>
         public int AddMethodBody(
+            InstructionEncoder instructionEncoder,
+            int maxStack,
+            StandaloneSignatureHandle localVariablesSignature,
+            MethodBodyAttributes attributes)
+            => AddMethodBody(instructionEncoder, maxStack, localVariablesSignature, attributes, hasDynamicStackAllocation: false);
+
+        /// <summary>
+        /// Encodes a method body and adds it to the method body stream.
+        /// </summary>
+        /// <param name="instructionEncoder">Instruction encoder.</param>
+        /// <param name="maxStack">Max stack.</param>
+        /// <param name="localVariablesSignature">Local variables signature handle.</param>
+        /// <param name="attributes">Attributes.</param>
+        /// <param name="hasDynamicStackAllocation">True if the method allocates from dynamic local memory pool (the IL contains <c>localloc</c> instruction).
+        /// </param>
+        /// <returns>The offset of the encoded body within the method body stream.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="instructionEncoder"/> has default value.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxStack"/> is out of range [0, <see cref="ushort.MaxValue"/>].</exception>
+        /// <exception cref="InvalidOperationException">
+        /// A label targeted by a branch in the instruction stream has not been marked,
+        /// or the distance between a branch instruction and the target label is doesn't fit the size of the instruction operand.
+        /// </exception>
+        public int AddMethodBody(
             InstructionEncoder instructionEncoder, 
             int maxStack = 8,
-            StandaloneSignatureHandle localVariablesSignature = default(StandaloneSignatureHandle),
-            MethodBodyAttributes attributes = MethodBodyAttributes.InitLocals)
+            StandaloneSignatureHandle localVariablesSignature = default,
+            MethodBodyAttributes attributes = MethodBodyAttributes.InitLocals,
+            bool hasDynamicStackAllocation = false)
         {
             if (unchecked((uint)maxStack) > ushort.MaxValue)
             {
@@ -142,7 +190,20 @@ namespace System.Reflection.Metadata.Ecma335
                 Throw.ArgumentOutOfRange(nameof(instructionEncoder), SR.TooManyExceptionRegions);
             }
 
-            int bodyOffset = SerializeHeader(codeBuilder.Count, (ushort)maxStack, exceptionRegionCount, attributes, localVariablesSignature);
+            // Note (see also https://github.com/dotnet/corefx/issues/26910)
+            // 
+            // We could potentially automatically determine whether a tiny method with no variables and InitLocals flag set 
+            // has localloc instruction and thus needs a fat header. We could parse the IL stored in codeBuilder.
+            // However, it would unnecessarily slow down emit of virtually all tiny methods, which do not use localloc 
+            // and would only address uninitialized memory issues in very rare scenarios when the pointer returned by 
+            // localloc is not stored in a local variable but passed to a method call or stored in a field.
+            // 
+            // Since emitting code with localloc is already a pretty advanced scenario that emits unsafe code
+            // that can be potentially incorrect in many other ways we decide that it's not worth the complexity 
+            // and a perf regression to do so. Instead we rely on the caller to let us know if there is a localloc 
+            // in the code they emitted.
+
+            int bodyOffset = SerializeHeader(codeBuilder.Count, (ushort)maxStack, exceptionRegionCount, attributes, localVariablesSignature, hasDynamicStackAllocation);
 
             if (flowBuilder?.BranchCount > 0)
             {
@@ -158,17 +219,27 @@ namespace System.Reflection.Metadata.Ecma335
             return bodyOffset;
         }
 
-        private int SerializeHeader(int codeSize, ushort maxStack, int exceptionRegionCount, MethodBodyAttributes attributes, StandaloneSignatureHandle localVariablesSignature)
+        private int SerializeHeader(
+            int codeSize, 
+            ushort maxStack,
+            int exceptionRegionCount,
+            MethodBodyAttributes attributes,
+            StandaloneSignatureHandle localVariablesSignature,
+            bool hasDynamicStackAllocation)
         {
             const int TinyFormat = 2;
             const int FatFormat = 3;
             const int MoreSections = 8;
             const byte InitLocals = 0x10;
 
+            bool initLocals = (attributes & MethodBodyAttributes.InitLocals) != 0;
+
+            bool isTiny = codeSize < 64 &&
+                          maxStack <= 8 && 
+                          localVariablesSignature.IsNil && (!hasDynamicStackAllocation || !initLocals) && 
+                          exceptionRegionCount == 0;
+
             int offset;
-
-            bool isTiny = codeSize < 64 && maxStack <= 8 && localVariablesSignature.IsNil && exceptionRegionCount == 0;
-
             if (isTiny)
             {
                 offset = Builder.Count;
@@ -186,7 +257,7 @@ namespace System.Reflection.Metadata.Ecma335
                     flags |= MoreSections;
                 }
 
-                if ((attributes & MethodBodyAttributes.InitLocals) != 0)
+                if (initLocals)
                 {
                     flags |= InitLocals;
                 }

--- a/src/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/MethodBodyStreamEncoderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/MethodBodyStreamEncoderTests.cs
@@ -261,7 +261,7 @@ namespace System.Reflection.Metadata.Ecma335.Tests
             int bodyOffset = streamEncoder.AddMethodBody(
                 il,
                 maxStack: 2,
-                localVariablesSignature: default(StandaloneSignatureHandle),
+                localVariablesSignature: default,
                 attributes: MethodBodyAttributes.None);
 
             var bodyBytes = streamBuilder.ToArray();
@@ -284,7 +284,8 @@ namespace System.Reflection.Metadata.Ecma335.Tests
                 var body = MethodBodyBlock.Create(new BlobReader(bodyPtr, bodyBytes.Length));
 
                 Assert.Equal(0, body.ExceptionRegions.Length);
-                Assert.Equal(default(StandaloneSignatureHandle), body.LocalSignature);
+                Assert.Equal(default, body.LocalSignature);
+                Assert.False(body.LocalVariablesInitialized);
                 Assert.Equal(8, body.MaxStack);
                 Assert.Equal(bodyBytes.Length, body.Size);
 
@@ -330,7 +331,7 @@ namespace System.Reflection.Metadata.Ecma335.Tests
             int bodyOffset = streamEncoder.AddMethodBody(
                 il,
                 maxStack: 2,
-                localVariablesSignature: default(StandaloneSignatureHandle),
+                localVariablesSignature: default,
                 attributes: MethodBodyAttributes.None);
 
             var bodyBytes = streamBuilder.ToArray();
@@ -353,7 +354,8 @@ namespace System.Reflection.Metadata.Ecma335.Tests
                 var body = MethodBodyBlock.Create(new BlobReader(bodyPtr, bodyBytes.Length));
 
                 Assert.Equal(0, body.ExceptionRegions.Length);
-                Assert.Equal(default(StandaloneSignatureHandle), body.LocalSignature);
+                Assert.Equal(default, body.LocalSignature);
+                Assert.False(body.LocalVariablesInitialized);
                 Assert.Equal(2, body.MaxStack);
                 Assert.Equal(bodyBytes.Length, body.Size);
 
@@ -368,6 +370,64 @@ namespace System.Reflection.Metadata.Ecma335.Tests
                     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x2B, 0xFE
+                }, ilBytes);
+            }
+        }
+
+        [Fact, ActiveIssue(26910)]
+        public unsafe void LocAlloc()
+        {
+            var streamBuilder = new BlobBuilder();
+            var codeBuilder = new BlobBuilder();
+            var flowBuilder = new ControlFlowBuilder();
+
+            var il = new InstructionEncoder(codeBuilder, flowBuilder);
+
+            il.OpCode(ILOpCode.Ldc_i4_4);
+            il.OpCode(ILOpCode.Localloc);
+            il.Call(MetadataTokens.MethodDefinitionHandle(1));
+            il.OpCode(ILOpCode.Ret);
+
+            var streamEncoder = new MethodBodyStreamEncoder(streamBuilder);
+            int bodyOffset = streamEncoder.AddMethodBody(
+                il,
+                maxStack: 2,
+                localVariablesSignature: default,
+                attributes: MethodBodyAttributes.InitLocals,
+                hasDynamicStackAllocation: true);
+
+            var bodyBytes = streamBuilder.ToArray();
+
+            AssertEx.Equal(new byte[]
+            {
+                0x13, 0x30,                   // flags and header size 
+                0x02, 0x00,                   // max stack 
+                0x09, 0x00, 0x00, 0x00,       // code size
+                0x00, 0x00, 0x00, 0x00,       // local variable signature      
+
+                0x1A,                         // ldc.i4.0
+                0xFE, 0x0F,                   // localloc
+                0x28, 0x01, 0x00, 0x00, 0x06, // call 0x06000001
+                0x2A
+            }, bodyBytes);
+
+            fixed (byte* bodyPtr = &bodyBytes[0])
+            {
+                var body = MethodBodyBlock.Create(new BlobReader(bodyPtr, bodyBytes.Length));
+
+                Assert.Equal(0, body.ExceptionRegions.Length);
+                Assert.Equal(default, body.LocalSignature);
+                Assert.Equal(2, body.MaxStack);
+                Assert.True(body.LocalVariablesInitialized);
+                Assert.Equal(bodyBytes.Length, body.Size);
+
+                var ilBytes = body.GetILBytes();
+                AssertEx.Equal(new byte[]
+                {
+                    0x1A,                         // ldc.i4.0
+                    0xFE, 0x0F,                   // localloc
+                    0x28, 0x01, 0x00, 0x00, 0x06, // call 0x06000001
+                    0x2A
                 }, ilBytes);
             }
         }

--- a/src/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/MethodBodyStreamEncoderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/MethodBodyStreamEncoderTests.cs
@@ -381,6 +381,51 @@ namespace System.Reflection.Metadata.Ecma335.Tests
             var codeBuilder = new BlobBuilder();
             var flowBuilder = new ControlFlowBuilder();
 
+            var il = new byte[]
+            {
+                0x1A,                         // ldc.i4.0
+                0xFE, 0x0F,                   // localloc
+                0x28, 0x01, 0x00, 0x00, 0x06, // call 0x06000001
+                0x2A                          // ret
+            };
+
+            var streamEncoder = new MethodBodyStreamEncoder(streamBuilder);
+            var methodBody = streamEncoder.AddMethodBody(
+                il.Length,
+                maxStack: 2,
+                localVariablesSignature: default,
+                attributes: MethodBodyAttributes.InitLocals,
+                hasDynamicStackAllocation: true);
+
+            Assert.Equal(0, methodBody.Offset);
+            Assert.Null(methodBody.ExceptionRegions.Builder);
+            Assert.False(methodBody.ExceptionRegions.HasSmallFormat);
+
+            new BlobWriter(methodBody.Instructions).WriteBytes(il);
+
+            var bodyBytes = streamBuilder.ToArray();
+
+            AssertEx.Equal(new byte[]
+            {
+                0x13, 0x30,                   // flags and header size 
+                0x02, 0x00,                   // max stack 
+                0x09, 0x00, 0x00, 0x00,       // code size
+                0x00, 0x00, 0x00, 0x00,       // local variable signature      
+
+                0x1A,                         // ldc.i4.0
+                0xFE, 0x0F,                   // localloc
+                0x28, 0x01, 0x00, 0x00, 0x06, // call 0x06000001
+                0x2A                          // ret
+            }, bodyBytes);
+        }
+
+        [Fact, ActiveIssue(26910)]
+        public unsafe void LocAlloc_WithInstructionEncoder()
+        {
+            var streamBuilder = new BlobBuilder();
+            var codeBuilder = new BlobBuilder();
+            var flowBuilder = new ControlFlowBuilder();
+
             var il = new InstructionEncoder(codeBuilder, flowBuilder);
 
             il.OpCode(ILOpCode.Ldc_i4_4);
@@ -408,7 +453,7 @@ namespace System.Reflection.Metadata.Ecma335.Tests
                 0x1A,                         // ldc.i4.0
                 0xFE, 0x0F,                   // localloc
                 0x28, 0x01, 0x00, 0x00, 0x06, // call 0x06000001
-                0x2A
+                0x2A                          // ret
             }, bodyBytes);
 
             fixed (byte* bodyPtr = &bodyBytes[0])
@@ -427,7 +472,7 @@ namespace System.Reflection.Metadata.Ecma335.Tests
                     0x1A,                         // ldc.i4.0
                     0xFE, 0x0F,                   // localloc
                     0x28, 0x01, 0x00, 0x00, 0x06, // call 0x06000001
-                    0x2A
+                    0x2A                          // ret
                 }, ilBytes);
             }
         }


### PR DESCRIPTION
When encoding method body header the encoder needs to decide whether to emit tiny or fat header. A small method that has no locals but contains `localloc` instruction and has InitLocals set to true should not be encoded with tiny header since tiny header implies InitLocals is false. The presence of `localloc` instruction needs to be indicated by the caller of the method body encoder similarly to max stack and other info. Hence we need to add an overload that takes an extra bool parameter.

Fixes https://github.com/dotnet/corefx/issues/26910
Implements https://github.com/dotnet/corefx/issues/27611