### PR TITLE
Add .NET 4.5 functionality and API to WindowsIdentity

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.ClaimSecurityAttributes.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.ClaimSecurityAttributes.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct CLAIM_SECURITY_ATTRIBUTE_INFORMATION_V1
+    {
+        // defined as union in CLAIM_SECURITY_ATTRIBUTES_INFORMATION
+        [FieldOffset(0)]
+        public IntPtr pAttributeV1;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct CLAIM_SECURITY_ATTRIBUTES_INFORMATION
+    {
+        /// WORD->unsigned short
+        public ushort Version;
+
+        /// WORD->unsigned short
+        public ushort Reserved;
+
+        /// DWORD->unsigned int
+        public uint AttributeCount;
+
+        /// CLAIM_SECURITY_ATTRIBUTE_V1
+        public CLAIM_SECURITY_ATTRIBUTE_INFORMATION_V1 Attribute;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE
+    {
+        // DWORD64->unsigned __int64
+        public ulong Version;
+
+        // PWSTR->WCHAR*
+        [MarshalAsAttribute(UnmanagedType.LPWStr)]
+        public string Name;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE
+    {
+        /// PVOID->void*
+        public IntPtr pValue;
+
+        /// DWORD->unsigned int
+        public uint ValueLength;
+    }
+
+    [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Unicode)]
+    internal struct CLAIM_VALUES_ATTRIBUTE_V1
+    {
+        // PLONG64->__int64*
+        [FieldOffset(0)]
+        public IntPtr pInt64;
+
+        // PDWORD64->unsigned __int64*
+        [FieldOffset(0)]
+        public IntPtr pUint64;
+
+        // PWSTR*
+        [FieldOffset(0)]
+        public IntPtr ppString;
+
+        // PCLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE->_CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE*
+        [FieldOffset(0)]
+        public IntPtr pFqbn;
+
+        // PCLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE->_CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE*
+        [FieldOffset(0)]
+        public IntPtr pOctetString;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct CLAIM_SECURITY_ATTRIBUTE_V1
+    {
+        // PWSTR->WCHAR*
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string Name;
+
+        // WORD->unsigned short
+        public ClaimSecurityAttributeType ValueType;
+
+        // WORD->unsigned short
+        public ushort Reserved;
+
+        // DWORD->unsigned int
+        public uint Flags;
+
+        // DWORD->unsigned int
+        public uint ValueCount;
+
+        // struct CLAIM_VALUES - a union of 4 possible values
+        public CLAIM_VALUES_ATTRIBUTE_V1 Values;
+    }
+
+    internal enum ClaimSecurityAttributeType : ushort
+    {
+        // CLAIM_SECURITY_ATTRIBUTE_TYPE_INVALID -> 0x00
+        CLAIM_SECURITY_ATTRIBUTE_TYPE_INVALID = 0,
+
+        // CLAIM_SECURITY_ATTRIBUTE_TYPE_INT64 -> 0x01
+        CLAIM_SECURITY_ATTRIBUTE_TYPE_INT64 = 1,
+
+        // CLAIM_SECURITY_ATTRIBUTE_TYPE_UINT64 -> 0x02
+        CLAIM_SECURITY_ATTRIBUTE_TYPE_UINT64 = 2,
+
+        // CLAIM_SECURITY_ATTRIBUTE_TYPE_STRING -> 0x03
+        CLAIM_SECURITY_ATTRIBUTE_TYPE_STRING = 3,
+
+        // CLAIM_SECURITY_ATTRIBUTE_TYPE_FQBN -> 0x04
+        CLAIM_SECURITY_ATTRIBUTE_TYPE_FQBN = 4,
+
+        // CLAIM_SECURITY_ATTRIBUTE_TYPE_SID -> 0x05
+        CLAIM_SECURITY_ATTRIBUTE_TYPE_SID = 5,
+
+        // CLAIM_SECURITY_ATTRIBUTE_TYPE_BOOLEAN -> 0x06
+        CLAIM_SECURITY_ATTRIBUTE_TYPE_BOOLEAN = 6,
+
+        // CLAIM_SECURITY_ATTRIBUTE_TYPE_OCTET_STRING -> 0x10
+        CLAIM_SECURITY_ATTRIBUTE_TYPE_OCTET_STRING = 16,
+    }
+}

--- a/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
+++ b/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
@@ -325,9 +325,11 @@ namespace System.Security.Principal
         public WindowsIdentity(System.IntPtr userToken, string type) { }
         public WindowsIdentity(string sUserPrincipalName) { }
         public WindowsIdentity(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected WindowsIdentity(System.Security.Principal.WindowsIdentity identity) { }
         public Microsoft.Win32.SafeHandles.SafeAccessTokenHandle AccessToken { get { throw null; } }
         public sealed override string AuthenticationType { get { throw null; } }
         public override System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get { throw null; } }
+        public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> DeviceClaims { get { throw null; } }
         public System.Security.Principal.IdentityReferenceCollection Groups { get { throw null; } }
         public System.Security.Principal.TokenImpersonationLevel ImpersonationLevel { get { throw null; } }
         public virtual bool IsAnonymous { get { throw null; } }
@@ -338,6 +340,7 @@ namespace System.Security.Principal
         public System.Security.Principal.SecurityIdentifier Owner { get { throw null; } }
         public virtual IntPtr Token { get { throw null; } }
         public System.Security.Principal.SecurityIdentifier User { get { throw null; } }
+        public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> UserClaims { get { throw null; } }
         public override System.Security.Claims.ClaimsIdentity Clone() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
@@ -353,10 +356,12 @@ namespace System.Security.Principal
     public partial class WindowsPrincipal : System.Security.Claims.ClaimsPrincipal
     {
         public WindowsPrincipal(System.Security.Principal.WindowsIdentity ntIdentity) { }
+        public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> DeviceClaims { get { throw null; } }
         public override System.Security.Principal.IIdentity Identity { get { throw null; } }
         public virtual bool IsInRole(int rid) { throw null; }
         public virtual bool IsInRole(System.Security.Principal.SecurityIdentifier sid) { throw null; }
         public virtual bool IsInRole(System.Security.Principal.WindowsBuiltInRole role) { throw null; }
         public override bool IsInRole(string role) { throw null; }
+        public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> UserClaims { get { throw null; } }
     }
 }

--- a/src/System.Security.Principal.Windows/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Security.Principal.Windows/src/MatchingRefApiCompatBaseline.txt
@@ -1,7 +1,0 @@
-Compat issues with assembly System.Security.Principal.Windows:
-MembersMustExist : Member 'System.Security.Principal.WindowsIdentity..ctor(System.Security.Principal.WindowsIdentity)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Principal.WindowsIdentity.DeviceClaims.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Principal.WindowsIdentity.UserClaims.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Principal.WindowsPrincipal.DeviceClaims.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Principal.WindowsPrincipal.UserClaims.get()' does not exist in the implementation but it does exist in the contract.
-Total Issues: 5

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -68,6 +68,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentThread.cs">
       <Link>Common\Interop\Interop.GetCurrentThread.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.ClaimSecurityAttributes.cs">
+      <Link>Common\Interop\Interop.ClaimSecurityAttributes.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
       <Link>Common\Interop\Interop.OpenProcessToken.cs</Link>
     </Compile>

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -6,6 +6,7 @@ using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security.Claims;
 using System.Text;
@@ -42,6 +43,8 @@ namespace System.Security.Principal
         private volatile bool _claimsInitialized;
         private List<Claim> _deviceClaims;
         private List<Claim> _userClaims;
+
+        private static readonly Lazy<bool> s_hasWindows8Properties = new Lazy<bool>(CheckForWindows8Properties);
 
         //
         // Constructors.
@@ -941,6 +944,18 @@ namespace System.Security.Principal
                         // group sids
                         AddGroupSidClaims(_userClaims);
 
+                        if (s_hasWindows8Properties.Value)
+                        {
+                            // Device group sids
+                            AddDeviceGroupSidClaims(_deviceClaims, TokenInformationClass.TokenDeviceGroups);
+
+                            // User token claims
+                            AddTokenClaims(_userClaims, TokenInformationClass.TokenUserClaimAttributes, ClaimTypes.WindowsUserClaim);
+
+                            // Device token claims
+                            AddTokenClaims(_deviceClaims, TokenInformationClass.TokenDeviceClaimAttributes, ClaimTypes.WindowsDeviceClaim);
+                        }
+
                         _claimsInitialized = true;
                     }
                 }
