### PR TITLE
fix some conditional test logic related to SocketsHttpHandler

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -160,9 +160,14 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
-        [ActiveIssue(9228, TestPlatforms.Windows)]
         public async Task PostNonRewindableContentUsingAuth_PreAuthenticate_Success(Uri serverUri)
         {
+            if (IsWinHttpHandler)
+            {
+                // Issue #9228
+                return;
+            }
+
             HttpContent content = CustomContent.Create(ExpectedContent, false);
             var credential = new NetworkCredential(UserName, Password);
             await PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, preAuthenticate: true);

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -182,9 +182,9 @@ namespace System.Net.Http.Functional.Tests
                 Assert.True(task.IsCompleted, "Task was not yet completed");
 
                 // Verify that the task completed successfully or is canceled.
-                if (PlatformDetection.IsWindows)
+                if (IsWinHttpHandler)
                 {
-                    // On Windows, we may fault because canceling the task destroys the request handle
+                    // With WinHttpHandler, we may fault because canceling the task destroys the request handle
                     // which may randomly cause an ObjectDisposedException (or other exception).
                     Assert.True(
                         task.Status == TaskStatus.RanToCompletion ||


### PR DESCRIPTION
There were a few test cases where we were using platform tests like IsWindows to disable or modify tests.  Clean these up so they run properly on SocketsHttpHandler.

@stephentoub @davidsh 