### PR TITLE
Fixing MatchingRefApiCompat issues with Sys.Configuration.ConfigurationManager

### DIFF
--- a/src/System.Configuration.ConfigurationManager/ref/System.Configuration.cs
+++ b/src/System.Configuration.ConfigurationManager/ref/System.Configuration.cs
@@ -1386,7 +1386,7 @@ namespace System.Configuration
 }
 namespace System.Configuration.Internal
 {
-    public partial class DelegatingConfigHost : System.Configuration.Internal.IInternalConfigHost, System.Configuration.Internal.IInternalConfigHostPaths
+    public partial class DelegatingConfigHost : System.Configuration.Internal.IInternalConfigHost
     {
         protected DelegatingConfigHost() { }
         protected System.Configuration.Internal.IInternalConfigHost Host { get { throw null; } set { } }
@@ -1522,13 +1522,6 @@ namespace System.Configuration.Internal
         void VerifyDefinitionAllowed(string configPath, System.Configuration.ConfigurationAllowDefinition allowDefinition, System.Configuration.ConfigurationAllowExeDefinition allowExeDefinition, System.Configuration.Internal.IConfigErrorInfo errorInfo);
         void WriteCompleted(string streamName, bool success, object writeContext);
         void WriteCompleted(string streamName, bool success, object writeContext, bool assertPermissions);
-    }
-    internal interface IInternalConfigHostPaths
-    {
-        void RefreshConfigPaths();
-        bool HasLocalConfig { get; }
-        bool HasRoamingConfig { get; }
-        bool IsAppConfigHttp { get; }
     }
     public partial interface IInternalConfigRecord
     {

--- a/src/System.Configuration.ConfigurationManager/ref/System.Configuration.cs
+++ b/src/System.Configuration.ConfigurationManager/ref/System.Configuration.cs
@@ -1386,7 +1386,7 @@ namespace System.Configuration
 }
 namespace System.Configuration.Internal
 {
-    public partial class DelegatingConfigHost : System.Configuration.Internal.IInternalConfigHost
+    public partial class DelegatingConfigHost : System.Configuration.Internal.IInternalConfigHost, System.Configuration.Internal.IInternalConfigHostPaths
     {
         protected DelegatingConfigHost() { }
         protected System.Configuration.Internal.IInternalConfigHost Host { get { throw null; } set { } }
@@ -1404,10 +1404,12 @@ namespace System.Configuration.Internal
         public virtual System.Type GetConfigType(string typeName, bool throwOnError) { throw null; }
         public virtual string GetConfigTypeName(System.Type t) { throw null; }
         public virtual void GetRestrictedPermissions(IInternalConfigRecord configRecord, out System.Security.PermissionSet permissionSet, out bool isHostReady) { throw null; }
-
         public virtual string GetStreamName(string configPath) { throw null; }
         public virtual string GetStreamNameForConfigSource(string streamName, string configSource) { throw null; }
         public virtual object GetStreamVersion(string streamName) { throw null; }
+        public virtual bool HasLocalConfig { get; }
+        public virtual bool HasRoamingConfig { get; }
+        public virtual bool IsAppConfigHttp { get; }
         public virtual System.IDisposable Impersonate() { throw null; }
         public virtual void Init(System.Configuration.Internal.IInternalConfigRoot configRoot, params object[] hostInitParams) { }
         public virtual void InitForConfiguration(ref string locationSubPath, out string configPath, out string locationConfigPath, System.Configuration.Internal.IInternalConfigRoot configRoot, params object[] hostInitConfigurationParams) { configPath = default(string); locationConfigPath = default(string); }
@@ -1427,6 +1429,7 @@ namespace System.Configuration.Internal
         public virtual bool PrefetchAll(string configPath, string streamName) { throw null; }
         public virtual bool PrefetchSection(string sectionGroupName, string sectionName) { throw null; }
         public virtual void RequireCompleteInit(System.Configuration.Internal.IInternalConfigRecord configRecord) { }
+        public virtual void RefreshConfigPaths() { }
         public virtual object StartMonitoringStreamForChanges(string streamName, System.Configuration.Internal.StreamChangeCallback callback) { throw null; }
         public virtual void StopMonitoringStreamForChanges(string streamName, System.Configuration.Internal.StreamChangeCallback callback) { }
         public virtual void VerifyDefinitionAllowed(string configPath, System.Configuration.ConfigurationAllowDefinition allowDefinition, System.Configuration.ConfigurationAllowExeDefinition allowExeDefinition, System.Configuration.Internal.IConfigErrorInfo errorInfo) { }
@@ -1519,6 +1522,13 @@ namespace System.Configuration.Internal
         void VerifyDefinitionAllowed(string configPath, System.Configuration.ConfigurationAllowDefinition allowDefinition, System.Configuration.ConfigurationAllowExeDefinition allowExeDefinition, System.Configuration.Internal.IConfigErrorInfo errorInfo);
         void WriteCompleted(string streamName, bool success, object writeContext);
         void WriteCompleted(string streamName, bool success, object writeContext, bool assertPermissions);
+    }
+    internal interface IInternalConfigHostPaths
+    {
+        void RefreshConfigPaths();
+        bool HasLocalConfig { get; }
+        bool HasRoamingConfig { get; }
+        bool IsAppConfigHttp { get; }
     }
     public partial interface IInternalConfigRecord
     {

--- a/src/System.Configuration.ConfigurationManager/src/MatchingRefApiCompatBaseline.netstandard.txt
+++ b/src/System.Configuration.ConfigurationManager/src/MatchingRefApiCompatBaseline.netstandard.txt
@@ -1,12 +1,4 @@
 Compat issues with assembly System.Configuration.ConfigurationManager:
-MembersMustExist : Member 'System.Configuration.ConfigurationSettings..ctor()' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Configuration.DateTimeConfigurationCollection' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Configuration.SettingsAttributeDictionary..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Configuration.SettingsContext..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
-CannotRemoveBaseTypeOrInterface : Type 'System.Configuration.Internal.DelegatingConfigHost' does not implement interface 'System.Configuration.Internal.IInternalConfigHostPaths' in the implementation but it does in the contract.
-MembersMustExist : Member 'System.Configuration.Internal.DelegatingConfigHost.HasLocalConfig.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Configuration.Internal.DelegatingConfigHost.HasRoamingConfig.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Configuration.Internal.DelegatingConfigHost.IsAppConfigHttp.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Configuration.Internal.DelegatingConfigHost.RefreshConfigPaths()' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Configuration.Internal.IInternalConfigHostPaths' does not exist in the implementation but it does exist in the contract.
-Total Issues: 10
+Total Issues: 2

--- a/src/System.Configuration.ConfigurationManager/src/MatchingRefApiCompatBaseline.netstandard.txt
+++ b/src/System.Configuration.ConfigurationManager/src/MatchingRefApiCompatBaseline.netstandard.txt
@@ -1,4 +1,5 @@
 Compat issues with assembly System.Configuration.ConfigurationManager:
+# Cannot remove the serialization constructors because they are needed for serialization
 MembersMustExist : Member 'System.Configuration.SettingsAttributeDictionary..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Configuration.SettingsContext..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 Total Issues: 2

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationSettings.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationSettings.cs
@@ -8,7 +8,7 @@ namespace System.Configuration
 {
     public sealed class ConfigurationSettings
     {
-        public ConfigurationSettings() { }
+        internal ConfigurationSettings() { }
 
         [Obsolete("This method is obsolete, it has been replaced by System.Configuration!System.Configuration.ConfigurationManager.AppSettings")]
         public static NameValueCollection AppSettings

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/DateTimeConfigurationCollection.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/DateTimeConfigurationCollection.cs
@@ -5,7 +5,7 @@
 namespace System.Configuration
 {
     [ConfigurationCollection(typeof(DateTimeConfigurationElement))]
-    public sealed class DateTimeConfigurationCollection : ConfigurationElementCollection
+    internal sealed class DateTimeConfigurationCollection : ConfigurationElementCollection
     {
         private static readonly ConfigurationPropertyCollection s_properties;
 

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/IInternalConfigHostPaths.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/IInternalConfigHostPaths.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Configuration.Internal
 {
-    public interface IInternalConfigHostPaths
+    internal interface IInternalConfigHostPaths
     {
         void RefreshConfigPaths();
         bool HasLocalConfig { get; }


### PR DESCRIPTION
Reduced the number of MatchingRefApiCompat errors with Sys.Configuration.ConfigurationManager

Added a comment for the remaining two serialization issues

Fixes: #27973 

cc: @weshaggard @danmosemsft @ViktorHofer 