### PR TITLE
Adding a null value to ConcurrentDictionary using System.Collections.IDictionary interface causes exception

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1453,7 +1453,17 @@ namespace System.Collections.Concurrent
             if (!(key is TKey)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfKeyIncorrect);
             ThrowIfNullAndNullsAreIllegal(value);
 
-            ((IDictionary<TKey, TValue>)this).Add((TKey)key, (TValue)value);
+            TValue typedValue;
+            try
+            {
+                typedValue = (TValue)value;
+            }
+            catch (InvalidCastException)
+            {
+                throw new ArgumentException(SR.ConcurrentDictionary_TypeOfValueIncorrect);
+            }
+
+            ((IDictionary<TKey, TValue>)this).Add((TKey)key, typedValue);
         }
 
         /// <summary>
@@ -1585,6 +1595,7 @@ namespace System.Collections.Concurrent
                 if (key == null) ThrowKeyNullException();
 
                 if (!(key is TKey)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfKeyIncorrect);
+                if ((value != null) && !(value is TValue)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfValueIncorrect);
                 ThrowIfNullAndNullsAreIllegal(value);
 
                 ((ConcurrentDictionary<TKey, TValue>)this)[(TKey)key] = (TValue)value;

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -184,16 +184,16 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConcurrentDictionary{TKey,TValue}"/> 
-        /// class that contains elements copied from the specified <see cref="T:System.Collections.IEnumerable"/>, 
-        /// has the specified concurrency level, has the specified initial capacity, and uses the specified 
+        /// Initializes a new instance of the <see cref="ConcurrentDictionary{TKey,TValue}"/>
+        /// class that contains elements copied from the specified <see cref="T:System.Collections.IEnumerable"/>,
+        /// has the specified concurrency level, has the specified initial capacity, and uses the specified
         /// <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>.
         /// </summary>
-        /// <param name="concurrencyLevel">The estimated number of threads that will update the 
+        /// <param name="concurrencyLevel">The estimated number of threads that will update the
         /// <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently.</param>
-        /// <param name="collection">The <see cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}"/> whose elements are copied to the new 
+        /// <param name="collection">The <see cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}"/> whose elements are copied to the new
         /// <see cref="ConcurrentDictionary{TKey,TValue}"/>.</param>
-        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/> implementation to use 
+        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/> implementation to use
         /// when comparing keys.</param>
         /// <exception cref="T:System.ArgumentNullException">
         /// <paramref name="collection"/> is a null reference (Nothing in Visual Basic).
