### PR TITLE
Restore EOF check in UDS test

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs
@@ -205,11 +205,14 @@ namespace System.Net.Sockets.Tests
 
                     Task clientReceives = Task.Run(async () =>
                     {
-                        int bytesRead;
                         byte[] buffer = new byte[readBufferSize];
-                        while (readData.Length < writeBuffer.Length)
+                        while (true)
                         {
-                            bytesRead = await client.ReceiveAsync(new ArraySegment<byte>(buffer), SocketFlags.None);
+                            int bytesRead = await client.ReceiveAsync(new Memory<byte>(buffer), SocketFlags.None);
+                            if (bytesRead == 0)
+                            {
+                                break;
+                            }
                             Assert.InRange(bytesRead, 1, writeBuffer.Length - readData.Length);
                             readData.Write(buffer, 0, bytesRead);
                         }


### PR DESCRIPTION
With a previous Windows build, support for Unix domain sockets had some issues regarding connection shutdown that caused Read{Async} to not properly return 0 when the connection was shut down, and so we changed a test to not rely on that.  Now that those issues have been fixed, I'm restoring the test to its original intent.

cc: @sunilmut, @eerhardt 