### PR TITLE
Re-enable SocketsHttpHandler proxy test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2831,12 +2831,6 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(CredentialsForProxyNonRfcCompliant))]
         public async Task Proxy_BypassFalse_GetRequestGoesThroughCustomProxy_NonRfcCompliant(ICredentials creds, bool wrapCredsInCache)
         {
-            if (UseSocketsHttpHandler)
-            {
-                // TODO #23135: SocketsHttpHandler currently gets error "System.NotImplementedException : Basic auth: can't handle ':' in domain "dom:\ain""
-                return;
-            }
-
             await Proxy_BypassFalse_GetRequestGoesThroughCustomProxy_Implementation(creds, wrapCredsInCache);
         }
 


### PR DESCRIPTION
Closes https://github.com/dotnet/corefx/issues/23135
Fixed by https://github.com/dotnet/corefx/pull/28047
cc: @pjanotti 