### PR TITLE
Unify HTTP Authentication Tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -132,6 +132,12 @@ namespace System.Net.Http.Functional.Tests
 
         public static IEnumerable<object[]> Authentication_TestData()
         {
+            yield return new object[] { "Basic realm=\"testrealm1\", basic realm=\"testrealm1\"", true };
+            yield return new object[] { "Basic realm=\"testrealm1\", digest realm=\"testrealm1\", nonce=\"testnonce\"", true };
+            yield return new object[] { "Basic, digest realm=\"testrealm1\", nonce=\"testnonce\"", true };
+            yield return new object[] { "Digest ", false };
+            yield return new object[] { "Digest realm=withoutquotes, nonce=withoutquotes", false };
+            yield return new object[] { "Digest realm=\"testrealm\", nonce=\"testnonce\", algorithm=\"myown\"", false };
             yield return new object[] { "Basic realm=\"testrealm\"", true };
             yield return new object[] { "Basic ", true };
             yield return new object[] { "Basic realm=withoutquotes", true };

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -132,6 +132,7 @@ namespace System.Net.Http.Functional.Tests
 
         public static IEnumerable<object[]> Authentication_TestData()
         {
+            yield return new object[] { "Basic realm=\"testrealm1\" basic realm=\"testrealm1\"", true };
             yield return new object[] { "Basic realm=\"testrealm1\", basic realm=\"testrealm1\"", true };
             yield return new object[] { "Basic realm=\"testrealm1\", digest realm=\"testrealm1\", nonce=\"testnonce\"", true };
             yield return new object[] { "Basic, digest realm=\"testrealm1\", nonce=\"testnonce\"", true };

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -548,24 +548,6 @@ namespace System.Net.Http.Functional.Tests
     public sealed class SocketsHttpHandler_HttpClientHandler_Authentication_Test : HttpClientHandler_Authentication_Test
     {
         protected override bool UseSocketsHttpHandler => true;
-
-        [Theory]
-        [MemberData(nameof(Authentication_SocketsHttpHandler_TestData))]
-        public async void SocketsHttpHandler_Authentication_Succeeds(string authenticateHeader, bool result)
-        {
-            await HttpClientHandler_Authentication_Succeeds(authenticateHeader, result);
-        }
-
-        public static IEnumerable<object[]> Authentication_SocketsHttpHandler_TestData()
-        {
-            // These test cases pass on SocketsHttpHandler, fail everywhere else.
-            // TODO: #28065: Investigate failing authentication test cases on WinHttpHandler & CurlHandler.
-            yield return new object[] { "Basic realm=\"testrealm1\" basic realm=\"testrealm1\"", true };
-            yield return new object[] { "Basic something digest something", true };
-            yield return new object[] { "Digest ", false };
-            yield return new object[] { "Digest realm=withoutquotes, nonce=withoutquotes", false };
-            yield return new object[] { "Digest realm=\"testrealm\", nonce=\"testnonce\", algorithm=\"myown\"", false };
-        }
     }
 
     public sealed class SocketsHttpHandler_ConnectionUpgrade_Test : HttpClientTestBase


### PR DESCRIPTION
Most of these were failing due to issues in the loopback authentication server that were fixed by @wfurt. I'll explain the other changes one by one below:

Original:
```csharp
yield return new object[] { "Basic realm=\"testrealm1\" basic realm=\"testrealm1\"", true };
```
Updated:
```csharp
yield return new object[] { "Basic realm=\"testrealm1\" basic realm=\"testrealm1\"", true };
yield return new object[] { "Basic realm=\"testrealm1\", basic realm=\"testrealm1\"", true };
```

The first is an invalid case, but actually does work with WinHttpHandler. This test was failing just because of the loopback server. I added a valid version of this test, but left the original in to pin our current behavior.

Original (removed):
```csharp
yield return new object[] { "Basic something digest something", true };
```

The second change is to remove an invalid test case. This case highlights a minor behavior difference between WinHttpHandler and SocketsHttpHandler. Since there is no comma following the first scheme, all handlers will view this as a header requesting basic auth. The difference is that WinHttpHandler will refuse to authenticate when there are unknown tokens following the scheme. SocketsHttpHandler will just ignore the extra information. The correct behavior here isn't clear -- the only token allowed after basic auth is the realm, so either behavior sounds reasonable. I don't know if this is something we'd like to unify.

Fixes: #28065 