### PR TITLE
Fixed netfx System.Configuration.ConfigurationManager.Tests on non English Windows

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationErrorsExceptionTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationErrorsExceptionTest.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Configuration;
 using System.Configuration.Internal;
+using System.Globalization;
 using System.IO;
 using System.Xml;
 
@@ -42,15 +43,25 @@ namespace MonoTests.System.Configuration
         [Fact] // ctor ()
         public void Constructor1()
         {
-            ConfigurationErrorsException cee = new ConfigurationErrorsException();
-            Assert.NotNull(cee.BareMessage);
-            Assert.True(cee.BareMessage.IndexOf("'" + typeof(ConfigurationErrorsException).FullName + "'") != -1, "#2:" + cee.BareMessage);
-            Assert.NotNull(cee.Data);
-            Assert.Equal(0, cee.Data.Count);
-            Assert.Null(cee.Filename);
-            Assert.Null(cee.InnerException);
-            Assert.Equal(0, cee.Line);
-            Assert.Equal(cee.BareMessage, cee.Message);
+            var cc = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            try
+            {
+
+                ConfigurationErrorsException cee = new ConfigurationErrorsException();
+                Assert.NotNull(cee.BareMessage);
+                Assert.True(cee.BareMessage.IndexOf("'" + typeof(ConfigurationErrorsException).FullName + "'") != -1, "#2:" + cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Null(cee.Filename);
+                Assert.Null(cee.InnerException);
+                Assert.Equal(0, cee.Line);
+                Assert.Equal(cee.BareMessage, cee.Message);
+            }
+            finally
+            {
+                CultureInfo.CurrentUICulture = cc;
+            }
         }
 
         [Fact] // ctor (String)

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationErrorsExceptionTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationErrorsExceptionTest.cs
@@ -30,8 +30,8 @@
 using System;
 using System.Configuration;
 using System.Configuration.Internal;
-using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Xml;
 
 using Xunit;
@@ -43,25 +43,20 @@ namespace MonoTests.System.Configuration
         [Fact] // ctor ()
         public void Constructor1()
         {
-            var cc = CultureInfo.CurrentUICulture;
-            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-            try
-            {
+            ConfigurationErrorsException cee = new ConfigurationErrorsException();
+            Assert.NotNull(cee.BareMessage);
 
-                ConfigurationErrorsException cee = new ConfigurationErrorsException();
-                Assert.NotNull(cee.BareMessage);
-                Assert.True(cee.BareMessage.IndexOf("'" + typeof(ConfigurationErrorsException).FullName + "'") != -1, "#2:" + cee.BareMessage);
-                Assert.NotNull(cee.Data);
-                Assert.Equal(0, cee.Data.Count);
-                Assert.Null(cee.Filename);
-                Assert.Null(cee.InnerException);
-                Assert.Equal(0, cee.Line);
-                Assert.Equal(cee.BareMessage, cee.Message);
-            }
-            finally
-            {
-                CultureInfo.CurrentUICulture = cc;
-            }
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.True(Regex.IsMatch(cee.BareMessage, @"[\p{Pi}\p{Po}]" + Regex.Escape(typeof(ConfigurationErrorsException).FullName) + @"[\p{Pf}\p{Po}]"), "#2:" + cee.BareMessage);
+
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Null(cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Equal(cee.BareMessage, cee.Message);
         }
 
         [Fact] // ctor (String)

--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -105,5 +105,11 @@
     <Compile Include="System\Configuration\ValidatiorUtilsTests.cs" />
     <Compile Include="System\Drawing\Configuration\SystemDrawingSectionTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TimeSpanValidatorAttributeTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TimeSpanValidatorAttributeTests.cs
@@ -3,13 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Configuration;
+using System.Diagnostics;
 using System.Globalization;
 
 using Xunit;
 
 namespace System.ConfigurationTests
 {
-    public class TimeSpanValidatorAttributeTests
+    public class TimeSpanValidatorAttributeTests : RemoteExecutorTestBase
     {
         [Fact]
         public void MinValueString_GetString()
@@ -116,10 +117,10 @@ namespace System.ConfigurationTests
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Exception messages are different")]
         public void MinValueString_TooSmall()
         {
-            var cc = CultureInfo.CurrentUICulture;
-            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-            try
+            RemoteInvoke(() =>
             {
+                CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
                 TimeSpanValidatorAttribute attribute = new TimeSpanValidatorAttribute();
 
                 attribute.MaxValueString = new TimeSpan(2, 2, 2, 2).ToString();
@@ -128,21 +129,17 @@ namespace System.ConfigurationTests
                 ArgumentOutOfRangeException expectedException =
                     new ArgumentOutOfRangeException("value", SR.Validator_min_greater_than_max);
                 Assert.Equal(expectedException.Message, result.Message);
-            }
-            finally
-            {
-                CultureInfo.CurrentUICulture = cc;
-            }
+            }).Dispose();
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Exception messages are different")]
         public void MaxValueString_TooBig()
         {
-            var cc = CultureInfo.CurrentUICulture;
-            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-            try
+            RemoteInvoke(() =>
             {
+                CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
                 TimeSpanValidatorAttribute attribute = new TimeSpanValidatorAttribute();
 
                 attribute.MinValueString = new TimeSpan(2, 2, 2, 2).ToString();
@@ -151,11 +148,7 @@ namespace System.ConfigurationTests
                 ArgumentOutOfRangeException expectedException =
                     new ArgumentOutOfRangeException("value", SR.Validator_min_greater_than_max);
                 Assert.Equal(expectedException.Message, result.Message);
-            }
-            finally
-            {
-                CultureInfo.CurrentUICulture = cc;
-            }
+            }).Dispose();
         }
     }
 }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TimeSpanValidatorAttributeTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TimeSpanValidatorAttributeTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Configuration;
+using System.Globalization;
+
 using Xunit;
 
 namespace System.ConfigurationTests
@@ -111,27 +113,49 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot,"Exception messages are different")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Exception messages are different")]
         public void MinValueString_TooSmall()
         {
-            TimeSpanValidatorAttribute attribute = new TimeSpanValidatorAttribute();
+            var cc = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            try
+            {
+                TimeSpanValidatorAttribute attribute = new TimeSpanValidatorAttribute();
 
-            attribute.MaxValueString = new TimeSpan(2, 2, 2, 2).ToString();
-            ArgumentOutOfRangeException result = Assert.Throws<ArgumentOutOfRangeException>(() => attribute.MinValueString = new TimeSpan(3, 3, 3, 3).ToString());
-            ArgumentOutOfRangeException expectedException = new ArgumentOutOfRangeException("value", SR.Validator_min_greater_than_max);
-            Assert.Equal(expectedException.Message, result.Message);
+                attribute.MaxValueString = new TimeSpan(2, 2, 2, 2).ToString();
+                ArgumentOutOfRangeException result = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    attribute.MinValueString = new TimeSpan(3, 3, 3, 3).ToString());
+                ArgumentOutOfRangeException expectedException =
+                    new ArgumentOutOfRangeException("value", SR.Validator_min_greater_than_max);
+                Assert.Equal(expectedException.Message, result.Message);
+            }
+            finally
+            {
+                CultureInfo.CurrentUICulture = cc;
+            }
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Exception messages are different")]
         public void MaxValueString_TooBig()
         {
-            TimeSpanValidatorAttribute attribute = new TimeSpanValidatorAttribute();
+            var cc = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            try
+            {
+                TimeSpanValidatorAttribute attribute = new TimeSpanValidatorAttribute();
 
-            attribute.MinValueString = new TimeSpan(2, 2, 2, 2).ToString();
-            ArgumentOutOfRangeException result = Assert.Throws<ArgumentOutOfRangeException>(() => attribute.MaxValueString = new TimeSpan(1, 1, 1, 1).ToString());
-            ArgumentOutOfRangeException expectedException = new ArgumentOutOfRangeException("value", SR.Validator_min_greater_than_max);
-            Assert.Equal(expectedException.Message, result.Message);
+                attribute.MinValueString = new TimeSpan(2, 2, 2, 2).ToString();
+                ArgumentOutOfRangeException result = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    attribute.MaxValueString = new TimeSpan(1, 1, 1, 1).ToString());
+                ArgumentOutOfRangeException expectedException =
+                    new ArgumentOutOfRangeException("value", SR.Validator_min_greater_than_max);
+                Assert.Equal(expectedException.Message, result.Message);
+            }
+            finally
+            {
+                CultureInfo.CurrentUICulture = cc;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed netfx System.Configuration.ConfigurationManager.Tests on non English Windows
```
             MonoTests.System.Configuration.ConfigurationErrorsExceptionTest.Constructor1 [FAIL]
               #2:Выдано исключение типа "System.Configuration.ConfigurationErrorsException".
               Expected: True
               Actual:   False
               Stack Trace:
                    в Xunit.Assert.True(Nullable`1 condition, String userMessage) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\BooleanAsserts.cs:строка 90
                    в MonoTests.System.Configuration.ConfigurationErrorsExceptionTest.Constructor1()
             System.ConfigurationTests.TimeSpanValidatorAttributeTests.MaxValueString_TooBig [FAIL]
               Assert.Equal() Failure
                          (pos 0)
               Expected: The upper range limit value must be great···
               Actual:   Значение верхнего предела диапазона должн···
                          (pos 0)
               Stack Trace:
                    в Xunit.Assert.Equal(String expected, String actual, Boolean ignoreCase, Boolean ignoreLineEndingDifferences, Boolean ignoreWhiteSpaceDifferences) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 239
                    в Xunit.Assert.Equal(String expected, String actual) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 170
                    в System.ConfigurationTests.TimeSpanValidatorAttributeTests.MaxValueString_TooBig()
             System.ConfigurationTests.TimeSpanValidatorAttributeTests.MinValueString_TooSmall [FAIL]
               Assert.Equal() Failure
                          (pos 0)
               Expected: The upper range limit value must be great···
               Actual:   Значение верхнего предела диапазона должн···
                          (pos 0)
               Stack Trace:
                    в Xunit.Assert.Equal(String expected, String actual, Boolean ignoreCase, Boolean ignoreLineEndingDifferences, Boolean ignoreWhiteSpaceDifferences) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 239
                    в Xunit.Assert.Equal(String expected, String actual) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 170
                    в System.ConfigurationTests.TimeSpanValidatorAttributeTests.MinValueString_TooSmall()
```
See https://github.com/dotnet/corefx/issues/28136 also