### PR TITLE
Remove apis that duplicate implicit operators.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1V2.Serializer.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1V2.Serializer.cs
@@ -881,7 +881,7 @@ namespace System.Security.Cryptography.Asn1
                         {
                             if (reader.TryCopyBitStringBytes(rented, out _, out int bytesWritten))
                             {
-                                return new ReadOnlyMemory<byte>(rented.AsReadOnlySpan().Slice(0, bytesWritten).ToArray());
+                                return new ReadOnlyMemory<byte>(rented.AsSpan().Slice(0, bytesWritten).ToArray());
                             }
 
                             Debug.Fail("TryCopyBitStringBytes produced more data than the encoded size");
@@ -912,7 +912,7 @@ namespace System.Security.Cryptography.Asn1
                         {
                             if (reader.TryCopyOctetStringBytes(rented, out int bytesWritten))
                             {
-                                return new ReadOnlyMemory<byte>(rented.AsReadOnlySpan().Slice(0, bytesWritten).ToArray());
+                                return new ReadOnlyMemory<byte>(rented.AsSpan().Slice(0, bytesWritten).ToArray());
                             }
 
                             Debug.Fail("TryCopyOctetStringBytes produced more data than the encoded size");

--- a/src/Common/tests/System/Security/Cryptography/ByteUtils.cs
+++ b/src/Common/tests/System/Security/Cryptography/ByteUtils.cs
@@ -37,7 +37,7 @@ namespace Test.Cryptography
 
         internal static string ByteArrayToHex(this byte[] bytes)
         {
-            return ByteArrayToHex(bytes.AsReadOnlySpan());
+            return ByteArrayToHex(bytes);
         }
 
         internal static string ByteArrayToHex(this Span<byte> bytes)

--- a/src/Common/tests/System/Security/Cryptography/ByteUtils.cs
+++ b/src/Common/tests/System/Security/Cryptography/ByteUtils.cs
@@ -37,7 +37,7 @@ namespace Test.Cryptography
 
         internal static string ByteArrayToHex(this byte[] bytes)
         {
-            return ByteArrayToHex(bytes);
+            return ByteArrayToHex((ReadOnlySpan<byte>)bytes);
         }
 
         internal static string ByteArrayToHex(this Span<byte> bytes)

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -20,13 +20,9 @@ namespace System
         public static System.ReadOnlyMemory<char> AsMemory(this string text) { throw null; }
         public static System.ReadOnlyMemory<char> AsMemory(this string text, int start) { throw null; }
         public static System.ReadOnlyMemory<char> AsMemory(this string text, int start, int length) { throw null; }
-        public static System.ReadOnlyMemory<T> AsReadOnlyMemory<T>(this System.Memory<T> memory) { throw null; }
         public static System.ReadOnlySpan<char> AsSpan(this string text) { throw null; }
         public static System.ReadOnlySpan<char> AsSpan(this string text, int start) { throw null; }
         public static System.ReadOnlySpan<char> AsSpan(this string text, int start, int length) { throw null; }
-        public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this System.ArraySegment<T> arraySegment) { throw null; }
-        public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this System.Span<T> span) { throw null; }
-        public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) { throw null; }
         public static System.Span<T> AsSpan<T>(this System.ArraySegment<T> segment) { throw null; }
         public static System.Span<T> AsSpan<T>(this System.ArraySegment<T> segment, int start) { throw null; }
         public static System.Span<T> AsSpan<T>(this System.ArraySegment<T> segment, int start, int length) { throw null; }

--- a/src/System.Memory/tests/TestHelpers.cs
+++ b/src/System.Memory/tests/TestHelpers.cs
@@ -378,6 +378,12 @@ namespace System
                 }
             }
         }
+
+        // @todo: https://github.com/dotnet/corefx/issues/26894 - these emulate MemoryExtension apis that we removed. Clean up the callsites and remove this class.
+        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this Span<T> span) => span;
+        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) => new ReadOnlySpan<T>(array);
+        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this ArraySegment<T> segment) => new ReadOnlySpan<T>(segment.Array, segment.Offset, segment.Count);
+        public static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this Memory<T> memory) => memory;
     }
 }
 

