### PR TITLE
Fixed netfx System.IO.FileSystem.Tests fails on non-English Windows

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/Name.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Name.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.IO;
 using Xunit;
 
@@ -39,11 +40,16 @@ namespace System.IO.Tests
         [Fact]
         public void NameReturnsUnknownForHandle()
         {
-            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite))
-            using (FileStream fsh = new FileStream(fs.SafeFileHandle, FileAccess.ReadWrite))
+            RemoteInvoke(() =>
             {
-                Assert.Equal("[Unknown]", fsh.Name);
-            }
+                CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
+                using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite))
+                using (FileStream fsh = new FileStream(fs.SafeFileHandle, FileAccess.ReadWrite))
+                {
+                    Assert.Equal("[Unknown]", fsh.Name);
+                }
+            }).Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixed netfx System.IO.FileSystem.Tests fails on non-English Windows. See https://github.com/dotnet/corefx/issues/28136