### PR TITLE
Increasing AllowedWindow time

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -686,7 +686,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void TestProcessStartTime()
         {
-            TimeSpan allowedWindow = TimeSpan.FromSeconds(1);
+            TimeSpan allowedWindow = TimeSpan.FromSeconds(3);
 
             for (int i = 0; i < 2; i++)
             {


### PR DESCRIPTION
This Process test would sometimes fail on RedHat7.3 by getting slightly out of the allowed window time.
So I am increasing 1000s to 3000s to make sure it passes all the time.

Fixes #28479

cc: @danmosemsft @joperezr 