### PR TITLE
Improve inling in ImmutableArray<T>.Builder

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -127,6 +127,8 @@ namespace System.Collections.Immutable
                 }
             }
 
+            private static void ThrowIndexOutOfRangeException() => throw new IndexOutOfRangeException();
+
             /// <summary>
             /// Gets or sets the element at the specified index.
             /// </summary>
@@ -140,7 +142,7 @@ namespace System.Collections.Immutable
                 {
                     if (index >= this.Count)
                     {
-                        throw new IndexOutOfRangeException();
+                        ThrowIndexOutOfRangeException();
                     }
 
                     return _elements[index];
@@ -150,7 +152,7 @@ namespace System.Collections.Immutable
                 {
                     if (index >= this.Count)
                     {
-                        throw new IndexOutOfRangeException();
+                        ThrowIndexOutOfRangeException();
                     }
 
                     _elements[index] = value;
@@ -169,7 +171,7 @@ namespace System.Collections.Immutable
             {
                 if (index >= this.Count)
                 {
-                    throw new IndexOutOfRangeException();
+                    ThrowIndexOutOfRangeException();
                 }
 
                 return ref this._elements[index];
@@ -247,8 +249,10 @@ namespace System.Collections.Immutable
             /// <param name="item">The object to add to the <see cref="ICollection{T}"/>.</param>
             public void Add(T item)
             {
-                this.EnsureCapacity(this.Count + 1);
-                _elements[_count++] = item;
+                int newCount = _count + 1;
+                this.EnsureCapacity(newCount);
+                _elements[_count] = item;
+                _count = newCount;
             }
 
             /// <summary>


### PR DESCRIPTION
The issue https://github.com/dotnet/corefx/issues/28064 is about a benchmark whose performance is so bad that a new dangerous method was considered to improve that situation. But almost the same effect can be achieved just by ensuring that the `Add()` method and the indexer setter on `ImmutableArray<T>.Builder` can be inlined (see https://github.com/dotnet/corefx/issues/28064#issuecomment-373950250 for more details). This PR does that.

I have only verified that extracting the `throw` is useful for the indexer setter. But the indexer getter and `ItemRef` are very similar, so I assumed it makes sense for them too.

Performance results using BenchmarkDotNet ([source](https://github.com/svick/Benchmark/blob/3504a3c/Program.cs)):

Before:

|  Method |      Mean |     Error |    StdDev |    Median |
|-------- |----------:|----------:|----------:|----------:|
|     Add | 11.053 us | 0.4281 us | 1.2623 us | 11.004 us |
| Indexer |  6.246 us | 0.1827 us | 0.5242 us |  6.063 us |

After:

|  Method |     Mean |     Error |    StdDev |   Median |
|-------- |---------:|----------:|----------:|---------:|
|     Add | 5.538 us | 0.1310 us | 0.3863 us | 5.422 us |
| Indexer | 3.159 us | 0.0631 us | 0.1138 us | 3.188 us |

Relevant portions of JIT dumps:

Before:

```
*************** In fgFindBasicBlocks() for Builder[Int64][System.Int64]:Add(long):this
weight= 10 : state   3 [ ldarg.0 ]
weight= 10 : state   3 [ ldarg.0 ]
weight= 79 : state  40 [ call ]
weight= 28 : state  24 [ ldc.i4.1 ]
weight=-12 : state  76 [ add ]
weight= 79 : state  40 [ call ]
weight= 31 : state 191 [ ldarg.0 -> ldfld ]
weight= 10 : state   3 [ ldarg.0 ]
weight= 31 : state 191 [ ldarg.0 -> ldfld ]
weight= 20 : state 199 [ stloc.0 -> ldloc.0 ]
weight= 28 : state  24 [ ldc.i4.1 ]
weight=-12 : state  76 [ add ]
weight= 31 : state 111 [ stfld ]
weight= 12 : state   7 [ ldloc.0 ]
weight= 16 : state   4 [ ldarg.1 ]
weight= 65 : state 141 [ stelem ]
weight= 19 : state  42 [ ret ]

Inline candidate callsite is in a loop.  Multiplier increased to 3.
calleeNativeSizeEstimate=445
callsiteNativeSizeEstimate=115
benefit multiplier=3
threshold=345
Native estimate for function size exceeds threshold for inlining 44.5 > 34.5 (multiplier = 3)


Inline expansion aborted, inline not profitable
INLINER: during 'fgInline' result 'failed this call site' reason 'unprofitable inline' for 'Bench:Add():this' calling 'Builder[Int64][System.Int64]:Add(long):this'
INLINER: during 'fgInline' result 'failed this call site' reason 'unprofitable inline'

…

INLINER impTokenLookupContextHandle for Builder[Int64][System.Int64]:set_Item(int,long):this is 0x00007FF8B1B089D1.
*************** In fgFindBasicBlocks() for Builder[Int64][System.Int64]:set_Item(int,long):this
weight= 16 : state   4 [ ldarg.1 ]
weight= 10 : state   3 [ ldarg.0 ]
weight= 79 : state  40 [ call ]
weight= 28 : state  50 [ blt.s ]
weight=227 : state 103 [ newobj ]
weight=210 : state 108 [ throw ]
weight= 31 : state 191 [ ldarg.0 -> ldfld ]
weight= 16 : state   4 [ ldarg.1 ]
weight= 35 : state   5 [ ldarg.2 ]
weight= 65 : state 141 [ stelem ]
weight= 19 : state  42 [ ret ]

Inline candidate callsite is in a loop.  Multiplier increased to 3.
calleeNativeSizeEstimate=736
callsiteNativeSizeEstimate=145
benefit multiplier=3
threshold=435
Native estimate for function size exceeds threshold for inlining 73.6 > 43.5 (multiplier = 3)


Inline expansion aborted, inline not profitable
INLINER: during 'fgInline' result 'failed this call site' reason 'unprofitable inline' for 'Bench:Indexer():this' calling 'Builder[Int64][System.Int64]:set_Item(int,long):this'
INLINER: during 'fgInline' result 'failed this call site' reason 'unprofitable inline'
```

After:

```
INLINER impTokenLookupContextHandle for Builder[Int64][System.Int64]:Add(long):this is 0x00007FF8B8698A39.
*************** In fgFindBasicBlocks() for Builder[Int64][System.Int64]:Add(long):this
weight= 31 : state 191 [ ldarg.0 -> ldfld ]
weight= 28 : state  24 [ ldc.i4.1 ]
weight=-12 : state  76 [ add ]
weight=  6 : state  11 [ stloc.0 ]
weight= 10 : state   3 [ ldarg.0 ]
weight= 12 : state   7 [ ldloc.0 ]
weight= 79 : state  40 [ call ]
weight= 31 : state 191 [ ldarg.0 -> ldfld ]
weight= 31 : state 191 [ ldarg.0 -> ldfld ]
weight= 16 : state   4 [ ldarg.1 ]
weight= 65 : state 141 [ stelem ]
weight= 10 : state   3 [ ldarg.0 ]
weight= 12 : state   7 [ ldloc.0 ]
weight= 31 : state 111 [ stfld ]
weight= 19 : state  42 [ ret ]

Inline candidate is mostly loads and stores.  Multiplier increased to 3.
Inline candidate callsite is in a loop.  Multiplier increased to 6.
calleeNativeSizeEstimate=369
callsiteNativeSizeEstimate=115
benefit multiplier=6
threshold=690
Native estimate for function size is within threshold for inlining 36.9 <= 69 (multiplier = 6)
…
Successfully inlined Builder[Int64][System.Int64]:Add(long):this (42 IL bytes) (depth 1) [profitable inline]
--------------------------------------------------------------------------------------------

INLINER: during 'fgInline' result 'success' reason 'profitable inline' for 'Bench:Add():this' calling 'Builder[Int64][System.Int64]:Add(long):this'
INLINER: during 'fgInline' result 'success' reason 'profitable inline'

…

INLINER impTokenLookupContextHandle for Builder[Int64][System.Int64]:set_Item(int,long):this is 0x00007FF8B8698A39.
*************** In fgFindBasicBlocks() for Builder[Int64][System.Int64]:set_Item(int,long):this
weight= 16 : state   4 [ ldarg.1 ]
weight= 10 : state   3 [ ldarg.0 ]
weight= 79 : state  40 [ call ]
weight= 28 : state  50 [ blt.s ]
weight= 79 : state  40 [ call ]
weight= 31 : state 191 [ ldarg.0 -> ldfld ]
weight= 16 : state   4 [ ldarg.1 ]
weight= 35 : state   5 [ ldarg.2 ]
weight= 65 : state 141 [ stelem ]
weight= 19 : state  42 [ ret ]

Inline candidate callsite is in a loop.  Multiplier increased to 3.
calleeNativeSizeEstimate=378
callsiteNativeSizeEstimate=145
benefit multiplier=3
threshold=435
Native estimate for function size is within threshold for inlining 37.8 <= 43.5 (multiplier = 3)
…
Successfully inlined Builder[Int64][System.Int64]:set_Item(int,long):this (28 IL bytes) (depth 1) [profitable inline]
--------------------------------------------------------------------------------------------

INLINER: during 'fgInline' result 'success' reason 'profitable inline' for 'Bench:Indexer():this' calling 'Builder[Int64][System.Int64]:set_Item(int,long):this'
INLINER: during 'fgInline' result 'success' reason 'profitable inline'
```