### PR TITLE
Add tests that exercise encoding methods on explicit Span.Empty

### DIFF
--- a/src/System.Text.Encoding/tests/EncodingTestHelpers.netcoreapp.cs
+++ b/src/System.Text.Encoding/tests/EncodingTestHelpers.netcoreapp.cs
@@ -15,6 +15,9 @@ namespace System.Text.Tests
 
             // Use GetByteCount(ReadOnlySpan<char> chars)
             Assert.Equal(expected, encoding.GetByteCount(chars.AsSpan().Slice(index, count)));
+
+            if (count == 0)
+                Assert.Equal(expected, encoding.GetByteCount(ReadOnlySpan<char>.Empty));
         }
 
         static partial void GetBytes_NetCoreApp(Encoding encoding, string chars, int index, int count, byte[] expected)
@@ -27,12 +30,18 @@ namespace System.Text.Tests
             Array.Clear(stringResultAdvanced, 0, stringResultAdvanced.Length);
             Assert.Equal(expected.Length, encoding.GetBytes(chars.AsSpan().Slice(index, count), (Span<byte>)stringResultAdvanced));
             VerifyGetBytes(stringResultAdvanced, 0, stringResultAdvanced.Length, new byte[expected.Length], expected);
+
+            if (count == 0)
+                Assert.Equal(expected.Length, encoding.GetBytes(ReadOnlySpan<char>.Empty, (Span<byte>)stringResultAdvanced));
         }
 
         static partial void GetCharCount_NetCoreApp(Encoding encoding, byte[] bytes, int index, int count, int expected)
         {
             // Use GetCharCount(ReadOnlySpan<byte>)
             Assert.Equal(expected, encoding.GetCharCount(new ReadOnlySpan<byte>(bytes, index, count)));
+
+            if (count == 0)
+                Assert.Equal(expected, encoding.GetCharCount(ReadOnlySpan<byte>.Empty));
         }
 
         static partial void VerifyGetChars_NetCoreApp(Encoding encoding, byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, char[] expectedChars)
@@ -42,12 +51,21 @@ namespace System.Text.Tests
             int charCount = encoding.GetChars(new ReadOnlySpan<byte>(bytes, byteIndex, byteCount), new Span<char>(byteChars).Slice(charIndex));
             VerifyGetChars(byteChars, charIndex, charCount, (char[])chars.Clone(), expectedChars);
             Assert.Equal(expectedChars.Length, charCount);
+
+            if (byteCount == 0)
+            {
+                charCount = encoding.GetChars(ReadOnlySpan<byte>.Empty, new Span<char>(byteChars).Slice(charIndex));
+                Assert.Equal(expectedChars.Length, charCount);
+            }
         }
 
         static partial void GetString_NetCoreApp(Encoding encoding, byte[] bytes, int index, int count, string expected)
         {
             // Use GetString(ReadOnlySpan<byte>)
             Assert.Equal(expected, encoding.GetString(new ReadOnlySpan<byte>(bytes, index, count)));
+
+            if (count == 0)
+                Assert.Equal(expected, encoding.GetString(ReadOnlySpan<byte>.Empty));
         }
     }
 }


### PR DESCRIPTION
Encoding had a historic confusion about handling null pointers. Make sure that this confusion is not leaking into the new Span methods.