### PR TITLE
Avoid allocating long[] in Uri's ParseNonCanonical

### DIFF
--- a/src/System.Private.Uri/src/System/IPv4AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv4AddressHelper.cs
@@ -184,7 +184,7 @@ namespace System
         {
             int numberBase = Decimal;
             char ch;
-            long[] parts = new long[4];
+            Span<long> parts = stackalloc long[4];
             long currentValue = 0;
             bool atLeastOneChar = false;
 


### PR DESCRIPTION
Avoid the long[] allocated while creating a Uri from an IPv4 address.

cc: @krwq, @ahsonkhan 