### PR TITLE
Ensure SocketsHttpHandler throws TaskCanceledExceptions instead of OperationCanceledExceptions

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -55,7 +55,6 @@
     <Compile Include="System\Net\Http\MultipartFormDataContent.cs" />
     <Compile Include="System\Net\Http\NetEventSource.Http.cs" />
     <Compile Include="System\Net\Http\ReadOnlyMemoryContent.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnectionKind.cs" />
     <Compile Include="System\Net\Http\StreamContent.cs" />
     <Compile Include="System\Net\Http\StreamToStreamCopy.cs" />
     <Compile Include="System\Net\Http\StringContent.cs" />
@@ -128,6 +127,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\AuthenticationHelper.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\AuthenticationHelper.Digest.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\AuthenticationHelper.NtAuth.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\CancellationHelper.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\ChunkedEncodingReadStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\ChunkedEncodingWriteStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\ConnectHelper.cs" />
@@ -140,6 +140,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpAuthenticatedConnectionHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnection.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnectionHandler.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnectionKind.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnectionPool.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnectionPoolManager.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnectionResponseContent.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CancellationHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CancellationHelper.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    /// <summary>Provides utilities related to cancellation.</summary>
+    internal static class CancellationHelper
+    {
+        /// <summary>The default message used by <see cref="OperationCanceledException"/>.</summary>
+        private static readonly string s_cancellationMessage = new OperationCanceledException().Message; // use same message as the default ctor
+
+        /// <summary>Determines whether to wrap an <see cref="Exception"/> in a cancellation exception.</summary>
+        /// <param name="exception">The exception.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that may have triggered the exception.</param>
+        /// <returns>true if the exception should be wrapped; otherwise, false.</returns>
+        internal static bool ShouldWrapInOperationCanceledException(Exception exception, CancellationToken cancellationToken) =>
+            !(exception is OperationCanceledException) && cancellationToken.IsCancellationRequested;
+
+        /// <summary>Creates a cancellation exception.</summary>
+        /// <param name="innerException">The inner exception to wrap. May be null.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that triggered the cancellation.</param>
+        /// <returns>The cancellation exception.</returns>
+        internal static Exception CreateOperationCanceledException(Exception innerException, CancellationToken cancellationToken) =>
+            new TaskCanceledException(s_cancellationMessage, innerException, cancellationToken); // TCE for compatibility with other handlers that use TaskCompletionSource.TrySetCanceled()
+
+        /// <summary>Throws a cancellation exception.</summary>
+        /// <param name="innerException">The inner exception to wrap. May be null.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that triggered the cancellation.</param>
+        private static void ThrowOperationCanceledException(Exception innerException, CancellationToken cancellationToken) =>
+            throw CreateOperationCanceledException(innerException, cancellationToken);
+
+        /// <summary>Throws a cancellation exception if cancellation has been requested via <paramref name="cancellationToken"/>.</summary>
+        /// <param name="cancellationToken">The token to check for a cancellation request.</param>
+        internal static void ThrowIfCancellationRequested(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                ThrowOperationCanceledException(innerException:null, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -115,9 +115,9 @@ namespace System.Net.Http
                         }
                     }
                 }
-                catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                 {
-                    throw new OperationCanceledException(s_cancellationMessage, exc, cancellationToken);
+                    throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                 }
                 finally
                 {
@@ -161,9 +161,9 @@ namespace System.Net.Http
                         await _connection.FillAsync().ConfigureAwait(false);
                     }
                 }
