### PR TITLE
Use generic WeakReference and avoid casting in Regex

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -119,21 +119,15 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public virtual string Result(string replacement)
         {
-            RegexReplacement repl;
-
             if (replacement == null)
                 throw new ArgumentNullException(nameof(replacement));
 
             if (_regex == null)
                 throw new NotSupportedException(SR.NoResultOnFailed);
 
-            repl = (RegexReplacement)_regex._replref.Get();
-
-            if (repl == null || !repl.Pattern.Equals(replacement))
-            {
-                repl = RegexParser.ParseReplacement(replacement, _regex.caps, _regex.capsize, _regex.capnames, _regex.roptions);
-                _regex._replref.Cache(repl);
-            }
+            // Gets the weakly cached replacement helper or creates one if there isn't one already.
+            RegexReplacement repl = RegexReplacement.GetOrCreate(_regex._replref, replacement, _regex.caps, _regex.capsize,
+                _regex.capnames, _regex.roptions);
 
             return repl.Replacement(this);
         }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Reference.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Reference.cs
@@ -12,7 +12,7 @@ namespace System.Text.RegularExpressions
     internal sealed class ExclusiveReference
     {
         private RegexRunner _ref;
-        private object _obj;
+        private RegexRunner _obj;
         private volatile int _locked;
 
         /// <summary>
@@ -21,14 +21,14 @@ namespace System.Text.RegularExpressions
         /// If the exclusive lock can't be obtained, null is returned;
         /// if the object can't be returned, the lock is released.
         /// </summary>
-        public object Get()
+        public RegexRunner Get()
         {
             // try to obtain the lock
 
             if (0 == Interlocked.Exchange(ref _locked, 1))
             {
                 // grab reference
-                object obj = _ref;
+                RegexRunner obj = _ref;
 
                 // release the lock and return null if no reference
                 if (obj == null)
@@ -53,7 +53,7 @@ namespace System.Text.RegularExpressions
         /// If the object is the one that's under lock, the lock is released.
         /// If there is no cached object, then the lock is obtained and the object is placed in the cache.
         /// </summary>
-        public void Release(object obj)
+        public void Release(RegexRunner obj)
         {
             if (obj == null)
                 throw new ArgumentNullException(nameof(obj));
@@ -75,54 +75,13 @@ namespace System.Text.RegularExpressions
                 {
                     // if there's really no reference, cache this reference
                     if (_ref == null)
-                        _ref = (RegexRunner)obj;
+                        _ref = obj;
 
                     // release the lock
                     _locked = 0;
 
                     return;
                 }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Used to cache a weak reference in a threadsafe way
-    /// </summary>
-    internal sealed class SharedReference
-    {
-        private readonly WeakReference _ref = new WeakReference(null);
-        private volatile int _locked;
-
-        /// <summary>
-        /// Return an object from a weakref, protected by a lock.
-        /// 
-        /// If the exclusive lock can't be obtained, null is returned;
-        /// Note that _ref.Target is referenced only under the protection of the lock. (Is this necessary?)
-        /// </summary>
-        public object Get()
-        {
-            if (0 == Interlocked.Exchange(ref _locked, 1))
-            {
-                object obj = _ref.Target;
-                _locked = 0;
-                return obj;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Suggest an object into a weakref, protected by a lock.
-        /// 
-        /// Note that _ref.Target is referenced only under the protection of the lock. (Is this necessary?)
-        /// </summary>
-        public void Cache(object obj)
-        {
-            if (0 == Interlocked.Exchange(ref _locked, 1))
-            {
-                _ref.Target = obj;
-                _locked = 0;
             }
         }
     }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
@@ -148,10 +148,10 @@ namespace System.Text.RegularExpressions
 #endif
             public int _capsize;
             public ExclusiveReference _runnerref;
-            public SharedReference _replref;
+            public WeakReference<RegexReplacement> _replref;
 
             public CachedCodeEntry(CachedCodeEntryKey key, Hashtable capnames, string[] capslist, RegexCode code, 
-                Hashtable caps, int capsize, ExclusiveReference runner, SharedReference repl)
+                Hashtable caps, int capsize, ExclusiveReference runner, WeakReference<RegexReplacement> replref)
             {
                 _key = key;
                 _capnames = capnames;
@@ -162,7 +162,7 @@ namespace System.Text.RegularExpressions
                 _capsize = capsize;
 
                 _runnerref = runner;
-                _replref = repl;
+                _replref = replref;
             }
 
 #if FEATURE_COMPILED

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -75,14 +75,8 @@ namespace System.Text.RegularExpressions
             if (replacement == null)
                 throw new ArgumentNullException(nameof(replacement));
 
-            // a little code to grab a cached parsed replacement object
-            RegexReplacement repl = (RegexReplacement)_replref.Get();
-
-            if (repl == null || !repl.Pattern.Equals(replacement))
-            {
-                repl = RegexParser.ParseReplacement(replacement, caps, capsize, capnames, roptions);
-                _replref.Cache(repl);
-            }
+            // Gets the weakly cached replacement helper or creates one if there isn't one already.
+            RegexReplacement repl = RegexReplacement.GetOrCreate(_replref, replacement, caps, capsize, capnames, roptions);
 
             return repl.Replace(this, input, count, startat);
         }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -35,7 +35,7 @@ namespace System.Text.RegularExpressions
         protected internal int capsize;                      // the size of the capture array
         
         internal ExclusiveReference _runnerref;              // cached runner
-        internal SharedReference _replref;                   // cached parsed replacement pattern
+        internal WeakReference<RegexReplacement> _replref; // cached parsed replacement pattern
         internal RegexCode _code;                            // if interpreted, this is the code for RegexInterpreter
         internal bool _refsInitialized = false;
 
@@ -430,7 +430,7 @@ namespace System.Text.RegularExpressions
 
             _refsInitialized = true;
             _runnerref = new ExclusiveReference();
-            _replref = new SharedReference();
+            _replref = new WeakReference<RegexReplacement>(null);
         }
 
         /// <summary>
@@ -446,7 +446,7 @@ namespace System.Text.RegularExpressions
                 throw new ArgumentOutOfRangeException(nameof(length), SR.LengthNotNegative);
 
             // There may be a cached runner; grab ownership of it if we can.
-            RegexRunner runner = (RegexRunner)_runnerref.Get();
+            RegexRunner runner = _runnerref.Get();
 
             // Create a RegexRunner instance if we need to
             if (runner == null)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -86,6 +86,24 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
+        /// Either returns a weakly cached RegexReplacement helper or creates one and caches it.
+        /// </summary>
+        /// <returns></returns>
+        public static RegexReplacement GetOrCreate(WeakReference<RegexReplacement> replRef, string replacement, Hashtable caps,
+            int capsize, Hashtable capnames, RegexOptions roptions)
+        {
+            RegexReplacement repl;
+
+            if (!replRef.TryGetTarget(out repl) || !repl.Pattern.Equals(replacement))
+            {
+                repl = RegexParser.ParseReplacement(replacement, caps, capsize, capnames, roptions);
+                replRef.SetTarget(repl);
+            }
+
+            return repl;
+        }
+
+        /// <summary>
         /// The original pattern string
         /// </summary>
         public string Pattern { get; }


### PR DESCRIPTION
Based on https://github.com/dotnet/corefx/pull/27726, had to create a new PR.

@danmosemsft I don't think this change needs perf justification.