### PR TITLE
Fix synchronization in Channel's AsyncOperation

### DIFF
--- a/src/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
@@ -90,7 +90,7 @@ namespace System.Threading.Channels
                     AsyncOperation<bool> next = c.Next;
                     c.Next = null;
 
-                    bool completed = error != null ? c.Fail(error) : c.Success(result);
+                    bool completed = error != null ? c.TrySetException(error) : c.TrySetResult(result);
                     Debug.Assert(completed || c.CancellationToken.CanBeCanceled);
 
                     c = next;
@@ -107,7 +107,7 @@ namespace System.Threading.Channels
             Debug.Assert(error != null);
             while (!operations.IsEmpty)
             {
-                operations.DequeueHead().Fail(error);
+                operations.DequeueHead().TrySetException(error);
             }
         }
 

--- a/src/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
@@ -59,8 +59,8 @@ namespace System.Threading.Channels
             internal UnboundedChannelReader(SingleConsumerUnboundedChannel<T> parent)
             {
                 _parent = parent;
-                _readerSingleton = new AsyncOperation<T>(parent._runContinuationsAsynchronously) { UnsafeState = ResettableValueTaskSource.States.Released };
-                _waiterSingleton = new AsyncOperation<bool>(parent._runContinuationsAsynchronously) { UnsafeState = ResettableValueTaskSource.States.Released };
+                _readerSingleton = new AsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
+                _waiterSingleton = new AsyncOperation<bool>(parent._runContinuationsAsynchronously, pooled: true);
             }
 
             public override Task Completion => _parent._completion.Task;
@@ -252,7 +252,7 @@ namespace System.Threading.Channels
                 if (blockedReader != null)
                 {
                     error = ChannelUtilities.CreateInvalidCompletionException(error);
-                    blockedReader.Fail(error);
+                    blockedReader.TrySetException(error);
                 }
 
                 // Complete a waiting reader if necessary.  (We really shouldn't have both a blockedReader
@@ -261,11 +261,11 @@ namespace System.Threading.Channels
                 {
                     if (error != null)
                     {
-                        waitingReader.Fail(error);
+                        waitingReader.TrySetException(error);
                     }
                     else
                     {
-                        waitingReader.Success(item: false);
+                        waitingReader.TrySetResult(item: false);
                     }
                 }
 
@@ -314,8 +314,9 @@ namespace System.Threading.Channels
 
                     // If we have a waiting reader, notify it that an item was written and exit.
                     if (waitingReader != null)
-                    {                // If we get here, we grabbed a waiting reader.
-                        waitingReader.Success(item: true);
+                    {
+                        // If we get here, we grabbed a waiting reader.
+                        waitingReader.TrySetResult(item: true);
                         return true;
                     }
 
@@ -324,7 +325,7 @@ namespace System.Threading.Channels
                     // have been completed due to cancellation by the time we get here.  In that case,
                     // we'll loop around to try again so as not to lose the item being written.
                     Debug.Assert(blockedReader != null);
-                    if (blockedReader.Success(item))
+                    if (blockedReader.TrySetResult(item))
                     {
                         return true;
                     }

--- a/src/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
@@ -48,8 +48,8 @@ namespace System.Threading.Channels
             internal UnboundedChannelReader(UnboundedChannel<T> parent)
             {
                 _parent = parent;
-                _readerSingleton = new AsyncOperation<T>(parent._runContinuationsAsynchronously) { UnsafeState = ResettableValueTaskSource.States.Released };
-                _waiterSingleton = new AsyncOperation<bool>(parent._runContinuationsAsynchronously) { UnsafeState = ResettableValueTaskSource.States.Released };
+                _readerSingleton = new AsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
+                _waiterSingleton = new AsyncOperation<bool>(parent._runContinuationsAsynchronously, pooled: true);
             }
 
             public override Task Completion => _parent._completion.Task;
@@ -274,7 +274,7 @@ namespace System.Threading.Channels
                     {
                         // Complete the reader.  It's possible the reader was canceled, in which
                         // case we loop around to try everything again.
-                        if (blockedReader.Success(item))
+                        if (blockedReader.TrySetResult(item))
                         {
                             return true;
                         }


### PR DESCRIPTION
The synchronization in System.Threading.Channel's AsyncOperation was messed up after the switch to ValueTask, in particular in the face of cancellation.  The key issue was that we were using two different fields to represent operation completion, which meant they weren't being updated atomically and allowed for things to get out of sync.

For example, a thread could be completing an operation and after setting Completed but before setting the s_completedSentinel, another thread could check IsCompleted, call GetResult, make the operation available for pooled reuse, another renter of it could claim it, and then the original thread could end up continuing and storing the s_completedSentinel into an object it no longer owns.  Running the perf or stress tests would cause asserts to fire sporadically.

This commit restructures AsyncOperation to avoid such issues.  Now the _continuation field is the sole source of truth as to whether the operation has completed.  This has the nice side-effect of reducing interlocked operations for the common path (e.g. using a pooled object).  It also fixes the issues that prevented us from using pooling in BoundedChannel, so the change also enables that.

Fixes https://github.com/dotnet/corefx/issues/27714
Fixes https://github.com/dotnet/corefx/issues/27718 (I think; if it resurfaces after this change we can investigate separately)
cc: @tarekgh 