### PR TITLE
Expose SocketsHttpHandler.ResponseDrainTimeout

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
         public const int DefaultMaxAutomaticRedirections = 50;
         public const int DefaultMaxConnectionsPerServer = int.MaxValue;
         public const int DefaultMaxResponseDrainSize = 1024 * 1024;
-        public static readonly TimeSpan DefaultMaxResponseDrainTime = TimeSpan.FromSeconds(2);
+        public static readonly TimeSpan DefaultResponseDrainTimeout = TimeSpan.FromSeconds(2);
         public const int DefaultMaxResponseHeadersLength = 64; // Units in K (1024) bytes.
         public const DecompressionMethods DefaultAutomaticDecompression = DecompressionMethods.None;
         public const bool DefaultAutomaticRedirection = true;

--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -256,6 +256,7 @@ namespace System.Net.Http
         public System.TimeSpan PooledConnectionLifetime { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
         public System.Net.IWebProxy Proxy { get { throw null; } set { } }
+        public System.TimeSpan ResponseDrainTimeout { get { throw null; } set { } }
         public System.Net.Security.SslClientAuthenticationOptions SslOptions { get { throw null; } set { } }
         public bool UseCookies { get { throw null; } set { } }
         public bool UseProxy { get { throw null; } set { } }

--- a/src/System.Net.Http/src/ILLinkTrim.xml
+++ b/src/System.Net.Http/src/ILLinkTrim.xml
@@ -2,9 +2,5 @@
   <assembly fullname="System.Net.Http">
     <!-- Anonymous types are used with DiagnosticSource logging and subscribers reflect over those, calling their public getters. -->
     <type fullname="*f__AnonymousType*" />
-    <type fullname="System.Net.Http.SocketsHttpHandler"> <!-- TODO #27685: Remove once public. -->
-      <method name="get_MaxResponseDrainTime" />
-      <method name="set_MaxResponseDrainTime" />
-    </type>
   </assembly>
 </linker>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
 
         internal int _maxConnectionsPerServer = HttpHandlerDefaults.DefaultMaxConnectionsPerServer;
         internal int _maxResponseDrainSize = HttpHandlerDefaults.DefaultMaxResponseDrainSize;
-        internal TimeSpan _maxResponseDrainTime = HttpHandlerDefaults.DefaultMaxResponseDrainTime;
+        internal TimeSpan _maxResponseDrainTime = HttpHandlerDefaults.DefaultResponseDrainTimeout;
         internal int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
 
         internal TimeSpan _pooledConnectionLifetime = HttpHandlerDefaults.DefaultPooledConnectionLifetime;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -167,7 +167,7 @@ namespace System.Net.Http
             }
         }
 
-        internal TimeSpan MaxResponseDrainTime // TODO #27685: Expose publicly.
+        public TimeSpan ResponseDrainTimeout
         {
             get => _settings._maxResponseDrainTime;
             set

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientHandler_ResponseDrain_Test : HttpClientTestBase
     {
-        protected virtual void SetMaxResponseDrainTime(HttpClientHandler handler, TimeSpan time) { }
+        protected virtual void SetResponseDrainTimeout(HttpClientHandler handler, TimeSpan time) { }
 
         public enum ContentMode
         {
@@ -134,7 +134,7 @@ namespace System.Net.Http.Functional.Tests
                 async url =>
                 {
                     HttpClientHandler handler = CreateHttpClientHandler();
-                    SetMaxResponseDrainTime(handler, Timeout.InfiniteTimeSpan);
+                    SetResponseDrainTimeout(handler, Timeout.InfiniteTimeSpan);
 
                     // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
                     handler.MaxConnectionsPerServer = 1;
@@ -212,7 +212,7 @@ namespace System.Net.Http.Functional.Tests
                 async url =>
                 {
                     HttpClientHandler handler = CreateHttpClientHandler();
-                    SetMaxResponseDrainTime(handler, Timeout.InfiniteTimeSpan);
+                    SetResponseDrainTimeout(handler, Timeout.InfiniteTimeSpan);
 
                     // Set MaxConnectionsPerServer to 1.  This will ensure we will wait for the previous request to drain (or fail to)
                     handler.MaxConnectionsPerServer = 1;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/27685

Just renames the internal property, makes it public, and fixes the tests to use it directly rather than via reflection.

cc: @geoffkizer 