### PR TITLE
Allow Socket.GetOrAllocateThreadPoolBoundHandle to fully inline

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
@@ -30,20 +30,10 @@ namespace System.Net.Sockets
             }
         }
 
+        public ThreadPoolBoundHandle GetThreadPoolBoundHandle() => !_released ? _iocpBoundHandle : null;
+
         // Binds the Socket Win32 Handle to the ThreadPool's CompletionPort.
         public ThreadPoolBoundHandle GetOrAllocateThreadPoolBoundHandle(bool trySkipCompletionPortOnSuccess)
-        {
-            // Check to see if the socket native _handle is already
-            // bound to the ThreadPool's completion port.
-            if (_released || _iocpBoundHandle == null)
-            {
-                GetOrAllocateThreadPoolBoundHandleSlow(trySkipCompletionPortOnSuccess);
-            }
-
-            return _iocpBoundHandle;
-        }
-
-        private void GetOrAllocateThreadPoolBoundHandleSlow(bool trySkipCompletionPortOnSuccess)
         {
             if (_released)
             {
@@ -51,14 +41,20 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException(typeof(Socket).FullName);
             }
 
+            if (_iocpBoundHandle != null)
+            {
+                return _iocpBoundHandle;
+            }
+
             lock (_iocpBindingLock)
             {
-                if (_iocpBoundHandle == null)
+                ThreadPoolBoundHandle boundHandle = _iocpBoundHandle;
+
+                if (boundHandle == null)
                 {
                     // Bind the socket native _handle to the ThreadPool.
                     if (NetEventSource.IsEnabled) NetEventSource.Info(this, "calling ThreadPool.BindHandle()");
 
-                    ThreadPoolBoundHandle boundHandle;
                     try
                     {
                         // The handle (this) may have been already released:
@@ -80,8 +76,10 @@ namespace System.Net.Sockets
                     }
 
                     // Don't set this until after we've configured the handle above (if we did)
-                    _iocpBoundHandle = boundHandle;
+                    Volatile.Write(ref _iocpBoundHandle, boundHandle);
                 }
+
+                return boundHandle;
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -5,8 +5,7 @@
 using Microsoft.Win32.SafeHandles;
 using System.Collections;
 using System.IO;
-using System.Runtime.ExceptionServices;
-using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Net.Sockets
@@ -285,10 +284,14 @@ namespace System.Net.Sockets
 
         }
 
-        internal ThreadPoolBoundHandle GetOrAllocateThreadPoolBoundHandle()
+        internal ThreadPoolBoundHandle GetOrAllocateThreadPoolBoundHandle() =>
+            _handle.GetThreadPoolBoundHandle() ??
+            GetOrAllocateThreadPoolBoundHandleSlow();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal ThreadPoolBoundHandle GetOrAllocateThreadPoolBoundHandleSlow()
         {
-            // There is a known bug that exists through Windows 7 with UDP and
-            // SetFileCompletionNotificationModes.
+            // There is a known bug that exists through Windows 7 with UDP and SetFileCompletionNotificationModes.
             // So, don't try to enable skipping the completion port on success in this case.
             bool trySkipCompletionPortOnSuccess = !(CompletionPortHelper.PlatformHasUdpIssue && _protocolType == ProtocolType.Udp);
             return _handle.GetOrAllocateThreadPoolBoundHandle(trySkipCompletionPortOnSuccess);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/27893
cc: @geoffkizer 