### PR TITLE
Fixed netfx System.Drawing.Common.Tests fails on non-English Windows

### DIFF
--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -322,7 +322,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Ctor_NullGraphics_ThrowsArgumentNullException()
         {
-            AssertExtensions.Throws<ArgumentNullException>("g", "Value of 'null' is not valid for 'g'.", () => new Bitmap(1, 1, null));
+            AssertExtensions.Throws<ArgumentNullException>("g", null, () => new Bitmap(1, 1, null));
         }
 
         [ConditionalFact(Helpers.GdiplusIsAvailable)]


### PR DESCRIPTION
Netfx System.Drawing.Common.Tests fails on non-English Windows with next log:
```
      System.Drawing.Tests.BitmapTests.Ctor_NullGraphics_ThrowsArgumentNullException [FAIL]
        Assert.Equal() Failure
                   (pos 0)
        Expected: Value of 'null' is not valid for 'g'.
        Actual:   Значение 'null' недопустимо для 'g'.
                   (pos 0)
        Stack Trace:
             в Xunit.Assert.Equal(String expected, String actual, Boolean ignoreCase, Boolean ignoreLineEndingDifferences, Boolean ignoreWhiteSpaceDifferences) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 239
             в Xunit.Assert.Equal(String expected, String actual) в C:\BuildAgent\work\cb37e9acf085d108\src\xunit.assert\Asserts\StringAsserts.cs:строка 170
             в System.AssertExtensions.Throws[T](String netCoreParamName, String netFxParamName, Action action)
             в System.Drawing.Tests.BitmapTests.Ctor_NullGraphics_ThrowsArgumentNullException()
```

See https://github.com/dotnet/corefx/issues/28136 also.