### PR TITLE
Improve support for URIs without hosts

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2019,7 +2019,7 @@ namespace System
                                         ((_flags & Flags.HasUnicode) != 0) &&
                                         ((_flags & Flags.HostUnicodeNormalized) == 0)) ? _originalUnicodeString : _string))
             {
-                // Cut trailing spaces in m_String
+                // Cut trailing spaces in _string
                 if (length > idx && UriHelper.IsLWS(pUriString[length - 1]))
                 {
                     --length;
@@ -2141,10 +2141,16 @@ namespace System
                         _flags |= Flags.AuthorityFound;
                         idx += 2;
                     }
+                    // There is no Authority component, save the Path index
+                    // Note: mailto is the only guy who is treated specially, should be not.
                     else if (_syntax.NotAny(UriSyntaxFlags.MailToLikeUri))
                     {
-                        // There is no Authority component, save the Path index
-                        // Note: mailto is the only guy who is treated specially, should be not.
+                        // By now we know the URI has no Authority, so if the URI must be normalized, initialize it without one.
+                        if (_iriParsing && (_flags & Flags.HasUnicode) != 0 && (_flags & Flags.HostUnicodeNormalized) == 0)
+                        {
+                            _string = _string.Substring(0, idx);
+                        }
+                        // Since there is no Authority, the path index is just the end of the scheme.
                         _flags |= ((Flags)idx | Flags.UnknownHostType);
                         return ParsingError.None;
                     }
@@ -2153,10 +2159,16 @@ namespace System
                 {
                     return ParsingError.BadAuthority;
                 }
+                // There is no Authority component, save the Path index
+                // mailto is treated specially.
                 else if (_syntax.NotAny(UriSyntaxFlags.MailToLikeUri))
                 {
-                    // There is no Authority component, save the Path index
-                    // mailto is treated specially.
+                    // By now we know the URI has no Authority, so if the URI must be normalized, initialize it without one.
+                    if (_iriParsing && (_flags & Flags.HasUnicode) != 0 && (_flags & Flags.HostUnicodeNormalized) == 0)
+                    {
+                        _string = _string.Substring(0, idx);
+                    }
+                    // Since there is no Authority, the path index is just the end of the scheme.
                     _flags |= ((Flags)idx | Flags.UnknownHostType);
                     return ParsingError.None;
                 }
@@ -3363,12 +3375,6 @@ namespace System
                     {
                         _string = _syntax.SchemeName + SchemeDelimiter;
                     }
-                }
-                
-                // If host is absent, uri is abnormal and relative as in RFC 3986 section 5.4.2
-                if (_info.Offset.Host == _info.Offset.Path)
-                {
-                    _string = _syntax.SchemeName + ":";
                 }
 
                 _info.Offset.Path = (ushort)_string.Length;

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2142,7 +2142,7 @@ namespace System
                         idx += 2;
                     }
                     // There is no Authority component, save the Path index
-                    // Note: mailto is the only guy who is treated specially, should be not.
+                    // Ideally we would treat mailto like any other URI, but for historical reasons we have to separate out its host parsing.
                     else if (_syntax.NotAny(UriSyntaxFlags.MailToLikeUri))
                     {
                         // By now we know the URI has no Authority, so if the URI must be normalized, initialize it without one.
@@ -2160,7 +2160,7 @@ namespace System
                     return ParsingError.BadAuthority;
                 }
                 // There is no Authority component, save the Path index
-                // mailto is treated specially.
+                // Ideally we would treat mailto like any other URI, but for historical reasons we have to separate out its host parsing.
                 else if (_syntax.NotAny(UriSyntaxFlags.MailToLikeUri))
                 {
                     // By now we know the URI has no Authority, so if the URI must be normalized, initialize it without one.

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -544,6 +544,7 @@ namespace System.PrivateUri.Tests
         [Theory]
         [InlineData(@"c:/path/with/unicode/ö/test.xml")]
         [InlineData(@"file://c:/path/with/unicode/ö/test.xml")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void Iri_WindowsPathWithUnicode_DoesRemoveScheme(string uriString)
         {
             var uri = new Uri(uriString);
@@ -555,6 +556,7 @@ namespace System.PrivateUri.Tests
         [InlineData("http:\u00E8")]
         [InlineData("%C3%A8")]
         [InlineData("\u00E8")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void Iri_RelativeUriCreation_ShouldNotNormalize(string uriString)
         {
             Uri href;

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -540,5 +540,29 @@ namespace System.PrivateUri.Tests
             Assert.Equal(authority, fileTwoSlashes.Authority); // Two slashes must be followed by an authority
             Assert.Equal(authority, fileFourSlashes.Authority); // More than three slashes looks like a UNC share
         }
+
+        [Theory]
+        [InlineData(@"c:/path/with/unicode/ö/test.xml")]
+        [InlineData(@"file://c:/path/with/unicode/ö/test.xml")]
+        public void Iri_WindowsPathWithUnicode_DoesRemoveScheme(string uriString)
+        {
+            var uri = new Uri(uriString);
+            Assert.False(uri.LocalPath.StartsWith("file:"));
+        }
+
+        [Theory]
+        public void Iri_RelativeUriCreation_ShouldNotNormalize()
+        {
+            Uri href;
+            Uri hrefAbsolute;
+            Uri baseIri = new Uri("http://www.contoso.com");
+            string[] iriTestData = { "http:%C3%A8", "http:\u00E8", "%C3%A8", "\u00E8" };
+            foreach (string iriToTest in iriTestData)
+            {
+                Assert.True(Uri.TryCreate(iriToTest, UriKind.RelativeOrAbsolute, out href));
+                Assert.True(Uri.TryCreate(baseIri, href, out hrefAbsolute));
+                Assert.Equal("http://www.contoso.com/\u00E8", hrefAbsolute.ToString());
+            }
+        }
     }
 }

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -551,18 +551,19 @@ namespace System.PrivateUri.Tests
         }
 
         [Theory]
-        public void Iri_RelativeUriCreation_ShouldNotNormalize()
+        [InlineData("http:%C3%A8")]
+        [InlineData("http:\u00E8")]
+        [InlineData("%C3%A8")]
+        [InlineData("\u00E8")]
+        public void Iri_RelativeUriCreation_ShouldNotNormalize(string uriString)
         {
             Uri href;
             Uri hrefAbsolute;
             Uri baseIri = new Uri("http://www.contoso.com");
-            string[] iriTestData = { "http:%C3%A8", "http:\u00E8", "%C3%A8", "\u00E8" };
-            foreach (string iriToTest in iriTestData)
-            {
-                Assert.True(Uri.TryCreate(iriToTest, UriKind.RelativeOrAbsolute, out href));
-                Assert.True(Uri.TryCreate(baseIri, href, out hrefAbsolute));
-                Assert.Equal("http://www.contoso.com/\u00E8", hrefAbsolute.ToString());
-            }
+
+            Assert.True(Uri.TryCreate(uriString, UriKind.RelativeOrAbsolute, out href));
+            Assert.True(Uri.TryCreate(baseIri, href, out hrefAbsolute));
+            Assert.Equal("http://www.contoso.com/%C3%A8", hrefAbsolute.AbsoluteUri);
         }
     }
 }


### PR DESCRIPTION
This change fixes a regression in `System.Uri` involving URIs that have no host. The change primarily impacts implicit file URIs and URIs with unknown schemes.

Behavior will change if both of the following are true:
- The URI contains Unicode characters
- The URI is an implicit file URI, or has an unknown scheme and no host

The change is just to revert #9542 and port a fix for the same issue from .NET Framework.

Fixes: #25632