### PR TITLE
Fixed netfx System.Diagnostics.TraceSource.Tests on non English Windows

### DIFF
--- a/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
@@ -354,7 +354,16 @@ namespace System.Diagnostics.TraceSourceTests
         [Fact]
         public void TraceTest02()
         {
+            String newLine = Environment.NewLine;
             var textTL = new TestTextTraceListener();
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(textTL);
+            Trace.IndentLevel = 0;
+            Trace.Fail("");
+            textTL.Flush();
+            var fail = textTL.Output.TrimEnd(newLine.ToCharArray());
+
+            textTL = new TestTextTraceListener();
             // We have to clear the listeners list on Trace since there is a trace listener by default with AssertUiEnabled = true in Desktop and that will pop up an assert window with Trace.Fail
             Trace.Listeners.Clear();
             Trace.Listeners.Add(textTL);
@@ -377,8 +386,8 @@ namespace System.Diagnostics.TraceSourceTests
             Trace.Unindent();
             Trace.WriteLine("Message end.");
             textTL.Flush();
-            String newLine = Environment.NewLine;
-            var expected = "Message start." + newLine + "    This message should be indented.This should not be indented." + newLine + "      Fail: This failure is reported with a detailed message" + newLine + "      Fail: " + newLine + "      Fail: This assert is reported" + newLine + "Message end." + newLine;
+            newLine = Environment.NewLine;
+            var expected = "Message start." + newLine + "    This message should be indented.This should not be indented." + newLine + "      " + fail + "This failure is reported with a detailed message" + newLine + "      " + fail + newLine + "      " + fail + "This assert is reported" + newLine + "Message end." + newLine;
             Assert.Equal(expected, textTL.Output);
         }
     }

--- a/src/System.Diagnostics.TraceSource/tests/TraceEventCacheClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceEventCacheClassTests.cs
@@ -60,7 +60,7 @@ namespace System.Diagnostics.TraceSourceTests
         public void CallstackTest_ContainsExpectedFrames()
         {
             var cache = new TraceEventCache();
-            Assert.Contains("at System.Environment.get_StackTrace()", cache.Callstack);
+            Assert.Contains("System.Environment.get_StackTrace()", cache.Callstack);
         }
 
         [Fact]


### PR DESCRIPTION
Fixed netfx System.Diagnostics.TraceSource.Tests on non English Windows
```
               Assert.Equal() Failure
                                                   (pos 88)
               Expected: ···be indented.\r\n      Fail: This failure is reported with a det···
               Actual:   ···be indented.\r\n      Сбой: This failure is reported with a det···
                                                   (pos 88)
               Stack Trace:
                    в Xunit.Assert.Equal(String expected, String actual, Boolean ignoreCase, Boolean ignoreLineEndingDifferences, Boolean ignoreWhiteSpaceDifferences) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 239
                    в Xunit.Assert.Equal(String expected, String actual) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 170
                    в System.Diagnostics.TraceSourceTests.TraceClassTests.TraceTest02()
             System.Diagnostics.TraceSourceTests.TraceEventCacheClassTests.CallstackTest_ContainsExpectedFrames [FAIL]
               Assert.Contains() Failure
               Not found: at System.Environment.get_StackTrace()
               In value:     в System.Environment.GetStackTrace(Exception e, Boolean needFileInfo)
                  в System.Environment.get_StackTrace()
                  в System.Diagnostics.TraceEventCache.get_Callstack()
                  в System.Diagnostics.TraceSourceTests.TraceEventCacheClassTests.CallstackTest_ContainsExpectedFrames()
                  в System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
                  в System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
                  в System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
                  в Xunit.Sdk.TestInvoker`1.CallTestMethod(Object testClassInstance) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:строка 147
                  в Xunit.Sdk.TestInvoker`1.<>c__DisplayClass46_1.<<InvokeTestMethodAsync>b__1>d.MoveNext() в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:строка 224
                  в System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
                  в Xunit.Sdk.TestInvoker`1.<>c__DisplayClass46_1.<InvokeTestMethodAsync>b__1()
                  в Xunit.Sdk.ExecutionTimer.<AggregateAsync>d__4.MoveNext() в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.execution\Sdk\Frameworks\ExecutionTimer.cs:строка 48
                  в System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
                  в Xunit.Sdk.ExecutionTimer.AggregateAsync(Func`1 asyncAction)
                  в Xunit.Sdk.ExceptionAggregator.<RunAsync>d__9.MoveNext() в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.core\Sdk\ExceptionAggregator.cs:строка 90
                  в System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
                  в Xunit.Sdk.ExceptionAggregator.RunAsync(Func`1 code)
                  в Xunit.Sdk.TestInvoker`1.<InvokeTestMethodAsync>d__46.MoveNext() в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:строка 208
                  в System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine)
                  в Xunit.Sdk.TestInvoker`1.InvokeTestMethodAsync(Object testClassInstance)
                  в Xunit.Sdk.TestInvoker`1.<<RunAsync>b__45_0>d.MoveNext() в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:строка 173
                  в System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine)
                  в Xunit.Sdk.TestInvoker`1.<RunAsync>b__45_0()
                  в Xunit.Sdk.ExceptionAggregator.<RunAsync>d__10`1.MoveNext() в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.core\Sdk\ExceptionAggregator.cs:строка 107
                  в System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine)
                  в Xunit.Sdk.ExceptionAggregator.RunAsync[T](Func`1 code)
                  в Xunit.Sdk.XunitTestRunner.<InvokeTestAsync>d__4.MoveNext() в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.execution\Sdk\Frameworks\Runners\XunitTestRunner.cs:строка 67
                  в System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine)
                  в Xunit.Sdk.XunitTestRunner.InvokeTestAsync(ExceptionAggregator aggregator)
```
See https://github.com/dotnet/corefx/issues/28136 also.