### PR TITLE
Use Intermediate path for GenerateReferenceSource

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -127,7 +127,7 @@
 
     <PropertyGroup>
       <_GenAPICmd>$(DotnetToolCommand) $(_GenApiExePath)</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) -assembly:$(TargetPath)</_GenAPICmd>
+      <_GenAPICmd>$(_GenAPICmd) -assembly:@(IntermediateAssembly)</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) -libPath:$(RefPath)</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) -out:$(_RefSourceFileOutputPath)</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) -excludeAttributesList:$(_ExcludeAPIList)</_GenAPICmd>


### PR DESCRIPTION
After the new reverse APICompat checks we fail the
src build if the ref doesn't match so we don't have
a great way to regenerate the reference assembly.
By using the intermediate path we can still generate
the reference assembly without having a successful
src build.

cc @ericstj 