### PR TITLE
Add response drain max time to SocketsHttpHandler

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -14,6 +14,7 @@ namespace System.Net.Http
         public const int DefaultMaxAutomaticRedirections = 50;
         public const int DefaultMaxConnectionsPerServer = int.MaxValue;
         public const int DefaultMaxResponseDrainSize = 1024 * 1024;
+        public static readonly TimeSpan DefaultMaxResponseDrainTime = TimeSpan.FromSeconds(5);
         public const int DefaultMaxResponseHeadersLength = 64; // Units in K (1024) bytes.
         public const DecompressionMethods DefaultAutomaticDecompression = DecompressionMethods.None;
         public const bool DefaultAutomaticRedirection = true;

--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
         public const int DefaultMaxAutomaticRedirections = 50;
         public const int DefaultMaxConnectionsPerServer = int.MaxValue;
         public const int DefaultMaxResponseDrainSize = 1024 * 1024;
-        public static readonly TimeSpan DefaultMaxResponseDrainTime = TimeSpan.FromSeconds(5);
+        public static readonly TimeSpan DefaultMaxResponseDrainTime = TimeSpan.FromSeconds(2);
         public const int DefaultMaxResponseHeadersLength = 64; // Units in K (1024) bytes.
         public const DecompressionMethods DefaultAutomaticDecompression = DecompressionMethods.None;
         public const bool DefaultAutomaticRedirection = true;

--- a/src/System.Net.Http/src/ILLinkTrim.xml
+++ b/src/System.Net.Http/src/ILLinkTrim.xml
@@ -2,5 +2,9 @@
   <assembly fullname="System.Net.Http">
     <!-- Anonymous types are used with DiagnosticSource logging and subscribers reflect over those, calling their public getters. -->
     <type fullname="*f__AnonymousType*" />
+    <type fullname="System.Net.Http.SocketsHttpHandler"> <!-- TODO #27685: Remove once public. -->
+      <method name="get_MaxResponseDrainTime" />
+      <method name="set_MaxResponseDrainTime" />
+    </type>
   </assembly>
 </linker>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -27,6 +27,7 @@ namespace System.Net.Http
 
         internal int _maxConnectionsPerServer = HttpHandlerDefaults.DefaultMaxConnectionsPerServer;
         internal int _maxResponseDrainSize = HttpHandlerDefaults.DefaultMaxResponseDrainSize;
+        internal TimeSpan _maxResponseDrainTime = HttpHandlerDefaults.DefaultMaxResponseDrainTime;
         internal int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
 
         internal TimeSpan _pooledConnectionLifetime = HttpHandlerDefaults.DefaultPooledConnectionLifetime;
@@ -58,6 +59,7 @@ namespace System.Net.Http
                 _maxAutomaticRedirections = _maxAutomaticRedirections,
                 _maxConnectionsPerServer = _maxConnectionsPerServer,
                 _maxResponseDrainSize = _maxResponseDrainSize,
+                _maxResponseDrainTime = _maxResponseDrainTime,
                 _maxResponseHeadersLength = _maxResponseHeadersLength,
                 _pooledConnectionLifetime = _pooledConnectionLifetime,
                 _pooledConnectionIdleTimeout = _pooledConnectionIdleTimeout,

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -167,6 +167,22 @@ namespace System.Net.Http
             }
         }
 