@@ -432,7 +432,7 @@ namespace System.Collections.Concurrent
         private bool TryGetValueInternal(TKey key, int hashcode, out TValue value)
         {
             Debug.Assert(_comparer.GetHashCode(key) == hashcode);
-            
+
             // We must capture the _buckets field in a local variable. It is set to a new table on each table resize.
             Tables tables = _tables;
 
@@ -499,7 +499,7 @@ namespace System.Collections.Concurrent
             Debug.Assert(_comparer.GetHashCode(key) == hashcode);
 
             IEqualityComparer<TValue> valueComparer = EqualityComparer<TValue>.Default;
-            
+
             while (true)
             {
                 int bucketNo;
@@ -668,7 +668,7 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Copy dictionary contents to an array - shared implementation between ToArray and CopyTo.
-        /// 
+        ///
         /// Important: the caller must hold all locks in _locks before calling CopyToPairs.
         /// </summary>
         private void CopyToPairs(KeyValuePair<TKey, TValue>[] array, int index)
@@ -686,7 +686,7 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Copy dictionary contents to an array - shared implementation between ToArray and CopyTo.
-        /// 
+        ///
         /// Important: the caller must hold all locks in _locks before calling CopyToEntries.
         /// </summary>
         private void CopyToEntries(DictionaryEntry[] array, int index)
@@ -704,7 +704,7 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Copy dictionary contents to an array - shared implementation between ToArray and CopyTo.
-        /// 
+        ///
         /// Important: the caller must hold all locks in _locks before calling CopyToObjects.
         /// </summary>
         private void CopyToObjects(object[] array, int index)
@@ -962,7 +962,7 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> 
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/>
         /// if the key does not already exist.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
@@ -992,7 +992,7 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> 
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/>
         /// if the key does not already exist.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
@@ -1023,7 +1023,7 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> 
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/>
         /// if the key does not already exist.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
@@ -1032,7 +1032,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         /// <exception cref="T:System.OverflowException">The dictionary contains too many
         /// elements.</exception>
-        /// <returns>The value for the key.  This will be either the existing value for the key if the 
+        /// <returns>The value for the key.  This will be either the existing value for the key if the
         /// key is already in the dictionary, or the new value if the key was not in the dictionary.</returns>
         public TValue GetOrAdd(TKey key, TValue value)
         {
@@ -1049,8 +1049,8 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already 
-        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key 
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already
+        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key
         /// already exists.
         /// </summary>
         /// <param name="key">The key to be added or whose value should be updated</param>
@@ -1066,7 +1066,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         /// <exception cref="T:System.OverflowException">The dictionary contains too many
         /// elements.</exception>
-        /// <returns>The new value for the key.  This will be either be the result of addValueFactory (if the key was 
+        /// <returns>The new value for the key.  This will be either be the result of addValueFactory (if the key was
         /// absent) or the result of updateValueFactory (if the key was present).</returns>
         public TValue AddOrUpdate<TArg>(
             TKey key, Func<TKey, TArg, TValue> addValueFactory, Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument)
@@ -1102,8 +1102,8 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already 
-        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key 
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already
+        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key
         /// already exists.
         /// </summary>
         /// <param name="key">The key to be added or whose value should be updated</param>
@@ -1118,7 +1118,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         /// <exception cref="T:System.OverflowException">The dictionary contains too many
         /// elements.</exception>
-        /// <returns>The new value for the key.  This will be either the result of addValueFactory (if the key was 
+        /// <returns>The new value for the key.  This will be either the result of addValueFactory (if the key was
         /// absent) or the result of updateValueFactory (if the key was present).</returns>
         public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
         {
@@ -1140,7 +1140,7 @@ namespace System.Collections.Concurrent
                         return newValue;
                     }
                 }
-                else 
+                else
                 {
                     // key doesn't exist, try to add
                     TValue resultingValue;
@@ -1153,13 +1153,13 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already 
-        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key 
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already
+        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key
         /// already exists.
         /// </summary>
         /// <param name="key">The key to be added or whose value should be updated</param>
         /// <param name="addValue">The value to be added for an absent key</param>
-        /// <param name="updateValueFactory">The function used to generate a new value for an existing key based on 
+        /// <param name="updateValueFactory">The function used to generate a new value for an existing key based on
         /// the key's existing value</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
@@ -1167,7 +1167,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         /// <exception cref="T:System.OverflowException">The dictionary contains too many
         /// elements.</exception>
-        /// <returns>The new value for the key.  This will be either the value of addValue (if the key was 
+        /// <returns>The new value for the key.  This will be either the value of addValue (if the key was
         /// absent) or the result of updateValueFactory (if the key was present).</returns>
         public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
         {
@@ -1188,7 +1188,7 @@ namespace System.Collections.Concurrent
                         return newValue;
                     }
                 }
-                else 
+                else
                 {
                     // key doesn't exist, try to add
                     TValue resultingValue;
@@ -1577,7 +1577,10 @@ namespace System.Collections.Concurrent
                 if (key == null) ThrowKeyNullException();
 
                 if (!(key is TKey)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfKeyIncorrect);
-                if (!(value is TValue)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfValueIncorrect);
+                if (((value != null) || (default(TValue) != null)) && !(value is TValue))
+                {
+                    throw new ArgumentException(SR.ConcurrentDictionary_TypeOfValueIncorrect);
+                }
 
                 ((ConcurrentDictionary<TKey, TValue>)this)[(TKey)key] = (TValue)value;
             }
@@ -1774,7 +1777,7 @@ namespace System.Collections.Concurrent
                     // We want to make sure that GrowTable will not be called again, since table is at the maximum size.
                     // To achieve that, we set the budget to int.MaxValue.
                     //
-                    // (There is one special case that would allow GrowTable() to be called in the future: 
+                    // (There is one special case that would allow GrowTable() to be called in the future:
                     // calling Clear() on the ConcurrentDictionary will shrink the table and lower the budget.)
                     _budget = int.MaxValue;
                 }
@@ -1833,7 +1836,7 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Computes the bucket for a particular key. 
+        /// Computes the bucket for a particular key.
         /// </summary>
         private static int GetBucket(int hashcode, int bucketCount)
         {
@@ -1843,7 +1846,7 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Computes the bucket and lock number for a particular key. 
+        /// Computes the bucket and lock number for a particular key.
         /// </summary>
         private static void GetBucketAndLockNo(int hashcode, out int bucketNo, out int lockNo, int bucketCount, int lockCount)
         {
@@ -2007,7 +2010,7 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// A private class to represent enumeration over the dictionary that implements the 
+        /// A private class to represent enumeration over the dictionary that implements the
         /// IDictionaryEnumerator interface.
         /// </summary>
         private sealed class DictionaryEnumerator : IDictionaryEnumerator

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -917,7 +917,6 @@ namespace System.Collections.Concurrent
                 ThrowValueNullException();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowValueNullException()
         {
             throw new ArgumentException(SR.ConcurrentDictionary_TypeOfValueIncorrect);

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
@@ -91,6 +91,24 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
+        public static void TestAddValueOfDifferentType()
+        {
+            Action action = () =>
+            {
+                IDictionary dict = new ConcurrentDictionary<string, string>();
+                dict["key"] = 1;
+            };
+            Assert.Throws<ArgumentException>(action);
+
+            action = () =>
+            {
+                IDictionary dict = new ConcurrentDictionary<string, string>();
+                dict.Add("key", 1);
+            };
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
         public static void TestAdd1()
         {
             TestAdd1(1, 1, 1, 10000);

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
@@ -75,6 +75,7 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Missing bug fix in https://github.com/dotnet/corefx/pull/28115")]
         public static void TestAddNullValue_IDictionary_ReferenceType_null()
         {
             // using IDictionary interface
@@ -96,6 +97,7 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Missing bug fix in https://github.com/dotnet/corefx/pull/28115")]
         public static void TestAddNullValue_IDictionary_ValueType_null_add()
         {
             Action action = () =>

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
@@ -58,22 +58,34 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
-        public static void TestAddNullValue()
+        public static void TestAddNullValue_ConcurrentDictionaryOfString_null()
         {
             // using ConcurrentDictionary<TKey, TValue> class
             ConcurrentDictionary<string, string> dict1 = new ConcurrentDictionary<string, string>();
             dict1["key"] = null;
+        }
 
+        [Fact]
+        public static void TestAddNullValue_IDictionaryOfString_null()
+        {
             // using IDictionary<TKey, TValue> interface
             IDictionary<string, string> dict2 = new ConcurrentDictionary<string, string>();
             dict2["key"] = null;
             dict2.Add("key2", null);
+        }
 
+        [Fact]
+        public static void TestAddNullValue_IDictionary_ReferenceType_null()
+        {
             // using IDictionary interface
             IDictionary dict3 = new ConcurrentDictionary<string, string>();
             dict3["key"] = null;
             dict3.Add("key2", null);
+        }
 
+        [Fact]
+        public static void TestAddNullValue_IDictionary_ValueType_null_indexer()
+        {
             // using IDictionary interface and value type values
             Action action = () =>
             {
@@ -81,8 +93,12 @@ namespace System.Collections.Concurrent.Tests
                 dict4["key"] = null;
             };
             Assert.Throws<ArgumentException>(action);
+        }
 
-            action = () =>
+        [Fact]
+        public static void TestAddNullValue_IDictionary_ValueType_null_add()
+        {
+            Action action = () =>
             {
                 IDictionary dict5 = new ConcurrentDictionary<string, int>();
                 dict5.Add("key", null);

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
@@ -67,16 +67,25 @@ namespace System.Collections.Concurrent.Tests
             // using IDictionary<TKey, TValue> interface
             IDictionary<string, string> dict2 = new ConcurrentDictionary<string, string>();
             dict2["key"] = null;
+            dict2.Add("key2", null);
 
             // using IDictionary interface
             IDictionary dict3 = new ConcurrentDictionary<string, string>();
             dict3["key"] = null;
+            dict3.Add("key2", null);
 
             // using IDictionary interface and value type values
             Action action = () =>
             {
                 IDictionary dict4 = new ConcurrentDictionary<string, int>();
                 dict4["key"] = null;
+            };
+            Assert.Throws<ArgumentException>(action);
+
+            action = () =>
+            {
+                IDictionary dict5 = new ConcurrentDictionary<string, int>();
+                dict5.Add("key", null);
             };
             Assert.Throws<ArgumentException>(action);
         }

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
@@ -58,6 +58,30 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
+        public static void TestAddNullValue()
+        {
+            // using ConcurrentDictionary<TKey, TValue> class
+            ConcurrentDictionary<string, string> dict1 = new ConcurrentDictionary<string, string>();
+            dict1["key"] = null;
+
+            // using IDictionary<TKey, TValue> interface
+            IDictionary<string, string> dict2 = new ConcurrentDictionary<string, string>();
+            dict2["key"] = null;
+
+            // using IDictionary interface
+            IDictionary dict3 = new ConcurrentDictionary<string, string>();
+            dict3["key"] = null;
+
+            // using IDictionary interface and value type values
+            Action action = () =>
+            {
+                IDictionary dict4 = new ConcurrentDictionary<string, int>();
+                dict4["key"] = null;
+            };
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
         public static void TestAdd1()
         {
             TestAdd1(1, 1, 1, 10000);
@@ -646,7 +670,7 @@ namespace System.Collections.Concurrent.Tests
 
             // Duplicate keys.
             AssertExtensions.Throws<ArgumentException>(null, () => new ConcurrentDictionary<int, int>(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(1, 2) }));
-            
+
             Assert.Throws<ArgumentNullException>(
                () => new ConcurrentDictionary<int, int>(1, null, EqualityComparer<int>.Default));
             // "TestConstructor:  FAILED.  Constructor didn't throw ANE when null collection is passed");


### PR DESCRIPTION
Fixes #26447

There are quite a lot of changes in `ConcurrentDictionary.cs`, but they are only trailing whitespaces (I have an extension which removes them automatically). The real change is on the line 1580.