### PR TITLE
Fix race condition in SystemEvents

### DIFF
--- a/src/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
+++ b/src/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
@@ -26,8 +26,7 @@ namespace Microsoft.Win32.SystemEventsTests
             Assert.Throws<ArgumentException>(() => SystemEvents.CreateTimer(-1));
             Assert.Throws<ArgumentException>(() => SystemEvents.CreateTimer(int.MinValue));
         }
-        
-        [ActiveIssue(27771)]
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TimerElapsedSignaled()
         {
@@ -48,6 +47,12 @@ namespace Microsoft.Win32.SystemEventsTests
             SystemEvents.TimerElapsed += handler;
             try
             {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    // desktop has a bug where it will allow EnsureSystemEvents to proceed without actually creating the HWND
+                    SystemEventsTest.WaitForSystemEventsWindow();
+                }
+
                 timer = SystemEvents.CreateTimer(TimerInterval);
 
                 Assert.True(elapsed.WaitOne(TimerInterval * SystemEventsTest.ExpectedEventMultiplier));
@@ -94,6 +99,12 @@ namespace Microsoft.Win32.SystemEventsTests
             SystemEvents.TimerElapsed += handler;
             try
             {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    // desktop has a bug where it will allow EnsureSystemEvents to proceed without actually creating the HWND
+                    SystemEventsTest.WaitForSystemEventsWindow();
+                }
+
                 for (int i = 0; i < NumConcurrentTimers; i++)
                 {
                     timersSignalled[SystemEvents.CreateTimer(TimerInterval)] = false;


### PR DESCRIPTION
When two threads attempt to create the SystemEvents HWND at the same time the first
will set a static field (indicating work is done) then kick off a thread to do the actual work.
The second will see the field has been set and skip the work.  This changes the field setting
to happen after the actual work, so that concurrent threads will block on the lock then
immediately return once they get it since the field will be set.

This change cannot be made on desktop so we must make the tests synchronize on the
creation of the window before calling methods which might fail (eg: SendMessage).

Fixes #27771 

/cc @stephentoub 