### PR TITLE
Fix WinHttpHandler error handling

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -121,6 +121,9 @@
   <data name="net_http_content_stream_already_read" xml:space="preserve">
     <value>The stream was already consumed. It cannot be read again.</value>
   </data>
+  <data name="net_http_winhttp_error" xml:space="preserve">
+    <value>Error {0} calling {1}, '{2}'.</value>
+  </data>
   <data name="PlatformNotSupported_WinHttpHandler" xml:space="preserve">
     <value>WinHttpHandler is only supported on .NET Framework and .NET Core runtimes on Windows. It is not supported for Windows Store Applications (UWP) or Unix platforms.</value>
   </data>

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -23,7 +23,6 @@
     <CompileItem Include="$(CommonPath)\System\Net\UriScheme.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs" />
-    <CompileItem Include="$(CommonPath)\System\Net\Http\WinHttpException.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Security\CertificateHelper.Windows.cs" />
     <CompileItem Include="$(CommonPath)\System\Runtime\ExceptionServices\ExceptionStackTrace.cs" />
@@ -33,6 +32,7 @@
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpCertificateHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpChannelBinding.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpCookieContainerAdapter.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpException.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpHandler.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestCallback.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestState.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -296,7 +296,7 @@ namespace System.Net.Http
                 Interop.WinHttp.WINHTTP_OPTION_AUTOLOGON_POLICY,
                 ref optionData))
             {
-                WinHttpException.ThrowExceptionUsingLastError();
+                WinHttpException.ThrowExceptionUsingLastError("WinHttpSetOption");
             }
         }
 
@@ -365,7 +365,7 @@ namespace System.Net.Http
                 password,
                 IntPtr.Zero))
             {
-                WinHttpException.ThrowExceptionUsingLastError();
+                WinHttpException.ThrowExceptionUsingLastError("WinHttpSetCredentials");
             }
 
             return true;

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -296,7 +296,7 @@ namespace System.Net.Http
                 Interop.WinHttp.WINHTTP_OPTION_AUTOLOGON_POLICY,
                 ref optionData))
             {
-                WinHttpException.ThrowExceptionUsingLastError("WinHttpSetOption");
+                WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpSetOption));
             }
         }
 
@@ -365,7 +365,7 @@ namespace System.Net.Http
                 password,
                 IntPtr.Zero))
             {
-                WinHttpException.ThrowExceptionUsingLastError("WinHttpSetCredentials");
+                WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpSetCredentials));
             }
 
             return true;

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
@@ -61,7 +61,7 @@ namespace System.Net.Http
                 int lastError = Marshal.GetLastWin32Error();
                 if (lastError != Interop.WinHttp.ERROR_WINHTTP_HEADER_NOT_FOUND)
                 {
-                    throw WinHttpException.CreateExceptionUsingError(lastError);
+                    throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpAddRequestHeaders");
                 }
             }
 
@@ -76,7 +76,7 @@ namespace System.Net.Http
                     (uint)cookieHeader.Length,
                     Interop.WinHttp.WINHTTP_ADDREQ_FLAG_ADD))
                 {
-                    WinHttpException.ThrowExceptionUsingLastError();
+                    WinHttpException.ThrowExceptionUsingLastError("WinHttpAddRequestHeaders");
                 }
             }
         }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
@@ -61,7 +61,7 @@ namespace System.Net.Http
                 int lastError = Marshal.GetLastWin32Error();
                 if (lastError != Interop.WinHttp.ERROR_WINHTTP_HEADER_NOT_FOUND)
                 {
-                    throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpAddRequestHeaders");
+                    throw WinHttpException.CreateExceptionUsingError(lastError, nameof(Interop.WinHttp.WinHttpAddRequestHeaders));
                 }
             }
 
