### PR TITLE
Fix SRM nuspec

### DIFF
--- a/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
+++ b/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
@@ -9,10 +9,6 @@
     <ProjectReference Include="..\src\System.Reflection.Metadata.csproj">
       <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <FilePackageDependency Include="System.Collections.Immutable">
-      <TargetFramework>portable-net45+win8</TargetFramework>
-      <Version>1.1.37</Version>
-    </FilePackageDependency>
     
     <!-- Since UAP and .NETCoreApp are package based we still want to enable
          OOBing libraries that happen to overlap with their framework package.


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/28334 from master. We need this change in Preview 2 to avoid Roslyn dependency on Preview 3 in prodcon.