### PR TITLE
 [1.1] Add packaging for Fedora27, OpenSuse423, Ubuntu1804

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -16,8 +16,8 @@
     <XmlDocFileRoot>$(PackagesDir)Microsoft.Private.Intellisense/1.0.0-rc4-24206-00/xmldocs</XmlDocFileRoot>
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
-    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.1.2</LineupPackageVersion>
-    <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.1.0</PlatformPackageVersion>
+    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.1.3</LineupPackageVersion>
+    <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.1.1</PlatformPackageVersion>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">4.3.0</PackageVersion>

--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.1.1</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <PackageVersion>1.1.2</PackageVersion>
+    <PackageVersion>1.1.3</PackageVersion>
     <IsLineupPackage>true</IsLineupPackage>
     <RuntimeFileSource>runtime.json</RuntimeFileSource>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -643,6 +643,53 @@
       ],
       "BaselineVersion": "4.3.2"
     },
+    "runtime.ubuntu.18.04-x64.runtime.native.System": {
+      "StableVersions": [
+        "1.0.1",
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.18.04-x64.runtime.native.System.IO.Compression": {
+      "StableVersions": [
+        "1.0.1",
+        "4.3.0",
+        "4.3.1"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.18.04-x64.runtime.native.System.Net.Http": {
+      "StableVersions": [
+        "1.0.1",
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.18.04-x64.runtime.native.System.Net.Security": {
+      "StableVersions": [
+        "1.0.1",
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography": {
+      "StableVersions": [
+        "1.0.1",
+        "4.3.0",
+        "4.3.1",
+        "4.3.2",
+        "4.3.3"
+      ],
+      "BaselineVersion": "4.3.2"
+    },
+    "runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "StableVersions": [
+        "4.3.0",
+        "4.3.1",
+        "4.3.2"
+      ],
+      "BaselineVersion": "4.3.2"
+    },
     "runtime.unix.Microsoft.Win32.Primitives": {
       "StableVersions": [
         "4.0.1",
@@ -2648,6 +2695,48 @@
       ],
       "BaselineVersion": "4.3.2"
     },
+    "runtime.fedora.27-x64.runtime.native.System.IO.Compression": {
+      "StableVersions": [
+        "4.3.0",
+        "4.3.1"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.27-x64.runtime.native.System.Net.Http": {
+      "StableVersions": [
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.27-x64.runtime.native.System.Net.Security": {
+      "StableVersions": [
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.27-x64.runtime.native.System": {
+      "StableVersions": [
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.27-x64.runtime.native.System.Security.Cryptography": {
+      "StableVersions": [
+        "4.3.0",
+        "4.3.1",
+        "4.3.2",
+        "4.3.3"
+      ],
+      "BaselineVersion": "4.3.2"
+    },
+    "runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "StableVersions": [
+        "4.3.0",
+        "4.3.1",
+        "4.3.2"
+      ],
+      "BaselineVersion": "4.3.2"
+    },
     "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
@@ -2691,6 +2780,48 @@
       "BaselineVersion": "4.3.2"
     },
     "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "StableVersions": [
+        "4.3.0",
+        "4.3.1",
+        "4.3.2"
+      ],
+      "BaselineVersion": "4.3.2"
+    },
+    "runtime.opensuse.42.3-x64.runtime.native.System.IO.Compression": {
+      "StableVersions": [
+        "4.3.0",
+        "4.3.1"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.3-x64.runtime.native.System.Net.Http": {
+      "StableVersions": [
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.3-x64.runtime.native.System.Net.Security": {
+      "StableVersions": [
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.3-x64.runtime.native.System": {
+      "StableVersions": [
+        "4.3.0"
+      ],
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography": {
+      "StableVersions": [
+        "4.3.0",
+        "4.3.1",
+        "4.3.2",
+        "4.3.3"
+      ],
+      "BaselineVersion": "4.3.2"
+    },
+    "runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1",

--- a/src/Native/pkg/dir.props
+++ b/src/Native/pkg/dir.props
@@ -31,12 +31,15 @@
     <DebianNativePath Condition="'$(DebianNativePath)' == ''">$(BuildNativePath)</DebianNativePath>
     <Fedora23NativePath Condition="'$(Fedora23NativePath)' == ''">$(BuildNativePath)</Fedora23NativePath>
     <Fedora24NativePath Condition="'$(Fedora24NativePath)' == ''">$(BuildNativePath)</Fedora24NativePath>
+    <Fedora27NativePath Condition="'$(Fedora27NativePath)' == ''">$(BuildNativePath)</Fedora27NativePath>
     <OSXNativePath Condition="'$(OSXNativePath)' == ''">$(BuildNativePath)</OSXNativePath>
     <OpenSuse132NativePath Condition="'$(OpenSuse132NativePath)' == ''">$(BuildNativePath)</OpenSuse132NativePath>
     <OpenSuse421NativePath Condition="'$(OpenSuse421NativePath)' == ''">$(BuildNativePath)</OpenSuse421NativePath>
+    <OpenSuse423NativePath Condition="'$(OpenSuse423NativePath)' == ''">$(BuildNativePath)</OpenSuse423NativePath>
     <Ubuntu1404NativePath Condition="'$(Ubuntu1404NativePath)' == ''">$(BuildNativePath)</Ubuntu1404NativePath>
     <Ubuntu1604NativePath Condition="'$(Ubuntu1604NativePath)' == ''">$(BuildNativePath)</Ubuntu1604NativePath>
     <Ubuntu1610NativePath Condition="'$(Ubuntu1610NativePath)' == ''">$(BuildNativePath)</Ubuntu1610NativePath>
+    <Ubuntu1804NativePath Condition="'$(Ubuntu1804NativePath)' == ''">$(BuildNativePath)</Ubuntu1804NativePath>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
   </PropertyGroup>
 

--- a/src/Native/pkg/runtime.native.System.IO.Compression/dir.props
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/dir.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>4.3.3</PackageVersion>
+    <PackageVersion>4.3.2</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/fedora/27/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/fedora/27/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>fedora.27-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Fedora27NativePath)System.IO.Compression.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/opensuse/42.3/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/opensuse/42.3/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>opensuse.42.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OpenSuse423NativePath)System.IO.Compression.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -18,6 +18,10 @@
       <OSGroup>fedora.24</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="fedora\27\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>fedora.27</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="ubuntu\14.04\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
@@ -30,6 +34,10 @@
       <OSGroup>ubuntu.16.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="ubuntu\18.04\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>ubuntu.18.04</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="osx\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
@@ -40,6 +48,10 @@
     </Project>
     <Project Include="opensuse\42.1\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>opensuse.42.1</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="opensuse\42.3\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>opensuse.42.3</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>    

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="dir.props" />
   <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>    
-    <PackageVersion>4.3.1</PackageVersion>
     <!-- the native compression packages require nuget >3.5 for nativeassets support -->
     <MinClientVersion3>3.5</MinClientVersion3>    
   </PropertyGroup>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -42,6 +42,9 @@
     <ProjectReference Include="fedora\24\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\27\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -51,6 +54,9 @@
     <ProjectReference Include="opensuse\42.1\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.3\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -58,6 +64,9 @@
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\18.04\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">

--- a/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/18.04/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/18.04/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>ubuntu.18.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Ubuntu1804NativePath)System.IO.Compression.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/dir.props
+++ b/src/Native/pkg/runtime.native.System.Net.Http/dir.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>4.3.3</PackageVersion>
+    <PackageVersion>4.3.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/fedora/27/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/fedora/27/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>fedora.27-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Fedora27NativePath)System.Net.Http.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/opensuse/42.3/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/opensuse/42.3/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>opensuse.42.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OpenSuse423NativePath)System.Net.Http.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
@@ -19,6 +19,10 @@
       <OSGroup>fedora.24</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="fedora\27\runtime.native.System.Net.Http.pkgproj">
