### PR TITLE
Fix major System.Memory performance regression on .NET Framework x86

### DIFF
--- a/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
@@ -125,21 +125,21 @@ namespace System
             {
                 nLength -= 8;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
                     goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
                     goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
                     goto Found3;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 4))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4))
                     goto Found4;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 5))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5))
                     goto Found5;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 6))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6))
                     goto Found6;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
                     goto Found7;
 
                 index += 8;
@@ -149,13 +149,13 @@ namespace System
             {
                 nLength -= 4;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
                     goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
                     goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
                     goto Found3;
 
                 index += 4;
@@ -165,7 +165,7 @@ namespace System
             {
                 nLength -= 1;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
 
                 index += 1;
@@ -274,21 +274,21 @@ namespace System
                 nLength -= 8;
                 index -= 8;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
                     goto Found7;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 6))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6))
                     goto Found6;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 5))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5))
                     goto Found5;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 4))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4))
                     goto Found4;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
                     goto Found3;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
                     goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
                     goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
             }
 
@@ -297,13 +297,13 @@ namespace System
                 nLength -= 4;
                 index -= 4;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
                     goto Found3;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
                     goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
                     goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
             }
 
@@ -312,7 +312,7 @@ namespace System
                 nLength -= 1;
                 index -= 1;
 
-                if (uValue == Unsafe.Add(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
                     goto Found;
             }
 #if !netstandard11
@@ -384,28 +384,28 @@ namespace System
             {
                 nLength -= 8;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
 
@@ -416,16 +416,16 @@ namespace System
             {
                 nLength -= 4;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
 
@@ -436,7 +436,7 @@ namespace System
             {
                 nLength -= 1;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
 
@@ -519,28 +519,28 @@ namespace System
             {
                 nLength -= 8;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
 
@@ -551,16 +551,16 @@ namespace System
             {
                 nLength -= 4;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
 
@@ -571,7 +571,7 @@ namespace System
             {
                 nLength -= 1;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
 
@@ -658,28 +658,28 @@ namespace System
                 nLength -= 8;
                 index -= 8;
 
-                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
-                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -689,16 +689,16 @@ namespace System
                 nLength -= 4;
                 index -= 4;
 
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -708,7 +708,7 @@ namespace System
                 nLength -= 1;
                 index -= 1;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -788,28 +788,28 @@ namespace System
                 nLength -= 8;
                 index -= 8;
 
-                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
-                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -819,16 +819,16 @@ namespace System
                 nLength -= 4;
                 index -= 4;
 
-                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -838,7 +838,7 @@ namespace System
                 nLength -= 1;
                 index -= 1;
 
-                lookUp = Unsafe.Add(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }

--- a/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
@@ -885,44 +885,44 @@ namespace System
             if (Unsafe.AreSame(ref first, ref second))
                 goto Equal;
 
-            nuint i = 0;
-            nuint n = length;
+            IntPtr i = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr n = (IntPtr)(void*)length;
 
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && n >= (nuint)Vector<byte>.Count)
+            if (Vector.IsHardwareAccelerated && (byte*)n >= (byte*)Vector<byte>.Count)
             {
-                n -= (nuint)Vector<byte>.Count;
-                while (n > i)
+                n -= Vector<byte>.Count;
+                while ((byte*)n > (byte*)i)
                 {
                     if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
                         Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
-                    i += (nuint)Vector<byte>.Count;
+                    i += Vector<byte>.Count;
                 }
                 return Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, n)) ==
                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, n));
             }
 #endif
 
-            if (n >= (nuint)sizeof(UIntPtr))
+            if ((byte*)n >= (byte*)sizeof(UIntPtr))
             {
-                n -= (nuint)sizeof(UIntPtr);
-                while (n > i)
+                n -= sizeof(UIntPtr);
+                while ((byte*)n > (byte*)i)
                 {
                     if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
                         Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
-                    i += (nuint)sizeof(UIntPtr);
+                    i += sizeof(UIntPtr);
                 }
                 return Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, n)) ==
                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, n));
             }
 