@@ -76,7 +76,7 @@ namespace System.Net.Http
                     (uint)cookieHeader.Length,
                     Interop.WinHttp.WINHTTP_ADDREQ_FLAG_ADD))
                 {
-                    WinHttpException.ThrowExceptionUsingLastError("WinHttpAddRequestHeaders");
+                    WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpAddRequestHeaders));
                 }
             }
         }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -661,7 +661,7 @@ namespace System.Net.Http
                 (uint)requestHeadersBuffer.Length,
                 Interop.WinHttp.WINHTTP_ADDREQ_FLAG_ADD))
             {
-                WinHttpException.ThrowExceptionUsingLastError("WinHttpAddRequestHeaders");
+                WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpAddRequestHeaders));
             }
         }
 
@@ -728,7 +728,7 @@ namespace System.Net.Http
                             WinHttpTraceHelper.Trace("WinHttpHandler.EnsureSessionHandleExists: error={0}", lastError);
                             if (lastError != Interop.WinHttp.ERROR_INVALID_PARAMETER)
                             {
-                                ThrowOnInvalidHandle(sessionHandle);
+                                ThrowOnInvalidHandle(sessionHandle, nameof(Interop.WinHttp.WinHttpOpen));
                             }
 
                             // We must be running on a platform earlier than Win8.1/Win2K12R2 which doesn't support
@@ -741,7 +741,7 @@ namespace System.Net.Http
                                 _proxyHelper.ManualSettingsOnly ? _proxyHelper.Proxy : Interop.WinHttp.WINHTTP_NO_PROXY_NAME,
                                 _proxyHelper.ManualSettingsOnly ? _proxyHelper.ProxyBypass : Interop.WinHttp.WINHTTP_NO_PROXY_BYPASS,
                                 (int)Interop.WinHttp.WINHTTP_FLAG_ASYNC);
-                            ThrowOnInvalidHandle(sessionHandle);
+                            ThrowOnInvalidHandle(sessionHandle, nameof(Interop.WinHttp.WinHttpOpen));
                         }
 
                         uint optionAssuredNonBlockingTrue = 1; // TRUE
@@ -757,7 +757,7 @@ namespace System.Net.Http
                             int lastError = Marshal.GetLastWin32Error();
                             if (lastError != Interop.WinHttp.ERROR_WINHTTP_INVALID_OPTION)
                             {
-                                throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpSetOption");
+                                throw WinHttpException.CreateExceptionUsingError(lastError, nameof(Interop.WinHttp.WinHttpSetOption));
                             }
                         }
 
@@ -788,7 +788,7 @@ namespace System.Net.Http
                     state.RequestMessage.RequestUri.Host,
                     (ushort)state.RequestMessage.RequestUri.Port,
                     0);
-                ThrowOnInvalidHandle(connectHandle);
+                ThrowOnInvalidHandle(connectHandle, nameof(Interop.WinHttp.WinHttpConnect));
                 connectHandle.SetParentHandle(_sessionHandle);
 
                 // Try to use the requested version if a known/supported version was explicitly requested.
@@ -821,7 +821,7 @@ namespace System.Net.Http
                     Interop.WinHttp.WINHTTP_NO_REFERER,
                     Interop.WinHttp.WINHTTP_DEFAULT_ACCEPT_TYPES,
                     flags);
-                ThrowOnInvalidHandle(state.RequestHandle);
+                ThrowOnInvalidHandle(state.RequestHandle, nameof(Interop.WinHttp.WinHttpOpenRequest));
                 state.RequestHandle.SetParentHandle(connectHandle);
 
                 // Set callback function.
@@ -957,7 +957,7 @@ namespace System.Net.Http
                 (int)_sendTimeout.TotalMilliseconds,
                 (int)_receiveHeadersTimeout.TotalMilliseconds))
             {
-                WinHttpException.ThrowExceptionUsingLastError("WinHttpSetTimeouts");
+                WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpSetTimeouts));
             }
         }
 
@@ -1214,7 +1214,7 @@ namespace System.Net.Http
                 option,
                 ref optionData))
             {
-                WinHttpException.ThrowExceptionUsingLastError("WinHttpSetOption");
+                WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpSetOption));
             }
         }
 
@@ -1227,7 +1227,7 @@ namespace System.Net.Http
                 optionData,
                 (uint)optionData.Length))
             {
-                WinHttpException.ThrowExceptionUsingLastError("WinHttpSetOption");
+                WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpSetOption));
             }
         }
 
