### PR TITLE
Named pipe in Unix respects absolute path

### DIFF
--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -267,7 +267,7 @@
   <data name="PlatformNotSupported_RemotePipes" xml:space="preserve">
     <value>Access to remote named pipes is not supported on this platform.</value>
   </data>
-  <data name="PlatformNotSupproted_InvalidPipeNameChars" xml:space="preserve">
+  <data name="PlatformNotSupported_InvalidPipeNameChars" xml:space="preserve">
     <value>The name of a pipe on this platform must be a valid file name or a valid absolute path to a file name.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">

--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -267,8 +267,8 @@
   <data name="PlatformNotSupported_RemotePipes" xml:space="preserve">
     <value>Access to remote named pipes is not supported on this platform.</value>
   </data>
-  <data name="PlatformNotSupproted_InvalidNameChars" xml:space="preserve">
-    <value>The name of a pipe on this platform must only include characters valid in file names.</value>
+  <data name="PlatformNotSupproted_InvalidPipeNameChars" xml:space="preserve">
+    <value>The name of a pipe on this platform must be a valid file name or a valid absolute path to a file name.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
     <value>Cannot access a closed Stream.</value>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -47,13 +47,13 @@ namespace System.IO.Pipes
             }
 
             // Since pipes are stored as files in the system we support either an absolute path to a file name
-            // or a file name. The support of absolute path was added to allow a work around the limited
+            // or a file name. The support of absolute path was added to allow working around the limited
             // length available for the pipe name when concatenated with the temp path, while being
             // cross-platform with Windows (which has only '\' as an invalid char).
             if (Path.IsPathRooted(pipeName))
             {
                 if (pipeName.IndexOfAny(s_invalidPathNameChars) >= 0 || pipeName[pipeName.Length - 1] == Path.DirectorySeparatorChar)
-                    throw new PlatformNotSupportedException(SR.PlatformNotSupproted_InvalidPipeNameChars);
+                    throw new PlatformNotSupportedException(SR.PlatformNotSupported_InvalidPipeNameChars);
                 
                 // Caller is in full control of file location.
                 return pipeName;
@@ -61,7 +61,7 @@ namespace System.IO.Pipes
 
             if (pipeName.IndexOfAny(s_invalidFileNameChars) >= 0)
             {
-                throw new PlatformNotSupportedException(SR.PlatformNotSupproted_InvalidPipeNameChars);
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_InvalidPipeNameChars);
             }
 
             // The pipe is created directly under Path.GetTempPath() with "CoreFXPipe_" prefix.

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -26,6 +26,9 @@ namespace System.IO.Pipes
         /// <summary>Characters that can't be used in a pipe's name.</summary>
         private static readonly char[] s_invalidFileNameChars = Path.GetInvalidFileNameChars();
 
+        /// <summary>Characters that can't be used in an absolute path pipe's name.</summary>
+        private static readonly char[] s_invalidPathNameChars = Path.GetInvalidPathChars();
+
         /// <summary>Prefix to prepend to all pipe names.</summary>
         private static readonly string s_pipePrefix = Path.Combine(Path.GetTempPath(), "CoreFxPipe_");
 
@@ -43,16 +46,27 @@ namespace System.IO.Pipes
                 throw new ArgumentOutOfRangeException(nameof(pipeName), SR.ArgumentOutOfRange_AnonymousReserved);
             }
 
-            if (pipeName.IndexOfAny(s_invalidFileNameChars) >= 0)
+            // Since pipes are stored as files in the system we support either an absolute path to a file name
+            // or a file name. The support of absolute path was added to allow a work around the limited
+            // length available for the pipe name when concatenated with the temp path, while being
+            // cross-platform with Windows (which has only '\' as an invalid char).
+            if (Path.IsPathRooted(pipeName))
             {
-                // Since pipes are stored as files in the file system, we don't support
-                // pipe names that are actually paths or that otherwise have invalid
-                // filename characters in them.
-                throw new PlatformNotSupportedException(SR.PlatformNotSupproted_InvalidNameChars);
+                if (pipeName.IndexOfAny(s_invalidPathNameChars) >= 0 || pipeName[pipeName.Length - 1] == Path.DirectorySeparatorChar)
+                    throw new PlatformNotSupportedException(SR.PlatformNotSupproted_InvalidPipeNameChars);
+                
+                // Caller is in full control of file location.
+                return pipeName;
             }
 
