### PR TITLE
Add back Memory.ToString() to referencey assembly and add tests

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -117,6 +117,7 @@ namespace System
         public System.Memory<T> Slice(int start) { throw null; }
         public System.Memory<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
+        public override string ToString() { throw null; }
         public bool TryCopyTo(System.Memory<T> destination) { throw null; }
     }
     public readonly partial struct ReadOnlyMemory<T>
@@ -140,6 +141,7 @@ namespace System
         public System.ReadOnlyMemory<T> Slice(int start) { throw null; }
         public System.ReadOnlyMemory<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
+        public override string ToString() { throw null; }
         public bool TryCopyTo(System.Memory<T> destination) { throw null; }
     }
     public readonly ref partial struct ReadOnlySpan<T>

--- a/src/System.Memory/tests/Memory/ToString.cs
+++ b/src/System.Memory/tests/Memory/ToString.cs
@@ -1,0 +1,130 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.MemoryTests
+{
+    public static partial class MemoryTests
+    {
+        [Fact]
+        public static void ToStringInt()
+        {
+            int[] a = { 91, 92, 93 };
+            var memory = new Memory<int>(a);
+            Assert.Equal("System.Memory<Int32>[3]", memory.ToString());
+            Assert.Equal("System.Memory<Int32>[1]", memory.Slice(1, 1).ToString());
+            Assert.Equal("System.Span<Int32>[3]", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringInt_Empty()
+        {
+            var memory = new Memory<int>();
+            Assert.Equal("System.Memory<Int32>[0]", memory.ToString());
+            Assert.Equal("System.Memory<Int32>[0]", Memory<int>.Empty.ToString());
+            Assert.Equal("System.Span<Int32>[0]", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringChar()
+        {
+            char[] a = { 'a', 'b', 'c' };
+            var memory = new Memory<char>(a);
+            Assert.Equal("abc", memory.ToString());
+            Assert.Equal("b", memory.Slice(1, 1).ToString());
+            Assert.Equal("abc", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringChar_Empty()
+        {
+            var memory = new Memory<char>();
+            Assert.Equal("", memory.ToString());
+            Assert.Equal("", Memory<char>.Empty.ToString());
+            Assert.Equal("", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringMemoryFromReadOnlyMemory()
+        {
+            string testString = "abcdefg";
+            Memory<char> memory = MemoryMarshal.AsMemory(testString.AsMemory());
+            Assert.Equal(testString, memory.ToString());
+            Assert.Equal(testString.Substring(1, 1), memory.Slice(1, 1).ToString());
+            Assert.Equal(testString, memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringForMemoryOfString()
+        {
+            string[] a = { "a", "b", "c" };
+            var memory = new Memory<string>(a);
+            Assert.Equal("System.Memory<String>[3]", memory.ToString());
+            Assert.Equal("System.Memory<String>[1]", memory.Slice(1, 1).ToString());
+            Assert.Equal("System.Span<String>[3]", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringFroMemoryFromOwnedMemory()
+        {
+            int[] a = { 91, 92, -93, 94 };
+            OwnedMemory<int> intOwner = new CustomMemoryForTest<int>(a);
+            Assert.Equal("System.Memory<Int32>[4]", intOwner.Memory.ToString());
+
+            intOwner = new CustomMemoryForTest<int>(Array.Empty<int>());
+            Assert.Equal("System.Memory<Int32>[0]", intOwner.Memory.ToString());
+
+            char[] charArray = { '1', '2', '-', '4' };
+            OwnedMemory<char> charOwner = new CustomMemoryForTest<char>(charArray);
+            Assert.Equal("12-4", charOwner.Memory.ToString());
+
+            charOwner = new CustomMemoryForTest<char>(Array.Empty<char>());
+            Assert.Equal("", charOwner.Memory.ToString());
+
+            string[] strArray = { "91", "92", "-93", "94" };
+            OwnedMemory<string> strOwner = new CustomMemoryForTest<string>(strArray);
+            Assert.Equal("System.Memory<String>[4]", strOwner.Memory.ToString());
+
+            strOwner = new CustomMemoryForTest<string>(Array.Empty<string>());
+            Assert.Equal("System.Memory<String>[0]", strOwner.Memory.ToString());
+        }
+
+        [Fact]
+        public static void ToStringMemoryOverFullStringReturnsOriginal()
+        {
+            string original = TestHelpers.BuildString(10, 42);
+
+            ReadOnlyMemory<char> readOnlyMemory = original.AsMemory();
+            Memory<char> memory = MemoryMarshal.AsMemory(readOnlyMemory);
+
+            string returnedString = memory.ToString();
+            string returnedStringUsingSlice = memory.Slice(0, original.Length).ToString();
+
+            string subString1 = memory.Slice(1).ToString();
+            string subString2 = memory.Slice(0, 2).ToString();
+            string subString3 = memory.Slice(1, 2).ToString();
+
+            Assert.Equal(original, returnedString);
+            Assert.Equal(original, returnedStringUsingSlice);
+
+            Assert.Equal(original.Substring(1), subString1);
+            Assert.Equal(original.Substring(0, 2), subString2);
+            Assert.Equal(original.Substring(1, 2), subString3);
+
+            Assert.Same(original, returnedString);
+            Assert.Same(original, returnedStringUsingSlice);
+
+            Assert.NotSame(original, subString1);
+            Assert.NotSame(original, subString2);
+            Assert.NotSame(original, subString3);
+
+            Assert.NotSame(subString1, subString2);
+            Assert.NotSame(subString1, subString3);
+            Assert.NotSame(subString2, subString3);
+        }
+    }
+}

--- a/src/System.Memory/tests/Memory/ToString.cs
+++ b/src/System.Memory/tests/Memory/ToString.cs
@@ -69,7 +69,7 @@ namespace System.MemoryTests
         }
 
         [Fact]
-        public static void ToStringFroMemoryFromOwnedMemory()
+        public static void ToStringFromMemoryFromOwnedMemory()
         {
             int[] a = { 91, 92, -93, 94 };
             OwnedMemory<int> intOwner = new CustomMemoryForTest<int>(a);

--- a/src/System.Memory/tests/ReadOnlyMemory/ToString.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/ToString.cs
@@ -1,0 +1,128 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using Xunit;
+
+namespace System.MemoryTests
+{
+    public static partial class ReadOnlyMemoryTests
+    {
+        [Fact]
+        public static void ToStringInt()
+        {
+            int[] a = { 91, 92, 93 };
+            var memory = new ReadOnlyMemory<int>(a);
+            Assert.Equal("System.ReadOnlyMemory<Int32>[3]", memory.ToString());
+            Assert.Equal("System.ReadOnlyMemory<Int32>[1]", memory.Slice(1, 1).ToString());
+            Assert.Equal("System.ReadOnlySpan<Int32>[3]", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringInt_Empty()
+        {
+            var memory = new ReadOnlyMemory<int>();
+            Assert.Equal("System.ReadOnlyMemory<Int32>[0]", memory.ToString());
+            Assert.Equal("System.ReadOnlyMemory<Int32>[0]", ReadOnlyMemory<int>.Empty.ToString());
+            Assert.Equal("System.ReadOnlySpan<Int32>[0]", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringChar()
+        {
+            char[] a = { 'a', 'b', 'c' };
+            var memory = new ReadOnlyMemory<char>(a);
+            Assert.Equal("abc", memory.ToString());
+            Assert.Equal("b", memory.Slice(1, 1).ToString());
+            Assert.Equal("abc", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringChar_Empty()
+        {
+            var memory = new ReadOnlyMemory<char>();
+            Assert.Equal("", memory.ToString());
+            Assert.Equal("", ReadOnlyMemory<char>.Empty.ToString());
+            Assert.Equal("", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringMemoryFromReadOnlyMemory()
+        {
+            string testString = "abcdefg";
+            ReadOnlyMemory<char> memory = testString.AsMemory();
+            Assert.Equal(testString, memory.ToString());
+            Assert.Equal(testString.Substring(1, 1), memory.Slice(1, 1).ToString());
+            Assert.Equal(testString, memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringForMemoryOfString()
+        {
+            string[] a = { "a", "b", "c" };
+            var memory = new ReadOnlyMemory<string>(a);
+            Assert.Equal("System.ReadOnlyMemory<String>[3]", memory.ToString());
+            Assert.Equal("System.ReadOnlyMemory<String>[1]", memory.Slice(1, 1).ToString());
+            Assert.Equal("System.ReadOnlySpan<String>[3]", memory.Span.ToString());
+        }
+
+        [Fact]
+        public static void ToStringFroMemoryFromOwnedMemory()
+        {
+            int[] a = { 91, 92, -93, 94 };
+            OwnedMemory<int> intOwner = new CustomMemoryForTest<int>(a);
+            Assert.Equal("System.ReadOnlyMemory<Int32>[4]", ((ReadOnlyMemory<int>)intOwner.Memory).ToString());
+
+            intOwner = new CustomMemoryForTest<int>(Array.Empty<int>());
+            Assert.Equal("System.ReadOnlyMemory<Int32>[0]", ((ReadOnlyMemory<int>)intOwner.Memory).ToString());
+
+            char[] charArray = { '1', '2', '-', '4' };
+            OwnedMemory<char> charOwner = new CustomMemoryForTest<char>(charArray);
+            Assert.Equal("12-4", ((ReadOnlyMemory<char>)charOwner.Memory).ToString());
+
+            charOwner = new CustomMemoryForTest<char>(Array.Empty<char>());
+            Assert.Equal("", ((ReadOnlyMemory<char>)charOwner.Memory).ToString());
+
+            string[] strArray = { "91", "92", "-93", "94" };
+            OwnedMemory<string> strOwner = new CustomMemoryForTest<string>(strArray);
+            Assert.Equal("System.ReadOnlyMemory<String>[4]", ((ReadOnlyMemory<string>)strOwner.Memory).ToString());
+
+            strOwner = new CustomMemoryForTest<string>(Array.Empty<string>());
+            Assert.Equal("System.ReadOnlyMemory<String>[0]", ((ReadOnlyMemory<string>)strOwner.Memory).ToString());
+        }
+
+        [Fact]
+        public static void ToStringMemoryOverFullStringReturnsOriginal()
+        {
+            string original = TestHelpers.BuildString(10, 42);
+
+            ReadOnlyMemory<char> memory = original.AsMemory();
+
+            string returnedString = memory.ToString();
+            string returnedStringUsingSlice = memory.Slice(0, original.Length).ToString();
+
+            string subString1 = memory.Slice(1).ToString();
+            string subString2 = memory.Slice(0, 2).ToString();
+            string subString3 = memory.Slice(1, 2).ToString();
+
+            Assert.Equal(original, returnedString);
+            Assert.Equal(original, returnedStringUsingSlice);
+
+            Assert.Equal(original.Substring(1), subString1);
+            Assert.Equal(original.Substring(0, 2), subString2);
+            Assert.Equal(original.Substring(1, 2), subString3);
+
+            Assert.Same(original, returnedString);
+            Assert.Same(original, returnedStringUsingSlice);
+
+            Assert.NotSame(original, subString1);
+            Assert.NotSame(original, subString2);
+            Assert.NotSame(original, subString3);
+
+            Assert.NotSame(subString1, subString2);
+            Assert.NotSame(subString1, subString3);
+            Assert.NotSame(subString2, subString3);
+        }
+    }
+}

--- a/src/System.Memory/tests/ReadOnlyMemory/ToString.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/ToString.cs
@@ -68,7 +68,7 @@ namespace System.MemoryTests
         }
 
         [Fact]
-        public static void ToStringFroMemoryFromOwnedMemory()
+        public static void ToStringFromMemoryFromOwnedMemory()
         {
             int[] a = { 91, 92, -93, 94 };
             OwnedMemory<int> intOwner = new CustomMemoryForTest<int>(a);

--- a/src/System.Memory/tests/ReadOnlySpan/ToString.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/ToString.cs
@@ -60,10 +60,8 @@ namespace System.SpanTests
             Assert.Equal(orig.Substring(1, 3), orig.AsSpan(1, 3).ToString());
         }
 
-        // This test is only relevant for portable span
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Optimization only applies to portable span.")]
         [Fact]
-        public static void ToStringSpanOverFullStringReturnsOriginal()
+        public static void ToStringSpanOverSubstringDoesNotReturnOriginal()
         {
             string original = TestHelpers.BuildString(10, 42);
             ReadOnlySpan<char> span = original.AsSpan();
@@ -82,9 +80,6 @@ namespace System.SpanTests
             Assert.Equal(original.Substring(0, 2), subString2);
             Assert.Equal(original.Substring(1, 2), subString3);
 
-            Assert.Same(original, returnedString);
-            Assert.Same(original, returnedStringUsingSlice);
-
             Assert.NotSame(original, subString1);
             Assert.NotSame(original, subString2);
             Assert.NotSame(original, subString3);
@@ -92,6 +87,21 @@ namespace System.SpanTests
             Assert.NotSame(subString1, subString2);
             Assert.NotSame(subString1, subString3);
             Assert.NotSame(subString2, subString3);
+        }
+
+        // This test is only relevant for portable span
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Optimization only applies to portable span.")]
+        [Fact]
+        public static void ToStringSpanOverFullStringReturnsOriginal()
+        {
+            string original = TestHelpers.BuildString(10, 42);
+            ReadOnlySpan<char> span = original.AsSpan();
+
+            string returnedString = span.ToString();
+            string returnedStringUsingSlice = span.Slice(0, original.Length).ToString();
+
+            Assert.Same(original, returnedString);
+            Assert.Same(original, returnedStringUsingSlice);
         }
     }
 }

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Memory\Span.cs" />
     <Compile Include="Memory\Strings.cs" />
     <Compile Include="Memory\ToArray.cs" />
+    <Compile Include="Memory\ToString.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MemoryMarshal\AsMemory.cs" />
@@ -176,6 +177,7 @@
     <Compile Include="ReadOnlyMemory\Span.cs" />
     <Compile Include="ReadOnlyMemory\Strings.cs" />
     <Compile Include="ReadOnlyMemory\ToArray.cs" />
+    <Compile Include="ReadOnlyMemory\ToString.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Binary\BinaryReaderUnitTests.cs" />


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/16732 and the subsequent mirror PR (https://github.com/dotnet/corefx/pull/27697).

cc @jkotas, @KrzysztofCwalina, @stephentoub, @pakrym, @khellang 