### PR TITLE
Handle recycled child PIDs

### DIFF
--- a/src/System.Diagnostics.Process/src/FxCopBaseline.cs
+++ b/src/System.Diagnostics.Process/src/FxCopBaseline.cs
@@ -7,3 +7,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.Diagnostics.Process.#EnsureWatchingForExit()")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.Diagnostics.Process.#RaiseOnExited()")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.Diagnostics.Process.#StopWatchingForExit()")]
+[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.Diagnostics.Process.#CompletionCallback(System.Object,System.Boolean)")]

--- a/src/System.Diagnostics.Process/src/FxCopBaseline.cs
+++ b/src/System.Diagnostics.Process/src/FxCopBaseline.cs
@@ -8,3 +8,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.Diagnostics.Process.#RaiseOnExited()")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.Diagnostics.Process.#StopWatchingForExit()")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.Diagnostics.Process.#CompletionCallback(System.Object,System.Boolean)")]
+[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.Diagnostics.Process.Close()")]

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -110,7 +110,7 @@ namespace System.Diagnostics
                         {
                             _waitHandle = new ProcessWaitHandle(GetWaitState());
                             _registeredWaitHandle = ThreadPool.RegisterWaitForSingleObject(_waitHandle,
-                                new WaitOrTimerCallback(CompletionCallback), null, -1, true);
+                                new WaitOrTimerCallback(CompletionCallback), _waitHandle, -1, true);
                         }
                         catch
                         {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -85,10 +85,7 @@ namespace System.Diagnostics
             // Make sure that we configure the wait state holder for this process object, which we can only do once we have a process ID.
             Debug.Assert(_haveProcessId, $"{nameof(ConfigureAfterProcessIdSet)} should only be called once a process ID is set");
             // Initialize WaitStateHolder for non-child processes
-            if (_waitStateHolder == null)
-            {
-                _waitStateHolder = new ProcessWaitState.Holder(_processId);
-            }
+            GetWaitState();
         }
 
         /// <devdoc>
@@ -624,13 +621,12 @@ namespace System.Diagnostics
         /// <summary>Gets the wait state for this Process object.</summary>
         private ProcessWaitState GetWaitState()
         {
-            ProcessWaitState waitState = _waitStateHolder?._state;
-            if (waitState == null)
+            if (_waitStateHolder == null)
             {
-                // This will throw
                 EnsureState(State.HaveId);
+                _waitStateHolder = new ProcessWaitState.Holder(_processId);
             }
-            return waitState;
+            return _waitStateHolder._state;
         }
 
         private static (uint userId, uint groupId) GetUserAndGroupIds(ProcessStartInfo startInfo)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -126,7 +126,7 @@ namespace System.Diagnostics
                         {
                             _waitHandle = new Interop.Kernel32.ProcessWaitHandle(_processHandle);
                             _registeredWaitHandle = ThreadPool.RegisterWaitForSingleObject(_waitHandle,
-                                new WaitOrTimerCallback(CompletionCallback), null, -1, true);
+                                new WaitOrTimerCallback(CompletionCallback), _waitHandle, -1, true);
                         }
                         catch
                         {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -117,9 +117,10 @@ namespace System.Diagnostics
             _processInfo = processInfo;
             _machineName = machineName;
             _isRemoteMachine = isRemoteMachine;
+            _processId = processId;
+            _haveProcessId = true;
             _outputStreamReadMode = StreamReadMode.Undefined;
             _errorStreamReadMode = StreamReadMode.Undefined;
-            SetProcessId(processId);
         }
 
         public SafeProcessHandle SafeHandle

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -782,10 +782,20 @@ namespace System.Diagnostics
         ///     This is called from the threadpool when a process exits.
         /// </devdoc>
         /// <internalonly/>
-        private void CompletionCallback(object context, bool wasSignaled)
+        private void CompletionCallback(object waitHandleContext, bool wasSignaled)
         {
-            StopWatchingForExit();
-            RaiseOnExited();
+            Debug.Assert(waitHandleContext != null, "Process.CompletionCallback called with no waitHandleContext");
+            lock (this)
+            {
+                // Check the exited event that we get from the threadpool
+                // matches the event we are waiting for.
+                if (waitHandleContext != _waitHandle)
+                {
+                    return;
+                }
+                StopWatchingForExit();
+                RaiseOnExited();
+            }
         }
 
         /// <internalonly/>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -117,10 +117,9 @@ namespace System.Diagnostics
             _processInfo = processInfo;
             _machineName = machineName;
             _isRemoteMachine = isRemoteMachine;
