### PR TITLE
Add tests to cover CurrentUserOnly in Unix when users are actually different.

### DIFF
--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.Unix.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.Unix.cs
@@ -59,8 +59,7 @@ namespace System.IO.Pipes.Tests
                     client.Connect();
             }
 
-            // Hard-coded value expected by the remote invoker in case of successful run.
-            return 42;
+            return SuccessExitCode;
         }
     }
 }

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.Unix.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.Unix.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.NetCore.Extensions;
+
+namespace System.IO.Pipes.Tests
+{
+    /// <summary>
+    /// Negative tests for PipeOptions.CurrentUserOnly in Unix.
+    /// </summary>
+    public class NamedPipeTest_CurrentUserOnly_Unix : RemoteExecutorTestBase
+    {
+        [Theory]
+        [OuterLoop("Needs sudo access")]
+        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
+        [InlineData(PipeOptions.None, PipeOptions.None)]
+        [InlineData(PipeOptions.None, PipeOptions.CurrentUserOnly)]
+        [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.None)]
+        [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.CurrentUserOnly)]
+        public async Task Connection_UnderDifferentUsers_BehavesAsExpected(
+            PipeOptions serverPipeOptions, PipeOptions clientPipeOptions)
+        {
+            // Use an absolute path, otherwise, the test can fail if the remote invoker and test runner have
+            // different working and/or temp directories. 
+            string pipeName = "/tmp/" + Path.GetRandomFileName(); 
+            using (var server = new NamedPipeServerStream(
+                pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, serverPipeOptions | PipeOptions.Asynchronous))
+            {
+                Task serverTask = server.WaitForConnectionAsync(CancellationToken.None);
+
+                using (RemoteInvoke(
+                    new Func<string, string, int>(ConnectClientFromRemoteInvoker),
+                    pipeName,
+                    clientPipeOptions == PipeOptions.CurrentUserOnly ? "true" : "false",
+                    new RemoteInvokeOptions { RunAsSudo = true }))
+                {
+                }
+
+                if (serverPipeOptions == PipeOptions.CurrentUserOnly)
+                    await Assert.ThrowsAsync<UnauthorizedAccessException>(() => serverTask);
+                else
+                    await serverTask;
+            }
+        }
+
+        private static int ConnectClientFromRemoteInvoker(string pipeName, string isCurrentUserOnly)
+        {
+            PipeOptions pipeOptions = bool.Parse(isCurrentUserOnly) ? PipeOptions.CurrentUserOnly : PipeOptions.None;
+            using (var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, pipeOptions))
+            {
+                if (pipeOptions == PipeOptions.CurrentUserOnly)
+                    Assert.Throws<UnauthorizedAccessException>(() => client.Connect());
+                else
+                    client.Connect();
+            }
+
+            // Hard-coded value expected by the remote invoker in case of successful run.
+            return 42;
+        }
+    }
+}

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.Windows.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.netcoreapp.Windows.cs
@@ -120,7 +120,7 @@ namespace System.IO.Pipes.Tests
     }
 
     /// <summary>
-    /// Tests for the constructors for NamedPipeClientStream
+    /// Negative tests for PipeOptions.CurrentUserOnly in Windows.
     /// </summary>
     public class NamedPipeTest_CurrentUserOnly_Windows : NamedPipeTestBase, IClassFixture<TestAccountImpersonator>
     {

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="NamedPipeTests\NamedPipeTest.CurrentUserOnly.netcoreapp.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' and '$(TargetsUnix)' == 'true'">
+    <Compile Include="NamedPipeTests\NamedPipeTest.CurrentUserOnly.netcoreapp.Unix.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.UnixDomainSockets.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">


### PR DESCRIPTION
Leveraging sudo to run pipe client as a different user and enforcing expected behavior regarding `PipeOptions.CurrentUserOnly` in such scenario.