### PR TITLE
Fix System.IO.Pipelines reference assembly

### DIFF
--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
@@ -80,8 +80,8 @@ namespace System.IO.Pipelines
         public abstract void CancelPendingFlush();
         public abstract void Complete(System.Exception exception = null);
         public abstract System.IO.Pipelines.PipeAwaiter<System.IO.Pipelines.FlushResult> FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-        public abstract System.Memory<byte> GetMemory(int minimumLength = 0);
-        public abstract System.Span<byte> GetSpan(int minimumLength = 0);
+        public abstract System.Memory<byte> GetMemory(int sizeHint = 0);
+        public abstract System.Span<byte> GetSpan(int sizeHint = 0);
         public abstract void OnReaderCompleted(System.Action<System.Exception, object> callback, object state);
         public virtual System.IO.Pipelines.PipeAwaiter<System.IO.Pipelines.FlushResult> WriteAsync(System.ReadOnlyMemory<byte> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }

--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.csproj
@@ -16,8 +16,7 @@
     <Reference Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Memory\ref\System.Memory.csproj" />
-    <ProjectReference Include="..\..\System.Buffers\ref\System.Buffers.csproj" />
+    <Reference Include="System.Memory" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.csproj
@@ -16,7 +16,8 @@
     <Reference Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Memory" />
+    <ProjectReference Include="..\..\System.Buffers\ref\System.Buffers.csproj" />
+    <ProjectReference Include="..\..\System.Memory\ref\System.Memory.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -53,7 +53,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
-    <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Threading.Tasks" Condition="'$(TargetGroup)' == 'netstandard1.1'" />
     <Reference Include="System.Threading.ThreadPool" Condition="'$(TargetGroup)' != 'netstandard1.1'" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
cc @pakrym, @davidfowl, @joperezr, @weshaggard 

~The ref csproj doesn't need System.Buffers.~

And if I reference System.Memory as a ProjectReference, I get the following errors, when I run `msbuild` after navigating to `corefx\src\System.IO.Pipelines`:
```text
...
System.IO.Pipelines.cs(86,107): error CS1069: The type name 'ReadOnlyMemory<>' could not be found in the namespace 'System'. This type has been forwarded to assembly 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b0
3f5f7f11d50a3a' Consider adding a reference to that assembly. [D:\GitHub\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
  System.IO.Pipelines.cs(76,48): error CS0012: The type 'Memory<>' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
'. [D:\GitHub\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
  System.IO.Pipelines.cs(76,48): error CS0012: The type 'Span<>' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
 [D:\GitHub\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
  CSC : error CS0012: The type 'CLSCompliantAttribute' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. [D:\GitHu
b\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
  System.IO.Pipelines.cs(91,65): error CS3001: Argument type 'ReadOnlySequence<byte>' is not CLS-compliant [D:\GitHub\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
  System.IO.Pipelines.cs(48,60): error CS3001: Argument type 'MemoryPool<byte>' is not CLS-compliant [D:\GitHub\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
  System.IO.Pipelines.cs(60,64): error CS3001: Argument type 'SequencePosition' is not CLS-compliant [D:\GitHub\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
  System.IO.Pipelines.cs(61,64): error CS3001: Argument type 'SequencePosition' is not CLS-compliant [D:\GitHub\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
  System.IO.Pipelines.cs(61,98): error CS3001: Argument type 'SequencePosition' is not CLS-compliant [D:\GitHub\Fork\corefx\src\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
...
```

Also, only include reference to System.Threading.Tasks when necessary in src csproj.
