### PR TITLE
Fix Utf8ParserFormatter test culture settings dependency

### DIFF
--- a/src/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Globalization;
 using System.Numerics;
 using System.Collections.Generic;
 
@@ -212,8 +213,8 @@ namespace System.Buffers.Text.Tests
                     for (int offset = -20; offset <= 0; offset++)
                     {
                         BigInteger bigValue = maxValue + offset;
-                        string textD = bigValue.ToString("D");
-                        string text = bigValue.ToString(format.Symbol.ToString());
+                        string textD = bigValue.ToString("D", CultureInfo.InvariantCulture);
+                        string text = bigValue.ToString(format.Symbol.ToString(), CultureInfo.InvariantCulture);
                         T expectedValue = (T)(Convert.ChangeType(textD, typeof(T)));
                         yield return new ParserTestData<T>(text, expectedValue, format.Symbol, expectedSuccess: true);
                     }
@@ -222,13 +223,13 @@ namespace System.Buffers.Text.Tests
                     for (int offset = 1; offset <= 20; offset++)
                     {
                         BigInteger bigValue = maxValue + offset;
-                        string text = bigValue.ToString(format.Symbol.ToString());
+                        string text = bigValue.ToString(format.Symbol.ToString(), CultureInfo.InvariantCulture);
                         yield return new ParserTestData<T>(text, default, format.Symbol, expectedSuccess: false);
                     }
 
                     {
                         BigInteger bigValue = maxValue * 10;
-                        string text = bigValue.ToString(format.Symbol.ToString());
+                        string text = bigValue.ToString(format.Symbol.ToString(), CultureInfo.InvariantCulture);
                         yield return new ParserTestData<T>(text, default, format.Symbol, expectedSuccess: false);
                     }
 
@@ -238,8 +239,8 @@ namespace System.Buffers.Text.Tests
                         for (int offset = 0; offset <= 20; offset++)
                         {
                             BigInteger bigValue = minValue + offset;
-                            string textD = bigValue.ToString("D");
-                            string text = bigValue.ToString(format.Symbol.ToString());
+                            string textD = bigValue.ToString("D", CultureInfo.InvariantCulture);
+                            string text = bigValue.ToString(format.Symbol.ToString(), CultureInfo.InvariantCulture);
                             T expectedValue = (T)(Convert.ChangeType(textD, typeof(T)));
                             yield return new ParserTestData<T>(text, expectedValue, format.Symbol, expectedSuccess: true);
                         }
@@ -248,13 +249,13 @@ namespace System.Buffers.Text.Tests
                         for (int offset = -20; offset <= -1; offset++)
                         {
                             BigInteger bigValue = minValue + offset;
-                            string text = bigValue.ToString(format.Symbol.ToString());
+                            string text = bigValue.ToString(format.Symbol.ToString(), CultureInfo.InvariantCulture);
                             yield return new ParserTestData<T>(text, default, format.Symbol, expectedSuccess: false);
                         }
 
                         {
                             BigInteger bigValue = minValue * 10;
-                            string text = bigValue.ToString(format.Symbol.ToString());
+                            string text = bigValue.ToString(format.Symbol.ToString(), CultureInfo.InvariantCulture);
                             yield return new ParserTestData<T>(text, default, format.Symbol, expectedSuccess: false);
                         }
                     }

--- a/src/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.TimeSpan.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.TimeSpan.cs
@@ -4,6 +4,7 @@
 
 using System.Text;
 using System.Linq;
+using System.Globalization;
 using System.Collections.Generic;
 
 namespace System.Buffers.Text.Tests
