### PR TITLE
[Arm64/Ubuntu] Rework official build flow to support bootstrapping

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -163,7 +163,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build.sh",
+      "displayName": "Run build-native.sh",
       "timeoutInMinutes": 0,
       "refName": "Task9",
       "task": {
@@ -173,7 +173,47 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run -e ROOTFS_DIR $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
+        "arguments": "run -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-native.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildNativeArguments)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run build-managed.sh",
+      "timeoutInMinutes": 0,
+      "refName": "Task10",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-managed.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildManagedArguments)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run build-packages.sh",
+      "timeoutInMinutes": 0,
+      "refName": "Task11",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-packages.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildPackagesArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -185,7 +225,7 @@
       "alwaysRun": false,
       "displayName": "Run publish-packages.sh",
       "timeoutInMinutes": 0,
-      "refName": "Task10",
+      "refName": "Task12",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -252,7 +292,7 @@
       "displayName": "Cleanup Docker",
       "timeoutInMinutes": 0,
       "condition": "always()",
-      "refName": "Task12",
+      "refName": "Task14",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -273,7 +313,7 @@
       "displayName": "Cleanup VSTS Agent",
       "timeoutInMinutes": 0,
       "condition": "always()",
-      "refName": "Task13",
+      "refName": "Task15",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -335,6 +375,15 @@
     },
     "PB_BuildArguments": {
       "value": "-BuildArch=$(PB_Architecture)"
+    },
+    "PB_BuildNativeArguments": {
+      "value": "$(PB_BuildArguments)"
+    },
+    "PB_BuildManagedArguments": {
+      "value": "$(PB_BuildArguments)"
+    },
+    "PB_BuildPackagesArguments": {
+      "value": "$(PB_BuildArguments)"
     },
     "PB_CleanAgent": {
       "value": "true"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -79,7 +79,8 @@
             "PB_DockerTag": "ubuntu-16.04-cross-arm64-a3ae44b-20180315221921",
             "PB_Architecture": "arm64",
             "PB_BuildArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -stripSymbols -- /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)"
+            "PB_BuildManagedArguments": "-BuildPackages=false -buildArch=x64 -$(PB_ConfigurationGroup) -stripSymbols -- /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_SyncArguments": "-p -BuildTests=false -- /p:ArchGroup=arm64 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)"
           },
           "ReportingParameters": {
             "OperatingSystem": "Linux",


### PR DESCRIPTION
@mmitche @weshaggard @janvorli @stephentoub PTAL

I was concerned the `buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json` wouldn't work for arm64.  I took a detailed look and I think I understood it enough to be certain it wouldn't work for arm64.  

I manually built arm64 corefx packages.  Using this process so it should be close.

The primary impact of this patch is that 
```
./build.sh              $(PB_BuildArguments)
```
becomes
```
./build-native.sh       $(PB_BuildNativeArguments)
./build-managed.sh      $(PB_BuildManagedArguments)
./build-packages.sh     $(PB_BuildPackagesArguments)
```
This allows cross bootstrapped builds by allowing the managed build to be built against x64.

The original draft of the patch added a new file 
`DotNet-CoreFx-Trusted-Linux-Crossbuild-Bootstrap.json`, but this shared approach seemed better.

I will also update #28280 to use a similar flow and build all the way to packages.