### PR TITLE
Fix stack overflow exception due to XmlDictionaryReader.Close override

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
@@ -1322,11 +1322,6 @@ namespace System.Xml
             return ReadArray(XmlDictionaryString.GetString(localName), XmlDictionaryString.GetString(namespaceUri), array, offset, count);
         }
 
-        public override void Close()
-        {
-            base.Dispose();
-        }
-
         private class XmlWrappedReader : XmlDictionaryReader, IXmlLineInfo
         {
             private XmlReader _reader;

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
@@ -183,5 +183,40 @@ namespace System.Runtime.Serialization.Xml.Tests
 
             return sb.ToString();
         }
+
+        [Fact]
+        public static void Close_DerivedReader_Success()
+        {
+            new NotImplementedXmlDictionaryReader().Close();
+        }
+
+        private sealed class NotImplementedXmlDictionaryReader : XmlDictionaryReader
+        {
+            public override ReadState ReadState => ReadState.Initial;
+
+            public override int AttributeCount => throw new NotImplementedException();
+            public override string BaseURI => throw new NotImplementedException();
+            public override int Depth => throw new NotImplementedException();
+            public override bool EOF => throw new NotImplementedException();
+            public override bool IsEmptyElement => throw new NotImplementedException();
+            public override string LocalName => throw new NotImplementedException();
+            public override string NamespaceURI => throw new NotImplementedException();
+            public override XmlNameTable NameTable => throw new NotImplementedException();
+            public override XmlNodeType NodeType => throw new NotImplementedException();
+            public override string Prefix => throw new NotImplementedException();
+            public override string Value => throw new NotImplementedException();
+            public override string GetAttribute(int i) => throw new NotImplementedException();
+            public override string GetAttribute(string name) => throw new NotImplementedException();
+            public override string GetAttribute(string name, string namespaceURI) => throw new NotImplementedException();
+            public override string LookupNamespace(string prefix) => throw new NotImplementedException();
+            public override bool MoveToAttribute(string name) => throw new NotImplementedException();
+            public override bool MoveToAttribute(string name, string ns) => throw new NotImplementedException();
+            public override bool MoveToElement() => throw new NotImplementedException();
+            public override bool MoveToFirstAttribute() => throw new NotImplementedException();
+            public override bool MoveToNextAttribute() => throw new NotImplementedException();
+            public override bool Read() => throw new NotImplementedException();
+            public override bool ReadAttributeValue() => throw new NotImplementedException();
+            public override void ResolveEntity() => throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
It looks like a virtual Close was added to XmlDictionaryReader when XmlReader.Close didn't yet exist in corefx.  Then when XmlReader.Close was added, the virtual on the derived type was changed to an override, but that override's behavior doesn't play well with the base's.  The fix is just to delete it, matching netfx.

Fixes https://github.com/dotnet/corefx/issues/28402
cc: @krwq, @huanwu, @zhenlan 