### PR TITLE
Fixed netfx System.ComponentModel.DataAnnotations.Tests.ValidatorTest…

### DIFF
--- a/src/System.ComponentModel.Annotations/tests/ValidatorTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/ValidatorTests.cs
@@ -229,7 +229,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
 
             var results = new List<ValidationResult>();
             Assert.False(Validator.TryValidateObject(instance, context, results));
-            Assert.Equal("The Required field is required.", Assert.Single(results).ErrorMessage);
+            Assert.Contains("Required", Assert.Single(results).ErrorMessage);
         }
 
         public class RequiredFailure


### PR DESCRIPTION
Fixed netfx System.ComponentModel.DataAnnotations.Tests.ValidatorTests.TryValidateObject_RequiredNull_Error on non English Windows.
```
             System.ComponentModel.DataAnnotations.Tests.ValidatorTests.TryValidateObject_RequiredNull_Error [FAIL]
               Assert.Equal() Failure
                          (pos 0)
               Expected: The Required field is required.
               Actual:   Требуется поле Required.
                          (pos 0)
               Stack Trace:
                    в Xunit.Assert.Equal(String expected, String actual, Boolean ignoreCase, Boolean ignoreLineEndingDifferences, Boolean ignoreWhiteSpaceDifferences) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 239
                    в Xunit.Assert.Equal(String expected, String actual) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 170
                    в System.ComponentModel.DataAnnotations.Tests.ValidatorTests.TryValidateObject_RequiredNull_Error()
```
See https://github.com/dotnet/corefx/issues/28136 also