### PR TITLE
Revert "Add an empty dependency group for net45 to DataFlow package"

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/pkg/System.Threading.Tasks.Dataflow.pkgproj
+++ b/src/System.Threading.Tasks.Dataflow/pkg/System.Threading.Tasks.Dataflow.pkgproj
@@ -8,20 +8,12 @@
 
     <!-- Since UAP and .NETCoreApp are package based we still want to enable
          OOBing libraries that happen to overlap with their framework package.
-         This avoids us having to lock the API in our NuGet packages just
-         to match what shipped inbox: since we can provide a new library
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
          we can update it to add API without raising the netstandard version. -->
     <ValidatePackageSuppression Include="TreatAsOutOfBox">
       <Value>.NETCoreApp;UAP</Value>
     </ValidatePackageSuppression>
-
-    <!--
-      Include empty dependency group for net45 and higher to avoid unncessary package dependencies
-      because all the dependencies are known to be inbox already.
-    -->
-    <Dependency Include="_._">
-      <TargetFramework>net45</TargetFramework>
-    </Dependency>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
This reverts commit eb2025d6d36ac7de4b1f0c9a047383e2253758c1.

The change is no longer needed now that we have https://github.com/dotnet/buildtools/pull/1875.

The change has zero impact on the produced NUSPEC/NUPKG since we create the empty net45 group in the tools now.

Fixes #26162