-                catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                 {
-                    throw new OperationCanceledException(s_cancellationMessage, exc, cancellationToken);
+                    throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                 }
                 finally
                 {
@@ -295,7 +295,7 @@ namespace System.Net.Http
                                     // (e.g. if a timer is used and has already queued its callback but the
                                     // callback hasn't yet run).
                                     cancellationRegistration.Dispose();
-                                    cancellationRegistration.Token.ThrowIfCancellationRequested();
+                                    CancellationHelper.ThrowIfCancellationRequested(cancellationRegistration.Token);
 
                                     _state = ParsingState.Done;
                                     _connection.CompleteResponse();

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -59,7 +59,7 @@ namespace System.Net.Http
                             case SocketError.ConnectionAborted:
                                 if (csaea.CancellationToken.IsCancellationRequested)
                                 {
-                                    csaea.Builder.SetException(new OperationCanceledException(csaea.CancellationToken));
+                                    csaea.Builder.SetException(CancellationHelper.CreateOperationCanceledException(null, csaea.CancellationToken));
                                     break;
                                 }
                                 goto default;
@@ -95,8 +95,8 @@ namespace System.Net.Http
             }
             catch (Exception error)
             {
-                throw HttpConnection.ShouldWrapInOperationCanceledException(error, cancellationToken) ?
-                    HttpConnection.CreateOperationCanceledException(error, cancellationToken) :
+                throw CancellationHelper.ShouldWrapInOperationCanceledException(error, cancellationToken) ?
+                    CancellationHelper.CreateOperationCanceledException(error, cancellationToken) :
                     new HttpRequestException(error.Message, error);
             }
         }
