### PR TITLE
Fix wrong target type in UInt16Converter

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt16Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt16Converter.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(short);
+        internal override Type TargetType => typeof(ushort);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/tests/UInt16ConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/UInt16ConverterTests.cs
@@ -41,5 +41,12 @@ namespace System.ComponentModel.Tests
                 },
                 UInt16ConverterTests.s_converter);
         }
+
+        [Fact]
+        public static void ConvertFrom_InvalidValue_ExceptionMessageContainsTypeName()
+        {
+            Exception e = Assert.ThrowsAny<Exception>(() => s_converter.ConvertFrom("badvalue"));
+            Assert.Contains(typeof(ushort).Name, e.Message);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28195

@AlexGhiondea, I added a test for this specific case, but I'd suggest subsequently we refactor the tests to move most of the [Fact]s to the (abstract) base class, such that this test can be made to apply to other derived test classes as well, and other tests moved down as well to avoid the duplication.  The derived types would override various properties to customize how the base tests behave (e.g. what converter to use, the target type, etc.)