+      <OSGroup>fedora.27</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="ubuntu\14.04\runtime.native.System.Net.Http.pkgproj">
       <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
@@ -31,6 +35,10 @@
       <OSGroup>ubuntu.16.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="ubuntu\18.04\runtime.native.System.Net.Http.pkgproj">
+      <OSGroup>ubuntu.18.04</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="osx\runtime.native.System.Net.Http.pkgproj">
       <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
@@ -41,6 +49,10 @@
     </Project>
     <Project Include="opensuse\42.1\runtime.native.System.Net.Http.pkgproj">
       <OSGroup>opensuse.42.1</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="opensuse\42.3\runtime.native.System.Net.Http.pkgproj">
+      <OSGroup>opensuse.42.3</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="dir.props" />
   <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
@@ -22,6 +22,9 @@
     <ProjectReference Include="fedora\24\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\27\runtime.native.System.Net.Http.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -31,6 +34,9 @@
     <ProjectReference Include="opensuse\42.1\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.3\runtime.native.System.Net.Http.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -38,6 +44,9 @@
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Net.Http.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\18.04\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/18.04/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/18.04/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>ubuntu.18.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Ubuntu1804NativePath)System.Net.Http.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Security/dir.props
+++ b/src/Native/pkg/runtime.native.System.Net.Security/dir.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>4.3.3</PackageVersion>
+    <PackageVersion>4.3.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Native/pkg/runtime.native.System.Net.Security/fedora/27/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/fedora/27/runtime.native.System.Net.Security.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>fedora.27-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Fedora27NativePath)\System.Net.Security.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Security/opensuse/42.3/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/opensuse/42.3/runtime.native.System.Net.Security.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>opensuse.42.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OpenSuse423NativePath)\System.Net.Security.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
@@ -19,6 +19,10 @@
       <OSGroup>fedora.24</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="fedora\27\runtime.native.System.Net.Security.pkgproj">
