### PR TITLE
Fix semantics of ArrayMemoryPool

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -61,7 +61,6 @@ namespace System.IO.Pipelines
         public void SetMemory(OwnedMemory<byte> ownedMemory, int start, int end, bool readOnly = false)
         {
             _ownedMemory = ownedMemory;
-            _ownedMemory.Retain();
 
             AvailableMemory = _ownedMemory.Memory;
 
@@ -75,6 +74,7 @@ namespace System.IO.Pipelines
         public void ResetMemory()
         {
             _ownedMemory.Release();
+            _ownedMemory.Dispose();
             _ownedMemory = null;
             AvailableMemory = default;
         }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -74,7 +74,6 @@ namespace System.IO.Pipelines
         public void ResetMemory()
         {
             _ownedMemory.Release();
-            _ownedMemory.Dispose();
             _ownedMemory = null;
             AvailableMemory = default;
         }

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -313,7 +313,7 @@ namespace System.IO.Pipelines.Tests
     {
         public static PipeWriter WriteEmpty(this PipeWriter writer, int count)
         {
-            writer.GetMemory(count);
+            writer.GetSpan(count).Slice(0, count).Fill(0);
             writer.Advance(count);
             return writer;
         }

--- a/src/System.IO.Pipelines/tests/PipePoolTests.cs
+++ b/src/System.IO.Pipelines/tests/PipePoolTests.cs
@@ -13,6 +13,7 @@ namespace System.IO.Pipelines.Tests
         private class DisposeTrackingBufferPool : TestMemoryPool
         {
             public int ReturnedBlocks { get; set; }
+            public int DisposedBlocks { get; set; }
             public int CurrentlyRentedBlocks { get; set; }
 
             public override OwnedMemory<byte> Rent(int size)
@@ -26,9 +27,11 @@ namespace System.IO.Pipelines.Tests
 
             private class DisposeTrackingOwnedMemory : OwnedMemory<byte>
             {
-                private readonly byte[] _array;
+                private byte[] _array;
 
                 private readonly DisposeTrackingBufferPool _bufferPool;
+
+                private int _refCount = 1;
 
                 public DisposeTrackingOwnedMemory(byte[] array, DisposeTrackingBufferPool bufferPool)
                 {
@@ -49,9 +52,9 @@ namespace System.IO.Pipelines.Tests
                     }
                 }
 
-                public override bool IsDisposed { get; }
+                public override bool IsDisposed => _array == null;
 
-                protected override bool IsRetained => true;
+                protected override bool IsRetained => _refCount > 0;
 
                 public override MemoryHandle Pin(int byteOffset = 0)
                 {
@@ -68,18 +71,26 @@ namespace System.IO.Pipelines.Tests
 
                 protected override void Dispose(bool disposing)
                 {
-                    throw new NotImplementedException();
+                    if (IsRetained)
+                    {
+                        throw new InvalidOperationException();
+                    }
+                    _bufferPool.DisposedBlocks++;
+
+                    _array = null;
                 }
 
                 public override bool Release()
                 {
                     _bufferPool.ReturnedBlocks++;
                     _bufferPool.CurrentlyRentedBlocks--;
+                    _refCount--;
                     return IsRetained;
                 }
 
                 public override void Retain()
                 {
+                    _refCount++;
                 }
             }
         }
@@ -102,6 +113,8 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.AdvanceTo(readResult.Buffer.End);
 
             Assert.Equal(0, pool.CurrentlyRentedBlocks);
+            Assert.Equal(0, pool.DisposedBlocks);
+            Assert.Equal(3, pool.ReturnedBlocks);
         }
 
         [Fact]
@@ -128,6 +141,10 @@ namespace System.IO.Pipelines.Tests
 
             // Try writing more
             await pipe.Writer.WriteAsync(new byte[writeSize]);
+
+            Assert.Equal(1, pool.CurrentlyRentedBlocks);
+            Assert.Equal(0, pool.DisposedBlocks);
+            Assert.Equal(2, pool.ReturnedBlocks);
         }
 
         [Fact]
@@ -141,10 +158,12 @@ namespace System.IO.Pipelines.Tests
             readerWriter.Writer.Complete();
             readerWriter.Reader.Complete();
             Assert.Equal(1, pool.ReturnedBlocks);
