### PR TITLE
Ensure SendAsync token source is disposed when handler throws

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -452,8 +452,18 @@ namespace System.Net.Http
                 cts = _pendingRequestsCts;
             }
 
-            // Initiate the send
-            Task<HttpResponseMessage> sendTask = base.SendAsync(request, cts.Token);
+            // Initiate the send.
+            Task<HttpResponseMessage> sendTask;
+            try
+            {
+                sendTask = base.SendAsync(request, cts.Token);
+            }
+            catch
+            {
+                HandleFinishSendAsyncCleanup(cts, disposeCts);
+                throw;
+            }
+
             return completionOption == HttpCompletionOption.ResponseContentRead ?
                 FinishSendAsyncBuffered(sendTask, request, cts, disposeCts) :
                 FinishSendAsyncUnbuffered(sendTask, request, cts, disposeCts);


### PR DESCRIPTION
If HttpClient has a non-infinite timeout set, and/or if a cancelable token is passed in, it creates a token source linked to the pending requests token source and the passed in token, and passes that token into base.SendAsync, which in turn just delegates to the wrapped handler's SendAsync.  If that wrapped handler throws an exception synchronously that propagates out of SendAsync, we never end up disposing of the linked token, which will end up leaving a reference to it in both the pending requests token source and the provided token's source.

cc: @davidsh, @geoffkizer 