### PR TITLE
Enable CloseAsync_Cancel_Success test

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -75,7 +75,6 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue(27211)]
         public async Task CloseAsync_Cancel_Success(Uri server)
         {
             await TestCancellation(async (cws) =>


### PR DESCRIPTION
Have run the test locally and in CI many times, no failure. Enable the test.

Closes: #27211 
