### PR TITLE
add proxy bypass list processing for windows

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -605,6 +605,7 @@
     <Reference Include="System.Diagnostics.Tracing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Memory" />
+    <Reference Include="System.Net.NetworkInformation" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Net.Security" />
     <Reference Include="System.Net.Sockets" />
@@ -622,6 +623,7 @@
     <Reference Include="System.Security.Principal.Windows" />
     <Reference Include="System.Text.Encoding" />
     <Reference Include="System.Text.Encoding.Extensions" />
+    <Reference Include="System.Text.RegularExpressions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Threading.Tasks" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -140,7 +140,7 @@ namespace System.Net.Http
             if (!string.IsNullOrWhiteSpace(bypassList))
             {
                 string[] list = bypassList.Split(',');
-                List<string> tmpList = new List<string>();
+                List<string> tmpList = new List<string>(list.Length);
 
                 foreach (string value in list)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -34,6 +34,7 @@ namespace System.Net.Http
             {
                 return false;
             }
+
             if (proxyHelper.AutoSettingsUsed)
             {
                 sessionHandle = Interop.WinHttp.WinHttpOpen(
@@ -42,12 +43,14 @@ namespace System.Net.Http
                     Interop.WinHttp.WINHTTP_NO_PROXY_NAME,
                     Interop.WinHttp.WINHTTP_NO_PROXY_BYPASS,
                     (int)Interop.WinHttp.WINHTTP_FLAG_ASYNC);
+
                 if (sessionHandle.IsInvalid)
                 {
                     // Proxy failures are currently ignored by managed handler.
                     return false;
                 }
             }
+
             proxy  = new HttpSystemProxy(proxyHelper, sessionHandle);
             return true;
         }
@@ -74,11 +77,13 @@ namespace System.Net.Http
                         {
                             continue;
                         }
+
                         if (tmp == "<local>")
                         {
                             _bypassLocal = true;
                             continue;
                         }
+
                         try
                         {
                             // Escape any special characters and unescape * to get wildcard pattern match.
@@ -95,6 +100,7 @@ namespace System.Net.Http
                         }
                     }
                 }
