### PR TITLE
Make WindowsPrincipalIsInRoleNeg pass when a domain client is offline

### DIFF
--- a/src/System.Security.Principal.Windows/tests/WindowsPrincipalTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsPrincipalTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.ComponentModel;
 using System.Security.Principal;
 using Xunit;
 
@@ -12,7 +14,23 @@ public class WindowsPrincipalTests
     {
         WindowsIdentity windowsIdentity = WindowsIdentity.GetAnonymous();
         WindowsPrincipal windowsPrincipal = new WindowsPrincipal(windowsIdentity);
-        var ret = windowsPrincipal.IsInRole("FAKEDOMAIN\\nonexist");
-        Assert.False(ret);
+
+        try
+        {
+            bool ret = windowsPrincipal.IsInRole("FAKEDOMAIN\\nonexist");
+            Assert.False(ret);
+        }
+        catch (SystemException e)
+        {
+            // If a domain joined machine can't talk to the domain controller then it
+            // can't determine if "FAKEDOMAIN" is resolvable within the AD forest, so it
+            // fails with ERROR_TRUSTED_RELATIONSHIP_FAILURE (resulting in an exception).
+            const int ERROR_TRUSTED_RELATIONSHIP_FAILURE = 0x6FD;
+            Win32Exception win32Exception = new Win32Exception(ERROR_TRUSTED_RELATIONSHIP_FAILURE);
+
+            // NetFx throws a plain SystemException which has the message built via FormatMessage.
+            // CoreFx throws a Win32Exception based on the error, which gets the same message value.
+            Assert.Equal(win32Exception.Message, e.Message);
+        }
     }
 }


### PR DESCRIPTION
Fixes #16511.

At least, it fixed it for my machine when I unplugged my office from corpnet.  But since it's the same message as the various versions of the issue have reported it seems like the right fix.