### PR TITLE
 CurlHandler: set ssl options to match X509 machine store certificates

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -632,6 +632,7 @@
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Encoding" />
     <Reference Include="System.Security.Cryptography.Primitives" />
+    <Reference Include="System.IO.FileSystem" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -629,10 +629,10 @@
     <Reference Include="System.Threading.Timer" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Encoding" />
     <Reference Include="System.Security.Cryptography.Primitives" />
-    <Reference Include="System.IO.FileSystem" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.IO;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
@@ -24,6 +25,8 @@ namespace System.Net.Http
             private static readonly Interop.Http.SslCtxCallback s_sslCtxCallback = SslCtxCallback;
             private static readonly Interop.Ssl.AppVerifyCallback s_sslVerifyCallback = VerifyCertChain;
             private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1");
+            private static string _sslCaPath;
+            private static string _sslCaInfo;
 
             internal static void SetSslOptions(EasyRequest easy, ClientCertificateOption clientCertOption)
             {
@@ -101,25 +104,64 @@ namespace System.Net.Http
                 }
             }
 
+            private static void GetSslCaLocations(out string path, out string info)
+            {
+                // We only provide curl option values when SSL_CERT_FILE or SSL_CERT_DIR is set.
+                // When that is the case, we set the options so curl ends up using the same certificates as the
+                // X509 machine store.
+                path = _sslCaPath;
+                info = _sslCaInfo;
+
+                if (path == null || info == null)
+                {
+                    bool hasEnvironmentVariables = Environment.GetEnvironmentVariable("SSL_CERT_FILE") != null ||
+                                                   Environment.GetEnvironmentVariable("SSL_CERT_DIR") != null;
+
+                    if (hasEnvironmentVariables)
+                    {
+                        path = Interop.Crypto.GetX509RootStorePath();
+                        if (!Directory.Exists(path))
+                        {
+                            // X509 store ignores non-existing.
+                            path = string.Empty;
+                        }
+
+                        info = Interop.Crypto.GetX509RootStoreFile();
+                        if (!File.Exists(info))
+                        {
+                            // X509 store ignores non-existing.
+                            info = string.Empty;
+                        }
+                    }
+                    else
+                    {
+                        path = string.Empty;
+                        info = string.Empty;
+                    }
+                    _sslCaPath = path;
+                    _sslCaInfo = info;
+                }
+            }
+
             private static void SetSslOptionsForCertificateStore(EasyRequest easy)
             {
                 // Support specifying certificate directory/bundle via environment variables: SSL_CERT_DIR, SSL_CERT_FILE.
-                string sslCertDir = Environment.GetEnvironmentVariable("SSL_CERT_DIR");
-                if (sslCertDir != null)
+                GetSslCaLocations(out string sslCaPath, out string sslCaInfo);
+
+                if (sslCaPath != string.Empty)
                 {
-                    easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_CAPATH, sslCertDir);
+                    easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_CAPATH, sslCaPath);
 
                     // https proxy support requires libcurl 7.52.0+
-                    easy.TrySetCurlOption(Interop.Http.CURLoption.CURLOPT_PROXY_CAPATH, sslCertDir);
+                    easy.TrySetCurlOption(Interop.Http.CURLoption.CURLOPT_PROXY_CAPATH, sslCaPath);
                 }
 
-                string sslCertFile = Environment.GetEnvironmentVariable("SSL_CERT_FILE");
-                if (sslCertFile != null)
+                if (sslCaInfo != string.Empty)
                 {
-                    easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_CAINFO, sslCertFile);
+                    easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_CAINFO, sslCaInfo);
 
                     // https proxy support requires libcurl 7.52.0+
-                    easy.TrySetCurlOption(Interop.Http.CURLoption.CURLOPT_PROXY_CAINFO, sslCertFile);
+                    easy.TrySetCurlOption(Interop.Http.CURLoption.CURLOPT_PROXY_CAINFO, sslCaInfo);
                 }
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
@@ -73,17 +73,9 @@ namespace System.Net.Http.Functional.Tests
         [PlatformSpecific(~TestPlatforms.OSX)] // Not implemented
         [InlineData(false, false, false, false, false)] // system -> ok
         [InlineData(true, true, true, true, true)]      // empty dir, empty bundle file -> fail
-        // It is enough to override the bundle, since all tested platforms don't have a default dir:
-        [InlineData(false, false, true, true, true)]    // empty bundle -> fail
-        [InlineData(false, false, true, false, true)]   // non-existing bundle -> fail
         public void HttpClientUsesSslCertEnvironmentVariables(bool setSslCertDir, bool createSslCertDir,
             bool setSslCertFile, bool createSslCertFile, bool expectedFailure)
         {
-            if (expectedFailure && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return; // [ActiveIssue(28002)]
-            }
-
             // This test sets SSL_CERT_DIR and SSL_CERT_FILE to empty/non-existing locations and then
             // checks the http request fails.
             // Some platforms will use the system default when not specifying a value, while others

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
@@ -69,11 +69,9 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [PlatformSpecific(~TestPlatforms.OSX)] // Not implemented
-        public void HttpClientUsesSslCertEnvironmentVariables(bool useCurl)
+        public void HttpClientUsesSslCertEnvironmentVariables()
         {
             // We set SSL_CERT_DIR and SSL_CERT_FILE to empty locations.
             // The HttpClient should fail to validate the server certificate.
@@ -87,21 +85,16 @@ namespace System.Net.Http.Functional.Tests
             File.WriteAllText(sslCertFile, "");
             psi.Environment.Add("SSL_CERT_FILE", sslCertFile);
 
-            if (useCurl)
-            {
-                psi.Environment.Add("DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER", "false");
-            }
-
-            RemoteInvoke(async () =>
+            RemoteInvoke(async useSocketsHttpHandlerString =>
             {
                 const string Url = "https://www.microsoft.com";
 
-                using (HttpClient client = new HttpClient())
+                using (var client = CreateHttpClient(useSocketsHttpHandlerString))
                 {
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(Url));
                 }
                 return SuccessExitCode;
-            }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
+            }, UseSocketsHttpHandler.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28002

CC @caesar1995 @stephentoub @bartonjs @wfurt @karelz 