### PR TITLE
Fixed netfx System.Runtime.Serialization.Formatters.Tests fails on non-English Windows

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTestData.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTestData.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Common.Tests;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.ComponentModel.DataAnnotations;
@@ -63,17 +64,9 @@ namespace System.Runtime.Serialization.Formatters.Tests
         public static IEnumerable<object[]> SerializableObjects_MemberData()
         {
             // Save old culture and set a fixed culture for object instantiation
-            CultureInfo oldCulture = CultureInfo.CurrentCulture;
-
-            try
+            using (new ThreadCultureChange(CultureInfo.InvariantCulture))
             {
-                CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
                 return SerializableObjects().ToArray();
-            }
-            finally
-            {
-                // Revert setting a fixed culture
-                CultureInfo.CurrentCulture = oldCulture;
             }
         }
 

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -29,7 +29,9 @@
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
-  </ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\ThreadCultureChange.cs">
+      <Link>Common\System\ThreadCultureChange.cs</Link>
+    </Compile>  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="BinaryFormatterTests.rd.xml" />
   </ItemGroup>


### PR DESCRIPTION
See https://github.com/dotnet/corefx/issues/28136