### PR TITLE
Re-enable hostname resolution test on Linux, but skip under certain conditions

### DIFF
--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -28,6 +28,14 @@ namespace System.Net.NameResolution.PalTests
             IPHostEntry hostEntry;
             int nativeErrorCode;
             SocketError error = NameResolutionPal.TryGetAddrInfo("localhost", out hostEntry, out nativeErrorCode);
+            if (error == SocketError.HostNotFound)
+            {
+                // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the 
+                // machine configurations, which varies by distro and is often inconsistent.
+                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+                return;
+            }
+
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(hostEntry);
             Assert.NotNull(hostEntry.HostName);
@@ -35,7 +43,6 @@ namespace System.Net.NameResolution.PalTests
             Assert.NotNull(hostEntry.Aliases);
         }
 
-        [ActiveIssue(20245, TestPlatforms.AnyUnix)]
         [Fact]
         public void TryGetAddrInfo_HostName()
         {

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -28,13 +28,6 @@ namespace System.Net.NameResolution.PalTests
             IPHostEntry hostEntry;
             int nativeErrorCode;
             SocketError error = NameResolutionPal.TryGetAddrInfo("localhost", out hostEntry, out nativeErrorCode);
-            if (error == SocketError.HostNotFound)
-            {
-                // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the 
-                // machine configurations, which varies by distro and is often inconsistent.
-                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
-                return;
-            }
 
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(hostEntry);

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -44,11 +44,10 @@ namespace System.Net.NameResolution.PalTests
             IPHostEntry hostEntry;
             int nativeErrorCode;
             SocketError error = NameResolutionPal.TryGetAddrInfo(hostName, out hostEntry, out nativeErrorCode);
-            if (error == SocketError.HostNotFound)
+            if (error == SocketError.HostNotFound && (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the 
                 // machine configurations, which varies by distro and is often inconsistent.
-                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
                 return;
             }
             

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -44,7 +44,7 @@ namespace System.Net.NameResolution.PalTests
             IPHostEntry hostEntry;
             int nativeErrorCode;
             SocketError error = NameResolutionPal.TryGetAddrInfo(hostName, out hostEntry, out nativeErrorCode);
-            if (error == SocketError.HostNotFound && (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (error == SocketError.HostNotFound && (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
             {
                 // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the 
                 // machine configurations, which varies by distro and is often inconsistent.

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -52,6 +52,14 @@ namespace System.Net.NameResolution.PalTests
             IPHostEntry hostEntry;
             int nativeErrorCode;
             SocketError error = NameResolutionPal.TryGetAddrInfo(hostName, out hostEntry, out nativeErrorCode);
+            if (error == SocketError.HostNotFound)
+            {
+                // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the 
+                // machine configurations, which varies by distro and is often inconsistent.
+                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+                return;
+            }
+            
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(hostEntry);
             Assert.NotNull(hostEntry.HostName);

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -28,7 +28,6 @@ namespace System.Net.NameResolution.PalTests
             IPHostEntry hostEntry;
             int nativeErrorCode;
             SocketError error = NameResolutionPal.TryGetAddrInfo("localhost", out hostEntry, out nativeErrorCode);
-
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(hostEntry);
             Assert.NotNull(hostEntry.HostName);


### PR DESCRIPTION
This test assumed that the host name can always be resolved, which isn't guaranteed on Unix.

In the interest of "testing as much as we can" I'm going to enable the test, but pass it if we get the specific error that indicates we haven't been able to resolve the localhost on Unix. That way we'll hopefully still see failures if things go wrong somewhere else.

The logic to skip the test is taken from another test in the same file:
https://github.com/dotnet/corefx/blob/643bccc7f2c24a897cc15c42486d4184e1f931eb/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs#L89-L104

Fixes: #20245