### PR TITLE
Add tests for completing awaited tasks in non-default contexts

### DIFF
--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
@@ -123,6 +123,55 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
+        [ActiveIssue(27675, ~TargetFrameworkMonikers.NetFramework)]
+        [Fact]
+        public async Task Await_TaskCompletesOnNonDefaultSyncCtx_ContinuesOnDefaultSyncCtx()
+        {
+            await Task.Run(async delegate // escape xunit's sync context
+            {
+                Assert.Null(SynchronizationContext.Current);
+                Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
+
+                var ctx = new ValidateCorrectContextSynchronizationContext();
+                var tcs = new TaskCompletionSource<bool>();
+                var ignored = Task.Delay(1).ContinueWith(_ =>
+                {
+                    SynchronizationContext orig = SynchronizationContext.Current;
+                    SynchronizationContext.SetSynchronizationContext(ctx);
+                    try
+                    {
+                        tcs.SetResult(true);
+                    }
+                    finally
+                    {
+                        SynchronizationContext.SetSynchronizationContext(orig);
+                    }
+                }, TaskScheduler.Default);
+                await tcs.Task;
+
+                Assert.Null(SynchronizationContext.Current);
+                Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
+            });
+        }
+
+        [ActiveIssue(27675, ~TargetFrameworkMonikers.NetFramework)]
+        [Fact]
+        public async Task Await_TaskCompletesOnNonDefaultScheduler_ContinuesOnDefaultScheduler()
+        {
+            await Task.Run(async delegate // escape xunit's sync context
+            {
+                Assert.Null(SynchronizationContext.Current);
+                Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
+
+                var tcs = new TaskCompletionSource<bool>();
+                var ignored = Task.Delay(1).ContinueWith(_ => tcs.SetResult(true), new QUWITaskScheduler());
+                await tcs.Task;
+
+                Assert.Null(SynchronizationContext.Current);
+                Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
+            });
+        }
+
         [Fact]
         public static void GetResult_Completed_Success()
         {


### PR DESCRIPTION
Prior to .NET Core 2.1, if a task was awaited in a default context (or if ConfigureAwait(false) was used), and if the task is then completed on a non-default context, the continuation is not inlined by default.  Optimizations added in 2.1 erroneously end up bypassing those checks, leading to continuations getting inlined in places they weren't previously.  This adds regression tests for that behavior.

Contributes to https://github.com/dotnet/corefx/issues/27675
cc: @kouvel 