### PR TITLE
Fix WebException to handle SocketsHttpHandler generated errors

### DIFF
--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
@@ -109,6 +110,29 @@ namespace System.Net
             }
 
             return exception;
+        }
+        
+        private static WebExceptionStatus GetStatusFromExceptionHelper(HttpRequestException ex)
+        {
+            WebExceptionStatus status;
+            SocketException socketEx = ex.InnerException as SocketException;
+
+            if (socketEx is null)
+            {
+                return WebExceptionStatus.UnknownError;
+            }
+
+            switch (socketEx.ErrorCode)
+            {
+                case (int)SocketError.HostNotFound:
+                    status = WebExceptionStatus.NameResolutionFailure;
+                    break;
+                default:
+                    status = WebExceptionStatus.UnknownError;
+                    break;
+            }
+
+            return status;
         }
     }
 }

--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -122,9 +122,9 @@ namespace System.Net
             }
 
             WebExceptionStatus status;
-            switch (socketEx.ErrorCode)
+            switch (socketEx.SocketErrorCode)
             {
-                case (int)SocketError.HostNotFound:
+                case SocketError.HostNotFound:
                     status = WebExceptionStatus.NameResolutionFailure;
                     break;
                 default:

--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -114,7 +114,6 @@ namespace System.Net
         
         private static WebExceptionStatus GetStatusFromExceptionHelper(HttpRequestException ex)
         {
-            WebExceptionStatus status;
             SocketException socketEx = ex.InnerException as SocketException;
 
             if (socketEx is null)
@@ -122,6 +121,7 @@ namespace System.Net
                 return WebExceptionStatus.UnknownError;
             }
 
+            WebExceptionStatus status;
             switch (socketEx.ErrorCode)
             {
                 case (int)SocketError.HostNotFound:

--- a/src/System.Net.Requests/src/System/Net/WebExceptionPal.Unix.cs
+++ b/src/System.Net.Requests/src/System/Net/WebExceptionPal.Unix.cs
@@ -26,7 +26,7 @@ namespace System.Net
                     status = WebExceptionStatus.NameResolutionFailure;
                     break;
                 default:
-                    status = WebExceptionStatus.UnknownError;
+                    status = GetStatusFromExceptionHelper(ex);
                     break;
             }
 

--- a/src/System.Net.Requests/src/System/Net/WebExceptionPal.Windows.cs
+++ b/src/System.Net.Requests/src/System/Net/WebExceptionPal.Windows.cs
@@ -26,7 +26,7 @@ namespace System.Net
                     status = WebExceptionStatus.NameResolutionFailure;
                     break;
                 default:
-                    status = WebExceptionStatus.UnknownError;
+                    status = GetStatusFromExceptionHelper(ex);
                     break;
             }
 

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1045,7 +1045,6 @@ namespace System.Net.Tests
             response.Dispose();
         }
 
-        [ActiveIssue(27906)]
         [OuterLoop] // fails on networks with DNS servers that provide a dummy page for invalid addresses
         [Fact]
         public async Task GetResponseAsync_ServerNameNotInDns_ThrowsWebException()


### PR DESCRIPTION
Now that we are using the new handler within HttpClient, we have to revise the code
that maps various exceptions to enum values of the WebExceptionStatus. We have separate
versions of this mapping for Windows vs. Linux. But the new handler runs on both. So,
added a common helper method.

There will probably be additional mappings we need to do here. But for now, this
PR fixes the issue.

Fixes #27906