### PR TITLE
Keep memory a MetadataReader created from provider/PEReader accesses alive until the provider/PEReader is released

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReaderProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReaderProvider.cs
@@ -266,7 +266,7 @@ namespace System.Reflection.Metadata
                 }
 
                 AbstractMemoryBlock metadata = GetMetadataBlock();
-                var newReader = new MetadataReader(metadata.Pointer, metadata.Size, options, utf8Decoder);
+                var newReader = new MetadataReader(metadata.Pointer, metadata.Size, options, utf8Decoder, memoryOwner: this);
                 _lazyMetadataReader = newReader;
                 return newReader;
             }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReaderProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReaderProvider.cs
@@ -234,7 +234,7 @@ namespace System.Reflection.Metadata
         /// Gets a <see cref="MetadataReader"/> from a <see cref="MetadataReaderProvider"/>.
         /// </summary>
         /// <remarks>
-        /// The caller must keep the <see cref="MetadataReaderProvider"/> alive and undisposed throughout the lifetime of the metadata reader.
+        /// The caller must keep the <see cref="MetadataReaderProvider"/> undisposed throughout the lifetime of the metadata reader.
         /// 
         /// If this method is called multiple times each call with arguments equal to the arguments passed to the previous successful call 
         /// returns the same instance of <see cref="MetadataReader"/> as the previous call.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PEReaderExtensions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PEReaderExtensions.cs
@@ -85,7 +85,7 @@ namespace System.Reflection.Metadata
             }
 
             var metadata = peReader.GetMetadata();
-            return new MetadataReader(metadata.Pointer, metadata.Length, options, utf8Decoder);
+            return new MetadataReader(metadata.Pointer, metadata.Length, options, utf8Decoder, memoryOwner: peReader);
         }
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PEReaderExtensions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PEReaderExtensions.cs
@@ -71,7 +71,7 @@ namespace System.Reflection.Metadata
         /// Gets a <see cref="MetadataReader"/> from a <see cref="PEReader"/>.
         /// </summary>
         /// <remarks>
-        /// The caller must keep the <see cref="PEReader"/> alive and undisposed throughout the lifetime of the metadata reader.
+        /// The caller must keep the <see cref="PEReader"/> undisposed throughout the lifetime of the metadata reader.
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="peReader"/> is null</exception>
         /// <exception cref="ArgumentException">The encoding of <paramref name="utf8Decoder"/> is not <see cref="UTF8Encoding"/>.</exception>


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/25946.