### PR TITLE
Remove IncrementPendingCallback from MARS sync reads

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -763,7 +763,7 @@ namespace System.Data.SqlClient
 
         internal abstract bool IsPacketEmpty(object readPacket);
 
-        internal abstract object ReadSyncOverAsync(int timeoutRemaining, bool isMarsOn, out uint error);
+        internal abstract object ReadSyncOverAsync(int timeoutRemaining, out uint error);
 
         internal abstract object ReadAsync(out uint error, ref object handle);
 
@@ -2079,7 +2079,7 @@ namespace System.Data.SqlClient
                 Interlocked.Increment(ref _readingCount);
                 shouldDecrement = true;
 
-                readPacket = ReadSyncOverAsync(GetTimeoutRemaining(), false, out error);
+                readPacket = ReadSyncOverAsync(GetTimeoutRemaining(), out error);
 
                 Interlocked.Decrement(ref _readingCount);
                 shouldDecrement = false;
@@ -2520,7 +2520,7 @@ namespace System.Data.SqlClient
                                 Interlocked.Increment(ref _readingCount);
                                 shouldDecrement = true;
 
-                                syncReadPacket = ReadSyncOverAsync(stateObj.GetTimeoutRemaining(), _parser.MARSOn, out error);
+                                syncReadPacket = ReadSyncOverAsync(stateObj.GetTimeoutRemaining(), out error);
 
                                 Interlocked.Decrement(ref _readingCount);
                                 shouldDecrement = false;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -125,7 +125,7 @@ namespace System.Data.SqlClient.SNI
 
         internal override bool IsFailedHandle() => _sessionHandle.Status != TdsEnums.SNI_SUCCESS;
 
-        internal override object ReadSyncOverAsync(int timeoutRemaining, bool isMarsOn, out uint error)
+        internal override object ReadSyncOverAsync(int timeoutRemaining, out uint error)
         {
             SNIHandle handle = Handle;
             if (handle == null)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -132,10 +132,6 @@ namespace System.Data.SqlClient.SNI
             {
                 throw ADP.ClosedConnectionError();
             }
-            if (isMarsOn)
-            {
-                IncrementPendingCallbacks();
-            }
             SNIPacket packet = null;
             error = SNIProxy.Singleton.ReadSyncOverAsync(handle, out packet, timeoutRemaining);
             return packet;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -169,7 +169,7 @@ namespace System.Data.SqlClient
 
         internal override bool IsFailedHandle() => _sessionHandle.Status != TdsEnums.SNI_SUCCESS;
 
-        internal override object ReadSyncOverAsync(int timeoutRemaining, bool isMarsOn, out uint error)
+        internal override object ReadSyncOverAsync(int timeoutRemaining, out uint error)
         {
             SNIHandle handle = Handle;
             if (handle == null)


### PR DESCRIPTION
While looking into the usage of the LongRunning option usage with SqlClient in the issue https://github.com/dotnet/corefx/issues/19836 it seemed that there is a particular order of MARS execution which can result in hangs (for which the LongRunning options was originally introduced) 

A hang in MARS is happening still when a sync execution is followed by an async execution this can be easily reproduced if the following two tests are executed one after another. 

System.Data.SqlClient.ManualTesting.Tests.CommandCancelTest.TimeoutCancel 
System.Data.SqlClient.ManualTesting.Tests.CommandCancelTest.PlainCancelTestAsync 

In case of Mars, SqlClient increments the pending counter by one for sync reads, which is then checked in Async operations at https://github.com/dotnet/corefx/blob/master/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs#L2742 and the pending Callback is >=2 causing the Task result to not be set at all. This results in a hang while executing a MARS async operation since the Task result or error will never be set.

Incrementing the pending callbacks were always made for Async operations and in case of MARS, SqlClient was incrementing this counter for sync reads as well. 

The code review has two commits
1. Removes the call to the IncrementPendingCallbacks
2. Removes the flag which signals the method that MARS is on, and should increment the counter, since the flag is not needed anymore. 

We had added the LongRunning option to MARS async Network API calls because the EF tests were hanging. Given that there is a specific pattern in which this hang can be reproed consistently, LongRunning flag on task continuation may not have been solving any problems for us. I need to confirm that by running EF tests by removing LongRunning continuation option.

 