-            _processId = processId;
-            _haveProcessId = true;
             _outputStreamReadMode = StreamReadMode.Undefined;
             _errorStreamReadMode = StreamReadMode.Undefined;
+            SetProcessId(processId);
         }
 
         public SafeProcessHandle SafeHandle

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitHandle.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitHandle.Unix.cs
@@ -9,26 +9,12 @@ namespace System.Diagnostics
 {
     internal sealed class ProcessWaitHandle : WaitHandle
     {
-        /// <summary>
-        /// Holds a wait state object associated with this handle.
-        /// </summary>
-        private ProcessWaitState.Holder _waitStateHolder;
-
-        internal ProcessWaitHandle(SafeProcessHandle processHandle)
+        internal ProcessWaitHandle(ProcessWaitState processWaitState)
         {
-            // Get the process ID from the process handle.  The handle is just a facade that wraps
-            // the process ID, and closing the handle won't affect the process or its ID at all.
-            // So we can grab it, and it's not "dangerous".
-            int processId = (int)processHandle.DangerousGetHandle();
-
-            // Create a wait state holder for this process ID.  This gives us access to the shared
-            // wait state associated with this process.
-            _waitStateHolder = new ProcessWaitState.Holder(processId);
-
             // Get the wait state's event, and use that event's safe wait handle
             // in place of ours.  This will let code register for completion notifications
             // on this ProcessWaitHandle and be notified when the wait state's handle completes.
-            ManualResetEvent mre = _waitStateHolder._state.EnsureExitedEvent();
+            ManualResetEvent mre = processWaitState.EnsureExitedEvent();
             this.SetSafeWaitHandle(mre.GetSafeWaitHandle());
         }
 
@@ -36,14 +22,6 @@ namespace System.Diagnostics
         {
             // ProcessWaitState will dispose the handle
             this.SafeWaitHandle = null;
-            if (explicitDisposing)
-            {
-                if (_waitStateHolder != null)
-                {
-                    _waitStateHolder.Dispose();
-                    _waitStateHolder = null;
-                }
-            }
             base.Dispose(explicitDisposing);
         }
     }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -515,6 +515,39 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        /// <summary>
+        /// Verifies a new Process instance can refer to a process with a recycled pid
+        /// for which there is still an existing Process instance.
+        /// </summary>
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
+        public void TestProcessRecycledPid()
+        {
+            const int LinuxPidMaxDefault = 32768;
+            var processes = new Dictionary<int, Process>(LinuxPidMaxDefault);
+            bool foundRecycled = false;
+            for (int i = 0; i < int.MaxValue; i++)
+            {
+                var process = CreateProcessLong();
+                process.Start();
+
+                foundRecycled = processes.ContainsKey(process.Id);
+
+                process.Kill();
+                process.WaitForExit();
+
+                if (foundRecycled)
+                {
+                    break;
+                }
+                else
+                {
+                    processes.Add(process.Id, process);
+                }
+            }
+
+            Assert.True(foundRecycled);
+        }
+
         private static IDictionary GetWaitStateDictionary(bool childDictionary)
         {
             Assembly assembly = typeof(Process).Assembly;


### PR DESCRIPTION
When the user keeping references to old processes, a new child would re-use some state of an old process with the same PID.
This causes the following code to throw when PID is recycled (https://github.com/dotnet/corefx/issues/27249#issuecomment-367288949).
```C#
            List<Process> processes = new List<Process>();
            for (int i = 0; i < 1_000_000; i++)
            {
                if (i % 100 == 0)
                {
                    System.Console.Write(".");
                }
                try
                {
                    var process = new Process();
                    processes.Add(process);
                    process.StartInfo.FileName = "/usr/bin/sleep";
                    process.StartInfo.Arguments = "0";
                    process.EnableRaisingEvents = true;
                    process.Start();

                    process.WaitForExit();
                }
                catch
                {
                    System.Console.WriteLine($"Exception when creating process {i}");
                    throw;
                }
            }
```

We detect when the PID is recycled and use a new ProcessWaitState for the new child.
Also, we ensure the ProcessWaitHandle is using the same ProcessWaitState as the Process it was created for.

The above test code no longer throws now when the PID is recycled. I have not added a test because it takes a long time to run.

CC @stephentoub @danmosemsft 