### PR TITLE
Normalize the too-big-to-decrypt message across RSA implementations

### DIFF
--- a/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -19,6 +19,8 @@ namespace System.Security.Cryptography
 #endif
     public sealed partial class RSACng : RSA
     {
+        private const int Pkcs1PaddingOverhead = 11;
+
         /// <summary>Encrypts data using the public key.</summary>
         public override unsafe byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) =>
             EncryptOrDecrypt(data, padding, encrypt: true);
@@ -54,6 +56,14 @@ namespace System.Security.Cryptography
             {
                 throw new CryptographicException(
                     SR.Format(SR.Cryptography_Padding_DecDataTooBig, modulusSizeInBytes));
+            }
+
+            if (encrypt &&
+                padding.Mode == RSAEncryptionPaddingMode.Pkcs1 &&
+                data.Length > modulusSizeInBytes - Pkcs1PaddingOverhead)
+            {
+                throw new CryptographicException(
+                    SR.Format(SR.Cryptography_Encryption_MessageTooLong, modulusSizeInBytes - Pkcs1PaddingOverhead));
             }
 
             using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
@@ -135,6 +145,14 @@ namespace System.Security.Cryptography
             {
                 throw new CryptographicException(
                     SR.Format(SR.Cryptography_Padding_DecDataTooBig, modulusSizeInBytes));
+            }
+
+            if (encrypt &&
+                padding.Mode == RSAEncryptionPaddingMode.Pkcs1 &&
+                data.Length > modulusSizeInBytes - Pkcs1PaddingOverhead)
+            {
+                throw new CryptographicException(
+                    SR.Format(SR.Cryptography_Encryption_MessageTooLong, modulusSizeInBytes - Pkcs1PaddingOverhead));
             }
 
             using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())

--- a/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -48,13 +48,20 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(padding));
             }
 
+            int modulusSizeInBytes = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
+
+            if (!encrypt && data.Length > modulusSizeInBytes)
+            {
+                throw new CryptographicException(
+                    SR.Format(SR.Cryptography_Padding_DecDataTooBig, modulusSizeInBytes));
+            }
+
             using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
             {
                 if (encrypt && data.Length == 0)
                 {
-                    int bufSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
-                    byte[] rented = ArrayPool<byte>.Shared.Rent(bufSize);
-                    Span<byte> paddedMessage = new Span<byte>(rented, 0, bufSize);
+                    byte[] rented = ArrayPool<byte>.Shared.Rent(modulusSizeInBytes);
+                    Span<byte> paddedMessage = new Span<byte>(rented, 0, modulusSizeInBytes);
 
                     try
                     {
@@ -122,13 +129,20 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(padding));
             }
 
+            int modulusSizeInBytes = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
+
+            if (!encrypt && data.Length > modulusSizeInBytes)
+            {
+                throw new CryptographicException(
+                    SR.Format(SR.Cryptography_Padding_DecDataTooBig, modulusSizeInBytes));
+            }
+
             using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
             {
                 if (encrypt && data.Length == 0)
                 {
-                    int bufSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
-                    byte[] rented = ArrayPool<byte>.Shared.Rent(bufSize);
-                    Span<byte> paddedMessage = new Span<byte>(rented, 0, bufSize);
+                    byte[] rented = ArrayPool<byte>.Shared.Rent(modulusSizeInBytes);
+                    Span<byte> paddedMessage = new Span<byte>(rented, 0, modulusSizeInBytes);
 
                     try
                     {

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -154,6 +154,12 @@ namespace System.Security.Cryptography
 
             int rsaSize = Interop.Crypto.RsaSize(key);
 
+            if (data.Length > rsaSize)
+            {
+                throw new CryptographicException(
+                    SR.Format(SR.Cryptography_Padding_DecDataTooBig, rsaSize));
+            }
+
             if (destination.Length < rsaSize)
             {
                 bytesWritten = 0;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -346,6 +346,32 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        public void RsaPkcsEncryptMaxSize()
+        {
+            RSAParameters rsaParameters = TestData.RSA2048Params;
+
+            using (RSA rsa = RSAFactory.Create(rsaParameters))
+            {
+                RSAEncryptionPadding paddingMode1 = RSAEncryptionPadding.Pkcs1;
+                // The overhead required is 8 + 3 => 11.
+
+                const int Pkcs1Overhead = 11;
+                int maxSize = rsaParameters.Modulus.Length - Pkcs1Overhead;
+
+                byte[] data = new byte[maxSize];
+                byte[] encrypted = Encrypt(rsa, data, paddingMode1);
+                byte[] decrypted = Decrypt(rsa, encrypted, paddingMode1);
+
+                Assert.Equal(data.ByteArrayToHex(), decrypted.ByteArrayToHex());
+
+                data = new byte[maxSize + 1];
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => Encrypt(rsa, data, paddingMode1));
+            }
+        }
+
+        [Fact]
         public void RsaOaepMaxSize()
         {
             RSAParameters rsaParameters = TestData.RSA2048Params;
@@ -441,6 +467,26 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        public void RsaDecryptPkcs1WrongDataLength()
+        {
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
+            {
+                byte[] data = TestData.HelloBytes;
+
+                byte[] encrypted = Encrypt(rsa, data, RSAEncryptionPadding.Pkcs1);
+                Array.Resize(ref encrypted, encrypted.Length + 1);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => Decrypt(rsa, encrypted, RSAEncryptionPadding.Pkcs1));
+
+                Array.Resize(ref encrypted, encrypted.Length - 2);
+
+                Assert.ThrowsAny<CryptographicException>(
+                    () => Decrypt(rsa, encrypted, RSAEncryptionPadding.Pkcs1));
+            }
+        }
+
+        [Fact]
         public void RsaDecryptOaepWrongDataLength()
         {
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
@@ -464,12 +510,12 @@ namespace System.Security.Cryptography.Rsa.Tests
                     Array.Resize(ref encrypted, encrypted.Length + 1);
 
                     Assert.ThrowsAny<CryptographicException>(
-                        () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA1));
+                        () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA256));
 
                     Array.Resize(ref encrypted, encrypted.Length - 2);
 
                     Assert.ThrowsAny<CryptographicException>(
-                        () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA1));
+                        () => Decrypt(rsa, encrypted, RSAEncryptionPadding.OaepSHA256));
                 }
             }
         }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -476,8 +476,13 @@ namespace System.Security.Cryptography.Rsa.Tests
                 byte[] encrypted = Encrypt(rsa, data, RSAEncryptionPadding.Pkcs1);
                 Array.Resize(ref encrypted, encrypted.Length + 1);
 
