### PR TITLE
Fix calling FlushAsync with cancelled token

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -298,6 +298,7 @@ namespace System.IO.Pipelines
             {
                 CommitUnsynchronized();
 
+                // AttachToken before completing reader awaiter in case cancellationToken is already completed
                 cancellationTokenRegistration = _writerAwaitable.AttachToken(cancellationToken, s_signalWriterAwaitable, this);
 
                 _readerAwaitable.Complete(out completionData);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -298,9 +298,9 @@ namespace System.IO.Pipelines
             {
                 CommitUnsynchronized();
 
-                _readerAwaitable.Complete(out completionData);
-
                 cancellationTokenRegistration = _writerAwaitable.AttachToken(cancellationToken, s_signalWriterAwaitable, this);
+
+                _readerAwaitable.Complete(out completionData);
 
                 // If the writer is completed (which it will be most of the time) the return a completed ValueTask
                 if (_writerAwaitable.IsCompleted)

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -317,22 +317,11 @@ namespace System.IO.Pipelines.Tests
             // AsTask is important here, it validates that we are calling completion callback
             // and not only setting IsCompleted flag
             var task = Pipe.Reader.ReadAsync().AsTask();
-            bool threwException = false;
 
-            try
-            {
-                await Pipe.Writer.FlushAsync(cancellationTokenSource.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                threwException = true;
-            }
-            finally
-            {
-                Pipe.Writer.Complete();
-            }
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await Pipe.Writer.FlushAsync(cancellationTokenSource.Token));
 
-            Assert.True(threwException);
+            Pipe.Writer.Complete();
+
             Assert.True(task.IsCompleted);
             Assert.True(task.Result.IsCompleted);
         }

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -307,6 +307,35 @@ namespace System.IO.Pipelines.Tests
             Assert.False(awaiterIsCompleted);
             Assert.True(onCompletedCalled);
         }
+
+        [Fact]
+        public async Task FlushAsyncThrowsIfPassedCanceledCancellationTokenAndPipeIsAbleToComplete()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            // AsTask is important here, it validates that we are calling completion callback
+            // and not only setting IsCompleted flag
+            var task = Pipe.Reader.ReadAsync().AsTask();
+            bool threwException = false;
+
+            try
+            {
+                await Pipe.Writer.FlushAsync(cancellationTokenSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                threwException = true;
+            }
+            finally
+            {
+                Pipe.Writer.Complete();
+            }
+
+            Assert.True(threwException);
+            Assert.True(task.IsCompleted);
+            Assert.True(task.Result.IsCompleted);
+        }
     }
 
     public static class TestWriterExtensions


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/28492

We were marking awaitable as completed but never calling the callback because `AttachToken` threw.

Reorder calls to allow it to throw before completing awaitable.