### PR TITLE
Fix missing port number in HttpRequestMessage constructed by HttpWebRequest

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1163,7 +1163,7 @@ namespace System.Net
 
                 if (_hostUri != null)
                 {
-                    request.Headers.Host = _hostUri.Host;
+                    request.Headers.Host = Host;
                 }
 
                 // Copy the HttpWebRequest request headers from the WebHeaderCollection into HttpRequestMessage.Headers and

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -200,10 +200,16 @@ namespace System.Net.Tests
 
                 await server.AcceptConnectionAsync(async connection =>
                 {
-                    // Skip status line.
-                    await connection.Reader.ReadLineAsync();
+                    await connection.Reader.ReadLineAsync(); // Skip status line.
                     Assert.Contains(host, await connection.Reader.ReadLineAsync());
+
+                    await connection.SendResponseAsync();
                 });
+
+                using (HttpWebResponse response = (HttpWebResponse)await getResponse)
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
             });
         }
 

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -200,10 +200,8 @@ namespace System.Net.Tests
 
                 await server.AcceptConnectionAsync(async connection =>
                 {
-                    await connection.Reader.ReadLineAsync(); // Skip status line.
-                    Assert.Contains(host, await connection.Reader.ReadLineAsync());
-
-                    await connection.SendResponseAsync();
+                    List<string> headers = await connection.ReadRequestHeaderAndSendResponseAsync();
+                    Assert.Contains($"Host: {host}", headers);
                 });
 
                 using (var response = (HttpWebResponse) await getResponse)

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -206,7 +206,7 @@ namespace System.Net.Tests
                     await connection.SendResponseAsync();
                 });
 
-                using (HttpWebResponse response = (HttpWebResponse)await getResponse)
+                using (var response = (HttpWebResponse) await getResponse)
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 }

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -188,6 +188,25 @@ namespace System.Net.Tests
             });
         }
 
+        [Fact]
+        public async Task HttpWebRequest_SetHostHeader_ContainsPortNumber()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                string host = uri.Host + ":" + uri.Port;
+                request.Host = host;
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    // Skip status line.
+                    await connection.Reader.ReadLineAsync();
+                    Assert.Contains(host, await connection.Reader.ReadLineAsync());
+                });
+            });
+        }
+
         [Theory, MemberData(nameof(EchoServers))]
         public void MaximumResponseHeadersLength_SetNegativeTwo_ThrowsArgumentOutOfRangeException(Uri remoteServer)
         {


### PR DESCRIPTION
Fix #28344.