### PR TITLE
Fix UTF32Encoding BOM being emitted by XmlWriter when ByteOrderMark set to false

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -171,6 +171,9 @@ namespace System.Xml
             _textContentMarks[0] = 1;
 
             _charEntityFallback = new CharEntityEncoderFallback();
+
+            ReadOnlySpan<byte> bom = encoding.Preamble;
+
             this.encoding = Encoding.GetEncoding(
                 settings.Encoding.CodePage,
                 _charEntityFallback,
@@ -180,7 +183,6 @@ namespace System.Xml
 
             if (!stream.CanSeek || stream.Position == 0)
             {
-                ReadOnlySpan<byte> bom = encoding.Preamble;
                 if (bom.Length != 0)
                 {
                     this.stream.Write(bom);

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -172,8 +172,10 @@ namespace System.Xml
 
             _charEntityFallback = new CharEntityEncoderFallback();
 
+            // grab bom before possibly changing encoding settings
             ReadOnlySpan<byte> bom = encoding.Preamble;
-
+            
+            // the encoding instance this creates can differ from the one passed in
             this.encoding = Encoding.GetEncoding(
                 settings.Encoding.CodePage,
                 _charEntityFallback,

--- a/src/System.Private.Xml/tests/XmlWriter/WriteWithEncoding.cs
+++ b/src/System.Private.Xml/tests/XmlWriter/WriteWithEncoding.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Xml.Xsl;
 using Xunit;
 
 namespace System.Xml.Tests
@@ -35,6 +37,42 @@ namespace System.Xml.Tests
             string s = settings.Encoding.GetString(bytes, 0, bytesCount);
 
             Assert.Equal("<orderID>1-456-ab&#x661;</orderID><orderID>2-36-00a&#x10000;&#x10401;</orderID>", s);
+        }
+
+        [Fact]
+        [Trait("MyTrait", "MyTraitValue")]
+        public void Should_Transform_Xml_String_And_Xsl_String_To_Result_String_With_Utf32Xml_Declaration()
+        {
+            // Given
+            var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<breakfast_menu>\n    <food>\n        <name>Belgian Waffles</name>\n        <price>$5.95</price>\n        <description>Two of our famous Belgian Waffles with plenty of real maple syrup</description>\n        <calories>650</calories>\n    </food>\n    <food>\n        <name>Strawberry Belgian Waffles</name>\n        <price>$7.95</price>\n        <description>Light Belgian waffles covered with strawberries and whipped cream</description>\n        <calories>900</calories>\n    </food>\n</breakfast_menu>";
+            var xsl = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<html xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" xsl:version=\"1.0\">\n    <body style=\"font-family:Arial;font-size:12pt;background-color:#EEEEEE\">\n        <xsl:for-each select=\"breakfast_menu/food\">\n            <div style=\"background-color:teal;color:white;padding:4px\">\n                <span style=\"font-weight:bold\">\n                    <xsl:value-of select=\"name\" />\n                    -\n                </span>\n                <xsl:value-of select=\"price\" />\n            </div>\n            <div style=\"margin-left:20px;margin-bottom:1em;font-size:10pt\">\n                <p>\n                    <xsl:value-of select=\"description\" />\n                    <span style=\"font-style:italic\">\n                        (\n                        <xsl:value-of select=\"calories\" />\n                        calories per serving)\n                    </span>\n                </p>\n            </div>\n        </xsl:for-each>\n    </body>\n</html>";
+            var settings = new XmlWriterSettings
+            {
+                Encoding = new UTF32Encoding(false, false, true)
+            };
+
+            string resultString;
+            using (TextReader xslReader = new StringReader(xsl),
+                           xmlReader = new StringReader(xml))
+            {
+                using (var result = new MemoryStream())
+                {
+                    var xslXmlReader = XmlReader.Create(xslReader);
+                    var xmlXmlReader = XmlReader.Create(xmlReader);
+                    var resultXmlTextWriter = XmlWriter.Create(result, settings);
+
+                    var xslTransform = new XslCompiledTransform();
+                    xslTransform.Load(xslXmlReader);
+                    xslTransform.Transform(xmlXmlReader, resultXmlTextWriter);
+                    result.Position = 0;
+                    resultString = settings.Encoding.GetString(result.ToArray());
+                }
+            }
+            // When
+            var result2 = string.Concat(resultString.Take(39));
+
+            // Then
+            Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-32\"?>", result2);
         }
     }
 }