--- a/src/System.Private.Xml/src/System/Xml/NameTable.cs
+++ b/src/System.Private.Xml/src/System/Xml/NameTable.cs
@@ -240,7 +240,7 @@ namespace System.Xml
 
         private static int ComputeHash32(char[] key, int start, int len)
         {
-            ReadOnlySpan<byte> bytes = key.AsReadOnlySpan().Slice(start, len).AsBytes();
+            ReadOnlySpan<byte> bytes = key.AsSpan().Slice(start, len).AsBytes();
             return Marvin.ComputeHash32(bytes, Marvin.DefaultSeed);
         }
     }

--- a/src/System.Runtime.Extensions/tests/System/Convert.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.netcoreapp.cs
@@ -14,9 +14,9 @@ namespace System.Tests
         [InlineData(new byte[] { 5, 6, 7, 8 }, "BQYHCA==")]
         public void ToBase64String_Span_ProducesExpectedOutput(byte[] input, string expected)
         {
-            Assert.Equal(expected, Convert.ToBase64String(input.AsReadOnlySpan()));
-            Assert.Equal(expected, Convert.ToBase64String(input.AsReadOnlySpan(), Base64FormattingOptions.None));
-            Assert.Equal(expected, Convert.ToBase64String(input.AsReadOnlySpan(), Base64FormattingOptions.InsertLineBreaks));
+            Assert.Equal(expected, Convert.ToBase64String(input));
+            Assert.Equal(expected, Convert.ToBase64String(input, Base64FormattingOptions.None));
+            Assert.Equal(expected, Convert.ToBase64String(input, Base64FormattingOptions.InsertLineBreaks));
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace System.Tests
         [InlineData((Base64FormattingOptions)(2))]
         public void ToBase64String_Span_InvalidOptions_Throws(Base64FormattingOptions invalidOption)
         {
-            AssertExtensions.Throws<ArgumentException>("options", () => Convert.ToBase64String(new byte[0].AsReadOnlySpan(), invalidOption));
+            AssertExtensions.Throws<ArgumentException>("options", () => Convert.ToBase64String(new byte[0], invalidOption));
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace System.Tests
 
             // Just right
             dest = new char[expected.Length];
-            Assert.True(Convert.TryToBase64Chars(input.AsReadOnlySpan(), dest, out int charsWritten));
+            Assert.True(Convert.TryToBase64Chars(input, dest, out int charsWritten));
             Assert.Equal(expected.Length, charsWritten);
             Assert.Equal<char>(expected.ToCharArray(), dest.ToArray());
 
@@ -68,13 +68,13 @@ namespace System.Tests
             if (expected.Length > 0)
             {
                 dest = new char[expected.Length - 1];
-                Assert.False(Convert.TryToBase64Chars(input.AsReadOnlySpan(), dest, out charsWritten));
+                Assert.False(Convert.TryToBase64Chars(input, dest, out charsWritten));
                 Assert.Equal(0, charsWritten);
             }
 
             // Longer than needed
             dest = new char[expected.Length + 1];
-            Assert.True(Convert.TryToBase64Chars(input.AsReadOnlySpan(), dest, out charsWritten));
+            Assert.True(Convert.TryToBase64Chars(input, dest, out charsWritten));
             Assert.Equal(expected.Length, charsWritten);
             Assert.Equal<char>(expected.ToCharArray(), dest.Slice(0, expected.Length).ToArray());
             Assert.Equal(0, dest[dest.Length - 1]);
@@ -86,7 +86,7 @@ namespace System.Tests
         public void TryToBase64Chars_InvalidOptions_Throws(Base64FormattingOptions invalidOption)
         {
             AssertExtensions.Throws<ArgumentException>("options",
-                () => Convert.TryToBase64Chars(new byte[0].AsReadOnlySpan(), new char[0].AsSpan(), out int charsWritten, invalidOption));
+                () => Convert.TryToBase64Chars(new byte[0], new char[0].AsSpan(), out int charsWritten, invalidOption));
         }
 
         [Theory]
@@ -138,7 +138,7 @@ namespace System.Tests
 
             // Just the right length
             dest = new byte[expected.Length];
-            Assert.True(Convert.TryFromBase64Chars(charArrayInput.AsReadOnlySpan(), dest, out int bytesWritten));
+            Assert.True(Convert.TryFromBase64Chars(charArrayInput, dest, out int bytesWritten));
             Assert.Equal(expected.Length, bytesWritten);
             Assert.Equal<byte>(expected, dest.ToArray());
 
@@ -146,13 +146,13 @@ namespace System.Tests
             if (expected.Length > 0)
             {
                 dest = new byte[expected.Length - 1];
-                Assert.False(Convert.TryFromBase64Chars(charArrayInput.AsReadOnlySpan(), dest, out bytesWritten));
+                Assert.False(Convert.TryFromBase64Chars(charArrayInput, dest, out bytesWritten));
                 Assert.Equal(0, bytesWritten);
             }
 
             // Longer than needed
             dest = new byte[expected.Length + 1];
-            Assert.True(Convert.TryFromBase64Chars(charArrayInput.AsReadOnlySpan(), dest, out bytesWritten));
+            Assert.True(Convert.TryFromBase64Chars(charArrayInput, dest, out bytesWritten));
             Assert.Equal(expected.Length, bytesWritten);
             Assert.Equal<byte>(expected, dest.Slice(0, dest.Length - 1).ToArray());
             Assert.Equal(0, dest[dest.Length - 1]);

--- a/src/System.Runtime.Extensions/tests/System/Convert.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.netcoreapp.cs
@@ -14,9 +14,9 @@ namespace System.Tests
         [InlineData(new byte[] { 5, 6, 7, 8 }, "BQYHCA==")]
         public void ToBase64String_Span_ProducesExpectedOutput(byte[] input, string expected)
         {
-            Assert.Equal(expected, Convert.ToBase64String(input));
-            Assert.Equal(expected, Convert.ToBase64String(input, Base64FormattingOptions.None));
-            Assert.Equal(expected, Convert.ToBase64String(input, Base64FormattingOptions.InsertLineBreaks));
+            Assert.Equal(expected, Convert.ToBase64String(input.AsReadOnlySpan()));
+            Assert.Equal(expected, Convert.ToBase64String(input.AsReadOnlySpan(), Base64FormattingOptions.None));
+            Assert.Equal(expected, Convert.ToBase64String(input.AsReadOnlySpan(), Base64FormattingOptions.InsertLineBreaks));
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace System.Tests
         [InlineData((Base64FormattingOptions)(2))]
         public void ToBase64String_Span_InvalidOptions_Throws(Base64FormattingOptions invalidOption)
         {
-            AssertExtensions.Throws<ArgumentException>("options", () => Convert.ToBase64String(new byte[0], invalidOption));
+            AssertExtensions.Throws<ArgumentException>("options", () => Convert.ToBase64String(new byte[0].AsReadOnlySpan(), invalidOption));
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace System.Tests
 
             // Just right
             dest = new char[expected.Length];
-            Assert.True(Convert.TryToBase64Chars(input, dest, out int charsWritten));
+            Assert.True(Convert.TryToBase64Chars(input.AsReadOnlySpan(), dest, out int charsWritten));
             Assert.Equal(expected.Length, charsWritten);
             Assert.Equal<char>(expected.ToCharArray(), dest.ToArray());
 
@@ -68,13 +68,13 @@ namespace System.Tests
             if (expected.Length > 0)
             {
                 dest = new char[expected.Length - 1];
-                Assert.False(Convert.TryToBase64Chars(input, dest, out charsWritten));
+                Assert.False(Convert.TryToBase64Chars(input.AsReadOnlySpan(), dest, out charsWritten));
                 Assert.Equal(0, charsWritten);
             }
 
             // Longer than needed
             dest = new char[expected.Length + 1];
-            Assert.True(Convert.TryToBase64Chars(input, dest, out charsWritten));
+            Assert.True(Convert.TryToBase64Chars(input.AsReadOnlySpan(), dest, out charsWritten));
             Assert.Equal(expected.Length, charsWritten);
             Assert.Equal<char>(expected.ToCharArray(), dest.Slice(0, expected.Length).ToArray());
             Assert.Equal(0, dest[dest.Length - 1]);
@@ -86,7 +86,7 @@ namespace System.Tests
         public void TryToBase64Chars_InvalidOptions_Throws(Base64FormattingOptions invalidOption)
         {
             AssertExtensions.Throws<ArgumentException>("options",
-                () => Convert.TryToBase64Chars(new byte[0], new char[0].AsSpan(), out int charsWritten, invalidOption));
+                () => Convert.TryToBase64Chars(new byte[0].AsReadOnlySpan(), new char[0].AsSpan(), out int charsWritten, invalidOption));
         }
 
         [Theory]
@@ -138,7 +138,7 @@ namespace System.Tests
 
             // Just the right length
             dest = new byte[expected.Length];
-            Assert.True(Convert.TryFromBase64Chars(charArrayInput, dest, out int bytesWritten));
+            Assert.True(Convert.TryFromBase64Chars(charArrayInput.AsReadOnlySpan(), dest, out int bytesWritten));
             Assert.Equal(expected.Length, bytesWritten);
             Assert.Equal<byte>(expected, dest.ToArray());
 
@@ -146,13 +146,13 @@ namespace System.Tests
             if (expected.Length > 0)
             {
                 dest = new byte[expected.Length - 1];
-                Assert.False(Convert.TryFromBase64Chars(charArrayInput, dest, out bytesWritten));
+                Assert.False(Convert.TryFromBase64Chars(charArrayInput.AsReadOnlySpan(), dest, out bytesWritten));
                 Assert.Equal(0, bytesWritten);
             }
 
             // Longer than needed
             dest = new byte[expected.Length + 1];
-            Assert.True(Convert.TryFromBase64Chars(charArrayInput, dest, out bytesWritten));
+            Assert.True(Convert.TryFromBase64Chars(charArrayInput.AsReadOnlySpan(), dest, out bytesWritten));
             Assert.Equal(expected.Length, bytesWritten);
             Assert.Equal<byte>(expected, dest.Slice(0, dest.Length - 1).ToArray());
             Assert.Equal(0, dest[dest.Length - 1]);

--- a/src/System.Runtime.Extensions/tests/TestHelpers.cs
+++ b/src/System.Runtime.Extensions/tests/TestHelpers.cs
@@ -28,5 +28,8 @@ namespace System
                 data.Add((T)item[0]);
             return data;
         }
+
+        // @todo: https://github.com/dotnet/corefx/issues/26894 - these emulate MemoryExtension apis that we removed. Clean up the callsites and remove this class.
+        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) => new ReadOnlySpan<T>(array);
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/DSATests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DSATests.cs
@@ -107,7 +107,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
                 byte[] signature = wrapperDsa.SignData(input, HashAlgorithmName.SHA1);
                 Assert.True(wrapperDsa.VerifyData(input.AsSpan(), signature, HashAlgorithmName.SHA1));