+            Assert.Equal(0, pool.DisposedBlocks);
 
             readerWriter.Writer.Complete();
             readerWriter.Reader.Complete();
             Assert.Equal(1, pool.ReturnedBlocks);
+            Assert.Equal(0, pool.DisposedBlocks);
         }
 
         [Fact]
@@ -174,11 +193,13 @@ namespace System.IO.Pipelines.Tests
         {
             var pool = new DisposeTrackingBufferPool();
             var pipe = new Pipe(new PipeOptions(pool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
-            var memory = pipe.Writer.GetMemory(512);
+            pipe.Writer.GetMemory(512);
 
             pipe.Reader.Complete();
             pipe.Writer.Complete();
             Assert.Equal(0, pool.CurrentlyRentedBlocks);
+            Assert.Equal(1, pool.ReturnedBlocks);
+            Assert.Equal(0, pool.DisposedBlocks);
         }
 
         [Fact]
@@ -186,12 +207,14 @@ namespace System.IO.Pipelines.Tests
         {
             var pool = new DisposeTrackingBufferPool();
             var pipe = new Pipe(new PipeOptions(pool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
-            var memory = pipe.Writer.GetMemory(512);
+            pipe.Writer.GetMemory(512);
             pipe.Writer.GetMemory(4096);
 
             pipe.Reader.Complete();
             pipe.Writer.Complete();
             Assert.Equal(0, pool.CurrentlyRentedBlocks);
+            Assert.Equal(2, pool.ReturnedBlocks);
+            Assert.Equal(0, pool.DisposedBlocks);
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/TestMemoryPool.cs
+++ b/src/System.IO.Pipelines/tests/TestMemoryPool.cs
@@ -53,6 +53,7 @@ namespace System.IO.Pipelines
                 _ownedMemory = ownedMemory;
                 _pool = pool;
                 _leaser = Environment.StackTrace;
+                _referenceCount = 1;
             }
 
             ~PooledMemory()
@@ -75,12 +76,15 @@ namespace System.IO.Pipelines
             public override void Retain()
             {
                 _pool.CheckDisposed();
+                _ownedMemory.Retain();
                 Interlocked.Increment(ref _referenceCount);
             }
 
             public override bool Release()
             {
                 _pool.CheckDisposed();
+                _ownedMemory.Release();
+
                 int newRefCount = Interlocked.Decrement(ref _referenceCount);
 
                 if (newRefCount < 0)

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -147,6 +147,7 @@
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
+    <Reference Include="System.Threading" />
     <Reference Condition="'$(TargetGroup)' != 'netstandard1.1'" Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">

--- a/src/System.Memory/src/System/Buffers/ArrayMemoryPool.ArrayMemoryPoolBuffer.cs
+++ b/src/System.Memory/src/System/Buffers/ArrayMemoryPool.ArrayMemoryPoolBuffer.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using System.Threading;
+
 #if !netstandard
 using Internal.Runtime.CompilerServices;
 #else

--- a/src/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
+++ b/src/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
@@ -22,9 +22,7 @@ namespace System.Buffers
             else if (((uint)minimumBufferSize) > s_maxBufferSize)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumBufferSize);
 
-            var buffer = new ArrayMemoryPoolBuffer(minimumBufferSize);
-            buffer.Retain();
-            return buffer;
+            return new ArrayMemoryPoolBuffer(minimumBufferSize);
         }
 
         protected sealed override void Dispose(bool disposing) {}  // ArrayMemoryPool is a shared pool so Dispose() would be a nop even if there were native resources to dispose.

--- a/src/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
+++ b/src/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
@@ -22,7 +22,9 @@ namespace System.Buffers
             else if (((uint)minimumBufferSize) > s_maxBufferSize)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumBufferSize);
 
-            return new ArrayMemoryPoolBuffer(minimumBufferSize);
+            var buffer = new ArrayMemoryPoolBuffer(minimumBufferSize);
+            buffer.Retain();
+            return buffer;
         }
 
         protected sealed override void Dispose(bool disposing) {}  // ArrayMemoryPool is a shared pool so Dispose() would be a nop even if there were native resources to dispose.


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/27544
https://github.com/dotnet/corefx/issues/27543

1. Make ArrayMemoryPool block ref counting thread-safe.
2. ArrayMemoryPool block returned from the pool has ref count == 1
3. Releasing ArrayMemoryPool block causes it to be disposed and returned to the pool.