### PR TITLE
Fix shim APICompat checks to fail build

### DIFF
--- a/src/shims/ApiCompat.proj
+++ b/src/shims/ApiCompat.proj
@@ -59,6 +59,8 @@
       <Output TaskParameter="ExitCode" PropertyName="ApiCompatExitCode" />
     </Exec>
 
+    <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed comparing netfx to $(TargetGroup)" />
+
     <PropertyGroup>
       <NETStandard20OnlyRef>$(NetStandardRefPath)/netstandard.dll</NETStandard20OnlyRef>
       <!-- For netcoreapp also pass in System.Runtime to workaround issue in apicompat tool when it cannot find a core assembly -->
@@ -73,6 +75,8 @@
       <Output TaskParameter="ExitCode" PropertyName="ApiCompatExitCode" />
     </Exec>
 
+    <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed comparing netstandard.dll to $(TargetGroup)" />
+
     <Exec Command="$(ApiCompatCmd) &quot;$(NetStandardRefPath)&quot; @&quot;$(ApiCompatResponseFile)&quot; -baseline:$(ApiCompatNSBaselineFile)"
           CustomErrorRegularExpression="^[a-zA-Z]+ :"
           StandardOutputImportance="Low"
@@ -80,6 +84,8 @@
     >
       <Output TaskParameter="ExitCode" PropertyName="ApiCompatExitCode" />
     </Exec>
+
+    <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed comparing netstandard to $(TargetGroup)" />
 
   </Target>
 

--- a/src/shims/ApiCompatBaseline.netcoreapp.netstandard20.txt
+++ b/src/shims/ApiCompatBaseline.netcoreapp.netstandard20.txt
@@ -1,6 +1,18 @@
 Compat issues with assembly mscorlib:
-TypeCannotChangeClassification : Type 'System.RuntimeArgumentHandle' is a 'ref struct' in the implementation but is a 'struct' in the contract.
 TypesMustExist : Type 'System.TupleExtensions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.TupleElementNamesAttribute' does not exist in the implementation but it does exist in the contract.
+Compat issues with assembly netstandard:
+TypeCannotChangeClassification : Type 'System.RuntimeArgumentHandle' is a 'ref struct' in the implementation but is a 'struct' in the contract.
+TypeCannotChangeClassification : Type 'System.TypedReference' is a 'ref struct' in the implementation but is a 'struct' in the contract.
+Compat issues with assembly System.Core:
+TypesMustExist : Type 'System.Security.Cryptography.ECCurve' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.ECParameters' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.ECPoint' does not exist in the implementation but it does exist in the contract.
+
+# Compat issues complaining about class vs delegate and class vs struct are because of a bug in APICompat tool where the implementation is picking
+# the wrong core assembly. It is picking System.Runtime instead of System.Private.CoreLib, there isn't any straight forward way to fix so baselining.
+
+TypeCannotChangeClassification : Type 'System.RuntimeArgumentHandle' is a 'ref struct' in the implementation but is a 'struct' in the contract.
 TypeCannotChangeClassification : Type 'System.TypedReference' is a 'ref struct' in the implementation but is a 'struct' in the contract.
 TypesMustExist : Type 'System.ValueTuple' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ValueTuple<T1>' does not exist in the implementation but it does exist in the contract.
@@ -11,12 +23,4 @@ TypesMustExist : Type 'System.ValueTuple<T1, T2, T3, T4, T5>' does not exist in 
 TypesMustExist : Type 'System.ValueTuple<T1, T2, T3, T4, T5, T6>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Runtime.CompilerServices.TupleElementNamesAttribute' does not exist in the implementation but it does exist in the contract.
-Compat issues with assembly netstandard:
-TypeCannotChangeClassification : Type 'System.RuntimeArgumentHandle' is a 'ref struct' in the implementation but is a 'struct' in the contract.
-TypeCannotChangeClassification : Type 'System.TypedReference' is a 'ref struct' in the implementation but is a 'struct' in the contract.
-Compat issues with assembly System.Core:
-TypesMustExist : Type 'System.Security.Cryptography.ECCurve' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Security.Cryptography.ECParameters' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Security.Cryptography.ECPoint' does not exist in the implementation but it does exist in the contract.
-Total Issues: 18
+

