### PR TITLE
Add async overloads to SslOverTdsStream

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -22,9 +22,7 @@ namespace System.Data.SqlClient.SNI
 
         private readonly string _targetServer;
         private readonly object _callbackObject;
-        private readonly TaskScheduler _writeScheduler;
-        private readonly TaskFactory _writeTaskFactory;
-
+        
         private Stream _stream;
         private NamedPipeClientStream _pipeStream;
         private SslOverTdsStream _sslOverTdsStream;
@@ -41,8 +39,6 @@ namespace System.Data.SqlClient.SNI
         {
             _targetServer = serverName;
             _callbackObject = callbackObject;
-            _writeScheduler = new ConcurrentExclusiveSchedulerPair().ExclusiveScheduler;
-            _writeTaskFactory = new TaskFactory(_writeScheduler);
 
             try
             {
@@ -222,43 +218,11 @@ namespace System.Data.SqlClient.SNI
 
         public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
         {
-            SNIPacket newPacket = packet;
-
-            _writeTaskFactory.StartNew(() =>
+            SNIAsyncCallback cb = callback ?? _sendCallback;
+            lock (this)
             {
-                try
-                {
-                    lock (this)
-                    {
-                        packet.WriteToStream(_stream);
-                    }
-                }
-                catch (Exception e)
-                {
-                    SNICommon.ReportSNIError(SNIProviders.NP_PROV, SNICommon.InternalExceptionError, e);
-
-                    if (callback != null)
-                    {
-                        callback(packet, TdsEnums.SNI_ERROR);
-                    }
-                    else
-                    {
-                        _sendCallback(packet, TdsEnums.SNI_ERROR);
-                    }
-
-                    return;
-                }
-
-                if (callback != null)
-                {
-                    callback(packet, TdsEnums.SNI_SUCCESS);
-                }
-                else
-                {
-                    _sendCallback(packet, TdsEnums.SNI_SUCCESS);
-                }
-            });
-
+                packet.WriteToStreamAsync(_stream, cb, SNIProviders.NP_PROV);
+            }
             return TdsEnums.SNI_SUCCESS_IO_PENDING;
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -175,24 +175,21 @@ namespace System.Data.SqlClient.SNI
 
         public override uint ReceiveAsync(ref SNIPacket packet, bool isMars = false)
         {
-            lock (this)
-            {
-                packet = new SNIPacket(null);
-                packet.Allocate(_bufferSize);
+            packet = new SNIPacket(null);
+            packet.Allocate(_bufferSize);
 
-                try
-                {
-                    packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
-                    return TdsEnums.SNI_SUCCESS_IO_PENDING;
-                }
-                catch (ObjectDisposedException ode)
-                {
-                    return ReportErrorAndReleasePacket(packet, ode);
-                }
-                catch (IOException ioe)
-                {
-                    return ReportErrorAndReleasePacket(packet, ioe);
-                }
+            try
+            {
+                packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
+                return TdsEnums.SNI_SUCCESS_IO_PENDING;
+            }
+            catch (ObjectDisposedException ode)
+            {
+                return ReportErrorAndReleasePacket(packet, ode);
+            }
+            catch (IOException ioe)
+            {
+                return ReportErrorAndReleasePacket(packet, ioe);
             }
         }
 
@@ -219,10 +216,7 @@ namespace System.Data.SqlClient.SNI
         public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
         {
             SNIAsyncCallback cb = callback ?? _sendCallback;
-            lock (this)
-            {
-                packet.WriteToStreamAsync(_stream, cb, SNIProviders.NP_PROV);
-            }
+            packet.WriteToStreamAsync(_stream, cb, SNIProviders.NP_PROV);
             return TdsEnums.SNI_SUCCESS_IO_PENDING;
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -302,16 +302,16 @@ namespace System.Data.SqlClient.SNI
         /// Write data to a stream asynchronously
         /// </summary>
         /// <param name="stream">Stream to write to</param>
-        public async void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback)
+        public async void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback, SNIProviders provider)
         {
             uint status = TdsEnums.SNI_SUCCESS;
             try
             {
-                await stream.WriteAsync(_data, 0, _length, CancellationToken.None);
+                await stream.WriteAsync(_data, 0, _length, CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception e)
             {
-                SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InternalExceptionError, e);
+                SNILoadHandle.SingletonInstance.LastError = new SNIError(provider, SNICommon.InternalExceptionError, e);
                 status = TdsEnums.SNI_ERROR;
             }
             callback(this, status);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -249,7 +249,7 @@ namespace System.Data.SqlClient.SNI
                 options |= TaskContinuationOptions.LongRunning;
             }
 
-            stream.ReadAsync(_data, 0, _capacity).ContinueWith(t =>
+            stream.ReadAsync(_data, 0, _capacity, CancellationToken.None).ContinueWith(t =>
             {
                 Exception e = t.Exception != null ? t.Exception.InnerException : null;
                 if (e != null)
@@ -296,6 +296,25 @@ namespace System.Data.SqlClient.SNI
         public void WriteToStream(Stream stream)
         {
             stream.Write(_data, 0, _length);
+        }
+
+        /// <summary>
+        /// Write data to a stream asynchronously
+        /// </summary>
+        /// <param name="stream">Stream to write to</param>
+        public async void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback)
+        {
+            uint status = TdsEnums.SNI_SUCCESS;
+            try
+            {
+                await stream.WriteAsync(_data, 0, _length, CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InternalExceptionError, e);
+                status = TdsEnums.SNI_ERROR;
+            }
+            callback(this, status);
         }
 
         /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -529,7 +529,7 @@ namespace System.Data.SqlClient.SNI
             SNIAsyncCallback cb = callback ?? _sendCallback;
             lock(this)
             {
-                packet.WriteToStreamAsync(_stream, cb);
+                packet.WriteToStreamAsync(_stream, cb, SNIProviders.TCP_PROV);
             }
             return TdsEnums.SNI_SUCCESS_IO_PENDING;
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -541,28 +541,25 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint ReceiveAsync(ref SNIPacket packet, bool isMars = false)
         {
-            lock (this)
-            {
-                packet = new SNIPacket(null);
-                packet.Allocate(_bufferSize);
+            packet = new SNIPacket(null);
+            packet.Allocate(_bufferSize);
 
-                try
-                {
-                    packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
-                    return TdsEnums.SNI_SUCCESS_IO_PENDING;
-                }
-                catch (ObjectDisposedException ode)
-                {
-                    return ReportErrorAndReleasePacket(packet, ode);
-                }
-                catch (SocketException se)
-                {
-                    return ReportErrorAndReleasePacket(packet, se);
-                }
-                catch (IOException ioe)
-                {
-                    return ReportErrorAndReleasePacket(packet, ioe);
-                }
+            try
+            {
+                packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
+                return TdsEnums.SNI_SUCCESS_IO_PENDING;
+            }
+            catch (ObjectDisposedException ode)
+            {
+                return ReportErrorAndReleasePacket(packet, ode);
+            }
+            catch (SocketException se)
+            {
+                return ReportErrorAndReleasePacket(packet, se);
+            }
+            catch (IOException ioe)
+            {
+                return ReportErrorAndReleasePacket(packet, ioe);
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -4,13 +4,11 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -27,9 +25,7 @@ namespace System.Data.SqlClient.SNI
         private readonly object _callbackObject;
         private readonly Socket _socket;
         private NetworkStream _tcpStream;
-        private readonly TaskScheduler _writeScheduler;
-        private readonly TaskFactory _writeTaskFactory;
-
+        
         private Stream _stream;
         private SslStream _sslStream;
         private SslOverTdsStream _sslOverTdsStream;
@@ -104,8 +100,6 @@ namespace System.Data.SqlClient.SNI
         /// <param name="callbackObject">Callback object</param>
         public SNITCPHandle(string serverName, int port, long timerExpire, object callbackObject, bool parallel)
         {
-            _writeScheduler = new ConcurrentExclusiveSchedulerPair().ExclusiveScheduler;
-            _writeTaskFactory = new TaskFactory(_writeScheduler);
             _callbackObject = callbackObject;
             _targetServer = serverName;
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -549,17 +549,9 @@ namespace System.Data.SqlClient.SNI
                 packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
                 return TdsEnums.SNI_SUCCESS_IO_PENDING;
             }
-            catch (ObjectDisposedException ode)
+            catch (Exception e) when (e is ObjectDisposedException || e is SocketException || e is IOException)
             {
-                return ReportErrorAndReleasePacket(packet, ode);
-            }
-            catch (SocketException se)
-            {
-                return ReportErrorAndReleasePacket(packet, se);
-            }
-            catch (IOException ioe)
-            {
-                return ReportErrorAndReleasePacket(packet, ioe);
+                return ReportErrorAndReleasePacket(packet, e);
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
@@ -4,6 +4,8 @@
 
 using System.IO;
 using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Data.SqlClient.SNI
 {
@@ -49,6 +51,51 @@ namespace System.Data.SqlClient.SNI
         /// <returns>Bytes read</returns>
         public override int Read(byte[] buffer, int offset, int count)
         {
+            return ReadInternal(buffer, offset, count, CancellationToken.None, false).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Write Buffer
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        public override void Write(byte[] buffer, int offset, int count)
+            => WriteInternal(buffer, offset, count, CancellationToken.None, false).Wait();
+
+        /// <summary>
+        /// Write Buffer Asynchronosly
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token)
+            => WriteInternal(buffer, offset, count, token, true);
+
+        /// <summary>
+        /// Read Buffer Asynchronosly
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken token)
+            => ReadInternal(buffer, offset, count, token, true);
+
+        /// <summary>
+        /// Read Internal is called synchronosly when async is false
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        /// <param name="token"></param>
+        /// <param name="async"></param>
+        /// <returns></returns>
+        private async Task<int> ReadInternal(byte[] buffer, int offset, int count, CancellationToken token, bool async)
+        {
             int readBytes = 0;
             byte[] packetData = new byte[count < TdsEnums.HEADER_LEN ? TdsEnums.HEADER_LEN : count];
 
@@ -59,7 +106,14 @@ namespace System.Data.SqlClient.SNI
                     // Account for split packets
                     while (readBytes < TdsEnums.HEADER_LEN)
                     {
-                        readBytes += _stream.Read(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes);
+                        if (async)
+                        {
+                            readBytes += await _stream.ReadAsync(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes, token).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            readBytes += _stream.Read(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes);
+                        }
                     }
 
                     _packetBytes = (packetData[TdsEnums.HEADER_LEN_FIELD_OFFSET] << 8) | packetData[TdsEnums.HEADER_LEN_FIELD_OFFSET + 1];
@@ -72,7 +126,14 @@ namespace System.Data.SqlClient.SNI
                 }
             }
 
-            readBytes = _stream.Read(packetData, 0, count);
+            if (async)
+            {
+                readBytes = await _stream.ReadAsync(packetData, 0, count, token).ConfigureAwait(false);
+            }
+            else
+            {
+                readBytes = _stream.Read(packetData, 0, count);
+            }
 
             if (_encapsulate)
             {
@@ -84,12 +145,15 @@ namespace System.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Write buffer
+        /// The internal write method calls Sync APIs when Async flag is false
         /// </summary>
-        /// <param name="buffer">Buffer</param>
-        /// <param name="offset">Offset</param>
-        /// <param name="count">Byte count</param>
-        public override void Write(byte[] buffer, int offset, int count)
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        /// <param name="token"></param>
+        /// <param name="async"></param>
+        /// <returns></returns>
+        private async Task WriteInternal(byte[] buffer, int offset, int count, CancellationToken token, bool async)
         {
             int currentCount = 0;
             int currentOffset = offset;
@@ -127,25 +191,48 @@ namespace System.Data.SqlClient.SNI
                     combinedBuffer[6] = 0;
                     combinedBuffer[7] = 0;
 
-                    for(int i = TdsEnums.HEADER_LEN; i < combinedBuffer.Length; i++)
+                    for (int i = TdsEnums.HEADER_LEN; i < combinedBuffer.Length; i++)
                     {
                         combinedBuffer[i] = buffer[currentOffset + (i - TdsEnums.HEADER_LEN)];
                     }
 
-                    _stream.Write(combinedBuffer, 0, combinedBuffer.Length);
+                    if (async)
+                    {
+                        await _stream.WriteAsync(combinedBuffer, 0, combinedBuffer.Length, token).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _stream.Write(combinedBuffer, 0, combinedBuffer.Length);
+                    }
                 }
                 else
                 {
                     currentCount = count;
                     count = 0;
 
-                    _stream.Write(buffer, currentOffset, currentCount);
+                    if (async)
+                    {
+                        await _stream.WriteAsync(buffer, currentOffset, currentCount, token).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _stream.Write(buffer, currentOffset, currentCount);
+                    }
                 }
 
-                _stream.Flush();
+                if (async)
+                {
+                    await _stream.FlushAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    _stream.Flush();
+                }
+
                 currentOffset += currentCount;
             }
         }
+
 
         /// <summary>
         /// Set stream length. 
@@ -194,6 +281,7 @@ namespace System.Data.SqlClient.SNI
         {
             throw new NotSupportedException();
         }
+
 
         /// <summary>
         /// Check if stream can be read from

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
@@ -209,7 +209,6 @@ namespace System.Data.SqlClient.SNI
             }
         }
 
-
         /// <summary>
         /// Set stream length. 
         /// </summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
@@ -49,10 +49,8 @@ namespace System.Data.SqlClient.SNI
         /// <param name="offset">Offset</param>
         /// <param name="count">Byte count</param>
         /// <returns>Bytes read</returns>
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            return ReadInternal(buffer, offset, count, CancellationToken.None, false).GetAwaiter().GetResult();
-        }
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadInternal(buffer, offset, count, CancellationToken.None, false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Write Buffer


### PR DESCRIPTION
Added `ReadAsync` and `WriteAsync` overloads to SslOverTdsStream in SqlClient so that the async apis over encrypted connection are full async instead of calling the `Read` and `Write` methods of SslOverTdsStream.

I also modified the SNITcpPacket to call into the Stream's WriteAsync APIs. 

This impacts SSL connections to Sql server. 
Tests done:
1. Tested the SqlClient Manual Tests.
2. Tested the EF tests. 
