### PR TITLE
Improve performance of Span.Clear for referential T

### DIFF
--- a/src/Common/src/CoreLib/System/SpanHelpers.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.cs
@@ -511,7 +511,7 @@ namespace System
                 return; // nothing to write
             }
 
-Write4To7:
+        Write4To7:
             Debug.Assert(pointerSizeLength >= 4);
 
             // Write first four and last three.
@@ -521,14 +521,14 @@ Write4To7:
             Unsafe.Add(ref Unsafe.Add(ref ip, (IntPtr)pointerSizeLength), -3) = default(IntPtr);
             Unsafe.Add(ref Unsafe.Add(ref ip, (IntPtr)pointerSizeLength), -2) = default(IntPtr);
 
-Write2To3:
+        Write2To3:
             Debug.Assert(pointerSizeLength >= 2);
 
             // Write first two and last one.
             Unsafe.Add(ref ip, 1) = default(IntPtr);
             Unsafe.Add(ref Unsafe.Add(ref ip, (IntPtr)pointerSizeLength), -1) = default(IntPtr);
 
-Write1:
+        Write1:
             Debug.Assert(pointerSizeLength >= 1);
 
             // Write only element.

--- a/src/Common/src/CoreLib/System/SpanHelpers.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.cs
@@ -455,7 +455,7 @@ namespace System
             return;
 #endif
 
-PInvoke:
+        PInvoke:
             RuntimeImports.RhZeroMemory(ref b, byteLength);
         }
 

--- a/src/System.Memory/tests/Performance/Perf.Span.Clear.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.Clear.cs
@@ -9,7 +9,9 @@ namespace System.Memory.Tests
 {
     public class Perf_Span_Clear
     {
-        [Benchmark]
+        private const int NumIters = 10000;
+
+        [Benchmark(InnerIterationCount = NumIters)]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
@@ -41,7 +43,7 @@ namespace System.Memory.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < 10000; i++)
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
                         span.Clear();
                     }
@@ -49,7 +51,7 @@ namespace System.Memory.Tests
             }
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = NumIters)]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
@@ -81,7 +83,7 @@ namespace System.Memory.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < 10000; i++)
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
                         span.Clear();
                     }

--- a/src/System.Memory/tests/Performance/Perf.Span.Clear.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.Clear.cs
@@ -48,5 +48,45 @@ namespace System.Memory.Tests
                 }
             }
         }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(11)]
