### PR TITLE
Use BuildTools Defaults for Nuget Versions

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
+++ b/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <PropertyGroup>
-    <!-- we need to be supported on pre-nuget-3 platforms (Dev12, Dev11, etc) -->
-    <MinClientVersion>2.8.6</MinClientVersion>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Diagnostics.DiagnosticSource.csproj">
       <SupportedFramework>net46;net45;netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>

--- a/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
+++ b/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <PropertyGroup>
-    <!-- we need to be supported on pre-nuget-3 platforms (Dev12, Dev11, etc) -->
-    <MinClientVersion>2.8.6</MinClientVersion>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Reflection.Metadata.csproj">
       <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>

--- a/src/System.Threading.Tasks.Dataflow/pkg/System.Threading.Tasks.Dataflow.pkgproj
+++ b/src/System.Threading.Tasks.Dataflow/pkg/System.Threading.Tasks.Dataflow.pkgproj
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <PropertyGroup>
-    <!-- we need to be supported on pre-nuget-3 platforms (Dev12, Dev11, etc) -->
-    <MinClientVersion>2.8.6</MinClientVersion>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Threading.Tasks.Dataflow.csproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>


### PR DESCRIPTION
This removes manually specified Nuget required versions for the following packages:

 - System.Diagnostics.DiagnosticSource
 - System.Reflection.Metadata
 - System.Threading.Tasks.Dataflow

These packages don't install successfully with Nuget 2.8.6 because they have a netstandard dependency which is not supported on Nuget 2.8.6.  Per comments in #23843, we are going with the simple fix of increasing the required version to 2.12 which is the BuildTools default.  Thus, the actual code change is to use the default rather than specify 2.12 directly.

Fixes #23843.