### PR TITLE
Fixed netfx System.Security.Cryptography.Xml.Tests fails on non-English Windows

### DIFF
--- a/src/System.Security.Cryptography.Xml/tests/EncryptionMethodTests.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptionMethodTests.cs
@@ -45,10 +45,7 @@ namespace System.Security.Cryptography.Xml.Tests
         public void KeySize_SetNegativeValue_ThrowsArgumentOutOfRangeException(int value)
         {
             EncryptionMethod method = new EncryptionMethod();
-            if (PlatformDetection.IsFullFramework)
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("The key size should be a non negative integer.", () => method.KeySize = value);
-            else
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => method.KeySize = value);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", null, () => method.KeySize = value);
         }
 
         [Theory]


### PR DESCRIPTION
Fixed netfx System.Security.Cryptography.Xml.Tests fails on non-English Windows. See https://github.com/dotnet/corefx/issues/28136