### PR TITLE
Replace IntPtr and pointer casts in SpanHelpers.Byte.cs with nuint

### DIFF
--- a/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
@@ -178,7 +178,7 @@ namespace System
                     var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index)));
                     if (Vector<byte>.Zero.Equals(vMatches))
                     {
-                        index += Vector<byte>.Count;
+                        index += (uint)Vector<byte>.Count;
                         continue;
                     }
                     // Find offset of first match
@@ -313,13 +313,13 @@ namespace System
 
                 // Get comparison Vector
                 Vector<byte> vComparison = GetVector(value);
-                while (nLength > (Vector<byte>.Count - 1))
+                while (nLength > (uint)(Vector<byte>.Count - 1))
                 {
-                    var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count)));
+                    var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - (uint)Vector<byte>.Count)));
                     if (Vector<byte>.Zero.Equals(vMatches))
                     {
-                        index -= Vector<byte>.Count;
-                        nLength -= Vector<byte>.Count;
+                        index -= (uint)Vector<byte>.Count;
+                        nLength -= (uint)Vector<byte>.Count;
                         continue;
                     }
                     // Find offset of first match
@@ -446,7 +446,7 @@ namespace System
                                     Vector.Equals(vData, values1));
                     if (Vector<byte>.Zero.Equals(vMatches))
                     {
-                        index += Vector<byte>.Count;
+                        index += (uint)Vector<byte>.Count;
                         continue;
                     }
                     // Find offset of first match
@@ -579,7 +579,7 @@ namespace System
 
                     if (Vector<byte>.Zero.Equals(vMatches))
                     {
-                        index += Vector<byte>.Count;
+                        index += (uint)Vector<byte>.Count;
                         continue;
                     }
                     // Find offset of first match
@@ -696,16 +696,16 @@ namespace System
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
-                while (nLength > (Vector<byte>.Count - 1))
+                while (nLength > (uint)(Vector<byte>.Count - 1))
                 {
-                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
+                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - (uint)Vector<byte>.Count));
                     var vMatches = Vector.BitwiseOr(
                                     Vector.Equals(vData, values0),
                                     Vector.Equals(vData, values1));
                     if (Vector<byte>.Zero.Equals(vMatches))
                     {
-                        index -= Vector<byte>.Count;
-                        nLength -= Vector<byte>.Count;
+                        index -= (uint)Vector<byte>.Count;
+                        nLength -= (uint)Vector<byte>.Count;
                         continue;
                     }
                     // Find offset of first match
@@ -824,9 +824,9 @@ namespace System
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
                 Vector<byte> values2 = GetVector(value2);
-                while (nLength > (Vector<byte>.Count - 1))
+                while (nLength > (uint)(Vector<byte>.Count - 1))
                 {
-                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
+                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - (uint)Vector<byte>.Count));
 
                     var vMatches = Vector.BitwiseOr(
                                     Vector.BitwiseOr(
@@ -836,8 +836,8 @@ namespace System
 
                     if (Vector<byte>.Zero.Equals(vMatches))
                     {
-                        index -= Vector<byte>.Count;
-                        nLength -= Vector<byte>.Count;
+                        index -= (uint)Vector<byte>.Count;
+                        nLength -= (uint)Vector<byte>.Count;
                         continue;
                     }
                     // Find offset of first match

--- a/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
@@ -108,75 +108,72 @@ namespace System
             Debug.Assert(length >= 0);
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            nuint index = 0;
+            nuint nLength = (nuint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (nuint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
-            while ((byte*)nLength >= (byte*)8)
+            while (nLength >= 8)
             {
                 nLength -= 8;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
                     goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
                     goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
                     goto Found3;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 4))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4))
                     goto Found4;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 5))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5))
                     goto Found5;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 6))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6))
                     goto Found6;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
                     goto Found7;
 
                 index += 8;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if (nLength >= 4)
             {
                 nLength -= 4;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
                     goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
                     goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
                     goto Found3;
 
                 index += 4;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while (nLength > 0)
             {
                 nLength -= 1;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
 
                 index += 1;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
+            if (Vector.IsHardwareAccelerated && ((int)index < length))
             {
-                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                nLength = (nuint)((length - (int)index) & ~(Vector<byte>.Count - 1));
                 // Get comparison Vector
                 Vector<byte> vComparison = GetVector(value);
-                while ((byte*)nLength > (byte*)index)
+                while (nLength > index)
                 {
                     var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index)));
                     if (Vector<byte>.Zero.Equals(vMatches))
@@ -185,36 +182,33 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)index + LocateFirstFoundByte(vMatches);
+                    return (int)index + LocateFirstFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index < length)
+                if ((int)index < length)
                 {
-                    unchecked
-                    {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
-                    }
+                    nLength = (nuint)length - index;
                     goto SequentialScan;
                 }
             }
 #endif
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)index;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(index + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(index + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(index + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(index + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(index + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(index + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(index + 7);
         }
 
         public static int LastIndexOf(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
@@ -256,73 +250,70 @@ namespace System
             Debug.Assert(length >= 0);
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            nuint index = (nuint)length;
+            nuint nLength = (nuint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (nuint)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
-            while ((byte*)nLength >= (byte*)8)
+            while (nLength >= 8)
             {
                 nLength -= 8;
                 index -= 8;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
                     goto Found7;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 6))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6))
                     goto Found6;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 5))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5))
                     goto Found5;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 4))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4))
                     goto Found4;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
                     goto Found3;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
                     goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
                     goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if (nLength >= 4)
             {
                 nLength -= 4;
                 index -= 4;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
                     goto Found3;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
                     goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
                     goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while (nLength > 0)
             {
                 nLength -= 1;
                 index -= 1;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index > 0))