+        [InlineData(12)]
+        [InlineData(13)]
+        [InlineData(14)]
+        [InlineData(15)]
+        [InlineData(16)]
+        [InlineData(32)]
+        [InlineData(64)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void References(int size)
+        {
+            var a = new object[size];
+            var span = new Span<object>(a);
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < 10000; i++)
+                    {
+                        span.Clear();
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
(Related to https://github.com/dotnet/corefx/issues/26604.)

Improves the performance of `Span.Clear<T>()` where `T` is a reference type or contains references. The perf improvement is particularly noticeable for smaller spans (length = 8 natural words or fewer).

 System.Memory.Performance.Tests.dll (original)               | Metric   | Unit | Iterations | Average | STDEV.S |     Min |     Max
:------------------------------------------------------------ |:-------- |:----:|:----------:| -------:| -------:| -------:| -------:
 System.Memory.Tests.Perf_Span_Clear.References(size: 0)      | Duration | msec |    1000    |   0.016 |   0.010 |   0.013 |   0.291
 System.Memory.Tests.Perf_Span_Clear.References(size: 1)      | Duration | msec |    1000    |   0.028 |   0.015 |   0.023 |   0.362
 System.Memory.Tests.Perf_Span_Clear.References(size: 10)     | Duration | msec |    1000    |   0.043 |   0.018 |   0.037 |   0.462
 System.Memory.Tests.Perf_Span_Clear.References(size: 100)    | Duration | msec |    1000    |   0.280 |   0.047 |   0.254 |   0.715
 System.Memory.Tests.Perf_Span_Clear.References(size: 1000)   | Duration | msec |    1000    |   2.682 |   0.221 |   2.518 |   4.165
 System.Memory.Tests.Perf_Span_Clear.References(size: 10000)  | Duration | msec |    329     |  30.377 |   1.766 |  28.669 |  41.233
 System.Memory.Tests.Perf_Span_Clear.References(size: 100000) | Duration | msec |     31     | 327.312 |  11.889 | 317.892 | 377.056
 System.Memory.Tests.Perf_Span_Clear.References(size: 11)     | Duration | msec |    1000    |   0.041 |   0.012 |   0.036 |   0.137
 System.Memory.Tests.Perf_Span_Clear.References(size: 12)     | Duration | msec |    1000    |   0.048 |   0.018 |   0.042 |   0.436
 System.Memory.Tests.Perf_Span_Clear.References(size: 13)     | Duration | msec |    1000    |   0.048 |   0.016 |   0.041 |   0.241
 System.Memory.Tests.Perf_Span_Clear.References(size: 14)     | Duration | msec |    1000    |   0.052 |   0.014 |   0.044 |   0.159
 System.Memory.Tests.Perf_Span_Clear.References(size: 15)     | Duration | msec |    1000    |   0.050 |   0.016 |   0.044 |   0.234
 System.Memory.Tests.Perf_Span_Clear.References(size: 16)     | Duration | msec |    1000    |   0.065 |   0.023 |   0.049 |   0.385
 System.Memory.Tests.Perf_Span_Clear.References(size: 2)      | Duration | msec |    1000    |   0.031 |   0.016 |   0.026 |   0.410
 System.Memory.Tests.Perf_Span_Clear.References(size: 3)      | Duration | msec |    1000    |   0.026 |   0.009 |   0.023 |   0.195
 System.Memory.Tests.Perf_Span_Clear.References(size: 32)     | Duration | msec |    1000    |   0.091 |   0.019 |   0.084 |   0.276
 System.Memory.Tests.Perf_Span_Clear.References(size: 4)      | Duration | msec |    1000    |   0.032 |   0.009 |   0.026 |   0.107
 System.Memory.Tests.Perf_Span_Clear.References(size: 5)      | Duration | msec |    1000    |   0.031 |   0.018 |   0.026 |   0.485
 System.Memory.Tests.Perf_Span_Clear.References(size: 6)      | Duration | msec |    1000    |   0.034 |   0.012 |   0.029 |   0.208
 System.Memory.Tests.Perf_Span_Clear.References(size: 64)     | Duration | msec |    1000    |   0.187 |   0.047 |   0.164 |   0.899
 System.Memory.Tests.Perf_Span_Clear.References(size: 7)      | Duration | msec |    1000    |   0.035 |   0.012 |   0.029 |   0.128
 System.Memory.Tests.Perf_Span_Clear.References(size: 8)      | Duration | msec |    1000    |   0.045 |   0.018 |   0.037 |   0.321
 System.Memory.Tests.Perf_Span_Clear.References(size: 9)      | Duration | msec |    1000    |   0.039 |   0.017 |   0.034 |   0.414

 System.Memory.Performance.Tests.dll (new)                    | Metric   | Unit | Iterations | Average | STDEV.S |     Min |     Max
:------------------------------------------------------------ |:-------- |:----:|:----------:| -------:| -------:| -------:| -------:
 System.Memory.Tests.Perf_Span_Clear.References(size: 0)      | Duration | msec |    1000    |   0.018 |   0.005 |   0.016 |   0.076
 System.Memory.Tests.Perf_Span_Clear.References(size: 1)      | Duration | msec |    1000    |   0.021 |   0.006 |   0.018 |   0.062
 System.Memory.Tests.Perf_Span_Clear.References(size: 10)     | Duration | msec |    1000    |   0.036 |   0.010 |   0.031 |   0.109
 System.Memory.Tests.Perf_Span_Clear.References(size: 100)    | Duration | msec |    1000    |   0.282 |   0.040 |   0.264 |   0.639
 System.Memory.Tests.Perf_Span_Clear.References(size: 1000)   | Duration | msec |    1000    |   2.678 |   0.300 |   2.512 |   6.985
 System.Memory.Tests.Perf_Span_Clear.References(size: 10000)  | Duration | msec |    337     |  29.684 |   1.063 |  28.828 |  36.611
 System.Memory.Tests.Perf_Span_Clear.References(size: 100000) | Duration | msec |     32     | 320.899 |   6.557 | 316.642 | 350.625
 System.Memory.Tests.Perf_Span_Clear.References(size: 11)     | Duration | msec |    1000    |   0.036 |   0.021 |   0.031 |   0.500
 System.Memory.Tests.Perf_Span_Clear.References(size: 12)     | Duration | msec |    1000    |   0.049 |   0.011 |   0.044 |   0.143
 System.Memory.Tests.Perf_Span_Clear.References(size: 13)     | Duration | msec |    1000    |   0.050 |   0.014 |   0.044 |   0.253
 System.Memory.Tests.Perf_Span_Clear.References(size: 14)     | Duration | msec |    1000    |   0.050 |   0.013 |   0.044 |   0.230
 System.Memory.Tests.Perf_Span_Clear.References(size: 15)     | Duration | msec |    1000    |   0.050 |   0.018 |   0.044 |   0.352
 System.Memory.Tests.Perf_Span_Clear.References(size: 16)     | Duration | msec |    1000    |   0.051 |   0.017 |   0.044 |   0.377
 System.Memory.Tests.Perf_Span_Clear.References(size: 2)      | Duration | msec |    1000    |   0.026 |   0.009 |   0.021 |   0.112
 System.Memory.Tests.Perf_Span_Clear.References(size: 3)      | Duration | msec |    1000    |   0.027 |   0.010 |   0.021 |   0.098
 System.Memory.Tests.Perf_Span_Clear.References(size: 32)     | Duration | msec |    1000    |   0.091 |   0.020 |   0.084 |   0.241
 System.Memory.Tests.Perf_Span_Clear.References(size: 4)      | Duration | msec |    1000    |   0.030 |   0.010 |   0.023 |   0.121
 System.Memory.Tests.Perf_Span_Clear.References(size: 5)      | Duration | msec |    1000    |   0.026 |   0.007 |   0.024 |   0.091
 System.Memory.Tests.Perf_Span_Clear.References(size: 6)      | Duration | msec |    1000    |   0.028 |   0.012 |   0.023 |   0.202
 System.Memory.Tests.Perf_Span_Clear.References(size: 64)     | Duration | msec |    1000    |   0.178 |   0.031 |   0.164 |   0.548
 System.Memory.Tests.Perf_Span_Clear.References(size: 7)      | Duration | msec |    1000    |   0.029 |   0.011 |   0.023 |   0.177
 System.Memory.Tests.Perf_Span_Clear.References(size: 8)      | Duration | msec |    1000    |   0.027 |   0.010 |   0.024 |   0.200
 System.Memory.Tests.Perf_Span_Clear.References(size: 9)      | Duration | msec |    1000    |   0.031 |   0.009 |   0.027 |   0.116