@@ -45,7 +46,7 @@ namespace System.Buffers.Text.Tests
                         StringBuilder sb = new StringBuilder();
                         for (int i = 0; i < numComponents; i++)
                         {
-                            sb.Append((20 + i).ToString());
+                            sb.Append((20 + i).ToString("D", CultureInfo.InvariantCulture));
                             if (i != numComponents - 1)
                             {
                                 char separator = ((separatorMask & (1 << i)) != 0) ? '.' : ':';

--- a/src/System.Memory/tests/ParsersAndFormatters/PseudoDateTime.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/PseudoDateTime.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 namespace System.Buffers.Text.Tests
 {
     //
@@ -38,9 +40,9 @@ namespace System.Buffers.Text.Tests
                 if (Fraction != 0)
                     return null;
 
-                return Month.ToString("D2") + "/" + Day.ToString("D2") + "/" + Year.ToString("D4") +
-                    " " + Hour.ToString("D2") + ":" + Minute.ToString("D2") + ":" + Second.ToString("D2") +
-                    " " + (OffsetNegative ? "-" : "+") + OffsetHours.ToString("D2") + ":" + OffsetMinutes.ToString("D2");
+                return Month.ToString("D2", CultureInfo.InvariantCulture) + "/" + Day.ToString("D2", CultureInfo.InvariantCulture) + "/" + Year.ToString("D4", CultureInfo.InvariantCulture) +
+                    " " + Hour.ToString("D2", CultureInfo.InvariantCulture) + ":" + Minute.ToString("D2", CultureInfo.InvariantCulture) + ":" + Second.ToString("D2", CultureInfo.InvariantCulture) +
+                    " " + (OffsetNegative ? "-" : "+") + OffsetHours.ToString("D2", CultureInfo.InvariantCulture) + ":" + OffsetMinutes.ToString("D2", CultureInfo.InvariantCulture);
             }
         }
 
@@ -53,8 +55,8 @@ namespace System.Buffers.Text.Tests
                 if (OffsetHours != 0 || OffsetMinutes != 0)
                     return null;
 
-                return Month.ToString("D2") + "/" + Day.ToString("D2") + "/" + Year.ToString("D4") +
-                    " " + Hour.ToString("D2") + ":" + Minute.ToString("D2") + ":" + Second.ToString("D2");
+                return Month.ToString("D2", CultureInfo.InvariantCulture) + "/" + Day.ToString("D2", CultureInfo.InvariantCulture) + "/" + Year.ToString("D4", CultureInfo.InvariantCulture) +
+                    " " + Hour.ToString("D2", CultureInfo.InvariantCulture) + ":" + Minute.ToString("D2", CultureInfo.InvariantCulture) + ":" + Second.ToString("D2", CultureInfo.InvariantCulture);
             }
         }
 
@@ -94,8 +96,8 @@ namespace System.Buffers.Text.Tests
                     monthAbbrevation = "Jan";
                 }
 
-                return dayAbbreviation + ", " + Day.ToString("D2") + " " + monthAbbrevation + " " + Year.ToString("D4") + " "
-                    + Hour.ToString("D2") + ":" + Minute.ToString("D2") + ":" + Second.ToString("D2") + " "
+                return dayAbbreviation + ", " + Day.ToString("D2", CultureInfo.InvariantCulture) + " " + monthAbbrevation + " " + Year.ToString("D4", CultureInfo.InvariantCulture) + " "
+                    + Hour.ToString("D2", CultureInfo.InvariantCulture) + ":" + Minute.ToString("D2", CultureInfo.InvariantCulture) + ":" + Second.ToString("D2", CultureInfo.InvariantCulture) + " "
                     + "GMT";
             }
         }
@@ -109,8 +111,8 @@ namespace System.Buffers.Text.Tests
                 if (OffsetHours != 0 || OffsetMinutes != 0)
                     return null;
 
