### PR TITLE
Don't skip blocks passed end and simplify the Seek implementation.

### DIFF
--- a/src/System.Memory/src/System/Buffers/ArrayMemoryPool.ArrayMemoryPoolBuffer.cs
+++ b/src/System.Memory/src/System/Buffers/ArrayMemoryPool.ArrayMemoryPoolBuffer.cs
@@ -52,9 +52,10 @@ namespace System.Buffers
                 }
             }
 
+            // TryGetArray is exposed as "protected internal". Normally, the rules of C# dictate we override it as "protected" because the base class is
+            // in a different assembly. Except in the netstandard config where the base class is in the same assembly.
             protected
-#if netstandard // TryGetArray is exposed as "protected internal". Normally, the rules of C# dictate we override it as "protected" because the base class is
-                // in a different assembly. Except in the netstandard config where the base class is in the same assembly.
+#if netstandard  
             internal
 #endif
             sealed override bool TryGetArray(out ArraySegment<T> arraySegment)
@@ -96,8 +97,10 @@ namespace System.Buffers
                 while (true)
                 {
                     int currentCount = Volatile.Read(ref _refCount);
-                    if (currentCount <= 0) ThrowHelper.ThrowObjectDisposedException_ArrayMemoryPoolBuffer();
-                    if (Interlocked.CompareExchange(ref _refCount, currentCount + 1, currentCount) == currentCount) break;
+                    if (currentCount <= 0)
+                        ThrowHelper.ThrowObjectDisposedException_ArrayMemoryPoolBuffer();
+                    if (Interlocked.CompareExchange(ref _refCount, currentCount + 1, currentCount) == currentCount)
+                        break;
                 }
             }
 
@@ -106,7 +109,8 @@ namespace System.Buffers
                 while (true)
                 {
                     int currentCount = Volatile.Read(ref _refCount);
-                    if (currentCount <= 0) ThrowHelper.ThrowObjectDisposedException_ArrayMemoryPoolBuffer();
+                    if (currentCount <= 0)
+                        ThrowHelper.ThrowObjectDisposedException_ArrayMemoryPoolBuffer();
                     if (Interlocked.CompareExchange(ref _refCount, currentCount - 1, currentCount) == currentCount)
                     {
                         if (currentCount == 1)

--- a/src/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
+++ b/src/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
@@ -25,6 +25,6 @@ namespace System.Buffers
             return new ArrayMemoryPoolBuffer(minimumBufferSize);
         }
 
-        protected sealed override void Dispose(bool disposing) {}  // ArrayMemoryPool is a shared pool so Dispose() would be a nop even if there were native resources to dispose.
+        protected sealed override void Dispose(bool disposing) { }  // ArrayMemoryPool is a shared pool so Dispose() would be a nop even if there were native resources to dispose.
     }
 }

--- a/src/System.Memory/src/System/Buffers/MemoryPool.cs
+++ b/src/System.Memory/src/System/Buffers/MemoryPool.cs
@@ -30,7 +30,7 @@ namespace System.Buffers
         /// <summary>
         /// Constructs a new instance of a memory pool.
         /// </summary>
-        protected MemoryPool() {}
+        protected MemoryPool() { }
 
         /// <summary>
         /// Frees all resources used by the memory pool.

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -20,10 +20,11 @@ namespace System.Buffers
         /// Returns empty <see cref="ReadOnlySequence{T}"/>
         /// </summary>
 #if FEATURE_PORTABLE_SPAN
-        public static readonly ReadOnlySequence<T> Empty = new ReadOnlySequence<T>(SpanHelpers.PerTypeValues<T>.EmptyArray); 
+        public static readonly ReadOnlySequence<T> Empty = new ReadOnlySequence<T>(SpanHelpers.PerTypeValues<T>.EmptyArray);
 #else
-        public static readonly ReadOnlySequence<T> Empty = new ReadOnlySequence<T>(Array.Empty<T>()); 
+        public static readonly ReadOnlySequence<T> Empty = new ReadOnlySequence<T>(Array.Empty<T>());
 #endif // FEATURE_PORTABLE_SPAN 
