### PR TITLE
Rethrown exception call stack tests

### DIFF
--- a/src/System.Runtime/tests/Configurations.props
+++ b/src/System.Runtime/tests/Configurations.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
-      netstandard;
+      netfx;
       uap;
       uapaot;
     </BuildConfigurations>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -8,12 +8,12 @@
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);uapaot</DefineConstants>
     <!-- Please don't delete. We need App.config for netfx -->
-    <NETFxTestRunnerAppConfig Condition="'$(TargetGroup)' == 'netstandard'">$(MSBuildProjectDirectory)\App.config</NETFxTestRunnerAppConfig>
+    <NETFxTestRunnerAppConfig Condition="'$(TargetGroup)' == 'netfx'">$(MSBuildProjectDirectory)\App.config</NETFxTestRunnerAppConfig>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Debug|AnyCPU'" />

--- a/src/System.Runtime/tests/System/ExceptionTests.cs
+++ b/src/System.Runtime/tests/System/ExceptionTests.cs
@@ -144,6 +144,7 @@ namespace System.Tests
         private static void VerifyCallStack(
             Stack<(string CallerMemberName, string SourceFilePath, int SourceLineNumber)> expectedCallStack, string reportedCallStack)
         {
+            Console.WriteLine("* ExceptionTests - reported call stack:\n{0}", reportedCallStack);
             const string FrameParserRegex = @"\s+at\s.+\.(?<memberName>[^(]+)\([^)]*\)\sin\s(?<filePath>.*)\:line\s(?<lineNumber>[\d]+)";
 
             using (var sr = new StringReader(reportedCallStack))

--- a/src/System.Runtime/tests/System/ExceptionTests.cs
+++ b/src/System.Runtime/tests/System/ExceptionTests.cs
@@ -81,12 +81,16 @@ namespace System.Tests
         {
             try
             {
-                // Keep the two statements below together
-                callStack.Push(GetSourceInformation());
+                // Keep the statements below together
+                if (!PlatformDetection.IsFullFramework)
+                    callStack.Push(GetSourceInformation());
                 throw new Exception("Boom!");
             }
             catch
             {
+                // Keep the statements below together
+                if (PlatformDetection.IsFullFramework)
+                    callStack.Push(GetSourceInformation());
                 throw;
             }
         }
@@ -112,12 +116,20 @@ namespace System.Tests
         {
             try
             {
-                // Keep the two statements below together
-                callStack.Push(GetSourceInformation());
+                // Keep the statements below together
+                if (!PlatformDetection.IsFullFramework)
+                    callStack.Push(GetSourceInformation());
                 ThrowException(callStack);
             }
             catch
             {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    var throwFrame = callStack.Pop();
+                    // Keep the statements below in the same line
+                    callStack.Push(GetSourceInformation()); callStack.Push(throwFrame);
+                    throw;
+                }
                 throw;
             }
         }
@@ -139,12 +151,12 @@ namespace System.Tests
                 string frame;
                 while (!string.IsNullOrEmpty(frame = sr.ReadLine()))
                 {
-                    var reportedFrame = expectedCallStack.Pop();
+                    var exptectedFrame = expectedCallStack.Pop();
                     var match = Regex.Match(frame, FrameParserRegex);
                     Assert.True(match.Success);
-                    Assert.Equal(reportedFrame.CallerMemberName, match.Groups["memberName"].Value);
-                    Assert.Equal(reportedFrame.SourceFilePath, match.Groups["filePath"].Value);
-                    Assert.Equal(reportedFrame.SourceLineNumber + 1, Convert.ToInt32(match.Groups["lineNumber"].Value));
+                    Assert.Equal(exptectedFrame.CallerMemberName, match.Groups["memberName"].Value);
+                    Assert.Equal(exptectedFrame.SourceFilePath, match.Groups["filePath"].Value);
+                    Assert.Equal(exptectedFrame.SourceLineNumber + 1, Convert.ToInt32(match.Groups["lineNumber"].Value));
                 }
             }
         }