-            while (n > i)
+            while ((byte*)n > (byte*)i)
             {
                 if (Unsafe.AddByteOffset(ref first, i) != Unsafe.AddByteOffset(ref second, i))
                     goto NotEqual;
@@ -967,45 +967,44 @@ namespace System
             if (Unsafe.AreSame(ref first, ref second))
                 goto Equal;
 
-            nuint minLength = (nuint)firstLength;
-            if (minLength > (nuint)secondLength) minLength = (nuint)secondLength;
+            IntPtr minLength = (IntPtr)((firstLength < secondLength) ? firstLength : secondLength);
 
-            nuint i = 0;
-            nuint n = minLength;
+            IntPtr i = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr n = (IntPtr)(void*)minLength;
 
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && n > (nuint)Vector<byte>.Count)
+            if (Vector.IsHardwareAccelerated && (byte*)n > (byte*)Vector<byte>.Count)
             {
-                n -= (nuint)Vector<byte>.Count;
-                while (n > i)
+                n -= Vector<byte>.Count;
+                while ((byte*)n > (byte*)i)
                 {
                     if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
                         Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
-                    i += (nuint)Vector<byte>.Count;
+                    i += Vector<byte>.Count;
                 }
                 goto NotEqual;
             }
 #endif
 
-            if (n > (nuint)sizeof(UIntPtr))
+            if ((byte*)n > (byte*)sizeof(UIntPtr))
             {
-                n -= (nuint)sizeof(UIntPtr);
-                while (n > i)
+                n -= sizeof(UIntPtr);
+                while ((byte*)n > (byte*)i)
                 {
                     if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
                         Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
-                    i += (nuint)sizeof(UIntPtr);
+                    i += sizeof(UIntPtr);
                 }
             }
 
         NotEqual:  // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            while (minLength > i)
+            while ((byte*)minLength > (byte*)i)
             {
                 int result = Unsafe.AddByteOffset(ref first, i).CompareTo(Unsafe.AddByteOffset(ref second, i));
                 if (result != 0) return result;

--- a/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
@@ -108,16 +108,13 @@ namespace System
             Debug.Assert(length >= 0);
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)(uint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -190,10 +187,7 @@ namespace System
 
                 if ((int)(byte*)index < length)
                 {
-                    unchecked
-                    {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
-                    }
+                    nLength = (IntPtr)(length - (int)(byte*)index);
                     goto SequentialScan;
                 }
             }
@@ -256,16 +250,13 @@ namespace System
             Debug.Assert(length >= 0);
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr index = (IntPtr)(uint)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)(uint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -366,16 +357,13 @@ namespace System
 
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)(uint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -467,10 +455,7 @@ namespace System
 
                 if ((int)(byte*)index < length)
                 {
-                    unchecked
-                    {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
-                    }
+                    nLength = (IntPtr)(length - (int)(byte*)index);
                     goto SequentialScan;
                 }
             }
@@ -501,16 +486,13 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)(uint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -606,10 +588,7 @@ namespace System
 
                 if ((int)(byte*)index < length)
                 {
-                    unchecked
-                    {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
-                    }
+                    nLength = (IntPtr)(length - (int)(byte*)index);
                     goto SequentialScan;
                 }
             }
@@ -639,16 +618,13 @@ namespace System
 
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr index = (IntPtr)(uint)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)(uint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -769,16 +745,13 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr index = (IntPtr)(uint)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)(uint)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                unchecked
-                {
-                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
-                }
+                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -903,7 +876,7 @@ namespace System
             if (Unsafe.AreSame(ref first, ref second))
                 goto Equal;
 
-            nuint i = (nuint)0; // Explicit conversion required for netfx (NUInt)
+            nuint i = 0;
             nuint n = length;
 
 #if !netstandard11
@@ -912,15 +885,15 @@ namespace System
                 n -= (nuint)Vector<byte>.Count;
                 while (n > i)
                 {
-                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, (IntPtr)i)) !=
-                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, (IntPtr)i)))
+                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
                     i += (nuint)Vector<byte>.Count;
                 }
-                return Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, (IntPtr)n)) ==
-                       Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, (IntPtr)n));
+                return Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, n)) ==
+                       Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, n));
             }
 #endif
 
@@ -929,20 +902,20 @@ namespace System
                 n -= (nuint)sizeof(UIntPtr);
                 while (n > i)
                 {
-                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, (IntPtr)i)) !=
-                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, (IntPtr)i)))
+                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
                     i += (nuint)sizeof(UIntPtr);
                 }
-                return Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, (IntPtr)n)) ==
-                       Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, (IntPtr)n));
+                return Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, n)) ==
+                       Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, n));
             }
 
             while (n > i)
             {
-                if (Unsafe.AddByteOffset(ref first, (IntPtr)i) != Unsafe.AddByteOffset(ref second, (IntPtr)i))
+                if (Unsafe.AddByteOffset(ref first, i) != Unsafe.AddByteOffset(ref second, i))
                     goto NotEqual;
                 i += 1;
             }
