### PR TITLE
SNIPacket memory allocation perf improvement (revised)

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -424,6 +424,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(OSGroup)' != 'AnyOS'">
     <Reference Include="Microsoft.Win32.Primitives" />
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.ComponentModel" />

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
@@ -41,7 +41,7 @@ namespace System.Data.SqlClient.SNI
         /// <param name="packet">SNI packet</param>
         /// <param name="callback">Completion callback</param>
         /// <returns>SNI error code</returns>
-        public abstract uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null);
+        public abstract uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null, bool disposeSNIPacketAfterSendAsync = false);
 
         /// <summary>
         /// Receive a packet synchronously

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
@@ -41,7 +41,7 @@ namespace System.Data.SqlClient.SNI
         /// <param name="packet">SNI packet</param>
         /// <param name="callback">Completion callback</param>
         /// <returns>SNI error code</returns>
-        public abstract uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null, bool disposeSNIPacketAfterSendAsync = false);
+        public abstract uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null);
 
         /// <summary>
         /// Receive a packet synchronously

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -95,7 +95,7 @@ namespace System.Data.SqlClient.SNI
         {
             lock (this)
             {
-                return _lowerHandle.SendAsync(packet, callback);
+                return _lowerHandle.SendAsync(packet, false, callback);
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -207,8 +207,7 @@ namespace System.Data.SqlClient.SNI
                         };
 
                         _dataBytesLeft = (int)_currentHeader.length;
-                        _currentPacket = new SNIPacket(null);
-                        _currentPacket.Allocate((int)_currentHeader.length);
+                        _currentPacket = new SNIPacket((int)_currentHeader.length);
                     }
 
                     currentHeader = _currentHeader;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -100,7 +100,7 @@ namespace System.Data.SqlClient.SNI
                 GetSMUXHeaderBytes(0, (byte)flags, ref headerBytes);
             }
 
-            SNIPacket packet = new SNIPacket(null);
+            SNIPacket packet = new SNIPacket();
             packet.SetData(headerBytes, SNISMUXHeader.HEADER_LENGTH);
             
             _connection.Send(packet);
@@ -143,9 +143,8 @@ namespace System.Data.SqlClient.SNI
             byte[] headerBytes = null;
             GetSMUXHeaderBytes(packet.Length, (byte)SNISMUXFlags.SMUX_DATA, ref headerBytes);
 
-            SNIPacket smuxPacket = new SNIPacket(null);
+            SNIPacket smuxPacket = new SNIPacket(16 + packet.Length);
             smuxPacket.Description = string.Format("({0}) SMUX packet {1}", packet.Description == null ? "" : packet.Description, xSequenceNumber);
-            smuxPacket.Allocate(16 + packet.Length);
             smuxPacket.AppendData(headerBytes, 16);
             smuxPacket.AppendPacket(packet);
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -256,7 +256,7 @@ namespace System.Data.SqlClient.SNI
         /// <param name="packet">SNI packet</param>
         /// <param name="callback">Completion callback</param>
         /// <returns>SNI error code</returns>
-        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null, bool disposeSNIPacketAfterSendAsync = false)
+        public override uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null)
         {
             lock (this)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -256,7 +256,7 @@ namespace System.Data.SqlClient.SNI
         /// <param name="packet">SNI packet</param>
         /// <param name="callback">Completion callback</param>
         /// <returns>SNI error code</returns>
-        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
+        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null, bool disposeSNIPacketAfterSendAsync = false)
         {
             lock (this)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -214,7 +214,7 @@ namespace System.Data.SqlClient.SNI
         public override uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null)
         {
             SNIAsyncCallback cb = callback ?? _sendCallback;
-            packet.WriteToStreamAsync(_stream, cb, SNIProviders.NP_PROV);
+            packet.WriteToStreamAsync(_stream, cb, SNIProviders.NP_PROV, disposePacketAfterSendAsync);
             return TdsEnums.SNI_SUCCESS_IO_PENDING;
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -150,8 +150,7 @@ namespace System.Data.SqlClient.SNI
                 packet = null;
                 try
                 {
-                    packet = new SNIPacket(null);
-                    packet.Allocate(_bufferSize);
+                    packet = new SNIPacket(_bufferSize);
                     packet.ReadFromStream(_stream);
 
                     if (packet.Length == 0)
@@ -175,9 +174,8 @@ namespace System.Data.SqlClient.SNI
 
         public override uint ReceiveAsync(ref SNIPacket packet, bool isMars = false)
         {
-            packet = new SNIPacket(null);
-            packet.Allocate(_bufferSize);
-
+            packet = new SNIPacket(_bufferSize);
+            
             try
             {
                 packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -211,7 +211,7 @@ namespace System.Data.SqlClient.SNI
             }
         }
 
-        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
+        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null, bool disposeSNIPacketAfterSendAsync = false)
         {
             SNIAsyncCallback cb = callback ?? _sendCallback;
             packet.WriteToStreamAsync(_stream, cb, SNIProviders.NP_PROV);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -211,7 +211,7 @@ namespace System.Data.SqlClient.SNI
             }
         }
 
