### PR TITLE
Fixed netfx System.Xml.Linq.xNodeBuilder.Tests fails on non English Windows

### DIFF
--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Globalization;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions; 
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XmlDiff;
@@ -3418,8 +3419,9 @@ namespace CoreXml.Test.XLinq
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
                         if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
                         {
-                            string expectedMsg = "Cannot have ']]>' inside an XML CDATA block.";
-                            Assert.Equal(expectedMsg, exception.Message);
+                            Assert.True(Regex.IsMatch(exception.Message, @"[\p{Pi}\p{Po}]" + Regex.Escape("]]>") + @"[\p{Pf}\p{Po}]"));
+                            Assert.True(Regex.IsMatch(exception.Message, @"\b" + "XML" + @"\b"));
+                            Assert.True(Regex.IsMatch(exception.Message, @"\b" + "CDATA" + @"\b"));
                         }
                     }
                 }
@@ -3612,8 +3614,9 @@ namespace CoreXml.Test.XLinq
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
                         if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
                         {
-                            string expectedMsg = "An XML comment cannot contain '--', and '-' cannot be the last character.";
-                            Assert.Equal(expectedMsg, exception.Message);
+                            Assert.True(Regex.IsMatch(exception.Message, @"\b" + "XML" + @"\b"));
+                            Assert.True(Regex.IsMatch(exception.Message, @"[\p{Pi}\p{Po}]" + Regex.Escape("--") + @"[\p{Pf}\p{Po}]"));
+                            Assert.True(Regex.IsMatch(exception.Message, @"[\p{Pi}\p{Po}]" + Regex.Escape("-") + @"[\p{Pf}\p{Po}]"));
                         }
                     }
                 }
@@ -4215,8 +4218,8 @@ namespace CoreXml.Test.XLinq
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
                         if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
                         {
-                            string expectedMsg = "Cannot have '?>' inside an XML processing instruction.";
-                            Assert.Equal(expectedMsg, exception.Message);
+                            Assert.True(Regex.IsMatch(exception.Message, @"[\p{Pi}\p{Po}]" + Regex.Escape("?>") + @"[\p{Pf}\p{Po}]"));
+                            Assert.True(Regex.IsMatch(exception.Message, @"\b" + "XML" + @"\b"));
                         }
                     }
                 }

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -3419,6 +3419,9 @@ namespace CoreXml.Test.XLinq
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
                         if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
                         {
+                            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+                            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+                            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
                             Assert.True(Regex.IsMatch(exception.Message, @"[\p{Pi}\p{Po}]" + Regex.Escape("]]>") + @"[\p{Pf}\p{Po}]"));
                             Assert.True(Regex.IsMatch(exception.Message, @"\b" + "XML" + @"\b"));
                             Assert.True(Regex.IsMatch(exception.Message, @"\b" + "CDATA" + @"\b"));
@@ -3614,6 +3617,10 @@ namespace CoreXml.Test.XLinq
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
                         if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
                         {
+                            // \b word boundary
+                            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+                            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+                            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
                             Assert.True(Regex.IsMatch(exception.Message, @"\b" + "XML" + @"\b"));
                             Assert.True(Regex.IsMatch(exception.Message, @"[\p{Pi}\p{Po}]" + Regex.Escape("--") + @"[\p{Pf}\p{Po}]"));
                             Assert.True(Regex.IsMatch(exception.Message, @"[\p{Pi}\p{Po}]" + Regex.Escape("-") + @"[\p{Pf}\p{Po}]"));
@@ -4218,6 +4225,10 @@ namespace CoreXml.Test.XLinq
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
                         if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
                         {
+                            // \b word boundary
+                            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+                            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+                            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
                             Assert.True(Regex.IsMatch(exception.Message, @"[\p{Pi}\p{Po}]" + Regex.Escape("?>") + @"[\p{Pf}\p{Po}]"));
                             Assert.True(Regex.IsMatch(exception.Message, @"\b" + "XML" + @"\b"));
                         }


### PR DESCRIPTION
Fixed netfx System.Xml.Linq.xNodeBuilder.Tests fails on non English Windows. See https://github.com/dotnet/corefx/issues/28136