### PR TITLE
Avoid timing issue in IOControl_SIOCATMARK tests

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -162,7 +162,7 @@ namespace System.Net.Sockets.Tests
                         server.Send(new byte[] { 42 }, SocketFlags.None);
                         server.Send(new byte[] { 43 }, SocketFlags.OutOfBand);
 
-                         // OOB data recieved, but read pointer not at mark
+                        // OOB data recieved, but read pointer not at mark
                         Assert.True(SpinWait.SpinUntil(() =>
                         {
                             Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));

--- a/src/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -109,8 +109,11 @@ namespace System.Net.Sockets.Tests
                         server.Send(new byte[] { 43 }, SocketFlags.OutOfBand);
 
                         // OOB data recieved, but read pointer not at mark.
-                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
-                        Assert.Equal(0, BitConverter.ToInt32(siocatmarkResult, 0));
+                        Assert.True(SpinWait.SpinUntil(() =>
+                        {
+                            Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                            return BitConverter.ToInt32(siocatmarkResult, 0) == 0;
+                        }, 10_000));
 
                         var received = new byte[1];
 
@@ -125,11 +128,8 @@ namespace System.Net.Sockets.Tests
                         Assert.Equal(43, received[0]);
 
                         // OOB data read, read pointer at mark.
-                        Assert.True(SpinWait.SpinUntil(() =>
-                        {
-                            Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
-                            return BitConverter.ToInt32(siocatmarkResult, 0) == (PlatformDetection.IsOSX ? 0 : 1);
-                        }, 10_000));
+                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                        Assert.Equal(PlatformDetection.IsOSX ? 0 : 1, BitConverter.ToInt32(siocatmarkResult, 0));
                     }
                 }
             }
@@ -162,9 +162,12 @@ namespace System.Net.Sockets.Tests
                         server.Send(new byte[] { 42 }, SocketFlags.None);
                         server.Send(new byte[] { 43 }, SocketFlags.OutOfBand);
 
-                        // OOB data recieved, but read pointer not at mark.
-                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
-                        Assert.Equal(0, BitConverter.ToInt32(siocatmarkResult, 0));
+                         // OOB data recieved, but read pointer not at mark
+                        Assert.True(SpinWait.SpinUntil(() =>
+                        {
+                            Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                            return BitConverter.ToInt32(siocatmarkResult, 0) == 0;
+                        }, 10_000));
 
                         var received = new byte[1];
 
@@ -179,11 +182,8 @@ namespace System.Net.Sockets.Tests
                         Assert.Equal(43, received[0]);
 
                         // OOB data read, read pointer at mark.
-                        Assert.True(SpinWait.SpinUntil(() =>
-                        {
-                            Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
-                            return BitConverter.ToInt32(siocatmarkResult, 0) == 1;
-                        }, 10_000));
+                        Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
+                        Assert.Equal(1, BitConverter.ToInt32(siocatmarkResult, 0));
                     }
                 }
             }


### PR DESCRIPTION
This test is sending out of band data, and then checking that it has been received immediately. Depending on timing the check may actually be hit before the data is received, so we need to give it some time.

When I updated these tests in PR #27583 I didn't consider that sent data wouldn't be received instantaneously. That was taken into consideration in the original tests and mitigated with `SpinWait.SpinUntil`, but after my update that check was in the wrong spot. This fix moves them to the right place.

Fixes: #27835, #27717