@@ -988,7 +961,7 @@ namespace System
             nuint minLength = (nuint)firstLength;
             if (minLength > (nuint)secondLength) minLength = (nuint)secondLength;
 
-            nuint i = (nuint)0;  // Explicit conversion required for netfx (NUInt)
+            nuint i = 0;
             nuint n = minLength;
 
 #if !netstandard11
@@ -997,8 +970,8 @@ namespace System
                 n -= (nuint)Vector<byte>.Count;
                 while (n > i)
                 {
-                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, (IntPtr)i)) !=
-                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, (IntPtr)i)))
+                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
@@ -1013,8 +986,8 @@ namespace System
                 n -= (nuint)sizeof(UIntPtr);
                 while (n > i)
                 {
-                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, (IntPtr)i)) !=
-                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, (IntPtr)i)))
+                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
                     {
                         goto NotEqual;
                     }
@@ -1025,7 +998,7 @@ namespace System
         NotEqual:  // Workaround for https://github.com/dotnet/coreclr/issues/13549
             while (minLength > i)
             {
-                int result = Unsafe.AddByteOffset(ref first, (IntPtr)i).CompareTo(Unsafe.AddByteOffset(ref second, (IntPtr)i));
+                int result = Unsafe.AddByteOffset(ref first, i).CompareTo(Unsafe.AddByteOffset(ref second, i));
                 if (result != 0) return result;
                 i += 1;
             }
@@ -1061,13 +1034,10 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundByte(ulong match)
         {
-            unchecked
-            {
-                // Flag least significant power of two bit
-                var powerOfTwoFlag = match ^ (match - 1);
-                // Shift all powers of two into the high byte and extract
-                return (int)((powerOfTwoFlag * XorPowerOfTwoToHighByte) >> 57);
-            }
+            // Flag least significant power of two bit
+            var powerOfTwoFlag = match ^ (match - 1);
+            // Shift all powers of two into the high byte and extract
+            return (int)((powerOfTwoFlag * XorPowerOfTwoToHighByte) >> 57);
         }
 #endif
 

--- a/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
@@ -109,12 +109,12 @@ namespace System
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            IntPtr nLength = (IntPtr)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -170,9 +170,11 @@ namespace System
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
             {
-                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+
                 // Get comparison Vector
                 Vector<byte> vComparison = GetVector(value);
+
                 while ((byte*)nLength > (byte*)index)
                 {
                     var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index)));
@@ -250,12 +252,12 @@ namespace System
             Debug.Assert(length >= 0);
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            IntPtr index = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
                 nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
@@ -307,12 +309,13 @@ namespace System
                     goto Found;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index > 0))
+            if (Vector.IsHardwareAccelerated && ((byte*)index > (byte*)0))
             {
-                nLength = (IntPtr)(uint)((uint)index & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((int)(byte*)index & ~(Vector<byte>.Count - 1));
 
                 // Get comparison Vector
                 Vector<byte> vComparison = GetVector(value);
+
                 while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
                 {
                     var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count)));
@@ -323,9 +326,9 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
                 }