+        internal TimeSpan MaxResponseDrainTime // TODO #27685: Expose publicly.
+        {
+            get => _settings._maxResponseDrainTime;
+            set
+            {
+                if ((value < TimeSpan.Zero && value != Timeout.InfiniteTimeSpan) ||
+                    (value.TotalMilliseconds > int.MaxValue))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                CheckDisposedOrStarted();
+                _settings._maxResponseDrainTime = value;
+            }
+        }
+
         public int MaxResponseHeadersLength
         {
             get => _settings._maxResponseHeadersLength;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Net.Test.Common;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,6 +13,8 @@ namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientHandler_ResponseDrain_Test : HttpClientTestBase
     {
+        protected virtual void SetMaxResponseDrainTime(HttpClientHandler handler, TimeSpan time) { }
+
         public enum ContentMode
         {
             ContentLength,
@@ -131,6 +134,7 @@ namespace System.Net.Http.Functional.Tests
                 async url =>
                 {
                     HttpClientHandler handler = CreateHttpClientHandler();
+                    SetMaxResponseDrainTime(handler, Timeout.InfiniteTimeSpan);
 
                     // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
                     handler.MaxConnectionsPerServer = 1;
@@ -208,6 +212,7 @@ namespace System.Net.Http.Functional.Tests
                 async url =>
                 {
                     HttpClientHandler handler = CreateHttpClientHandler();
+                    SetMaxResponseDrainTime(handler, Timeout.InfiniteTimeSpan);
 
                     // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
                     handler.MaxConnectionsPerServer = 1;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTestBase.cs
@@ -42,21 +42,13 @@ namespace System.Net.Http.Functional.Tests
             return handler;
         }
 
-        protected static bool IsSocketsHttpHandler(HttpClientHandler handler)
+        protected static bool IsSocketsHttpHandler(HttpClientHandler handler) =>
+            GetUnderlyingSocketsHttpHandler(handler) != null;
+
+        protected static object GetUnderlyingSocketsHttpHandler(HttpClientHandler handler)
         {
             FieldInfo field = typeof(HttpClientHandler).GetField("_socketsHttpHandler", BindingFlags.Instance | BindingFlags.NonPublic);
-            if (field == null)
-            {
-                return false;
-            }
-
-            object socketsHttpHandler = field.GetValue(handler);
-            if (socketsHttpHandler == null)
-            {
-                return false;
-            }
-
-            return true;
+            return field?.GetValue(handler);
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -77,6 +77,13 @@ namespace System.Net.Http.Functional.Tests
     {
         protected override bool UseSocketsHttpHandler => true;
 
+        protected override void SetMaxResponseDrainTime(HttpClientHandler handler, TimeSpan time)
+        {
+            SocketsHttpHandler s = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+            Assert.NotNull(s);
+            SetMaxResponseDrainTime(s, time);
+        }
+
         [Fact]
         public void MaxResponseDrainSize_Roundtrips()
         {
@@ -119,6 +126,64 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        // TODO #27685: Remove once MaxResponseDrainTime is public.
+        private TimeSpan GetMaxResponseDrainTime(SocketsHttpHandler handler) =>
+            (TimeSpan)handler.GetType().GetProperty("MaxResponseDrainTime", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(handler);
+        private void SetMaxResponseDrainTime(SocketsHttpHandler handler, TimeSpan value)
+        {
+            try
+            {
+                handler.GetType().GetProperty("MaxResponseDrainTime", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(handler, value);
+            }
+            catch (TargetInvocationException tie)
+            {
+                throw tie.InnerException;
+            }
+        }
+
+        [Fact]
+        public void MaxResponseDrainTime_Roundtrips()
+        {
+            using (var handler = new SocketsHttpHandler())
+            {
+                Assert.Equal(TimeSpan.FromSeconds(5), GetMaxResponseDrainTime(handler));
+
+                SetMaxResponseDrainTime(handler, TimeSpan.Zero);
+                Assert.Equal(TimeSpan.Zero, GetMaxResponseDrainTime(handler));
+
+                SetMaxResponseDrainTime(handler, TimeSpan.FromTicks(int.MaxValue));
+                Assert.Equal(TimeSpan.FromTicks(int.MaxValue), GetMaxResponseDrainTime(handler));
+            }
+        }
+
+        [Fact]
+        public void MaxResponseDraiTime_InvalidArgument_Throws()
+        {
+            using (var handler = new SocketsHttpHandler())
+            {
+                Assert.Equal(TimeSpan.FromSeconds(5), GetMaxResponseDrainTime(handler));
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => SetMaxResponseDrainTime(handler, TimeSpan.FromSeconds(-1)));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => SetMaxResponseDrainTime(handler, TimeSpan.MaxValue));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => SetMaxResponseDrainTime(handler, TimeSpan.FromSeconds(int.MaxValue)));
+
+                Assert.Equal(TimeSpan.FromSeconds(5), GetMaxResponseDrainTime(handler));
+            }
+        }
+
+        [Fact]
+        public void MaxResponseDrainTime_SetAfterUse_Throws()
+        {
+            using (var handler = new SocketsHttpHandler())
+            using (var client = new HttpClient(handler))
+            {
+                SetMaxResponseDrainTime(handler, TimeSpan.FromSeconds(42));
+                client.GetAsync("http://" + Guid.NewGuid().ToString("N")); // ignoring failure
+                Assert.Equal(TimeSpan.FromSeconds(42), GetMaxResponseDrainTime(handler));
+                Assert.Throws<InvalidOperationException>(() => SetMaxResponseDrainTime(handler, TimeSpan.FromSeconds(42)));
+            }
+        }
+
         [OuterLoop]
         [Theory]
         [InlineData(1024 * 1024 * 2, 9_500, 1024 * 1024 * 3, ContentMode.ContentLength)]
@@ -131,6 +196,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     var handler = new SocketsHttpHandler();
                     handler.MaxResponseDrainSize = maxDrainSize;
+                    SetMaxResponseDrainTime(handler, Timeout.InfiniteTimeSpan);
 
                     // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
                     handler.MaxConnectionsPerServer = 1;
@@ -176,6 +242,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     var handler = new SocketsHttpHandler();
                     handler.MaxResponseDrainSize = maxDrainSize;
+                    SetMaxResponseDrainTime(handler, Timeout.InfiniteTimeSpan);
 
                     // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
                     handler.MaxConnectionsPerServer = 1;
@@ -202,6 +269,58 @@ namespace System.Net.Http.Functional.Tests
                         try
                         {
                             await connection.Writer.WriteAsync(response);
+                        }
+                        catch (Exception) { }     // Eat errors from client disconnect.
+
+                        await server.AcceptConnectionSendCustomResponseAndCloseAsync(response);
+                    });
+                });
+        }
+
+        [OuterLoop]
+        [Theory]
+        [InlineData(ContentMode.ContentLength)]
+        [InlineData(ContentMode.SingleChunk)]
+        [InlineData(ContentMode.BytePerChunk)]
+        public async Task GetAsyncWithMaxConnections_DrainTakesLongerThanTimeout_KillsConnection(ContentMode mode)
+        {
+            const int ContentLength = 10_000;
+
+            await LoopbackServer.CreateClientAndServerAsync(
+                async url =>
+                {
+                    var handler = new SocketsHttpHandler();
+                    handler.MaxResponseDrainSize = int.MaxValue;
+                    SetMaxResponseDrainTime(handler, TimeSpan.FromMilliseconds(1));
+
+                    // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
+                    handler.MaxConnectionsPerServer = 1;
+
+                    using (var client = new HttpClient(handler))
+                    {
+                        client.Timeout = Timeout.InfiniteTimeSpan;
+
+                        HttpResponseMessage response1 = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                        ValidateResponseHeaders(response1, ContentLength, mode);
+                        response1.Dispose();
+
+                        // Issue another request.  We'll confirm that it comes on a new connection.
+                        HttpResponseMessage response2 = await client.GetAsync(url);
+                        ValidateResponseHeaders(response2, ContentLength, mode);
+                        Assert.Equal(ContentLength, (await response2.Content.ReadAsStringAsync()).Length);
+                    }
+                },
+                async server =>
+                {
+                    string content = new string('a', ContentLength);
+                    string response = GetResponseForContentMode(content, mode);
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        await connection.ReadRequestHeaderAsync();
+                        try
+                        {
+                            // Write out only part of the response
+                            await connection.Writer.WriteAsync(response.Substring(0, response.Length / 2));
                         }
                         catch (Exception) { }     // Eat errors from client disconnect.
 

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -146,7 +146,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new SocketsHttpHandler())
             {
-                Assert.Equal(TimeSpan.FromSeconds(5), GetMaxResponseDrainTime(handler));
+                Assert.Equal(TimeSpan.FromSeconds(2), GetMaxResponseDrainTime(handler));
 
                 SetMaxResponseDrainTime(handler, TimeSpan.Zero);
                 Assert.Equal(TimeSpan.Zero, GetMaxResponseDrainTime(handler));
@@ -161,13 +161,13 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new SocketsHttpHandler())
             {
-                Assert.Equal(TimeSpan.FromSeconds(5), GetMaxResponseDrainTime(handler));
+                Assert.Equal(TimeSpan.FromSeconds(2), GetMaxResponseDrainTime(handler));
 
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => SetMaxResponseDrainTime(handler, TimeSpan.FromSeconds(-1)));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => SetMaxResponseDrainTime(handler, TimeSpan.MaxValue));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => SetMaxResponseDrainTime(handler, TimeSpan.FromSeconds(int.MaxValue)));
 
-                Assert.Equal(TimeSpan.FromSeconds(5), GetMaxResponseDrainTime(handler));
+                Assert.Equal(TimeSpan.FromSeconds(2), GetMaxResponseDrainTime(handler));
             }
         }
 


### PR DESCRIPTION
Adds support for a max time limit on how long we'll try to drain a connection before returning it to the pool, and adds a (currently non-public) knob for controlling that limit.

This also fixes a race condition with regards to cancellation and chunked responses.  If cancellation was requested after returning the connection to the pool but before we disposed of the cancellation registration, someone else could get the pooled connection and then cancellation of one request could end up canceling the other request.

Contributes to https://github.com/dotnet/corefx/issues/27685
cc: @geoffkizer, @davidsh