### PR TITLE
System.Diagnostics.EventLog.Tests fails 2 tests in non-English Windows

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -80,7 +80,9 @@ namespace System.Diagnostics.Tests
         {
             using (EventLog eventLog = new EventLog("Application"))
             {
-                Assert.Equal("Application", eventLog.LogDisplayName);
+                Assert.False(string.IsNullOrEmpty(eventLog.LogDisplayName));
+                if (CultureInfo.CurrentCulture.Name.Split('-')[0] == "en" )
+                    Assert.Equal("Application", eventLog.LogDisplayName);
             }
         }
 
@@ -109,7 +111,10 @@ namespace System.Diagnostics.Tests
             using (EventLog eventLog = new EventLog())
             {
                 eventLog.Log = "Application";
-                Assert.Equal("Application", eventLog.LogDisplayName);
+
+                Assert.False(string.IsNullOrEmpty(eventLog.LogDisplayName));
+                if (CultureInfo.CurrentCulture.Name.Split('-')[0] == "en" )
+                    Assert.Equal("Application", eventLog.LogDisplayName);
             }
         }
 


### PR DESCRIPTION
See https://github.com/dotnet/corefx/issues/27646