### PR TITLE
Add tests for ClientWebSocket connections thru a proxy

### DIFF
--- a/src/Common/tests/System/Net/Configuration.WebSockets.cs
+++ b/src/Common/tests/System/Net/Configuration.WebSockets.cs
@@ -8,6 +8,8 @@ namespace System.Net.Test.Common
     {
         public static partial class WebSockets
         {
+            public static string ProxyServerUri => GetValue("COREFX_WEBSOCKETPROXYSERVERURI");
+
             public static string Host => GetValue("COREFX_WEBSOCKETHOST", DefaultAzureServer);
 
             public static string SecureHost => GetValue("COREFX_SECUREWEBSOCKETHOST", DefaultAzureServer);

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -51,7 +51,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        public async Task NullProxySet_ConnectsSuccessfully(Uri server)
+        public async Task Proxy_SetNull_ConnectsSuccessfully(Uri server)
         {
             for (int i = 0; i < 3; i++) // Connect and disconnect multiple times to exercise shared handler on netcoreapp
             {
@@ -64,6 +64,43 @@ namespace System.Net.WebSockets.Client.Tests
                 });
                 await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, default);
                 ws.Dispose();
+            }
+        }
+
+        [ActiveIssue(28027)]
+        [OuterLoop] // TODO: Issue #11345
+        [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        public async Task Proxy_ConnectThruProxy_Success(Uri server)
+        {
+            string proxyServerUri = System.Net.Test.Common.Configuration.WebSockets.ProxyServerUri;
+            if (string.IsNullOrEmpty(proxyServerUri))
+            {
+                _output.WriteLine("Skipping test...no proxy server defined.");
+                return;
+            }
+            
+            _output.WriteLine($"ProxyServer: {proxyServerUri}");
+            
+            IWebProxy proxy = new WebProxy(new Uri(proxyServerUri));
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(
+                server,
+                TimeOutMilliseconds,
+                _output,
+                default(TimeSpan),
+                proxy))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+                Assert.Equal(WebSocketState.Open, cws.State);
+
+                var closeStatus = WebSocketCloseStatus.NormalClosure;
+                string closeDescription = "Normal Closure";
+
+                await cws.CloseAsync(closeStatus, closeDescription, cts.Token);
+
+                // Verify a clean close frame handshake.
+                Assert.Equal(WebSocketState.Closed, cws.State);
+                Assert.Equal(closeStatus, cws.CloseStatus);
+                Assert.Equal(closeDescription, cws.CloseStatusDescription);
             }
         }
 

--- a/src/System.Net.WebSockets.Client/tests/WebSocketHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/WebSocketHelper.cs
@@ -65,10 +65,16 @@ namespace System.Net.WebSockets.Client.Tests
             Uri server,
             int timeOutMilliseconds,
             ITestOutputHelper output,
-            TimeSpan keepAliveInterval = default) =>
+            TimeSpan keepAliveInterval = default,
+            IWebProxy proxy = null) =>
             Retry(output, async () =>
             {
                 var cws = new ClientWebSocket();
+                if (proxy != null)
+                {
+                    cws.Options.Proxy = proxy;
+                }
+                
                 if (keepAliveInterval.TotalSeconds > 0)
                 {
                     cws.Options.KeepAliveInterval = keepAliveInterval;


### PR DESCRIPTION
Created new tests for verifying ClientWebSocket connections end-to-end thru a proxy.

Opened new issues #28024 and #28027 which cause the new tests to fail.

Fixes #26957