### PR TITLE
User Data Source to construct SPN when Dns lookup fails

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -350,9 +350,9 @@ namespace System.Data.SqlClient.SNI
             {
                 hostEntry = Dns.GetHostEntry(hostNameOrAddress);
             }
-            catch
+            catch (SocketException)
             {
-                // An exception can occur while resolving the hostname. We dont care about this exception.
+                // A SocketException can occur while resolving the hostname.
                 // We will fallback on using hostname from the connection string in the finally block
             }
             finally
@@ -360,7 +360,7 @@ namespace System.Data.SqlClient.SNI
                 // If the DNS lookup failed, then resort to using the user provided hostname to construct the SPN.
                 fullyQualifiedDomainName = hostEntry?.HostName ?? hostNameOrAddress;
             }
-            string serverSpn = $"{SqlServerSpnHeader}/{fullyQualifiedDomainName}";
+            string serverSpn = SqlServerSpnHeader + "/" + fullyQualifiedDomainName;
             if (!string.IsNullOrWhiteSpace(portOrInstanceName))
             {
                 serverSpn += ":" + portOrInstanceName;


### PR DESCRIPTION
While constructing the SPN for integrated Auth, SqlClient looksup the DNS name of the data source. This lookup doesn't always succeed. 
In case of a failure in Dns lookup, we should resort to using the hostname provided by the connection string to construct the SPN. This is in sync with the behavior of the native library the SqlClient uses on Windows. 
This was reported on SqlOpsStudio https://github.com/Microsoft/sqlopsstudio/issues/447 