### PR TITLE
Disable hanging Proxy_UseSecureProxyTunnel_Success test on netfx

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2920,9 +2920,9 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task Proxy_UseSecureProxyTunnel_Success()
         {
-            if (IsWinHttpHandler)
+            if (IsWinHttpHandler || IsNetfxHandler)
             {
-                // Issue #27746: WinHttpHandler hangs on this test
+                // Issue #27746: WinHttpHandler and netfx hang on this test
                 return;
             }
 


### PR DESCRIPTION
cc: @geoffkizer 

@danmosemsft, this is the cause (or at least the primary cause) of the netfx hangs we've been seeing in CI.