@@ -1244,7 +1244,7 @@ namespace System.Net.Http
                 optionData,
                 optionSize))
             {
-                WinHttpException.ThrowExceptionUsingLastError("WinHttpSetOption");
+                WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpSetOption));
             }
         }
 
@@ -1314,18 +1314,18 @@ namespace System.Net.Http
                 int lastError = Marshal.GetLastWin32Error();
                 if (lastError != Interop.WinHttp.ERROR_INVALID_HANDLE) // Ignore error if handle was already closed.
                 {
-                    throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpSetStatusCallback");
+                    throw WinHttpException.CreateExceptionUsingError(lastError, nameof(Interop.WinHttp.WinHttpSetStatusCallback));
                 }
             }
         }
 
-        private void ThrowOnInvalidHandle(SafeWinHttpHandle handle)
+        private void ThrowOnInvalidHandle(SafeWinHttpHandle handle, string nameOfCalledFunction)
         {
             if (handle.IsInvalid)
             {
                 int lastError = Marshal.GetLastWin32Error();
                 WinHttpTraceHelper.Trace("WinHttpHandler.ThrowOnInvalidHandle: error={0}", lastError);
-                throw WinHttpException.CreateExceptionUsingError(lastError, "Handle creation??"); // TODO:
+                throw WinHttpException.CreateExceptionUsingError(lastError, nameOfCalledFunction);
             }
         }
 
@@ -1349,7 +1349,7 @@ namespace System.Net.Http
                     // state object here.
                     state.RequestHandle.Dispose();
                     state.Dispose();
-                    WinHttpException.ThrowExceptionUsingLastError("WinHttpSendRequest");
+                    WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpSendRequest));
                 }
             }
 
@@ -1373,7 +1373,7 @@ namespace System.Net.Http
             {
                 if (!Interop.WinHttp.WinHttpReceiveResponse(state.RequestHandle, IntPtr.Zero))
                 {
-                    throw WinHttpException.CreateExceptionUsingLastError("WinHttpReceiveResponse");
+                    throw WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpReceiveResponse));
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -249,7 +249,7 @@ namespace System.Net.Http
                     IntPtr.Zero))
                 {
                     _state.TcsInternalWriteDataToRequestStream.TrySetException(
-                        new IOException(SR.net_http_io_write, WinHttpException.CreateExceptionUsingLastError("WinHttpWriteData")));
+                        new IOException(SR.net_http_io_write, WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpWriteData))));
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -249,7 +249,7 @@ namespace System.Net.Http
                     IntPtr.Zero))
                 {
                     _state.TcsInternalWriteDataToRequestStream.TrySetException(
-                        new IOException(SR.net_http_io_write, WinHttpException.CreateExceptionUsingLastError()));
+                        new IOException(SR.net_http_io_write, WinHttpException.CreateExceptionUsingLastError("WinHttpWriteData")));
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -127,7 +127,7 @@ namespace System.Net.Http
                 ref resultSize,
                 IntPtr.Zero))
             {
-                WinHttpException.ThrowExceptionUsingLastError();
+                WinHttpException.ThrowExceptionUsingLastError("WinHttpQueryHeaders");
             }
 
             return result;
@@ -189,7 +189,7 @@ namespace System.Net.Http
                 return GetResponseHeader(requestHandle, infoLevel, ref buffer, ref index, out headerValue);
             }
 
-            throw WinHttpException.CreateExceptionUsingError(lastError);
+            throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpQueryHeaders");
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace System.Net.Http
 
                     Debug.Assert(lastError != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER, "buffer must be of sufficient size.");
 
-                    throw WinHttpException.CreateExceptionUsingError(lastError);
+                    throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpQueryHeaders");
                 }
             }
 
