### PR TITLE
Fix incorrect bounds check in ArrayMemoryPoolBuffer.Pin

### DIFF
--- a/src/System.Memory/tests/Memory/OwnedMemory.cs
+++ b/src/System.Memory/tests/Memory/OwnedMemory.cs
@@ -118,6 +118,15 @@ namespace System.MemoryTests
         }
 
         [Fact]
+        [OuterLoop]
+        public static void OwnedMemoryPinLargeArray()
+        {
+            int[] array = new int[0x2000_0000]; // will produce array with total byte length > 2 GB
+            OwnedMemory<int> owner = new CustomMemoryForTest<int>(array);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.Pin(int.MinValue));
+        }
+
+        [Fact]
         public static void MemoryFromOwnedMemoryAfterDispose()
         {
             int[] a = { 91, 92, -93, 94 };


### PR DESCRIPTION
The bounds check in `Pin` was susceptible to integer underflow. This addresses the issue by making sure we're always using an unsigned `size_t` equivalent when performing the check. Also moved around the logic slightly to Release if an exception occurred after the call to Retain.