### PR TITLE
Avoid lots of small allocations when parsing Uri with IP address

### DIFF
--- a/src/System.Private.Uri/src/System/IPv4AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv4AddressHelper.cs
@@ -27,7 +27,18 @@ namespace System
             {
                 byte* numbers = stackalloc byte[NumberOfLabels];
                 isLoopback = Parse(str, numbers, start, end);
-                return numbers[0] + "." + numbers[1] + "." + numbers[2] + "." + numbers[3];
+
+                Span<char> stackSpace = stackalloc char[NumberOfLabels * 3 + 3];
+                int totalChars = 0, charsWritten;
+                for (int i = 0; i < 3; i++)
+                {
+                    numbers[i].TryFormat(stackSpace.Slice(totalChars), out charsWritten);
+                    int periodPos = totalChars + charsWritten;
+                    stackSpace[periodPos] = '.';
+                    totalChars = periodPos + 1;
+                }
+                numbers[3].TryFormat(stackSpace.Slice(totalChars), out charsWritten);
+                return new string(stackSpace.Slice(0, totalChars + charsWritten));
             }
         }
 


### PR DESCRIPTION
When using a member like Uri.AbsoluteUri on a Uri created from an IPv4 address string like "127.0.0.1", it ends up calling ParseCanonicalName, which boxes four bytes and then allocates an object[] to store them and periods to pass to string.Concat. We can instead just format ourselves onto a span on the stack, avoiding all four boxes and the object[].

cc: @krwq, @ahsonkhan 