### PR TITLE
Fixing System.Diagnostics.Tests.ProcessTests failures on Unix

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
@@ -74,7 +74,7 @@ namespace System.Diagnostics
         {
             if (IsRemoteMachine(machineName))
             {
-                throw new InvalidOperationException(SR.CouldntConnectToRemoteMachine);
+                throw new PlatformNotSupportedException(SR.RemoteMachinesNotSupported);
             }
         }
         public static IntPtr GetMainWindowHandle(int processId)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
@@ -74,7 +74,7 @@ namespace System.Diagnostics
         {
             if (IsRemoteMachine(machineName))
             {
-                throw new PlatformNotSupportedException(SR.RemoteMachinesNotSupported);
+                throw new InvalidOperationException(SR.CouldntConnectToRemoteMachine);
             }
         }
         public static IntPtr GetMainWindowHandle(int processId)

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -42,8 +42,8 @@ namespace System.Diagnostics.Tests
         {
             Process currentProcess = Process.GetCurrentProcess();
 
-            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, "127.0.0.1"));
-            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessById(currentProcess.Id, "127.0.0.1"));
+            Assert.Throws<InvalidOperationException>(() => Process.GetProcessesByName(currentProcess.ProcessName, "127.0.0.1"));
+            Assert.Throws<InvalidOperationException>(() => Process.GetProcessById(currentProcess.Id, "127.0.0.1"));
         }
 
         [Theory]
@@ -51,7 +51,7 @@ namespace System.Diagnostics.Tests
         public void GetProcessesByName_RemoteMachineNameUnix_ThrowsPlatformNotSupportedException(string machineName)
         {
             Process currentProcess = Process.GetCurrentProcess();
-            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, machineName));
+            Assert.Throws<InvalidOperationException>(() => Process.GetProcessesByName(currentProcess.ProcessName, machineName));
         }
 
         [Fact]
@@ -445,6 +445,6 @@ namespace System.Diagnostics.Tests
         [DllImport("libc")]
         private static extern int seteuid(uint euid);
 
-        private readonly string[] s_allowedProgramsToRun = new string[] { "xdg-open", "gnome-open", "kfmclient" };
+        private static readonly string[] s_allowedProgramsToRun = new string[] { "xdg-open", "gnome-open", "kfmclient" };
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -42,8 +42,8 @@ namespace System.Diagnostics.Tests
         {
             Process currentProcess = Process.GetCurrentProcess();
 
-            Assert.Throws<InvalidOperationException>(() => Process.GetProcessesByName(currentProcess.ProcessName, "127.0.0.1"));
-            Assert.Throws<InvalidOperationException>(() => Process.GetProcessById(currentProcess.Id, "127.0.0.1"));
+            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, "127.0.0.1"));
+            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessById(currentProcess.Id, "127.0.0.1"));
         }
 
         [Theory]
@@ -51,7 +51,7 @@ namespace System.Diagnostics.Tests
         public void GetProcessesByName_RemoteMachineNameUnix_ThrowsPlatformNotSupportedException(string machineName)
         {
             Process currentProcess = Process.GetCurrentProcess();
-            Assert.Throws<InvalidOperationException>(() => Process.GetProcessesByName(currentProcess.ProcessName, machineName));
+            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, machineName));
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -923,7 +923,6 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [ActiveIssue(26720, TargetFrameworkMonikers.Uap)]
-        [ActiveIssue(27459)]
         public void GetProcesses_InvalidMachineName_ThrowsInvalidOperationException()
         {
             Assert.Throws<InvalidOperationException>(() => Process.GetProcesses(Guid.NewGuid().ToString()));
@@ -1285,7 +1284,6 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Windows)]  // Expected process HandleCounts differs on OSX
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Handle count change is not reliable, but seems less robust on NETFX")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Retrieving information about local processes is not supported on uap")]
-        [ActiveIssue(27459)]
         public void HandleCountChanges()
         {
             RemoteInvoke(() =>

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -925,7 +925,8 @@ namespace System.Diagnostics.Tests
         [ActiveIssue(26720, TargetFrameworkMonikers.Uap)]
         public void GetProcesses_InvalidMachineName_ThrowsInvalidOperationException()
         {
-            Assert.Throws<InvalidOperationException>(() => Process.GetProcesses(Guid.NewGuid().ToString()));
+            Type exceptionType = PlatformDetection.IsWindows ? typeof(InvalidOperationException) : typeof(PlatformNotSupportedException);
+            var exception = Assert.Throws(exceptionType, () => Process.GetProcesses(Guid.NewGuid().ToString()));
         }
 
         [Fact]


### PR DESCRIPTION
Making sure we throw InvalidOperationException and with proper message to be consistent with netfx.

This fixes test HandleCountChanges and updates two other existing tests

Making s_allowedProgramsToRun field static in order to fix the 'field marshalling' error occuring during RemoteInvoke

Fixes #27459 

cc: @wtgodbe @danmosemsft @jkotas 