### PR TITLE
Use .Net Core for UpdatePublishDependencies

### DIFF
--- a/UpdatePublishedVersions.ps1
+++ b/UpdatePublishedVersions.ps1
@@ -16,7 +16,7 @@ param(
     # A pattern matching all packages in the set that the versions repository should be set to.
     [Parameter(Mandatory=$true)][string]$nupkgPath)
 
-. "$PSScriptRoot\Tools\dotnetcli\dotnet.exe" Tools\msbuild.exe Tools\VersionTools.targets /t:UpdatePublishedVersions `
+. "$PSScriptRoot\Tools\dotnetcli\dotnet.exe" Tools\msbuild.exe build.proj /t:UpdatePublishedVersions `
     /p:GitHubUser="$gitHubUser" `
     /p:GitHubEmail="$gitHubEmail" `
     /p:GitHubAuthToken="$gitHubAuthToken" `

--- a/UpdatePublishedVersions.ps1
+++ b/UpdatePublishedVersions.ps1
@@ -16,7 +16,7 @@ param(
     # A pattern matching all packages in the set that the versions repository should be set to.
     [Parameter(Mandatory=$true)][string]$nupkgPath)
 
-. "$PSScriptRoot\build-managed.cmd" -- /t:UpdatePublishedVersions `
+. "$PSScriptRoot\Tools\dotnetcli\dotnet.exe" Tools\msbuild.exe Tools\VersionTools.targets /t:UpdatePublishedVersions `
     /p:GitHubUser="$gitHubUser" `
     /p:GitHubEmail="$gitHubEmail" `
     /p:GitHubAuthToken="$gitHubAuthToken" `


### PR DESCRIPTION
To unblock updating Versions repo in 1.1.0 pipebuild

@dagood PTAL (this one is different than the CoreCLR ones due to directly invoking VersionTools.targets)