### PR TITLE
Make HashAlgorithm.Create(string) and friends work on .NET Core

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
@@ -192,7 +192,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
                 yield return new object[] { "System.Security.Cryptography.AsymmetricAlgorithm", "System.Security.Cryptography.RSACryptoServiceProvider", true };
                 yield return new object[] { "DSA", "System.Security.Cryptography.DSACryptoServiceProvider", true };
                 yield return new object[] { "System.Security.Cryptography.DSA", "System.Security.Cryptography.DSACryptoServiceProvider", true };
-                yield return new object[] { "ECDsa", "System.Security.Cryptography.ECDsaCng", false };
+                yield return new object[] { "ECDsa", "System.Security.Cryptography.ECDsaCng", true };
                 yield return new object[] { "ECDsaCng", "System.Security.Cryptography.ECDsaCng", false };
                 yield return new object[] { "System.Security.Cryptography.ECDsaCng", null, false };
                 yield return new object[] { "DES", "System.Security.Cryptography.DESCryptoServiceProvider", true };
@@ -256,7 +256,9 @@ namespace System.Security.Cryptography.CryptoConfigTests
         [Theory, MemberData(nameof(AllValidNames))]
         public static void CreateFromName_AllValidNames(string name, string typeName, bool supportsUnixMac)
         {
-            if (supportsUnixMac || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+            if (supportsUnixMac || isWindows)
             {
                 object obj = CryptoConfig.CreateFromName(name);
                 Assert.NotNull(obj);
@@ -266,7 +268,15 @@ namespace System.Security.Cryptography.CryptoConfigTests
                     typeName = name;
                 }
 
-                Assert.Equal(typeName, obj.GetType().FullName);
+                // ECDsa is special on non-Windows
+                if (isWindows || name != "ECDsa")
+                {
+                    Assert.Equal(typeName, obj.GetType().FullName);
+                }
+                else
+                {
+                    Assert.NotEqual(typeName, obj.GetType().FullName);
+                }
 
                 if (obj is IDisposable)
                 {

--- a/src/System.Security.Cryptography.Primitives/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Primitives/src/Resources/Strings.resx
@@ -79,6 +79,9 @@
   <data name="Cryptography_CryptoStream_FlushFinalBlockTwice" xml:space="preserve">
     <value>FlushFinalBlock() method was called twice on a CryptoStream. It can only be called once.</value>
   </data>
+  <data name="Cryptography_DefaultAlgorithm_NotSupported" xml:space="preserve">
+    <value>This platform does not allow the automatic selection of an algorithm.</value>
+  </data>
   <data name="Cryptography_HashNotYetFinalized" xml:space="preserve">
     <value>Hash must be finalized before the hash value is retrieved.</value>
   </data>

--- a/src/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.csproj
+++ b/src/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="System\Security\Cryptography\AsymmetricAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\CipherMode.cs" />
+    <Compile Include="System\Security\Cryptography\CryptoConfigForwarder.cs" />
     <Compile Include="System\Security\Cryptography\CryptographicOperations.cs" />
     <Compile Include="System\Security\Cryptography\CryptographicUnexpectedOperationException.cs" />
     <Compile Include="System\Security\Cryptography\CryptoStream.cs" />

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
@@ -11,15 +11,11 @@ namespace System.Security.Cryptography
 
         protected AsymmetricAlgorithm() { }
 
-        public static AsymmetricAlgorithm Create()
-        {
-            return Create("System.Security.Cryptography.AsymmetricAlgorithm");
-        }
+        public static AsymmetricAlgorithm Create() =>
+            throw new PlatformNotSupportedException(SR.Cryptography_DefaultAlgorithm_NotSupported);
 
-        public static AsymmetricAlgorithm Create(string algName)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public static AsymmetricAlgorithm Create(string algName) =>
+            (AsymmetricAlgorithm)CryptoConfigForwarder.CreateFromName(algName);
 
         public virtual int KeySize
         {

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace System.Security.Cryptography
+{
+    internal static class CryptoConfigForwarder
+    {
+        private static readonly Func<string, object> s_createFromName;
+
+        static CryptoConfigForwarder()
+        {
+            const string CryptoConfigTypeName =
+                "System.Security.Cryptography.CryptoConfig, System.Security.Cryptography.Algorithms";
+
+            const string CreateFromNameMethodName = "CreateFromName";
+
+            Type t = Type.GetType(CryptoConfigTypeName, true);
+            MethodInfo createFromName = t.GetMethod(CreateFromNameMethodName, new[] { typeof(string) });
+
+            if (createFromName == null)
+            {
+                throw new MissingMethodException(CryptoConfigTypeName, CreateFromNameMethodName);
+            }
+
+            s_createFromName = (Func<string, object>)createFromName.CreateDelegate(typeof(Func<string, object>));
+        }
+
+        internal static object CreateFromName(string name) => s_createFromName(name);
+    }
+}

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
@@ -8,24 +8,24 @@ namespace System.Security.Cryptography
 {
     internal static class CryptoConfigForwarder
     {
-        private static readonly Func<string, object> s_createFromName;
+        private static readonly Func<string, object> s_createFromName = BindCreateFromName();
 
-        static CryptoConfigForwarder()
+        private static Func<string, object> BindCreateFromName()
         {
             const string CryptoConfigTypeName =
                 "System.Security.Cryptography.CryptoConfig, System.Security.Cryptography.Algorithms";
 
             const string CreateFromNameMethodName = "CreateFromName";
 
-            Type t = Type.GetType(CryptoConfigTypeName, true);
+            Type t = Type.GetType(CryptoConfigTypeName, throwOnError: true);
             MethodInfo createFromName = t.GetMethod(CreateFromNameMethodName, new[] { typeof(string) });
 
             if (createFromName == null)
             {
-                throw new MissingMethodException(CryptoConfigTypeName, CreateFromNameMethodName);
+                throw new MissingMethodException(t.FullName, CreateFromNameMethodName);
             }
 
-            s_createFromName = (Func<string, object>)createFromName.CreateDelegate(typeof(Func<string, object>));
+            return (Func<string, object>)createFromName.CreateDelegate(typeof(Func<string, object>));
         }
 
         internal static object CreateFromName(string name) => s_createFromName(name);

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
@@ -17,9 +17,11 @@ namespace System.Security.Cryptography
 
         protected HMAC() { }
 
-        public static new HMAC Create() => Create("System.Security.Cryptography.HMAC");
+        public static new HMAC Create() =>
+            throw new PlatformNotSupportedException(SR.Cryptography_DefaultAlgorithm_NotSupported);
 
-        public static new HMAC Create(string algorithmName) => throw new PlatformNotSupportedException();
+        public static new HMAC Create(string algorithmName) =>
+            (HMAC)CryptoConfigForwarder.CreateFromName(algorithmName);
 
         public string HashName
         {

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
@@ -16,9 +16,11 @@ namespace System.Security.Cryptography
 
         protected HashAlgorithm() { }
 
-        public static HashAlgorithm Create() => Create("System.Security.Cryptography.HashAlgorithm");
+        public static HashAlgorithm Create() =>
+            throw new PlatformNotSupportedException(SR.Cryptography_DefaultAlgorithm_NotSupported);
 
-        public static HashAlgorithm Create(string hashName) => throw new PlatformNotSupportedException();
+        public static HashAlgorithm Create(string hashName) =>
+            (HashAlgorithm)CryptoConfigForwarder.CreateFromName(hashName);
 
         public virtual int HashSize => HashSizeValue;
 

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/KeyedHashAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/KeyedHashAlgorithm.cs
@@ -8,15 +8,11 @@ namespace System.Security.Cryptography
     {
         protected KeyedHashAlgorithm() { }
 
-        public static new KeyedHashAlgorithm Create()
-        {
-            return Create("System.Security.Cryptography.KeyedHashAlgorithm");
-        }
+        public static new KeyedHashAlgorithm Create() =>
+            throw new PlatformNotSupportedException(SR.Cryptography_DefaultAlgorithm_NotSupported);
 
-        public static new KeyedHashAlgorithm Create(string algName)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public static new KeyedHashAlgorithm Create(string algName) =>
+            (KeyedHashAlgorithm)CryptoConfigForwarder.CreateFromName(algName);
 
         public virtual byte[] Key
         {

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
@@ -12,15 +12,11 @@ namespace System.Security.Cryptography
             PaddingValue = PaddingMode.PKCS7;
         }
 
-        public static SymmetricAlgorithm Create()
-        {
-            return Create("System.Security.Cryptography.SymmetricAlgorithm");
-        }
+        public static SymmetricAlgorithm Create() =>
+            throw new PlatformNotSupportedException(SR.Cryptography_DefaultAlgorithm_NotSupported);
 
-        public static SymmetricAlgorithm Create(string algName)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public static SymmetricAlgorithm Create(string algName) =>
+            (SymmetricAlgorithm)CryptoConfigForwarder.CreateFromName(algName);
 
         public virtual int FeedbackSize
         {

--- a/src/System.Security.Cryptography.Primitives/tests/CryptoConfigTests.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoConfigTests.cs
@@ -9,20 +9,151 @@ namespace System.Security.Cryptography.CryptoConfigTests
     public static class CryptoConfigTests
     {
         [Fact]
-        public static void StaticCreateMethods()
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void DefaultStaticCreateMethods()
         {
-            // These are not supported because CryptoConfig exists in Algorithms assembly.
-            // CryptoConfig exists in Algorithms partly because it requires the Oid class in Encoding assembly.
+            // .NET Core does not allow the base classes to pick an algorithm.
             Assert.Throws<PlatformNotSupportedException>(() => AsymmetricAlgorithm.Create());
-            Assert.Throws<PlatformNotSupportedException>(() => AsymmetricAlgorithm.Create(null));
             Assert.Throws<PlatformNotSupportedException>(() => HashAlgorithm.Create());
-            Assert.Throws<PlatformNotSupportedException>(() => HashAlgorithm.Create(null));
             Assert.Throws<PlatformNotSupportedException>(() => KeyedHashAlgorithm.Create());
-            Assert.Throws<PlatformNotSupportedException>(() => KeyedHashAlgorithm.Create(null));
             Assert.Throws<PlatformNotSupportedException>(() => HMAC.Create());
-            Assert.Throws<PlatformNotSupportedException>(() => HMAC.Create(null));
             Assert.Throws<PlatformNotSupportedException>(() => SymmetricAlgorithm.Create());
-            Assert.Throws<PlatformNotSupportedException>(() => SymmetricAlgorithm.Create(null));
+        }
+
+        [Fact]
+        public static void NamedCreateMethods_NullInput()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("name", () => AsymmetricAlgorithm.Create(null));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => HashAlgorithm.Create(null));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => KeyedHashAlgorithm.Create(null));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => HMAC.Create(null));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => SymmetricAlgorithm.Create(null));
+        }
+
+        // The returned types on .NET Framework can differ when the machine is in FIPS mode.
+        // So check hash algorithms via a more complicated manner.
+        [Theory]
+        [InlineData("MD5", typeof(MD5))]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#md5", typeof(MD5))]
+        [InlineData("System.Security.Cryptography.HashAlgorithm", typeof(SHA1))]
+        [InlineData("SHA1", typeof(SHA1))]
+        [InlineData("http://www.w3.org/2000/09/xmldsig#sha1", typeof(SHA1))]
+        [InlineData("SHA256", typeof(SHA256))]
+        [InlineData("SHA-256", typeof(SHA256))]
+        [InlineData("http://www.w3.org/2001/04/xmlenc#sha256", typeof(SHA256))]
+        [InlineData("SHA384", typeof(SHA384))]
+        [InlineData("SHA-384", typeof(SHA384))]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#sha384", typeof(SHA384))]
+        [InlineData("SHA512", typeof(SHA512))]
+        [InlineData("SHA-512", typeof(SHA512))]
+        [InlineData("http://www.w3.org/2001/04/xmlenc#sha512", typeof(SHA512))]
+        public static void NamedHashAlgorithmCreate(string identifier, Type baseType)
+        {
+            using (HashAlgorithm created = HashAlgorithm.Create(identifier))
+            {
+                Assert.NotNull(created);
+                Assert.IsAssignableFrom(baseType, created);
+
+                using (HashAlgorithm equivalent =
+                    (HashAlgorithm)baseType.GetMethod("Create", Array.Empty<Type>()).Invoke(null, null))
+                {
+                    byte[] input = { 1, 2, 3, 4, 5 };
+                    byte[] equivHash = equivalent.ComputeHash(input);
+                    byte[] createdHash = created.ComputeHash(input);
+                    Assert.Equal(equivHash, createdHash);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("System.Security.Cryptography.HMAC", typeof(HMACSHA1))]
+        [InlineData("System.Security.Cryptography.KeyedHashAlgorithm", typeof(HMACSHA1))]
+        [InlineData("System.Security.Cryptography.HMACSHA1", typeof(HMACSHA1))]
+        [InlineData("HMACSHA1", typeof(HMACSHA1))]
+        [InlineData("http://www.w3.org/2000/09/xmldsig#hmac-sha1", typeof(HMACSHA1))]
+        [InlineData("System.Security.Cryptography.HMACSHA256", typeof(HMACSHA256))]
+        [InlineData("HMACSHA256", typeof(HMACSHA256))]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#hmac-sha256", typeof(HMACSHA256))]
+        [InlineData("System.Security.Cryptography.HMACSHA384", typeof(HMACSHA384))]
+        [InlineData("HMACSHA384", typeof(HMACSHA384))]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#hmac-sha384", typeof(HMACSHA384))]
+        [InlineData("System.Security.Cryptography.HMACSHA512", typeof(HMACSHA512))]
+        [InlineData("HMACSHA512", typeof(HMACSHA512))]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#hmac-sha512", typeof(HMACSHA512))]
+        [InlineData("System.Security.Cryptography.HMACMD5", typeof(HMACMD5))]
+        [InlineData("HMACMD5", typeof(HMACMD5))]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#hmac-md5", typeof(HMACMD5))]
+        public static void NamedKeyedHashAlgorithmCreate(string identifier, Type actualType)
+        {
+            using (KeyedHashAlgorithm kha = KeyedHashAlgorithm.Create(identifier))
+            {
+                Assert.IsType(actualType, kha);
+
+                // .NET Core only has HMAC keyed hash algorithms, so combine the two tests
+                using (HMAC hmac = HMAC.Create(identifier))
+                {
+                    Assert.IsType(actualType, hmac);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("AES", typeof(Aes))]
+        [InlineData("Rijndael", typeof(Rijndael))]
+        [InlineData("System.Security.Cryptography.Rijndael", typeof(Rijndael))]
+        [InlineData("http://www.w3.org/2001/04/xmlenc#aes128-cbc", typeof(Rijndael))]
+        [InlineData("http://www.w3.org/2001/04/xmlenc#aes192-cbc", typeof(Rijndael))]
+        [InlineData("http://www.w3.org/2001/04/xmlenc#aes256-cbc", typeof(Rijndael))]
+        [InlineData("3DES", typeof(TripleDES))]
+        [InlineData("TripleDES", typeof(TripleDES))]
+        [InlineData("System.Security.Cryptography.TripleDES", typeof(TripleDES))]
+        [InlineData("http://www.w3.org/2001/04/xmlenc#tripledes-cbc", typeof(TripleDES))]
+        [InlineData("DES", typeof(DES))]
+        [InlineData("System.Security.Cryptography.DES", typeof(DES))]
+        [InlineData("http://www.w3.org/2001/04/xmlenc#des-cbc", typeof(DES))]
+        public static void NamedSymmetricAlgorithmCreate(string identifier, Type baseType)
+        {
+            using (SymmetricAlgorithm created = SymmetricAlgorithm.Create(identifier))
+            {
+                Assert.NotNull(created);
+                Assert.IsAssignableFrom(baseType, created);
+            }
+        }
+
+        [Theory]
+        [InlineData("RSA", typeof(RSA))]
+        [InlineData("System.Security.Cryptography.RSA", typeof(RSA))]
+        [InlineData("ECDsa", typeof(ECDsa))]
+        [InlineData("DSA", typeof(DSA))]
+        [InlineData("System.Security.Cryptography.DSA", typeof(DSA))]
+        public static void NamedAsymmetricAlgorithmCreate(string identifier, Type baseType)
+        {
+            using (AsymmetricAlgorithm created = AsymmetricAlgorithm.Create(identifier))
+            {
+                Assert.NotNull(created);
+                Assert.IsAssignableFrom(baseType, created);
+            }
+        }
+
+        [Fact]
+        public static void NamedCreate_Mismatch()
+        {
+            Assert.Throws<InvalidCastException>(() => AsymmetricAlgorithm.Create("SHA1"));
+            Assert.Throws<InvalidCastException>(() => KeyedHashAlgorithm.Create("SHA1"));
+            Assert.Throws<InvalidCastException>(() => HMAC.Create("SHA1"));
+            Assert.Throws<InvalidCastException>(() => SymmetricAlgorithm.Create("SHA1"));
+            Assert.Throws<InvalidCastException>(() => HashAlgorithm.Create("RSA"));
+        }
+
+        [Fact]
+        public static void NamedCreate_Unknown()
+        {
+            const string UnknownAlgorithmName = "XYZZY";
+            Assert.Null(AsymmetricAlgorithm.Create(UnknownAlgorithmName));
+            Assert.Null(HashAlgorithm.Create(UnknownAlgorithmName));
+            Assert.Null(KeyedHashAlgorithm.Create(UnknownAlgorithmName));
+            Assert.Null(HMAC.Create(UnknownAlgorithmName));
+            Assert.Null(SymmetricAlgorithm.Create(UnknownAlgorithmName));
         }
     }
 }

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -11,8 +11,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
+      <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
+    </Compile>
     <Compile Include="AsymmetricAlgorithm\Trivial.cs" />
+    <Compile Include="CryptoConfigTests.cs" />
     <Compile Include="CryptoStream.cs" />
+    <Compile Include="CryptographicException.cs" />
     <Compile Include="HmacAlgorithmTest.cs" />
     <Compile Include="KeyedHashAlgorithmTests.cs" />
     <Compile Include="Length32Hash.cs" />
@@ -20,13 +25,8 @@
     <Compile Include="Sum32Hash.cs" />
     <Compile Include="SymmetricAlgorithm\Minimal.cs" />
     <Compile Include="SymmetricAlgorithm\Trivial.cs" />
-    <Compile Include="CryptographicException.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
-      <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
-    <Compile Include="CryptoConfigTests.cs" />
     <Compile Include="FixedTimeEqualsTests.cs" />
     <Compile Include="HashAlgorithmTest.netcoreapp.cs" />
     <Compile Include="ZeroMemoryTests.cs" />


### PR DESCRIPTION
The Create(void) methods will continue to throw PNSE, because we do not want
people depending on the "I'll create a thing for you" behavior and assuming that
it has positive value (historically it has been kept as-is in .NET Framework for
compatibility sake).  Now they have a message in their PNSE.

The Create(string) methods will forward to CryptoConfig, just like in .NET Framework.
The difference in .NET Core is that CryptoConfig lives in a future assembly, and
rather than build System.Private.Cryptography for this, just build a reflection bridge.

Fixes #22626.