@@ -240,7 +240,7 @@ namespace System.Net.Http
 
                 if (lastError != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER)
                 {
-                    throw WinHttpException.CreateExceptionUsingError(lastError);
+                    throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpQueryHeaders");
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -127,7 +127,7 @@ namespace System.Net.Http
                 ref resultSize,
                 IntPtr.Zero))
             {
-                WinHttpException.ThrowExceptionUsingLastError("WinHttpQueryHeaders");
+                WinHttpException.ThrowExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpQueryHeaders));
             }
 
             return result;
@@ -189,7 +189,7 @@ namespace System.Net.Http
                 return GetResponseHeader(requestHandle, infoLevel, ref buffer, ref index, out headerValue);
             }
 
-            throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpQueryHeaders");
+            throw WinHttpException.CreateExceptionUsingError(lastError, nameof(Interop.WinHttp.WinHttpQueryHeaders));
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace System.Net.Http
 
                     Debug.Assert(lastError != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER, "buffer must be of sufficient size.");
 
-                    throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpQueryHeaders");
+                    throw WinHttpException.CreateExceptionUsingError(lastError, nameof(Interop.WinHttp.WinHttpQueryHeaders));
                 }
             }
 
@@ -240,7 +240,7 @@ namespace System.Net.Http
 
                 if (lastError != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER)
                 {
-                    throw WinHttpException.CreateExceptionUsingError(lastError, "WinHttpQueryHeaders");
+                    throw WinHttpException.CreateExceptionUsingError(lastError, nameof(Interop.WinHttp.WinHttpQueryHeaders));
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -121,7 +121,7 @@ namespace System.Net.Http
                     {
                         if (!Interop.WinHttp.WinHttpQueryDataAvailable(_requestHandle, IntPtr.Zero))
                         {
-                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError("WinHttpQueryDataAvailable"));
+                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpQueryDataAvailable)));
                         }
                     }
                     int bytesAvailable = await _state.LifecycleAwaitable;
@@ -137,7 +137,7 @@ namespace System.Net.Http
                     {
                         if (!Interop.WinHttp.WinHttpReadData(_requestHandle, Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0), (uint)Math.Min(bytesAvailable, buffer.Length), IntPtr.Zero))
                         {
-                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError("WinHttpReadData"));
+                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpReadData)));
                         }
                     }
                     int bytesRead = await _state.LifecycleAwaitable;
@@ -222,7 +222,7 @@ namespace System.Net.Http
                     Debug.Assert(!_requestHandle.IsInvalid);
                     if (!Interop.WinHttp.WinHttpQueryDataAvailable(_requestHandle, IntPtr.Zero))
                     {
-                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError("WinHttpQueryDataAvailable"));
+                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpQueryDataAvailable)));
                     }
                 }
 
@@ -237,7 +237,7 @@ namespace System.Net.Http
                         (uint)Math.Min(bytesAvailable, count),
                         IntPtr.Zero))
                     {
-                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError("WinHttpReadData"));
+                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpReadData)));
                     }
                 }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -121,7 +121,7 @@ namespace System.Net.Http
                     {
                         if (!Interop.WinHttp.WinHttpQueryDataAvailable(_requestHandle, IntPtr.Zero))
                         {
-                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError("WinHttpQueryDataAvailable"));
                         }
                     }
                     int bytesAvailable = await _state.LifecycleAwaitable;
@@ -137,7 +137,7 @@ namespace System.Net.Http
                     {
                         if (!Interop.WinHttp.WinHttpReadData(_requestHandle, Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0), (uint)Math.Min(bytesAvailable, buffer.Length), IntPtr.Zero))
                         {
-                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError("WinHttpReadData"));
                         }
                     }
                     int bytesRead = await _state.LifecycleAwaitable;
@@ -222,7 +222,7 @@ namespace System.Net.Http
                     Debug.Assert(!_requestHandle.IsInvalid);
                     if (!Interop.WinHttp.WinHttpQueryDataAvailable(_requestHandle, IntPtr.Zero))
                     {
-                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError("WinHttpQueryDataAvailable"));
                     }
                 }
 
