### PR TITLE
[release/1.0.0] Enable TLS 1.2 in UpdateDependencies.ps1

### DIFF
--- a/UpdateDependencies.ps1
+++ b/UpdateDependencies.ps1
@@ -19,6 +19,9 @@ param(
     # a semi-colon delimited list of GitHub users to notify on the PR
     [string]$GitHubPullRequestNotifications='')
 
+# Enable TLS 1.2 for communication with GitHub.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 $LatestVersion = Invoke-WebRequest $VersionFileUrl -UseBasicParsing
 $LatestVersion = $LatestVersion.ToString().Trim()
 


### PR DESCRIPTION
This allows Maestro to run auto-update targets in .NET Core, where TLS 1.2 is supported by default.

CC @dagood @weshaggard 