### PR TITLE
Fix ParseRoundTripTime() breaks on some cultures

### DIFF
--- a/src/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.IO;
 using System.Text;
-using System.Globalization;
 
 namespace System.Net.NetworkInformation
 {

--- a/src/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Text;
+using System.Globalization;
 
 namespace System.Net.NetworkInformation
 {
@@ -88,7 +89,7 @@ namespace System.Net.NetworkInformation
             int msIndex = pingOutput.IndexOf("ms", afterTime);
             int numLength = msIndex - afterTime - 1;
             string timeSubstring = pingOutput.Substring(afterTime, numLength);
-            double parsedRtt = double.Parse(timeSubstring, System.Globalization.CultureInfo.InvariantCulture);
+            double parsedRtt = double.Parse(timeSubstring, CultureInfo.InvariantCulture);
             return (long)Math.Round(parsedRtt);
         }
     }

--- a/src/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -88,7 +88,7 @@ namespace System.Net.NetworkInformation
             int msIndex = pingOutput.IndexOf("ms", afterTime);
             int numLength = msIndex - afterTime - 1;
             string timeSubstring = pingOutput.Substring(afterTime, numLength);
-            double parsedRtt = double.Parse(timeSubstring);
+            double parsedRtt = double.Parse(timeSubstring, System.Globalization.CultureInfo.InvariantCulture);
             return (long)Math.Round(parsedRtt);
         }
     }


### PR DESCRIPTION
Using Ping.Ping().Send() and reading the RoundTripTime property breaks on some cultures (e.g. fr_FR) or returns wrong results (e.g. on de_DE).
Fix adds InvariantCulture to the parse methode responsible for converting the round trip time to the double type.