### PR TITLE
[1.1] Expand the RID graph, fix clang5 build

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -27,7 +27,6 @@ get_current_linux_name() {
             echo "ubuntu.16.10"
             return 0
         fi
-
         echo "ubuntu"
         return 0
     elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
@@ -40,23 +39,15 @@ get_current_linux_name() {
         echo "debian"
         return 0
     elif [ "$(cat /etc/*-release | grep -cim1 fedora)" -eq 1 ]; then
-        if [ "$(cat /etc/*-release | grep -cim1 23)" -eq 1 ]; then
-            echo "fedora.23"
-            return 0
-        fi
-        if [ "$(cat /etc/*-release | grep -cim1 24)" -eq 1 ]; then
-            echo "fedora.24"
-            return 0
-        fi
+        echo -n "fedora."; cat /etc/*-release | grep  VERSION_ID= | cut -d "=" -f2
+        return 0;
     elif [ "$(cat /etc/*-release | grep -cim1 opensuse)" -eq 1 ]; then
         if [ "$(cat /etc/*-release | grep -cim1 13.2)" -eq 1 ]; then
             echo "opensuse.13.2"
             return 0
         fi
-        if [ "$(cat /etc/*-release | grep -cim1 42.1)" -eq 1 ]; then
-            echo "opensuse.42.1"
-            return 0
-        fi
+        echo "opensuse.42.1"
+        return 0
     fi
 
     # Cannot determine Linux distribution, assuming Ubuntu 14.04.

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -476,20 +476,20 @@
             "#import": [ "fedora" ]
         },
         "fedora.25-x64": {
-            "#import": [ "fedora.25, "fedora-x64" ]
+            "#import": [ "fedora.25", "fedora-x64" ]
         },
 
         "fedora.26": {
             "#import": [ "fedora" ]
         },
         "fedora.26-x64": {
-            "#import": [ "fedora.26, "fedora-x64" ]
+            "#import": [ "fedora.26", "fedora-x64" ]
         },
 
         "fedora.27": {
             "#import": [ "fedora" ]
         },
-        "fedora.27x64": {
+        "fedora.27-x64": {
             "#import": [ "fedora.27", "fedora-x64" ]
         },
 

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -170,6 +170,13 @@
             "#import": [ "osx.10.12", "osx.10.11-x64" ]
         },
         
+        "osx.10.13": {
+            "#import": [ "osx.10.12" ]
+        },
+        "osx.10.13-x64": {
+            "#import": [ "osx.10.13", "osx.10.12-x64" ]
+        },
+
         "linux": {
             "#import": [ "unix" ]
         },
@@ -195,21 +202,35 @@
             "#import": [ "rhel.7" ]
         },
         "rhel.7.0-x64": {
-            "#import": [ "rhel.7", "rhel.7-x64" ]
+            "#import": [ "rhel.7.0", "rhel.7-x64" ]
         },
 
         "rhel.7.1": {
             "#import": [ "rhel.7.0" ]
         },
         "rhel.7.1-x64": {
-            "#import": [ "rhel.7.0", "rhel.7.0-x64" ]
+            "#import": [ "rhel.7.1", "rhel.7.0-x64" ]
         },
 
         "rhel.7.2": {
             "#import": [ "rhel.7.1" ]
         },
         "rhel.7.2-x64": {
-            "#import": [ "rhel.7.1", "rhel.7.1-x64" ]
+            "#import": [ "rhel.7.2", "rhel.7.1-x64" ]
+        },
+
+        "rhel.7.3": {
+            "#import": [ "rhel.7.2" ]
+        },
+        "rhel.7.3-x64": {
+            "#import": [ "rhel.7.3", "rhel.7.2-x64" ]
+        },
+
+        "rhel.7.4": {
+            "#import": [ "rhel.7.3" ]
+        },
+        "rhel.7.4-x64": {
+            "#import": [ "rhel.7.4", "rhel.7.3-x64" ]
         },
 
         "ol": {
@@ -230,21 +251,35 @@
             "#import": [ "ol.7", "rhel.7.0" ]
         },
         "ol.7.0-x64": {
-            "#import": [ "ol.7", "ol.7-x64", "rhel.7.0-x64" ]
+            "#import": [ "ol.7.0", "ol.7-x64", "rhel.7.0-x64" ]
         },
 
         "ol.7.1": {
             "#import": [ "ol.7.0", "rhel.7.1" ]
         },
         "ol.7.1-x64": {
-            "#import": [ "ol.7.0", "ol.7.0-x64", "rhel.7.1-x64" ]
+            "#import": [ "ol.7.1", "ol.7.0-x64", "rhel.7.1-x64" ]
         },
 
         "ol.7.2": {
             "#import": [ "ol.7.1", "rhel.7.2" ]
         },
         "ol.7.2-x64": {
-            "#import": [ "ol.7.1", "ol.7.1-x64", "rhel.7.2-x64" ]
+            "#import": [ "ol.7.2", "ol.7.1-x64", "rhel.7.2-x64" ]
+        },
+
+        "ol.7.3": {
+            "#import": [ "ol.7.2", "rhel.7.3" ]
+        },
+        "ol.7.3-x64": {
+            "#import": [ "ol.7.3", "ol.7.2-x64", "rhel.7.3-x64" ]
+        },
+
+        "ol.7.4": {
+            "#import": [ "ol.7.3", "rhel.7.4" ]
+        },
+        "ol.7.4-x64": {
+            "#import": [ "ol.7.4", "ol.7.3-x64", "rhel.7.4-x64" ]
         },
 
         "centos": {
@@ -273,6 +308,13 @@
         },
         "debian.8-x64": {
             "#import": [ "debian.8", "debian-x64" ]
+        },
+
+        "debian.9": {
+            "#import": [ "debian" ]
+        },
+        "debian.9-x64": {
+            "#import": [ "debian.9", "debian-x64" ]
         },
 
         "ubuntu": {
@@ -325,6 +367,27 @@
             "#import": [ "ubuntu.16.10", "ubuntu-x64" ]
         },
 
+        "ubuntu.17.04": {
+            "#import": [ "ubuntu" ]
+        },
+        "ubuntu.17.04-x64": {
+            "#import": [ "ubuntu.17.04", "ubuntu-x64" ]
+        },
+
+        "ubuntu.17.10": {
+            "#import": [ "ubuntu" ]
+        },
+        "ubuntu.17.10-x64": {
+            "#import": [ "ubuntu.17.10", "ubuntu-x64" ]
+        },
+
+        "ubuntu.18.04": {
+            "#import": [ "ubuntu" ]
+        },
+        "ubuntu.18.04-x64": {
+            "#import": [ "ubuntu.18.04", "ubuntu-x64" ]
+        },
+
         "linuxmint.17": {
             "#import": [ "ubuntu.14.04" ]
         },
@@ -360,6 +423,34 @@
             "#import": [ "linuxmint.18", "ubuntu.16.04-x64" ]
         },
 
+        "linuxmint.18.1": {
+            "#import": [ "linuxmint.18" ]
+        },
+        "linuxmint.18.1-x64": {
+            "#import": [ "linuxmint.18.1", "linuxmint.18-x64" ]
+        },
+
+        "linuxmint.18.2": {
+            "#import": [ "linuxmint.18.1" ]
+        },
+        "linuxmint.18.2-x64": {
+            "#import": [ "linuxmint.18.2", "linuxmint.18.1-x64" ]
+        },
+
+        "linuxmint.18.3": {
+            "#import": [ "linuxmint.18.2" ]
+        },
+        "linuxmint.18.3-x64": {
+            "#import": [ "linuxmint.18.3", "linuxmint.18.2-x64" ]
+        },
+
+        "linuxmint.19": {
+            "#import": [ "ubuntu.18.04" ]
+        },
+        "linuxmint.19-x64": {
+            "#import": [ "linuxmint.19", "ubuntu.18.04-x64" ]
+        },
+
         "fedora": {
             "#import": [ "linux" ]
         },
@@ -381,6 +472,34 @@
             "#import": [ "fedora.24", "fedora-x64" ]
         },
 
+        "fedora.25": {
+            "#import": [ "fedora" ]
+        },
+        "fedora.25-x64": {
+            "#import": [ "fedora.25, "fedora-x64" ]
+        },
+
+        "fedora.26": {
+            "#import": [ "fedora" ]
+        },
+        "fedora.26-x64": {
+            "#import": [ "fedora.26, "fedora-x64" ]
+        },
+
+        "fedora.27": {
+            "#import": [ "fedora" ]
+        },
+        "fedora.27x64": {
+            "#import": [ "fedora.27", "fedora-x64" ]
+        },
+
+        "fedora.28": {
+            "#import": [ "fedora" ]
+        },
+        "fedora.28-x64": {
+            "#import": [ "fedora.28", "fedora-x64" ]
+        },
+
         "opensuse": {
             "#import": [ "linux" ]
         },
@@ -400,6 +519,20 @@
         },
         "opensuse.42.1-x64": {
             "#import": [ "opensuse.42.1", "opensuse-x64" ]
+        },
+
+        "opensuse.42.2": {
+            "#import": [ "opensuse" ]
+        },
+        "opensuse.42.2-x64": {
+            "#import": [ "opensuse.42.2", "opensuse-x64" ]
+        },
+
+        "opensuse.42.3": {
+            "#import": [ "opensuse" ]
+        },
+        "opensuse.42.3-x64": {
+            "#import": [ "opensuse.42.3", "opensuse-x64" ]
         }
     }
  }

--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -21,6 +21,10 @@ add_compile_options(-I${CMAKE_CURRENT_SOURCE_DIR}/Common)
 add_compile_options(-I${CMAKE_CURRENT_BINARY_DIR}/Common)
 add_compile_options(-Wno-c99-extensions)
 
+if (HAVE_ZERO_AS_NULL_POINTER_CONSTANT_FLAG)
+    add_compile_options(-Wno-zero-as-null-pointer-constant)
+endif()
+
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)
     add_compile_options(-Wno-unreachable-code)
 endif ()
@@ -227,11 +231,6 @@ endfunction()
 include(configure.cmake)
 
 add_subdirectory(System.IO.Compression.Native)
-
-if (HAVE_ZERO_AS_NULL_POINTER_CONSTANT_FLAG)
-    add_compile_options(-Wno-zero-as-null-pointer-constant)
-endif()
-
 add_subdirectory(System.Native)
 add_subdirectory(System.Net.Http.Native)
 add_subdirectory(System.Net.Security.Native)

--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -227,6 +227,11 @@ endfunction()
 include(configure.cmake)
 
 add_subdirectory(System.IO.Compression.Native)
+
+if (HAVE_ZERO_AS_NULL_POINTER_CONSTANT_FLAG)
+    add_compile_options(-Wno-zero-as-null-pointer-constant)
+endif()
+
 add_subdirectory(System.Native)
 add_subdirectory(System.Net.Http.Native)
 add_subdirectory(System.Net.Security.Native)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -1,3 +1,4 @@
+include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 include(CheckCXXSourceRuns)
 include(CheckFunctionExists)
@@ -26,6 +27,13 @@ endif ()
 
 # We compile with -Werror, so we need to make sure these code fragments compile without warnings.
 set(CMAKE_REQUIRED_FLAGS -Werror)
+
+# This compiler warning will fail code as innocuous as:
+# static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+# Check if the compiler knows about this warning so we can disable it
+check_cxx_compiler_flag(
+    -Wzero-as-null-pointer-constant
+    HAVE_ZERO_AS_NULL_POINTER_CONSTANT_FLAG)
 
 # in_pktinfo: Find whether this struct exists
 check_include_files(


### PR DESCRIPTION
This ports the change necessary to fix building on clang5 and updates the RID graph to be up-to-date with recent new OSs. 

Unblocks running on Fedora27, OpenSuse42.3 in particular.