### PR TITLE
Fix compat pack dependencies to be live pre-release and harvest System.Buffers ref to previously shipped version

### DIFF
--- a/external/runtime/Configurations.props
+++ b/external/runtime/Configurations.props
@@ -4,8 +4,6 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
-      netcoreapp2.0-Windows_NT;
-      netcoreapp2.0-Unix;
       uap10.0.16299aot;
       uap;
       uapaot;

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <NugetRuntimeIdentifier>$(PackageRID)</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
-    <CoreClrPackageVersion Condition="'$(TargetGroup)' == 'netcoreapp2.0'">2.0.0</CoreClrPackageVersion>
     <NoWarn>$(NoWarn);NU1603;NU1605</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'  Or '$(TargetGroup)' == 'uap10.0.16299aot'">

--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -8,9 +8,6 @@
   </PropertyGroup>
 
   <ItemDefinitionGroup>
-    <LibraryPackage>
-      <Version>4.4.0</Version>
-    </LibraryPackage>
     <PrereleaseLibraryPackage>
       <Version>4.5.0</Version>
     </PrereleaseLibraryPackage>
@@ -29,6 +26,7 @@
     <PrereleaseLibraryPackage Include="System.Configuration.ConfigurationManager" />
     <PrereleaseLibraryPackage Include="System.Data.Odbc" />
     <PrereleaseLibraryPackage Include="System.Data.DataSetExtensions" />
+    <PrereleaseLibraryPackage Include="System.Data.SqlClient" />
     <PrereleaseLibraryPackage Include="System.Drawing.Common" />
     <PrereleaseLibraryPackage Include="System.Diagnostics.EventLog" />
     <PrereleaseLibraryPackage Include="System.Diagnostics.PerformanceCounter" />
@@ -42,6 +40,7 @@
     <PrereleaseLibraryPackage Include="System.Management" />
     <PrereleaseLibraryPackage Include="System.Runtime.Caching" />
     <PrereleaseLibraryPackage Include="System.Security.AccessControl" />
+    <PrereleaseLibraryPackage Include="System.Security.Cryptography.Cng" />
     <PrereleaseLibraryPackage Include="System.Security.Cryptography.Pkcs" />
     <PrereleaseLibraryPackage Include="System.Security.Cryptography.ProtectedData" />
     <PrereleaseLibraryPackage Include="System.Security.Cryptography.Xml" />
@@ -51,7 +50,6 @@
     <PrereleaseLibraryPackage Include="System.ServiceProcess.ServiceController" />
     <PrereleaseLibraryPackage Include="System.Text.Encoding.CodePages" />
     <PrereleaseLibraryPackage Include="System.Threading.AccessControl" />
-    <PrereleaseLibraryPackage Include="System.Security.Cryptography.Cng" />
 
     <!-- Service model packages -->
     <LibraryPackage Include="System.ServiceModel.Primitives">
@@ -69,9 +67,6 @@
     <LibraryPackage Include="System.ServiceModel.Security">
       <Version>$(ServiceModelVersion)</Version>
     </LibraryPackage>
-
-    <!-- Stable packages shipped already for netcoreapp2.0 -->
-    <LibraryPackage Include="System.Data.SqlClient" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -51,6 +51,7 @@
     <PrereleaseLibraryPackage Include="System.ServiceProcess.ServiceController" />
     <PrereleaseLibraryPackage Include="System.Text.Encoding.CodePages" />
     <PrereleaseLibraryPackage Include="System.Threading.AccessControl" />
+    <PrereleaseLibraryPackage Include="System.Security.Cryptography.Cng" />
 
     <!-- Service model packages -->
     <LibraryPackage Include="System.ServiceModel.Primitives">
@@ -71,7 +72,6 @@
 
     <!-- Stable packages shipped already for netcoreapp2.0 -->
     <LibraryPackage Include="System.Data.SqlClient" />
-    <LibraryPackage Include="System.Security.Cryptography.Cng" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0-*" />
    </ItemGroup>
    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.*" />
