### PR TITLE
Delete TODO from ByteArrayHelpers

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
@@ -8,8 +8,6 @@ namespace System
 {
     internal static class ByteArrayHelpers
     {
-        // TODO #21395:
-        // Replace with the MemoryExtensions implementation of Equals once it's available
         internal static bool EqualsOrdinalAsciiIgnoreCase(string left, ReadOnlySpan<byte> right)
         {
             Debug.Assert(left != null, "Expected non-null string");


### PR DESCRIPTION
We don't have a planned MemoryExtensions implementation that works with `string`/`ReadOnlySpan<char>` and `ReadOnlySpan<byte>`.