-                Assert.False(wrapperDsa.VerifyData(input.AsSpan(), signature.AsReadOnlySpan().Slice(0, signature.Length - 1), HashAlgorithmName.SHA1));
+                Assert.False(wrapperDsa.VerifyData(input.AsSpan(), signature.AsSpan().Slice(0, signature.Length - 1), HashAlgorithmName.SHA1));
             }
         }
 
@@ -126,7 +126,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
                 byte[] signature = wrapperDsa.SignData(new MemoryStream(input), HashAlgorithmName.SHA1);
                 Assert.True(wrapperDsa.VerifyData(new MemoryStream(input), signature, HashAlgorithmName.SHA1));
-                Assert.False(wrapperDsa.VerifyData(new MemoryStream(input), signature.AsReadOnlySpan().Slice(0, signature.Length - 1).ToArray(), HashAlgorithmName.SHA1));
+                Assert.False(wrapperDsa.VerifyData(new MemoryStream(input), signature.AsSpan().Slice(0, signature.Length - 1).ToArray(), HashAlgorithmName.SHA1));
             }
         }
 
@@ -143,7 +143,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
                 byte[] signature = wrapperDsa.SignData(input, HashAlgorithmName.SHA1);
                 Assert.True(wrapperDsa.VerifyData(input.AsSpan(), signature, HashAlgorithmName.SHA1));
