### PR TITLE
Fix SocketsNetHttpHandler TLS client cert handling

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -17,6 +17,7 @@ namespace System.Net.Http
         private readonly CurlHandler _curlHandler;
         private readonly SocketsHttpHandler _socketsHttpHandler;
         private readonly DiagnosticsHandler _diagnosticsHandler;
+        private ClientCertificateOption _clientCertificateOptions;
 
         public HttpClientHandler() : this(UseSocketsHttpHandler) { }
 
@@ -26,6 +27,7 @@ namespace System.Net.Http
             {
                 _socketsHttpHandler = new SocketsHttpHandler();
                 _diagnosticsHandler = new DiagnosticsHandler(_socketsHttpHandler);
+                ClientCertificateOptions = ClientCertificateOption.Manual;
             }
             else
             {
@@ -91,9 +93,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    return _socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback != null ?
-                        ClientCertificateOption.Automatic :
-                        ClientCertificateOption.Manual;
+                    return _clientCertificateOptions;
                 }
             }
             set
@@ -108,11 +108,13 @@ namespace System.Net.Http
                     {
                         case ClientCertificateOption.Manual:
                             ThrowForModifiedManagedSslOptionsIfStarted();
-                            _socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback = null;
+                            _clientCertificateOptions = value;
+                            _socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate(ClientCertificates);
                             break;
 
                         case ClientCertificateOption.Automatic:
                             ThrowForModifiedManagedSslOptionsIfStarted();
+                            _clientCertificateOptions = value;
                             _socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate();
                             break;
 

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -19,6 +19,7 @@ namespace System.Net.Http
         private readonly SocketsHttpHandler _socketsHttpHandler;
         private readonly DiagnosticsHandler _diagnosticsHandler;
         private bool _useProxy;
+        private ClientCertificateOption _clientCertificateOptions;
 
         public HttpClientHandler() : this(UseSocketsHttpHandler) { }
 
@@ -28,6 +29,8 @@ namespace System.Net.Http
             {
                 _socketsHttpHandler = new SocketsHttpHandler();
                 _diagnosticsHandler = new DiagnosticsHandler(_socketsHttpHandler);
+                ClientCertificateOptions = ClientCertificateOption.Manual;
+
             }
             else
             {
@@ -319,9 +322,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    return _socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback != null ?
-                        ClientCertificateOption.Automatic :
-                        ClientCertificateOption.Manual;
+                    return _clientCertificateOptions;
                 }
             }
             set
@@ -336,11 +337,13 @@ namespace System.Net.Http
                     {
                         case ClientCertificateOption.Manual:
                             ThrowForModifiedManagedSslOptionsIfStarted();
-                            _socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback = null;
+                            _clientCertificateOptions = value;
+                            _socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate(ClientCertificates);
                             break;
 
                         case ClientCertificateOption.Automatic:
                             ThrowForModifiedManagedSslOptionsIfStarted();
+                            _clientCertificateOptions = value;
                             _socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate();
                             break;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -142,12 +142,6 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void Manual_SendClientCertificateWithServerAuthEKUToRemoteServer_Forbidden()
         {
-            if (UseSocketsHttpHandler)
-            {
-                // TODO #23128: SocketsHttpHandler is currently sending out client certificates when it shouldn't.
-                return;
-            }
-
             if (!CanTestClientCertificates) // can't use [Conditional*] right now as it's evaluated at the wrong time for SocketsHttpHandler
             {
                 _output.WriteLine($"Skipping {nameof(Manual_SendClientCertificateWithServerAuthEKUToRemoteServer_Forbidden)}()");


### PR DESCRIPTION
SocketNetHttpHandler was not filtering down the client certificates when sending in
"Manual" mode. This caused a client certificate to be sent to a server when it
didn't have the proper EKU OID for "Client Authentication".

Changed this so that both "Manual" and "Automatic" modes will use the CertificateHelper
GetEligibleCertificate() API.

Fixes #23128