### PR TITLE
Revert "Skip CommandCancelTests [MultiThreadedCancel_NonAsync & MultiThreadedCancel_Async] on Unix (#27576)"

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -87,14 +87,12 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ActiveIssue(27574, TestPlatforms.AnyUnix)]
         [CheckConnStrSetupFact]
         public static void MultiThreadedCancel_NonAsync()
         {
             MultiThreadedCancel(s_connStr, false);
         }
 
-        [ActiveIssue(27574, TestPlatforms.AnyUnix)]
         [CheckConnStrSetupFact]
         public static void MultiThreadedCancel_Async()
         {


### PR DESCRIPTION
This reverts commit 7020ee17617f0563acf41a9d10ace814f8227de9.

After merging https://github.com/dotnet/corefx/pull/27591 this test is safe to re-enable. Tested on Ubuntu to make sure this doesn't fail

Fixes: https://github.com/dotnet/corefx/issues/27574