--- a/src/System.Runtime/tests/System/ExceptionTests.cs
+++ b/src/System.Runtime/tests/System/ExceptionTests.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace System.Tests
@@ -56,6 +58,103 @@ namespace System.Tests
             }
 
             Assert.True(caught);
+        }
+
+        [Fact]
+        public static void ThrowStatementDoesNotResetExceptionStackLineSameMethod()
+        {
+            var callStack = new Stack<(string, string, int)>();
+
+            try
+            {
+                // Keep the two statements below together
+                callStack.Push(GetSourceInformation());
+                ThrowAndRethrowSameMethod(callStack);
+            }
+            catch (Exception ex)
+            {
+                VerifyCallStack(callStack, ex.StackTrace);
+            }
+        }
+
+        private static void ThrowAndRethrowSameMethod(Stack<(string, string, int)> callStack)
+        {
+            try
+            {
+                // Keep the two statements below together
+                callStack.Push(GetSourceInformation());
+                throw new Exception("Boom!");
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        [Fact]
+        public static void ThrowStatementDoesNotResetExceptionStackLineOtherMethod()
+        {
+            var callStack = new Stack<(string, string, int)>();
+
+            try
+            {
+                // Keep the two statements below together
+                callStack.Push(GetSourceInformation());
+                ThrowAndRethrowOtherMethod(callStack);
+            }
+            catch (Exception ex)
+            {
+                VerifyCallStack(callStack, ex.StackTrace);
+            }
+        }
+
+        private static void ThrowAndRethrowOtherMethod(Stack<(string, string, int)> callStack)
+        {
+            try
+            {
+                // Keep the two statements below together
+                callStack.Push(GetSourceInformation());
+                ThrowException(callStack);
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        private static void ThrowException(Stack<(string, string, int)> callStack)
+        {
+            // Keep the two statements below together
+            callStack.Push(GetSourceInformation());
+            throw new Exception("Boom!");
+        }
+
+        private static void VerifyCallStack(
+            Stack<(string CallerMemberName, string SourceFilePath, int SourceLineNumber)> expectedCallStack, string reportedCallStack)
+        {
+            const string FrameParserRegex = @"\s+at\s.+\.(?<memberName>[^(]+)\([^)]*\)\sin\s(?<filePath>.*)\:line\s(?<lineNumber>[\d]+)";
+
+            using (var sr = new StringReader(reportedCallStack))
+            {
+                string frame;
+                while (!string.IsNullOrEmpty(frame = sr.ReadLine()))
+                {
+                    var reportedFrame = expectedCallStack.Pop();
+                    var match = Regex.Match(frame, FrameParserRegex);
+                    Assert.True(match.Success);
+                    Assert.Equal(reportedFrame.CallerMemberName, match.Groups["memberName"].Value);
+                    Assert.Equal(reportedFrame.SourceFilePath, match.Groups["filePath"].Value);
+                    Assert.Equal(reportedFrame.SourceLineNumber + 1, Convert.ToInt32(match.Groups["lineNumber"].Value));
+                }
+            }
+        }
+
+        private static (string, string, int) GetSourceInformation(
+            [CallerMemberName] string memberName = "",
+            [CallerFilePath] string sourceFilePath = "",
+            [CallerLineNumber] int sourceLineNumber = 0)
+        {
+            return (memberName, sourceFilePath, sourceLineNumber);
         }
     }
 


### PR DESCRIPTION
Added tests to verify the reported call stack for rethrown exceptions, as specified by dotnet/coreclr#15780.

1. **Exception rethrown in a method different than the method where it was originally thrown:** the stack trace contains both the location in the method where the exception was originally thrown, and the location where the method that threw the exception was called.

2. **Exception is thrown and later rethrown in the same method:** the stack trace only contains the location where the exception was originally thrown and does not include the location where the exception was rethrown.