-        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null, bool disposeSNIPacketAfterSendAsync = false)
+        public override uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null)
         {
             SNIAsyncCallback cb = callback ?? _sendCallback;
             packet.WriteToStreamAsync(_stream, cb, SNIProviders.NP_PROV);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -23,7 +23,6 @@ namespace System.Data.SqlClient.SNI
 
         private ArrayPool<byte>  _arrayPool = ArrayPool<byte>.Shared;
         private bool _isBufferFromArrayPool = false;
-        private bool _disposeAfterWriteAsync = false;
 
         public SNIPacket() { }
 
@@ -45,19 +44,6 @@ namespace System.Data.SqlClient.SNI
             set
             {
                 _description = value;
-            }
-        }
-
-        public bool DisposeAfterWriteAsync
-        {
-            get
-            {
-                return _disposeAfterWriteAsync;
-            }
-
-            set
-            {
-                _disposeAfterWriteAsync = value;
             }
         }
 
@@ -325,7 +311,7 @@ namespace System.Data.SqlClient.SNI
         /// Write data to a stream asynchronously
         /// </summary>
         /// <param name="stream">Stream to write to</param>
-        public async void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback, SNIProviders provider)
+        public async void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback, SNIProviders provider, bool disposeSNIPacketAfterWriteAsync = false)
         {
             uint status = TdsEnums.SNI_SUCCESS;
             try
@@ -339,7 +325,7 @@ namespace System.Data.SqlClient.SNI
             }
             callback(this, status);
 
-            if (_disposeAfterWriteAsync)
+            if (disposeSNIPacketAfterWriteAsync)
             {
                 Dispose();
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -105,7 +105,7 @@ namespace System.Data.SqlClient.SNI
         /// <summary>
         /// Allocate space for data
         /// </summary>
-        /// <param name="bufferSize">Length of byte array to be allocated</param>
+        /// <param name="capacity">Length of byte array to be allocated</param>
         public void Allocate(int capacity)
         {
             if (_data != null && _data.Length < capacity)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -297,11 +297,6 @@ namespace System.Data.SqlClient.SNI
                 }
 
                 callback(this, error ? TdsEnums.SNI_ERROR : TdsEnums.SNI_SUCCESS);
-
-                if (_disposeAfterWriteAsync)
-                {
-                    Dispose();
-                }
             },
             CancellationToken.None,
             options,

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -311,7 +311,7 @@ namespace System.Data.SqlClient.SNI
         /// Write data to a stream asynchronously
         /// </summary>
         /// <param name="stream">Stream to write to</param>
-        public async void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback, SNIProviders provider, bool disposeSNIPacketAfterWriteAsync = false)
+        public async void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback, SNIProviders provider, bool disposeAfterWriteAsync = false)
         {
             uint status = TdsEnums.SNI_SUCCESS;
             try
@@ -325,7 +325,7 @@ namespace System.Data.SqlClient.SNI
             }
             callback(this, status);
 
