### PR TITLE
SocketsHttpHandler: Change caching of Host header value to include port when necessary

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -112,7 +112,7 @@ namespace System.Net.Http
                 // Precalculate ASCII bytes for Host header
                 // Note that if _host is null, this is a (non-tunneled) proxy connection, and we can't cache the hostname.
                 string hostHeader =
-                    ((_sslOptions == null) ? _port != DefaultHttpPort : _port != DefaultHttpsPort) ?
+                    (_port != (_sslOptions == null ? DefaultHttpPort : DefaultHttpsPort)) ?
                     $"{_host}:{_port}" :
                     _host;
 


### PR DESCRIPTION
We already cache the hostname part of the header value.  Change this so the cached value includes the port as well when using a non-default port.

@stephentoub @davidsh 