### PR TITLE
Removed leaked secrets from pipebuild definitions

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -416,6 +416,10 @@
       "value": null,
       "isSecret": true
     },
+    "HelixApiAccessKey": {
+      "value": null,
+      "isSecret": true
+    },
     "PB_CloudResultsAccountName": {
       "value": "dotnetjobresult"
     },

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -291,7 +291,7 @@
       "value": null,
       "isSecret": true
     },
-    "CloudResultsAccessToken": {
+    "OutputCloudResultsAccessToken": {
       "value": null,
       "isSecret": true
     },

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -291,6 +291,14 @@
       "value": null,
       "isSecret": true
     },
+    "CloudResultsAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "HelixApiAccessKey": {
+      "value": null,
+      "isSecret": true
+    },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)",
       "allowOverride": true

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -415,6 +415,10 @@
       "value": null,
       "isSecret": true
     },
+    "OutputCloudResultsAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)",
       "allowOverride": true

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -411,6 +411,10 @@
       "value": null,
       "isSecret": true
     },
+    "HelixApiAccessKey": {
+      "value": null,
+      "isSecret": true
+    },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)",
       "allowOverride": true


### PR DESCRIPTION
We've been leaking some secrets in build logs. We are no longer going to do that.

This will close https://github.com/dotnet/core-eng/issues/2831.

@MattGal @weshaggard @markwilkie @chcosta 