-                Assert.False(wrapperDsa.VerifyData(input.AsSpan(), signature.AsReadOnlySpan().Slice(0, signature.Length - 1), HashAlgorithmName.SHA1));
+                Assert.False(wrapperDsa.VerifyData(input.AsSpan(), signature.AsSpan().Slice(0, signature.Length - 1), HashAlgorithmName.SHA1));
             }
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="DerSequenceReaderTests.cs" />
     <Compile Include="Oid.cs" />
     <Compile Include="OidCollectionTests.cs" />
+    <Compile Include="TestHelpers.cs" />
     <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1V2.cs">
       <Link>Common\System\Security\Cryptography\Asn1V2.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Encoding/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/TestHelpers.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using Xunit;
-
 namespace System
 {
     // @todo: https://github.com/dotnet/corefx/issues/26894 - these emulate MemoryExtension apis that we removed. Clean up the callsites and remove this class.

--- a/src/System.Security.Cryptography.Encoding/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/TestHelpers.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System
+{
+    // @todo: https://github.com/dotnet/corefx/issues/26894 - these emulate MemoryExtension apis that we removed. Clean up the callsites and remove this class.
+    internal static class TestHelpers
+    {
+        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) => new ReadOnlySpan<T>(array);
+    }
+}

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -255,7 +255,7 @@ namespace System.Security.Cryptography.Pkcs
 
                         if (i == last &&
                             IncludeOption == X509IncludeOption.ExcludeRoot &&
-                            cert.SubjectName.RawData.AsReadOnlySpan().SequenceEqual(cert.IssuerName.RawData))
+                            cert.SubjectName.RawData.AsSpan().SequenceEqual(cert.IssuerName.RawData))
                         {
                             break;
                         }

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
@@ -513,7 +513,7 @@ namespace System.Security.Cryptography.Pkcs
 
                             var digestAttr = (Pkcs9MessageDigest)obj.Values[0];
 
