### PR TITLE
Removed unnecessary Dispose in DistinctIterator.MoveNext method.

### DIFF
--- a/src/System.Linq/src/System/Linq/Distinct.cs
+++ b/src/System.Linq/src/System/Linq/Distinct.cs
@@ -50,7 +50,7 @@ namespace System.Linq
                         if (!_enumerator.MoveNext())
                         {
                             Dispose();
-                            return false;
+                            break;
                         }
 
                         TSource element = _enumerator.Current;
@@ -70,10 +70,10 @@ namespace System.Linq
                             }
                         }
 
+                        Dispose();
                         break;
                 }
 
-                Dispose();
                 return false;
             }
 


### PR DESCRIPTION
`DistinctIterator.MoveNext` method contains unnecessary call of `Dispose` method if to execute `MoveNext` method many times. Now `DistinctIterator.MoveNext` method call `Dispose` method only one time.