### PR TITLE
Add missing IInternalConfigHost method

### DIFF
--- a/src/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
+++ b/src/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
@@ -15,6 +15,9 @@
     <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
     <Compile Include="System.Configuration.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Security.Permissions\ref\System.Security.Permissions.csproj" />
+  </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)'  == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/src/System.Configuration.ConfigurationManager/ref/System.Configuration.cs
+++ b/src/System.Configuration.ConfigurationManager/ref/System.Configuration.cs
@@ -1403,6 +1403,8 @@ namespace System.Configuration.Internal
         public virtual string GetConfigPathFromLocationSubPath(string configPath, string locationSubPath) { throw null; }
         public virtual System.Type GetConfigType(string typeName, bool throwOnError) { throw null; }
         public virtual string GetConfigTypeName(System.Type t) { throw null; }
+        public virtual void GetRestrictedPermissions(IInternalConfigRecord configRecord, out System.Security.PermissionSet permissionSet, out bool isHostReady) { throw null; }
+
         public virtual string GetStreamName(string configPath) { throw null; }
         public virtual string GetStreamNameForConfigSource(string streamName, string configSource) { throw null; }
         public virtual object GetStreamVersion(string streamName) { throw null; }
@@ -1489,6 +1491,7 @@ namespace System.Configuration.Internal
         string GetConfigPathFromLocationSubPath(string configPath, string locationSubPath);
         System.Type GetConfigType(string typeName, bool throwOnError);
         string GetConfigTypeName(System.Type t);
+        void GetRestrictedPermissions(IInternalConfigRecord configRecord, out System.Security.PermissionSet permissionSet, out bool isHostReady);
         string GetStreamName(string configPath);
         string GetStreamNameForConfigSource(string streamName, string configSource);
         object GetStreamVersion(string streamName);

--- a/src/System.Configuration.ConfigurationManager/src/ApiCompatBaseline.netfx.txt
+++ b/src/System.Configuration.ConfigurationManager/src/ApiCompatBaseline.netfx.txt
@@ -1,3 +1,0 @@
-Compat issues with assembly System.Configuration.ConfigurationManager:
-InterfacesShouldHaveSameMembers : Implementation interface member 'System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, System.Security.PermissionSet, System.Boolean)' is not in the contract.
-Total Issues: 1

--- a/src/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -258,6 +258,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Reference Include="System.Security.Cryptography.ProtectedData" />
+    <Reference Include="System.Security.Permissions" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/DelegatingConfigHost.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/DelegatingConfigHost.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Security;
 
 namespace System.Configuration.Internal
 {
@@ -230,5 +231,11 @@ namespace System.Configuration.Internal
         public virtual bool IsFullTrustSectionWithoutAptcaAllowed(IInternalConfigRecord configRecord) => true;
 
         public virtual IDisposable Impersonate() => new DummyDisposable();
+
+        public virtual void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady)
+        {
+            permissionSet = new PermissionSet(null);
+            isHostReady = true;
+        }
     }
 }

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/IInternalConfigHost.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/IInternalConfigHost.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security;
 
 namespace System.Configuration.Internal
 {
@@ -102,5 +103,7 @@ namespace System.Configuration.Internal
         bool IsFullTrustSectionWithoutAptcaAllowed(IInternalConfigRecord configRecord);
 
         IDisposable Impersonate();
+
+        void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady);
     }
 }

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/InternalConfigHost.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/InternalConfigHost.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Security;
 
 namespace System.Configuration.Internal
 {
@@ -303,5 +304,11 @@ namespace System.Configuration.Internal
         public bool IsFullTrustSectionWithoutAptcaAllowed(IInternalConfigRecord configRecord) => true;
 
         public IDisposable Impersonate() => new DummyDisposable();
+
+        public void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady)
+        {
+            permissionSet = new PermissionSet(null);
+            isHostReady = true;
+        }
     }
 }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using System.Configuration;
 using System.Configuration.Internal;
 using System.IO;
+using System.Security;
 using Xunit;
 
 namespace System.ConfigurationTests
@@ -296,6 +297,11 @@ namespace System.ConfigurationTests
             }
 
             bool IInternalConfigHost.IsTrustedConfigPath(string configPath)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IInternalConfigHost.GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
The intital implementation of ConfigurationManager predated the Core impl of Security.

See https://github.com/dotnet/corefx/pull/19224#pullrequestreview-102082480.

cc: @danmosemsft, @joperezr, @weshaggard 