### PR TITLE
Cleanup one last StringBuilderCache usage in System.IO.FileSystem

### DIFF
--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -36,9 +36,6 @@
     <Compile Include="System\IO\ReadLinesIterator.cs" />
     <Compile Include="System\IO\SearchOption.cs" />
     <Compile Include="System\IO\SearchTarget.cs" />
-    <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
-      <Link>Common\System\IO\StringBuilderCache.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\CoreLib\System\Text\ValueStringBuilder.cs">
       <Link>Common\CoreLib\System\Text\ValueStringBuilder.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -713,13 +713,12 @@ namespace System.IO
             Debug.Assert(encoding != null);
 
             char[] buffer = null;
-            StringBuilder sb = null;
             StreamReader sr = AsyncStreamReader(path, encoding);
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                sb = StringBuilderCache.Acquire();
                 buffer = ArrayPool<char>.Shared.Rent(sr.CurrentEncoding.GetMaxCharCount(DefaultBufferSize));
+                StringBuilder sb = new StringBuilder();
                 for (;;)
                 {
                     int read = await sr.ReadAsync(new Memory<char>(buffer), cancellationToken).ConfigureAwait(false);
@@ -737,11 +736,6 @@ namespace System.IO
                 if (buffer != null)
                 {
                     ArrayPool<char>.Shared.Return(buffer);
-                }
-
-                if (sb != null)
-                {
-                    StringBuilderCache.Release(sb);
                 }
             }
         }


### PR DESCRIPTION
ReadAllTextAsync is convenience method that allocates a lot anyway, so the saving from StringBuilderCache is unlikely to show up. And this method is unlikely to be used for small strings where StringBuilderCache helps anyway.