### PR TITLE
Eat exceptions from SocketsHttpHandler's readahead task

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -958,6 +958,50 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
         }
+
+        [OuterLoop]
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ConnectionsPooledThenDisposed_NoUnobservedTaskExceptions(bool secure)
+        {
+            RemoteInvoke(async secureString =>
+            {
+                var releaseServer = new TaskCompletionSource<bool>();
+                await LoopbackServer.CreateClientAndServerAsync(async uri =>
+                {
+                    using (var handler = new SocketsHttpHandler())
+                    using (var client = new HttpClient(handler))
+                    {
+                        handler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
+                        handler.PooledConnectionLifetime = TimeSpan.FromMilliseconds(1);
+
+                        var exceptions = new List<Exception>();
+                        TaskScheduler.UnobservedTaskException += (s, e) => exceptions.Add(e.Exception);
+
+                        await client.GetStringAsync(uri);
+                        await Task.Delay(10); // any value >= the lifetime
+                        Task ignored = client.GetStringAsync(uri); // force the pool to look for the previous connection and find it's too old
+                        await Task.Delay(100); // give some time for the connection close to fail pending reads
+
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+
+                        // Note that there are race conditions here such that we may not catch every failure,
+                        // and thus could have some false negatives, but there won't be any false positives.
+                        Assert.True(exceptions.Count == 0, string.Concat(exceptions));
+
+                        releaseServer.SetResult(true);
+                    }
+                }, server => server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello world");
+                    await releaseServer.Task;
+                }),
+                new LoopbackServer.Options { UseSsl = bool.Parse(secureString) });
+                return SuccessExitCode;
+            }, secure.ToString()).Dispose();
+        }
     }
 
     public sealed class SocketsHttpHandler_PublicAPIBehavior_Test


### PR DESCRIPTION
When SocketsHttpHandler puts a connection back into the pool, it issues a pre-emptive asynchronous read on the transport stream.  This enables us to check whether any unexpected data has arrived on the connection, whether the connection has been closed, etc., and without polling (which could be done with a NetworkStream but not well with an SslStream).  However, when we dispose of a connection from the pool, this task will potentially end up getting faulted, and while it won't crash the application by default, it will end up invoking the TaskScheduler.UnobservedException event.

This commit address this by ensuring that we always observe any exceptions that come from the read ahead task when the connection is disposed of (in the rare case where an HttpConnection is instead left for finalization, the event may still be raised, which is arguably a good thing, as the developer should be disposing responses.)

(The alternative would be to stop using the read ahead, and instead poll every time we wanted to know if the connection was still valid.  That would mean storing the socket in addition to the stream on the connection, and would mean we might miss some errant data that was already pulled from the socket into an SslStream.  It would also mean at least one more syscall for each request, as we'd check whether a connection from the pool was valid.  For now I'm sticking with the read ahead.)

Fixes https://github.com/dotnet/corefx/issues/27877
cc: @geoffkizer 