### PR TITLE
Call CancellationTokenRegistration.Unregister in AsyncInfoToTaskBridge...

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System/InternalHelpers.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/InternalHelpers.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
-using System.Threading;
+using System.Runtime.InteropServices;
 
 namespace System
 {
@@ -11,12 +10,7 @@ namespace System
     {
         internal static void SetErrorCode(this Exception ex, int code)
         {
-            // Stub, until COM interop guys fix the exception logic
-        }
-
-        internal static void TryDeregister(this CancellationTokenRegistration ctr)
-        {
-            //nothing to do for projectN
+            InteropExtensions.SetExceptionErrorCode(ex, code);
         }
     }
 }

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreRT.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreRT.cs
@@ -2,16 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using Internal.Interop;
 using Internal.Threading.Tasks;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Windows.Foundation;
 
 namespace System.Threading.Tasks
@@ -68,7 +63,7 @@ namespace System.Threading.Tasks
                     }
 
                     if (disposeOfCtr)
-                        ctr.TryDeregister();
+                        ctr.Unregister();
                 }
             }
             catch (Exception ex)
@@ -151,7 +146,7 @@ namespace System.Threading.Tasks
                     ctr = _ctr; // under lock to avoid torn reads
                     _ctr = default(CancellationTokenRegistration);
                 }
-                ctr.TryDeregister(); // It's ok if we end up unregistering a not-initialized registration; it'll just be a nop.
+                ctr.Unregister(); // It's ok if we end up unregistering a not-initialized registration; it'll just be a nop.
 
                 try
                 {


### PR DESCRIPTION
to avoid leaking memory when the CancellationTokenSource is reused.
Addresses DevDiv 403992.