### PR TITLE
Make UnboundedChannel.ReadAsync check for cancellation first

### DIFF
--- a/src/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -153,7 +153,7 @@ namespace System.Threading.Channels
                     {
                         return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
                             new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
-                            new ValueTask<bool>(false);
+                            default;
                     }
 
                     // There were no items available, but there could be in the future, so ensure
@@ -413,7 +413,7 @@ namespace System.Threading.Channels
                     {
                         return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
                             new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
-                            new ValueTask<bool>(false);
+                            default;
                     }
 
                     // If there's space to write, a write is possible.

--- a/src/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
@@ -160,7 +160,7 @@ namespace System.Threading.Channels
                     {
                         return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
                             new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
-                            new ValueTask<bool>(false);
+                            default;
                     }
 
                     // Try to use the singleton waiter.  If it's currently being used, then the channel
@@ -339,7 +339,7 @@ namespace System.Threading.Channels
                     cancellationToken.IsCancellationRequested ? new ValueTask<bool>(Task.FromCanceled<bool>(cancellationToken)) :
                     doneWriting == null ? new ValueTask<bool>(true) :
                     doneWriting != ChannelUtilities.s_doneWritingSentinel ? new ValueTask<bool>(Task.FromException<bool>(doneWriting)) :
-                    new ValueTask<bool>(false);
+                    default;
             }
 
             public override ValueTask WriteAsync(T item, CancellationToken cancellationToken) =>


### PR DESCRIPTION
For consistency across implementations.

Also tweaked code to use `default` instead of `new ValueTask<bool>(false)`.

cc: @tarekgh 