### PR TITLE
Add SuppressMetaPackage to break circular dependency during package restore

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
@@ -7,6 +7,10 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
+
+    <!-- this package is part of the implementation closure of NETStandard.Library
+         therefore it cannot reference NETStandard.Library -->
+    <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
See https://github.com/dotnet/corefxlab/pull/2150#issuecomment-372785112 for context (where the issue was manifesting as a VS crash due to stackoverflow).

I tested this locally (by building and referencing the System.Threading.Tasks.Extensions/System.IO.Pipelines packages with this fix in a netstandard1.3 class library).

cc @weshaggard, @ericstj 