### PR TITLE
Update Microsoft.Diagnostics.Tracing.EventSource.Redist description

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -29,7 +29,7 @@
     "Name": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
     "Description": "This package includes the class Microsoft.Diagnostics.Tracing.EventSource which enables firing ETW events from managed code. This is the \"runtime\" or \"redist\" EventSource package and should be referenced directly only by other NuGet packages that need the EventSource functionality. Application developers that need this functionality should instead reference the Microsoft.Diagnostics.Tracing.EventSource NuGet package which provides an enhanced developer experience.
 
-      This package enables defining a strongly typed specification of an ETW provider that can be called by managed code. The EventSource class is also included in the .NET Framework. This package provides a newer version that has more features. It is meant to be used as a stop gap until those features it contains are ported to System.Diagnostics.Tracing.EventSource.
+      This package enables defining a strongly typed specification of an ETW provider that can be called by managed code. The EventSource class is also included in the .NET Framework, .NET Core, and netstandard2.0 in the System.Diagnostics.Tracing namespace. This package contains the latest version of EventSource and is meant to be used as a stop gap for .NET Framework developers until features and fixes are ported to System.Diagnostics.Tracing.EventSource in the .NET Framework.
 
       For more details, have a look at http://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventsource.aspx.
 


### PR DESCRIPTION
Fixes #26938.

Include reference to the fact that System.Diagnostics.Tracing.EventSource is available in .NET Framework, .NET Core and netstandard2.0 for when folks are unable to use this package in their netcoreapp or netstandard applications.