### PR TITLE
[1.1] Add OpenSuse423 and Ubuntun1804 to init-tools cli initialization

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -27,6 +27,10 @@ get_current_linux_name() {
             echo "ubuntu.16.10"
             return 0
         fi
+        if [ "$(cat /etc/*-release | grep -cim1 18.04)" -eq 1 ]; then
+            echo "ubuntu.18.04"
+            return 0
+        fi
         echo "ubuntu"
         return 0
     elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
@@ -46,7 +50,11 @@ get_current_linux_name() {
             echo "opensuse.13.2"
             return 0
         fi
-        echo "opensuse.42.1"
+        if [ "$(cat /etc/*-release | grep -cim1 42.1)" -eq 1 ]; then
+            echo "opensuse.42.1"
+            return 0
+        fi 
+        echo "opensuse.42.3"
         return 0
     fi
 


### PR DESCRIPTION
This updates the default tools version for an opensuse platform to 42.3 and adds detection for Ubuntu18.04. 

This will cause those platforms to explicitly fail unless they have a bootstrap cli version uploaded to blob storage.

A similar change will need to go into core-setup, but only after the above step is completed and those cli packages are made available.

cc @janvorli 