### PR TITLE
Use ReflectionBasedSerializer for all serializers if any of mappings are soap mappings

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -588,7 +588,7 @@ namespace System.Xml.Serialization
                     }
                     return DeserializePrimitive(xmlReader, events);
                 }
-                else if (ShouldUseReflectionBasedSerialization(_mapping))
+                else if (ShouldUseReflectionBasedSerialization(_mapping) || _isReflectionBasedSerializer)
                 {
                     return DeserializeUsingReflection(xmlReader, encodingStyle, events);
                 }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -159,6 +159,7 @@ namespace System.Xml.Serialization
         internal string DefaultNamespace = null;
 #endif
         private Type _rootType;
+        private bool _isReflectionBasedSerializer = false;
 
         private static TempAssemblyCache s_cache = new TempAssemblyCache();
         private static volatile XmlSerializerNamespaces s_defaultNamespaces;
@@ -447,7 +448,7 @@ namespace System.Xml.Serialization
                     }
                     SerializePrimitive(xmlWriter, o, namespaces);
                 }
-                else if (ShouldUseReflectionBasedSerialization(_mapping))
+                else if (ShouldUseReflectionBasedSerialization(_mapping) || _isReflectionBasedSerializer)
                 {
                     SerializeUsingReflection(xmlWriter, o, namespaces, encodingStyle, id);
                 }
@@ -797,6 +798,7 @@ namespace System.Xml.Serialization
                 serializers[i] = new XmlSerializer();
                 serializers[i]._rootType = type;
                 serializers[i]._mapping = mappings[i];
+                serializers[i]._isReflectionBasedSerializer = true;
             }
 
             return serializers;


### PR DESCRIPTION
When creating serializers for multiple mappings, if any of mappings are soap mapping, it will use ReflectionBasedSerializer and won't generate the serializer. However during serialization, for non soap mapping, it will try to use the serializer for serialization, which doesn't exist. The fix is to force all serializers using ReflectionBasedSerializer if there's any soap mapping.

#25298 
@zhenlan @mconnew @yujayee @Lxiamail 