### PR TITLE
Optimize the string-like Span APIs for OrdinalIgnoreCase (portable Span)

### DIFF
--- a/src/System.Memory/src/System/MemoryExtensions.Portable.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.Portable.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System
 {
@@ -40,8 +41,23 @@ namespace System
             {
                 return span.SequenceEqual<char>(value);
             }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                if (span.Length != value.Length)
+                    return false;
+                return EqualsOrdinalIgnoreCase(span, value);
+            }
 
             return span.ToString().Equals(value.ToString(), comparisonType);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool EqualsOrdinalIgnoreCase(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
+        {
+            Debug.Assert(span.Length == value.Length);
+            if (value.Length == 0)  // span.Length == value.Length == 0
+                return true;
+            return (CompareToOrdinalIgnoreCase(span, value) == 0);
         }
 
         /// <summary>
@@ -57,8 +73,58 @@ namespace System
             {
                 return span.SequenceCompareTo(value);
             }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                return CompareToOrdinalIgnoreCase(span, value);
+            }
 
             return string.Compare(span.ToString(), value.ToString(), comparisonType);
+        }
+
+        // Borrowed from https://github.com/dotnet/coreclr/blob/master/src/mscorlib/shared/System/Globalization/CompareInfo.cs#L539
+        private static unsafe int CompareToOrdinalIgnoreCase(ReadOnlySpan<char> strA, ReadOnlySpan<char> strB)
+        {
+            int length = Math.Min(strA.Length, strB.Length);
+            int range = length;
+
+            fixed (char* ap = &MemoryMarshal.GetReference(strA))
+            fixed (char* bp = &MemoryMarshal.GetReference(strB))
+            {
+                char* a = ap;
+                char* b = bp;
+
+                while (length != 0 && (*a <= 0x7F) && (*b <= 0x7F))
+                {
+                    int charA = *a;
+                    int charB = *b;
+
+                    if (charA == charB)
+                    {
+                        a++; b++;
+                        length--;
+                        continue;
+                    }
+
+                    // uppercase both chars - notice that we need just one compare per char
+                    if ((uint)(charA - 'a') <= 'z' - 'a') charA -= 0x20;
+                    if ((uint)(charB - 'a') <= 'z' - 'a') charB -= 0x20;
+
+                    // Return the (case-insensitive) difference between them.
+                    if (charA != charB)
+                        return charA - charB;
+
+                    // Next char
+                    a++; b++;
+                    length--;
+                }
+
+                if (length == 0)
+                    return strA.Length - strB.Length;
+
+                range -= length;
+
+                return string.Compare(strA.Slice(range).ToString(), strB.Slice(range).ToString(), StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         /// <summary>
@@ -175,6 +241,10 @@ namespace System
             {
                 return span.EndsWith<char>(value);
             }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                return value.Length <= span.Length && EqualsOrdinalIgnoreCase(span.Slice(span.Length - value.Length), value);
+            }
 
             string sourceString = span.ToString();
             string valueString = value.ToString();
@@ -192,6 +262,10 @@ namespace System
             if (comparisonType == StringComparison.Ordinal)
             {
                 return span.StartsWith<char>(value);
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                return value.Length <= span.Length && EqualsOrdinalIgnoreCase(span.Slice(0, value.Length), value);
             }
 
             string sourceString = span.ToString();

--- a/src/System.Memory/tests/ReadOnlySpan/CompareTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CompareTo.cs
@@ -115,9 +115,13 @@ namespace System.SpanTests
                     var secondSpan = new ReadOnlySpan<char>(second);
                     Assert.True(0 > firstSpan.CompareTo(secondSpan, StringComparison.Ordinal));
 
-                    Assert.Equal(
-                        string.Compare(firstSpan.ToString(), secondSpan.ToString(), StringComparison.OrdinalIgnoreCase),
-                        firstSpan.CompareTo(secondSpan, StringComparison.OrdinalIgnoreCase));
+                    Assert.True(0 != firstSpan.CompareTo(secondSpan, StringComparison.OrdinalIgnoreCase));
+                    // Due to differences in the implementation, the exact result of CompareTo will not necessarily match with string.Compare.
+                    // However, the sign will match, which is what defines correctness.
+                    Assert.True(
+                        string.Compare(firstSpan.ToString(), secondSpan.ToString(), StringComparison.OrdinalIgnoreCase) > 0 ==
+                        firstSpan.CompareTo(secondSpan, StringComparison.OrdinalIgnoreCase) > 0);
+
                     Assert.Equal(
                         string.Compare(firstSpan.ToString(), secondSpan.ToString(), StringComparison.CurrentCulture),
                         firstSpan.CompareTo(secondSpan, StringComparison.CurrentCulture));

--- a/src/System.Memory/tests/ReadOnlySpan/CompareTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CompareTo.cs
@@ -115,12 +115,11 @@ namespace System.SpanTests
                     var secondSpan = new ReadOnlySpan<char>(second);
                     Assert.True(0 > firstSpan.CompareTo(secondSpan, StringComparison.Ordinal));
 
-                    Assert.True(0 != firstSpan.CompareTo(secondSpan, StringComparison.OrdinalIgnoreCase));
                     // Due to differences in the implementation, the exact result of CompareTo will not necessarily match with string.Compare.
                     // However, the sign will match, which is what defines correctness.
-                    Assert.True(
-                        string.Compare(firstSpan.ToString(), secondSpan.ToString(), StringComparison.OrdinalIgnoreCase) > 0 ==
-                        firstSpan.CompareTo(secondSpan, StringComparison.OrdinalIgnoreCase) > 0);
+                    Assert.Equal(
+                        Math.Sign(string.Compare(firstSpan.ToString(), secondSpan.ToString(), StringComparison.OrdinalIgnoreCase)),
+                        Math.Sign(firstSpan.CompareTo(secondSpan, StringComparison.OrdinalIgnoreCase)));
 
                     Assert.Equal(
                         string.Compare(firstSpan.ToString(), secondSpan.ToString(), StringComparison.CurrentCulture),


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/27379

cc @KrzysztofCwalina, @jkotas, @tarekgh 

I was considering the following relatively naiive implementation of IndexOf for OrdinalIgnoreCase which performs better than allocating a string, in most cases, but could regress perf by up to 50% in the worst case:
`'aaa...aaa'.IndexOf('aaa...aaa€', StringComparison.OrdinalIgnoreCase)` which adds overhead without incrementing `i`

```C#
private static unsafe int IndexOfOrdinalIgnoreCase(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
{
    if (value.Length == 0) return 0;

    // Assuming changing case doesn't affect length
    if (value.Length > span.Length) return -1;

    int count = span.Length - value.Length + 1;
    int i = 0;

    uint charB = value[0];
    if (charB > 0x7F) goto StringAllocation;

    if ((charB - 'a') <= 'z' - 'a') charB -= 0x20;

    for (; i < count; i++)
    {
        uint charA = span[i];
        if (charA > 0x7F) goto StringAllocation;

        if ((charA - 'a') <= 'z' - 'a') charA -= 0x20;

        if (charA == charB)
        {
            int j = 1;
            for (; j < value.Length; j++)
            {
                charA = span[i + j];
                charB = value[j];

                if (charA > 0x7F || charB > 0x7F) goto StringAllocation;
                if (charA == charB) continue;

                // uppercase both chars
                if ((charA - 'a') <= 'z' - 'a') charA -= 0x20;
                if ((charB - 'a') <= 'z' - 'a') charB -= 0x20;
                if (charA != charB) break;
            }
            if (j == value.Length) return i;
        }
    }
    if (i == count) return -1;

StringAllocation:
    int result = span.Slice(i).ToString().IndexOf(value.ToString(), StringComparison.OrdinalIgnoreCase);
    return result == -1 ? result : result + i;
}
```