@@ -237,7 +237,7 @@ namespace System.Net.Http
                         (uint)Math.Min(bytesAvailable, count),
                         IntPtr.Zero))
                     {
-                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError("WinHttpReadData"));
                     }
                 }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -138,14 +138,14 @@ namespace System.Net.Http
 
             uint apiIndex = (uint)asyncResult.dwResult.ToInt32();
             uint error = asyncResult.dwError;
-
+            string apiName = GetNameFromApiIndex(apiIndex);
             WriteLine(
                 "{0}: api={1}, error={2}({3}) \"{4}\"",
                 message,
-                GetNameFromApiIndex(apiIndex),
+                apiName,
                 GetNameFromError(error),
                 error,
-                WinHttpException.GetErrorMessage((int)error));
+                WinHttpException.GetErrorMessage((int)error, apiName));
         }
 
         private static void WriteLine(string message)

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -73,9 +73,6 @@
     <Compile Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs">
       <Link>Common\System\Net\Http\NoWriteNoSeekStreamContent.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\WinHttpException.cs">
-      <Link>Common\System\Net\Http\WinHttpException.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs">
       <Link>Common\System\Net\Security\CertificateHelper.cs</Link>
     </Compile>
@@ -102,6 +99,9 @@
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpCookieContainerAdapter.cs">
       <Link>ProductionCode\WinHttpCookieContainerAdapter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpException.cs">
+      <Link>ProductionCode\WinHttpException.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpHandler.cs">
       <Link>ProductionCode\WinHttpHandler.cs</Link>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -399,6 +399,9 @@
   <data name="net_http_request_no_host" xml:space="preserve">
     <value>CONNECT request must contain Host header.</value>
   </data>
+  <data name="net_http_winhttp_error" xml:space="preserve">
+    <value>Error {0} calling {1}, '{2}'.</value>
+  </data>
   <data name="net_MethodNotImplementedException" xml:space="preserve">
     <value>This method is not implemented by this class.</value>
   </data>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -373,6 +373,9 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs">
       <Link>ProductionCode\System\Net\Http\HttpSystemProxy.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinHttpException.cs">
+      <Link>ProductionCode\System\Net\Http\WinHttpException.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinInetProxyHelper.cs">
       <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
     </Compile>
@@ -393,9 +396,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\winhttp\Interop.SafeWinHttpHandle.cs">
       <Link>Common\Interop\Windows\winhttp\Interop.SafeWinHttpHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\WinHttpException.cs">
-      <Link>Common\System\Net\Http\WinHttpException.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Runtime\ExceptionServices\ExceptionStackTrace.cs">
       <Link>Common\System\Runtime\ExceptionServices\ExceptionStackTrace.cs</Link>


### PR DESCRIPTION
This PR addresses some error handling problems in WinHttpHandler as well as
improves the error messages generated for WinHttpException.

This was root caused to a bug in WinHttp where it can't do a GET request with a
request body using chunked encoding. However, this exception was masked due to
an error handling bug caused by an inconsistency in how WinHttp associates
context values for callbacks during the WinHttpSendRequest API call. This PR now
fixes the error handling around synchronous errors being returned from
WinHttpSendRequest. The root WinHttp bug itself can't be fixed. So, doing a GET request
will still throw an exception, but it will be a catchable HttpRequestException.

Another bug was discovered while investigating #26278. WinHttpCloseHandle should only be
called once and should never race between threads. This is normally protected when
the request handle is closed via SafeHandle Dispose(). But there was a place in the
callback method where we called WinHttpCloseHandle directly against the raw handle.

Finally, the error messages for WinHttpExceptions have been improved to show the
error number and the probable WinHttp API call that generated the error. This will
save diagnostic time.

Example:

Original WinHttpException message: "The parameter is incorrect"
New WinHttpException message: "Error 87 calling WinHttpSendRequest, 'The parameter is incorrect'."

I also moved the WinHttpException source code back from Common. It was originally shared between WinHttpHandler and ClientWebSocket. But then ClientWebSocket moved away from WinHttp implementation. So, it makes more sense for this class to be under WinHttpHandler.

Closes #28156
Contributes to #26278