### PR TITLE
Ignore errors from SetPipeSz in AnonymousPipeServerStream on Unix

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
@@ -30,7 +30,7 @@ namespace System.IO.Pipes
             // bufferSize is just advisory and ignored if platform does not support setting pipe capacity via fcntl.
             if (bufferSize > 0 && Interop.Sys.Fcntl.CanGetSetPipeSz)
             {
-                CheckPipeCall(Interop.Sys.Fcntl.SetPipeSz(serverHandle, bufferSize));
+                Interop.Sys.Fcntl.SetPipeSz(serverHandle, bufferSize); // advisory, ignore errors
             }
 
             // We're connected.  Finish initialization using the newly created handles.


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28436
cc: @pjanotti, @sdmaclea, @wfurt 