### PR TITLE
Fix NullReferenceException when using client certs with ClientWebSocket

### DIFF
--- a/src/System.Net.WebSockets.Client/src/ILLinkTrim.xml
+++ b/src/System.Net.WebSockets.Client/src/ILLinkTrim.xml
@@ -1,0 +1,9 @@
+<linker>
+  <assembly fullname="System.Net.WebSockets.Client">
+    <!-- TODO #12038: Remove once exposed publicly. -->
+    <type fullname="System.Net.WebSockets.ClientWebSocketOptions">
+      <method name="get_RemoteCertificateValidationCallback" />
+      <method name="set_RemoteCertificateValidationCallback" />
+    </type>
+  </assembly>
+</linker>

--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Globalization" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Net.Primitives" />
+    <Reference Include="System.Net.Security" />
     <Reference Include="System.Net.WebHeaderCollection" />
     <Reference Include="System.Net.WebSockets" />
     <Reference Include="System.Resources.ResourceManager" />
@@ -84,7 +85,6 @@
     <Reference Include="System.Buffers" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.NameResolution" />
-    <Reference Include="System.Net.Security" />
     <Reference Include="System.Net.Sockets" />
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Security.Cryptography.Algorithms" />

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
@@ -21,6 +22,7 @@ namespace System.Net.WebSockets
         private int _receiveBufferSize = 0x1000;
         private int _sendBufferSize = 0x1000;
         private ArraySegment<byte>? _buffer;
+        private RemoteCertificateValidationCallback _remoteCertificateValidationCallback;
 
         internal X509CertificateCollection _clientCertificates;
         internal WebHeaderCollection _requestHeaders;
@@ -104,6 +106,16 @@ namespace System.Net.WebSockets
                     throw new ArgumentNullException(nameof(value));
                 }
                 _clientCertificates = value;
+            }
+        }
+
+        internal RemoteCertificateValidationCallback RemoteCertificateValidationCallback // TODO #12038: Expose publicly.
+        {
+            get => _remoteCertificateValidationCallback;
+            set
+            {
+                ThrowIfReadOnly();
+                _remoteCertificateValidationCallback = value;
             }
         }
 

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -92,8 +93,13 @@ namespace System.Net.WebSockets
                 handler.Credentials = options.Credentials;
                 handler.Proxy = options.Proxy;
                 handler.CookieContainer = options.Cookies;
+                handler.SslOptions.RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback;
                 if (options._clientCertificates?.Count > 0) // use field to avoid lazily initializing the collection
                 {
+                    if (handler.SslOptions.ClientCertificates == null)
+                    {
+                        handler.SslOptions.ClientCertificates = new X509Certificate2Collection();
+                    }
                     handler.SslOptions.ClientCertificates.AddRange(options.ClientCertificates);
                 }
 

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Reflection;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -22,13 +23,9 @@ namespace System.Net.WebSockets.Client.Tests
             Capability.IsTrustedRootCertificateInstalled() &&
             (BackendSupportsCustomCertificateHandling || Capability.AreHostsFileNamesInstalled());
 
-        public static bool CanTestClientCertificates =>
-            CanTestCertificates && BackendSupportsCustomCertificateHandling;
-
         // Windows 10 Version 1709 introduced the necessary APIs for the UAP version of
         // ClientWebSocket.ConnectAsync to carry out mutual TLS authentication.
-        public static bool ClientCertificatesSupported =>
-            !PlatformDetection.IsUap || PlatformDetection.IsWindows10Version1709OrGreater;
+        public static bool ClientCertificatesSupported => !PlatformDetection.IsUap;
 
         public ClientWebSocketOptionsTests(ITestOutputHelper output) : base(output) { }
 
@@ -82,46 +79,36 @@ namespace System.Net.WebSockets.Client.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => cws.Options.KeepAliveInterval = TimeSpan.MinValue);
         }
 
-        [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(5120, TargetFrameworkMonikers.Netcoreapp)]
-        [ConditionalFact(nameof(WebSocketsSupported), nameof(CanTestClientCertificates), nameof(ClientCertificatesSupported))]
+        [OuterLoop("Connects to remote service")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Lacks RemoteCertificateValidationCallback to enable loopback testing")]
+        [ConditionalFact(nameof(WebSocketsSupported), nameof(ClientCertificatesSupported))]
         public async Task ClientCertificates_ValidCertificate_ServerReceivesCertificateAndConnectAsyncSucceeds()
         {
-            var options = new LoopbackServer.Options { UseSsl = true, WebSocketEndpoint = true };
-
-            Func<ClientWebSocket, LoopbackServer, Uri, X509Certificate2, Task> connectToServerWithClientCert = async (clientSocket, server, url, clientCert) =>
+            using (X509Certificate2 clientCert = Test.Common.Configuration.Certificates.GetClientCertificate())
             {
-                // Start listening for incoming connections on the server side.
-                Task acceptTask = server.AcceptConnectionAsync(async connection =>
-                    {
-                        // Validate that the client certificate received by the server matches the one configured on
-                        // the client-side socket.
-                        SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);
-                        Assert.NotNull(sslStream.RemoteCertificate);
-                        Assert.Equal(clientCert, new X509Certificate2(sslStream.RemoteCertificate));
-
-                        // Complete the WebSocket upgrade over the secure channel. After this is done, the client-side
-                        // ConnectAsync should complete.
-                        Assert.True(await LoopbackHelper.WebSocketHandshakeAsync(connection));
-                    });
-
-                // Initiate a connection attempt with a client certificate configured on the socket.
-                clientSocket.Options.ClientCertificates.Add(clientCert);
-                var cts = new CancellationTokenSource(TimeOutMilliseconds);
-                await clientSocket.ConnectAsync(url, cts.Token);
-                acceptTask.Wait(cts.Token);
-            };
-
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
-            {
-                using (X509Certificate2 clientCert = Test.Common.Configuration.Certificates.GetClientCertificate())
+                await LoopbackServer.CreateClientAndServerAsync(async uri =>
                 {
-                    using (ClientWebSocket clientSocket = new ClientWebSocket())
+                    using (var clientSocket = new ClientWebSocket())
+                    using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                     {
-                        await connectToServerWithClientCert(clientSocket, server, url, clientCert);
+                        clientSocket.Options.ClientCertificates.Add(clientCert);
+                        clientSocket.Options.GetType().GetProperty("RemoteCertificateValidationCallback", BindingFlags.NonPublic | BindingFlags.Instance)
+                            .SetValue(clientSocket.Options, new RemoteCertificateValidationCallback(delegate { return true; })); // TODO: #12038: Simplify once property is public.
+                        await clientSocket.ConnectAsync(uri, cts.Token);
                     }
-                }
-            }, options);
+                }, server => server.AcceptConnectionAsync(async connection =>
+                {
+                    // Validate that the client certificate received by the server matches the one configured on
+                    // the client-side socket.
+                    SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);
+                    Assert.NotNull(sslStream.RemoteCertificate);
+                    Assert.Equal(clientCert, new X509Certificate2(sslStream.RemoteCertificate));
+
+                    // Complete the WebSocket upgrade over the secure channel. After this is done, the client-side
+                    // ConnectAsync should complete.
+                    Assert.True(await LoopbackHelper.WebSocketHandshakeAsync(connection));
+                }), new LoopbackServer.Options { UseSsl = true, WebSocketEndpoint = true });
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/27768
Contributes to https://github.com/dotnet/corefx/issues/12038 (necessary to test the fix well)
cc: @geoffkizer, @davidsh, @rmkerr, @caesar1995 

