### PR TITLE
Update Unsafe configuratations

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/System.Runtime.CompilerServices.Unsafe.sln
+++ b/src/System.Runtime.CompilerServices.Unsafe/System.Runtime.CompilerServices.Unsafe.sln
@@ -30,10 +30,10 @@ Global
 		{8012DD70-A6D7-45C0-BC8E-DFFB48D86E08}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{8012DD70-A6D7-45C0-BC8E-DFFB48D86E08}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{8012DD70-A6D7-45C0-BC8E-DFFB48D86E08}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{649A377C-1E07-4105-B01F-7F1044D3356C}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{649A377C-1E07-4105-B01F-7F1044D3356C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{649A377C-1E07-4105-B01F-7F1044D3356C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU

--- a/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
@@ -1,9 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
+      netcoreapp2.0;
       netstandard1.0;
       netstandard;
-    </BuildConfigurations>  
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netcoreapp
+    </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -4,10 +4,16 @@
   <PropertyGroup>
     <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
     <ProjectGuid>{04BA3E3C-6979-4792-B19E-C797AD607F42}</ProjectGuid>
-    <IlasmFlags>$(IlasmFlags) -INCLUDE=include\$(TargetGroup)</IlasmFlags>
+    <IncludePath>include\$(TargetGroup)</IncludePath>
+    <IncludePath Condition="'$(TargetGroup)' == 'netcoreapp2.0'">include\netcoreapp</IncludePath>
+    <IlasmFlags>$(IlasmFlags) -INCLUDE=$(IncludePath)</IlasmFlags>
     <!-- cannot build on unix, but package as OS-agnostic -->
     <PackageTargetRuntime />
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />


### PR DESCRIPTION
Add netcoreapp2.0 configuration to package to optimize a few parts
of the Unsafe APIs. https://github.com/dotnet/corefx/issues/26145

Add netcoreapp configuration so that netcoreapp vertical still builds
without needing the netcoreapp2.0 targeting pack.

Fixes https://github.com/dotnet/corefx/issues/26145

cc @ahsonkhan @jkotas @ericstj 