### PR TITLE
Revert "SNIPacket performance improvement (#27187)"

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -207,7 +207,7 @@ namespace System.Data.SqlClient.SNI
                         };
 
                         _dataBytesLeft = (int)_currentHeader.length;
-                        _currentPacket = new SNIPacket();
+                        _currentPacket = new SNIPacket(null);
                         _currentPacket.Allocate((int)_currentHeader.length);
                     }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -100,7 +100,7 @@ namespace System.Data.SqlClient.SNI
                 GetSMUXHeaderBytes(0, (byte)flags, ref headerBytes);
             }
 
-            SNIPacket packet = new SNIPacket();
+            SNIPacket packet = new SNIPacket(null);
             packet.SetData(headerBytes, SNISMUXHeader.HEADER_LENGTH);
             
             _connection.Send(packet);
@@ -143,7 +143,7 @@ namespace System.Data.SqlClient.SNI
             byte[] headerBytes = null;
             GetSMUXHeaderBytes(packet.Length, (byte)SNISMUXFlags.SMUX_DATA, ref headerBytes);
 
-            SNIPacket smuxPacket = new SNIPacket();
+            SNIPacket smuxPacket = new SNIPacket(null);
             smuxPacket.Description = string.Format("({0}) SMUX packet {1}", packet.Description == null ? "" : packet.Description, xSequenceNumber);
             smuxPacket.Allocate(16 + packet.Length);
             smuxPacket.AppendData(headerBytes, 16);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -154,7 +154,7 @@ namespace System.Data.SqlClient.SNI
                 packet = null;
                 try
                 {
-                    packet = new SNIPacket();
+                    packet = new SNIPacket(null);
                     packet.Allocate(_bufferSize);
                     packet.ReadFromStream(_stream);
 
@@ -181,7 +181,7 @@ namespace System.Data.SqlClient.SNI
         {
             lock (this)
             {
-                packet = new SNIPacket();
+                packet = new SNIPacket(null);
                 packet.Allocate(_bufferSize);
 
                 try

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -189,11 +189,11 @@ namespace System.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Copies data packets in SNIPacket object to given byte array parameter
+        /// Get packet data
         /// </summary>
-        /// <param name="packet">SNIPacket object containing data packets</param>
-        /// <param name="inBuff">Destination byte array where data packets are copied to</param>
-        /// <param name="dataSize">Length of data packets</param>
+        /// <param name="packet">SNI packet</param>
+        /// <param name="inBuff">Buffer</param>
+        /// <param name="dataSize">Data size</param>
         /// <returns>SNI error status</returns>
         public uint PacketGetData(SNIPacket packet, byte[] inBuff, ref uint dataSize)
         {
@@ -240,11 +240,11 @@ namespace System.Data.SqlClient.SNI
         {
             if (sync)
             {
-                return handle.Send(packet);
+                return handle.Send(packet.Clone());
             }
             else
             {
-                return handle.SendAsync(packet);
+                return handle.SendAsync(packet.Clone());
             }
         }
 
@@ -426,7 +426,8 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error status</returns>
         public uint ReadAsync(SNIHandle handle, out SNIPacket packet, bool isMars = false)
         {
-            packet = null;
+            packet = new SNIPacket(null);
+
             return handle.ReceiveAsync(ref packet);
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -4,11 +4,13 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -22,8 +24,11 @@ namespace System.Data.SqlClient.SNI
     internal class SNITCPHandle : SNIHandle
     {
         private readonly string _targetServer;
+        private readonly object _callbackObject;
         private readonly Socket _socket;
         private NetworkStream _tcpStream;
+        private readonly TaskScheduler _writeScheduler;
+        private readonly TaskFactory _writeTaskFactory;
 
         private Stream _stream;
         private SslStream _sslStream;
@@ -33,7 +38,6 @@ namespace System.Data.SqlClient.SNI
 
         private bool _validateCert = true;
         private int _bufferSize = TdsEnums.DEFAULT_LOGIN_PACKET_SIZE;
-        private SNIPacket _sniPacket = new SNIPacket();
         private uint _status = TdsEnums.SNI_UNINITIALIZED;
         private Guid _connectionId = Guid.NewGuid();
 
@@ -44,32 +48,29 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         public override void Dispose()
         {
-            if (_sslOverTdsStream != null)
+            lock (this)
             {
-                _sslOverTdsStream.Dispose();
-                _sslOverTdsStream = null;
-            }
+                if (_sslOverTdsStream != null)
+                {
+                    _sslOverTdsStream.Dispose();
+                    _sslOverTdsStream = null;
+                }
 
-            if (_sslStream != null)
-            {
-                _sslStream.Dispose();
-                _sslStream = null;
-            }
+                if (_sslStream != null)
+                {
+                    _sslStream.Dispose();
+                    _sslStream = null;
+                }
 
-            if (_tcpStream != null)
-            {
-                _tcpStream.Dispose();
-                _tcpStream = null;
-            }
+                if (_tcpStream != null)
+                {
+                    _tcpStream.Dispose();
+                    _tcpStream = null;
+                }
 
-            if (_sniPacket != null)
-            {
-                _sniPacket.Dispose();
-                _sniPacket = null;
+                //Release any references held by _stream.
+                _stream = null;
             }
-
-            //Release any references held by _stream.
-            _stream = null;
         }
 
         /// <summary>
@@ -103,6 +104,9 @@ namespace System.Data.SqlClient.SNI
         /// <param name="callbackObject">Callback object</param>
         public SNITCPHandle(string serverName, int port, long timerExpire, object callbackObject, bool parallel)
         {
+            _writeScheduler = new ConcurrentExclusiveSchedulerPair().ExclusiveScheduler;
+            _writeTaskFactory = new TaskFactory(_writeScheduler);
+            _callbackObject = callbackObject;
             _targetServer = serverName;
 
             try
@@ -178,7 +182,6 @@ namespace System.Data.SqlClient.SNI
             _stream = _tcpStream;
             _status = TdsEnums.SNI_SUCCESS;
         }
-
 
         private static Socket Connect(string serverName, int port, TimeSpan timeout)
         {
@@ -422,22 +425,25 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint Send(SNIPacket packet)
         {
-            try
+            lock (this)
             {
-                packet.WriteToStream(_stream);
-                return TdsEnums.SNI_SUCCESS;
-            }
-            catch (ObjectDisposedException ode)
-            {
-                return ReportTcpSNIError(ode);
-            }
-            catch (SocketException se)
-            {
-                return ReportTcpSNIError(se);
-            }
-            catch (IOException ioe)
-            {
-                return ReportTcpSNIError(ioe);
+                try
+                {
+                    packet.WriteToStream(_stream);
+                    return TdsEnums.SNI_SUCCESS;
+                }
+                catch (ObjectDisposedException ode)
+                {
+                    return ReportTcpSNIError(ode);
+                }
+                catch (SocketException se)
+                {
+                    return ReportTcpSNIError(se);
+                }
+                catch (IOException ioe)
+                {
+                    return ReportTcpSNIError(ioe);
+                }
             }
         }
 
@@ -449,59 +455,60 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint Receive(out SNIPacket packet, int timeoutInMilliseconds)
         {
-            packet = null;
-
-            if (timeoutInMilliseconds > 0)
+            lock (this)
             {
-                _socket.ReceiveTimeout = timeoutInMilliseconds;
-            }
-            else if (timeoutInMilliseconds == -1)
-            {   // SqlCient internally represents infinite timeout by -1, and for TcpClient this is translated to a timeout of 0 
-                _socket.ReceiveTimeout = 0;
-            }
-            else
-            {
-                // otherwise it is timeout for 0 or less than -1
-                ReportTcpSNIError(0, SNICommon.ConnTimeoutError, string.Empty);
-                return TdsEnums.SNI_WAIT_TIMEOUT;
-            }
-
-            _sniPacket.Allocate(_bufferSize);
-            try
-            {
-                _sniPacket.ReadFromStream(_stream);
-
-                if (_sniPacket.Length == 0)
+                packet = null;
+                try
                 {
-                    Win32Exception e = new Win32Exception();
-                    return ReportErrorAndReleasePacket(_sniPacket, (uint)e.NativeErrorCode, 0, e.Message);
-                }
+                    if (timeoutInMilliseconds > 0)
+                    {
+                        _socket.ReceiveTimeout = timeoutInMilliseconds;
+                    }
+                    else if (timeoutInMilliseconds == -1)
+                    {   // SqlCient internally represents infinite timeout by -1, and for TcpClient this is translated to a timeout of 0 
+                        _socket.ReceiveTimeout = 0;
+                    }
+                    else
+                    {
+                        // otherwise it is timeout for 0 or less than -1
+                        ReportTcpSNIError(0, SNICommon.ConnTimeoutError, string.Empty);
+                        return TdsEnums.SNI_WAIT_TIMEOUT;
+                    }
 
-                packet = _sniPacket;
-                return TdsEnums.SNI_SUCCESS;
-            }
-            catch (ObjectDisposedException ode)
-            {
-                return ReportErrorAndReleasePacket(packet, ode);
-            }
-            catch (SocketException se)
-            {
-                return ReportErrorAndReleasePacket(packet, se);
-            }
-            catch (IOException ioe)
-            {
-                if (ioe.InnerException is SocketException && ((SocketException)(ioe.InnerException)).SocketErrorCode == SocketError.TimedOut)
-                {
-                    return TdsEnums.SNI_WAIT_TIMEOUT;
+                    packet = new SNIPacket(null);
+                    packet.Allocate(_bufferSize);
+                    packet.ReadFromStream(_stream);
+
+                    if (packet.Length == 0)
+                    {
+                        var e = new Win32Exception();
+                        return ReportErrorAndReleasePacket(packet, (uint)e.NativeErrorCode, 0, e.Message);
+                    }
+
+                    return TdsEnums.SNI_SUCCESS;
                 }
-                else
+                catch (ObjectDisposedException ode)
                 {
-                    return ReportErrorAndReleasePacket(packet, ioe);
+                    return ReportErrorAndReleasePacket(packet, ode);
                 }
-            }
-            finally
-            {
-                _socket.ReceiveTimeout = 0;
+                catch (SocketException se)
+                {
+                    return ReportErrorAndReleasePacket(packet, se);
+                }
+                catch (IOException ioe)
+                {
+                    uint errorCode = ReportErrorAndReleasePacket(packet, ioe);
+                    if (ioe.InnerException is SocketException && ((SocketException)(ioe.InnerException)).SocketErrorCode == SocketError.TimedOut)
+                    {
+                        errorCode = TdsEnums.SNI_WAIT_TIMEOUT;
+                    }
+
+                    return errorCode;
+                }
+                finally
+                {
+                    _socket.ReceiveTimeout = 0;
+                }
             }
         }
 
@@ -525,19 +532,42 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
         {
-            Task writeTask = packet.WriteToStreamAsync(_stream);
-            writeTask.ContinueWith((t) =>
+            SNIPacket newPacket = packet;
+
+            _writeTaskFactory.StartNew(() =>
+            {
+                try
                 {
-                    SNIAsyncCallback cb = callback ?? _sendCallback;
-                    uint status = TdsEnums.SNI_SUCCESS;
-                    if (t.IsFaulted)
+                    lock (this)
                     {
-                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InternalExceptionError, t.Exception);
-                        status = TdsEnums.SNI_ERROR;
+                        packet.WriteToStream(_stream);
                     }
-                    cb(packet, status);
                 }
-            );
+                catch (Exception e)
+                {
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InternalExceptionError, e);
+
+                    if (callback != null)
+                    {
+                        callback(packet, TdsEnums.SNI_ERROR);
+                    }
+                    else
+                    {
+                        _sendCallback(packet, TdsEnums.SNI_ERROR);
+                    }
+
+                    return;
+                }
+
+                if (callback != null)
+                {
+                    callback(packet, TdsEnums.SNI_SUCCESS);
+                }
+                else
+                {
+                    _sendCallback(packet, TdsEnums.SNI_SUCCESS);
+                }
+            });
 
             return TdsEnums.SNI_SUCCESS_IO_PENDING;
         }
@@ -549,25 +579,28 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint ReceiveAsync(ref SNIPacket packet, bool isMars = false)
         {
-            packet = null;
-            _sniPacket.Allocate(_bufferSize);
-            try
+            lock (this)
             {
-                _sniPacket.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
-                packet = _sniPacket;
-                return TdsEnums.SNI_SUCCESS_IO_PENDING;
-            }
-            catch (ObjectDisposedException ode)
-            {
-                return ReportErrorAndReleasePacket(packet, ode);
-            }
-            catch (SocketException se)
-            {
-                return ReportErrorAndReleasePacket(packet, se);
-            }
-            catch (IOException ioe)
-            {
-                return ReportErrorAndReleasePacket(packet, ioe);
+                packet = new SNIPacket(null);
+                packet.Allocate(_bufferSize);
+
+                try
+                {
+                    packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
+                    return TdsEnums.SNI_SUCCESS_IO_PENDING;
+                }
+                catch (ObjectDisposedException ode)
+                {
+                    return ReportErrorAndReleasePacket(packet, ode);
+                }
+                catch (SocketException se)
+                {
+                    return ReportErrorAndReleasePacket(packet, se);
+                }
+                catch (IOException ioe)
+                {
+                    return ReportErrorAndReleasePacket(packet, ioe);
+                }
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -148,7 +148,7 @@ namespace System.Data.SqlClient.SNI
 
         internal override void ReleasePacket(object syncReadPacket)
         {
-            ((SNIPacket)syncReadPacket).Release();
+            ((SNIPacket)syncReadPacket).Dispose();
         }
 
         internal override uint CheckConnection()
@@ -166,13 +166,10 @@ namespace System.Data.SqlClient.SNI
 
         internal override object CreateAndSetAttentionPacket()
         {
-            if (_sniAsyncAttnPacket == null)
-            {
-                SNIPacket attnPacket = new SNIPacket();
-                SetPacketData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN);
-                _sniAsyncAttnPacket = attnPacket;
-            }
-            return _sniAsyncAttnPacket;
+            SNIPacket attnPacket = new SNIPacket(Handle);
+            _sniAsyncAttnPacket = attnPacket;
+            SetPacketData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN);
+            return attnPacket;
         }
 
         internal override uint WritePacket(object packet, bool sync)
@@ -271,7 +268,7 @@ namespace System.Data.SqlClient.SNI
                 else
                 {
                     // Failed to take a packet - create a new one
-                    packet = new SNIPacket();
+                    packet = new SNIPacket(sniHandle);
                 }
                 return packet;
             }


### PR DESCRIPTION
This reverts commit cb00beea1104f58a909192b7ac868d8787526371.

Due to this change, I can see test failures like the following:
1. EF tests fail due to removal of locks https://github.com/dotnet/corefx/issues/27587
2. EF tests hang due to packet optimization.
3. Failures in SqlClient server dependant tests like https://github.com/dotnet/corefx/issues/27574

Based on the test results that I am seeing, the change can destabilize SqlClient in Preview 2. 

We need to spend more time on the correctness of the change and break them up in different pieces. 