### PR TITLE
Fix the unhandled exception and test validation in manual tests

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -151,7 +151,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             return ex;
         }
 
-        public static TException ExpectFailure<TException>(Action actionThatFails, string exceptionMessage = null, bool innerExceptionMustBeNull = false, Func<TException, bool> customExceptionVerifier = null) where TException : Exception
+        public static TException ExpectFailure<TException>(Action actionThatFails, string[] exceptionMessages, bool innerExceptionMustBeNull = false, Func<TException, bool> customExceptionVerifier = null) where TException : Exception
         {
             try
             {
@@ -161,14 +161,14 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
             catch (Exception ex)
             {
-                if ((CheckException<TException>(ex, exceptionMessage, innerExceptionMustBeNull)) && ((customExceptionVerifier == null) || (customExceptionVerifier(ex as TException))))
+                foreach (string exceptionMessage in exceptionMessages)
                 {
-                    return (ex as TException);
+                    if ((CheckException<TException>(ex, exceptionMessage, innerExceptionMustBeNull)) && ((customExceptionVerifier == null) || (customExceptionVerifier(ex as TException))))
+                    {
+                        return (ex as TException);
+                    }
                 }
-                else
-                {
-                    throw;
-                }
+                throw;
             }
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -125,8 +125,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 var command = con.CreateCommand();
                 command.CommandText = "select * from orders; waitfor delay '00:00:08'; select * from customers";
 
-                Thread rThread1 = new Thread(ExecuteCommandCancelExpected);
-                Thread rThread2 = new Thread(CancelSharedCommand);
                 Barrier threadsReady = new Barrier(2);
                 object state = new Tuple<bool, SqlCommand, Barrier>(async, command, threadsReady);
                 Task t1 = new Task(ExecuteCommandCancelExpected, state);
@@ -134,7 +132,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 t1.Start();
                 t2.Start();
 
-                t1.Wait(15 * 10000);
+                t1.Wait(15 * 1000);
                 if (t1.IsFaulted)
                 {
                     throw t1.Exception;

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -135,10 +135,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 tasks[1].Start();
 
                 Task.WaitAll(tasks, 15 * 1000);
-                if (tasks[0].IsFaulted)
-                {
-                    throw tasks[0].Exception;
-                }
                 
                 CommandCancelTest.VerifyConnection(command);
             }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -127,15 +127,17 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 
                 Barrier threadsReady = new Barrier(2);
                 object state = new Tuple<bool, SqlCommand, Barrier>(async, command, threadsReady);
-                Task t1 = new Task(ExecuteCommandCancelExpected, state);
-                Task t2 = new Task(CancelSharedCommand, state);
-                t1.Start();
-                t2.Start();
 
-                t1.Wait(15 * 1000);
-                if (t1.IsFaulted)
+                Task[] tasks = new Task[2];
+                tasks[0] = new Task(ExecuteCommandCancelExpected, state);
+                tasks[1] = new Task(CancelSharedCommand, state);
+                tasks[0].Start();
+                tasks[1].Start();
+
+                Task.WaitAll(tasks, 15 * 1000);
+                if (tasks[0].IsFaulted)
                 {
-                    throw t1.Exception;
+                    throw tasks[0].Exception;
                 }
                 
                 CommandCancelTest.VerifyConnection(command);


### PR DESCRIPTION
There are two changes in this PR.

1. Handle all the exception thrown by the thread in the thread itself, so that it doesn't crash the tests.
2. Add the check for additional error message that can be thrown if the Command is Canceled. 

This was causing intermittent test crashes in Manual Test runs. 