### PR TITLE
Fixup merge conflict with CoreCLR

### DIFF
--- a/src/Common/src/CoreLib/Interop/Windows/Kernel32/Interop.GetTempFileNameW.cs
+++ b/src/Common/src/CoreLib/Interop/Windows/Kernel32/Interop.GetTempFileNameW.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text;
 using System.Runtime.InteropServices;
 
 internal partial class Interop

--- a/src/Common/src/CoreLib/Interop/Windows/Kernel32/Interop.GetTempPathW.cs
+++ b/src/Common/src/CoreLib/Interop/Windows/Kernel32/Interop.GetTempPathW.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
-using System.Text;
 using System.Runtime.InteropServices;
 
 internal partial class Interop


### PR DESCRIPTION
Fixing cosmetic CoreLib difference between CoreCLR and CoreFX caused by incorrectly resolved merge conflict.