### PR TITLE
WinHttpHandler: Check available credentials when choosing authentication scheme

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -102,7 +102,7 @@ namespace System.Net.Http
                     // But we can validate with assert.
                     Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_SERVER);
 
-                    serverAuthScheme = ChooseAuthScheme(supportedSchemes);
+                    serverAuthScheme = ChooseAuthScheme(supportedSchemes, state.RequestMessage.RequestUri, state.ServerCredentials);
                     if (serverAuthScheme != 0)
                     {
                         if (SetWinHttpCredential(
@@ -155,7 +155,7 @@ namespace System.Net.Http
                     // But we can validate with assert.
                     Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY);
 
-                    proxyAuthScheme = ChooseAuthScheme(supportedSchemes);
+                    proxyAuthScheme = ChooseAuthScheme(supportedSchemes, state.Proxy.GetProxy(state.RequestMessage.RequestUri), proxyCreds);
                     state.RetryRequest = true;
                     break;
 
@@ -371,11 +371,16 @@ namespace System.Net.Http
             return true;
         }
 
-        private static uint ChooseAuthScheme(uint supportedSchemes)
+        private static uint ChooseAuthScheme(uint supportedSchemes, Uri uri, ICredentials credentials)
         {
+            if (credentials == null)
+            {
+                return 0;
+            }
+
             foreach (uint authScheme in s_authSchemePriorityOrder)
             {
-                if ((supportedSchemes & authScheme) != 0)
+                if ((supportedSchemes & authScheme) != 0 && credentials.GetCredential(uri, s_authSchemeStringMapping[authScheme]) != null)
                 {
                     return authScheme;
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -97,7 +97,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (IsCurlHandler && authenticateHeader.Contains("Digest"))
             {
-                // TODO: #27113: Fix failing authentication test cases on different httpclienthandlers.
+                // TODO: #28065: Fix failing authentication test cases on different httpclienthandlers.
                 return;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -95,6 +95,12 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("WWW-Authenticate: Basic realm=\"hello\"\r\nWWW-Authenticate: Digest realm=\"hello\", nonce=\"hello\", algorithm=MD5\r\nWWW-Authenticate: Negotiate\r\nx-identifier: Test\r\n", "Digest")]
         public async Task HttpClientHandler_MultipleAuthenticateHeaders_PicksSupported(string authenticateHeader, string supportedAuth)
         {
+            if (IsCurlHandler && authenticateHeader.Contains("Digest"))
+            {
+                // TODO: #27113: Fix failing authentication test cases on different httpclienthandlers.
+                return;
+            }
+
             var options = new LoopbackServer.Options { Domain = Domain, Username = Username, Password = Password };
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -95,7 +95,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("WWW-Authenticate: Basic realm=\"hello\"\r\nWWW-Authenticate: Digest realm=\"hello\", nonce=\"hello\", algorithm=MD5\r\nWWW-Authenticate: NTLM\r\n", "Digest", "Negotiate")]
         public async Task HttpClientHandler_MultipleAuthenticateHeaders_PicksSupported(string authenticateHeader, string supportedAuth, string unsupportedAuth)
         {
-            if (IsCurlHandler && authenticateHeader.Contains("Digest"))
+            if (PlatformDetection.IsWindowsNanoServer || (IsCurlHandler && authenticateHeader.Contains("Digest")))
             {
                 // TODO: #28065: Fix failing authentication test cases on different httpclienthandlers.
                 return;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -19,7 +19,7 @@ namespace System.Net.Http.Functional.Tests
 
         private static readonly NetworkCredential s_credentials = new NetworkCredential(Username, Password, Domain);
 
-        private static readonly Func<HttpClientHandler, Uri, HttpStatusCode, NetworkCredential, Task> s_createAndValidateRequest = async (handler, url, expectedStatusCode, credentials) =>
+        private static readonly Func<HttpClientHandler, Uri, HttpStatusCode, ICredentials, Task> s_createAndValidateRequest = async (handler, url, expectedStatusCode, credentials) =>
         {
             handler.Credentials = credentials;
 
@@ -87,6 +87,25 @@ namespace System.Net.Http.Functional.Tests
                 HttpClientHandler handler = CreateHttpClientHandler();
                 Task serverTask = server.AcceptConnectionPerformAuthenticationAndCloseAsync(authenticateHeader);
                 await TestHelper.WhenAllCompletedOrAnyFailed(s_createAndValidateRequest(handler, url, HttpStatusCode.OK, s_credentials), serverTask);
+            }, options);
+        }
+
+        [Theory]
+        [InlineData("WWW-Authenticate: Basic realm=\"hello\"\r\nWWW-Authenticate: Negotiate\r\nx-identifier: Test\r\n", "Basic")]
+        [InlineData("WWW-Authenticate: Basic realm=\"hello\"\r\nWWW-Authenticate: Digest realm=\"hello\", nonce=\"hello\", algorithm=MD5\r\nWWW-Authenticate: Negotiate\r\nx-identifier: Test\r\n", "Digest")]
+        public async Task HttpClientHandler_MultipleAuthenticateHeaders_PicksSupported(string authenticateHeader, string supportedAuth)
+        {
+            var options = new LoopbackServer.Options { Domain = Domain, Username = Username, Password = Password };
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpClientHandler handler = CreateHttpClientHandler();
+
+                var credentials = new CredentialCache();
+                credentials.Add(url, supportedAuth, new NetworkCredential(Username, Password, Domain));
+                handler.UseDefaultCredentials = false;
+
+                Task serverTask = server.AcceptConnectionPerformAuthenticationAndCloseAsync(authenticateHeader);
+                await TestHelper.WhenAllCompletedOrAnyFailed(s_createAndValidateRequest(handler, url, HttpStatusCode.OK, credentials), serverTask);
             }, options);
         }
 


### PR DESCRIPTION
When choosing what authentication scheme to use, WinHttpHandler picks the most secure scheme supported by the server. When the client does not support this scheme it closes the connection. We need to instead pick the most secure scheme offered by the server and supported by the client.

The incorrect behavior occurs under the following conditions:
 - There are at least two authentication schemes enabled on the server.
 - The user only provides credentials that have an authentication scheme less secure than the most secure option offered by the server.

In the conditions described in the original report, the user provides NTLM credentials, but the server supports both NTLM and Negotiate (which is considered more secure). WinHttpHandler erroneously chooses to attempt authentication with Negotiate. When we later detect that there are no credentials in the cache that support Negotiate, we close the connection.

The fix is a simple change to `WinHttpAuthHelper`, and an additional test. There is an open issue tracking auth problems with Windows Nano, so depending on the results in CI I may disable the test there.

Fixes: #27672