### PR TITLE
TestChildProcessCleanupAfterDispose: increase timeout from 1s to 30s; sleep async

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -421,7 +421,7 @@ namespace System.Diagnostics.Tests
             using (Process process = CreateShortProcess())
             {
                 process.Start();
-                bool processReaped = await TryWaitProcessReapedAsync(process.Id, timeout: 30000);
+                bool processReaped = await TryWaitProcessReapedAsync(process.Id, timeoutMs: 30000);
                 Assert.True(processReaped);
             }
         }
@@ -452,7 +452,7 @@ namespace System.Diagnostics.Tests
                     process.EnableRaisingEvents = true;
                 }
             }
-            bool processReaped = await TryWaitProcessReapedAsync(processId, timeout: 30000);
+            bool processReaped = await TryWaitProcessReapedAsync(processId, timeoutMs: 30000);
             Assert.True(processReaped);
         }
 
@@ -463,17 +463,17 @@ namespace System.Diagnostics.Tests
             return process;
         }
 
-        private static async Task<bool> TryWaitProcessReapedAsync(int pid, int timeout)
+        private static async Task<bool> TryWaitProcessReapedAsync(int pid, int timeoutMs)
         {
-            const int sleepTime = 50;
+            const int SleepTimeMs = 50;
             // When the process is reaped, the '/proc/<pid>' directory to disappears.
             bool procPidExists = true;
-            for (int attempt = 0; attempt < (timeout / sleepTime); attempt++)
+            for (int attempt = 0; attempt < (timeoutMs / SleepTimeMs); attempt++)
             {
                 procPidExists = Directory.Exists("/proc/" + pid);
                 if (procPidExists)
                 {
-                    await Task.Delay(sleepTime);
+                    await Task.Delay(SleepTimeMs);
                 }
                 else
                 {
@@ -514,8 +514,8 @@ namespace System.Diagnostics.Tests
 
                 // Child reaping holds a reference too
                 int referenceCount = -1;
-                const int sleepTime = 50;
-                for (int i = 0; i < (30000 / sleepTime); i++)
+                const int SleepTimeMs = 50;
+                for (int i = 0; i < (30000 / SleepTimeMs); i++)
                 {
                     referenceCount = GetWaitStateReferenceCount(waitState);
                     if (referenceCount == 0)
@@ -525,7 +525,7 @@ namespace System.Diagnostics.Tests
                     else
                     {
                         // Process was reaped but ProcessWaitState not unrefed yet
-                        await Task.Delay(sleepTime);
+                        await Task.Delay(SleepTimeMs);
                     }
                 }
                 Assert.Equal(0, referenceCount);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/27823

CC @stephentoub 