### PR TITLE
Fix System.Reflection.Metadata nuspec

### DIFF
--- a/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
+++ b/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
@@ -5,10 +5,6 @@
     <ProjectReference Include="..\src\System.Reflection.Metadata.csproj">
       <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <FilePackageDependency Include="System.Collections.Immutable">
-      <TargetFramework>portable-net45+win8</TargetFramework>
-      <Version>1.1.37</Version>
-    </FilePackageDependency>
     
     <!-- Since UAP and .NETCoreApp are package based we still want to enable
          OOBing libraries that happen to overlap with their framework package.


### PR DESCRIPTION
Corrects SCI dependency version in nuspec. Currently it's 1.4.0 for Profile7, but should be 1.5.0-*

```
<dependencies>
      <group targetFramework=".NETCoreApp2.1" />
      <group targetFramework=".NETStandard1.1">
        <dependency id="NETStandard.Library" version="1.6.1" />
        <dependency id="System.Collections.Immutable" version="1.5.0-preview3-26319-04" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="System.Collections.Immutable" version="1.5.0-preview3-26319-04" />
      </group>
      <group targetFramework=".NETPortable0.0-Profile7">
        <dependency id="System.Collections.Immutable" version="1.4.0" />
      </group>
      <group targetFramework=".NETPortable4.5-Profile111">
        <dependency id="System.Collections.Immutable" version="1.5.0-preview3-26319-04" />
      </group>
      <group targetFramework="UAP10.0.16299" />
      <group targetFramework="WindowsPhoneApp8.1">
        <dependency id="System.Collections.Immutable" version="1.5.0-preview3-26319-04" />
      </group>
    </dependencies>
```