-                Assert.ThrowsAny<CryptographicException>(
-                    () => Decrypt(rsa, encrypted, RSAEncryptionPadding.Pkcs1));
+                // Baseline/exempt a NetFx difference for RSACng
+                if (!PlatformDetection.IsFullFramework ||
+                    rsa.GetType().Assembly.GetName().Name != "System.Core")
+                {
+                    Assert.ThrowsAny<CryptographicException>(
+                        () => Decrypt(rsa, encrypted, RSAEncryptionPadding.Pkcs1));
+                }
 
                 Array.Resize(ref encrypted, encrypted.Length - 2);
 

--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -214,6 +214,9 @@
   <data name="Cryptography_OpenInvalidHandle" xml:space="preserve">
     <value>Cannot open an invalid handle.</value>
   </data>
+  <data name="Cryptography_Padding_DecDataTooBig" xml:space="preserve">
+    <value>The data to be decrypted exceeds the maximum for this modulus of {0} bytes.</value>
+  </data>
   <data name="Cryptography_PartialBlock" xml:space="preserve">
     <value>The input data is not a complete block.</value>
   </data>

--- a/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -181,6 +181,9 @@
   <data name="Cryptography_OAEP_Decryption_Failed" xml:space="preserve">
     <value>Error occurred while decoding OAEP padding.</value>
   </data>
+  <data name="Cryptography_Padding_DecDataTooBig" xml:space="preserve">
+    <value>The data to be decrypted exceeds the maximum for this modulus of {0} bytes.</value>
+  </data>
   <data name="Cryptography_PartialBlock" xml:space="preserve">
     <value>The input data is not a complete block.</value>
   </data>

--- a/src/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
@@ -174,6 +174,9 @@
   <data name="Cryptography_OpenInvalidHandle" xml:space="preserve">
     <value>Cannot open an invalid handle.</value>
   </data>
+  <data name="Cryptography_Padding_DecDataTooBig" xml:space="preserve">
+    <value>The data to be decrypted exceeds the maximum for this modulus of {0} bytes.</value>
+  </data>
   <data name="Cryptography_TlsRequires64ByteSeed" xml:space="preserve">
     <value>The TLS key derivation function requires a seed value of exactly 64 bytes.</value>
   </data>

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -190,6 +190,9 @@
   <data name="Cryptography_OpenInvalidHandle" xml:space="preserve">
     <value>Cannot open an invalid handle.</value>
   </data>
+  <data name="Cryptography_Padding_DecDataTooBig" xml:space="preserve">
+    <value>The data to be decrypted exceeds the maximum for this modulus of {0} bytes.</value>
+  </data>
   <data name="Cryptography_PrivateKey_DoesNotMatch" xml:space="preserve">
     <value>The provided key does not match the public key for this certificate.</value>
   </data>


### PR DESCRIPTION
Also add some more tests to make sure other boundary cases are covered.

Fixes #27590.