### PR TITLE
wrap Read in loop as it can return less bytes than asked for

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Tests
 {
@@ -18,12 +19,15 @@ namespace System.Net.Tests
         private HttpListenerFactory _factory;
         private HttpListener _listener;
         private GetContextHelper _helper;
+        private static int s_timeout = 60 * 1000;
+        readonly ITestOutputHelper _output;
 
-        public HttpRequestStreamTests()
+        public HttpRequestStreamTests(ITestOutputHelper output)
         {
             _factory = new HttpListenerFactory();
             _listener = _factory.GetListener();
             _helper = new GetContextHelper(_listener, _factory.ListeningUrl);
+            _output = output;
         }
 
         public void Dispose()
@@ -32,8 +36,59 @@ namespace System.Net.Tests
             _helper.Dispose();
         }
 
+        // Try to read 'length' bytes from stream or fail after timeout.
+        private async Task<int> GetBytesAsync(Func<byte[], int, int, Task<int>> cb, byte[] array, int offset, int length)
+        {
+            int remaining = length;
+            int readLength;
+
+            do
+            {
+                readLength = await TaskTimeoutExtensions.TimeoutAfter(cb(array, offset, remaining), s_timeout);
+                if (readLength <= 0)
+                {
+                    break;
+                }
+                remaining -= readLength;
+                offset += readLength;
+            }
+            while (remaining > 0);
+
+            if (remaining != 0)
+            {
+                _output.WriteLine("Expected {0} bytes but got {1}", length, length-remaining);
+            }
+
+            return length - remaining;
+        }
+
+        // Synchronous version of GetBytesAsync above.
+        private int GetBytes(Func<byte[], int, int, int> cb, byte[] array, int offset, int length)
+        {
+            int remaining = length;
+            int readLength;
+
+            do
+            {
+                readLength = cb(array, offset, remaining);
+                if (readLength <= 0)
+                {
+                    break;
+                }
+                remaining -= readLength;
+                offset += readLength;
+            }
+            while (remaining > 0);
+
+            if (remaining != 0)
+            {
+                _output.WriteLine("Expected {0} bytes but got {1}", length, length-remaining);
+            }
+
+            return length - remaining;
+        }
+
         [Theory]
-        [ActiveIssue(27996, TestPlatforms.OSX)]
         [InlineData(true, "")]
         [InlineData(false, "")]
         [InlineData(true, "Non-Empty")]
@@ -61,7 +116,7 @@ namespace System.Net.Tests
                 }
 
                 byte[] buffer = new byte[expected.Length];
-                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length);
+                int bytesRead = await GetBytesAsync(context.Request.InputStream.ReadAsync, buffer, 0, expected.Length);
                 Assert.Equal(expected.Length, bytesRead);
                 Assert.Equal(expected, buffer);
 
@@ -78,7 +133,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(27996, TestPlatforms.OSX)]
         [InlineData(true, "")]
         [InlineData(false, "")]
         [InlineData(true, "Non-Empty")]
@@ -109,7 +163,7 @@ namespace System.Net.Tests
 
                 // Add padding at beginning and end to test for correct offset/size handling
                 byte[] buffer = new byte[pad + expected.Length + pad];
-                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, pad, expected.Length);
+                int bytesRead = await GetBytesAsync(context.Request.InputStream.ReadAsync, buffer, pad, expected.Length);
                 Assert.Equal(expected.Length, bytesRead);
                 Assert.Equal(expected, buffer.Skip(pad).Take(bytesRead));
 
@@ -125,7 +179,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(27996, TestPlatforms.OSX)]
         [InlineData(true, "")]
         [InlineData(false, "")]
         [InlineData(true, "Non-Empty")]
@@ -153,7 +206,7 @@ namespace System.Net.Tests
                 }
 
                 byte[] buffer = new byte[expected.Length];
-                int bytesRead = context.Request.InputStream.Read(buffer, 0, buffer.Length);
+                int bytesRead = GetBytes(context.Request.InputStream.Read, buffer, 0, buffer.Length);
                 Assert.Equal(expected.Length, bytesRead);
                 Assert.Equal(expected, buffer);
 
@@ -250,7 +303,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(27996, TestPlatforms.OSX)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_TooMuchAsynchronous_Success(bool transferEncodingChunked)
@@ -267,7 +319,7 @@ namespace System.Net.Tests
                 HttpListenerContext context = await contextTask;
 
                 byte[] buffer = new byte[expected.Length + 5];
-                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length);
+                int bytesRead = await GetBytesAsync(context.Request.InputStream.ReadAsync, buffer, 0, buffer.Length);
                 Assert.Equal(expected.Length, bytesRead);
                 Assert.Equal(expected.Concat(new byte[5]), buffer);
 
@@ -277,7 +329,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(27996, TestPlatforms.OSX)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_TooMuchSynchronous_Success(bool transferEncodingChunked)
@@ -294,7 +345,7 @@ namespace System.Net.Tests
                 HttpListenerContext context = await contextTask;
 
                 byte[] buffer = new byte[expected.Length + 5];
-                int bytesRead = context.Request.InputStream.Read(buffer, 0, buffer.Length);
+                int bytesRead = GetBytes(context.Request.InputStream.Read, buffer, 0, buffer.Length);
                 Assert.Equal(expected.Length, bytesRead);
                 Assert.Equal(expected.Concat(new byte[5]), buffer);
 
@@ -304,7 +355,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(27996, TestPlatforms.OSX)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_NotEnoughThenCloseAsynchronous_Success(bool transferEncodingChunked)
@@ -321,7 +371,7 @@ namespace System.Net.Tests
                 HttpListenerContext context = await contextTask;
 
                 byte[] buffer = new byte[expected.Length - 5];
-                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length);
+                int bytesRead = await GetBytesAsync(context.Request.InputStream.ReadAsync, buffer, 0, buffer.Length);
                 Assert.Equal(buffer.Length, bytesRead);
 
                 context.Response.Close();

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -31,6 +31,9 @@
     <Compile Include="SimpleHttpTests.cs" />
     <Compile Include="WebSocketTests.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+      <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\System.Net.HttpListener.Tests.rd.xml" />


### PR DESCRIPTION
fixes #27996

As described in the issue, new socket handler uses small buffers to provoke conditions like this and test was failing assuming it can always read all data at one.