@@ -1051,6 +1066,190 @@ namespace System.Security.Principal
             finally
             {
                 safeAllocHandle.Dispose();
+            }
+        }
+
+        private void AddDeviceGroupSidClaims(List<Claim> instanceClaims, TokenInformationClass tokenInformationClass)
+        {
+            // special case the anonymous identity.
+            if (_safeTokenHandle.IsInvalid)
+                return;
+
+            SafeLocalAllocHandle safeAllocHandle = SafeLocalAllocHandle.InvalidHandle;
+            try
+            {
+                // Retrieve all group sids
+
+                safeAllocHandle = GetTokenInformation(_safeTokenHandle, tokenInformationClass);
+                int count = Marshal.ReadInt32(safeAllocHandle.DangerousGetHandle());
+                IntPtr pSidAndAttributes = new IntPtr((long)safeAllocHandle.DangerousGetHandle() + (long)Marshal.OffsetOf(typeof(Interop.TOKEN_GROUPS), "Groups"));
+                string claimType = null;
+
+                for (int i = 0; i < count; ++i)
+                {
+                    Interop.SID_AND_ATTRIBUTES group = (Interop.SID_AND_ATTRIBUTES)Marshal.PtrToStructure(pSidAndAttributes, typeof(Interop.SID_AND_ATTRIBUTES));
+                    uint mask = Interop.SecurityGroups.SE_GROUP_ENABLED | Interop.SecurityGroups.SE_GROUP_LOGON_ID | Interop.SecurityGroups.SE_GROUP_USE_FOR_DENY_ONLY;
+                    SecurityIdentifier groupSid = new SecurityIdentifier(group.Sid, true);
+                    if ((group.Attributes & mask) == Interop.SecurityGroups.SE_GROUP_ENABLED)
+                    {
+                        claimType = ClaimTypes.WindowsDeviceGroup;
+                        Claim claim = new Claim(claimType, groupSid.Value, ClaimValueTypes.String, _issuerName, _issuerName, this);
+                        claim.Properties.Add(ClaimTypes.WindowsSubAuthority, Convert.ToString(groupSid.IdentifierAuthority, CultureInfo.InvariantCulture));
+                        claim.Properties.Add(claimType, "");
+                        instanceClaims.Add(claim);
+                    }
+                    else if ((group.Attributes & mask) == Interop.SecurityGroups.SE_GROUP_USE_FOR_DENY_ONLY)
+                    {
+                        claimType = ClaimTypes.DenyOnlyWindowsDeviceGroup;
+                        Claim claim = new Claim(claimType, groupSid.Value, ClaimValueTypes.String, _issuerName, _issuerName, this);
+                        claim.Properties.Add(ClaimTypes.WindowsSubAuthority, Convert.ToString(groupSid.IdentifierAuthority, CultureInfo.InvariantCulture));
+                        claim.Properties.Add(claimType, "");
+                        instanceClaims.Add(claim);
+                    }
+
+                    pSidAndAttributes = new IntPtr((long)pSidAndAttributes + Marshal.SizeOf<Interop.SID_AND_ATTRIBUTES>());
+                }
+            }
+            finally
+            {
+                safeAllocHandle.Close();
+            }
+        }
+
+        private void AddTokenClaims(List<Claim> instanceClaims, TokenInformationClass tokenInformationClass, string propertyValue)
+        {
+            // special case the anonymous identity.
+            if (_safeTokenHandle.IsInvalid)
+                return;
+
+            SafeLocalAllocHandle safeAllocHandle = SafeLocalAllocHandle.InvalidHandle;
+
+            try
+            {
+                safeAllocHandle = GetTokenInformation(_safeTokenHandle, tokenInformationClass);
+
+                Interop.CLAIM_SECURITY_ATTRIBUTES_INFORMATION claimAttributes = (Interop.CLAIM_SECURITY_ATTRIBUTES_INFORMATION)Marshal.PtrToStructure(safeAllocHandle.DangerousGetHandle(), typeof(Interop.CLAIM_SECURITY_ATTRIBUTES_INFORMATION));
+                // An attribute represents a collection of claims.  Inside each attribute a claim can be multivalued, we create a claim for each value.
+                // It is a ragged multi-dimentional array, where each cell can be of different lenghts.
+
+                // index into array of claims.
+                long offset = 0;
+
+                for (int attribute = 0; attribute < claimAttributes.AttributeCount; attribute++)
+                {
+                    IntPtr pAttribute = new IntPtr(claimAttributes.Attribute.pAttributeV1.ToInt64() + offset);
+                    Interop.CLAIM_SECURITY_ATTRIBUTE_V1 windowsClaim = (Interop.CLAIM_SECURITY_ATTRIBUTE_V1)Marshal.PtrToStructure(pAttribute, typeof(Interop.CLAIM_SECURITY_ATTRIBUTE_V1));
+
+                    // the switch was written this way, which appears to have multiple for loops, because each item in the ValueCount is of the same ValueType.  This saves the type check each item.
+                    switch (windowsClaim.ValueType)
+                    {
+                        case Interop.ClaimSecurityAttributeType.CLAIM_SECURITY_ATTRIBUTE_TYPE_STRING:
+                            IntPtr[] stringPointers = new IntPtr[windowsClaim.ValueCount];
+                            Marshal.Copy(windowsClaim.Values.ppString, stringPointers, 0, (int)windowsClaim.ValueCount);
+
+                            for (int item = 0; item < windowsClaim.ValueCount; item++)
+                            {
+                                Claim c = new Claim(windowsClaim.Name, Marshal.PtrToStringAuto(stringPointers[item]), ClaimValueTypes.String, _issuerName, _issuerName, this);
+                                c.Properties.Add(propertyValue, string.Empty);
+                                instanceClaims.Add(c);
+                            }
+                            break;
+
+                        case Interop.ClaimSecurityAttributeType.CLAIM_SECURITY_ATTRIBUTE_TYPE_INT64:
+                            long[] intValues = new long[windowsClaim.ValueCount];
+                            Marshal.Copy(windowsClaim.Values.pInt64, intValues, 0, (int)windowsClaim.ValueCount);
+
+                            for (int item = 0; item < windowsClaim.ValueCount; item++)
+                            {
+                                Claim c = new Claim(windowsClaim.Name, Convert.ToString(intValues[item], CultureInfo.InvariantCulture), ClaimValueTypes.Integer64, _issuerName, _issuerName, this);
+                                c.Properties.Add(propertyValue, string.Empty);
+                                instanceClaims.Add(c);
+                            }
+                            break;
+
+
+                        case Interop.ClaimSecurityAttributeType.CLAIM_SECURITY_ATTRIBUTE_TYPE_UINT64:
+                            long[] uintValues = new long[windowsClaim.ValueCount];
+                            Marshal.Copy(windowsClaim.Values.pUint64, uintValues, 0, (int)windowsClaim.ValueCount);
+
+                            for (int item = 0; item < windowsClaim.ValueCount; item++)
+                            {
+                                Claim c = new Claim(windowsClaim.Name, Convert.ToString((ulong)uintValues[item], CultureInfo.InvariantCulture), ClaimValueTypes.UInteger64, _issuerName, _issuerName, this);
+                                c.Properties.Add(propertyValue, string.Empty);
+                                instanceClaims.Add(c);
+                            }
+                            break;
+
+                        case Interop.ClaimSecurityAttributeType.CLAIM_SECURITY_ATTRIBUTE_TYPE_BOOLEAN:
+                            long[] boolValues = new long[windowsClaim.ValueCount];
+                            Marshal.Copy(windowsClaim.Values.pUint64, boolValues, 0, (int)windowsClaim.ValueCount);
+
+                            for (int item = 0; item < windowsClaim.ValueCount; item++)
+                            {
+                                Claim c = new Claim(
+                                    windowsClaim.Name,
+                                    ((ulong)boolValues[item] == 0
+                                        ? Convert.ToString(false, CultureInfo.InvariantCulture)
+                                        : Convert.ToString(true, CultureInfo.InvariantCulture)),
+                                    ClaimValueTypes.Boolean,
+                                    _issuerName,
+                                    _issuerName,
+                                    this);
+
+                                c.Properties.Add(propertyValue, string.Empty);
+                                instanceClaims.Add(c);
+                            }
+                            break;
+
+
+                            // These claim types are defined in the structure found in winnt.h, but I haven't received confirmation (may  2011) that they are supported and are not enabled.
+
+                            //case Interop.ClaimSecurityAttributeType.CLAIM_SECURITY_ATTRIBUTE_TYPE_FQBN:
+                            //    break;
+
+                            //case Interop.ClaimSecurityAttributeType.CLAIM_SECURITY_ATTRIBUTE_TYPE_SID:
+                            //    break;
+
+                            //case Interop.ClaimSecurityAttributeType.CLAIM_SECURITY_ATTRIBUTE_TYPE_OCTET_STRING:
+                            //    break;
+
+                    }
+
+                    offset += Marshal.SizeOf(windowsClaim);
+                }
+            }
+            finally
+            {
+                safeAllocHandle.Close();
+            }
+        }
+
+        private static bool CheckForWindows8Properties()
+        {
+            using (WindowsIdentity tmp = GetCurrent(TokenAccessLevels.Read))
+            using (SafeLocalAllocHandle safeLocalAllocHandle = new SafeLocalAllocHandle(IntPtr.Zero))
+            {
+                uint dwLength = (uint)sizeof(uint);
+                bool result = Interop.Advapi32.GetTokenInformation(
+                    tmp.AccessToken,
+                    (uint)TokenInformationClass.TokenDeviceClaimAttributes,
+                    safeLocalAllocHandle,
+                    0,
+                    out dwLength);
+
+                Debug.Assert(result == false);
+                int dwErrorCode = Marshal.GetLastWin32Error();
+
+                switch (dwErrorCode)
+                {
+                    case Interop.Errors.ERROR_INSUFFICIENT_BUFFER:
+                        return true;
+                    case Interop.Errors.ERROR_INVALID_PARAMETER:
+                        return false;
+                    default:
+                        Debug.Fail($"Unexpected return code: {dwErrorCode:X8}");
+                        return false;
+                }
             }
         }
     }