+      <OSGroup>fedora.27</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="ubuntu\14.04\runtime.native.System.Net.Security.pkgproj">
       <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
@@ -31,6 +35,10 @@
       <OSGroup>ubuntu.16.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="ubuntu\18.04\runtime.native.System.Net.Security.pkgproj">
+      <OSGroup>ubuntu.18.04</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="osx\runtime.native.System.Net.Security.pkgproj">
       <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
@@ -41,6 +49,10 @@
     </Project>
     <Project Include="opensuse\42.1\runtime.native.System.Net.Security.pkgproj">
       <OSGroup>opensuse.42.1</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="opensuse\42.3\runtime.native.System.Net.Security.pkgproj">
+      <OSGroup>opensuse.42.3</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="dir.props" />
   <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
@@ -22,6 +22,9 @@
     <ProjectReference Include="fedora\24\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\27\runtime.native.System.Net.Security.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -31,6 +34,9 @@
     <ProjectReference Include="opensuse\42.1\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.3\runtime.native.System.Net.Security.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -38,6 +44,9 @@
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Net.Security.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\18.04\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/18.04/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/18.04/runtime.native.System.Net.Security.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>ubuntu.18.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Ubuntu1804NativePath)\System.Net.Security.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/27/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/27/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageRid>fedora.27-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Fedora27NativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/42.3/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/42.3/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageRid>opensuse.42.3-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OpenSuse423NativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.builds
@@ -19,6 +19,10 @@
       <OSGroup>fedora.24</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="fedora\27\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>fedora.27</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
@@ -31,6 +35,10 @@
       <OSGroup>ubuntu.16.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="ubuntu\18.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>ubuntu.18.04</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="osx\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
@@ -41,6 +49,10 @@
     </Project>
     <Project Include="opensuse\42.1\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <OSGroup>opensuse.42.1</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="opensuse\42.3\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>opensuse.42.3</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -22,6 +22,9 @@
     <ProjectReference Include="fedora\24\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\27\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -31,6 +34,9 @@
     <ProjectReference Include="opensuse\42.1\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.3\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -38,6 +44,9 @@
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\18.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/18.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/18.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageRid>ubuntu.18.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Ubuntu1804NativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/dir.props
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/dir.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>4.3.3</PackageVersion>
+    <PackageVersion>4.3.4</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/27/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/27/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageRid>fedora.27-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Fedora27NativePath)System.Security.Cryptography.Native.so">
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/42.3/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/42.3/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageRid>opensuse.42.3-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OpenSuse423NativePath)System.Security.Cryptography.Native.so">
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
@@ -19,6 +19,10 @@
       <OSGroup>fedora.24</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="fedora\27\runtime.native.System.Security.Cryptography.pkgproj">
+      <OSGroup>fedora.24</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.pkgproj">
       <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
@@ -31,6 +35,10 @@
       <OSGroup>ubuntu.16.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="ubuntu\18.04\runtime.native.System.Security.Cryptography.pkgproj">
+      <OSGroup>ubuntu.18.04</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="osx\runtime.native.System.Security.Cryptography.pkgproj">
       <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
@@ -41,6 +49,10 @@
     </Project>
     <Project Include="opensuse\42.1\runtime.native.System.Security.Cryptography.pkgproj">
       <OSGroup>opensuse.42.1</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="opensuse\42.3\runtime.native.System.Security.Cryptography.pkgproj">
