### PR TITLE
EventSource Test for Write<T> With Embedded NULL Chars

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -386,6 +386,27 @@ namespace BasicEventSourceTests
                     Assert.Equal(evt.PayloadValue(1, "b"), "");
                 }));
 
+#if USE_ETW
+                // This test only applies to ETW and will fail on EventListeners due to different behavior
+                // for strings with embedded NULL characters.
+                if (listener is EtwListener)
+                {
+                    tests.Add(new SubTest("Write/Basic/WriteOfTWithEmbeddedNullString",
+                    delegate ()
+                    {
+                        string nullString = null;
+                        logger.Write("EmbeddedNullStringEvent", new { a = "Hello" + '\0' + "World!", b = nullString });
+                    },
+                    delegate (Event evt)
+                    {
+                        Assert.Equal(logger.Name, evt.ProviderName);
+                        Assert.Equal("EmbeddedNullStringEvent", evt.EventName);
+                        Assert.Equal(evt.PayloadValue(0, "a"), "Hello");
+                        Assert.Equal(evt.PayloadValue(1, "b"), "");
+                    }));
+                }
+#endif // USE_ETW
+
                 Guid activityId = new Guid("00000000-0000-0000-0000-000000000001");
                 Guid relActivityId = new Guid("00000000-0000-0000-0000-000000000002");
                 tests.Add(new SubTest("Write/Basic/WriteOfTWithOptios",


### PR DESCRIPTION
Write<T> can be passed strings with embedded NULL characters.  Adding a test to ensure that the proper  value comes through.

This test will fail until https://github.com/dotnet/coreclr/pull/16672 being merged and consumed by corefx.