--- a/src/shims/ApiCompatBaseline.uap.netstandard20.txt
+++ b/src/shims/ApiCompatBaseline.uap.netstandard20.txt
@@ -1,7 +1,5 @@
 Compat issues with assembly mscorlib:
-TypeCannotChangeClassification : Type 'System.RuntimeArgumentHandle' is a 'ref struct' in the implementation but is a 'struct' in the contract.
 TypesMustExist : Type 'System.TupleExtensions' does not exist in the implementation but it does exist in the contract.
-TypeCannotChangeClassification : Type 'System.TypedReference' is a 'ref struct' in the implementation but is a 'struct' in the contract.
 TypesMustExist : Type 'System.Runtime.CompilerServices.TupleElementNamesAttribute' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly netstandard:
 TypeCannotChangeClassification : Type 'System.RuntimeArgumentHandle' is a 'ref struct' in the implementation but is a 'struct' in the contract.
@@ -10,4 +8,25 @@ Compat issues with assembly System.Core:
 TypesMustExist : Type 'System.Security.Cryptography.ECCurve' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.ECParameters' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.ECPoint' does not exist in the implementation but it does exist in the contract.
-Total Issues: 9
+
+# Compat issues complaining about class vs delegate and class vs struct are because of a bug in APICompat tool where the implementation is picking
+# the wrong core assembly. It is picking System.Runtime instead of System.Private.CoreLib, there isn't any straight forward way to fix so baselining.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.IO.HandleInheritability' is a 'class' in the implementation but is a 'struct' in the contract.
+TypeCannotChangeClassification : Type 'System.IO.FileAttributes' is a 'class' in the implementation but is a 'struct' in the contract.
+

--- a/src/shims/ApiCompatBaseline.uapaot.netstandard20.txt
+++ b/src/shims/ApiCompatBaseline.uapaot.netstandard20.txt
@@ -1,7 +1,5 @@
 Compat issues with assembly mscorlib:
-TypeCannotChangeClassification : Type 'System.RuntimeArgumentHandle' is a 'ref struct' in the implementation but is a 'struct' in the contract.
 TypesMustExist : Type 'System.TupleExtensions' does not exist in the implementation but it does exist in the contract.
-TypeCannotChangeClassification : Type 'System.TypedReference' is a 'ref struct' in the implementation but is a 'struct' in the contract.
 TypesMustExist : Type 'System.Runtime.CompilerServices.TupleElementNamesAttribute' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly netstandard:
 TypeCannotChangeClassification : Type 'System.RuntimeArgumentHandle' is a 'ref struct' in the implementation but is a 'struct' in the contract.
@@ -10,4 +8,25 @@ Compat issues with assembly System.Core:
 TypesMustExist : Type 'System.Security.Cryptography.ECCurve' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.ECParameters' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.ECPoint' does not exist in the implementation but it does exist in the contract.
-Total Issues: 9
+
+# Compat issues complaining about class vs delegate and class vs struct are because of a bug in APICompat tool where the implementation is picking
+# the wrong core assembly. It is picking System.Runtime instead of System.Private.CoreLib, there isn't any straight forward way to fix so baselining.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>' is a 'class' in the implementation but is a 'delegate' in the contract.
+TypeCannotChangeClassification : Type 'System.IO.HandleInheritability' is a 'class' in the implementation but is a 'struct' in the contract.
+TypeCannotChangeClassification : Type 'System.IO.FileAttributes' is a 'class' in the implementation but is a 'struct' in the contract.
+


### PR DESCRIPTION
Update baseline files for netcoreapp and uap.

Compat issues complaining about class vs delegate and
class vs struct are because of a bug in APICompat tool
where the implementation is picking the wrong core assembly.
It is picking System.Runtime instead of System.Private.CoreLib,
there isn't any straight forward way to fix so baselining.

fixes https://github.com/dotnet/corefx/issues/26361

cc @danmosemsft @joperezr 