### PR TITLE
Fixed netfx System.Net.WebSockets.Client.Tests fails on non-English Windows

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Common.Tests;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -51,8 +53,16 @@ namespace System.Net.WebSockets.Client.Tests
         {
             using (var cws = new ClientWebSocket())
             {
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => cws.CloseOutputAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()));
+                InvalidOperationException exception;
+                using (var tcc = new ThreadCultureChange())
+                {
+                    // The .Net Native toolchain optimizes away exception messages.
+                    if (!PlatformDetection.IsNetNative)
+                        tcc.ChangeCultureInfo(CultureInfo.InvariantCulture);
+
+                    exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => cws.CloseOutputAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()));
+                }
 
                 // The .Net Native toolchain optimizes away exception messages.
                 if (!PlatformDetection.IsNetNative)
@@ -90,8 +100,17 @@ namespace System.Net.WebSockets.Client.Tests
                 var segment = new ArraySegment<byte>(buffer);
                 var ct = new CancellationToken();
 
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => cws.ReceiveAsync(segment, ct));
+                InvalidOperationException exception;
+
+                using (var tcc = new ThreadCultureChange())
+                {
+                    // The .Net Native toolchain optimizes away exception messages.
+                    if (!PlatformDetection.IsNetNative)
+                        tcc.ChangeCultureInfo(CultureInfo.InvariantCulture);
+
+                    exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => cws.ReceiveAsync(segment, ct));
+                }
 
                 // The .Net Native toolchain optimizes away exception messages.
                 if (!PlatformDetection.IsNetNative)
@@ -129,8 +148,16 @@ namespace System.Net.WebSockets.Client.Tests
                 var segment = new ArraySegment<byte>(buffer);
                 var ct = new CancellationToken();
 
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => cws.SendAsync(segment, WebSocketMessageType.Text, false, ct));
+                InvalidOperationException exception;
+                using (var tcc = new ThreadCultureChange())
+                {
+                    // The .Net Native toolchain optimizes away exception messages.
+                    if (!PlatformDetection.IsNetNative)
+                        tcc.ChangeCultureInfo(CultureInfo.InvariantCulture);
+
+                    exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => cws.SendAsync(segment, WebSocketMessageType.Text, false, ct));
+                }
 
                 // The .Net Native toolchain optimizes away exception messages.
                 if (!PlatformDetection.IsNetNative)

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -42,6 +42,9 @@
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\ThreadCultureChange.cs">
+      <Link>Common\System\ThreadCultureChange.cs</Link>
+    </Compile>
     <Compile Include="AbortTest.cs" />
     <Compile Include="CancelTest.cs" />
     <Compile Include="ClientWebSocketOptionsTests.cs" />


### PR DESCRIPTION
See https://github.com/dotnet/corefx/issues/28136