### PR TITLE
CurlHandler: Remove Transfer-Encoding on redirect from POST to GET

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.MultiAgent.cs
@@ -999,6 +999,12 @@ namespace System.Net.Http
                                     // our redirect limit, etc.), this will have been unnecessary work in reconfiguring the easy handle, but 
                                     // nothing incorrect, as we'll tear down the handle once the request finishes, anyway, and all of the configuration
                                     // we're doing is about initiating a new request.
+                                    if ((int)response.StatusCode >= 301 && (int)response.StatusCode <= 303)
+                                    {
+                                        // ISSUE: 25163
+                                        // Ideally we want to avoid modifying the users request message.
+                                        easy._requestMessage.Headers.TransferEncodingChunked = false;
+                                    }
                                     easy.SetPossibleRedirectForLocationHeader(headerValue);
                                 }
                                 else if (string.Equals(headerName, HttpKnownHeaderNames.SetCookie, StringComparison.OrdinalIgnoreCase))

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.cs
@@ -767,6 +767,8 @@ namespace System.Net.Http
 
             // Deal with conflict between 'Content-Length' vs. 'Transfer-Encoding: chunked' semantics.
             // libcurl adds a Transfer-Encoding header by default and the request fails if both are set.
+            // ISSUE: 25163
+            // Ideally we want to avoid modifying the users request message.
             if (requestContent.Headers.ContentLength.HasValue)
             {
                 if (chunkedMode)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -641,14 +641,6 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(303)]
         public async Task AllowAutoRedirect_True_PostToGetDoesNotSendTE(int statusCode)
         {
-            if (IsCurlHandler)
-            {
-                // ISSUE #27301:
-                // CurlHandler incorrectly sends Transfer-Encoding when the method changes from POST to GET.
-                // Also, note CurlHandler doesn't change POST to GET for 300 response, either (see above test)
-                return;
-            }
-
             if (IsWinHttpHandler)
             {
                 // ISSUE #27440:

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -641,6 +641,13 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(303)]
         public async Task AllowAutoRedirect_True_PostToGetDoesNotSendTE(int statusCode)
         {
+            if (IsCurlHandler && statusCode == 300)
+            {
+                // ISSUE #26434:
+                // CurlHandler doesn't change POST to GET for 300 response (see above test).
+                return;
+            }
+
             if (IsWinHttpHandler)
             {
                 // ISSUE #27440:


### PR DESCRIPTION
This fix removes the TransferEncoding header from a request when it is redirected from POST to GET. I chose to modify the request for the following reasons:

1. It's consistent with the behavior of WinHttpHandler.
2. At this point the header has already been modified by the code linked below.

https://github.com/dotnet/corefx/blob/444e6bb7fd274be680fb3bf4b22258821e77ae2c/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.cs#L777-L781

I also tagged the locations where the TransferEncoding header is being modified with an issue tracking removal of those modifications.

If anyone feels strongly about not modifying the request (despite the above), I think that it is possible. It's just a much more significant rework.

Fixes: #27301