### PR TITLE
Add more tests for Span<T>.Clear()

### DIFF
--- a/src/System.Memory/tests/Span/Clear.cs
+++ b/src/System.Memory/tests/Span/Clear.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using static System.TestHelpers;
 
@@ -196,6 +197,31 @@ namespace System.SpanTests
             var span = new Span<string>(actual);
             span.Clear();
             Assert.Equal<string>(expected, actual);
+        }
+
+        [Fact]
+        public static void ClearReferenceTypeSlice()
+        {
+            // A string array [ ""1", ..., "20" ]
+            string[] baseline = Enumerable.Range(1, 20).Select(i => i.ToString()).ToArray();
+
+            for (int i = 0; i < 16; i++)
+            {
+                // Going to clear array.Slice(1, i) manually,
+                // then compare it against array.Slice(1, i).Clear().
+                // Test is written this way to allow detecting overrunning bounds.
+
+                string[] expected = (string[])baseline.Clone();
+                for (int j = 0; j < i; j++)
+                {
+                    expected[j + 1] = null;
+                }
+
+                string[] actual = (string[])baseline.Clone();
+                new Span<string>(actual).Slice(1, i).Clear();
+
+                Assert.Equal(expected, actual);
+            }
         }
 
         [Fact]

--- a/src/System.Memory/tests/Span/Clear.cs
+++ b/src/System.Memory/tests/Span/Clear.cs
@@ -212,13 +212,13 @@ namespace System.SpanTests
                 // Test is written this way to allow detecting overrunning bounds.
 
                 string[] expected = (string[])baseline.Clone();
-                for (int j = 0; j < i; j++)
+                for (int j = 1; j <= i; j++)
                 {
-                    expected[j + 1] = null;
+                    expected[j] = null;
                 }
 
                 string[] actual = (string[])baseline.Clone();
-                new Span<string>(actual).Slice(1, i).Clear();
+                actual.AsSpan(1, i).Clear();
 
                 Assert.Equal(expected, actual);
             }


### PR DESCRIPTION
We didn't previously have tests that checked that `Span<T>.Clear()` (for referential T) stayed within its slice. Adding a test to check this.