+      <OSGroup>opensuse.42.3</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
@@ -22,6 +22,9 @@
     <ProjectReference Include="fedora\24\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\27\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -31,6 +34,9 @@
     <ProjectReference Include="opensuse\42.1\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.3\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -38,6 +44,9 @@
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\18.04\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/18.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/18.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageRid>ubuntu.18.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Ubuntu1804NativePath)System.Security.Cryptography.Native.so">
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System/dir.props
+++ b/src/Native/pkg/runtime.native.System/dir.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>4.3.3</PackageVersion>
+    <PackageVersion>4.3.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Native/pkg/runtime.native.System/fedora/27/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/fedora/27/runtime.native.System.pkgproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>fedora.27-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Fedora27NativePath)System.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+    <File Include="$(Fedora27NativePath)System.Native.a">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System/opensuse/42.3/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/opensuse/42.3/runtime.native.System.pkgproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>opensuse.42.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OpenSuse423NativePath)System.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+    <File Include="$(OpenSuse423NativePath)System.Native.a">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.builds
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.builds
@@ -19,6 +19,10 @@
       <OSGroup>fedora.24</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="fedora\27\runtime.native.System.pkgproj">
+      <OSGroup>fedora.27</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="ubuntu\14.04\runtime.native.System.pkgproj">
       <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
@@ -31,6 +35,10 @@
       <OSGroup>ubuntu.16.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="ubuntu\18.04\runtime.native.System.pkgproj">
+      <OSGroup>ubuntu.18.04</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="osx\runtime.native.System.pkgproj">
       <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
@@ -41,6 +49,10 @@
     </Project>
     <Project Include="opensuse\42.1\runtime.native.System.pkgproj">
       <OSGroup>opensuse.42.1</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="opensuse\42.3\runtime.native.System.pkgproj">
+      <OSGroup>opensuse.42.3</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="dir.props" />
   <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
@@ -22,6 +22,9 @@
     <ProjectReference Include="fedora\24\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\27\runtime.native.System.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -31,6 +34,9 @@
     <ProjectReference Include="opensuse\42.1\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.3\runtime.native.System.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
@@ -38,6 +44,9 @@
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\18.04\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System/ubuntu/18.04/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/ubuntu/18.04/runtime.native.System.pkgproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>ubuntu.18.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Ubuntu1804NativePath)System.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+    <File Include="$(Ubuntu1804NativePath)System.Native.a">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -37,7 +37,7 @@
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >   
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
     <Project Include="Native\pkg\**\*.builds">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
       <BuildAllOSGroups>true</BuildAllOSGroups>
     </Project>
   </ItemGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
     <BuildAllOSGroups Condition="'$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
-    <BuildAllPackages>false</BuildAllPackages>
+    <BuildAllPackages Condition="'$(BuildAllPackages)' == ''">false</BuildAllPackages>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'true'" >
@@ -25,11 +25,32 @@
     <Project Include="..\pkg\Microsoft.Private.PackageBaseline\Microsoft.Private.PackageBaseline.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >   
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
+    <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+      <BuildAllOSGroups>False</BuildAllOSGroups>
+      <FilterToOSGroup>fedora.27</FilterToOSGroup>
+    </Project>
+    <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+      <BuildAllOSGroups>False</BuildAllOSGroups>
+      <FilterToOSGroup>opensuse.42.3</FilterToOSGroup>
+    </Project>
+    <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+      <BuildAllOSGroups>False</BuildAllOSGroups>
+      <FilterToOSGroup>ubuntu.18.04</FilterToOSGroup>
+    </Project>
   </ItemGroup>
 
   <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -36,20 +36,9 @@
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >   
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
-    <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
+    <Project Include="Native\pkg\**\*.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-      <BuildAllOSGroups>False</BuildAllOSGroups>
-      <FilterToOSGroup>fedora.27</FilterToOSGroup>
-    </Project>
-    <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-      <BuildAllOSGroups>False</BuildAllOSGroups>
-      <FilterToOSGroup>opensuse.42.3</FilterToOSGroup>
-    </Project>
-    <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-      <BuildAllOSGroups>False</BuildAllOSGroups>
-      <FilterToOSGroup>ubuntu.18.04</FilterToOSGroup>
+      <BuildAllOSGroups>true</BuildAllOSGroups>
     </Project>
   </ItemGroup>
 


### PR DESCRIPTION
Adds packaging for servicing builds for Fedora27, OpenSuse 423, and Ubuntu1804. Requires https://github.com/dotnet/corefx/pull/28079

cc: @weshaggard @ericstj 