### PR TITLE
Improve performance of SystemNative_GetNonCryptographicallySecureRandomBytes

### DIFF
--- a/src/Native/Unix/System.Native/pal_random.cpp
+++ b/src/Native/Unix/System.Native/pal_random.cpp
@@ -21,7 +21,6 @@ extern "C" void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* b
     assert(buffer != NULL);
 
     int rand_des;
-    uint8_t* buf = (uint8_t*)alloca(bufferLength);
     long num = 0;
     static bool sMissingDevURandom;
     static bool sInitializedMRand;
@@ -42,7 +41,7 @@ extern "C" void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* b
             int32_t offset = 0;
             do
             {
-                ssize_t n = read(rand_des, buf + offset , (size_t)(bufferLength - offset));
+                ssize_t n = read(rand_des, buffer + offset , (size_t)(bufferLength - offset));
                 if (n == -1)
                 {
                     if (errno == EINTR)
@@ -79,7 +78,7 @@ extern "C" void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* b
             num = lrand48();
         }
 
-        *(buffer + i) ^= buf[i] ^ num;
+        *(buffer + i) ^= num;
         num >>= 8;
     }
 }

--- a/src/Native/Unix/System.Native/pal_random.cpp
+++ b/src/Native/Unix/System.Native/pal_random.cpp
@@ -29,7 +29,14 @@ extern "C" void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* b
     {
         if (rand_des == -1)
         {
-            int fd = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
+            int fd;
+
+            do
+            {
+                fd = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
+            }
+            while ((fd == -1) && (errno == EINTR));
+
             if (fd != -1)
             {
                 if (!__sync_bool_compare_and_swap(&rand_des, -1, fd))

--- a/src/Native/Unix/System.Native/pal_random.cpp
+++ b/src/Native/Unix/System.Native/pal_random.cpp
@@ -64,14 +64,13 @@ extern "C" void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* b
                         continue;
                     }
 
+                    assert(false && "read from /dev/urandom has failed");
                     break;
                 }
 
                 offset += n;
             }
             while (offset != bufferLength);
-
-            assert(offset == bufferLength);
         }
     }
 


### PR DESCRIPTION
Based on the same change in coreclr. Improves the performance 6 times.
Main improvement comes from using just one read per the whole buffer
instead of one per byte. Smaller part of the win comes from using only
the /dev/urandom.