+
                 if (_bypassLocal)
                 {
                     _localIp =  new List<IPAddress>();
@@ -156,7 +162,7 @@ namespace System.Net.Http
         {
             if (_proxyHelper.ManualSettingsOnly)
             {
-                if ( _bypassLocal)
+                if (_bypassLocal)
                 {
                     IPAddress address = null;
 
@@ -166,6 +172,7 @@ namespace System.Net.Http
                         // Unfortunately this does not work for all local addresses.
                         return null;
                     }
+
                     if (uri.Host[0] == '[' || Char.IsNumber(uri.Host[0]))
                     {
                         // RFC1123 allows labels to start with number.
@@ -173,11 +180,12 @@ namespace System.Net.Http
                         // IPv6 [::1] notation. '[' is not valid character in names.
                         IPAddress.TryParse(uri.Host, out address);
                     }
+
                     if (address != null)
                     {
                         // Host is valid IP address.
                         // Check if it belongs to local system.
-                        foreach (var a in _localIp)
+                        foreach (IPAddress a in _localIp)
                         {
                             if (a.Equals(address))
                             {
@@ -185,10 +193,10 @@ namespace System.Net.Http
                             }
                         }
                     }
-                    else
+                    else if (uri.Host.IndexOf('.') == -1)
                     {
                         // Hosts without FQDN are considered local.
-                        if (uri.Host.IndexOf('.') == -1) return null;
+                        return null;
                     }
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -78,11 +78,11 @@ namespace System.Net.Http
                     {
                         // Strip leading spaces and scheme if any.
                         while (idx < proxyHelper.ProxyBypass.Length && proxyHelper.ProxyBypass[idx] == ' ') { idx += 1; };
-                        if (String.Compare(proxyHelper.ProxyBypass, idx, "http://", 0, 7, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Compare(proxyHelper.ProxyBypass, idx, "http://", 0, 7, StringComparison.OrdinalIgnoreCase) == 0)
                         {
                             idx += 7;
                         }
-                        else if (String.Compare(proxyHelper.ProxyBypass, idx, "https://", 0, 8, StringComparison.OrdinalIgnoreCase) == 0)
+                        else if (string.Compare(proxyHelper.ProxyBypass, idx, "https://", 0, 8, StringComparison.OrdinalIgnoreCase) == 0)
                         {
                             idx += 8;
                         }
@@ -101,7 +101,7 @@ namespace System.Net.Http
                             // Empty string.
                             tmp = null;
                         }
-                        else if (String.Compare(proxyHelper.ProxyBypass, start, "<local>", 0, 7, StringComparison.OrdinalIgnoreCase) == 0)
+                        else if (string.Compare(proxyHelper.ProxyBypass, start, "<local>", 0, 7, StringComparison.OrdinalIgnoreCase) == 0)
                         {
                             _bypassLocal = true;
                             tmp = null;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -13,10 +13,10 @@ namespace System.Net.Http
 {
     internal sealed class HttpSystemProxy : IWebProxy, IDisposable
     {
-        private readonly Uri _proxyUri;         // URI of the system proxy if set
-        private List<Regex> _bypass;            // list of domains not to proxy
-        private bool _bypassLocal = false;      // we should bypass domain considered local
-        private List<IPAddress> _localIp;
+        private readonly Uri _proxyUri;                 // URI of the system proxy if set
+        private readonly List<Regex> _bypass;           // list of domains not to proxy
+        private readonly bool _bypassLocal = false;     // we should bypass domain considered local
+        private readonly List<IPAddress> _localIp;
         private ICredentials _credentials;
         private readonly WinInetProxyHelper _proxyHelper;
         private SafeWinHttpHandle _sessionHandle;
@@ -65,7 +65,7 @@ namespace System.Net.Http
                 {
                     // Process bypass list for manual setting.
                     string[] list = proxyHelper.ProxyBypass.Split(';');
-                    _bypass = new List<Regex>();
+                    _bypass = new List<Regex>(list.Length);
 
                     foreach (string value in list)
                     {
@@ -90,7 +90,7 @@ namespace System.Net.Http
                         {
                             if (NetEventSource.IsEnabled)
                             {
-                                NetEventSource.Info(this, $"Failed to process {tmp} from bypass list.");
+                                NetEventSource.Info(this, "Failed to process " + tmp + " from bypass list.");
                             }
                         }
                     }
@@ -171,11 +171,7 @@ namespace System.Net.Http
                         // RFC1123 allows labels to start with number.
                         // Leading number may or may not be IP address.
                         // IPv6 [::1] notation. '[' is not valid character in names.
-                        try
-                        {
-                            address = IPAddress.Parse(uri.Host);
-                        }
-                        catch { };
+                        IPAddress.TryParse(uri.Host, out address);
                     }
                     if (address != null)
                     {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -81,7 +81,8 @@ namespace System.Net.Http
                         }
                         try
                         {
-                            Regex re = new Regex(tmp.Replace(".", "\\.").Replace("*", ".*?") + "$",
+                            // Escape any special characters and unescape * to get wildcard pattern match.
+                            Regex re = new Regex(Regex.Escape(tmp).Replace("\\*", ".*?") + "$",
                                             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
                             _bypass.Add(re);
                         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using System.Net.NetworkInformation;
 
 using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
 

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -78,5 +78,41 @@ namespace System.Net.Http.Tests
                 return SuccessExitCode;
            }, name, shouldBypass.ToString()).Dispose();
         }
+
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData(" ", 0)]
+        [InlineData(" ; ;  ", 0)]
+        [InlineData("http://127.0.0.1/", 1)]
+        [InlineData("[::]", 1)]
+        public void HttpProxy_Local_Parsing(string bypass, int count)
+        {
+            RemoteInvoke((bypassValue, expected) =>
+            {
+                int expectedCount = Convert.ToInt32(expected);
+                IWebProxy p;
+
+                FakeRegistry.Reset();
+                FakeRegistry.WinInetProxySettings.Proxy = FakeProxyString;
+                FakeRegistry.WinInetProxySettings.ProxyBypass = bypassValue;
+
+                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.NotNull(p);
+
+                HttpSystemProxy sp = p as HttpSystemProxy;
+                Assert.NotNull(sp);
+
+                if (expectedCount > 0)
+                {
+                    Assert.Equal(expectedCount, sp.BypassList.Count);
+                }
+                else
+                {
+                    Assert.Null(sp.BypassList);
+                }
+                return SuccessExitCode;
+           }, bypass, count.ToString()).Dispose();
+
+        }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -45,7 +45,6 @@ namespace System.Net.Http.Tests
         [InlineData("http://localhost/", true)]
         [InlineData("http://127.0.0.1/", true)]
         [InlineData("http://128.0.0.1/", false)]
-        [InlineData("http://10.37.129.2/", true)]
         [InlineData("http://[::1]/", true)]
         [InlineData("http://foo/", true)]
         [InlineData("http://www.foo.com/", true)]

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -56,6 +56,8 @@ namespace System.Net.Http.Tests
         [InlineData("http://[2002::11]/", true)]
         [InlineData("http://[2607:f8b0:4005:80a::200e]/", true)]
         [InlineData("http://[2607:f8B0:4005:80A::200E]/", true)]
+        [InlineData("http://b\u00e9b\u00e9.eu/", true)]
+        [InlineData("http://www.b\u00e9b\u00e9.eu/", true)]
         public void HttpProxy_Local_Bypassed(string name, bool shouldBypass)
         {
             RemoteInvoke((url, expected) =>
@@ -65,7 +67,7 @@ namespace System.Net.Http.Tests
 
                 FakeRegistry.Reset();
                 FakeRegistry.WinInetProxySettings.Proxy = FakeProxyString;
-                FakeRegistry.WinInetProxySettings.ProxyBypass = "23.23.86.44;*.foo.com;<local>;BAR.COM; ; 162*;[2002::11];[*:f8b0:4005:80a::200e]";
+                FakeRegistry.WinInetProxySettings.ProxyBypass = "23.23.86.44;*.foo.com;<local>;BAR.COM; ; 162*;[2002::11];[*:f8b0:4005:80a::200e]; http://www.xn--mnchhausen-9db.at;http://*.xn--bb-bjab.eu;http://xn--bb-bjab.eu;";
 
                 Assert.True(HttpSystemProxy.TryCreate(out p));
                 Assert.NotNull(p);

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -33,7 +33,6 @@ namespace System.Net.Http.Tests
             Assert.False(HttpSystemProxy.TryCreate(out p));
 
             FakeRegistry.WinInetProxySettings.Proxy = FakeProxyString;
-            WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
 
             Assert.True(HttpSystemProxy.TryCreate(out p));
             Assert.NotNull(p);
@@ -59,7 +58,6 @@ namespace System.Net.Http.Tests
         [InlineData("http://[2607:f8B0:4005:80A::200E]/", true)]
         public void HttpProxy_Local_Bypassed(string name, bool shouldBypass)
         {
-
             RemoteInvoke((url, expected) =>
             {
                 bool expectedResult = Boolean.Parse(expected);
@@ -68,7 +66,6 @@ namespace System.Net.Http.Tests
                 FakeRegistry.Reset();
                 FakeRegistry.WinInetProxySettings.Proxy = FakeProxyString;
                 FakeRegistry.WinInetProxySettings.ProxyBypass = "23.23.86.44;*.foo.com;<local>;BAR.COM; ; 162*;[2002::11];[*:f8b0:4005:80a::200e]";
-                WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
 
                 Assert.True(HttpSystemProxy.TryCreate(out p));
                 Assert.NotNull(p);

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -54,6 +54,9 @@ namespace System.Net.Http.Tests
         [InlineData("http://BAR.COM/", true)]
         [InlineData("http://162.1.1.1/", true)]
         [InlineData("http://[2a01:5b40:0:248::52]/", false)]
+        [InlineData("http://[2002::11]/", true)]
+        [InlineData("http://[2607:f8b0:4005:80a::200e]/", true)]
+        [InlineData("http://[2607:f8B0:4005:80A::200E]/", true)]
         public void HttpProxy_Local_Bypassed(string name, bool shouldBypass)
         {
 
@@ -64,7 +67,7 @@ namespace System.Net.Http.Tests
 
                 FakeRegistry.Reset();
                 FakeRegistry.WinInetProxySettings.Proxy = FakeProxyString;
-                FakeRegistry.WinInetProxySettings.ProxyBypass = "23.23.86.44;*.foo.com;<local>;BAR.COM; ; 162*";
+                FakeRegistry.WinInetProxySettings.ProxyBypass = "23.23.86.44;*.foo.com;<local>;BAR.COM; ; 162*;[2002::11];[*:f8b0:4005:80a::200e]";
                 WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
 
                 Assert.True(HttpSystemProxy.TryCreate(out p));


### PR DESCRIPTION
fixes #23150

This is last chunk for proxy configuration for HttpSocketHandler.
The functionality matches code provided by WinHttp team as well as my experiments and testing.
The pattern processing can possibly be compiled to single mega-match so we can do parallel processing but it does not seems necessary at the moment.
WinHttp does does process entries sequentially.