### PR TITLE
Fix order of native overlapped freeing in SocketAsyncEventArgs on Windows

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -58,6 +58,7 @@ namespace System.Net.Sockets
 
         private unsafe NativeOverlapped* AllocateNativeOverlapped()
         {
+            Debug.Assert(_operating == InProgress, $"Expected {nameof(_operating)} == {nameof(InProgress)}, got {_operating}");
             Debug.Assert(_currentSocket != null, "_currentSocket is null");
             Debug.Assert(_currentSocket.SafeHandle != null, "_currentSocket.SafeHandle is null");
             Debug.Assert(!_currentSocket.SafeHandle.IsInvalid, "_currentSocket.SafeHandle is invalid");
@@ -70,6 +71,7 @@ namespace System.Net.Sockets
         private unsafe void FreeNativeOverlapped(NativeOverlapped* overlapped)
         {
             Debug.Assert(overlapped != null, "overlapped is null");
+            Debug.Assert(_operating == InProgress, $"Expected _operating == InProgress, got {_operating}");
             Debug.Assert(_currentSocket != null, "_currentSocket is null");
             Debug.Assert(_currentSocket.SafeHandle != null, "_currentSocket.SafeHandle is null");
             Debug.Assert(_currentSocket.SafeHandle.IOCPBoundHandle != null, "_currentSocket.SafeHandle.IOCPBoundHandle is null");
@@ -78,16 +80,16 @@ namespace System.Net.Sockets
             _currentSocket.SafeHandle.IOCPBoundHandle.FreeNativeOverlapped(overlapped);
         }
 
-        private unsafe void FreeNativeOverlappedIfNotPending(NativeOverlapped* overlapped, SocketError error)
+        /// <summary>Handles the result of an IOCP operation.</summary>
+        /// <param name="success">true if the operation completed synchronously and successfully; otherwise, false.</param>
+        /// <param name="bytesTransferred">The number of bytes transferred, if the operation completed synchronously and successfully.</param>
+        /// <param name="overlapped">The overlapped to be freed if the operation completed synchronously.</param>
+        /// <returns>The result status of the operation.</returns>
+        private unsafe SocketError ProcessIOCPResult(bool success, int bytesTransferred, NativeOverlapped* overlapped)
         {
-            if (error != SocketError.IOPending)
-            {
-                FreeNativeOverlapped(overlapped);
-            }
-        }
+            // Note: We need to dispose of the overlapped iff the operation completed synchronously,
+            // and if we do, we must do so before we mark the operation as completed.
 
-        private SocketError ProcessIOCPResult(bool success, int bytesTransferred)
-        {
             if (success)
             {
                 // Synchronous success.
@@ -95,6 +97,7 @@ namespace System.Net.Sockets
                 {
                     // The socket handle is configured to skip completion on success, 
                     // so we can set the results right now.
+                    FreeNativeOverlapped(overlapped);
                     FinishOperationSyncSuccess(bytesTransferred, SocketFlags.None);
                     return SocketError.Success;
                 }
@@ -109,6 +112,7 @@ namespace System.Net.Sockets
                 if (socketError != SocketError.IOPending)
                 {
                     // Completed synchronously with a failure.
+                    FreeNativeOverlapped(overlapped);
                     FinishOperationSyncFailure(socketError, bytesTransferred, SocketFlags.None);
                     return socketError;
                 }
@@ -121,8 +125,16 @@ namespace System.Net.Sockets
             return SocketError.IOPending;
         }
 
-        private SocketError ProcessIOCPResultWithSingleBufferHandle(SocketError socketError, int bytesTransferred)
+        /// <summary>Handles the result of an IOCP operation.</summary>
+        /// <param name="socketError">The result status of the operation, as returned from the API call.</param>
+        /// <param name="bytesTransferred">The number of bytes transferred, if the operation completed synchronously and successfully.</param>
+        /// <param name="overlapped">The overlapped to be freed if the operation completed synchronously.</param>
+        /// <returns>The result status of the operation.</returns>
+        private unsafe SocketError ProcessIOCPResultWithSingleBufferHandle(SocketError socketError, int bytesTransferred, NativeOverlapped* overlapped)
         {
+            // Note: We need to dispose of the overlapped iff the operation completed synchronously,
+            // and if we do, we must do so before we mark the operation as completed.
+
             if (socketError == SocketError.Success)
             {
                 // Synchronous success.
@@ -131,6 +143,7 @@ namespace System.Net.Sockets
                     // The socket handle is configured to skip completion on success, 
                     // so we can set the results right now.
                     _singleBufferHandleState = SingleBufferHandleState.None;
+                    FreeNativeOverlapped(overlapped);
                     FinishOperationSyncSuccess(bytesTransferred, SocketFlags.None);
                     return SocketError.Success;
                 }
@@ -146,6 +159,7 @@ namespace System.Net.Sockets
                 {
                     // Completed synchronously with a failure.
                     _singleBufferHandleState = SingleBufferHandleState.None;
+                    FreeNativeOverlapped(overlapped);
                     FinishOperationSyncFailure(socketError, bytesTransferred, SocketFlags.None);
                     return socketError;
                 }
@@ -165,14 +179,14 @@ namespace System.Net.Sockets
 
         internal unsafe SocketError DoOperationAccept(Socket socket, SafeCloseSocket handle, SafeCloseSocket acceptHandle)
         {
-            SocketError socketError = SocketError.Success;
+            bool userBuffer = _count != 0;
+            Debug.Assert(!userBuffer || (!_buffer.Equals(default) && _count >= _acceptAddressBufferCount));
+            Memory<byte> buffer = userBuffer ? _buffer : _acceptBuffer;
+            Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
+
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
-                bool userBuffer = _count != 0;
-                Debug.Assert(!userBuffer || (!_buffer.Equals(default) && _count >= _acceptAddressBufferCount));
-                Memory<byte> buffer = userBuffer ? _buffer : _acceptBuffer;
-                Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
                 _singleBufferHandle = buffer.Retain(pin: true);
                 _singleBufferHandleState = SingleBufferHandleState.Set;
 
@@ -186,18 +200,14 @@ namespace System.Net.Sockets
                     out int bytesTransferred,
                     overlapped);
 
-                socketError = ProcessIOCPResult(success, bytesTransferred);
-                return socketError;
+                return ProcessIOCPResult(success, bytesTransferred, overlapped);
             }
             catch
             {
+                FreeNativeOverlapped(overlapped);
                 _singleBufferHandle.Dispose();
                 _singleBufferHandleState = SingleBufferHandleState.None;
                 throw;
-            }
-            finally
-            {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
             }
         }
 
@@ -208,7 +218,6 @@ namespace System.Net.Sockets
             // The sockaddr is pinned with a GCHandle to avoid having to use the object array form of UnsafePack.
             PinSocketAddressBuffer();
 
-            SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
@@ -225,24 +234,19 @@ namespace System.Net.Sockets
                     out int bytesTransferred,
                     overlapped);
 