-            if (disposeSNIPacketAfterWriteAsync)
+            if (disposeAfterWriteAsync)
             {
                 Dispose();
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,13 +21,15 @@ namespace System.Data.SqlClient.SNI
         private string _description;
         private SNIAsyncCallback _completionCallback;
 
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="handle">Owning SNI handle</param>
-        public SNIPacket(SNIHandle handle)
+        private ArrayPool<byte>  _arrayPool = ArrayPool<byte>.Shared;
+        private bool _isBufferFromArrayPool = false;
+        private bool _disposeAfterWriteAsync = false;
+
+        public SNIPacket() { }
+
+        public SNIPacket(int capacity)
         {
-            _offset = 0;
+            Allocate(capacity);
         }
 
         /// <summary>
@@ -45,47 +48,40 @@ namespace System.Data.SqlClient.SNI
             }
         }
 
-        /// <summary>
-        /// Data left to process
-        /// </summary>
-        public int DataLeft
+        public bool DisposeAfterWriteAsync
         {
             get
             {
-                return _length - _offset;
+                return _disposeAfterWriteAsync;
+            }
+
+            set
+            {
+                _disposeAfterWriteAsync = value;
             }
         }
+
+        /// <summary>
+        /// Length of data left to process
+        /// </summary>
+        public int DataLeft => (_length - _offset);
 
         /// <summary>
         /// Length of data
         /// </summary>
-        public int Length
-        {
-            get
-            {
-                return _length;
-            }
-        }
+        public int Length => _length;
 
         /// <summary>
         /// Packet validity
         /// </summary>
-        public bool IsInvalid
-        {
-            get
-            {
-                return _data == null;
-            }
-        }
+        public bool IsInvalid => (_data == null);
 
         /// <summary>
         /// Packet data
         /// </summary>
         public void Dispose()
         {
-            _data = null;
-            _length = 0;
-            _capacity = 0;
+            Release();
         }
 
         /// <summary>
@@ -109,11 +105,27 @@ namespace System.Data.SqlClient.SNI
         /// <summary>
         /// Allocate space for data
         /// </summary>
-        /// <param name="capacity">Bytes to allocate</param>
+        /// <param name="bufferSize">Length of byte array to be allocated</param>
         public void Allocate(int capacity)
         {
+            if (_data != null && _data.Length < capacity)
+            {
+                if (_isBufferFromArrayPool)
+                {
+                    _arrayPool.Return(_data);
+                }
+                _data = null;
+            }
+
+            if (_data == null)
+            {
+                _data = _arrayPool.Rent(capacity);
+                _isBufferFromArrayPool = true;
+            }
+
             _capacity = capacity;
-            _data = new Byte[capacity];
+            _length = 0;
+            _offset = 0;
         }
 
         /// <summary>
@@ -122,10 +134,11 @@ namespace System.Data.SqlClient.SNI
         /// <returns>Cloned packet</returns>
         public SNIPacket Clone()
         {
-            SNIPacket packet = new SNIPacket(null);
-            packet._data = new byte[_length];
-            Buffer.BlockCopy(_data, 0, packet._data, 0, _length);
+            SNIPacket packet = new SNIPacket(_capacity);
+            Buffer.BlockCopy(_data, 0, packet._data, 0, _capacity);
             packet._length = _length;
+            packet._description = _description;
+            packet._completionCallback = _completionCallback;
 
             return packet;
         }
@@ -133,7 +146,7 @@ namespace System.Data.SqlClient.SNI
         /// <summary>
         /// Get packet data
         /// </summary>
-        /// <param name="inBuff">Buffer</param>
+        /// <param name="buffer">Buffer</param>
         /// <param name="dataSize">Data in packet</param>
         public void GetData(byte[] buffer, ref int dataSize)
         {
@@ -150,8 +163,9 @@ namespace System.Data.SqlClient.SNI
         {
             _data = data;
             _length = length;
-            _capacity = length;
+            _capacity = data.Length;
             _offset = 0;
+            _isBufferFromArrayPool = false;
         }
 
         /// <summary>
@@ -208,7 +222,7 @@ namespace System.Data.SqlClient.SNI
             }
 
             Buffer.BlockCopy(_data, _offset, buffer, dataOffset, size);
-            _offset = _offset + size;
+            _offset += size;
             return size;
         }
 
@@ -217,9 +231,16 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         public void Release()
         {
-            _length = 0;
-            _capacity = 0;
-            _data = null;
+            if (_data != null)
+            {
+                if(_isBufferFromArrayPool)
+                {
+                    _arrayPool.Return(_data);
+                }
+                _data = null;
+                _capacity = 0;
+            }
+            Reset();
         }
 
         /// <summary>
