### PR TITLE
Suppress NETStandard.Library package collapsing

### DIFF
--- a/src/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
+++ b/src/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
@@ -11,6 +11,12 @@
       <SupportedFramework>netcore50</SupportedFramework>
     </HarvestIncludePaths>
     <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+
+    <!-- 
+      Suppress NETStandard.Library collpasing as it add more dependencies then needed in some 
+      scenarios like .NET Framework which adds an unecessary amount of package dependencies to download 
+    -->
+    <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Packaging/pkg/System.IO.Packaging.pkgproj
+++ b/src/System.IO.Packaging/pkg/System.IO.Packaging.pkgproj
@@ -6,6 +6,12 @@
       <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Packaging.csproj" />
+
+    <!-- 
+      Suppress NETStandard.Library collpasing as it add more dependencies then needed in some 
+      scenarios like .NET Framework which adds an unecessary amount of package dependencies to download 
+    -->
+    <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
+++ b/src/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
@@ -8,6 +8,12 @@
     <ProjectReference Include="..\src\System.Security.Cryptography.Pkcs.csproj" />
     <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="ref/netstandard1.3;runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+
+    <!-- 
+      Suppress NETStandard.Library collpasing as it add more dependencies then needed in some 
+      scenarios like .NET Framework which adds an unecessary amount of package dependencies to download 
+    -->
+    <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
There are a few packages which have only a small number
of packages that are part of NETStandard.Library which we
should avoid replacing with NETStandard.Library because it adds
a lot of extra package dependencies which aren't necessary.

cc @ericstj @joperezr 

This is an alternative fix for https://github.com/dotnet/corefx/issues/26129, once BuildTools change https://github.com/dotnet/buildtools/pull/1978 goes in to fix https://github.com/dotnet/corefx/issues/26390.

@ericstj I considered bumping these to NETStandard.Library 2.0.1 references but even in those cases there are more packages than are needed for these packages so I decided to go with this approach to suppress just these cases. 