### PR TITLE
Renable some TLS callback tests with SocketsHttpHandler

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -377,13 +377,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.NotNull(request);
                     Assert.NotNull(cert);
                     Assert.NotNull(chain);
-                    if (!useSocketsHttpHandler)
-                    {
-                        // TODO #23137: This test is failing with SocketsHttpHandler on the exact value of the managed errors,
-                        // e.g. reporting "RemoteCertificateNameMismatch, RemoteCertificateChainErrors" when we only expect
-                        // "RemoteCertificateChainErrors"
-                        Assert.Equal(expectedErrors, errors);
-                    }
+                    Assert.Equal(expectedErrors, errors);
                     return true;
                 };
 


### PR DESCRIPTION
The UseCallback_BadCertificate_ExpectedPolicyErrors tests had been
disabled when running against SocketsHttpHandler. The reason in the
comments was that the tests were not returning the proper
SslPolicyErrors.

These particular tests use external third party servers (*.badssl.com).
Running these tests now against the latest code shows no errors.  It's
possible this was a problem related to those external servers. Renabling
the tests for now.

Fixes #23137