@@ -228,7 +249,9 @@ namespace System.Data.SqlClient.SNI
         public void Reset()
         {
             _length = 0;
-            _data = new byte[_capacity];
+            _offset = 0;
+            _description = null;
+            _completionCallback = null;
         }
 
         /// <summary>
@@ -270,10 +293,15 @@ namespace System.Data.SqlClient.SNI
 
                 if (error)
                 {
-                    this.Release();
+                    Release();
                 }
 
                 callback(this, error ? TdsEnums.SNI_ERROR : TdsEnums.SNI_SUCCESS);
+
+                if (_disposeAfterWriteAsync)
+                {
+                    Dispose();
+                }
             },
             CancellationToken.None,
             options,
@@ -315,6 +343,11 @@ namespace System.Data.SqlClient.SNI
                 status = TdsEnums.SNI_ERROR;
             }
             callback(this, status);
+
+            if (_disposeAfterWriteAsync)
+            {
+                Dispose();
+            }
         }
 
         /// <summary>
@@ -352,7 +385,7 @@ namespace System.Data.SqlClient.SNI
         {
             if (packet != null)
             {
-                return object.ReferenceEquals(packet, this);
+                return ReferenceEquals(packet, this);
             }
 
             return false;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -247,8 +247,7 @@ namespace System.Data.SqlClient.SNI
             }
             else
             {
-                clonedPacket.DisposeAfterWriteAsync = true;
-                result = handle.SendAsync(clonedPacket);
+                result = handle.SendAsync(clonedPacket, null, true);
             }
             
             return result;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -189,11 +189,11 @@ namespace System.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Get packet data
+        /// Copies data in SNIPacket to given byte array parameter
         /// </summary>
-        /// <param name="packet">SNI packet</param>
-        /// <param name="inBuff">Buffer</param>
-        /// <param name="dataSize">Data size</param>
+        /// <param name="packet">SNIPacket object containing data packets</param>
+        /// <param name="inBuff">Destination byte array where data packets are copied to</param>
+        /// <param name="dataSize">Length of data packets</param>
         /// <returns>SNI error status</returns>
         public uint PacketGetData(SNIPacket packet, byte[] inBuff, ref uint dataSize)
         {
@@ -238,14 +238,20 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error status</returns>
         public uint WritePacket(SNIHandle handle, SNIPacket packet, bool sync)
         {
+            SNIPacket clonedPacket = packet.Clone();
+            uint result;
             if (sync)
             {
-                return handle.Send(packet.Clone());
+                result = handle.Send(clonedPacket);
+                clonedPacket.Dispose();
             }
             else
             {
-                return handle.SendAsync(packet.Clone());
+                clonedPacket.DisposeAfterWriteAsync = true;
+                result = handle.SendAsync(clonedPacket);
             }
+            
+            return result;
         }
 
         /// <summary>
@@ -426,8 +432,7 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error status</returns>
         public uint ReadAsync(SNIHandle handle, out SNIPacket packet, bool isMars = false)
         {
-            packet = new SNIPacket(null);
-
+            packet = null;
             return handle.ReceiveAsync(ref packet);
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -247,7 +247,7 @@ namespace System.Data.SqlClient.SNI
             }
             else
             {
-                result = handle.SendAsync(clonedPacket, null, true);
+                result = handle.SendAsync(clonedPacket, true);
             }
             
             return result;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -381,7 +381,6 @@ namespace System.Data.SqlClient.SNI
             _sslStream = null;
             _sslOverTdsStream.Dispose();
             _sslOverTdsStream = null;
-
             _stream = _tcpStream;
         }
 
@@ -469,8 +468,7 @@ namespace System.Data.SqlClient.SNI
                         return TdsEnums.SNI_WAIT_TIMEOUT;
                     }
 
-                    packet = new SNIPacket(null);
-                    packet.Allocate(_bufferSize);
+                    packet = new SNIPacket(_bufferSize);
                     packet.ReadFromStream(_stream);
 
                     if (packet.Length == 0)