-                if ((int)(byte*)index > 0)
+                if ((byte*)index > (byte*)0)
                 {
                     nLength = index;
                     goto SequentialScan;
@@ -358,12 +361,12 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            IntPtr nLength = (IntPtr)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -433,7 +436,8 @@ namespace System
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
             {
-                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
@@ -487,12 +491,12 @@ namespace System
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            IntPtr nLength = (IntPtr)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (nuint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif
@@ -562,11 +566,13 @@ namespace System
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
             {
-                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
                 Vector<byte> values2 = GetVector(value2);
+
                 while ((byte*)nLength > (byte*)index)
                 {
                     Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
@@ -618,12 +624,12 @@ namespace System
 
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            IntPtr index = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
                 nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
@@ -689,9 +695,10 @@ namespace System
                     goto Found;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index > 0))
+            if (Vector.IsHardwareAccelerated && ((byte*)index > (byte*)0))
             {
-                nLength = (IntPtr)(uint)((uint)index & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((int)(byte*)index & ~(Vector<byte>.Count - 1));
+
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
@@ -709,10 +716,10 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index > 0)
+                if ((byte*)index > (byte*)0)
                 {
                     nLength = index;
                     goto SequentialScan;
@@ -745,12 +752,12 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)(uint)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(uint)length;
+            IntPtr index = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)length;
 #if !netstandard11
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
                 nLength = (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
@@ -816,13 +823,15 @@ namespace System
                     goto Found;
             }
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index > 0))
+            if (Vector.IsHardwareAccelerated && ((byte*)index > (byte*)0))
             {
-                nLength = (IntPtr)(uint)((uint)index & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((int)(byte*)index & ~(Vector<byte>.Count - 1));
+
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
                 Vector<byte> values2 = GetVector(value2);
+
                 while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
                 {
                     Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
@@ -840,10 +849,10 @@ namespace System
                         continue;
                     }
                     // Find offset of first match
-                    return (int)(byte*)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index > 0)
+                if ((byte*)index > (byte*)0)
                 {
                     nLength = index;
                     goto SequentialScan;

--- a/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
@@ -496,7 +496,7 @@ namespace System
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
                 int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                nLength = (nuint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
             }
         SequentialScan:
 #endif

--- a/src/System.Memory/src/System/NUint.cs
+++ b/src/System.Memory/src/System/NUint.cs
@@ -23,6 +23,7 @@ namespace System
 
         public static explicit operator int(NUInt value) => (int)value._value;
         public static explicit operator uint(NUInt value) => (uint)value._value;
+        public static explicit operator void* (NUInt value) => value._value;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator *(NUInt left, uint right)

--- a/src/System.Memory/src/System/NUint.cs
+++ b/src/System.Memory/src/System/NUint.cs
@@ -9,81 +9,82 @@ namespace System
     //
     // A makeshift native uint type for build configurations that don't build 32/64-bit specific binaries (and hence, can't alias them to UInt32/UInt64 via an ifdef.)
     //
-    internal struct NUInt
+    internal unsafe struct NUInt
     {
-        private readonly UIntPtr _value;
+        private readonly void* _value;
 
-        private NUInt(int value) => _value = (UIntPtr)value;
-        private NUInt(uint value) => _value = (UIntPtr)value;
-        private NUInt(ulong value) => _value = (UIntPtr)value;
+        private NUInt(uint value) => _value = (void*)value;
+        private NUInt(ulong value) => _value = (void*)value;
 
-        public static explicit operator NUInt(uint value) => new NUInt(value);
-        public static explicit operator UIntPtr(NUInt value) => value._value;
+        public static implicit operator NUInt(uint value) => new NUInt(value);
+        public static implicit operator IntPtr(NUInt value) => (IntPtr)value._value;
 
-        public static explicit operator NUInt(int value) => new NUInt(value);
-        public static explicit operator IntPtr(NUInt value) => (IntPtr)(long)(ulong)value._value;
+        public static explicit operator NUInt(int value) => new NUInt((uint)value);
+
+        public static explicit operator int(NUInt value) => (int)value._value;
+        public static explicit operator uint(NUInt value) => (uint)value._value;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator *(NUInt left, int right)
+        public static NUInt operator *(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * (uint)right) : new NUInt(((ulong)left._value) * (uint)right); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * right) : new NUInt(((ulong)left._value) * right);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator +(NUInt left, int right)
+        public static NUInt operator +(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + (uint)right) : new NUInt(((ulong)left._value) + (uint)right); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + right) : new NUInt(((ulong)left._value) + right);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator -(NUInt left, int right)
+        public static NUInt operator -(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - (uint)right) : new NUInt(((ulong)left._value) - (uint)right); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - right) : new NUInt(((ulong)left._value) - right);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator *(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * (uint)right._value) : new NUInt(((ulong)left._value) * (ulong)right._value); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * (uint)right._value) : new NUInt(((ulong)left._value) * (ulong)right._value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator +(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + (uint)right._value) : new NUInt(((ulong)left._value) + (ulong)right._value); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + (uint)right._value) : new NUInt(((ulong)left._value) + (ulong)right._value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator -(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - (uint)right._value) : new NUInt(((ulong)left._value) - (ulong)right._value); }
+            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - (uint)right._value) : new NUInt(((ulong)left._value) - (ulong)right._value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >=(NUInt left, int right)
+        public static bool operator >=(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= (uint)right : ((ulong)left._value) >= (uint)right; }
+            return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= right : ((ulong)left._value) >= right;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <=(NUInt left, int right)
+        public static bool operator <=(NUInt left, uint right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= (uint)right : ((ulong)left._value) <= (uint)right; }
+            return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= right : ((ulong)left._value) <= right;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >(NUInt left, int right) => !(left <= right);
+        public static bool operator >(NUInt left, uint right) => !(left <= right);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <(NUInt left, int right) => !(left >= right);
+        public static bool operator <(NUInt left, uint right) => !(left >= right);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator <=(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= (uint)right._value : ((ulong)left._value) <= (ulong)right._value; }
+            return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= (uint)right._value : ((ulong)left._value) <= (ulong)right._value;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator >=(NUInt left, NUInt right)
         {
-            unsafe { return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= (uint)right._value : ((ulong)left._value) >= (ulong)right._value; }
+            return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= (uint)right._value : ((ulong)left._value) >= (ulong)right._value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -95,8 +96,8 @@ namespace System
         public static bool operator !=(NUInt left, NUInt right) => left._value != right._value;
 
         public override bool Equals(object obj) => obj is NUInt other && _value == other._value;
-        public override int GetHashCode() => _value.GetHashCode();
+        public override int GetHashCode() => new UIntPtr(_value).GetHashCode();
 
-        public override string ToString() => _value.ToString();
+        public override string ToString() => new UIntPtr(_value).ToString();
     }
 }