+
         /// <summary>
         /// Length of the <see cref="ReadOnlySequence{T}"/>.
         /// </summary>

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -177,41 +177,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, int count)
-        {
-            GetTypeAndIndices(start.GetInteger(), end.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);
-
-            object startObject = start.GetObject();
-            object endObject = end.GetObject();
-
-            bool notInRange = endIndex - startIndex < count;
-            if (type == SequenceType.MultiSegment && startObject != endObject)
-            {
-                Debug.Assert(startObject is ReadOnlySequenceSegment<T>);
-                var startSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject);
-
-                int currentLength = startSegment.Memory.Length - startIndex;
-                if (currentLength > count)
-                {
-                    // Position in start segment, defer to single segment seek
-                    notInRange = false;
-                }
-                else
-                {
-                    return SeekMultiSegment(startSegment, startIndex, endObject, endIndex, count - currentLength);
-                }
-            }
-            else
-            {
-                Debug.Assert(startObject == endObject);
-            }
-
-            if (notInRange)
-                ThrowHelper.ThrowArgumentOutOfRangeException_CountOutOfRange();
-
-            // Single segment Seek
-            return new SequencePosition(startObject, startIndex + count);
-        }
+        internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, int count) => Seek(start, end, (long)count);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, long count)
@@ -221,32 +187,28 @@ namespace System.Buffers
             object startObject = start.GetObject();
             object endObject = end.GetObject();
 
-            bool notInRange = endIndex - startIndex < count;
             if (type == SequenceType.MultiSegment && startObject != endObject)
             {
                 Debug.Assert(startObject is ReadOnlySequenceSegment<T>);
                 var startSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject);
 
                 int currentLength = startSegment.Memory.Length - startIndex;
+                
+                // Position in start segment, defer to single segment seek
                 if (currentLength > count)
-                {
-                    // Position in start segment, defer to single segment seek
-                    notInRange = false;
-                }
-                else
-                {
-                    return SeekMultiSegment(startSegment, startIndex, endObject, endIndex, count - currentLength);
-                }
-            }
-            else
-            {
-                Debug.Assert(startObject == endObject);
+                    goto IsSingleSegment;
+
+                // End of segment. Move to start of next.
+                return SeekMultiSegment(startSegment.Next, startIndex, endObject, endIndex, count - currentLength);
             }
 
-            if (notInRange)
+            Debug.Assert(startObject == endObject);
+
+            if (endIndex - startIndex < count)
                 ThrowHelper.ThrowArgumentOutOfRangeException_CountOutOfRange();
 
             // Single segment Seek
+        IsSingleSegment:
             return new SequencePosition(startObject, startIndex + (int)count);
         }
 
