### PR TITLE
Fix File.ReadAllBytes{Async} for virtual file system files

### DIFF
--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests
@@ -119,6 +120,58 @@ namespace System.IO.Tests
             {
                 File.SetAttributes(path, FileAttributes.Normal);
             }
+        }
+
+        [Fact]
+        public void EmptyFile_ReturnsEmptyArray()
+        {
+            string path = GetTestFilePath();
+            File.Create(path).Dispose();
+            Assert.Equal(0, File.ReadAllBytes(path).Length);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        [InlineData("/proc/cmdline")]
+        [InlineData("/proc/version")]
+        [InlineData("/proc/filesystems")]
+        public void ProcFs_EqualsReadAllText(string path)
+        {
+            byte[] bytes = null;
+            string text = null;
+
+            const int NumTries = 3; // some of these could theoretically change between reads, so allow retries just in case
+            for (int i = 1; i <= NumTries; i++)
+            {
+                try
+                {
+                    bytes = File.ReadAllBytes(path);
+                    text = File.ReadAllText(path);
+                    Assert.Equal(text, Encoding.UTF8.GetString(bytes));
+                }
+                catch when (i < NumTries) { }
+            }
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        public void ReadAllBytes_ProcFs_Uptime_ContainsTwoNumbers()
+        {
+            string text = Encoding.UTF8.GetString(File.ReadAllBytes("/proc/uptime"));
+            string[] parts = text.Split(new [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(2, parts.Length);
+            Assert.True(double.TryParse(parts[0].Trim(), out _));
+            Assert.True(double.TryParse(parts[1].Trim(), out _));
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        [InlineData("/proc/meminfo")]
+        [InlineData("/proc/stat")]
+        [InlineData("/proc/cpuinfo")]
+        public void ProcFs_NotEmpty(string path)
+        {
+            Assert.InRange(File.ReadAllBytes(path).Length, 1, int.MaxValue);
         }
     }
 }


### PR DESCRIPTION
Some file systems, like procfs, can return 0 for a file's length, even though it actually contains on-demand computed contents.  This breaks File.ReadAllBytes{Async}, which currently assumes that a length of 0 means the file is empty.  This commit fixes it by changing the assumption to mean that a length of 0 means we can't depend on the Length and instead need to read until EOF.

This brings File.ReadAllBytes inline with the behavior of File.ReadAllText.  Note that this does mean that it'll also start OOM'ing in similar situations, e.g. if you try to do `File.ReadAllBytes("/dev/urandom")`, it'll eventually OOM whereas today it returns an empty array.

Fixes https://github.com/dotnet/corefx/issues/28343
cc: @JeremyKuhne, @tmds, @VasiliyNovikov