### PR TITLE
Remove matching ref baseline file for System.Memory

### DIFF
--- a/src/System.Memory/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Memory/src/MatchingRefApiCompatBaseline.txt
@@ -1,6 +1,0 @@
-Compat issues with assembly System.Memory:
-MembersMustExist : Member 'System.MemoryExtensions.AsReadOnlyMemory<T>(System.Memory<T>)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.MemoryExtensions.AsReadOnlySpan<T>(System.ArraySegment<T>)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.MemoryExtensions.AsReadOnlySpan<T>(System.Span<T>)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.MemoryExtensions.AsReadOnlySpan<T>(T[])' does not exist in the implementation but it does exist in the contract.
-Total Issues: 4


### PR DESCRIPTION
The implementation and ref now match after the latest
coreclr code mirror so we don't need the baseline file
any longer.