### PR TITLE
SocketsHttpHandler: fix logic to check for Proxy-support header

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -19,7 +19,7 @@ namespace System.Net.Http
                 connection.SendWithNtProxyAuthAsync(request, cancellationToken);
         }
 
-        private static bool CheckIfProxySupportsConnectionAuth(HttpResponseMessage response)
+        private static bool ProxySupportsConnectionAuth(HttpResponseMessage response)
         {
             if (!response.Headers.TryGetValues(KnownHeaders.ProxySupport.Descriptor, out IEnumerable<string> values))
             {
@@ -41,7 +41,7 @@ namespace System.Net.Http
         {
             HttpResponseMessage response = await InnerSendAsync(request, isProxyAuth, connection, cancellationToken).ConfigureAwait(false);
 
-            if (!isProxyAuth && connection.UsingProxy && !CheckIfProxySupportsConnectionAuth(response))
+            if (!isProxyAuth && connection.UsingProxy && !ProxySupportsConnectionAuth(response))
             {
                 // Proxy didn't indicate that it supports connection-based auth, so we can't proceed.
                 return response;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -152,6 +152,8 @@ namespace System.Net.Http
 
         public TransportContext TransportContext => _transportContext;
 
+        public bool UsingProxy => _usingProxy;
+
         private int ReadBufferSize => _readBuffer.Length;
 
         private ReadOnlyMemory<byte> RemainingBuffer => new ReadOnlyMemory<byte>(_readBuffer, _readOffset, _readLength - _readOffset);


### PR DESCRIPTION
Currently we're looking for this header when we do proxy auth.  This is wrong.  We should look for this header when we are trying to do regular auth through a proxy.

@davidsh @wfurt @stephentoub 

Fixes #27872 

@wfurt can you test and confirm that this fixes #27872?  (Windows only)