### PR TITLE
ImmutableArray<T>.Builder.Add splitted in fast- and cold-path

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -254,6 +254,8 @@ namespace System.Collections.Immutable
                 int count = _count;
                 T[] elements = _elements;
 
+                // PERF: The uint-casts allow the JIT to eliminate bound-checks.
+                // https://github.com/dotnet/coreclr/pull/9773
                 if ((uint)count < (uint)elements.Length)
                 {
                     elements[count] = item;
@@ -265,7 +267,7 @@ namespace System.Collections.Immutable
                 }
             }
 
-            // Improve code quality as uncommon path
+            // Specify NoInlining so that we are guaranteed an opportunity to service this method
             [MethodImpl(MethodImplOptions.NoInlining)]
             private void AddWithResize(T item)
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -247,7 +247,26 @@ namespace System.Collections.Immutable
             /// Adds an item to the <see cref="ICollection{T}"/>.
             /// </summary>
             /// <param name="item">The object to add to the <see cref="ICollection{T}"/>.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void Add(T item)
+            {
+                int count = _count;
+                T[] elements = _elements;
+
+                if ((uint)count < (uint)elements.Length)
+                {
+                    elements[count] = item;
+                    _count = count + 1;
+                }
+                else
+                {
+                    AddWithResize(item);
+                }
+            }
+
+            // Improve code quality as uncommon path
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private void AddWithResize(T item)
             {
                 int newCount = _count + 1;
                 this.EnsureCapacity(newCount);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Immutable
 {


### PR DESCRIPTION
# Description

Based on https://github.com/dotnet/corefx/pull/28177#discussion_r175290368
`Add` is split in a fast-path without resizing the array, and a cold-path that does the resize.
On the fast-path the bounds-check for the array-access is also eliminated.

# Benchmarks

Code for benchmarks is taken from [svick](https://github.com/svick/Benchmark/tree/66aed74)

`SimpleAdd` is the original code, i.e. before https://github.com/dotnet/corefx/pull/28177
`TweakedAdd` is code of https://github.com/dotnet/corefx/pull/28177
`SplitAdd` is code of this PR.

## win-x64

``` ini

BenchmarkDotNet=v0.10.11, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.309)
Processor=Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), ProcessorCount=8
Frequency=2742189 Hz, Resolution=364.6722 ns, Timer=TSC
.NET Core SDK=2.1.300-preview1-008174
  [Host]     : .NET Core 2.1.0-preview1-26216-03 (Framework 4.6.26216.04), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-preview1-26216-03 (Framework 4.6.26216.04), 64bit RyuJIT


```
|     Method |     Mean |     Error |    StdDev |
|----------- |---------:|----------:|----------:|
|  SimpleAdd | 4.192 us | 0.0240 us | 0.0213 us |
| TweakedAdd | 2.178 us | 0.0203 us | 0.0190 us |
|   SplitAdd | 1.950 us | 0.0140 us | 0.0124 us |

## linux-x64

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), ProcessorCount=4
.NET Core SDK=2.1.300-preview1-008174
  [Host]     : .NET Core 2.1.0-preview1-26216-03 (Framework 4.6.26216.04), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-preview1-26216-03 (Framework 4.6.26216.04), 64bit RyuJIT


```
|     Method |     Mean |     Error |    StdDev |   Median |
|----------- |---------:|----------:|----------:|---------:|
|  SimpleAdd | 4.823 us | 0.0891 us | 0.0790 us | 4.816 us |
| TweakedAdd | 2.547 us | 0.0521 us | 0.1318 us | 2.505 us |
|   SplitAdd | 2.232 us | 0.0434 us | 0.0426 us | 2.228 us |

## linux-x64 (different CPU)

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 17.10
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT


```
|     Method |     Mean |     Error |    StdDev |   Median |
|----------- |---------:|----------:|----------:|---------:|
|  SimpleAdd | 6.320 us | 0.1574 us | 0.2673 us | 6.182 us |
| TweakedAdd | 3.947 us | 0.0767 us | 0.0788 us | 3.933 us |
|   SplitAdd | 3.439 us | 0.2023 us | 0.2408 us | 3.306 us |

# Notes

In https://github.com/dotnet/corefx/pull/28177#discussion_r175297033 @svick reports that this change decreases perf on his machine. That's why I tested on three different machines, and all show a perf improvement. [List<T>.Add](https://github.com/dotnet/coreclr/blob/4e1ec7f1dfd70d1a84fcc3282add9bdf3be115e3/src/mscorlib/shared/System/Collections/Generic/List.cs#L238), [Stack<T>.Push](https://github.com/gfoidl/corefx/blob/36ae61031f94c7d92ce8750c088bfa640b5ccb1e/src/System.Collections/src/System/Collections/Generic/Stack.cs#L290) and similar classes use this pattern and all show an improvement.