--- a/src/System.Security.Principal.Windows/tests/WindowsPrincipalTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsPrincipalTests.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
+using System.Security.Claims;
 using System.Security.Principal;
 using Xunit;
 
@@ -31,6 +33,35 @@ public class WindowsPrincipalTests
             // NetFx throws a plain SystemException which has the message built via FormatMessage.
             // CoreFx throws a Win32Exception based on the error, which gets the same message value.
             Assert.Equal(win32Exception.Message, e.Message);
+        }
+    }
+
+    [Fact]
+    public static void CheckDeviceClaims()
+    {
+        using (WindowsIdentity id = WindowsIdentity.GetCurrent())
+        {
+            WindowsPrincipal principal = new WindowsPrincipal(id);
+
+            int manualCount = principal.Claims.Count(c => c.Properties.ContainsKey(ClaimTypes.WindowsDeviceClaim));
+            int autoCount = principal.DeviceClaims.Count();
+
+            Assert.Equal(manualCount, autoCount);
+        }
+    }
+
+    [Fact]
+    public static void CheckUserClaims()
+    {
+        using (WindowsIdentity id = WindowsIdentity.GetCurrent())
+        {
+            WindowsPrincipal principal = new WindowsPrincipal(id);
+            Claim[] allClaims = principal.Claims.ToArray();
+            int deviceCount = allClaims.Count(c => c.Properties.ContainsKey(ClaimTypes.WindowsDeviceClaim));
+            int manualCount = allClaims.Length - deviceCount;
+            int autoCount = principal.UserClaims.Count();
+
+            Assert.Equal(manualCount, autoCount);
         }
     }
 }


### PR DESCRIPTION
This change exposes the DeviceClaims and UserClaims properties on
WindowsIdentity and WindowsPrincipal which were added in net45.

The existing (uncallable) API for these in .NET Core was missing the Windows 8
token information, so that has been added (with sanity tests) in this change.

Aside for Interop style and detecting Win8 by feature use vs OS version,
this is a simple port from netfx.