+            if (Vector.IsHardwareAccelerated && (index > 0))
             {
-                nLength = (IntPtr)(uint)((uint)index & ~(Vector<byte>.Count - 1));
+                nLength = (nuint)((int)index & ~(Vector<byte>.Count - 1));
 
                 // Get comparison Vector
                 Vector<byte> vComparison = GetVector(value);
-                while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
+                while (nLength > (Vector<byte>.Count - 1))
                 {
                     var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count)));
                     if (Vector<byte>.Zero.Equals(vMatches))
@@ -332,9 +323,9 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
                 }
-                if ((int)(byte*)index > 0)
+                if (index > 0)
                 {
                     nLength = index;
                     goto SequentialScan;
@@ -343,21 +334,21 @@ namespace System
 #endif
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)index;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(index + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(index + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(index + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(index + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(index + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(index + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(index + 7);
         }
 
         public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
@@ -366,91 +357,88 @@ namespace System
 
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            nuint index = 0;
+            nuint nLength = (nuint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (nuint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
             uint lookUp;
-            while ((byte*)nLength >= (byte*)8)
+            while (nLength >= 8)
             {
                 nLength -= 8;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
 
                 index += 8;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if (nLength >= 4)
             {
                 nLength -= 4;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
 
                 index += 4;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while (nLength > 0)
             {
                 nLength -= 1;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
 
                 index += 1;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
+            if (Vector.IsHardwareAccelerated && ((int)index < length))
             {
-                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                nLength = (nuint)((length - (int)index) & ~(Vector<byte>.Count - 1));
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
 
-                while ((byte*)nLength > (byte*)index)
+                while (nLength > index)
                 {
                     Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
                     var vMatches = Vector.BitwiseOr(
@@ -462,36 +450,33 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)index + LocateFirstFoundByte(vMatches);
+                    return (int)index + LocateFirstFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index < length)
+                if ((int)index < length)
                 {
-                    unchecked
-                    {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
-                    }
+                    nLength = (nuint)length - index;
                     goto SequentialScan;
                 }
             }
 #endif
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)index;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(index + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(index + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(index + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(index + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(index + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(index + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(index + 7);
         }
 
         public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
@@ -501,91 +486,88 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            nuint index = 0;
+            nuint nLength = (nuint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (nuint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
             uint lookUp;
-            while ((byte*)nLength >= (byte*)8)
+            while (nLength >= 8)
             {
                 nLength -= 8;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
 
                 index += 8;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if (nLength >= 4)
             {
                 nLength -= 4;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
 
                 index += 4;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while (nLength > 0)
             {
                 nLength -= 1;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
 
                 index += 1;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
+            if (Vector.IsHardwareAccelerated && ((int)index < length))
             {
-                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                nLength = (nuint)((length - (int)index) & ~(Vector<byte>.Count - 1));
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
                 Vector<byte> values2 = GetVector(value2);
-                while ((byte*)nLength > (byte*)index)
+                while (nLength > index)
                 {
                     Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
 
@@ -601,36 +583,33 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)index + LocateFirstFoundByte(vMatches);
+                    return (int)index + LocateFirstFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index < length)
+                if ((int)index < length)
                 {
-                    unchecked
-                    {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
-                    }
+                    nLength = (nuint)length - index;
                     goto SequentialScan;
                 }
             }
 #endif
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)index;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(index + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(index + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(index + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(index + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(index + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(index + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(index + 7);
         }
 
         public static unsafe int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
@@ -639,88 +618,85 @@ namespace System
 
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            nuint index = (nuint)length;
+            nuint nLength = (nuint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (nuint)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
             uint lookUp;
-            while ((byte*)nLength >= (byte*)8)
+            while (nLength >= 8)
             {
                 nLength -= 8;
                 index -= 8;
 
-                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
-                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if (nLength >= 4)
             {
                 nLength -= 4;
                 index -= 4;
 
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while (nLength > 0)
             {
                 nLength -= 1;
                 index -= 1;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index > 0))
+            if (Vector.IsHardwareAccelerated && (index > 0))
             {
-                nLength = (IntPtr)(uint)((uint)index & ~(Vector<byte>.Count - 1));
+                nLength = (nuint)((int)index & ~(Vector<byte>.Count - 1));
+
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
-
-                while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
+                while (nLength > (Vector<byte>.Count - 1))
                 {
                     Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
                     var vMatches = Vector.BitwiseOr(
@@ -733,10 +709,10 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index > 0)
+                if (index > 0)
                 {
                     nLength = index;
                     goto SequentialScan;
@@ -745,21 +721,21 @@ namespace System
 #endif
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)index;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(index + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(index + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(index + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(index + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(index + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(index + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(index + 7);
         }
 
         public static unsafe int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
@@ -769,88 +745,86 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            nuint index = (nuint)length;
+            nuint nLength = (nuint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (nuint)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
             uint lookUp;
-            while ((byte*)nLength >= (byte*)8)
+            while (nLength >= 8)
             {
                 nLength -= 8;
                 index -= 8;
 
-                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
-                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if (nLength >= 4)
             {
                 nLength -= 4;
                 index -= 4;
 
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while (nLength > 0)
             {
                 nLength -= 1;
                 index -= 1;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index > 0))
+            if (Vector.IsHardwareAccelerated && (index > 0))
             {
-                nLength = (IntPtr)(uint)((uint)index & ~(Vector<byte>.Count - 1));
+                nLength = (nuint)((int)index & ~(Vector<byte>.Count - 1));
+
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
                 Vector<byte> values2 = GetVector(value2);
-                while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
+                while (nLength > (Vector<byte>.Count - 1))
                 {
                     Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
 
@@ -867,10 +841,10 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index > 0)
+                if (index > 0)
                 {
                     nLength = index;
                     goto SequentialScan;
@@ -879,21 +853,21 @@ namespace System
 #endif
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)index;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(index + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(index + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(index + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(index + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(index + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(index + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(index + 7);
         }
 
         // Optimized byte-based SequenceEquals. The "length" parameter for this one is declared a nuint rather than int as we also use it for types other than byte
@@ -903,7 +877,7 @@ namespace System
             if (Unsafe.AreSame(ref first, ref second))
                 goto Equal;
 
-            nuint i = (nuint)0; // Explicit conversion required for netfx (NUInt)
+            nuint i = 0;
             nuint n = length;
 
 #if !netstandard11
@@ -912,15 +886,15 @@ namespace System
                 n -= (nuint)Vector<byte>.Count;
                 while (n > i)
                 {
-                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, (IntPtr)i)) !=
-                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, (IntPtr)i)))
+                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
                     i += (nuint)Vector<byte>.Count;
                 }
-                return Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, (IntPtr)n)) ==
-                       Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, (IntPtr)n));
+                return Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, n)) ==
+                       Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, n));
             }
 #endif
 
@@ -929,20 +903,20 @@ namespace System
                 n -= (nuint)sizeof(UIntPtr);
                 while (n > i)
                 {
-                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, (IntPtr)i)) !=
-                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, (IntPtr)i)))
+                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
                     i += (nuint)sizeof(UIntPtr);
                 }
-                return Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, (IntPtr)n)) ==
-                       Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, (IntPtr)n));
+                return Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, n)) ==
+                       Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, n));
             }
 
             while (n > i)
             {
-                if (Unsafe.AddByteOffset(ref first, (IntPtr)i) != Unsafe.AddByteOffset(ref second, (IntPtr)i))
+                if (Unsafe.AddByteOffset(ref first, i) != Unsafe.AddByteOffset(ref second, i))
                     goto NotEqual;
                 i += 1;
             }
@@ -988,7 +962,7 @@ namespace System
             nuint minLength = (nuint)firstLength;
             if (minLength > (nuint)secondLength) minLength = (nuint)secondLength;
 
-            nuint i = (nuint)0;  // Explicit conversion required for netfx (NUInt)
+            nuint i = 0;
             nuint n = minLength;
 
 #if !netstandard11
@@ -997,8 +971,8 @@ namespace System
                 n -= (nuint)Vector<byte>.Count;
                 while (n > i)
                 {
-                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, (IntPtr)i)) !=
-                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, (IntPtr)i)))
+                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
@@ -1013,8 +987,8 @@ namespace System
                 n -= (nuint)sizeof(UIntPtr);
                 while (n > i)
                 {
-                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, (IntPtr)i)) !=
-                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, (IntPtr)i)))
+                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
@@ -1025,7 +999,7 @@ namespace System
         NotEqual:  // Workaround for https://github.com/dotnet/coreclr/issues/13549
             while (minLength > i)
             {
-                int result = Unsafe.AddByteOffset(ref first, (IntPtr)i).CompareTo(Unsafe.AddByteOffset(ref second, (IntPtr)i));
+                int result = Unsafe.AddByteOffset(ref first, i).CompareTo(Unsafe.AddByteOffset(ref second, i));
                 if (result != 0) return result;
                 i += 1;
             }
@@ -1061,13 +1035,10 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundByte(ulong match)
         {
-            unchecked
-            {
-                // Flag least significant power of two bit
-                var powerOfTwoFlag = match ^ (match - 1);
-                // Shift all powers of two into the high byte and extract
-                return (int)((powerOfTwoFlag * XorPowerOfTwoToHighByte) >> 57);
-            }
+            // Flag least significant power of two bit
+            var powerOfTwoFlag = match ^ (match - 1);
+            // Shift all powers of two into the high byte and extract
+            return (int)((powerOfTwoFlag * XorPowerOfTwoToHighByte) >> 57);
         }
 #endif
 

--- a/src/System.Memory/src/System/NUint.cs
+++ b/src/System.Memory/src/System/NUint.cs
@@ -17,11 +17,13 @@ namespace System
         private NUInt(uint value) => _value = (UIntPtr)value;
         private NUInt(ulong value) => _value = (UIntPtr)value;
 
-        public static explicit operator NUInt(uint value) => new NUInt(value);
-        public static explicit operator UIntPtr(NUInt value) => value._value;
+
+        public static implicit operator NUInt(uint value) => new NUInt(value);
+        public static implicit operator IntPtr(NUInt value) => (IntPtr)(long)(ulong)value._value;
 
         public static explicit operator NUInt(int value) => new NUInt(value);
-        public static explicit operator IntPtr(NUInt value) => (IntPtr)(long)(ulong)value._value;
+        public static explicit operator int(NUInt value) => (int)(long)value._value;
+        public static explicit operator uint(NUInt value) => (uint)(long)value._value;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator *(NUInt left, int right)

--- a/src/System.Memory/src/System/NUint.cs
+++ b/src/System.Memory/src/System/NUint.cs
@@ -25,66 +25,66 @@ namespace System
         public static explicit operator uint(NUInt value) => (uint)value._value;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator *(NUInt left, int right)
+        public static NUInt operator *(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * (uint)right) : new NUInt(((ulong)left._value) * (uint)right); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * right) : new NUInt(((ulong)left._value) * right);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator +(NUInt left, int right)
+        public static NUInt operator +(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + (uint)right) : new NUInt(((ulong)left._value) + (uint)right); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + right) : new NUInt(((ulong)left._value) + right);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator -(NUInt left, int right)
+        public static NUInt operator -(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - (uint)right) : new NUInt(((ulong)left._value) - (uint)right); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - right) : new NUInt(((ulong)left._value) - right);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator *(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * (uint)right._value) : new NUInt(((ulong)left._value) * (ulong)right._value); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * (uint)right._value) : new NUInt(((ulong)left._value) * (ulong)right._value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator +(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + (uint)right._value) : new NUInt(((ulong)left._value) + (ulong)right._value); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + (uint)right._value) : new NUInt(((ulong)left._value) + (ulong)right._value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator -(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - (uint)right._value) : new NUInt(((ulong)left._value) - (ulong)right._value); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - (uint)right._value) : new NUInt(((ulong)left._value) - (ulong)right._value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >=(NUInt left, int right)
+        public static bool operator >=(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= (uint)right : ((ulong)left._value) >= (uint)right; }
+            return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= right : ((ulong)left._value) >= right;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <=(NUInt left, int right)
+        public static bool operator <=(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= (uint)right : ((ulong)left._value) <= (uint)right; }
+            return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= right : ((ulong)left._value) <= right;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >(NUInt left, int right) => !(left <= right);
+        public static bool operator >(NUInt left, uint right) => !(left <= right);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <(NUInt left, int right) => !(left >= right);
+        public static bool operator <(NUInt left, uint right) => !(left >= right);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator <=(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= (uint)right._value : ((ulong)left._value) <= (ulong)right._value; }
+            return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= (uint)right._value : ((ulong)left._value) <= (ulong)right._value;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator >=(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= (uint)right._value : ((ulong)left._value) >= (ulong)right._value; }
+            return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= (uint)right._value : ((ulong)left._value) >= (ulong)right._value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Memory/src/System/NUint.cs
+++ b/src/System.Memory/src/System/NUint.cs
@@ -9,21 +9,20 @@ namespace System
     //
     // A makeshift native uint type for build configurations that don't build 32/64-bit specific binaries (and hence, can't alias them to UInt32/UInt64 via an ifdef.)
     //
-    internal struct NUInt
+    internal unsafe struct NUInt
     {
-        private readonly UIntPtr _value;
+        private readonly void* _value;
 
-        private NUInt(int value) => _value = (UIntPtr)value;
-        private NUInt(uint value) => _value = (UIntPtr)value;
-        private NUInt(ulong value) => _value = (UIntPtr)value;
-
+        private NUInt(uint value) => _value = (void*)value;
+        private NUInt(ulong value) => _value = (void*)value;
 
         public static implicit operator NUInt(uint value) => new NUInt(value);
-        public static implicit operator IntPtr(NUInt value) => (IntPtr)(long)(ulong)value._value;
+        public static implicit operator IntPtr(NUInt value) => (IntPtr)value._value;
 
-        public static explicit operator NUInt(int value) => new NUInt(value);
-        public static explicit operator int(NUInt value) => (int)(long)value._value;
-        public static explicit operator uint(NUInt value) => (uint)(long)value._value;
+        public static explicit operator NUInt(int value) => new NUInt((uint)value);
+
+        public static explicit operator int(NUInt value) => (int)value._value;
+        public static explicit operator uint(NUInt value) => (uint)value._value;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator *(NUInt left, int right)
@@ -97,8 +96,8 @@ namespace System
         public static bool operator !=(NUInt left, NUInt right) => left._value != right._value;
 
         public override bool Equals(object obj) => obj is NUInt other && _value == other._value;
-        public override int GetHashCode() => _value.GetHashCode();
+        public override int GetHashCode() => new UIntPtr(_value).GetHashCode();
 
-        public override string ToString() => _value.ToString();
+        public override string ToString() => new UIntPtr(_value).ToString();
     }
 }


### PR DESCRIPTION
Cleanup tricky IntPtr and pointer casts that simulated native int arithmetic with nuint to make the code more readable.