### PR TITLE
Start adding alternate data stream tests

### DIFF
--- a/src/System.IO.FileSystem/tests/Enumeration/ExampleTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/ExampleTests.netcoreapp.cs
@@ -4,16 +4,20 @@
 
 using System.Collections.Generic;
 using System.IO.Enumeration;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.Tests.Enumeration
 {
-    // For tests that cover examples from documentation, blog posts, etc.
+    // For tests that cover examples from documentation, blog posts, etc. While these overlap with
+    // existing tests, having explicit coverage here is extra insurance we are covering the
+    // examples we've given out publicly.
     public class ExampleTests : FileSystemTest
     {
         [Fact]
         public void GetFileNamesEnumerable()
         {
+            // https://blogs.msdn.microsoft.com/jeremykuhne/2018/03/09/custom-directory-enumeration-in-net-core-2-1/
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
             File.Create(Path.Join(testDirectory.FullName, "one")).Dispose();
             File.Create(Path.Join(testDirectory.FullName, "two")).Dispose();
@@ -28,6 +32,110 @@ namespace System.IO.Tests.Enumeration
                 };
 
             FSAssert.EqualWhenOrdered(new string[] { "one", "two" }, fileNames);
+        }
+
+        private static IEnumerable<FileInfo> GetFilesWithExtensions(string directory,
+            bool recursive, params string[] extensions)
+        {
+            return new FileSystemEnumerable<FileInfo>(
+                directory,
+                (ref FileSystemEntry entry) => (FileInfo)entry.ToFileSystemInfo(),
+                new EnumerationOptions() { RecurseSubdirectories = recursive })
+            {
+                ShouldIncludePredicate = (ref FileSystemEntry entry) =>
+                {
+                    if (entry.IsDirectory)
+                        return false;
+                    foreach (string extension in extensions)
+                    {
+                        if (Path.GetExtension(entry.FileName).SequenceEqual(extension))
+                            return true;
+                    }
+                    return false;
+                }
+            };
+        }
+
+        [Fact]
+        public void TestGetFilesWithExtensions()
+        {
+            // https://blogs.msdn.microsoft.com/jeremykuhne/2018/03/09/custom-directory-enumeration-in-net-core-2-1/
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            File.Create(Path.Join(testDirectory.FullName, "file.one")).Dispose();
+            File.Create(Path.Join(testDirectory.FullName, "file.two")).Dispose();
+            File.Create(Path.Join(testDirectory.FullName, "file.three")).Dispose();
+            DirectoryInfo subDirectory = testDirectory.CreateSubdirectory("three.one");
+            File.Create(Path.Join(subDirectory.FullName, "subfile.one")).Dispose();
+
+            FSAssert.EqualWhenOrdered(
+                new string[] { "file.one", "file.three" },
+                GetFilesWithExtensions(testDirectory.FullName, false, ".one", ".three").Select(f => f.Name));
+
+            FSAssert.EqualWhenOrdered(
+                new string[] { "file.one", "file.three", "subfile.one" },
+                GetFilesWithExtensions(testDirectory.FullName, true, ".one", ".three").Select(f => f.Name));
+        }
+
+        private static int CountFiles(string directory, bool recursive)
+        {
+            return (new FileSystemEnumerable<int>(
+                directory,
+                (ref FileSystemEntry entry) => 1,
+                new EnumerationOptions() { RecurseSubdirectories = recursive })
+            {
+                ShouldIncludePredicate = (ref FileSystemEntry entry) => !entry.IsDirectory
+            }).Count();
+        }
+
+        [Fact]
+        public void TestCountFiles()
+        {
+            // https://blogs.msdn.microsoft.com/jeremykuhne/2018/03/09/custom-directory-enumeration-in-net-core-2-1/
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            File.Create(Path.Join(testDirectory.FullName, "file.one")).Dispose();
+            File.Create(Path.Join(testDirectory.FullName, "file.two")).Dispose();
+            File.Create(Path.Join(testDirectory.FullName, "file.three")).Dispose();
+            DirectoryInfo subDirectory = testDirectory.CreateSubdirectory("three.one");
+            File.Create(Path.Join(subDirectory.FullName, "subfile.one")).Dispose();
+
+            Assert.Equal(3, CountFiles(testDirectory.FullName, false));
+
+            Assert.Equal(4, CountFiles(testDirectory.FullName, true));
+        }
+
+        private static long CountFileBytes(string directory, bool recursive)
+        {
+            return (new FileSystemEnumerable<long>(
+                directory,
+                (ref FileSystemEntry entry) => entry.Length,
+                new EnumerationOptions() { RecurseSubdirectories = recursive })
+            {
+                ShouldIncludePredicate = (ref FileSystemEntry entry) => !entry.IsDirectory
+            }).Sum();
+        }
+
+        [Fact]
+        public void TestCountFileBytes()
+        {
+            // https://blogs.msdn.microsoft.com/jeremykuhne/2018/03/09/custom-directory-enumeration-in-net-core-2-1/
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            FileInfo firstFile = new FileInfo(Path.Join(testDirectory.FullName, "file.one"));
+            using (var writer = firstFile.CreateText())
+            {
+                for (int i = 0; i < 100; i++)
+                    writer.WriteLine("The quick brown fox jumped over the lazy dog.");
+            }
+
+            firstFile.CopyTo(Path.Join(testDirectory.FullName, "file.two"));
+            firstFile.CopyTo(Path.Join(testDirectory.FullName, "file.three"));
+            DirectoryInfo subDirectory = testDirectory.CreateSubdirectory("three.one");
+            firstFile.CopyTo(Path.Join(subDirectory.FullName, "subfile.one"));
+
+            firstFile.Refresh();
+            Assert.True(firstFile.Length > 0, "The file we wrote should have a length.");
+            Assert.Equal(firstFile.Length * 3, CountFileBytes(testDirectory.FullName, false));
+
+            Assert.Equal(firstFile.Length * 4, CountFileBytes(testDirectory.FullName, true));
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -224,6 +224,7 @@ namespace System.IO.Tests
             InlineData("::$DATA", ":bar"),
             InlineData("::$DATA", ":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void WindowsAlternateDataStream(string defaultStream, string alternateStream)
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
@@ -321,6 +322,7 @@ namespace System.IO.Tests
             InlineData("::$DATA", ":bar"),
             InlineData("::$DATA", ":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void WindowsAlternateDataStreamOverwrite(string defaultStream, string alternateStream)
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -4,22 +4,16 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.IO.Tests
 {
     public partial class File_Copy_str_str : FileSystemTest
     {
-        #region Utilities
-
-        public static TheoryData WindowsInvalidUnixValid = new TheoryData<string> { "         ",  };
         public virtual void Copy(string source, string dest)
         {
             File.Copy(source, dest);
         }
-
-        #endregion
 
         #region UniversalTests
 
@@ -223,13 +217,42 @@ namespace System.IO.Tests
             Assert.True(File.Exists(testFile));
             Assert.True(File.Exists(Path.Combine(TestDirectory, valid)));
         }
+
+        [Theory,
+            InlineData("", ":bar"),
+            InlineData("", ":bar:$DATA"),
+            InlineData("::$DATA", ":bar"),
+            InlineData("::$DATA", ":bar:$DATA")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void WindowsAlternateDataStream(string defaultStream, string alternateStream)
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            string testFile = Path.Combine(testDirectory.FullName, GetTestFileName());
+            string testFileDefaultStream = testFile + defaultStream;
+            string testFileAlternateStream = testFile + alternateStream;
+
+            // Copy the default stream into an alternate stream
+            File.WriteAllText(testFileDefaultStream, "Foo");
+            Copy(testFileDefaultStream, testFileAlternateStream);
+            Assert.Equal(testFile, testDirectory.GetFiles().Single().FullName);
+            Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
+            Assert.Equal("Foo", File.ReadAllText(testFileAlternateStream));
+
+            // Copy another file over the alternate stream
+            string testFile2 = Path.Combine(testDirectory.FullName, GetTestFileName());
+            string testFile2DefaultStream = testFile2 + defaultStream;
+            File.WriteAllText(testFile2DefaultStream, "Bar");
+            Assert.Throws<IOException>(() => Copy(testFile2DefaultStream, testFileAlternateStream));
+
+            // This always throws as you can't copy an alternate stream out (oddly)
+            Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2));
+            Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2 + alternateStream));
+        }
         #endregion
     }
 
     public class File_Copy_str_str_b : File_Copy_str_str
     {
-        #region Utilities
-
         public override void Copy(string source, string dest)
         {
             File.Copy(source, dest, false);
@@ -239,10 +262,6 @@ namespace System.IO.Tests
         {
             File.Copy(source, dest, overwrite);
         }
-
-        #endregion
-
-        #region UniversalTests
 
         [Fact]
         public void OverwriteTrue()
@@ -296,6 +315,37 @@ namespace System.IO.Tests
             }
         }
 
