### PR TITLE
Small tweaks to PipeReader behaviors

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -79,6 +79,8 @@ namespace System.IO.Pipelines
             AvailableMemory = default;
         }
 
+        internal OwnedMemory<byte> OwnedMemory => _ownedMemory;
+
         public Memory<byte> AvailableMemory { get; private set; }
 
         public int Length => End - Start;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
@@ -39,15 +39,11 @@ namespace System.IO.Pipelines
         public static void ThrowInvalidOperationException_NoWritingAllowed() => throw CreateInvalidOperationException_NoWritingAllowed();
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Exception CreateInvalidOperationException_NoWritingAllowed() => new InvalidOperationException(SR.ReadingAfterCompleted);
+        public static Exception CreateInvalidOperationException_NoWritingAllowed() => new InvalidOperationException(SR.WritingAfterCompleted);
 
         public static void ThrowInvalidOperationException_NoReadingAllowed() => throw CreateInvalidOperationException_NoReadingAllowed();
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Exception CreateInvalidOperationException_NoReadingAllowed() => new InvalidOperationException(SR.WritingAfterCompleted);
-
-        public static void ThrowInvalidOperationException_CompleteReaderActiveReader() => throw CreateInvalidOperationException_CompleteReaderActiveReader();
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Exception CreateInvalidOperationException_CompleteReaderActiveReader() => new InvalidOperationException(SR.CannotCompleteWhileReading);
+        public static Exception CreateInvalidOperationException_NoReadingAllowed() => new InvalidOperationException(SR.ReadingAfterCompleted);
 
         public static void ThrowInvalidOperationException_AdvancingPastBufferSize() => throw CreateInvalidOperationException_AdvancingPastBufferSize();
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/System.IO.Pipelines/tests/BackpressureTests.cs
+++ b/src/System.IO.Pipelines/tests/BackpressureTests.cs
@@ -107,6 +107,36 @@ namespace System.IO.Pipelines.Tests
             Assert.True(flushAsync.IsCompleted);
             FlushResult flushResult = flushAsync.GetResult();
             Assert.True(flushResult.IsCompleted);
+
+            writableBuffer = _pipe.Writer.WriteEmpty(64);
+            flushAsync = writableBuffer.FlushAsync();
+            flushResult = flushAsync.GetResult();
+
+            Assert.True(flushResult.IsCompleted);
+            Assert.True(flushAsync.IsCompleted);
+        }
+
+        [Fact]
+        public async Task FlushAsyncReturnsCompletedIfReaderCompletesWithoutAdvance()
+        {
+            PipeWriter writableBuffer = _pipe.Writer.WriteEmpty(64);
+            PipeAwaiter<FlushResult> flushAsync = writableBuffer.FlushAsync();
+
+            Assert.False(flushAsync.IsCompleted);
+
+            ReadResult result = await _pipe.Reader.ReadAsync();
+            _pipe.Reader.Complete();
+
+            Assert.True(flushAsync.IsCompleted);
+            FlushResult flushResult = flushAsync.GetResult();
+            Assert.True(flushResult.IsCompleted);
+
+            writableBuffer = _pipe.Writer.WriteEmpty(64);
+            flushAsync = writableBuffer.FlushAsync();
+            flushResult = flushAsync.GetResult();
+
+            Assert.True(flushResult.IsCompleted);
+            Assert.True(flushAsync.IsCompleted);
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -149,13 +150,49 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task CompleteReaderAfterFlushWithoutAdvancing()
+        public async Task CompleteReaderAfterFlushWithoutAdvancingDoesNotThrow()
         {
             await _pipe.Writer.FlushAsync();
             ReadResult result = await _pipe.Reader.ReadAsync();
             ReadOnlySequence<byte> buffer = result.Buffer;
 
             _pipe.Reader.Complete();
+        }
+
+        [Fact]
+        public async Task ResetAfterCompleteReaderAndWriterWithoutAdvancingClearsEverything()
+        {
+            _pipe.Writer.WriteEmpty(4094);
+            _pipe.Writer.WriteEmpty(4094);
+            await _pipe.Writer.FlushAsync();
+            ReadResult result = await _pipe.Reader.ReadAsync();
+            ReadOnlySequence<byte> buffer = result.Buffer;
+
+            SequenceMarshal.TryGetReadOnlySequenceSegment(
+                buffer,
+                out ReadOnlySequenceSegment<byte> start,
+                out int startIndex,
+                out ReadOnlySequenceSegment<byte> end,
+                out int endIndex);
+
+            var startSegment = (BufferSegment)start;
+            var endSegment = (BufferSegment)end;
+            Assert.NotNull(startSegment.OwnedMemory);
+            Assert.NotNull(endSegment.OwnedMemory);
+
+            _pipe.Reader.Complete();
+
+            // Nothing cleaned up
+            Assert.NotNull(startSegment.OwnedMemory);
+            Assert.NotNull(endSegment.OwnedMemory);
+
+            _pipe.Writer.Complete();
+
+            // Should be cleaned up now
+            Assert.Null(startSegment.OwnedMemory);
+            Assert.Null(endSegment.OwnedMemory);
+
+            _pipe.Reset();
         }
 
         [Fact]


### PR DESCRIPTION
- Throw if AdvanceTo is called after completing the reader
- Don't throw if Complete is called without AdvanceTo
- Swapped the reading and writing exceptions
- Added AdvanceReader that takes BufferSegment and int, this cleans up
the API a bit as we touch SequencePosition in less places.

Fixes https://github.com/dotnet/corefx/issues/27467 and https://github.com/dotnet/corefx/issues/27465