### PR TITLE
Don't crash from RemoteInvoke if remote test fails

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -224,8 +224,8 @@ namespace System.Diagnostics
 
             public void Dispose()
             {
-                Dispose(disposing: true);
                 GC.SuppressFinalize(this);
+                Dispose(disposing: true);
             }
 
             private void Dispose(bool disposing)


### PR DESCRIPTION
If the remote test fails, RemoteInvokeHandle.Dispose propagates the exception.  But since we're suppressing finalization only after the Dispose() call, finalization is never suppressed, and the test process later crashes.

cc: @danmosemsft, @maryamariyan 