-                return Year.ToString("D4") + "-" + Month.ToString("D2") + "-" + Day.ToString("D2") + "T"
-                    + Hour.ToString("D2") + ":" + Minute.ToString("D2") + ":" + Second.ToString("D2")
+                return Year.ToString("D4", CultureInfo.InvariantCulture) + "-" + Month.ToString("D2", CultureInfo.InvariantCulture) + "-" + Day.ToString("D2", CultureInfo.InvariantCulture) + "T"
+                    + Hour.ToString("D2", CultureInfo.InvariantCulture) + ":" + Minute.ToString("D2", CultureInfo.InvariantCulture) + ":" + Second.ToString("D2", CultureInfo.InvariantCulture)
                     + "." + Fraction.ToString("D7");
             }
         }
@@ -120,10 +122,10 @@ namespace System.Buffers.Text.Tests
         {
             get
             {
-                return Year.ToString("D4") + "-" + Month.ToString("D2") + "-" + Day.ToString("D2") + "T"
-                    + Hour.ToString("D2") + ":" + Minute.ToString("D2") + ":" + Second.ToString("D2")
-                    + "." + Fraction.ToString("D7")
-                    + (OffsetNegative ? "-" : "+") + OffsetHours.ToString("D2") + ":" + OffsetMinutes.ToString("D2");
+                return Year.ToString("D4", CultureInfo.InvariantCulture) + "-" + Month.ToString("D2", CultureInfo.InvariantCulture) + "-" + Day.ToString("D2", CultureInfo.InvariantCulture) + "T"
+                    + Hour.ToString("D2", CultureInfo.InvariantCulture) + ":" + Minute.ToString("D2", CultureInfo.InvariantCulture) + ":" + Second.ToString("D2", CultureInfo.InvariantCulture)
+                    + "." + Fraction.ToString("D7", CultureInfo.InvariantCulture)
+                    + (OffsetNegative ? "-" : "+") + OffsetHours.ToString("D2", CultureInfo.InvariantCulture) + ":" + OffsetMinutes.ToString("D2", CultureInfo.InvariantCulture);
             }
         }
 

--- a/src/System.Memory/tests/ParsersAndFormatters/TestData.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/TestData.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Globalization;
 using System.Collections.Generic;
 
 namespace System.Buffers.Text.Tests
@@ -397,16 +398,16 @@ namespace System.Buffers.Text.Tests
                 yield return "0.000045";
                 yield return "000000123.000045";
 
-                yield return decimal.MinValue.ToString("G");
-                yield return decimal.MaxValue.ToString("G");
+                yield return decimal.MinValue.ToString("G", CultureInfo.InvariantCulture);
+                yield return decimal.MaxValue.ToString("G", CultureInfo.InvariantCulture);
 
-                yield return float.MinValue.ToString("G9");
-                yield return float.MaxValue.ToString("G9");
-                yield return float.Epsilon.ToString("G9");
+                yield return float.MinValue.ToString("G9", CultureInfo.InvariantCulture);
+                yield return float.MaxValue.ToString("G9", CultureInfo.InvariantCulture);
+                yield return float.Epsilon.ToString("G9", CultureInfo.InvariantCulture);
 
-                yield return double.MinValue.ToString("G17");
-                yield return double.MaxValue.ToString("G17");
-                yield return double.Epsilon.ToString("G9");
+                yield return double.MinValue.ToString("G17", CultureInfo.InvariantCulture);
+                yield return double.MaxValue.ToString("G17", CultureInfo.InvariantCulture);
+                yield return double.Epsilon.ToString("G9", CultureInfo.InvariantCulture);
 
                 yield return "1e";
                 yield return "1e+";

--- a/src/System.Memory/tests/ParsersAndFormatters/TestUtils.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/TestUtils.cs
@@ -62,7 +62,7 @@ namespace System.Buffers.Text.Tests
 
                 string sign = isNegative ? "-" : "+";
 
-                return "[" + sign + dec.ToString("G") + ", scale=" + scale + "]";
+                return "[" + sign + dec.ToString("G", CultureInfo.InvariantCulture) + ", scale=" + scale + "]";
             }
             else if (value is TimeSpan timeSpan)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/27664

Make sure we're always using the invariant culture
when generating test data using the classic .NET api.