### PR TITLE
Avoid usage of MemoryMarshal.Cast in Marvin

### DIFF
--- a/src/Common/src/System/Marvin.cs
+++ b/src/Common/src/System/Marvin.cs
@@ -57,11 +57,11 @@ namespace System
                     break;
 
                 case 2:
-                    p0 += 0x800000u | MemoryMarshal.Cast<byte, ushort>(data)[0];
+                    p0 += 0x800000u | (((uint)data[0]) << 8) | data[1];
                     break;
 
                 case 3:
-                    p0 += 0x80000000u | (((uint)data[2]) << 16) | (uint)(MemoryMarshal.Cast<byte, ushort>(data)[0]);
+                    p0 += 0x80000000u | (((uint)data[2]) << 16) | (((uint)data[0]) << 8) | data[1];
                     break;
 
                 default:


### PR DESCRIPTION
Based on the discussion from https://github.com/dotnet/corefx/pull/25735#discussion_r155290532