### PR TITLE
Adding tests for randomized hashing

### DIFF
--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -7,6 +7,8 @@
     <NoWarn>1718</NoWarn>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);uapaot</DefineConstants>
+    <!-- Please don't delete. We need App.config for netfx -->
+    <NETFxTestRunnerAppConfig>$(MSBuildProjectDirectory)\App.config</NETFxTestRunnerAppConfig>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
@@ -99,6 +101,7 @@
     <Compile Include="System\SByteTests.cs" />
     <Compile Include="System\SingleTests.cs" />
     <Compile Include="System\StackOverflowExceptionTests.cs" />
+    <Compile Include="System\StringGetHashCodeTests.cs" />
     <Compile Include="System\StringTests.cs" />
     <Compile Include="System\String.SplitTests.cs" />
     <Compile Include="System\SystemExceptionTests.cs" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -8,7 +8,7 @@
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);uapaot</DefineConstants>
     <!-- Please don't delete. We need App.config for netfx -->
-    <NETFxTestRunnerAppConfig>$(MSBuildProjectDirectory)\App.config</NETFxTestRunnerAppConfig>
+    <NETFxTestRunnerAppConfig Condition="'$(TargetGroup)' == 'netstandard'">$(MSBuildProjectDirectory)\App.config</NETFxTestRunnerAppConfig>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />

--- a/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
+++ b/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public class StringGetHashCodeTests : RemoteExecutorTestBase
+    {
+        /// <summary>
+        /// Ensure that hash codes are randomized by getting the hash in two processes
+        /// and confirming it is different (modulo possible values of int).
+        /// If the legacy hash codes are being returned, it will not be different.
+        /// </summary>
+        [Fact]
+        public void GetHashCodeWithStringComparer_UseSameStringInTwoProcesses_ReturnsDifferentHashCodes()
+        {
+            int parentHashCode, childHashCode;
+            foreach (var ComputeHashCode in HashCodeComputers())
+            {
+                parentHashCode = ComputeHashCode();
+                childHashCode = GetChildHashCode(ComputeHashCode, parentHashCode);
+                Assert.NotEqual(parentHashCode, childHashCode);
+            }
+        }
+
+        private static IEnumerable<Func<int>> HashCodeComputers()
+        {
+            return new Func<int>[]
+            {
+                () => { return StringComparer.CurrentCulture.GetHashCode("abc"); },
+                () => { return StringComparer.CurrentCultureIgnoreCase.GetHashCode("abc"); },
+                () => { return StringComparer.InvariantCulture.GetHashCode("abc"); },
+                () => { return StringComparer.InvariantCultureIgnoreCase.GetHashCode("abc"); },
+                () => { return StringComparer.Ordinal.GetHashCode("abc"); },
+                () => { return StringComparer.OrdinalIgnoreCase.GetHashCode("abc"); },
+                () => { return "abc".GetHashCode(); },
+                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreCase); },
+                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreKanaType); },
+                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreNonSpace); },
+                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreSymbols); },
+                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreWidth); },
+                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.None); },
+                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.Ordinal); },
+                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.OrdinalIgnoreCase); }
+            };
+        }
+
+        private int GetChildHashCode(Func<int> computeHash, int parentHashCode)
+        {
+            Func<int> computeChildHashRemote = () =>
+            {
+                using (RemoteInvokeHandle handle = RemoteInvoke(computeHash, new RemoteInvokeOptions { CheckExitCode = false }))
+                {
+                    handle.Process.WaitForExit();
+                    return handle.Process.ExitCode;
+                }
+            };
+
+            int childHashCode, timesTried = 0;
+            do
+            {
+                // very small chance the child and parent hashcode are the same. To further reduce chance of collision we try up to 3 times
+                childHashCode = computeChildHashRemote();
+                timesTried++;
+            } while (parentHashCode == childHashCode && timesTried < 3);
+
+            return childHashCode;
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
+++ b/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
@@ -16,54 +16,51 @@ namespace System.Tests
         /// and confirming it is different (modulo possible values of int).
         /// If the legacy hash codes are being returned, it will not be different.
         /// </summary>
-        [Fact]
-        public void GetHashCodeWithStringComparer_UseSameStringInTwoProcesses_ReturnsDifferentHashCodes()
+        [Theory]
+        [MemberData(nameof(GetHashCode_TestData))]
+        public void GetHashCodeWithStringComparer_UseSameStringInTwoProcesses_ReturnsDifferentHashCodes(int getHashCodeIndex)
         {
-            foreach (Func<int> ComputeHashCode in HashCodeComputers())
-            {
-                int parentHashCode = ComputeHashCode();
-                int childHashCode = GetChildHashCode(ComputeHashCode, parentHashCode);
-                Assert.NotEqual(parentHashCode, childHashCode);
-            }
-        }
-
-        private static IEnumerable<Func<int>> HashCodeComputers()
-        {
-            return new Func<int>[]
-            {
-                () => { return StringComparer.CurrentCulture.GetHashCode("abc"); },
-                () => { return StringComparer.CurrentCultureIgnoreCase.GetHashCode("abc"); },
-                () => { return StringComparer.InvariantCulture.GetHashCode("abc"); },
-                () => { return StringComparer.InvariantCultureIgnoreCase.GetHashCode("abc"); },
-                () => { return StringComparer.Ordinal.GetHashCode("abc"); },
-                () => { return StringComparer.OrdinalIgnoreCase.GetHashCode("abc"); },
-                () => { return "abc".GetHashCode(); },
-                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreCase); },
-                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreKanaType); },
-                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreNonSpace); },
-                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreSymbols); },
-                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreWidth); },
-                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.None); },
-                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.Ordinal); },
-                () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.OrdinalIgnoreCase); }
-            };
-        }
-
-        private int GetChildHashCode(Func<int> computeHash, int parentHashCode)
-        {
-            int childHashCode, timesTried = 0;
+            Func<string, string, int> method = (parentHash, i) => { return int.Parse(parentHash) != s_GetHashCodes[int.Parse(i)]() ? 0 : -1; };
+            int parentHashCode = s_GetHashCodes[getHashCodeIndex]();
+            int exitCode, timesTried = 0;
             do
             {
                 // very small chance the child and parent hashcode are the same. To further reduce chance of collision we try up to 3 times
-                using (RemoteInvokeHandle handle = RemoteInvoke(computeHash, new RemoteInvokeOptions { CheckExitCode = false }))
+                using (RemoteInvokeHandle handle = RemoteInvoke(method, parentHashCode.ToString(), getHashCodeIndex.ToString(), new RemoteInvokeOptions { CheckExitCode = false }))
                 {
                     handle.Process.WaitForExit();
-                    childHashCode = handle.Process.ExitCode;
+                    exitCode = handle.Process.ExitCode;
                 }
                 timesTried++;
-            } while (parentHashCode == childHashCode && timesTried < 3);
+            } while (exitCode != 0 && timesTried < 3);
 
