### PR TITLE
SocketsHttpHandler, support for custom endpoint address resolving

### DIFF
--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -176,6 +176,8 @@ namespace System.Net.Http
         public HttpRequestMessage() { }
         public HttpRequestMessage(System.Net.Http.HttpMethod method, string requestUri) { }
         public HttpRequestMessage(System.Net.Http.HttpMethod method, System.Uri requestUri) { }
+        public HttpRequestMessage(HttpMethod method, Uri requestUri, System.Net.Sockets.AddressFamily resolveAddressFamily) { }
+        public HttpRequestMessage(HttpMethod method, string requestUri, System.Net.Sockets.AddressFamily resolveAddressFamily) { }
         public System.Net.Http.HttpContent Content { get { throw null; } set { } }
         public System.Net.Http.Headers.HttpRequestHeaders Headers { get { throw null; } }
         public System.Net.Http.HttpMethod Method { get { throw null; } set { } }
@@ -185,6 +187,7 @@ namespace System.Net.Http
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public override string ToString() { throw null; }
+        public System.Net.Sockets.AddressFamily ResolveAddressFamily { get { throw null; } set { } }
     }
     public partial class HttpResponseMessage : System.IDisposable
     {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -306,11 +306,11 @@ namespace System.Net.Http
                     case HttpConnectionKind.Http:
                     case HttpConnectionKind.Https:
                     case HttpConnectionKind.ProxyConnect:
-                        stream = await ConnectHelper.ConnectAsync(_host, _port, cancellationToken).ConfigureAwait(false);
+                        stream = await ConnectHelper.ConnectAsync(_host, _port, request.ResolveAddressFamily, cancellationToken).ConfigureAwait(false);
                         break;
 
                     case HttpConnectionKind.Proxy:
-                        stream = await ConnectHelper.ConnectAsync(_proxyUri.IdnHost, _proxyUri.Port, cancellationToken).ConfigureAwait(false);
+                        stream = await ConnectHelper.ConnectAsync(_proxyUri.IdnHost, _proxyUri.Port, request.ResolveAddressFamily, cancellationToken).ConfigureAwait(false);
                         break;
 
                     case HttpConnectionKind.SslProxyTunnel:

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -388,5 +389,14 @@ namespace System.Net.Http
 
             return null;
         }
+
+        public delegate Task<EndPoint> ResolveEndpointAsyncDelegate(string host, int port, AddressFamily addressFamily, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// With this property user can have more control when resolving IP address. For example one could prefer to resolve IPv6 addresses over IPv4
+        /// or completely override system default DNS resolving logic.
+        /// If set to null (default) client behaves same as before (backward compatible).
+        /// </summary>
+        public static ResolveEndpointAsyncDelegate ResolveEndpointAsync { get; set; } = null;
     }
 }


### PR DESCRIPTION
Hello.

I created my first commit to corefx fork / System.Net.Http project with small improvement to SocketsHttpHandler where user can now have more control over endpoint address resolving.

For example user can prefer IPv6 resolving over IPv4 version or even write custom logic which completely overrides system DNS resolve.

This feature is optional and should be backwards compatible.

Please check if this feature could be generally useful :)

@stephentoub @geoffkizer @karelz