### PR TITLE
Re-enable unaccounted disabled tests on UapAot

### DIFF
--- a/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
@@ -629,7 +629,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue("TFS 444333 - Should ExceptionMiniaturizer exempt CultureNotFoundException.InvalidCultureName from being optimized away?", TargetFrameworkMonikers.UapAot)]
         public void CultureNotFoundExceptionTest()
         {
             AssertExtensions.Throws<CultureNotFoundException>("name", () => new CultureInfo("!@#$%^&*()"));

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -310,7 +310,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "This test causes a fail fast on uapaot: https://github.com/dotnet/corefx/issues/19129")]
         [MemberData(nameof(ReadAndWriteRefCases))]
         public void ReadAndWriteRefParameters(bool useInterpreter, object value, object increment, object result)
         {

--- a/src/System.Linq.Parallel/tests/ParallelEnumerableTests.cs
+++ b/src/System.Linq.Parallel/tests/ParallelEnumerableTests.cs
@@ -259,7 +259,6 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(EmptyData))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "This causes assertion failure on UAPAoT")]
         public static void Empty<T>(T def)
         {
             Assert.Empty(ParallelEnumerable.Empty<T>());

--- a/src/System.Runtime.Extensions/tests/System/MathTests.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathTests.netcoreapp.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace System.Tests
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Math.Clamp is not in CoreRT yet.")]
     public static partial class MathTests
     {
         public static IEnumerable<object[]> Clamp_UnsignedInt_TestData()

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingDecode.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingDecode.cs
@@ -103,7 +103,6 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Decode_TestData))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20525", TargetFrameworkMonikers.UapAot)]
         public void Decode(byte[] bytes, int index, int count, string expected)
         {
             EncodingHelpers.Decode(new UTF8Encoding(true, false), bytes, index, count, expected);

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingDecode.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingDecode.cs
@@ -73,7 +73,6 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Decode_TestData))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20525", TargetFrameworkMonikers.UapAot)]
         public void Decode(byte[] littleEndianBytes, int index, int count, string expected)
         {
             byte[] bigEndianBytes = GetBigEndianBytes(littleEndianBytes, index, count);


### PR DESCRIPTION
Three categories:

* Disabled on issues that have been resolved
* Disabled with a message that is not true anymore
* Disabled without an issue (that's the Linq.Parallel test - Linq.Parallel tests are great stress tests, so I want to either see them running, or have a bug that someone is looking at)