### PR TITLE
Default the TheadPool PipeScheduler to global thread pool queuing

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.NetCoreApp21.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.NetCoreApp21.cs
@@ -11,14 +11,12 @@ namespace System.IO.Pipelines
     {
         public override void Schedule(Action action)
         {
-            // Queue to low contention local ThreadPool queue; rather than global queue as per Task
-            System.Threading.ThreadPool.QueueUserWorkItem(s_actionCallback, action, preferLocal: true);
+            System.Threading.ThreadPool.QueueUserWorkItem(s_actionCallback, action, preferLocal: false);
         }
 
         public override void Schedule(Action<object> action, object state)
         {
-            // Queue to low contention local ThreadPool queue; rather than global queue as per Task
-            System.Threading.ThreadPool.QueueUserWorkItem(action, state, preferLocal: true);
+            System.Threading.ThreadPool.QueueUserWorkItem(action, state, preferLocal: false);
         }
 
         private static readonly Action<Action> s_actionCallback = state => state();

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.NetStandard.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.NetStandard.cs
@@ -11,12 +11,12 @@ namespace System.IO.Pipelines
     {
         public override void Schedule(Action action)
         {
-            Task.Factory.StartNew(action);
+            Task.Factory.StartNew(action, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         public override void Schedule(Action<object> action, object state)
         {
-            Task.Factory.StartNew(action, state);
+            Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
     }
 }


### PR DESCRIPTION
- The lower netstandard version still uses Task.Factory.StartNew (which goes to the local queue)

Seems like this performs better in the general case for the pipe scenarios. I also ran some tests against kestrel's socket transport:

## JSON

preferLocal:true

[01:18:44.186] RequestsPerSecond:           249,409

preferLocal:false

[01:13:26.435] RequestsPerSecond:           311,087

preferLocal:true

## PlainText

1,309,719

preferLocal:false

1,395,586

Those were linux but I also saw similar results for Windows.

/cc @benaadams 