-            // Return the pipe path.  The pipe is created directly under %TMPDIR%.  We previously
-            // didn't put it into a subdirectory because it only existed on disk for the duration
+            if (pipeName.IndexOfAny(s_invalidFileNameChars) >= 0)
+            {
+                throw new PlatformNotSupportedException(SR.PlatformNotSupproted_InvalidPipeNameChars);
+            }
+
+            // The pipe is created directly under Path.GetTempPath() with "CoreFXPipe_" prefix.
+            //
+            // We previously didn't put it into a subdirectory because it only existed on disk for the duration
             // between when the server started listening in WaitForConnection and when the client
             // connected, after which the pipe was deleted.  We now create the pipe when the
             // server stream is created, which leaves it on disk longer, but we can't change the

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
@@ -77,6 +77,8 @@ namespace System.IO.Pipes.Tests
             Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream(hostName, "foobar" + Path.GetInvalidFileNameChars()[0]));
             Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream(hostName, "/tmp/foo\0bar"));
             Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream(hostName, "/tmp/foobar/"));
+            Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream(hostName, "/"));
+            Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream(hostName, "\0"));
         }
 
         [Theory]

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
@@ -75,6 +75,8 @@ namespace System.IO.Pipes.Tests
 
             Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream("foobar" + hostName, "foobar"));
             Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream(hostName, "foobar" + Path.GetInvalidFileNameChars()[0]));
+            Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream(hostName, "/tmp/foo\0bar"));
+            Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeClientStream(hostName, "/tmp/foobar/"));
         }
 
         [Theory]

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.cs
@@ -41,6 +41,19 @@ namespace System.IO.Pipes.Tests
             }
         }
 
