### PR TITLE
fix SocketsHttpHandler to ignore invalid Set-Cookie

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CookieHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CookieHelper.cs
@@ -29,6 +29,10 @@ namespace System.Net.Http
                     catch (CookieException)
                     {
                         // Ignore invalid Set-Cookie header and continue processing.
+                        if (NetEventSource.IsEnabled)
+                        {
+                            NetEventSource.Info(response, $"Invalid Set-Cookie '{valuesArray[i]}' ignored.");
+                        }
                     }
                 }
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CookieHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CookieHelper.cs
@@ -22,7 +22,14 @@ namespace System.Net.Http
                 Uri requestUri = response.RequestMessage.RequestUri;
                 for (int i = 0; i < valuesArray.Length; i++)
                 {
-                    cookieContainer.SetCookies(requestUri, valuesArray[i]);
+                    try
+                    {
+                        cookieContainer.SetCookies(requestUri, valuesArray[i]);
+                    }
+                    catch (CookieException)
+                    {
+                        // Ignore invalid Set-Cookie header and continue processing.
+                    }
                 }
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -450,6 +450,12 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_ReceiveInvalidSetCookieHeader_ValidCookiesAdded()
         {
+            if (IsNetfxHandler)
+            {
+                // NetfxHandler incorrectly only processes one valid cookie 
+                return;
+            }
+
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -448,6 +448,37 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        public async Task GetAsync_ReceiveInvalidSetCookieHeader_ValidCookiesAdded()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpClientHandler handler = CreateHttpClientHandler();
+
+                using (HttpClient client = new HttpClient(handler))
+                {
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
+                        HttpStatusCode.OK,
+                        $"Set-Cookie: A=1; Path=/;Expires=asdfsadgads\r\n" +    // invalid Expires
+                        $"Set-Cookie: B=2; Path=/\r\n" + 
+                        $"Set-Cookie: C=3; Path=/\r\n",
+                        s_simpleContent);
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    CookieCollection collection = handler.CookieContainer.GetCookies(url);
+                    Assert.Equal(2, collection.Count);
+
+                    // Convert to array so we can more easily process contents, since CookieCollection does not implement IEnumerable<Cookie>
+                    Cookie[] cookies = new Cookie[3];
+                    collection.CopyTo(cookies, 0);
+
+                    Assert.Contains(cookies, c => c.Name == "B" && c.Value == "2");
+                    Assert.Contains(cookies, c => c.Name == "C" && c.Value == "3");
+                }
+            });
+        }
+
+        [Fact]
         public async Task GetAsyncWithRedirect_ReceiveSetCookie_CookieSent()
         {
             const string path1 = "/foo";


### PR DESCRIPTION
Partial fix for #27861

@Tratcher @stephentoub @davidsh 