--- a/src/System.Private.Xml/tests/XmlWriter/WriteWithEncoding.cs
+++ b/src/System.Private.Xml/tests/XmlWriter/WriteWithEncoding.cs
@@ -40,12 +40,13 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [Trait("MyTrait", "MyTraitValue")]
-        public void Should_Transform_Xml_String_And_Xsl_String_To_Result_String_With_Utf32Xml_Declaration()
+        public void WriteWithUtf32EncodingNoBom()
         {
             // Given
             var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<breakfast_menu>\n    <food>\n        <name>Belgian Waffles</name>\n        <price>$5.95</price>\n        <description>Two of our famous Belgian Waffles with plenty of real maple syrup</description>\n        <calories>650</calories>\n    </food>\n    <food>\n        <name>Strawberry Belgian Waffles</name>\n        <price>$7.95</price>\n        <description>Light Belgian waffles covered with strawberries and whipped cream</description>\n        <calories>900</calories>\n    </food>\n</breakfast_menu>";
             var xsl = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<html xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" xsl:version=\"1.0\">\n    <body style=\"font-family:Arial;font-size:12pt;background-color:#EEEEEE\">\n        <xsl:for-each select=\"breakfast_menu/food\">\n            <div style=\"background-color:teal;color:white;padding:4px\">\n                <span style=\"font-weight:bold\">\n                    <xsl:value-of select=\"name\" />\n                    -\n                </span>\n                <xsl:value-of select=\"price\" />\n            </div>\n            <div style=\"margin-left:20px;margin-bottom:1em;font-size:10pt\">\n                <p>\n                    <xsl:value-of select=\"description\" />\n                    <span style=\"font-style:italic\">\n                        (\n                        <xsl:value-of select=\"calories\" />\n                        calories per serving)\n                    </span>\n                </p>\n            </div>\n        </xsl:for-each>\n    </body>\n</html>";
+
+            // set encoding to UTF32 with no BOM
             var settings = new XmlWriterSettings
             {
                 Encoding = new UTF32Encoding(false, false, true)
@@ -53,14 +54,17 @@ namespace System.Xml.Tests
 
             string resultString;
             using (TextReader xslReader = new StringReader(xsl),
-                           xmlReader = new StringReader(xml))
+                              xmlReader = new StringReader(xml))
             {
                 using (var result = new MemoryStream())
                 {
                     var xslXmlReader = XmlReader.Create(xslReader);
                     var xmlXmlReader = XmlReader.Create(xmlReader);
+
+                    // BOM can be written in this call 
                     var resultXmlTextWriter = XmlWriter.Create(result, settings);
 
+                    // When, do work and get result
                     var xslTransform = new XslCompiledTransform();
                     xslTransform.Load(xslXmlReader);
                     xslTransform.Transform(xmlXmlReader, resultXmlTextWriter);
@@ -68,11 +72,9 @@ namespace System.Xml.Tests
                     resultString = settings.Encoding.GetString(result.ToArray());
                 }
             }
-            // When
-            var result2 = string.Concat(resultString.Take(39));
 
             // Then
-            Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-32\"?>", result2);
+            Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-32\"?>", string.Concat(resultString.Take(39)));
         }
     }
 }


### PR DESCRIPTION
As mentioned in #26544, the BOM is still being emitted by XmlWriter when the supplied UTF32Encoding instance has it disabled by setting ByteOrderMark, in the UTF32Encoding ctor, to false. This is due XmlWriter.Create(...) creating a new Encoding instance (with a FallbackEncoder) from the one supplied in XmlWriterSettings. However, it only uses the CodePage to create the new Encoding instance which initializes with the defaults. The default for ByteOrderMark in the UTF32Encoding class is true.

This fixes it by grabbing the BOM before creating a the new Encoding instance.

cc: @krwq @pjanotti 

Resolves #26544 