+        [Fact]
+        public static void CreateServer_ConnectClient_UsingUnixAbsolutePath()
+        {
+            string name = Path.Combine("/tmp", GetUniquePipeName());
+            using (var server = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
+            {
+                using (var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.CurrentUserOnly))
+                {
+                    client.Connect();
+                }
+            }
+        }
+
         [Theory]
         [InlineData(PipeOptions.None, PipeOptions.CurrentUserOnly)]
         [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.None)]

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading;
@@ -502,50 +501,6 @@ namespace System.IO.Pipes.Tests
                 server.ReadMode = PipeTransmissionMode.Byte;
                 client.ReadMode = PipeTransmissionMode.Byte;
             }
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void NamedPipeServer_Connects_With_UnixDomainSocketEndPointClient()
-        {
-            string absoluteHomePath = Path.GetFullPath(Environment.GetEnvironmentVariable("HOME"));
-            string pipeName = Path.Combine(absoluteHomePath, "pipe-tests-corefx-" + Path.GetRandomFileName());
-            var endPoint = new UnixDomainSocketEndPoint(pipeName);
-            
-            using (var pipeServer = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
-            using (var sockectClient = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
-            {
-                sockectClient.Connect(endPoint);
-                Assert.True(File.Exists(pipeName));
-            }
-
-            Assert.False(File.Exists(pipeName));
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public async Task NamedPipeClient_Connects_With_UnixDomainSocketEndPointServer()
-        {
-            string absoluteHomePath = Path.GetFullPath(Environment.GetEnvironmentVariable("HOME"));
-            string pipeName = Path.Combine(absoluteHomePath, "pipe-tests-corefx-" + Path.GetRandomFileName());
-            var endPoint = new UnixDomainSocketEndPoint(pipeName);
-
-            using (var socketServer = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
-            using (var pipeClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None))
-            {
-                socketServer.Bind(endPoint);
-                socketServer.Listen(1);
-
-                var pipeConnectTask = pipeClient.ConnectAsync(15_000);
-                using (Socket accepted = socketServer.Accept())
-                {
-                    await pipeConnectTask;
-                    Assert.True(File.Exists(pipeName));
-                }
-            }
-
-            Assert.True(File.Exists(pipeName));
-            try { File.Delete(pipeName); } catch { }
         }
 
         [Fact]

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading;
@@ -501,6 +502,47 @@ namespace System.IO.Pipes.Tests
                 server.ReadMode = PipeTransmissionMode.Byte;
                 client.ReadMode = PipeTransmissionMode.Byte;
             }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void NamedPipeServer_Connects_With_UnixDomainSocketEndPointClient()
+        {
+            string pipeName = Path.Combine("/tmp", "CoreFxTests_" + Path.GetRandomFileName());
+            var endPoint = new UnixDomainSocketEndPoint(pipeName);
+            
+            using (var pipeServer = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
+            using (var sockectClient = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
+            {
+                sockectClient.Connect(endPoint);
+                Assert.True(File.Exists(pipeName));
+            }
+
+            Assert.False(File.Exists(pipeName));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public async Task NamedPipeClient_Connects_With_UnixDomainSocketEndPointServer()
+        {
+            string pipeName = Path.Combine("/tmp", "CoreFxTests_" + Path.GetRandomFileName());
+            var endPoint = new UnixDomainSocketEndPoint(pipeName);
+            using (var socketServer = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
+            using (var pipeClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None))
+            {
+                socketServer.Bind(endPoint);
+                socketServer.Listen(1);
+
+                var pipeConnectTask = pipeClient.ConnectAsync(15_000);
+                using (Socket accepted = socketServer.Accept())
+                {
+                    await pipeConnectTask;
+                    Assert.True(File.Exists(pipeName));
+                }
+            }
+
+            Assert.True(File.Exists(pipeName));
+            try { File.Delete(pipeName); } catch { }
         }
 
         [Fact]

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -508,7 +508,8 @@ namespace System.IO.Pipes.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void NamedPipeServer_Connects_With_UnixDomainSocketEndPointClient()
         {
-            string pipeName = Path.Combine("/tmp", "CoreFxTests_" + Path.GetRandomFileName());
+            string absoluteHomePath = Path.GetFullPath(Environment.GetEnvironmentVariable("HOME"));
+            string pipeName = Path.Combine(absoluteHomePath, "pipe-tests-corefx-" + Path.GetRandomFileName());
             var endPoint = new UnixDomainSocketEndPoint(pipeName);
             
             using (var pipeServer = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
@@ -525,8 +526,10 @@ namespace System.IO.Pipes.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public async Task NamedPipeClient_Connects_With_UnixDomainSocketEndPointServer()
         {
-            string pipeName = Path.Combine("/tmp", "CoreFxTests_" + Path.GetRandomFileName());
+            string absoluteHomePath = Path.GetFullPath(Environment.GetEnvironmentVariable("HOME"));
+            string pipeName = Path.Combine(absoluteHomePath, "pipe-tests-corefx-" + Path.GetRandomFileName());
             var endPoint = new UnixDomainSocketEndPoint(pipeName);
+
             using (var socketServer = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
             using (var pipeClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None))
             {

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.UnixDomainSockets.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.UnixDomainSockets.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    public class NamedPipeTest_UnixDomainSockets : NamedPipeTestBase
+    {
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void NamedPipeServer_Connects_With_UnixDomainSocketEndPointClient()
+        {
+            string absoluteHomePath = Path.GetFullPath(Environment.GetEnvironmentVariable("HOME"));
+            string pipeName = Path.Combine(absoluteHomePath, "pipe-tests-corefx-" + Path.GetRandomFileName());
+            var endPoint = new UnixDomainSocketEndPoint(pipeName);
+            
+            using (var pipeServer = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly))
+            using (var sockectClient = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
+            {
+                sockectClient.Connect(endPoint);
+                Assert.True(File.Exists(pipeName));
+            }
+
+            Assert.False(File.Exists(pipeName));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public async Task NamedPipeClient_Connects_With_UnixDomainSocketEndPointServer()
+        {
+            string absoluteHomePath = Path.GetFullPath(Environment.GetEnvironmentVariable("HOME"));
+            string pipeName = Path.Combine(absoluteHomePath, "pipe-tests-corefx-" + Path.GetRandomFileName());
+            var endPoint = new UnixDomainSocketEndPoint(pipeName);
+
+            using (var socketServer = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
+            using (var pipeClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None))
+            {
+                socketServer.Bind(endPoint);
+                socketServer.Listen(1);
+
+                var pipeConnectTask = pipeClient.ConnectAsync(15_000);
+                using (Socket accepted = socketServer.Accept())
+                {
+                    await pipeConnectTask;
+                    Assert.True(File.Exists(pipeName));
+                }
+            }
+
+            Assert.True(File.Exists(pipeName));
+            try { File.Delete(pipeName); } catch { }
+        }
+    }
+}

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -45,6 +45,9 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' and '$(TargetsWindows)' == 'true'">
     <Compile Include="NamedPipeTests\NamedPipeTest.CurrentUserOnly.netcoreapp.Windows.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' and '$(TargetsUnix)' == 'true'">
+    <Compile Include="NamedPipeTests\NamedPipeTest.UnixDomainSockets.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="Interop.Windows.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.RunAsClient.Windows.cs" />


### PR DESCRIPTION
This was added for two reasons:

1. Allow users to workaround the hard limit on Unix domain sockets that can be very limiting if the $TMPDIR has a long path;

2. Make easy to make that works both on Unix and Windows without having to check platform, e.g.: "/tmp/myAppPipe" works on both platforms.