### PR TITLE
Remove faulty assert from SocketAsyncEventArgs

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -61,7 +61,6 @@ namespace System.Net.Sockets
             Debug.Assert(_operating == InProgress, $"Expected {nameof(_operating)} == {nameof(InProgress)}, got {_operating}");
             Debug.Assert(_currentSocket != null, "_currentSocket is null");
             Debug.Assert(_currentSocket.SafeHandle != null, "_currentSocket.SafeHandle is null");
-            Debug.Assert(!_currentSocket.SafeHandle.IsInvalid, "_currentSocket.SafeHandle is invalid");
             Debug.Assert(_preAllocatedOverlapped != null, "_preAllocatedOverlapped is null");
 
             ThreadPoolBoundHandle boundHandle = _currentSocket.GetOrAllocateThreadPoolBoundHandle();


### PR DESCRIPTION
AllocateNativeOverlapped asserts that !_currentSocket.SafeHandle.IsValid.  This should be a fine assert, except that SafeCloseSocket for some reason overrides IsInvalid to actually be IsClosed || IsInvalid.  And so that assert is actually checking whether the SafeHandle is both not invalid and not closed, but disposal could be racing with the operation and the socket could have been closed by the time we get here.

Fixes https://github.com/dotnet/corefx/issues/27784
cc: @geoffkizer, @davidsh