### PR TITLE
improve handling of proxy environmental variables

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -184,7 +184,7 @@ namespace System.Net.Http
             }
             string user = null;
             string password = null;
-            int port = 80;
+            UInt16 port = 80;
             string host = null;
 
             // Check if there is authentication part with user and possibly password.
@@ -224,12 +224,8 @@ namespace System.Net.Http
             }
             else
             {
-                try
-                {
-                    host = value.Substring(0, separatorIndex);
-                    port = Convert.ToInt32(value.Substring(separatorIndex + 1));
-                }
-                catch
+                host = value.Substring(0, separatorIndex);
+                if (!UInt16.TryParse(value.Substring(separatorIndex + 1), out port))
                 {
                     return null;
                 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -66,13 +66,7 @@ namespace System.Net.Http
                 return null;
             }
 
-            // The User and password may or may not be URL encoded.
-            // Curl seems to accept both. To match that we do opportunistic decode.
-            try
-            {
-                value = Uri.UnescapeDataString(value);
-            }
-            catch { };
+            value = Uri.UnescapeDataString(value);
 
             string password = "";
             string domain = null;
@@ -82,6 +76,7 @@ namespace System.Net.Http
                 password = value.Substring(idx+1);
                 value = value.Substring(0, idx);
             }
+
             idx = value.IndexOf('\\');
             if (idx != -1)
             {
@@ -183,7 +178,7 @@ namespace System.Net.Http
             {
                 return null;
             }
-            if (value.StartsWith("http://"))
+            if (value.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
             {
                 value = value.Substring(7);
             }
@@ -239,7 +234,9 @@ namespace System.Net.Http
                     return null;
                 }
             }
-            try {
+
+            try
+            {
                 UriBuilder ub = new UriBuilder("http", host, port);
                 if (user != null)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -182,6 +182,7 @@ namespace System.Net.Http
             {
                 value = value.Substring(7);
             }
+
             string user = null;
             string password = null;
             UInt16 port = 80;
@@ -193,6 +194,7 @@ namespace System.Net.Http
             if (separatorIndex != -1)
             {
                 string auth = value.Substring(0, separatorIndex);
+
                 // The User and password may or may not be URL encoded.
                 // Curl seems to accept both. To match that,
                 // we do opportunistic decode and we use original string if it fails.
@@ -238,10 +240,12 @@ namespace System.Net.Http
                 {
                     ub.UserName = Uri.EscapeDataString(user);
                 }
+
                 if (password != null)
                 {
                     ub.Password = Uri.EscapeDataString(password);
                 }
+
                 return ub.Uri;
             }
             catch { };

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -225,7 +225,7 @@ namespace System.Net.Http
             else
             {
                 host = value.Substring(0, separatorIndex);
-                if (!UInt16.TryParse(value.Substring(separatorIndex + 1), out port))
+                if (!UInt16.TryParse(value.AsSpan().Slice(separatorIndex + 1), out port))
                 {
                     return null;
                 }

--- a/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -111,6 +111,7 @@ namespace System.Net.Http.Tests
         [InlineData("[::1]", "[::1]", "80", null, null)]
         [InlineData("domain\\foo:bar@1.1.1.1", "1.1.1.1", "80", "foo", "bar")]
         [InlineData("domain%5Cfoo:bar@1.1.1.1", "1.1.1.1", "80", "foo", "bar")]
+        [InlineData("HTTP://ABC.COM/", "abc.com", "80", null, null)]
         public void HttpProxy_Uri_Parsing(string _input, string _host, string _port, string _user , string _password)
         {
             RemoteInvoke((input, host, port, user, password) =>

--- a/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -101,6 +101,53 @@ namespace System.Net.Http.Tests
             }).Dispose();
         }
 
+        [Theory]
+        [InlineData("1.1.1.5", "1.1.1.5", "80", null, null)]
+        [InlineData("http://1.1.1.5:3005", "1.1.1.5", "3005", null, null)]
+        [InlineData("http://foo@1.1.1.5", "1.1.1.5", "80", "foo", "")]
+        [InlineData("http://[::1]:80", "[::1]", "80", null, null)]
+        [InlineData("foo:bar@[::1]:3128", "[::1]", "3128", "foo", "bar")]
+        [InlineData("foo:Pass$!#\\.$@127.0.0.1:3128", "127.0.0.1", "3128", "foo", "Pass$!#\\.$")]
+        [InlineData("[::1]", "[::1]", "80", null, null)]
+        [InlineData("domain\\foo:bar@1.1.1.1", "1.1.1.1", "80", "foo", "bar")]
+        [InlineData("domain%5Cfoo:bar@1.1.1.1", "1.1.1.1", "80", "foo", "bar")]
+        public void HttpProxy_Uri_Parsing(string _input, string _host, string _port, string _user , string _password)
+        {
+            RemoteInvoke((input, host, port, user, password) =>
+            {
+                // Remote exec does not allow to pass null at this moment.
+                if (user == "null")
+                {
+                    user = null;
+                }
+                if (password == "null")
+                {
+                    password = null;
+                }
+
+                Environment.SetEnvironmentVariable("all_proxy", input);
+                IWebProxy p;
+                Uri u;
+
+                Assert.True(HttpEnvironmentProxy.TryCreate(out p));
+                Assert.NotNull(p);
+
+                u = p.GetProxy(fooHttp);
+                Assert.Equal(host, u.Host);
+                Assert.Equal(Convert.ToInt32(port), u.Port);
+
+                if (user != null)
+                {
+                    NetworkCredential nc = p.Credentials.GetCredential(u, "Basic");
+                    Assert.NotNull(nc);
+                    Assert.Equal(user, nc.UserName);
+                    Assert.Equal(password, nc.Password);
+                }
+
+                return SuccessExitCode;
+            }, _input, _host, _port, _user ?? "null" , _password ?? "null").Dispose();
+        }
+
         [Fact]
         public void HttpProxy_CredentialParsing_Basic()
         {


### PR DESCRIPTION
fixes #27871

This change has three improvements:
- The special characters in passwords mentioned  in linked issue
- handling of [xx::xx] IPv6 format 
- domain\user format

I added new test with parametrized execution. 