-                socketError = ProcessIOCPResult(success, bytesTransferred);
-                return socketError;
+                return ProcessIOCPResult(success, bytesTransferred, overlapped);
             }
             catch
             {
+                FreeNativeOverlapped(overlapped);
                 _singleBufferHandle.Dispose();
                 _singleBufferHandleState = SingleBufferHandleState.None;
                 throw;
-            }
-            finally
-            {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
             }
         }
 
         internal unsafe SocketError DoOperationDisconnect(Socket socket, SafeCloseSocket handle)
         {
-            SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
@@ -252,12 +256,12 @@ namespace System.Net.Sockets
                     (int)(DisconnectReuseSocket ? TransmitFileOptions.ReuseSocket : 0),
                     0);
 
-                socketError = ProcessIOCPResult(success, 0);
-                return socketError;
+                return ProcessIOCPResult(success, 0, overlapped);
             }
-            finally
+            catch
             {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                FreeNativeOverlapped(overlapped);
+                throw;
             }
         }
 
@@ -267,18 +271,17 @@ namespace System.Net.Sockets
 
         internal unsafe SocketError DoOperationReceiveSingleBuffer(SafeCloseSocket handle)
         {
-            SocketError socketError = SocketError.Success;
-            NativeOverlapped* overlapped = AllocateNativeOverlapped();
-            try
+            fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
-                fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
-                {
-                    Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None, $"Expected None, got {_singleBufferHandleState}");
-                    _singleBufferHandleState = SingleBufferHandleState.InProcess;
-                    var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
-                    SocketFlags flags = _socketFlags;
+                Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None, $"Expected None, got {_singleBufferHandleState}");
+                _singleBufferHandleState = SingleBufferHandleState.InProcess;
+                var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
-                    socketError = Interop.Winsock.WSARecv(
+                NativeOverlapped* overlapped = AllocateNativeOverlapped();
+                try
+                {
+                    SocketFlags flags = _socketFlags;
+                    SocketError socketError = Interop.Winsock.WSARecv(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref wsaBuffer,
                         1,
@@ -288,29 +291,24 @@ namespace System.Net.Sockets
                         IntPtr.Zero);
                     GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
-                    socketError = ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred);
+                    return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped);
                 }
