### PR TITLE
Fix NamedPipe tests failing in Windows 7 and Nano

### DIFF
--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.Windows.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.Windows.cs
@@ -124,6 +124,10 @@ namespace System.IO.Pipes.Tests
     /// </summary>
     public class NamedPipeTest_CurrentUserOnly_Windows : NamedPipeTestBase, IClassFixture<TestAccountImpersonator>
     {
+        public static bool IsAdminOnSupportedWindowsVersions => PlatformDetection.IsWindowsAndElevated
+            && !PlatformDetection.IsWindows7
+            && !PlatformDetection.IsWindowsNanoServer;
+
         private TestAccountImpersonator _testAccountImpersonator;
 
         public NamedPipeTest_CurrentUserOnly_Windows(TestAccountImpersonator testAccountImpersonator)
@@ -132,7 +136,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [OuterLoop]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsAndElevated))]
+        [ConditionalTheory(nameof(IsAdminOnSupportedWindowsVersions))]
         [InlineData(PipeOptions.None, PipeOptions.CurrentUserOnly)]
         [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.None)]
         public void Connection_UnderDifferentUser_SingleSide_CurrentUserOnly_Fails(PipeOptions serverPipeOptions, PipeOptions clientPipeOptions)


### PR DESCRIPTION
Fixes CI failures: https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fcli~2F/build/20180302.04/workItem/System.IO.Pipes.Tests