### PR TITLE
Update the System.Memory package description and common types listed.

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1012,13 +1012,16 @@
   },
   {
     "Name": "System.Memory",
-    "Description": "Provides types for efficient low-allocation access to memory.",
+    "Description": "Provides types for efficient representation and pooling of managed, stack, and native memory segments and sequences of such segments, along with primitives to parse and format UTF-8 encoded text stored in those memory segments.",
     "CommonTypes": [
         "System.Span",
         "System.ReadOnlySpan",
         "System.Memory",
         "System.ReadOnlyMemory",
-        "System.MemoryExtensions"
+        "System.Buffers.MemoryPool",
+        "System.Buffers.ReadOnlySequence",
+        "System.Buffers.Text.Utf8Parser",
+        "System.Buffers.Text.Utf8Formatter"
     ]
   },
   {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/27481.

I explicitly chose to highlight the most common subset of the types available here (and intentionally exclude the classes that contain the extension methods). Please provide feedback if you disagree with the choices.

cc @KrzysztofCwalina, @dotnet/corefxlab-contrib, @davidfowl, @AtsushiKan, @stephentoub  