### PR TITLE
Change csharp_indent_labels from flush_left to one_less_than_current

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,7 +30,7 @@ csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = flush_left
+csharp_indent_labels = one_less_than_current
 
 # avoid this. unless absolutely necessary
 dotnet_style_qualification_for_field = false:suggestion

--- a/Documentation/coding-guidelines/coding-style.md
+++ b/Documentation/coding-guidelines/coding-style.md
@@ -29,6 +29,7 @@ The general rule we follow is "use Visual Studio defaults".
 13. We use ```nameof(...)``` instead of ```"..."``` whenever possible and relevant.
 14. Fields should be specified at the top within type declarations.
 15. When including non-ASCII characters in the source code use Unicode escape sequences (\uXXXX) instead of literal characters. Literal non-ASCII characters occasionally get garbled by a tool or editor.
+16. When using labels (for goto), indent the label one less than the current indentation.
 
 We have provided a Visual Studio 2013 vssettings file (`corefx.vssettings`) at the root of the corefx repository, enabling C# auto-formatting conforming to the above guidelines. Note that rules 7 and 8 are not covered by the vssettings, since these are not rules currently supported by VS formatting.
 


### PR DESCRIPTION
Most of the places where we use goto and labels (that I have come across) use one_less_than_current formatting pattern.

I will make the same change in coreclr as well - https://github.com/dotnet/coreclr/pull/16983

cc @jkotas, @danmosemsft, @cod7alex, @karelz, @tannergooding 