@@ -149,9 +149,9 @@ namespace System.Net.Http
             {
                 sslStream.Dispose();
 
-                if (HttpConnection.ShouldWrapInOperationCanceledException(e, cancellationToken))
+                if (CancellationHelper.ShouldWrapInOperationCanceledException(e, cancellationToken))
                 {
-                    throw HttpConnection.CreateOperationCanceledException(e, cancellationToken);
+                    throw CancellationHelper.CreateOperationCanceledException(e, cancellationToken);
                 }
 
                 throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
@@ -165,7 +165,7 @@ namespace System.Net.Http
             if (cancellationToken.IsCancellationRequested)
             {
                 sslStream.Dispose();
-                throw new OperationCanceledException(cancellationToken);
+                throw CancellationHelper.CreateOperationCanceledException(null, cancellationToken);
             }
 
             return sslStream;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http
 
             public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                 if (_connection == null || destination.Length == 0)
                 {
@@ -39,9 +39,9 @@ namespace System.Net.Http
                     {
                         bytesRead = await readTask.ConfigureAwait(false);
                     }
-                    catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                    catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                     {
-                        throw CreateOperationCanceledException(exc, cancellationToken);
+                        throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                     }
                     finally
                     {
@@ -57,7 +57,7 @@ namespace System.Net.Http
                     // early due to cancellation.  So we prioritize cancellation in this race condition, and
                     // if we read 0 bytes and then find that cancellation has requested, we assume cancellation
                     // was the cause and throw.
-                    cancellationToken.ThrowIfCancellationRequested();
+                    CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
                     _connection.Dispose();
@@ -100,9 +100,9 @@ namespace System.Net.Http
                 {
                     await copyTask.ConfigureAwait(false);
                 }
-                catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                 {
-                    throw CreateOperationCanceledException(exc, cancellationToken);
+                    throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                 }
                 finally
                 {
@@ -113,7 +113,7 @@ namespace System.Net.Http
                 // to end early but think it ended successfully. So we prioritize cancellation in this
                 // race condition, and if we find after the copy has completed that cancellation has
                 // been requested, we assume the copy completed due to cancellation and throw.
-                cancellationToken.ThrowIfCancellationRequested();
+                CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                 Finish();
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http
 
             public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                 if (_connection == null || destination.Length == 0)
                 {
@@ -51,9 +51,9 @@ namespace System.Net.Http
                     {
                         bytesRead = await readTask.ConfigureAwait(false);
                     }
-                    catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                    catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                     {
-                        throw CreateOperationCanceledException(exc, cancellationToken);
+                        throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                     }
                     finally
                     {
@@ -64,7 +64,7 @@ namespace System.Net.Http
                 if (bytesRead <= 0)
                 {
                     // A cancellation request may have caused the EOF.
-                    cancellationToken.ThrowIfCancellationRequested();
+                    CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // Unexpected end of response stream.
                     throw new IOException(SR.net_http_invalid_response);
@@ -115,9 +115,9 @@ namespace System.Net.Http
                 {
                     await copyTask.ConfigureAwait(false);
                 }
-                catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                 {
-                    throw CreateOperationCanceledException(exc, cancellationToken);
+                    throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                 }
                 finally
                 {
@@ -198,7 +198,7 @@ namespace System.Net.Http
                             // (e.g. if a timer is used and has already queued its callback but the
                             // callback hasn't yet run).
                             ctr.Dispose();
-                            ctr.Token.ThrowIfCancellationRequested();
+                            CancellationHelper.ThrowIfCancellationRequested(ctr.Token);
 
                             Finish();
                             return true;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http
 
             public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                 if (_connection == null || destination.Length == 0)
                 {
@@ -39,9 +39,9 @@ namespace System.Net.Http
                     {
                         bytesRead = await readTask.ConfigureAwait(false);
                     }
-                    catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                    catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                     {
-                        throw CreateOperationCanceledException(exc, cancellationToken);
+                        throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                     }
                     finally
                     {
@@ -52,7 +52,7 @@ namespace System.Net.Http
                 if (bytesRead == 0)
                 {
                     // A cancellation request may have caused the EOF.
-                    cancellationToken.ThrowIfCancellationRequested();
+                    CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
                     _connection.Dispose();
@@ -95,9 +95,9 @@ namespace System.Net.Http
                 {
                     await copyTask.ConfigureAwait(false);
                 }
-                catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                 {
-                    throw CreateOperationCanceledException(exc, cancellationToken);
+                    throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                 }
                 finally
                 {
@@ -108,7 +108,7 @@ namespace System.Net.Http
                 // to end early but think it ended successfully. So we prioritize cancellation in this
                 // race condition, and if we find after the copy has completed that cancellation has
                 // been requested, we assume the copy completed due to cancellation and throw.
-                cancellationToken.ThrowIfCancellationRequested();
+                CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                 Finish();
             }
@@ -168,9 +168,9 @@ namespace System.Net.Http
                 {
                     await task.ConfigureAwait(false);
                 }
-                catch (Exception exc) when (ShouldWrapInOperationCanceledException(exc, cancellationToken))
+                catch (Exception exc) when (CancellationHelper.ShouldWrapInOperationCanceledException(exc, cancellationToken))
                 {
-                    throw CreateOperationCanceledException(exc, cancellationToken);
+                    throw CancellationHelper.CreateOperationCanceledException(exc, cancellationToken);
                 }
                 finally
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -438,7 +438,7 @@ namespace System.Net.Http.Functional.Tests
             using (HttpClient client = CreateHttpClient())
             {
                 var request = new HttpRequestMessage(HttpMethod.Post, Configuration.Http.RemoteEchoServer);
-                OperationCanceledException ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                TaskCanceledException ex = await Assert.ThrowsAsync<TaskCanceledException>(() =>
                     client.SendAsync(request, cts.Token));
                 Assert.True(cts.Token.IsCancellationRequested, "cts token IsCancellationRequested");
                 if (!PlatformDetection.IsFullFramework)
@@ -2035,8 +2035,8 @@ namespace System.Net.Http.Functional.Tests
                         } // Dispose the handler while requests are still outstanding
 
                         // Requests 1 and 2 should be canceled as we haven't finished receiving their headers
-                        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => get1);
-                        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => get2);
+                        await Assert.ThrowsAsync<TaskCanceledException>(() => get1);
+                        await Assert.ThrowsAsync<TaskCanceledException>(() => get2);
 
                         // Request 3 should still be active, and we should be able to receive all of the data.
                         unblockServers.SetResult(true);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -267,11 +267,11 @@ namespace System.Net.Http.Functional.Tests
 
                 cts.Cancel();
 
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t1);
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t2);
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t3);
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t4);
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t5);
+                await Assert.ThrowsAsync<TaskCanceledException>(() => t1);
+                await Assert.ThrowsAsync<TaskCanceledException>(() => t2);
+                await Assert.ThrowsAsync<TaskCanceledException>(() => t3);
+                await Assert.ThrowsAsync<TaskCanceledException>(() => t4);
+                await Assert.ThrowsAsync<TaskCanceledException>(() => t5);
             }
         }
 
@@ -383,7 +383,7 @@ namespace System.Net.Http.Functional.Tests
                 }
                 Task<HttpResponseMessage>[] tasks = Enumerable.Range(0, 3).Select(_ => client.GetAsync(CreateFakeUri())).ToArray();
                 client.CancelPendingRequests();
-                Assert.All(tasks, task => Assert.ThrowsAny<OperationCanceledException>(() => task.GetAwaiter().GetResult()));
+                Assert.All(tasks, task => Assert.Throws<TaskCanceledException>(() => task.GetAwaiter().GetResult()));
             }
         }
 
