### PR TITLE
Pass publish params to release publish build only

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -564,7 +564,8 @@
         "TreatWarningsAsErrors": "false"
       },
       "BuildParameters": {
-        "PB_ConfigurationGroup": "Release"
+        "PB_ConfigurationGroup": "Release",
+        "PB_PublishType": "myget-blob-versions-msdl"
       },
       "Definitions": [{
         "Name": "DotNet-Trusted-Publish",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -565,7 +565,7 @@
       },
       "BuildParameters": {
         "PB_ConfigurationGroup": "Release",
-        "PB_PublishType": "myget-blob-versions-msdl"
+        "PB_PublishType": "myget-blob-versions"
       },
       "Definitions": [{
         "Name": "DotNet-Trusted-Publish",


### PR DESCRIPTION
@MattGal PTAL - this would replace passing this parameter to all child builds through the pipebuild. We don't want to pass these params to the symbol publish build - those were disabled on purpose, as @mikem8361 has been publishing symbols manually.