-                return socketError;
-            }
-            catch
-            {
-                _singleBufferHandleState = SingleBufferHandleState.None;
-                throw;
-            }
-            finally
-            {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                catch
+                {
+                    FreeNativeOverlapped(overlapped);
+                    _singleBufferHandleState = SingleBufferHandleState.None;
+                    throw;
+                }
             }
         }
 
         internal unsafe SocketError DoOperationReceiveMultiBuffer(SafeCloseSocket handle)
         {
-            SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
                 SocketFlags flags = _socketFlags;
-                socketError = Interop.Winsock.WSARecv(
+                SocketError socketError = Interop.Winsock.WSARecv(
                     handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     _wsaBufferArray,
                     _bufferListInternal.Count,
@@ -320,12 +318,12 @@ namespace System.Net.Sockets
                     IntPtr.Zero);
                 GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
-                socketError = ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
-                return socketError;
+                return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred, overlapped);
             }
-            finally
+            catch
             {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                FreeNativeOverlapped(overlapped);
+                throw;
             }
         }
 
@@ -345,19 +343,17 @@ namespace System.Net.Sockets
 
         internal unsafe SocketError DoOperationReceiveFromSingleBuffer(SafeCloseSocket handle)
         {
-
-            SocketError socketError = SocketError.Success;
-            NativeOverlapped* overlapped = AllocateNativeOverlapped();
-            try
+            fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
-                fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
-                {
-                    Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
-                    _singleBufferHandleState = SingleBufferHandleState.InProcess;
-                    var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
-                    SocketFlags flags = _socketFlags;
+                Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
+                _singleBufferHandleState = SingleBufferHandleState.InProcess;
+                var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
-                    socketError = Interop.Winsock.WSARecvFrom(
+                NativeOverlapped* overlapped = AllocateNativeOverlapped();
+                try
+                {
+                    SocketFlags flags = _socketFlags;
+                    SocketError socketError = Interop.Winsock.WSARecvFrom(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref wsaBuffer,
                         1,
@@ -369,30 +365,24 @@ namespace System.Net.Sockets
                         IntPtr.Zero);
                     GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
-                    socketError = ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred);
-                    return socketError;
+                    return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped);
                 }
-            }
-            catch
-            {
-                _singleBufferHandleState = SingleBufferHandleState.None;
-                throw;
-            }
-            finally
-            {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                catch
+                {
+                    FreeNativeOverlapped(overlapped);
+                    _singleBufferHandleState = SingleBufferHandleState.None;
+                    throw;
+                }
             }
         }
 
         internal unsafe SocketError DoOperationReceiveFromMultiBuffer(SafeCloseSocket handle)
         {
-
-            SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
                 SocketFlags flags = _socketFlags;
-                socketError = Interop.Winsock.WSARecvFrom(
+                SocketError socketError = Interop.Winsock.WSARecvFrom(
                     handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     _wsaBufferArray,
                     _bufferListInternal.Count,
@@ -404,12 +394,12 @@ namespace System.Net.Sockets
                     IntPtr.Zero);
                 GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
-                socketError = ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
-                return socketError;
+                return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred, overlapped);
             }
-            finally
+            catch
             {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                FreeNativeOverlapped(overlapped);
+                throw;
             }
         }
 
@@ -522,29 +512,24 @@ namespace System.Net.Sockets
                 pMessage->flags = _socketFlags;
             }
 
-            SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
-                socketError = socket.WSARecvMsg(
+                SocketError socketError = socket.WSARecvMsg(
                     handle,
                     Marshal.UnsafeAddrOfPinnedArrayElement(_wsaMessageBuffer, 0),
                     out int bytesTransferred,
                     overlapped,
                     IntPtr.Zero);
 
-                socketError = ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred);
-                return socketError;
+                return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped);
             }
             catch
             {
+                FreeNativeOverlapped(overlapped);
                 _singleBufferHandle.Dispose();
                 _singleBufferHandleState = SingleBufferHandleState.None;
                 throw;
-            }
-            finally
-            {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
             }
         }
 
@@ -554,17 +539,16 @@ namespace System.Net.Sockets
 
         internal unsafe SocketError DoOperationSendSingleBuffer(SafeCloseSocket handle)
         {
-            SocketError socketError = SocketError.Success;
-            NativeOverlapped* overlapped = AllocateNativeOverlapped();
-            try
+            fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
-                fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
-                {
-                    Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
-                    _singleBufferHandleState = SingleBufferHandleState.InProcess;
-                    var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
+                Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
+                _singleBufferHandleState = SingleBufferHandleState.InProcess;
+                var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
-                    socketError = Interop.Winsock.WSASend(
+                NativeOverlapped* overlapped = AllocateNativeOverlapped();
+                try
+                {
+                    SocketError socketError = Interop.Winsock.WSASend(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref wsaBuffer,
                         1,
@@ -574,28 +558,23 @@ namespace System.Net.Sockets
                         IntPtr.Zero);
                     GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
-                    socketError = ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred);
-                    return socketError;
+                    return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped);
                 }
-            }
-            catch
-            {
-                _singleBufferHandleState = SingleBufferHandleState.None;
-                throw;
-            }
-            finally
-            {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                catch
+                {
+                    FreeNativeOverlapped(overlapped);
+                    _singleBufferHandleState = SingleBufferHandleState.None;
+                    throw;
+                }
             }
         }
 
         internal unsafe SocketError DoOperationSendMultiBuffer(SafeCloseSocket handle)
         {
-            SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
-                socketError = Interop.Winsock.WSASend(
+                SocketError socketError = Interop.Winsock.WSASend(
                     handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     _wsaBufferArray,
                     _bufferListInternal.Count,
@@ -605,12 +584,12 @@ namespace System.Net.Sockets
                     IntPtr.Zero);
                 GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
-                socketError = ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
-                return socketError;
+                return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred, overlapped);
             }