-    <PackageReference Include="Microsoft.NETCore.App" Version="2.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
@@ -1,11 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-  	<DisableImplicitFrameworkReferences Condition="'$(TargetFramework)' == 'netcoreapp2.0'">true</DisableImplicitFrameworkReferences>
-  	<PreserveCompilationContext>true</PreserveCompilationContext>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+    <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RID).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
+    <DisableImplicitFrameworkReferences Condition="$(TargetFramework.Contains('netcoreapp'))">true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="$(CompatibilityPackageVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="Microsoft.NETCore.App" Version="2.0.0" />
+   </ItemGroup>
+   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(PrivateCorefxPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0-*" />
+   </ItemGroup>
+   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.*" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="2.0.*" />
   </ItemGroup>
 </Project>

--- a/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
+++ b/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
@@ -1,27 +1,16 @@
-$repoRoot = ((get-item $PSScriptRoot).parent.parent.parent.FullName);
-$winRID = "win7-x64";
-$dotnetPath = -join($repoRoot, "\Tools\dotnetcli\dotnet.exe")
-$csprojPath = -join($PSScriptRoot, "\", (Get-ChildItem $PSScriptRoot"\*.csproj" | Select-Object -ExpandProperty Name))
-$packagesCachePath = -join($repoRoot, "\packages")
-$localPackageSourcePath = -join($repoRoot, "\bin\packages\Debug\")
-$packageName = "Microsoft.Windows.Compatibility"
+param (
+$targetFramework = "netcoreapp2.1",
+$runtimeVersion = "2.1.0-*",
+$refDirName = "netcoreapp21_compat",
+$rid = "win7-x64"
+)
 
-if (!(Test-Path $localPackageSourcePath))
-{
-	$localPackageSourcePath = -join($repoRoot, "\bin\packages\Release\")
-	if (!(Test-Path $localPackageSourcePath))
-	{
-		Write-Error -Message "Local package source must exist.";
-		Exit;
-	}
-}
-
-function _getPackageVersion()
+function _getPackageVersion($packageName)
 {
 	$searchPattern = -join($localPackageSourcePath, $packageName, ".[0-9].[0-9].[0-9]*.nupkg")
 	if (!(Test-Path $searchPattern))
 	{
-		Write-Error -Message (-join("Didn't find package: Microsoft.Windows.Compatibility in source: ", $localPackageSourcePath, " please run build -allConfigurations"))
+		Write-Error -Message (-join("Didn't find package: ", $packageName, " in source: ", $localPackageSourcePath, " please run build -allConfigurations"))
 		Exit;
 	}
 
@@ -34,32 +23,46 @@ function _getPackageVersion()
 	return $matches[0]
 }
 
-function _restoreAndPublish($targetFramework, $rid, $runtimeFramework, $refDirName)
+$repoRoot = ((get-item $PSScriptRoot).parent.parent.parent.FullName);
+$dotnetPath = -join($repoRoot, "\Tools\dotnetcli\dotnet.exe")
+$csprojPath = -join($PSScriptRoot, "\", (Get-ChildItem $PSScriptRoot"\*.csproj" | Select-Object -ExpandProperty Name))
+$packagesCachePath = -join($repoRoot, "\packages")
+$localPackageSourcePath = -join($repoRoot, "\bin\packages\Debug\")
+$restoreSources = -join("https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;https://api.nuget.org/v3/index.json;https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;", $localPackageSourcePath)
+
+if (!(Test-Path $localPackageSourcePath))
 {
-	$packageVersion = _getPackageVersion
-    & $dotnetPath restore --packages $packagesCachePath /p:RestoreSources="https://api.nuget.org/v3/index.json;$localPackageSourcePath" /p:TargetFramework=$targetFramework /p:CompatibilityPackageVersion=$packageVersion $csprojPath
-    & $dotnetPath publish -r $rid /p:RestoreSources="https://api.nuget.org/v3/index.json;$localPackageSourcePath" /p:TargetFramework=$targetFramework /p:CompatibilityPackageVersion=$packageVersion /p:RuntimeFrameworkVersion=$runtimeFramework $csprojPath
-
-    $outputPath = -join($PSScriptRoot, "\bin\Debug\", $targetFramework, "\", $rid, "\publish\refs\")
-
-    if (!(Test-Path $outputPath))
-    {
-    	Write-Error -Message (-join("There was an error while publishing for framework: ", $targetFramework))
-		Exit;
-    }
-
-	Write-Output (-join("Published succedded for: ", $targetFramework))
-	
-	$refPath = -join($repoRoot, "\bin\ref\", $refDirName)
-
-	if (Test-Path $refPath)
+	$localPackageSourcePath = -join($repoRoot, "\bin\packages\Release\")
+	if (!(Test-Path $localPackageSourcePath))
 	{
-		Remove-Item $refPath -r -force
+		Write-Error -Message "Local package source must exist.";
+		Exit;
 	}
-
-	New-Item $refPath -ItemType directory
-	Copy-Item (-join($outputPath, "*")) $refPath
 }
 
-_restoreAndPublish "netcoreapp2.0" $winRID "2.0.0" "netcoreapp20_compat"
-_restoreAndPublish "netstandard2.0" $winRID "2.0.0" "netstandard20_compat"
+$compatPackageVersion = _getPackageVersion "Microsoft.Windows.Compatibility"
+$privatePackageVersion = _getPackageVersion "Microsoft.Private.CoreFx.NETCoreApp"
+
+& $dotnetPath restore --packages $packagesCachePath /p:RestoreSources="$restoreSources" /p:TargetFramework=$targetFramework /p:CompatibilityPackageVersion=$compatPackageVersion /p:PrivateCorefxPackageVersion=$privatePackageVersion /p:RID=$rid $csprojPath
+
+& $dotnetPath publish -r $rid /p:RestoreSources="$restoreSources" /p:TargetFramework=$targetFramework /p:CompatibilityPackageVersion=$compatPackageVersion /p:RuntimeFrameworkVersion=$runtimeFramework /p:PrivateCorefxPackageVersion=$privatePackageVersion /p:RID=$rid $csprojPath
+
+$outputPath = -join($PSScriptRoot, "\bin\Debug\", $targetFramework, "\", $rid, "\publish\refs\")
+
+if (!(Test-Path $outputPath))
+{
+	Write-Error -Message (-join("There was an error while publishing for framework: ", $targetFramework))
+	Exit;
+}
+
+Write-Output (-join("Published succedded for: ", $targetFramework))
+
+$refPath = -join($repoRoot, "\bin\ref\", $refDirName)
+
+if (Test-Path $refPath)
+{
+	Remove-Item $refPath -r -force
+}
+
+New-Item $refPath -ItemType directory
+Copy-Item (-join($outputPath, "*")) $refPath

--- a/src/System.Buffers/pkg/System.Buffers.pkgproj
+++ b/src/System.Buffers/pkg/System.Buffers.pkgproj
@@ -2,8 +2,11 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <HarvestIncludePath Include="ref\netstandard1.1;ref\netstandard2.0">
+      <SupportedFramework>netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
+    </HarvestIncludePath>
     <ProjectReference Include="..\ref\System.Buffers.csproj">
-      <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net45</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Buffers.csproj" />
 
@@ -13,7 +16,6 @@
 
     <InboxOnTargetFramework Include="netcoreapp2.0" />
     <InboxOnTargetFramework Include="uap10.0.16299" />
-    <InboxOnTargetFramework Include="uap10.0.16300" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Buffers/pkg/System.Buffers.pkgproj
+++ b/src/System.Buffers/pkg/System.Buffers.pkgproj
@@ -11,14 +11,9 @@
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
 
-    <!-- Since UAP and .NETCoreApp are package based we still want to enable
-         OOBing libraries that happen to overlap with their framework package.
-         This avoids us having to lock the API in our NuGet packages just 
-         to match what shipped inbox: since we can provide a new library 
-         we can update it to add API without raising the netstandard version. -->
-    <ValidatePackageSuppression Include="TreatAsOutOfBox">
-      <Value>.NETCoreApp;UAP</Value>
-    </ValidatePackageSuppression>
+    <InboxOnTargetFramework Include="netcoreapp2.0" />
+    <InboxOnTargetFramework Include="uap10.0.16299" />
+    <InboxOnTargetFramework Include="uap10.0.16300" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Buffers/ref/Configurations.props
+++ b/src/System.Buffers/ref/Configurations.props
@@ -4,7 +4,7 @@
     <PackageConfigurations>
       netstandard;
       netstandard1.1;
-	    net45;
+      net45;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Buffers/ref/Configurations.props
+++ b/src/System.Buffers/ref/Configurations.props
@@ -5,6 +5,7 @@
       netstandard;
       netstandard1.1;
       uap10.0.16299;
+	  net45;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Buffers/ref/Configurations.props
+++ b/src/System.Buffers/ref/Configurations.props
@@ -10,6 +10,7 @@
       $(PackageConfigurations);
       uap10.0.16299;
       uap;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Buffers/ref/Configurations.props
+++ b/src/System.Buffers/ref/Configurations.props
@@ -4,11 +4,11 @@
     <PackageConfigurations>
       netstandard;
       netstandard1.1;
-      uap10.0.16299;
-	  net45;
+	    net45;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      uap10.0.16299;
       uap;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Buffers/ref/Configurations.props
+++ b/src/System.Buffers/ref/Configurations.props
@@ -8,7 +8,6 @@
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
-      uap10.0.16299;
       uap;
       netfx;
     </BuildConfigurations>

--- a/src/System.Buffers/ref/System.Buffers.csproj
+++ b/src/System.Buffers/ref/System.Buffers.csproj
@@ -11,8 +11,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Debug|AnyCPU'" />

--- a/src/System.Buffers/ref/System.Buffers.csproj
+++ b/src/System.Buffers/ref/System.Buffers.csproj
@@ -7,14 +7,16 @@
          Can be removed when API is added and this assembly is versioned to 4.1.* -->
     <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.0.2.0</AssemblyVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Buffers.cs" />
   </ItemGroup>

--- a/src/System.Buffers/ref/System.Buffers.csproj
+++ b/src/System.Buffers/ref/System.Buffers.csproj
@@ -15,6 +15,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Buffers.cs" />
   </ItemGroup>

--- a/src/System.Buffers/ref/System.Buffers.csproj
+++ b/src/System.Buffers/ref/System.Buffers.csproj
@@ -3,6 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{11AE73F7-3532-47B9-8FF6-B4F22D76456C}</ProjectGuid>
+    <!-- Must match version supported by frameworks which support 4.0.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.1.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.0.2.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
@@ -20,6 +23,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Buffers/src/Configurations.props
+++ b/src/System.Buffers/src/Configurations.props
@@ -4,8 +4,6 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
-      netcoreapp2.0-Windows_NT;
-      netcoreapp2.0-Unix;
       uap10.0.16299-Windows_NT;
       uap10.0.16299aot-Windows_NT;
     </PackageConfigurations>

--- a/src/System.Buffers/src/Configurations.props
+++ b/src/System.Buffers/src/Configurations.props
@@ -9,8 +9,6 @@
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
-      uap10.0.16299-Windows_NT;
-      uap10.0.16299aot-Windows_NT;
       uap-Windows_NT;
       uapaot-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Buffers/src/Configurations.props
+++ b/src/System.Buffers/src/Configurations.props
@@ -4,13 +4,13 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
-      uap10.0.16299-Windows_NT;
-      uap10.0.16299aot-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
+      uap10.0.16299-Windows_NT;
+      uap10.0.16299aot-Windows_NT;
       uap-Windows_NT;
       uapaot-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -12,10 +12,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Unix-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Unix-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Debug|AnyCPU'" />

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -19,11 +19,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299aot-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299aot-Windows_NT-Release|AnyCPU'" />
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Buffers\ArrayPool.cs" />
     <Compile Include="System\Buffers\ArrayPoolEventSource.cs" />

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -19,6 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Buffers\ArrayPool.cs" />
     <Compile Include="System\Buffers\ArrayPoolEventSource.cs" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/28326

System.Security.Cryptography.Cng pre-release needs to be included in the compat pack since System.Security.Cryptography.Xml is now taking a dependency on it and we haven't shipped it stable, so if we depend on the Cng stable version it will fail because there will be a downgrade on that dependency.

Also this freezes the implementation for netstandard2.0 for System.Buffers to not take a reference to System.Private.CoreLib in an OOB package.

Also I'm updating the compat pack publish script to be able to generate the netcoreapp2.1 ApiCatalog layout from the live everyday build.

cc: @ericstj @weshaggard @danmosemsft @joperezr @terrajobst 