@@ -527,7 +525,7 @@ namespace System.Data.SqlClient.SNI
         public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
         {
             SNIAsyncCallback cb = callback ?? _sendCallback;
-            lock(this)
+            lock (this)
             {
                 packet.WriteToStreamAsync(_stream, cb, SNIProviders.TCP_PROV);
             }
@@ -541,8 +539,7 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint ReceiveAsync(ref SNIPacket packet, bool isMars = false)
         {
-            packet = new SNIPacket(null);
-            packet.Allocate(_bufferSize);
+            packet = new SNIPacket(_bufferSize);
 
             try
             {
@@ -619,6 +616,6 @@ namespace System.Data.SqlClient.SNI
         {
             _socket.Shutdown(SocketShutdown.Both);
         }
-#endif		
+#endif
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -522,12 +522,12 @@ namespace System.Data.SqlClient.SNI
         /// <param name="packet">SNI packet</param>
         /// <param name="callback">Completion callback</param>
         /// <returns>SNI error code</returns>
-        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null, bool disposeSNIPacketAfterSendAsync = false)
+        public override uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null)
         {
             SNIAsyncCallback cb = callback ?? _sendCallback;
             lock (this)
             {
-                packet.WriteToStreamAsync(_stream, cb, SNIProviders.TCP_PROV, disposeSNIPacketAfterSendAsync);
+                packet.WriteToStreamAsync(_stream, cb, SNIProviders.TCP_PROV, disposePacketAfterSendAsync);
             }
             return TdsEnums.SNI_SUCCESS_IO_PENDING;
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -522,12 +522,12 @@ namespace System.Data.SqlClient.SNI
         /// <param name="packet">SNI packet</param>
         /// <param name="callback">Completion callback</param>
         /// <returns>SNI error code</returns>
-        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
+        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null, bool disposeSNIPacketAfterSendAsync = false)
         {
             SNIAsyncCallback cb = callback ?? _sendCallback;
             lock (this)
             {
-                packet.WriteToStreamAsync(_stream, cb, SNIProviders.TCP_PROV);
+                packet.WriteToStreamAsync(_stream, cb, SNIProviders.TCP_PROV, disposeSNIPacketAfterSendAsync);
             }
             return TdsEnums.SNI_SUCCESS_IO_PENDING;
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -3166,15 +3166,16 @@ namespace System.Data.SqlClient
                 // Add packet to the pending list (since the callback can happen any time after we call SNIWritePacket)
                 packetPointer = AddPacketToPendingList(packet);
             }
+
             // Async operation completion may be delayed (success pending).
             try
             {
             }
             finally
             {
-
                 sniError = WritePacket(packet, sync);
             }
+
             if (sniError == TdsEnums.SNI_SUCCESS_IO_PENDING)
             {
                 Debug.Assert(!sync, "Completion should be handled in SniManagedWwrapper");

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -166,10 +166,13 @@ namespace System.Data.SqlClient.SNI
 
         internal override object CreateAndSetAttentionPacket()
         {
-            SNIPacket attnPacket = new SNIPacket(Handle);
-            _sniAsyncAttnPacket = attnPacket;
-            SetPacketData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN);
-            return attnPacket;
+            if (_sniAsyncAttnPacket == null)
+            {
+                SNIPacket attnPacket = new SNIPacket();
+                SetPacketData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN);
+                _sniAsyncAttnPacket = attnPacket;
+            }
+            return _sniAsyncAttnPacket;
         }
 
         internal override uint WritePacket(object packet, bool sync)
@@ -268,7 +271,7 @@ namespace System.Data.SqlClient.SNI
                 else
                 {
                     // Failed to take a packet - create a new one
-                    packet = new SNIPacket(sniHandle);
+                    packet = new SNIPacket();
                 }
                 return packet;
             }


### PR DESCRIPTION
Previous version of `SNIPacket` change (https://github.com/dotnet/corefx/pull/27187) contains couple of issues, and caused several test failures (https://github.com/dotnet/corefx/issues/27587, https://github.com/dotnet/corefx/issues/27574).
One of the failures caused by missing locks, and other ones were caused by unreleased byte array on `SNIPacket.Release()`. This revised fix excludes dealing with locks, and also properly deallocates byte array when `SNIPacket.Release()` is called.