### PR TITLE
Restore ProjectN package consistency check

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -182,16 +182,10 @@
           SkipUnchangedFiles="true"/>
   </Target>
 
-<!--
-  
-  Disable this check until we get the CoreCLR and TFS versions of System.Private.CoreLib back in sync after recent breaking changes.
-  https://github.com/dotnet/corefx/issues/27619
-
   <Target Name="VerifyMatchingProjectNVersions"
           BeforeTargets="Build">
     <Error Condition="'$(ProjectNTfsExpectedPrerelease)' != '$(ProjectNTfsTestILCExpectedPrerelease)'" Text="The versions of ProjectN Targeting pack and TestILC have gone out of sync. Please make sure both of the prerelease versions on dependencies.props match." />
   </Target>
--->
 
   <Target Name="CopyTestILCToolsToTestHost"
           AfterTargets="RestorePackages"


### PR DESCRIPTION
Re-enable validation that ProjectN compiler and targeting pack are the same version. This was disabled while we worked to update System.Private.CoreLib with breaking public API changes.

Resolves https://github.com/dotnet/corefx/issues/27619