### PR TITLE
Change behavior of SocketsHttpHandler for redirects

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -372,9 +372,6 @@
   <data name="net_http_feature_UWPClientCertSupportRequiresCertInPersonalCertificateStore" xml:space="preserve">
     <value>Client certificate was not found in the personal (\"MY\") certificate store. In UWP, client certificates are only supported if they have been added to that certificate store.</value>
   </data>
-  <data name="net_http_max_redirects" xml:space="preserve">
-    <value>The maximum number of redirects was exceeded.</value>
-  </data>
   <data name="net_http_invalid_proxy_scheme" xml:space="preserve">
     <value>Only the 'http' scheme is allowed for proxies.</value>
   </data>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -33,13 +33,21 @@ namespace System.Net.Http
             Uri redirectUri;
             while ((redirectUri = GetUriForRedirect(request.RequestUri, response)) != null)
             {
-                response.Dispose();
-
                 redirectCount++;
+
                 if (redirectCount > _maxAutomaticRedirections)
                 {
-                    throw new HttpRequestException(SR.net_http_max_redirects);
+                    // If we exceed the maximum number of redirects
+                    // then just return the 3xx response.
+                    if (NetEventSource.IsEnabled)
+                    {
+                        NetEventSource.Info(this, $"Exceeded max number of redirects. Redirect from {request.RequestUri} to {redirectUri} blocked.");
+                    }
+
+                    break;
                 }
+
+                response.Dispose();
 
                 // Clear the authorization header.
                 request.Headers.Authorization = null;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -873,7 +873,17 @@ namespace System.Net.Http.Functional.Tests
                 }
                 else
                 {
-                    await Assert.ThrowsAsync<HttpRequestException>(() => t);
+                    if (UseSocketsHttpHandler)
+                    {
+                        using (HttpResponseMessage response = await t)
+                        {
+                            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+                        }
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync<HttpRequestException>(() => t);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When exceeding the max number of redirecs, .NET Framework will
not throw an exception. Instead, it will return the 3xx response.
This PR changes the behavior of SocketsHttpHandler to match.

Fixes #27285