-                            if (!contentDigest.AsSpan().SequenceEqual(digestAttr.MessageDigest.AsReadOnlySpan()))
+                            if (!contentDigest.AsSpan().SequenceEqual(digestAttr.MessageDigest))
                             {
                                 throw new CryptographicException(SR.Cryptography_BadHashValue);
                             }

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
@@ -70,7 +70,7 @@ namespace System.Security.Cryptography.Pkcs
                 // If the serial number is zero and the subject is exactly "CN=Dummy Signer"
                 // then this is the special "NoSignature" signer.
                 if (!nonZero &&
-                    DummySignerEncodedValue.AsReadOnlySpan().SequenceEqual(issuerNameSpan))
+                    DummySignerEncodedValue.AsSpan().SequenceEqual(issuerNameSpan))
                 {
                     Type = SubjectIdentifierType.NoSignature;
                     Value = null;

--- a/src/System.Text.Encoding/tests/Decoder/DecoderSpanTests.netcoreapp.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderSpanTests.netcoreapp.cs
@@ -26,7 +26,7 @@ namespace System.Text.Encodings.Tests
             byte[] textBytes = e.GetBytes(TextString);
 
             char[] chars = new char[TextString.Length];
-            Assert.Equal(chars.Length, e.GetDecoder().GetChars(textBytes.AsReadOnlySpan(), chars.AsSpan(), flush: true));
+            Assert.Equal(chars.Length, e.GetDecoder().GetChars(textBytes, chars.AsSpan(), flush: true));
             Assert.Equal(TextString, new string(chars));
         }
 


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/26894

Last set of approved api changes from this issue.

Since we have to get this in by 3/7, we're doing
the minbar here of removing the methods from the
reference assemblies only and (in some cases) adding the
"api" internally in some test assemblies rather
than clean up dozens of individual callsites.
(I wouldn't be surprised if we end up adding
these back in the next version anyway...)