### PR TITLE
Close file in XmlSchemaSet tests in attempt to fix intermittent test failure

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
@@ -635,13 +635,15 @@ namespace System.Xml.Tests
             string correctUri = Path.GetFullPath(path);
             _output.WriteLine("Include uri: " + includeUri);
             _output.WriteLine("Correct uri: " + correctUri);
-            Stream s = new FileStream(Path.GetFullPath(path), FileMode.Open, FileAccess.Read, FileShare.Read, 1);
-            XmlReader r = XmlReader.Create(s, new XmlReaderSettings(), includeUri);
-            _output.WriteLine("Reader uri: " + r.BaseURI);
-            XmlSchema som = null;
-            using (r)
+            using (Stream s = new FileStream(Path.GetFullPath(path), FileMode.Open, FileAccess.Read, FileShare.Read, 1))
             {
-                som = XmlSchema.Read(r, new ValidationEventHandler(ValidationCallback));
+                XmlReader r = XmlReader.Create(s, new XmlReaderSettings(), includeUri);
+                _output.WriteLine("Reader uri: " + r.BaseURI);
+                XmlSchema som = null;
+                using (r)
+                {
+                    som = XmlSchema.Read(r, new ValidationEventHandler(ValidationCallback));
+                }
             }
             return som;
         }


### PR DESCRIPTION
Lucky guess on fixing this: https://github.com/dotnet/corefx/issues/27740
There is a separate issue tracking infra problem

Problem is that infra occasionally fails during the clean-up but always on the same project. Current guess is some file which didn't get closed - from quick search I found this.