### PR TITLE
Dial back `\\?\ ` insertion

### DIFF
--- a/src/Common/src/CoreLib/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/CoreLib/System/IO/PathInternal.Windows.cs
@@ -70,7 +70,7 @@ namespace System.IO
             return ((value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z'));
         }
 
-        private static bool EndsWithPeriodOrSpace(string path)
+        internal static bool EndsWithPeriodOrSpace(string path)
         {
             if (string.IsNullOrEmpty(path))
                 return false;

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Windows.cs
@@ -14,7 +14,7 @@ namespace System.IO
 
         // Cache any error retrieving the file/directory information
         // We use this field in conjunction with the Refresh method which should never throw.
-        // If we succeed we store a zero, on failure we store the HResult so that we can
+        // If we succeed we store a zero, on failure we store the error code so that we can
         // throw an appropriate error when attempting to access the cached info.
         private int _dataInitialized = -1;
 
@@ -153,6 +153,7 @@ namespace System.IO
 
         // If we're opened around a enumerated path that ends in a period or space we need to be able to
         // act on the path normally (open streams/writers/etc.)
-        internal string NormalizedPath => PathInternal.EnsureExtendedPrefixIfNeeded(FullPath);
+        internal string NormalizedPath
+            => PathInternal.EndsWithPeriodOrSpace(FullPath) ? PathInternal.EnsureExtendedPrefix(FullPath) : FullPath;
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
@@ -31,7 +31,6 @@ namespace System.IO
         {
             get
             {
-                // GetFullPathInternal would have already stripped out the terminating "." if present.
                 int length = FullPath.Length;
                 for (int i = length; --i >= 0;)
                 {
@@ -68,76 +67,39 @@ namespace System.IO
 
         public DateTime CreationTime
         {
-            get
-            {
-                // depends on the security check in get_CreationTimeUtc
-                return CreationTimeUtc.ToLocalTime();
-            }
-            set
-            {
-                CreationTimeUtc = value.ToUniversalTime();
-            }
+            get => CreationTimeUtc.ToLocalTime();
+            set => CreationTimeUtc = value.ToUniversalTime();
         }
 
         public DateTime CreationTimeUtc
         {
-            get
-            {
-                return CreationTimeCore.UtcDateTime;
-            }
-            set
-            {
-                CreationTimeCore = File.GetUtcDateTimeOffset(value);
-            }
+            get => CreationTimeCore.UtcDateTime;
+            set => CreationTimeCore = File.GetUtcDateTimeOffset(value);
         }
 
 
         public DateTime LastAccessTime
         {
-            get
-            {
-                return LastAccessTimeUtc.ToLocalTime();
-            }
-            set
-            {
-                LastAccessTimeUtc = value.ToUniversalTime();
-            }
+            get => LastAccessTimeUtc.ToLocalTime();
+            set => LastAccessTimeUtc = value.ToUniversalTime();
         }
 
         public DateTime LastAccessTimeUtc
         {
-            get
-            {
-                return LastAccessTimeCore.UtcDateTime;
-            }
-            set
-            {
-                LastAccessTimeCore = File.GetUtcDateTimeOffset(value);
-            }
+            get => LastAccessTimeCore.UtcDateTime;
+            set => LastAccessTimeCore = File.GetUtcDateTimeOffset(value);
         }
 
         public DateTime LastWriteTime
         {
-            get
-            {
-                return LastWriteTimeUtc.ToLocalTime();
-            }
-            set
-            {
-                LastWriteTimeUtc = value.ToUniversalTime();
-            }
+            get => LastWriteTimeUtc.ToLocalTime();
+            set => LastWriteTimeUtc = value.ToUniversalTime();
         }
 
         public DateTime LastWriteTimeUtc
         {
-            get
-            {
-                return LastWriteTimeCore.UtcDateTime;
-            }
-            set
-            {
-                LastWriteTimeCore = File.GetUtcDateTimeOffset(value);
-            }
+            get => LastWriteTimeCore.UtcDateTime;
+            set => LastWriteTimeCore = File.GetUtcDateTimeOffset(value);
         }
 
         /// <summary>


### PR DESCRIPTION
Only premptively adding for FileSystemInfo if we end in period or space.
Long path is taken care of later.

Clean up code a little and add test for DirectoryInfo.Move.

cc: @danmosemsft, @pjanotti, @Anipik 