### PR TITLE
Remove ignore pragma for cast-align

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -813,13 +813,12 @@ struct cmsghdr* GET_CMSG_NXTHDR(struct msghdr* mhdr, struct cmsghdr* cmsg)
 #ifndef __GLIBC__
 // Tracking issue: #6312
 // In musl-libc, CMSG_NXTHDR typecasts char* to struct cmsghdr* which causes
-// clang to throw cast-align warning. This is to suppress the warning
+// clang to throw sign-compare warning. This is to suppress the warning
 // inline.
 // There is also a problem in the CMSG_NXTHDR macro in musl-libc.
 // It compares signed and unsigned value and clang warns about that.
 // So we suppress the warning inline too.
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-align"
 #pragma clang diagnostic ignored "-Wsign-compare"
 #endif
     return CMSG_NXTHDR(mhdr, cmsg);


### PR DESCRIPTION
Since pal_networking is switched from C++ to C,
clang on Alpine Linux does not throw cast-aling
warning.

Related issue: #6312

Now the remaining error (without disabling `-Wsign-compare`) looks like:

```ash
[ 34%] Building C object System.Native/CMakeFiles/System.Native.dir/pal_networking.c.o
[ 35%] Building C object System.Native/CMakeFiles/System.Native-Static.dir/pal_networking.c.o
/corefx/src/Native/Unix/System.Native/pal_networking.c:846:31: error: comparison of integers of different signs: 'unsigned long' and 'long' [-Werror,-Wsign-compare]
             controlMessage = CMSG_NXTHDR(&header, controlMessage))
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/socket.h:288:44: note: expanded from macro 'CMSG_NXTHDR'
        __CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/corefx/src/Native/Unix/System.Native/pal_networking.c:857:31: error: comparison of integers of different signs: 'unsigned long' and 'long' [-Werror,-Wsign-compare]
             controlMessage = CMSG_NXTHDR(&header, controlMessage))
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/socket.h:288:44: note: expanded from macro 'CMSG_NXTHDR'
        __CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/corefx/src/Native/Unix/System.Native/pal_networking.c:846:31: error: comparison of integers of different signs: 'unsigned long' and 'long' [-Werror,-Wsign-compare]
             controlMessage = CMSG_NXTHDR(&header, controlMessage))
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/socket.h:288:44: note: expanded from macro 'CMSG_NXTHDR'
        __CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/corefx/src/Native/Unix/System.Native/pal_networking.c:857:31: error: comparison of integers of different signs: 'unsigned long' and 'long' [-Werror,-Wsign-compare]
             controlMessage = CMSG_NXTHDR(&header, controlMessage))
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/socket.h:288:44: note: expanded from macro 'CMSG_NXTHDR'
        __CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

musl-libc's IRC channel suggests that like GCC, Clang shouldn't inspect and complain about system headers. So it might be clang bug?