### PR TITLE
WIP: Enable TimesIncludeMillisecondPart on selected filesystems only

### DIFF
--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -16,6 +16,8 @@ namespace System.IO.Tests
         public abstract T GetExistingItem();
         public abstract T GetMissingItem();
 
+        public abstract string GetItemPath(T item);
+
         public abstract IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false);
 
         public class TimeFunction : Tuple<SetTime, GetTime, DateTimeKind>
@@ -80,8 +82,8 @@ namespace System.IO.Tests
                 {
                     DateTime time = function.Getter(item);
                     msec = time.Millisecond;
-                    if (msec != 0)
-                        break;
+                    // if (msec != 0)
+                    //    break;
 
                     // This case should only happen 1/1000 times, unless the OS/Filesystem does
                     // not support millisecond granularity.
@@ -92,7 +94,8 @@ namespace System.IO.Tests
                     // If it's the OS/Filesystem often returns 0 for the millisecond part, this may
                     // help prove it. This should only be written 1/1000 runs, unless the test is going to
                     // fail.
-                    Console.WriteLine($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")}");
+                    string driveFormat = new DriveInfo(GetItemPath(item)).DriveFormat;
+                    Console.WriteLine($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")} on {driveFormat}");
 
                     item = GetExistingItem(); // try a new file/directory
                 }

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -71,10 +71,13 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)] // OSX does not currently support millisec granularity
-        public void TimesIncludeMillisecondPart()
+        [PlatformSpecific(TestPlatforms.Linux)] // Windows tested below, and OSX does not currently support millisec granularity
+        public void TimesIncludeMillisecondPart_Linux()
         {
             T item = GetExistingItem();
+
+            string driveFormat = new DriveInfo(GetItemPath(item)).DriveFormat;
+
             Assert.All(TimeFunctions(), (function) =>
             {
                 var msec = 0;
@@ -82,7 +85,8 @@ namespace System.IO.Tests
                 {
                     DateTime time = function.Getter(item);
                     msec = time.Millisecond;
-                    // if (msec != 0)
+
+                    //if (msec != 0)
                     //    break;
 
                     // This case should only happen 1/1000 times, unless the OS/Filesystem does
@@ -94,9 +98,42 @@ namespace System.IO.Tests
                     // If it's the OS/Filesystem often returns 0 for the millisecond part, this may
                     // help prove it. This should only be written 1/1000 runs, unless the test is going to
                     // fail.
-                    string driveFormat = new DriveInfo(GetItemPath(item)).DriveFormat;
-                    Console.WriteLine($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")} on {driveFormat}");
-                    throw new Exception($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")} on {driveFormat}");
+                    //Console.WriteLine($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")}");
+                    Console.WriteLine($"## TimesIncludeMillisecondPart got a file time of {time.ToString("o")} on {driveFormat}");
+
+                    item = GetExistingItem(); // try a new file/directory
+                }
+
+                Assert.NotEqual(0, msec);
+            });
+        }
+
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Breaking out Windows as it passes no problem there
+        public void TimesIncludeMillisecondPart_Windows()
+        {
+            T item = GetExistingItem();
+            Assert.All(TimeFunctions(), (function) =>
+            {
+                var msec = 0;
+                for (int i = 0; i < 5; i++)
+                {
+                    DateTime time = function.Getter(item);
+                    msec = time.Millisecond;
+                    if (msec != 0)
+                        break;
+
+                    // This case should only happen 1/1000 times, unless the OS/Filesystem does
+                    // not support millisecond granularity.
+
+                    // If it's 1/1000, or low granularity, this may help:
+                    Thread.Sleep(1234);
+
+                    // If it's the OS/Filesystem often returns 0 for the millisecond part, this may
+                    // help prove it. This should only be written 1/1000 runs, unless the test is going to
+                    // fail.
+                    Console.WriteLine($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")}");
 
                     item = GetExistingItem(); // try a new file/directory
                 }

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -96,6 +96,7 @@ namespace System.IO.Tests
                     // fail.
                     string driveFormat = new DriveInfo(GetItemPath(item)).DriveFormat;
                     Console.WriteLine($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")} on {driveFormat}");
+                    throw new Exception($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")} on {driveFormat}");
 
                     item = GetExistingItem(); // try a new file/directory
                 }

--- a/src/System.IO.FileSystem/tests/Base/StaticGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/StaticGetSetTimes.cs
@@ -10,6 +10,8 @@ namespace System.IO.Tests
     {
         public override string GetMissingItem() => GetTestFilePath();
 
+        public override string GetItemPath(string item) => item;
+
         [Fact]
         public void NullPath_ThrowsArgumentNullException()
         {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -12,6 +12,8 @@ namespace System.IO.Tests
 
         public override DirectoryInfo GetMissingItem() => new DirectoryInfo(GetTestFilePath());
 
+        public override string GetItemPath(DirectoryInfo item) => item.FullName;
+
         public override void InvokeCreate(DirectoryInfo item) => item.Create();
 
         public override IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false)

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -19,6 +19,8 @@ namespace System.IO.Tests
 
         public override FileInfo GetMissingItem() => new FileInfo(GetTestFilePath());
 
+        public override string GetItemPath(FileInfo item) => item.FullName;
+
         public override void InvokeCreate(FileInfo item) => item.Create();
 
         public override IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false)


### PR DESCRIPTION
Use filesystem name to suppress the test failure