@@ -254,33 +216,23 @@ namespace System.Buffers
         private static SequencePosition SeekMultiSegment(ReadOnlySequenceSegment<T> currentSegment, int startIndex, object endObject, int endPosition, long count)
         {
             Debug.Assert(currentSegment != null);
-            Debug.Assert(currentSegment.Next != null);
             Debug.Assert(count >= 0);
 
-            // End of segment. Move to start of next.
-            currentSegment = currentSegment.Next;
-
-            if (count > 0 || currentSegment.Memory.Length == 0)
+            while (currentSegment != null && currentSegment != endObject)
             {
-                while (currentSegment != null)
-                {
-                    bool isCurrentAtEnd = currentSegment == endObject;
-                    int memoryLength = isCurrentAtEnd ? endPosition : currentSegment.Memory.Length;
+                int memoryLength = currentSegment.Memory.Length;
 
-                    if (memoryLength > count || (memoryLength == count && isCurrentAtEnd))
-                    {
-                        // Fully contained in this segment; or at end of segment but there isn't a next one to move to
-                        break;
-                    }
+                // Fully contained in this segment; or at end of segment but there isn't a next one to move to
+                if (memoryLength > count)
+                    break;
 
-                    // Move to next
-                    count -= memoryLength;
-                    currentSegment = currentSegment.Next;
-                }
+                // Move to next
+                count -= memoryLength;
+                currentSegment = currentSegment.Next;
             }
 
             // Hit the end of the segments but didn't reach the count
-            if (currentSegment == null)
+            if (currentSegment == null || (currentSegment == endObject && endPosition < count))
                 ThrowHelper.ThrowArgumentOutOfRangeException_CountOutOfRange();
 
             return new SequencePosition(currentSegment, (int)count);

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -224,7 +224,7 @@ namespace System.Buffers
 
                 // Fully contained in this segment
                 if (memoryLength > count)
-                    break;
+                    goto FoundSegment;
 
                 // Move to next
                 count -= memoryLength;
@@ -234,7 +234,8 @@ namespace System.Buffers
             // Hit the end of the segments but didn't reach the count
             if (currentSegment == null || (currentSegment == endObject && endPosition < count))
                 ThrowHelper.ThrowArgumentOutOfRangeException_CountOutOfRange();
-
+        
+        FoundSegment:
             return new SequencePosition(currentSegment, (int)count);
         }
 

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -222,7 +222,7 @@ namespace System.Buffers
             {
                 int memoryLength = currentSegment.Memory.Length;
 
-                // Fully contained in this segment; or at end of segment but there isn't a next one to move to
+                // Fully contained in this segment
                 if (memoryLength > count)
                     break;
 

--- a/src/System.Memory/src/System/SequencePosition.cs
+++ b/src/System.Memory/src/System/SequencePosition.cs
@@ -40,7 +40,7 @@ namespace System
         /// <summary>
         /// Returns true if left and right point at the same segment and have the same index.
         /// </summary>
-        public static bool operator ==(SequencePosition left, SequencePosition right) => left._integer== right._integer && left._object == right._object;
+        public static bool operator ==(SequencePosition left, SequencePosition right) => left._integer == right._integer && left._object == right._object;
 
         /// <summary>
         /// Returns true if left and right do not point at the same segment and have the same index.

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
@@ -82,7 +82,7 @@ namespace System.Memory.Tests
         [MemberData(nameof(ValidSliceCases))]
         public void Slice_Works(Func<ReadOnlySequence<byte>, ReadOnlySequence<byte>> func)
         {
-            ReadOnlySequence<byte> buffer = Factory.CreateWithContent(new byte[] { 0, 1, 2 ,3 ,4, 5, 6, 7, 8, 9 });
+            ReadOnlySequence<byte> buffer = Factory.CreateWithContent(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
             ReadOnlySequence<byte> slice = func(buffer);
             Assert.Equal(new byte[] { 5, 6, 7, 8, 9 }, slice.ToArray());
         }
@@ -196,7 +196,7 @@ namespace System.Memory.Tests
         public void Create_WorksWithArray()
         {
             var buffer = new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5 });
-            Assert.Equal(buffer.ToArray(), new byte[] {  1, 2, 3, 4, 5 });
+            Assert.Equal(buffer.ToArray(), new byte[] { 1, 2, 3, 4, 5 });
         }
 
         [Fact]

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.char.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.char.cs
@@ -87,7 +87,7 @@ namespace System.Memory.Tests
         [MemberData(nameof(ValidSliceCases))]
         public void Slice_Works(Func<ReadOnlySequence<char>, ReadOnlySequence<char>> func)
         {
-            ReadOnlySequence<char> buffer = Factory.CreateWithContent(new char[] { (char)0, (char)1, (char)2 , (char)3 , (char)4, (char)5, (char)6, (char)7, (char)8, (char)9 });
+            ReadOnlySequence<char> buffer = Factory.CreateWithContent(new char[] { (char)0, (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9 });
             ReadOnlySequence<char> slice = func(buffer);
             Assert.Equal(new char[] { (char)5, (char)6, (char)7, (char)8, (char)9 }, slice.ToArray());
         }

--- a/src/System.Memory/tests/ReadOnlyBuffer/SequencePosition.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/SequencePosition.cs
@@ -19,7 +19,7 @@ namespace System.Memory.Tests
             Assert.True(position.Equals(position2));
             Assert.True(position.Equals((object)position2));
             Assert.False(position != position2);
-            Assert.Equal(position.GetHashCode(),position2.GetHashCode());
+            Assert.Equal(position.GetHashCode(), position2.GetHashCode());
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace System.Memory.Tests
             Assert.True(position.Equals(position2));
             Assert.True(position.Equals((object)position2));
             Assert.False(position != position2);
-            Assert.Equal(position.GetHashCode(),position2.GetHashCode());
+            Assert.Equal(position.GetHashCode(), position2.GetHashCode());
         }
     }
 }


### PR DESCRIPTION
Borrows the tests from https://github.com/dotnet/corefx/pull/28261 by @benaadams and builds on top of it.

- Ignore the formatting/clean up changes.
- The most important change is to the Seek and SeekMultiSegment methods. With this simplification, the fix in https://github.com/dotnet/corefx/pull/28261 is no longer necessary, since this PR supersedes it.
   - This change greatly simplifies the implementation (and the disassembly shrinks, i.e. this will almost certainly help performance). The loop body shrinks to 14 instructions, from 23.

**Before (loop highlighted):**
![image](https://user-images.githubusercontent.com/6527137/37695448-8ca866a8-2c8c-11e8-961b-caf2acac7987.png)

**After (loop highlighted):**
![image](https://user-images.githubusercontent.com/6527137/37695437-7c3affce-2c8c-11e8-88cd-69a09e03d59e.png)


cc @AlexRadch, @pakrym, @davidfowl, @joshfree, @benaadams 