### PR TITLE
Reduce ExecutionContext.Run calls with SocketAsyncEventArgs

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -779,6 +779,11 @@ namespace System.Net.Sockets
             /// </summary>
             internal bool _accessed = false;
 
+            internal TaskSocketAsyncEventArgs() :
+                base(flowExecutionContext: false) // avoid flowing context at lower layers as we only expose Task, which handles it
+            {
+            }
+
             /// <summary>Gets the builder's task with appropriate synchronization.</summary>
             internal AsyncTaskMethodBuilder<TResult> GetCompletionResponsibility(out bool responsibleForReturningToPool)
             {
@@ -860,7 +865,11 @@ namespace System.Net.Sockets
             /// <summary>Initializes the event args.</summary>
             /// <param name="socket">The associated socket.</param>
             /// <param name="buffer">The buffer to use for all operations.</param>
-            public AwaitableSocketAsyncEventArgs() => Completed += s_completedHandler;
+            public AwaitableSocketAsyncEventArgs() :
+                base(flowExecutionContext: false) // avoid flowing context at lower layers as we only expose ValueTask, which handles it
+            {
+                Completed += s_completedHandler;
+            }
 
             public bool WrapExceptionsInIOExceptions { get; set; }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -71,6 +71,7 @@ namespace System.Net.Sockets
         internal Internals.SocketAddress _socketAddress;
 
         // Misc state variables.
+        private readonly bool _flowExecutionContext;
         private ExecutionContext _context;
         private static readonly ContextCallback s_executionCallback = ExecutionCallback;
         private Socket _currentSocket;
@@ -85,8 +86,18 @@ namespace System.Net.Sockets
 
         private MultipleConnectAsync _multipleConnect;
 
-        public SocketAsyncEventArgs()
+        public SocketAsyncEventArgs() : this(flowExecutionContext: true)
         {
+        }
+
+        /// <summary>Initialize the SocketAsyncEventArgs</summary>
+        /// <param name="flowExecutionContext">
+        /// Whether to capture and flow ExecutionContext. ExecutionContext flow should only
+        /// be disabled if it's going to be handled by higher layers.
+        /// </param>
+        internal SocketAsyncEventArgs(bool flowExecutionContext)
+        {
+            _flowExecutionContext = flowExecutionContext;
             InitializeInternals();
         }
 
@@ -520,8 +531,8 @@ namespace System.Net.Sockets
                 _context = null;
             }
 
-            // Capture execution context if none already.
-            if (_context == null)
+            // Capture execution context if necessary.
+            if (_flowExecutionContext && _context == null)
             {
                 _context = ExecutionContext.Capture();
             }

