### PR TITLE
Improve Integrated Auth Failure message with SQL Server

### DIFF
--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -431,8 +431,7 @@
     <value>Failed to generate SSPI context.</value>
   </data>
   <data name="SQL_KerberosTicketMissingError" xml:space="preserve">
-    <value>Cannot access Kerberos ticket. Ensure Kerberos has been initialized with 'kinit'.</value>
-  </data>
+    <value>Cannot authenticate using Kerberos. Ensure Kerberos has been initialized on the client with 'kinit' and a Service Principal Name has been registered for the SQL Server to allow Kerberos authentication.</value>  </data>
   <data name="SQL_SqlServerBrowserNotAccessible" xml:space="preserve">
     <value>Cannot connect to SQL Server Browser. Ensure SQL Server Browser has been started.</value>
   </data>

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -431,7 +431,8 @@
     <value>Failed to generate SSPI context.</value>
   </data>
   <data name="SQL_KerberosTicketMissingError" xml:space="preserve">
-    <value>Cannot authenticate using Kerberos. Ensure Kerberos has been initialized on the client with 'kinit' and a Service Principal Name has been registered for the SQL Server to allow Kerberos authentication.</value>  </data>
+    <value>Cannot authenticate using Kerberos. Ensure Kerberos has been initialized on the client with 'kinit' and a Service Principal Name has been registered for the SQL Server to allow Kerberos authentication.</value>  
+  </data>
   <data name="SQL_SqlServerBrowserNotAccessible" xml:space="preserve">
     <value>Cannot connect to SQL Server Browser. Ensure SQL Server Browser has been started.</value>
   </data>


### PR DESCRIPTION
When an integrated auth failure occurs, then an error message pointing to running kinit is shown. Based on the experiences of Sql Ops Studio users, it seems like lot of customers don't have an SPN registered for the SQL Server to which they are trying to connect to, hence a Kerberos token for Sql Server cannot be generated correctly from the KDC and the authentication cannot be performed correctly. The error message should hint the users to check for both kinit command on the client side and to check the server configuration to make sure that an SPN is registered. 

Fixes https://github.com/dotnet/corefx/issues/25328