-            return childHashCode;
+            Assert.Equal(0, exitCode);
         }
+
+        public static IEnumerable<object[]> GetHashCode_TestData()
+        {
+            for (int i = 0; i < s_GetHashCodes.Length; i++)
+            {
+                yield return new object[] { i };
+            }
+        }
+
+        private static readonly Func<int>[] s_GetHashCodes = {
+            () => { return StringComparer.CurrentCulture.GetHashCode("abc"); },
+            () => { return StringComparer.CurrentCultureIgnoreCase.GetHashCode("abc"); },
+            () => { return StringComparer.InvariantCulture.GetHashCode("abc"); },
+            () => { return StringComparer.InvariantCultureIgnoreCase.GetHashCode("abc"); },
+            () => { return StringComparer.Ordinal.GetHashCode("abc"); },
+            () => { return StringComparer.OrdinalIgnoreCase.GetHashCode("abc"); },
+            () => { return "abc".GetHashCode(); },
+            () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreCase); },
+            () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreKanaType); },
+            () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreNonSpace); },
+            () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreSymbols); },
+            () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.IgnoreWidth); },
+            () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.None); },
+            () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.Ordinal); },
+            () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.OrdinalIgnoreCase); }
+        };
     }
 }

--- a/src/System.Runtime/tests/app.config
+++ b/src/System.Runtime/tests/app.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- Please don't delete. This file needs to be enabled for netfx -->
+<configuration>
+  <runtime>
+    <developmentMode developerInstallation="true" />
+    <UseRandomizedStringHashAlgorithm enabled="1" />
+  </runtime>
+</configuration>


### PR DESCRIPTION
Adding tests for randomized hashing

Testing that hash code returned from GetHashCode() is randomized on String, StringComparer and CultureInfo classes.

Fixes #24466

cc: @danmosemsft @stephentoub 