### PR TITLE
Disable Millisec test on Linux

### DIFF
--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -104,7 +104,7 @@ namespace System.IO.Tests
                     item = GetExistingItem(); // try a new file/directory
                 }
 
-                Assert.NotEqual(0, msec);
+                //Assert.NotEqual(0, msec);
             });
         }
 

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -104,7 +104,8 @@ namespace System.IO.Tests
                     item = GetExistingItem(); // try a new file/directory
                 }
 
-                //Assert.NotEqual(0, msec);
+                // Temporarily disabled while investigating failures in #27662
+                // Assert.NotEqual(0, msec);
             });
         }
 


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/28342

I should have done this earlier. Commenting out the assert rather than disabling as it's handy for debugging.