### PR TITLE
Fix Console.CancelKeyPress deadlock

### DIFF
--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -688,68 +688,17 @@ namespace System
             Out.Write(value);
         }
 
-        private sealed class ControlCDelegateData
-        {
-            private readonly ConsoleSpecialKey _controlKey;
-            private readonly ConsoleCancelEventHandler _cancelCallbacks;
-
-            internal bool Cancel;
-            internal bool DelegateStarted;
-
-            internal ControlCDelegateData(ConsoleSpecialKey controlKey, ConsoleCancelEventHandler cancelCallbacks)
-            {
-                _controlKey = controlKey;
-                _cancelCallbacks = cancelCallbacks;
-            }
-
-            // This is the worker delegate that is called on the Threadpool thread to fire the actual events. It sets the DelegateStarted flag so
-            // the thread that queued the work to the threadpool knows it has started (since it does not want to block indefinitely on the task
-            // to start).
-            internal void HandleBreakEvent()
-            {
-                DelegateStarted = true;
-                var args = new ConsoleCancelEventArgs(_controlKey);
-                _cancelCallbacks(null, args);
-                Cancel = args.Cancel;
-            }
-        }
-
         internal static bool HandleBreakEvent(ConsoleSpecialKey controlKey)
         {
-            // The thread that this gets called back on has a very small stack on some systems. There is
-            // not enough space to handle a managed exception being caught and thrown. So, run a task
-            // on the threadpool for the actual event callback.
-
-            // To avoid the race condition between remove handler and raising the event
-            ConsoleCancelEventHandler cancelCallbacks = Console._cancelCallbacks;
-            if (cancelCallbacks == null)
+            ConsoleCancelEventHandler handler = _cancelCallbacks;
+            if (handler == null)
             {
                 return false;
             }
 
-            var delegateData = new ControlCDelegateData(controlKey, cancelCallbacks);
-            Task callBackTask = Task.Factory.StartNew(
-                d => ((ControlCDelegateData)d).HandleBreakEvent(),
-                delegateData,
-                CancellationToken.None,
-                TaskCreationOptions.DenyChildAttach,
-                TaskScheduler.Default);
-
-            // Block until the delegate is done. We need to be robust in the face of the task not executing
-            // but we also want to get control back immediately after it is done and we don't want to give the
-            // handler a fixed time limit in case it needs to display UI. Wait on the task twice, once with a
-            // timeout and a second time without if we are sure that the handler actually started.
-            TimeSpan controlCWaitTime = new TimeSpan(0, 0, 30); // 30 seconds
-            callBackTask.Wait(controlCWaitTime);
-            
-            if (!delegateData.DelegateStarted)
-            {
-                Debug.Assert(false, "The task to execute the handler did not start within 30 seconds.");
-                return false;
-            }
-
-            callBackTask.Wait();
-            return delegateData.Cancel;
+            var args = new ConsoleCancelEventArgs(controlKey);
+            handler(null, args);
+            return args.Cancel;
         }
     }
 }


### PR DESCRIPTION
If the CancelKeyPress handler tries to unregister itself, it can deadlock on Windows.  This is because there's a lock that's held by Windows while invoking the callback, and the .NET logic for handling that callback is queueing the actual user callback to run on a ThreadPool thread and is then blocking waiting for that queued work to complete.  So the calling thread that holds a lock is blocked waiting for another thread to run the user callback.  If that user callback then tries to unregister the callback, it ends up trying to take the same lock that's already held by the other thread, and we deadlock.

The simple fix is to stop queueing the work item and to just run it on the same thread.  The code that does the queueing goes back over a decade, and was added during a phase where we were trying to ensure there was a ton of stack space available, but a) even then there were hundreds of kb of stack space available, which is plenty, and b) that effort was abandoned.

(There is a small risk here for a corner case.  The code currently has a timeout, where if the queued work item hasn't completed within 30 seconds, it unblocks the calling thread (but leaves the queued work item running indefinitely).  With this change, we no longer have the work item and thus no longer have the timeout, but it is theoretically conceivable that someone somewhere was relying on the 30 second timeout.)

I unfortunately couldn't come up with a good way to write a test for this in xunit, so I verified the fix manually.

Fixes https://github.com/dotnet/corefx/issues/26043
cc: @danmosemsft, @Maxim-Kornilov 