### PR TITLE
Publish symbols using Microsoft.SymbolUploader.Build.Task package

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
@@ -187,31 +187,6 @@
     {
       "environment": {},
       "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Index symbol sources",
-      "timeoutInMinutes": 0,
-      "refName": "Task11",
-      "task": {
-        "id": "0675668a-7bba-4ccb-901d-5ad6554ca653",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "SymbolsPath": "",
-        "SearchPattern": "corefx\\bin\\*$(PB_Platform).$(PB_ConfigurationGroup)\\**\\*.pdb",
-        "SymbolsFolder": "",
-        "SkipIndexing": "false",
-        "TreatNotIndexedAsWarning": "false",
-        "SymbolsMaximumWaitTime": "",
-        "SymbolsProduct": "",
-        "SymbolsVersion": "",
-        "SymbolsArtifactName": "Symbols_$(PB_ConfigurationGroup)"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -238,31 +238,6 @@
     {
       "environment": {},
       "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Index symbol sources",
-      "timeoutInMinutes": 0,
-      "refName": "Task13",
-      "task": {
-        "id": "0675668a-7bba-4ccb-901d-5ad6554ca653",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "SymbolsPath": "",
-        "SearchPattern": "corefx\\bin\\*$(PB_Platform).$(PB_ConfigurationGroup)\\**\\*.pdb",
-        "SymbolsFolder": "",
-        "SkipIndexing": "false",
-        "TreatNotIndexedAsWarning": "false",
-        "SymbolsMaximumWaitTime": "",
-        "SymbolsProduct": "",
-        "SymbolsVersion": "",
-        "SymbolsArtifactName": "Symbols_$(PB_ConfigurationGroup)"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",

--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Run script $(VS140COMNTOOLS)\\VsDevCmd.bat",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(VS140COMNTOOLS)\\VsDevCmd.bat",
+        "arguments": "",
+        "modifyEnvironment": "true",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Set up pipeline-specific git repository",
       "timeoutInMinutes": 0,
       "task": {
@@ -24,7 +43,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "sync -ab",
+      "displayName": "Sync packages",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -36,52 +55,70 @@
         "scriptName": "",
         "arguments": "$(PB_CloudDropAccountName) $(CloudDropAccessToken) $(PB_Label)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($account, $token, $container)\n.\\sync.cmd -ab -- /p:CloudDropAccountName=$account /p:CloudDropAccessToken=$token /p:ContainerName=$container",
+        "inlineScript": "param($account, $token, $container)\n.\\sync.cmd -ab -- /v:D /p:CloudDropAccountName=$account /p:CloudDropAccessToken=$token /p:ContainerName=$container",
         "failOnStandardError": "false"
       }
     },
     {
+      "environment": {},
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Extract symbol packages; if release branch, archive",
+      "displayName": "symbol packages -> Blob Feed",
       "timeoutInMinutes": 0,
+      "condition": "and(succeeded(), contains(variables.PB_PublishType, 'blob'), eq(variables.PB_ConfigurationGroup, 'Release'))",
       "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "-ConfigGroup $(PB_ConfigurationGroup) -SymPkgGlob $(PB_AzureContainerSymbolPackageGlob) -Branch $(SourceBranch)",
+        "filename": "msbuild",
+        "arguments": "src\\publish.proj /t:PublishSymbolsToAzureBlobFeed /p:PublishSymbols=\"true\" $(FeedPublishArguments)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($ConfigGroup, $SymPkgGlob, $Branch)\nif ($ConfigGroup -ne \"Release\") { exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"GetAllSymbolFilesToPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\build-managed.cmd -- `\n/t:$target `\n/p:SkipCreateWindowsPdbsFromPortablePdbs=true `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/v:D",
-        "failOnStandardError": "true"
+        "failOnStandardError": "false"
       }
     },
     {
+      "environment": {},
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Publish Symbols to Artifact Services",
+      "displayName": "Publish symbols to msdl",
       "timeoutInMinutes": 0,
+      "condition": "and(succeeded(), contains(variables.PB_PublishType, 'msdl'), eq(variables.PB_ConfigurationGroup, 'Release'))",
       "task": {
-        "id": "29827cd1-5c33-4ff0-a817-abd46970ffc4",
-        "versionSpec": "0.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "symbolServiceURI": "https://microsoft.artifacts.visualstudio.com/DefaultCollection",
-        "requestName": "$(system.teamProject)/$(Build.BuildNumber)/$(Build.BuildId)",
-        "sourcePath": "$(Pipeline.SourcesDirectory)\\bin\\obj\\SymbolsRequest\\ExtractedPackages",
-        "assemblyPath": "",
-        "toLowerCase": "true",
-        "detailedLog": "true",
-        "expirationInDays": "30",
-        "usePat": "false"
+        "filename": "msbuild",
+        "arguments": "src\\publish.proj /v:D /t:PublishAllSymbols /p:SymbolServerPath=$(PB_MsdlSymbolServerPath) /p:SymbolServerPAT=$(PB_MsdlSymbolServerPAT) /p:SymbolExpirationInDays=$(PB_SymbolExpirationInDays) $(FeedPublishArguments)",
+        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "failOnStandardError": "false"
       }
-    }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish symbols to symweb",
+      "timeoutInMinutes": 0,
+      "condition": "and(succeeded(), contains(variables.PB_PublishType, 'symweb'), eq(variables.PB_ConfigurationGroup, 'Release'))",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "msbuild",
+        "arguments": "src\\publish.proj /v:D /t:PublishAllSymbols /p:SymbolServerPath=$(PB_SymwebSymbolServerPath) /p:SymbolServerPAT=$(PB_SymwebSymbolServerPAT) /p:SymbolExpirationInDays=$(PB_SymbolExpirationInDays) $(FeedPublishArguments)",
+        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "failOnStandardError": "false"
+      }
+    },
   ],
   "options": [
     {
@@ -132,7 +169,7 @@
       "allowOverride": true
     },
     "PB_ConfigurationGroup": {
-      "value": "Debug",
+      "value": "Release",
       "allowOverride": true
     },
     "PB_CloudDropAccountName": {
@@ -141,28 +178,21 @@
     },
     "CloudDropAccessToken": {
       "value": null,
-      "allowOverride": true,
       "isSecret": true
-    },
-    "OfficialBuildId": {
-      "value": "$(Build.BuildNumber)",
-      "allowOverride": true
     },
     "PB_Label": {
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
-    "PB_BuildConfiguration": {
-      "value": "release"
-    },
-    "PB_BuildPlatform": {
-      "value": "any cpu"
+    "PB_BlobNamePrefix": {
+      "value": "$(PB_PipeBuildIdentifier)/",
+      "allowOverride": true
     },
     "Pipeline.SourcesDirectory": {
       "value": "$(Build.BinariesDirectory)\\pipelineRepository"
     },
     "PB_VstsAccountName": {
-      "value": "dagood"
+      "value": "dn-bot"
     },
     "PB_VstsRepositoryName": {
       "value": "DotNet-CoreFX-Trusted",
@@ -175,6 +205,14 @@
       "value": null,
       "isSecret": true
     },
+    "AzureContainerSymbolPackageDirectory": {
+      "value": "$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(PB_ConfigurationGroup)\\symbols",
+      "allowOverride": true
+    },
+    "OfficialBuildId": {
+      "value": "$(Build.BuildNumber)",
+      "allowOverride": true
+    },
     "SourceVersion": {
       "value": "master",
       "allowOverride": true
@@ -183,35 +221,40 @@
       "value": "master",
       "allowOverride": true
     },
-    "PB_AzureContainerSymbolPackageGlob": {
-      "value": "$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(PB_ConfigurationGroup)\\symbols\\*.nupkg",
+    "FeedPublishArguments": {
+      "value": "$(PB_BuildOutputManifestArguments) /p:AccountKey=$(PB_PublishBlobFeedKey) /p:ExpectedFeedUrl=$(PB_PublishBlobFeedUrl) /p:ConfigurationGroup=$(PB_ConfigurationGroup)"
+    },
+    "PB_PublishBlobFeedUrl": {
+      "value": "",
       "allowOverride": true
     },
-    "PB_DotNetCoreShareDir": {
-      "value": "passed-by-pipebuild",
-      "allowOverride": true
+    "PB_PublishBlobFeedKey": {
+      "value": null,
+      "isSecret": true
     },
-    "SymbolsProject": {
-      "value": "CLR"
+    "PB_PublishType": {
+      "value": ""
     },
-    "SymbolsStatusMail": {
-      "value": "dagood;mawilkie"
+    "PB_BuildOutputManifestArguments": {
+      "value": "/p:ManifestBuildId=$(OfficialBuildId) /p:ManifestBranch=$(SourceBranch) /p:ManifestCommit=$(SourceVersion)"
     },
-    "SymbolsUserName": {
-      "value": "dlab"
+    "PB_MsdlSymbolServerPath": {
+      "value": "https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection"
     },
-    "SymbolsRelease": {
-      "value": "rtm"
+    "PB_MsdlSymbolServerPAT": {
+      "value": null,
+      "isSecret": true
     },
-    "SymbolsProductGroup": {
-      "value": "Visual_Studio"
+    "PB_SymwebSymbolServerPath": {
+      "value": "https://microsoft.artifacts.visualstudio.com/DefaultCollection"
     },
-    "SymbolsProductName": {
-      "value": "dotnetcore"
+    "PB_SymwebSymbolServerPAT": {
+      "value": null,
+      "isSecret": true
     },
-    "SymbolPublishDestinationDir": {
-      "value": "$(PB_DotNetCoreShareDir)\\$(PB_VstsRepositoryName)\\$(PB_Label)\\"
-    }
+    "PB_SymbolExpirationInDays": {
+      "value": "30"
+    },
   },
   "retentionRules": [
     {

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -8,7 +8,6 @@
       "displayName": "Install Signing Plugin",
       "timeoutInMinutes": 0,
       "condition": "and(succeeded(), in(variables.PB_SignType, 'real', 'test'))",
-      "refName": "Task1",
       "task": {
         "id": "30666190-6959-11e5-9f96-f56098202fef",
         "versionSpec": "1.*",
@@ -29,7 +28,6 @@
       "alwaysRun": false,
       "displayName": "Run script $(VS140COMNTOOLS)\\VsDevCmd.bat",
       "timeoutInMinutes": 0,
-      "refName": "Task2",
       "task": {
         "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
         "versionSpec": "1.*",
@@ -48,9 +46,8 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Fetch custom tooling (NuGet, EmbedIndex)",
+      "displayName": "Fetch custom tooling (NuGet)",
       "timeoutInMinutes": 0,
-      "refName": "Task3",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -72,7 +69,6 @@
       "alwaysRun": false,
       "displayName": "Set up pipeline-specific git repository",
       "timeoutInMinutes": 0,
-      "refName": "Task4",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -88,13 +84,11 @@
       }
     },
     {
-      "environment": {},
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "sync -ab",
+      "displayName": "Sync packages",
       "timeoutInMinutes": 0,
-      "refName": "Task5",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -105,53 +99,8 @@
         "scriptName": "",
         "arguments": "$(PB_CloudDropAccountName) $(CloudDropAccessToken) $(PB_Label)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($account, $token, $container)\n.\\sync.cmd -ab -- /p:CloudDropAccountName=$account /p:CloudDropAccessToken=$token /p:ContainerName=$container",
+        "inlineScript": "param($account, $token, $container)\n.\\sync.cmd -ab -- /v:D /p:CloudDropAccountName=$account /p:CloudDropAccessToken=$token /p:ContainerName=$container",
         "failOnStandardError": "false"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Inject signed symbol catalogs",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "refName": "Task6",
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "-ConfigGroup $(PB_ConfigurationGroup) -SymPkgGlob $(PB_AzureContainerSymbolPackageGlob) -PipelineSrcDir $(Pipeline.SourcesDirectory) -SignType $(PB_SignType)",
-        "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($ConfigGroup, $SymPkgGlob, $PipelineSrcDir, $SignType=\"unset\" )\n\nif ($SignType.ToLower() -ne \"real\" ) { Write-host \"Chose not to sign symbol catalogs\"; exit }\n\n\n.\\build-managed.cmd -- /t:InjectSignedSymbolCatalogIntoSymbolPackages `\n/p:SymbolPackagesToPublishGlob=$PipelineSrcDir\\packages\\AzureTransfer\\$ConfigGroup\\$SymPkgGlob `\n/p:SymbolCatalogCertificateId=400",
-        "failOnStandardError": "true"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Index symbol packages",
-      "timeoutInMinutes": 0,
-      "refName": "Task7",
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "-ConfigGroup $(PB_ConfigurationGroup) -SymPkgGlob $(PB_AzureContainerSymbolPackageGlob) -PipelineSrcDir $(Pipeline.SourcesDirectory)",
-        "workingFolder": "",
-        "inlineScript": "param($ConfigGroup, $SymPkgGlob, $PipelineSrcDir)\nif ($ConfigGroup -ne \"Release\") { exit }\n\n& $env:Build_SourcesDirectory\\scripts\\DotNet-Trusted-Publish\\Embed-Index.ps1 `\n  $PipelineSrcDir\\packages\\AzureTransfer\\$ConfigGroup\\$SymPkgGlob `\n  $env:Build_StagingDirectory\\IndexedSymbolPackages",
-        "failOnStandardError": "true"
       }
     },
     {
@@ -161,7 +110,6 @@
       "alwaysRun": false,
       "displayName": "Generate Version Assets",
       "timeoutInMinutes": 0,
-      "refName": "Task8",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -184,7 +132,6 @@
       "displayName": "packages -> dotnet.myget.org",
       "timeoutInMinutes": 0,
       "condition": "and(succeeded(), contains(variables.PB_PublishType, 'myget'), eq(variables.PB_ConfigurationGroup, 'Release'))",
-      "refName": "Task9",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -193,7 +140,7 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-ApiKey $(MyGetApiKey) -PackagesGlob $(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(PB_ConfigurationGroup)\\$(PB_AzureContainerPackageGlob) -MyGetFeedUrl $(PB_MyGetFeedUrl)",
+        "arguments": "-ApiKey $(MyGetApiKey) -PackagesGlob $(AzureContainerPackageDirectory)\\$(AzureContainerPackageGlob) -MyGetFeedUrl $(PB_MyGetFeedUrl)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "inlineScript": "param($ApiKey, $PackagesGlob, $MyGetFeedUrl)\n.\\build-managed.cmd -- /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
         "failOnStandardError": "true"
@@ -207,7 +154,6 @@
       "displayName": "packages -> Blob Feed",
       "timeoutInMinutes": 0,
       "condition": "and(succeeded(), contains(variables.PB_PublishType, 'blob'), eq(variables.PB_ConfigurationGroup, 'Release'))",
-      "refName": "CmdLine1",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -225,54 +171,9 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "symbol packages -> dotnet.myget.org",
-      "timeoutInMinutes": 0,
-      "condition": "and(succeeded(), contains(variables.PB_PublishType, 'myget'), eq(variables.PB_ConfigurationGroup, 'Release'))",
-      "refName": "Task11",
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "-ApiKey $(MyGetApiKey) -ConfigurationGroup $(PB_ConfigurationGroup) -PackagesGlob $(Build.StagingDirectory)\\IndexedSymbolPackages\\*.nupkg -MyGetFeedUrl $(PB_MyGetFeedUrl)",
-        "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($ApiKey, $ConfigurationGroup, $PackagesGlob, $MyGetFeedUrl)\nif ($env:SourceBranch.StartsWith(\"release/\")) { exit }\n\n.\\build-managed.cmd -- /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
-        "failOnStandardError": "true"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "symbol packages -> Blob Feed",
-      "timeoutInMinutes": 0,
-      "condition": "and(succeeded(), contains(variables.PB_PublishType, 'blob'), eq(variables.PB_ConfigurationGroup, 'Release'))",
-      "refName": "CmdLine2",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "msbuild",
-        "arguments": "src\\publish.proj /t:PublishSymbolsToAzureBlobFeed /p:PublishSymbols=\"true\" $(FeedPublishArguments)",
-        "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Update versions repository",
       "timeoutInMinutes": 0,
       "condition": "and(succeeded(), contains(variables.PB_PublishType, 'versions'), eq(variables.PB_ConfigurationGroup, 'Release'))",
-      "refName": "Task13",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -281,7 +182,7 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-ghAuthToken $(PB_DotNetBuildBotAccessToken) -root $(Pipeline.SourcesDirectory) -cg $(PB_ConfigurationGroup) -fullPkgGlob $(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(PB_ConfigurationGroup)\\$(PB_AzureContainerPackageGlob) ",
+        "arguments": "-ghAuthToken $(PB_DotNetBuildBotAccessToken) -root $(Pipeline.SourcesDirectory) -cg $(PB_ConfigurationGroup) -fullPkgGlob $(AzureContainerPackageDirectory)\\$(AzureContainerPackageGlob)",
         "workingFolder": "",
         "inlineScript": "param($ghAuthToken, $root, $cg, $fullPkgGlob, $SignType=\"unset\")\nif ($cg -ne \"Release\" ) { exit }\ncd $root\n. $root\\build-managed.cmd -- /t:UpdatePublishedVersions `\n/p:GitHubUser=dotnet-helix-bot `\n/p:GitHubEmail=dotnet-helix-bot@microsoft.com `\n/p:GitHubAuthToken=$ghAuthToken `\n/p:VersionsRepoOwner=$env:PB_VersionsRepoOwner `\n/p:VersionsRepo=versions `\n/p:VersionsRepoPath=build-info/dotnet/$env:PB_GitHubRepositoryName/$env:SourceBranch `\n/p:ShippedNuGetPackageGlobPath=$fullPkgGlob",
         "failOnStandardError": "true"
@@ -294,7 +195,6 @@
       "alwaysRun": false,
       "displayName": "Get Build Number",
       "timeoutInMinutes": 0,
-      "refName": "Task14",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -316,7 +216,6 @@
       "alwaysRun": false,
       "displayName": "Publish to Artifact Services Drop",
       "timeoutInMinutes": 0,
-      "refName": "Task15",
       "task": {
         "id": "f9d96d25-0c81-4e77-8282-1ad1f785cbb4",
         "versionSpec": "0.*",
@@ -342,7 +241,6 @@
       "displayName": "Send Telemetry",
       "timeoutInMinutes": 0,
       "condition": "always()",
-      "refName": "Task16",
       "task": {
         "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
         "versionSpec": "1.*",
@@ -389,25 +287,23 @@
       "allowOverride": true
     },
     "PB_ConfigurationGroup": {
-      "value": "Debug",
+      "value": "Release",
       "allowOverride": true
     },
-    "TeamName": {
-      "value": "DotNetCore"
-    },
     "PB_CloudDropAccountName": {
-      "value": "dotnetbuildoutput"
+      "value": "dotnetbuildoutput",
+      "allowOverride": true
     },
     "CloudDropAccessToken": {
       "value": null,
       "isSecret": true
     },
-    "OfficialBuildId": {
+    "PB_Label": {
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
-    "PB_Label": {
-      "value": "$(Build.BuildNumber)",
+    "PB_BlobNamePrefix": {
+      "value": "$(PB_PipeBuildIdentifier)/",
       "allowOverride": true
     },
     "PB_MyGetFeedUrl": {
@@ -418,9 +314,8 @@
       "value": null,
       "isSecret": true
     },
-    "VstsPat": {
-      "value": null,
-      "isSecret": true
+    "TeamName": {
+      "value": "DotNetCore"
     },
     "PB_VstsAuthedNuGetConfigPath": {
       "value": "$(Build.StagingDirectory)\\VstsAuthed.NuGet.Config"
@@ -451,14 +346,8 @@
     "PB_ManualReleaseName": {
       "value": ""
     },
-    "OfficialBuild": {
-      "value": "fake-test"
-    },
     "PB_BranchGroup": {
       "value": ""
-    },
-    "PB_SymbolRoot": {
-      "value": "\\\\fake\\symbol\\root"
     },
     "PB_DefinitionNames": {
       "value": "Fake-Windows Fake-Windows-Native"
@@ -487,6 +376,18 @@
       "value": null,
       "isSecret": true
     },
+    "AzureContainerPackageDirectory": {
+      "value": "$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(PB_ConfigurationGroup)",
+      "allowOverride": true
+    },
+    "AzureContainerPackageGlob": {
+      "value": "*.nupkg",
+      "allowOverride": true
+    },
+    "OfficialBuildId": {
+      "value": "$(Build.BuildNumber)",
+      "allowOverride": true
+    },
     "SourceVersion": {
       "value": "master",
       "allowOverride": true
@@ -498,24 +399,9 @@
     "FeedPublishArguments": {
       "value": "$(PB_BuildOutputManifestArguments) /p:AccountKey=$(PB_PublishBlobFeedKey) /p:ExpectedFeedUrl=$(PB_PublishBlobFeedUrl) /p:ConfigurationGroup=$(PB_ConfigurationGroup)"
     },
-    "PB_AzureContainerPackageGlob": {
-      "value": "*.nupkg",
-      "allowOverride": true
-    },
-    "PB_AzureContainerSymbolPackageGlob": {
-      "value": "symbols\\*.nupkg",
-      "allowOverride": true
-    },
     "PB_GitHubRepositoryName": {
       "value": "corefx",
       "allowOverride": true
-    },
-    "PB_UseLegacyBuildScripts": {
-      "value": "false",
-      "allowOverride": true
-    },
-    "PB_ToolPackageSource": {
-      "value": "https://www.myget.org/F/dagood-test-buildtools/api/v3/index.json"
     },
     "PB_PublishBlobFeedUrl": {
       "value": "",

--- a/dependencies.props
+++ b/dependencies.props
@@ -57,6 +57,12 @@
     <FeedTasksPackageVersion>2.1.0-preview2-02612-03</FeedTasksPackageVersion>
   </PropertyGroup>
 
+  <!-- Publish symbol build task package -->
+  <PropertyGroup>
+    <PublishSymbolsPackage>Microsoft.SymbolUploader.Build.Task</PublishSymbolsPackage>
+    <PublishSymbolsPackageVersion>1.0.0-beta-62709-01</PublishSymbolsPackageVersion>
+  </PropertyGroup>
+
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>

--- a/init-tools.msbuild
+++ b/init-tools.msbuild
@@ -9,5 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools" Version="$(BuildToolsPackageVersion)" />
     <PackageReference Include="$(FeedTasksPackage)" Version="$(FeedTasksPackageVersion)" />
+    <PackageReference Include="$(PublishSymbolsPackage)" Version="$(PublishSymbolsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -4,6 +4,7 @@
   <Import Project="$(ToolsDir)PublishContent.targets" />
   <Import Project="$(ToolsDir)versioning.targets" />
   <Import Project="$(PackagesDir)/$(FeedTasksPackage.ToLower())/$(FeedTasksPackageVersion)/build/$(FeedTasksPackage).targets" />
+  <Import Project="$(PackagesDir)/$(PublishSymbolsPackage.ToLower())/$(PublishSymbolsPackageVersion)/build/PublishSymbols.targets" />
 
   <PropertyGroup>
     <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)\**\*.nupkg</PublishPattern>
@@ -64,5 +65,22 @@
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
                     ManifestCommit="$(ManifestCommit)" />
+  </Target>
+
+
+  <Target Name="PublishAllSymbols" 
+          DependsOnTargets="SetupPublishSymbols;PublishSymbols"/>
+
+  <Target Name="SetupPublishSymbols">
+    <PropertyGroup>
+      <ConvertPortablePdbsToWindowsPdbs Condition="'$(ConvertPortablePdbsToWindowsPdbs)'==''">true</ConvertPortablePdbsToWindowsPdbs>
+      <SymbolVerboseLogging>true</SymbolVerboseLogging>
+    </PropertyGroup>
+    <ItemGroup>
+      <SymbolPackagesToPublish Include="$(FinalSymbolsPackagesPattern)" />
+    </ItemGroup>
+    <Error Condition="'$(SymbolServerPath)'==''" Text="Missing property SymbolServerPath" />
+    <Error Condition="'$(SymbolServerPAT)'==''" Text="Missing property SymbolServerPAT" />
+    <Message Importance="High" Text="Publishing @(SymbolPackagesToPublish) to $(SymbolServerPath)"/>
   </Target>
 </Project>

--- a/src/syncAzure.proj
+++ b/src/syncAzure.proj
@@ -3,9 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <ContainerNamePrefix Condition="'$(ContainerNamePrefix)' == ''">corefx-$(PreReleaseLabel)</ContainerNamePrefix>
-    <ContainerName Condition="'$(ContainerNamePrefix)' != '' and '$(BuildNumberMajor)' != '' and '$(BuildNumberMinor)' != ''">$(ContainerNamePrefix)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
-    <DownloadDirectory>$(PackagesDir)AzureTransfer</DownloadDirectory>
+    <ContainerName>$(ContainerName.Replace(".","-"))</ContainerName>
+    <DownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)AzureTransfer</DownloadDirectory>
   </PropertyGroup>
 
   <Import Project="$(ToolsDir)SyncCloudContent.targets" />


### PR DESCRIPTION
Added PB_SymbolExpirationInDays (settable at queue time), PB_MsdlSymbolServerPAT, PB_SymwebSymbolServerPAT variables.

Added "msdl" (publish symbols to public Microsoft server) and "symweb" (publish symbols to symweb) variables to PB_PublishType.

There was a little cleanup of the build def variable names between publish and symbol publish and between corefx and coreclr.

Issue #27343