@@ -394,7 +394,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 client.Timeout = TimeSpan.FromMilliseconds(1);
                 Task<HttpResponseMessage>[] tasks = Enumerable.Range(0, 3).Select(_ => client.GetAsync(CreateFakeUri())).ToArray();
-                Assert.All(tasks, task => Assert.ThrowsAny<OperationCanceledException>(() => task.GetAwaiter().GetResult()));
+                Assert.All(tasks, task => Assert.Throws<TaskCanceledException>(() => task.GetAwaiter().GetResult()));
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http.Functional.Tests
 
                 cts.Cancel();
                 
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t1);
+                await Assert.ThrowsAsync<TaskCanceledException>(() => t1);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -433,7 +433,7 @@ namespace System.Net.Http.Functional.Tests
                     handler.ConnectTimeout = TimeSpan.FromSeconds(1);
 
                     var sw = Stopwatch.StartNew();
-                    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                    await Assert.ThrowsAsync<TaskCanceledException>(() =>
                         invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get,
                             new UriBuilder(uri) { Scheme = "https" }.ToString()), default));
                     sw.Stop();

--- a/src/System.Threading.Tasks/ref/System.Threading.Tasks.cs
+++ b/src/System.Threading.Tasks/ref/System.Threading.Tasks.cs
@@ -116,6 +116,7 @@ namespace System.Threading.Tasks
         public TaskCanceledException() { }
         public TaskCanceledException(string message) { }
         public TaskCanceledException(string message, System.Exception innerException) { }
+        public TaskCanceledException(string message, System.Exception innerException, System.Threading.CancellationToken token) : base(message, innerException, token) { }
         public TaskCanceledException(System.Threading.Tasks.Task task) { }
         protected TaskCanceledException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.Threading.Tasks.Task Task { get { throw null; } }

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="CancellationTokenTests.netcoreapp.cs" />
+    <Compile Include="Task\TaskCanceledExceptionTests.netcoreapp.cs" />
     <Compile Include="Task\TaskStatusTest.netcoreapp.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Threading.Tasks/tests/Task/TaskCanceledExceptionTests.netcoreapp.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskCanceledExceptionTests.netcoreapp.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests
+{
+    public class TaskCanceledExceptionTests
+    {
+        [Fact]
+        public void TaskCanceledException_Ctor_StringExceptionToken()
+        {
+            string message = "my exception message";
+            var ioe = new InvalidOperationException();
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var tce = new TaskCanceledException(message, ioe, cts.Token);
+            Assert.Equal(message, tce.Message);
+            Assert.Null(tce.Task);
+            Assert.Same(ioe, tce.InnerException);
+            Assert.Equal(cts.Token, tce.CancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
To increase compatibility, as other handlers often throw the derived type instead of the base type, as a side-effect of how they were implemented.

Depends on https://github.com/dotnet/coreclr/pull/16939
cc: @geoffkizer