--- a/src/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Net.Sockets.Tests
 {
-    public class ExecutionContextFlowTest : FileCleanupTestBase
+    public partial class ExecutionContextFlowTest : FileCleanupTestBase
     {
         [Theory]
         [InlineData(false)]

--- a/src/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.netcoreapp.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public partial class ExecutionContextFlowTest : FileCleanupTestBase
+    {
+        [Fact]
+        public Task ExecutionContext_FlowsOnlyOnceAcrossAsyncOperations()
+        {
+            return Task.Run(async () => // escape xunit's sync ctx
+            {
+                using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                    listener.Listen(1);
+
+                    client.Connect(listener.LocalEndPoint);
+                    using (Socket server = listener.Accept())
+                    {
+                        int executionContextChanges = 0;
+                        var asyncLocal = new AsyncLocal<int>(_ => executionContextChanges++);
+                        Assert.Equal(0, executionContextChanges);
+
+                        int numAwaits = 20;
+                        for (int i = 1; i <= numAwaits; i++)
+                        {
+                            asyncLocal.Value = i;
+
+                            await new AwaitWithOnCompletedInvocation<int>(
+                                client.ReceiveAsync(new Memory<byte>(new byte[1]), SocketFlags.None),
+                                () => server.Send(new byte[1]));
+
+                            Assert.Equal(i, asyncLocal.Value);
+                        }
+
+                        // This doesn't count EC changes where EC.Run is passed the same context
+                        // as is current, but it's the best we can track via public API.
+                        Assert.InRange(executionContextChanges, 1, numAwaits * 3); // at most: 1 / AsyncLocal change + 1 / suspend + 1 / resume
+                    }
+                }
+            });
+        }
+
+        private readonly struct AwaitWithOnCompletedInvocation<T> : ICriticalNotifyCompletion
+        {
+            private readonly ValueTask<T> _valueTask;
+            private readonly Action _invokeAfterOnCompleted;
+
+            public AwaitWithOnCompletedInvocation(ValueTask<T> valueTask, Action invokeAfterOnCompleted)
+            {
+                _valueTask = valueTask;
+                _invokeAfterOnCompleted = invokeAfterOnCompleted;
+            }
+
+            public AwaitWithOnCompletedInvocation<T> GetAwaiter() => this;
+
+            public bool IsCompleted => false;
+            public T GetResult() => _valueTask.GetAwaiter().GetResult();
+            public void OnCompleted(Action continuation) => throw new NotSupportedException();
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                _valueTask.GetAwaiter().UnsafeOnCompleted(continuation);
+                _invokeAfterOnCompleted();
+            }
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="DnsEndPointTest.cs" />
     <Compile Include="DualModeSocketTest.cs" />
     <Compile Include="ExecutionContextFlowTest.cs" />
+    <Compile Include="ExecutionContextFlowTest.netcoreapp.cs" Condition="'$(TargetGroup)' != 'netstandard'" />
     <Compile Include="IPPacketInformationTest.cs" />
     <Compile Include="LingerStateTest.cs" />
     <Compile Include="LoggingTest.cs" />


### PR DESCRIPTION
ExecutionContext capturing/restoring when awaiting socket operations is currently happening at three places:
1. Captured inside the PreAllocatedOverlapped created on Windows when the SocketAsyncEventArgs is constructed, then used with ExecutionContext.Run in System.Threading._IOCompletionCallback.PerformIOCompletionCallback
2. Captured inside the SocketAsyncEventArgs.StartOperationCommon and then used with ExecutionContext.Run inside the FinishOperationAsync* methods
3. Captured inside the Task/ValueTask async method builder when the await suspends and then used with ExecutionContext.Run when it resumes

Only one of those is necessary, and it should ideally be done at the highest layer that needs it.  That means for when using SocketAsyncEventArgs directly, we need to do (2) but we don't need to do (1). And when using async methods, we don't need to do (2) or (1).

This commit fixes this by:
- Suppress context flow while we create the PreAllocatedOverlapped, so this it doesn't capture anything.
- Parameterizing SocketAsyncEventArgs's constructor to track whether context should be captured/flowed, and then setting that to false from the custom SocketAsyncEventArgs we use for the Task-based async methods on Socket.

The best way to see the impact of this is by looking at a call stack after an `await ReceiveAsync` that completes asynchronously. I've marked the relevant stack frames with `**`:

_Before_:
```
     at System.Net.Sockets.Tests.ExecutionContextFlowTest.<>c.<<ExecutionContext_FlowsOnlyOnceAcrossAsyncOperations>b__0_0>d.MoveNext() in d:\repos\corefx\src\System.Net.Sockets\tests\FunctionalTests\ExecutionContextFlowTest.netcoreapp.cs:line 43
**   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) in E:\A\_work\1125\s\src\mscorlib\shared\System\Threading\ExecutionContext.cs:line 166
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext() in E:\A\_work\1125\s\src\mscorlib\src\System\Runtime\CompilerServices\AsyncMethodBuilder.cs:line 559
     at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.InvokeContinuation(Action`1 continuation, Object state, Boolean forceAsync) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\Socket.Tasks.cs:line 1031
     at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.<>c.<.cctor>b__27_2(Object s, SocketAsyncEventArgs e) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\Socket.Tasks.cs:line 829
     at System.Net.Sockets.SocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs e) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 218
**   at System.Net.Sockets.SocketAsyncEventArgs.ExecutionCallback(Object state) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 438
**   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) in E:\A\_work\1125\s\src\mscorlib\shared\System\Threading\ExecutionContext.cs:line 166
     at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationAsyncSuccess(Int32 bytesTransferred, SocketFlags flags) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 780
     at System.Net.Sockets.SocketAsyncEventArgs.<>c.<.cctor>b__175_0(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.Windows.cs:line 1181
**   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) in E:\A\_work\1125\s\src\mscorlib\shared\System\Threading\ExecutionContext.cs:line 166
     at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP) in E:\A\_work\1125\s\src\mscorlib\src\System\Threading\Overlapped.cs:line 113
```

_After:_
```
     at System.Net.Sockets.Tests.ExecutionContextFlowTest.<>c.<<ExecutionContext_FlowsOnlyOnceAcrossAsyncOperations>b__0_0>d.MoveNext() in d:\repos\corefx\src\System.Net.Sockets\tests\FunctionalTests\ExecutionContextFlowTest.netcoreapp.cs:line 43
**   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) in E:\A\_work\1125\s\src\mscorlib\shared\System\Threading\ExecutionContext.cs:line 166
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext() in E:\A\_work\1125\s\src\mscorlib\src\System\Runtime\CompilerServices\AsyncMethodBuilder.cs:line 559
     at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.InvokeContinuation(Action`1 continuation, Object state, Boolean forceAsync) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\Socket.Tasks.cs:line 1031
     at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.<>c.<.cctor>b__27_2(Object s, SocketAsyncEventArgs e) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\Socket.Tasks.cs:line 829
     at System.Net.Sockets.SocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs e) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 218
     at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationAsyncSuccess(Int32 bytesTransferred, SocketFlags flags) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 776
     at System.Net.Sockets.SocketAsyncEventArgs.<>c.<.cctor>b__175_0(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped) in d:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.Windows.cs:line 1181
     at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP) in E:\A\_work\1125\s\src\mscorlib\src\System\Threading\Overlapped.cs:line 101
```

Fixes https://github.com/dotnet/corefx/issues/27892
cc: @geoffkizer, @benaadams, @davidsh 