--- a/src/System.Memory/src/System/NUint.cs
+++ b/src/System.Memory/src/System/NUint.cs
@@ -9,6 +9,9 @@ namespace System
     //
     // A makeshift native uint type for build configurations that don't build 32/64-bit specific binaries (and hence, can't alias them to UInt32/UInt64 via an ifdef.)
     //
+    // Note that .NET Framework x86 JIT inliner is only capable of inlining of limited number of NUInt operations per method. Do not use this type heavily
+    // in code that needs to be fast on .NET Framework x86.
+    //
     internal unsafe struct NUInt
     {
         private readonly void* _value;
@@ -21,84 +24,12 @@ namespace System
 
         public static explicit operator NUInt(int value) => new NUInt((uint)value);
 
-        public static explicit operator int(NUInt value) => (int)value._value;
-        public static explicit operator uint(NUInt value) => (uint)value._value;
         public static explicit operator void* (NUInt value) => value._value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator *(NUInt left, uint right)
-        {
-            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * right) : new NUInt(((ulong)left._value) * right);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator +(NUInt left, uint right)
-        {
-            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + right) : new NUInt(((ulong)left._value) + right);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator -(NUInt left, uint right)
-        {
-            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - right) : new NUInt(((ulong)left._value) - right);
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NUInt operator *(NUInt left, NUInt right)
         {
             return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) * (uint)right._value) : new NUInt(((ulong)left._value) * (ulong)right._value);
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator +(NUInt left, NUInt right)
-        {
-            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) + (uint)right._value) : new NUInt(((ulong)left._value) + (ulong)right._value);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NUInt operator -(NUInt left, NUInt right)
-        {
-            return (sizeof(IntPtr) == 4) ? new NUInt(((uint)left._value) - (uint)right._value) : new NUInt(((ulong)left._value) - (ulong)right._value);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >=(NUInt left, uint right)
-        {
-            return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= right : ((ulong)left._value) >= right;
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <=(NUInt left, uint right)
-        {
-            return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= right : ((ulong)left._value) <= right;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >(NUInt left, uint right) => !(left <= right);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <(NUInt left, uint right) => !(left >= right);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <=(NUInt left, NUInt right)
-        {
-            return (sizeof(IntPtr) == 4) ? ((uint)left._value) <= (uint)right._value : ((ulong)left._value) <= (ulong)right._value;
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >=(NUInt left, NUInt right)
-        {
-            return (sizeof(IntPtr) == 4) ? ((uint)left._value) >= (uint)right._value : ((ulong)left._value) >= (ulong)right._value;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >(NUInt left, NUInt right) => !(left <= right);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <(NUInt left, NUInt right) => !(left >= right);
-
-        public static bool operator ==(NUInt left, NUInt right) => left._value == right._value;
-        public static bool operator !=(NUInt left, NUInt right) => left._value != right._value;
-
-        public override bool Equals(object obj) => obj is NUInt other && _value == other._value;
-        public override int GetHashCode() => new UIntPtr(_value).GetHashCode();
-
-        public override string ToString() => new UIntPtr(_value).ToString();
     }
 }


### PR DESCRIPTION
JIT on .NET Framework x86 can do only a limited amount of inlining of NUint operations per method. This caused a major performance regression in `Span.SequenceEqual<byte>` on .NET Framework x86.

This change is switching the implementation of `SequenceEqual<byte>` to use pointer-based arithmetic to fix this performance regression. Also included are related performance tweaks like using Unsafe.AddByteOffset instead of Unsafe.Add where possible.