### PR TITLE
Fix Microsoft.VisualBasic Ref API surface issues

### DIFF
--- a/src/Microsoft.VisualBasic/src/MatchingRefApiCompatBaseline.netstandard.txt
+++ b/src/Microsoft.VisualBasic/src/MatchingRefApiCompatBaseline.netstandard.txt
@@ -1,6 +1,6 @@
 Compat issues with assembly Microsoft.VisualBasic:
 
-# Loaded via reflection, so it should not be added to the ref assembly:
+# Loaded via reflection so needs to be public in the implementation but we don't want to expose them publicly in the ref assembly:
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Conversions.FallbackUserDefinedConversion(System.Object, System.Type)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.FallbackCall(System.Object, System.String, System.Object[], System.String[], System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.FallbackGet(System.Object, System.String, System.Object[], System.String[])' does not exist in the implementation but it does exist in the contract.

--- a/src/Microsoft.VisualBasic/src/MatchingRefApiCompatBaseline.netstandard.txt
+++ b/src/Microsoft.VisualBasic/src/MatchingRefApiCompatBaseline.netstandard.txt
@@ -1,16 +1,7 @@
 Compat issues with assembly Microsoft.VisualBasic:
-TypesMustExist : Type 'Microsoft.VisualBasic.ControlChars' does not exist in the implementation but it does exist in the contract.
-CannotSealType : Type 'Microsoft.VisualBasic.HideModuleNameAttribute' is sealed in the implementation but not sealed in the contract.
-TypesMustExist : Type 'Microsoft.VisualBasic.Interaction' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.Strings.Left(System.String, System.Int32)' does not exist in the implementation but it does exist in the contract.
+
+# Loaded via reflection, so it should not be added to the ref assembly:
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Conversions.FallbackUserDefinedConversion(System.Object, System.Type)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Conversions.GetCultureInfo()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Conversions.IsHexOrOctValue(System.String, System.Int64)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Conversions.IsHexOrOctValue(System.String, System.UInt64)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Conversions.ToHalfwidthNumbers(System.String, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
-CannotSealType : Type 'Microsoft.VisualBasic.CompilerServices.DesignerGeneratedAttribute' is sealed in the implementation but not sealed in the contract.
-CannotSealType : Type 'Microsoft.VisualBasic.CompilerServices.IncompleteInitialization' is sealed in the implementation but not sealed in the contract.
-TypesMustExist : Type 'Microsoft.VisualBasic.CompilerServices.InternalErrorException' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.FallbackCall(System.Object, System.String, System.Object[], System.String[], System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.FallbackGet(System.Object, System.String, System.Object[], System.String[])' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.FallbackIndexSet(System.Object, System.Object[], System.String[])' does not exist in the implementation but it does exist in the contract.
@@ -20,12 +11,8 @@ MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.FallbackSet(System.Object, System.String, System.Object[])' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.FallbackSetComplex(System.Object, System.String, System.Object[], System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCallInvokeDefault(System.Object, System.Object[], System.String[], System.Boolean)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCanEvaluate(System.Object, System.Type, System.String, System.Object[], System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGetInvokeDefault(System.Object, System.Object[], System.String[], System.Boolean)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Operators.CompareObject(System.Object, System.Object, System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Operators.FallbackInvokeUserDefinedOperator(System.Object, System.Object[])' does not exist in the implementation but it does exist in the contract.
-CannotSealType : Type 'Microsoft.VisualBasic.CompilerServices.OptionCompareAttribute' is sealed in the implementation but not sealed in the contract.
-CannotSealType : Type 'Microsoft.VisualBasic.CompilerServices.OptionTextAttribute' is sealed in the implementation but not sealed in the contract.
 TypesMustExist : Type 'Microsoft.VisualBasic.CompilerServices.SiteDelegate0' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'Microsoft.VisualBasic.CompilerServices.SiteDelegate1' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'Microsoft.VisualBasic.CompilerServices.SiteDelegate2' does not exist in the implementation but it does exist in the contract.
@@ -34,8 +21,3 @@ TypesMustExist : Type 'Microsoft.VisualBasic.CompilerServices.SiteDelegate4' doe
 TypesMustExist : Type 'Microsoft.VisualBasic.CompilerServices.SiteDelegate5' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'Microsoft.VisualBasic.CompilerServices.SiteDelegate6' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'Microsoft.VisualBasic.CompilerServices.SiteDelegate7' does not exist in the implementation but it does exist in the contract.
-CannotSealType : Type 'Microsoft.VisualBasic.CompilerServices.StandardModuleAttribute' is sealed in the implementation but not sealed in the contract.
-CannotSealType : Type 'Microsoft.VisualBasic.CompilerServices.StaticLocalInitFlag' is sealed in the implementation but not sealed in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Utils.GetResourceString(System.String, System.String[])' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'Microsoft.VisualBasic.CompilerServices.Utils.MethodToString(System.Reflection.MethodBase)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 39

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Conversions.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Conversions.vb
@@ -919,13 +919,13 @@ MisMatch:
         Public Shared Shadows Function ToString(value As Char) As String
             Return value.ToString()
         End Function
-        Public Shared Function GetCultureInfo() As Global.System.Globalization.CultureInfo
+        Friend Shared Function GetCultureInfo() As Global.System.Globalization.CultureInfo
             Return Global.System.Globalization.CultureInfo.CurrentCulture
         End Function
-        Public Shared Function ToHalfwidthNumbers(s As String, culture As Global.System.Globalization.CultureInfo) As String
+        Friend Shared Function ToHalfwidthNumbers(s As String, culture As Global.System.Globalization.CultureInfo) As String
             Return s
         End Function
-        Public Shared Function IsHexOrOctValue(value As String, ByRef i64Value As Global.System.Int64) As Boolean
+        Friend Shared Function IsHexOrOctValue(value As String, ByRef i64Value As Global.System.Int64) As Boolean
             Dim ch As Char
             Dim length As Integer
             Dim firstNonspace As Integer
@@ -955,7 +955,7 @@ GetSpecialValue:
             Return True
         End Function
         <Global.System.CLSCompliant(False)>
-        Public Shared Function IsHexOrOctValue(value As String, ByRef ui64Value As Global.System.UInt64) As Boolean
+        Friend Shared Function IsHexOrOctValue(value As String, ByRef ui64Value As Global.System.UInt64) As Boolean
             Dim ch As Char
             Dim length As Integer
             Dim firstNonspace As Integer

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/DesignerGeneratedAttribute.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/DesignerGeneratedAttribute.vb
@@ -5,7 +5,7 @@
 Namespace Global.Microsoft.VisualBasic.CompilerServices
     <Global.System.AttributeUsage(Global.System.AttributeTargets.Class, Inherited:=False)>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
-    Public Class DesignerGeneratedAttribute
+    Public NotInheritable Class DesignerGeneratedAttribute
         Inherits Global.System.Attribute
     End Class
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ExceptionUtils.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ExceptionUtils.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
     End Class
 
-    Public NotInheritable Class InternalErrorException
+    Friend NotInheritable Class InternalErrorException
         Inherits System.Exception
 
         Public Sub New(ByVal message As String)

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/IncompleteInitialization.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/IncompleteInitialization.vb
@@ -5,7 +5,7 @@
 Namespace Global.Microsoft.VisualBasic.CompilerServices
     <Global.System.Diagnostics.DebuggerNonUserCode()>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
-    Public Class IncompleteInitialization
+    Public NotInheritable Class IncompleteInitialization
         Inherits Global.System.Exception
         Public Sub New()
             MyBase.New()

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/NewLateBinding.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/NewLateBinding.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Sub
 
         <DebuggerHiddenAttribute()> <DebuggerStepThroughAttribute()>
-        Public Shared Function LateCanEvaluate(
+        Friend Shared Function LateCanEvaluate(
                 ByVal instance As Object,
                 ByVal type As System.Type,
                 ByVal memberName As String,

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Operators.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Operators.vb
@@ -350,7 +350,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             End Select
         End Function
 
-        Public Shared Function CompareObject(ByVal left As Object, ByVal right As Object, ByVal textCompare As Boolean) As Integer
+        Friend Shared Function CompareObject(ByVal left As Object, ByVal right As Object, ByVal textCompare As Boolean) As Integer
             Dim comparison As CompareClass = CompareObject2(left, right, textCompare)
 
             Select Case comparison

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/OptionCompareAttribute.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/OptionCompareAttribute.vb
@@ -5,7 +5,7 @@
 Namespace Global.Microsoft.VisualBasic.CompilerServices
     <Global.System.AttributeUsage(Global.System.AttributeTargets.Parameter, Inherited:=False)>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
-    Public Class OptionCompareAttribute
+    Public NotInheritable Class OptionCompareAttribute
         Inherits Global.System.Attribute
     End Class
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/OptionTextAttribute.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/OptionTextAttribute.vb
@@ -5,7 +5,7 @@
 Namespace Global.Microsoft.VisualBasic.CompilerServices
     <Global.System.AttributeUsage(Global.System.AttributeTargets.Class, Inherited:=False)>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
-    Public Class OptionTextAttribute
+    Public NotInheritable Class OptionTextAttribute
         Inherits Global.System.Attribute
     End Class
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/StandardModuleAttribute.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/StandardModuleAttribute.vb
@@ -5,7 +5,7 @@
 Namespace Global.Microsoft.VisualBasic.CompilerServices
     <Global.System.AttributeUsage(Global.System.AttributeTargets.Class, Inherited:=False)>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
-    Public Class StandardModuleAttribute
+    Public NotInheritable Class StandardModuleAttribute
         Inherits Global.System.Attribute
     End Class
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/StaticLocalInitFlag.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/StaticLocalInitFlag.vb
@@ -5,7 +5,7 @@
 Namespace Global.Microsoft.VisualBasic.CompilerServices
     <Global.System.Diagnostics.DebuggerNonUserCode()>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
-    Public Class StaticLocalInitFlag
+    Public NotInheritable Class StaticLocalInitFlag
         Public State As Short
     End Class
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.LateBinder.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.LateBinder.vb
@@ -79,7 +79,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         '  Param: Args - An array of params used to replace placeholders.
         'Returns: The resource string if found or an error message string
         '*****************************************************************************
-        Public Shared Function GetResourceString(ByVal resourceKey As String, ByVal ParamArray args() As String) As String
+        Friend Shared Function GetResourceString(ByVal resourceKey As String, ByVal ParamArray args() As String) As String
             Return SR.Format(resourceKey, args)
         End Function
 
@@ -388,7 +388,7 @@ GetSpecialValue:
             Return resultString
         End Function
 
-        Public Shared Function MethodToString(ByVal method As Reflection.MethodBase) As String
+        Friend Shared Function MethodToString(ByVal method As Reflection.MethodBase) As String
 
             Dim returnType As System.Type = Nothing
             Dim first As Boolean

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/ControlChars.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/ControlChars.vb
@@ -4,7 +4,7 @@
 
 Namespace Microsoft.VisualBasic
     ' Contants for the Control Characters
-    Public NotInheritable Class ControlChars
+    Friend NotInheritable Class ControlChars
 
         Public Const CrLf As String = ChrW(13) & ChrW(10)
         Public Const NewLine As String = ChrW(13) & ChrW(10)

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/HideModuleNameAttribute.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/HideModuleNameAttribute.vb
@@ -5,7 +5,7 @@
 Namespace Global.Microsoft.VisualBasic
     <Global.System.AttributeUsage(Global.System.AttributeTargets.Class, Inherited:=False)>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
-    Public Class HideModuleNameAttribute
+    Public NotInheritable Class HideModuleNameAttribute
         Inherits Global.System.Attribute
     End Class
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Interaction.vb
@@ -4,7 +4,7 @@
 
 Namespace Microsoft.VisualBasic
 
-    Public Module Interaction
+    Friend Module Interaction
 
         Friend Function IIf(Of T)(ByVal condition As Boolean, ByVal truePart As T, ByVal falsePart As T) As T
             If condition Then

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Strings.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Strings.vb
@@ -28,7 +28,7 @@ Namespace Global.Microsoft.VisualBasic
         '============================================================================
         ' Left/Right/Mid/Trim functions.
         '============================================================================
-        Public Function Left(ByVal [str] As String, ByVal length As Integer) As String
+        Friend Function Left(ByVal [str] As String, ByVal length As Integer) As String
             '-------------------------------------------------------------
             '   lLen < 0 throws InvalidArgument exception
             '   lLen > Len([str]) let lLen = Len([str])


### PR DESCRIPTION
Fixes #27972 

I made the following changes:
* If the type is not exposed through the ref assembly, make it internal.
* Unless the type was used via reflection, keep it public, and add an exception.
* If the type is not sealed in the implementation but in the ref assembly, seal it in the implementation.