### PR TITLE
Add Regex perf test based on RegexRedux from benchmark game

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -83,6 +83,9 @@
     <PackageReference Include="System.Drawing.Common.TestData">
       <Version>1.0.6</Version>
     </PackageReference>
+    <PackageReference Include="System.Text.RegularExpressions.TestData">
+      <Version>1.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <PackageReference Include="xunit.runner.console">

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -84,7 +84,7 @@
       <Version>1.0.6</Version>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions.TestData">
-      <Version>1.0.1</Version>
+      <Version>1.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">

--- a/src/System.Text.RegularExpressions/tests/Performance/Perf.RegexRedux.cs
+++ b/src/System.Text.RegularExpressions/tests/Performance/Perf.RegexRedux.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Threading;
+using System.Collections.Generic;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Text.RegularExpressions.Tests
+{
+    public class RegexRedux
+    {
+        static readonly string input = File.ReadAllText(Path.Combine("regexredux", "200_000.in"));
+
+        static Regex regex(string re, RegexOptions options)
+        {
+             return new Regex(re, options);
+        }
+
+        static string regexCount(string s, string r, RegexOptions options)
+        {
+            int c = 0;
+            var m = regex(r, options).Match(s);
+            while (m.Success) { c++; m = m.NextMatch(); }
+            return r + " " + c;
+        }
+
+        [Benchmark]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
+        public void RegexReduxMini(RegexOptions options)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            using (iteration.StartMeasurement())
+            {
+                string sequences = input;
+                var initialLength = sequences.Length;
+                sequences = Regex.Replace(sequences, ">.*\n|\n", "");
+
+                var magicTask = Task.Run(() =>
+                {
+                    var newseq = regex("tHa[Nt]", options).Replace(sequences, "<4>");
+                    newseq = regex("aND|caN|Ha[DS]|WaS", options).Replace(newseq, "<3>");
+                    newseq = regex("a[NSt]|BY", options).Replace(newseq, "<2>");
+                    newseq = regex("<[^>]*>", options).Replace(newseq, "|");
+                    newseq = regex("\\|[^|][^|]*\\|", options).Replace(newseq, "-");
+                    return newseq.Length;
+                });
+
+                var variant2 = Task.Run(() => regexCount(sequences, "[cgt]gggtaaa|tttaccc[acg]", options));
+                var variant3 = Task.Run(() => regexCount(sequences, "a[act]ggtaaa|tttacc[agt]t", options));
+                var variant7 = Task.Run(() => regexCount(sequences, "agggt[cgt]aa|tt[acg]accct", options));
+                var variant6 = Task.Run(() => regexCount(sequences, "aggg[acg]aaa|ttt[cgt]ccct", options));
+                var variant4 = Task.Run(() => regexCount(sequences, "ag[act]gtaaa|tttac[agt]ct", options));
+                var variant5 = Task.Run(() => regexCount(sequences, "agg[act]taaa|ttta[agt]cct", options));
+                var variant1 = Task.Run(() => regexCount(sequences, "agggtaaa|tttaccct", options));
+                var variant9 = Task.Run(() => regexCount(sequences, "agggtaa[cgt]|[acg]ttaccct", options));
+                var variant8 = Task.Run(() => regexCount(sequences, "agggta[cgt]a|t[acg]taccct", options));
+
+                Task.WaitAll(magicTask, variant1, variant2, variant3, variant4, variant5, variant6, variant7, variant8, variant9);
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/Performance/System.Text.RegularExpressions.Performance.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/Performance/System.Text.RegularExpressions.Performance.Tests.csproj
@@ -10,9 +10,15 @@
   <!-- Default configurations to help VS understand the configurations -->
   <ItemGroup>
     <Compile Include="Perf.Regex.cs" />
+    <Compile Include="Perf.RegexRedux.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <SupplementalTestData Include="$(PackagesDir)system.text.regularexpressions.testdata\1.0.1\content\**\*.*">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </SupplementalTestData>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonPath)\..\perf\PerfRunner\PerfRunner.csproj">

--- a/src/System.Text.RegularExpressions/tests/Performance/System.Text.RegularExpressions.Performance.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/Performance/System.Text.RegularExpressions.Performance.Tests.csproj
@@ -16,7 +16,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.text.regularexpressions.testdata\1.0.1\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.text.regularexpressions.testdata\1.0.2\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.Text.RegularExpressions/tests/Performance/THIRD-PARTY-NOTICES
+++ b/src/System.Text.RegularExpressions/tests/Performance/THIRD-PARTY-NOTICES
@@ -1,5 +1,5 @@
 .NET Core uses third-party libraries or other resources that may be
-distributed under licenses different than the .NET Core software.
+distributed under licenses different than the .NET Core software. 
 
 In the event that we accidentally failed to list a required notice, please
 bring it to our attention. Post an issue or email us:
@@ -15,7 +15,7 @@ Benchmarks Game
 Revised BSD license
 This is a specific instance of the Open Source Initiative (OSI) BSD license template.
 
-Copyright © 2004-2008 Brent Fulgham, 2005-2018 Isaac Gouy
+Copyright (c) 2004-2008 Brent Fulgham, 2005-2018 Isaac Gouy
 
 All rights reserved.
 

--- a/src/System.Text.RegularExpressions/tests/Performance/THIRD-PARTY-NOTICES
+++ b/src/System.Text.RegularExpressions/tests/Performance/THIRD-PARTY-NOTICES
@@ -1,3 +1,15 @@
+.NET Core uses third-party libraries or other resources that may be
+distributed under licenses different than the .NET Core software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention. Post an issue or email us:
+
+           dotnet@microsoft.com
+
+The attached notices are provided for information only.
+
+===============
+
 The Computer Language
 Benchmarks Game
 Revised BSD license

--- a/src/System.Text.RegularExpressions/tests/Performance/THIRD-PARTY-NOTICES
+++ b/src/System.Text.RegularExpressions/tests/Performance/THIRD-PARTY-NOTICES
@@ -1,0 +1,19 @@
+The Computer Language
+Benchmarks Game
+Revised BSD license
+This is a specific instance of the Open Source Initiative (OSI) BSD license template.
+
+Copyright © 2004-2008 Brent Fulgham, 2005-2018 Isaac Gouy
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Neither the name of "The Computer Language Benchmarks Game" nor the name of "The Computer Language Shootout Benchmarks" nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+


### PR DESCRIPTION
Adds a perf test that runs [RegexRedux](https://benchmarksgame.alioth.debian.org/u64q/regexredux-description.html#regexredux) from the benchmarks game.

The inputs are too large to include: I put them in https://github.com/dotnet/corefx-testdata/pull/23 so we can pull them from myget. 

This is measuring with 200_000 input size to get reasonable iterations. The official measurements are done using a 5_000_000.in, which I put in corefx-testdata but left out of the package for now as it's so large.

On my box:
```
 System.Text.RegularExpressions.Performance.Tests.dll                              | Metric   | Unit | Iterations | Average | STDEV.S |     Min |     Max
:--------------------------------------------------------------------------------- |:-------- |:----:|:----------:| -------:| -------:| -------:| -------:
 System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: Compiled) | Duration | msec |     30     | 343.430 |  18.263 | 316.354 | 375.396
 System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: None)     | Duration | msec |     16     | 640.773 |  25.948 | 606.978 | 710.484

```