-            finally
+            catch
             {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                FreeNativeOverlapped(overlapped);
+                throw;
             }
         }
 
@@ -697,7 +676,6 @@ namespace System.Net.Sockets
             Debug.Assert(_multipleBufferGCHandles[0].IsAllocated);
             Debug.Assert(_multipleBufferGCHandles[0].Target == sendPacketsDescriptor);
 
-            SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
@@ -709,12 +687,12 @@ namespace System.Net.Sockets
                     overlapped,
                     _sendPacketsFlags);
 
-                socketError = ProcessIOCPResult(result, 0);
-                return socketError;
+                return ProcessIOCPResult(result, 0, overlapped);
             }
-            finally
+            catch
             {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                FreeNativeOverlapped(overlapped);
+                throw;
             }
         }
 
@@ -735,17 +713,16 @@ namespace System.Net.Sockets
 
         internal unsafe SocketError DoOperationSendToSingleBuffer(SafeCloseSocket handle)
         {
-            SocketError socketError = SocketError.Success;
-            NativeOverlapped* overlapped = AllocateNativeOverlapped();
-            try
+            fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
-                fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
-                {
-                    Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
-                    _singleBufferHandleState = SingleBufferHandleState.InProcess;
-                    var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
+                Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
+                _singleBufferHandleState = SingleBufferHandleState.InProcess;
+                var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
-                    socketError = Interop.Winsock.WSASendTo(
+                NativeOverlapped* overlapped = AllocateNativeOverlapped();
+                try
+                {
+                    SocketError socketError = Interop.Winsock.WSASendTo(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref wsaBuffer,
                         1,
@@ -757,28 +734,23 @@ namespace System.Net.Sockets
                         IntPtr.Zero);
                     GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
-                    socketError = ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred);
-                    return socketError;
+                    return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped);
                 }
-            }
-            catch
-            {
-                _singleBufferHandleState = SingleBufferHandleState.None;
-                throw;
-            }
-            finally
-            {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                catch
+                {
+                    FreeNativeOverlapped(overlapped);
+                    _singleBufferHandleState = SingleBufferHandleState.None;
+                    throw;
+                }
             }
         }
 
         internal unsafe SocketError DoOperationSendToMultiBuffer(SafeCloseSocket handle)
         {
-            SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
-                socketError = Interop.Winsock.WSASendTo(
+                SocketError socketError = Interop.Winsock.WSASendTo(
                     handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     _wsaBufferArray,
                     _bufferListInternal.Count,
@@ -790,12 +762,12 @@ namespace System.Net.Sockets
                     IntPtr.Zero);
                 GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
-                socketError = ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
-                return socketError;
+                return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred, overlapped);
             }
-            finally
+            catch
             {
-                FreeNativeOverlappedIfNotPending(overlapped, socketError);
+                FreeNativeOverlapped(overlapped);
+                throw;
             }
         }
 


### PR DESCRIPTION
SocketAsyncEventArgs tracks its disposal, and if it's disposed while an async operation is in flight, it delays the actual disposal until the operation completes.  That disposal includes disposing of the PreAllocatedOverlapped used for async operations.  When an operation is initiated, if the operation completes synchronously, then the NativeOverlapped associated with that PreAllocatedOverlapped is freed in a finally block once the operation completes synchronously.  But if during the operation the SAEA is disposed of, then the PreAllocatedOverlapped can get disposed of before the finally block.

The fix is to ensure we clean up the NativeOverlapped before completing the operation.  This was already handled correctly when an operation completed asynchronously, it just needed to be fixed for when it completes synchronously.  As a happy side-effect, fixing this also cleans up the call sites a bit.

(This was highlighted by an assert once we switched Socket.WriteAsync to return a ValueTask instead of a Task, because the way it was done means that when the Socket is disposed, the associated SocketAsyncEventArgs will be disposed, and SocketsHttpHandler is aggressive about disposing of the Socket as a way to enable cancellation, so the assert was triggering not-infrequently when running the System.Net.Http tests, especially in CI.)

Fixes https://github.com/dotnet/corefx/issues/27721
cc: @geoffkizer, @davidsh