### PR TITLE
Change Linux buffer size test to force small value.

### DIFF
--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
@@ -86,9 +86,10 @@ namespace System.IO.Pipes.Tests
             // On Linux, setting the buffer size of the server will also set the buffer size of the
             // client, regardless of the direction of the flow
 
-            int desiredBufferSize;
-            using (var server = new AnonymousPipeServerStream(PipeDirection.Out))
+            int desiredBufferSize = 4096;
+            using (var server = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.None, desiredBufferSize))
             {
+                Assert.Equal(desiredBufferSize, server.OutBufferSize);
                 desiredBufferSize = server.OutBufferSize * 2;
                 Assert.True(desiredBufferSize > 0);
             }


### PR DESCRIPTION
/cc @sdmaclea @wfurt @stephentoub 

It seems that on linux-arm64, per @sdmaclea traces, the buffer size is being created as 1MB. This PR tries to ensure that the test will pass by starting with a smaller value, there is a risk that some systems may have a minimum higher than 4KB, I want to use this PR to validate the various Linux distros, and will correct as needed.