### PR TITLE
Reverting the generic scheduler changes

### DIFF
--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
@@ -55,7 +55,7 @@ namespace System.IO.Pipelines
         protected PipeScheduler() { }
         public static System.IO.Pipelines.PipeScheduler Inline { get { throw null; } }
         public static System.IO.Pipelines.PipeScheduler ThreadPool { get { throw null; } }
-        public abstract void Schedule<TState>(System.Action<TState> action, TState state);
+        public abstract void Schedule(System.Action<object> action, object state);
     }
     public abstract partial class PipeWriter : System.Buffers.IBufferWriter<byte>
     {

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/InlineScheduler.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/InlineScheduler.cs
@@ -6,7 +6,7 @@ namespace System.IO.Pipelines
 {
     internal sealed class InlineScheduler : PipeScheduler
     {
-        public override void Schedule<TState>(Action<TState> action, TState state)
+        public override void Schedule(Action<object> action, object state)
         {
             action(state);
         }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -20,7 +20,7 @@ namespace System.IO.Pipelines
 
         private static readonly Action<object> s_signalReaderAwaitable = state => ((Pipe)state).ReaderCancellationRequested();
         private static readonly Action<object> s_signalWriterAwaitable = state => ((Pipe)state).WriterCancellationRequested();
-        private static readonly Action<PipeCompletionCallbacks> s_invokeCompletionCallbacks = state => state.Execute();
+        private static readonly Action<object> s_invokeCompletionCallbacks = state => ((PipeCompletionCallbacks)state).Execute();
 
         // These callbacks all point to the same methods but are different delegate types
         private static readonly ContextCallback s_executionContextCallback = ExecuteWithExecutionContext;
@@ -603,7 +603,7 @@ namespace System.IO.Pipelines
             }
         }
 
-        private static void TrySchedule<TState>(PipeScheduler scheduler, Action<TState> action, TState state)
+        private static void TrySchedule(PipeScheduler scheduler, Action<object> action, object state)
         {
             if (action != null)
             {

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeScheduler.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeScheduler.cs
@@ -25,6 +25,6 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Requests <paramref name="action"/> to be run on scheduler with <paramref name="state"/> being passed in
         /// </summary>
-        public abstract void Schedule<TState>(Action<TState> action, TState state);
+        public abstract void Schedule(Action<object> action, object state);
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netcoreapp.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netcoreapp.cs
@@ -9,7 +9,7 @@ namespace System.IO.Pipelines
 {
     internal sealed class ThreadPoolScheduler : PipeScheduler
     {
-        public override void Schedule<TState>(Action<TState> action, TState state)
+        public override void Schedule(Action<object> action, object state)
         {
             System.Threading.ThreadPool.QueueUserWorkItem(action, state, preferLocal: false);
         }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netstandard.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netstandard.cs
@@ -9,11 +9,11 @@ namespace System.IO.Pipelines
 {
     internal sealed class ThreadPoolScheduler : PipeScheduler
     {
-        public override void Schedule<TState>(Action<TState> action, TState state)
+        public override void Schedule(Action<object> action, object state)
         {
             System.Threading.ThreadPool.QueueUserWorkItem(s =>
             {
-                var tuple = (Tuple<Action<TState>, TState>)s;
+                var tuple = (Tuple<Action<object>, object>)s;
                 tuple.Item1(tuple.Item2);
             },
             Tuple.Create(action, state));

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netstandard1.3.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netstandard1.3.cs
@@ -9,17 +9,9 @@ namespace System.IO.Pipelines
 {
     internal sealed class ThreadPoolScheduler : PipeScheduler
     {
-        public override void Schedule<TState>(Action<TState> action, TState state)
+        public override void Schedule(Action<object> action, object state)
         {
-            Task.Factory.StartNew(s =>
-            {
-                var tuple = (Tuple<Action<TState>, TState>)s;
-                tuple.Item1(tuple.Item2);
-            }, 
-            Tuple.Create(action, state), 
-            CancellationToken.None, 
-            TaskCreationOptions.DenyChildAttach, 
-            TaskScheduler.Default);
+            Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
     }
 }

--- a/src/System.IO.Pipelines/tests/PipeCompletionCallbacksTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeCompletionCallbacksTests.cs
@@ -28,7 +28,7 @@ namespace System.IO.Pipelines.Tests
 
             public Exception LastException { get; set; }
 
-            public override void Schedule<TState>(Action<TState> action, TState state)
+            public override void Schedule(Action<object> action, object state)
             {
                 CallCount++;
                 try

--- a/src/System.IO.Pipelines/tests/SchedulerFacts.cs
+++ b/src/System.IO.Pipelines/tests/SchedulerFacts.cs
@@ -31,7 +31,7 @@ namespace System.IO.Pipelines.Tests
                 _work.CompleteAdding();
             }
 
-            public override void Schedule<TState>(Action<TState> action, TState state)
+            public override void Schedule(Action<object> action, object state)
             {
                 _work.Add(() => action(state));
             }


### PR DESCRIPTION
- This forces allocations on some implementations of schedulers (in particular kestrel)
- We never pass a struct to Schedule

Fixes #27887 