-        #endregion
+        [Theory,
+            InlineData("", ":bar"),
+            InlineData("", ":bar:$DATA"),
+            InlineData("::$DATA", ":bar"),
+            InlineData("::$DATA", ":bar:$DATA")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void WindowsAlternateDataStreamOverwrite(string defaultStream, string alternateStream)
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            string testFile = Path.Combine(testDirectory.FullName, GetTestFileName());
+            string testFileDefaultStream = testFile + defaultStream;
+            string testFileAlternateStream = testFile + alternateStream;
+
+            // Copy the default stream into an alternate stream
+            File.WriteAllText(testFileDefaultStream, "Foo");
+            Copy(testFileDefaultStream, testFileAlternateStream);
+            Assert.Equal(testFile, testDirectory.GetFiles().Single().FullName);
+            Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
+            Assert.Equal("Foo", File.ReadAllText(testFileAlternateStream));
+
+            // Copy another file over the alternate stream
+            string testFile2 = Path.Combine(testDirectory.FullName, GetTestFileName());
+            string testFile2DefaultStream = testFile2 + defaultStream;
+            File.WriteAllText(testFile2DefaultStream, "Bar");
+            Copy(testFile2DefaultStream, testFileAlternateStream, overwrite: true);
+            Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
+            Assert.Equal("Bar", File.ReadAllText(testFileAlternateStream));
+
+            // This always throws as you can't copy an alternate stream out (oddly)
+            Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2, overwrite: true));
+            Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2 + alternateStream, overwrite: true));
+        }
     }
 }

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -284,6 +284,7 @@ namespace System.IO.Tests
             InlineData(":bar:$DATA"),
             InlineData("::$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void WindowsAlternateDataStream(string streamName)
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
@@ -298,6 +299,7 @@ namespace System.IO.Tests
             InlineData(":bar"),
             InlineData(":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void WindowsAlternateDataStream_OnExisting(string streamName)
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -8,14 +8,10 @@ namespace System.IO.Tests
 {
     public class File_Create_str : FileSystemTest
     {
-        #region Utilities
-
         public virtual FileStream Create(string path)
         {
             return File.Create(path);
         }
-
-        #endregion
 
         #region UniversalTests
 
@@ -280,6 +276,47 @@ namespace System.IO.Tests
             using (Create(Path.Combine(testDir.FullName, path)))
             {
                 Assert.True(File.Exists(Path.Combine(testDir.FullName, path)));
+            }
+        }
+
+        [Theory,
+            InlineData(":bar"),
+            InlineData(":bar:$DATA"),
+            InlineData("::$DATA")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void WindowsAlternateDataStream(string streamName)
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            streamName = Path.Combine(testDirectory.FullName, GetTestFileName()) + streamName;
+            using (Create(streamName))
+            {
+                Assert.True(File.Exists(streamName));
+            }
+        }
+
+        [Theory,
+            InlineData(":bar"),
+            InlineData(":bar:$DATA")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void WindowsAlternateDataStream_OnExisting(string streamName)
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+
+            // On closed file
+            string fileName = Path.Combine(testDirectory.FullName, GetTestFileName());
+            Create(fileName).Dispose();
+            streamName = fileName + streamName;
+            using (Create(streamName))
+            {
+                Assert.True(File.Exists(streamName));
+            }
+
+            // On open file
+            fileName = Path.Combine(testDirectory.FullName, GetTestFileName());
+            using (Create(fileName))
+            using (Create(streamName))
+            {
+                Assert.True(File.Exists(streamName));
             }
         }
 


### PR DESCRIPTION
Also fill out ExampleTests.

We couldn't do this before without `\\?\` due to our path validation.

cc: @danmosemsft, @pjanotti, @Anipik 