### PR TITLE
Replace custom date parsing for HttpDateParse

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpDateParse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpDateParse.cs
@@ -2,401 +2,50 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 namespace System.Net
 {
     internal static class HttpDateParse
     {
-        private const int BASE_DEC  = 10; // base 10
+        private static readonly DateTimeFormatInfo s_format = DateTimeFormatInfo.InvariantInfo;
+        private static readonly DateTimeStyles s_style = DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowWhiteSpaces;
 
-        //
-        // Date indicies used to figure out what each entry is.
-        //
-
-        private const int DATE_INDEX_DAY_OF_WEEK     = 0;
-
-        private const int DATE_1123_INDEX_DAY        = 1;
-        private const int DATE_1123_INDEX_MONTH      = 2;
-        private const int DATE_1123_INDEX_YEAR       = 3;
-        private const int DATE_1123_INDEX_HRS        = 4;
-        private const int DATE_1123_INDEX_MINS       = 5;
-        private const int DATE_1123_INDEX_SECS       = 6;
-
-        private const int DATE_ANSI_INDEX_MONTH      = 1;
-        private const int DATE_ANSI_INDEX_DAY        = 2;
-        private const int DATE_ANSI_INDEX_HRS        = 3;
-        private const int DATE_ANSI_INDEX_MINS       = 4;
-        private const int DATE_ANSI_INDEX_SECS       = 5;
-        private const int DATE_ANSI_INDEX_YEAR       = 6;
-
-        private const int DATE_INDEX_TZ              = 7;
-
-        private const int DATE_INDEX_LAST            = DATE_INDEX_TZ;
-        private const int MAX_FIELD_DATE_ENTRIES     = (DATE_INDEX_LAST+1);
-
-        //
-        // DATE_TOKEN's DWORD values used to determine what day/month we're on
-        //
-
-        private const int DATE_TOKEN_JANUARY      = 1;
-        private const int DATE_TOKEN_FEBRUARY     = 2;
-        private const int DATE_TOKEN_MARCH        = 3;
-        private const int DATE_TOKEN_APRIL        = 4;
-        private const int DATE_TOKEN_MAY          = 5;
-        private const int DATE_TOKEN_JUNE         = 6;
-        private const int DATE_TOKEN_JULY         = 7;
-        private const int DATE_TOKEN_AUGUST       = 8;
-        private const int DATE_TOKEN_SEPTEMBER    = 9;
-        private const int DATE_TOKEN_OCTOBER      = 10;
-        private const int DATE_TOKEN_NOVEMBER     = 11;
-        private const int DATE_TOKEN_DECEMBER     = 12;
-
-        private const int DATE_TOKEN_LAST_MONTH   = (DATE_TOKEN_DECEMBER+1);
-
-        private const int DATE_TOKEN_SUNDAY       = 0;
-        private const int DATE_TOKEN_MONDAY       = 1;
-        private const int DATE_TOKEN_TUESDAY      = 2;
-        private const int DATE_TOKEN_WEDNESDAY    = 3;
-        private const int DATE_TOKEN_THURSDAY     = 4;
-        private const int DATE_TOKEN_FRIDAY       = 5;
-        private const int DATE_TOKEN_SATURDAY     = 6;
-
-        private const int DATE_TOKEN_LAST_DAY     = (DATE_TOKEN_SATURDAY+1);
-
-        private const int DATE_TOKEN_GMT          = -1000;
-
-        private const int DATE_TOKEN_LAST         = DATE_TOKEN_GMT;
-
-        private const int DATE_TOKEN_ERROR        = (DATE_TOKEN_LAST+1);
-
-        /// <summary>
-        /// Looks at the first three chars of a string at the index to determine if we're looking
-        /// at a Day of the Week, or Month, or "GMT" string.
-        /// </summary>
-        /// <returns>
-        /// The correct date token (0-6 for day of the week, 1-14 for month, etc.) if successful,
-        /// otherwise, DATE_TOKEN_ERROR.
-        /// </returns>
-        private static int MapDayMonthToDword(string day, int index)
+        private static readonly string[] s_dateFormats =
         {
-            switch (char.ToUpper(day[index]))
-            {
-                case 'A':
-                    switch (char.ToUpper(day[index + 1]))
-                    {
-                        case 'P':
-                            return DATE_TOKEN_APRIL;
-                        case 'U':
-                            return DATE_TOKEN_AUGUST;
-                    }
-                    return DATE_TOKEN_ERROR;
-
-                case 'D':
-                    return DATE_TOKEN_DECEMBER;
-
-                case 'F':
-                    switch (char.ToUpper(day[index + 1]))
-                    {
-                        case 'R':
-                            return DATE_TOKEN_FRIDAY;
-                        case 'E':
-                            return DATE_TOKEN_FEBRUARY;
-                    }
-                    return DATE_TOKEN_ERROR;
-
-                case 'G':
-                    return DATE_TOKEN_GMT;
-
-                case 'M':
-                    switch (char.ToUpper(day[index + 1]))
-                    {
-                        case 'O':
-                            return DATE_TOKEN_MONDAY;
-                        case 'A':
-                            switch (char.ToUpper(day[index + 2]))
-                            {
-                                case 'R':
-                                    return DATE_TOKEN_MARCH;
-                                case 'Y':
-                                    return DATE_TOKEN_MAY;
-                            }
-
-                            // fall through to error
-                            break;
-                    }
-                    return DATE_TOKEN_ERROR;
-
-                case 'N':
-                    return DATE_TOKEN_NOVEMBER;
-
-                case 'J':
-                    switch (char.ToUpper(day[index + 1]))
-                    {
-                        case 'A':
-                            return DATE_TOKEN_JANUARY;
-
-                        case 'U':
-                            switch (char.ToUpper(day[index + 2]))
-                            {
-                                case 'N':
-                                    return DATE_TOKEN_JUNE;
-                                case 'L':
-                                    return DATE_TOKEN_JULY;
-                            }
-
-                            // fall through to error
-                            break;
-                    }
-                    return DATE_TOKEN_ERROR;
-
-                case 'O':
-                    return DATE_TOKEN_OCTOBER;
-
-                case 'S':
-                    switch (char.ToUpper(day[index + 1]))
-                    {
-                        case 'A':
-                            return DATE_TOKEN_SATURDAY;
-                        case 'U':
-                            return DATE_TOKEN_SUNDAY;
-                        case 'E':
-                            return DATE_TOKEN_SEPTEMBER;
-                    }
-                    return DATE_TOKEN_ERROR;
-
-                case 'T':
-                    switch (char.ToUpper(day[index + 1]))
-                    {
-                        case 'U':
-                            return DATE_TOKEN_TUESDAY;
-                        case 'H':
-                            return DATE_TOKEN_THURSDAY;
-                    }
-                    return DATE_TOKEN_ERROR;
-
-                case 'U':
-                    return DATE_TOKEN_GMT;
-
-                case 'W':
-                    return DATE_TOKEN_WEDNESDAY;
-            }
-
-            return DATE_TOKEN_ERROR;
-        }
+            // RFC1123
+            "R",
+            // RFC1123 - UTC
+            "ddd, dd MMM yyyy HH:mm:ss \"UTC\"",
+            // RFC1123 - Offset
+            "ddd, dd MMM yyyy HH:mm:sszzz",
+            // RFC850
+            "dddd, dd-MMM-yy HH:mm:ss \"GMT\"",
+            // RFC850 - UTC
+            "dddd, dd-MMM-yy HH:mm:ss \"UTC\"",
+            // RFC850 - Offset
+            "dddd, dd-MMM-yy HH:mm:sszzz",
+            // ANSI
+            "ddd MMM d HH:mm:ss yyyy"
+        };
 
         /// <summary>
         /// Parses through an ANSI, RFC850, or RFC1123 date format and converts it to a <see cref="DateTime"/>.
         /// </summary>
         public static bool ParseHttpDate(string dateString, out DateTime result)
         {
-            int index = 0;
-            int i = 0, iLastLettered = -1;
-            bool isANSIDateFormat = false;
-            int[] dateParseResults = new int[MAX_FIELD_DATE_ENTRIES];
+            result = DateTime.MinValue;
+            // Convert to upper so that UTC/GMT case is ignored (if present).
+            // Parsing already ignores casing of day-of-week/month, but the zone is checked as an exact string.
+            dateString = dateString.ToUpperInvariant();
 
-            result = new DateTime();
-
-            //
-            // Date Parsing v2 (1 more to go), and here is how it works...
-            //  We take a date string and churn through it once, converting
-            //  integers to integers, Month,Day, and GMT strings into integers,
-            //  and all is then placed IN order in a temp array.
-            //
-            // At the completion of the parse stage, we simple look at
-            //  the data, and then map the results into a new DateTime.
-            //
-            // The end of the function does something munging and pretting
-            //  up of the results to handle the year 2000, and TZ offsets
-            //  Note: do we need to fully handle TZs anymore?
-            //
-
-            while (index < dateString.Length && i < MAX_FIELD_DATE_ENTRIES)
+            if (DateTimeOffset.TryParseExact(dateString, s_dateFormats, s_format, s_style, out var offset))
             {
-                if (dateString[index] >= '0' && dateString[index] <= '9')
-                {
-                    //
-                    // we have a numerical entry, scan through it and convent to DWORD
-                    //
-
-                    dateParseResults[i] = 0;
-
-                    do
-                    {
-                        dateParseResults[i] *= BASE_DEC;
-                        dateParseResults[i] += (dateString[index] - '0');
-                        index++;
-                    } while (index < dateString.Length &&
-                             dateString[index] >= '0' &&
-                             dateString[index] <= '9');
-
-                    i++; // next token
-                }
-                else if ((dateString[index] >= 'A' && dateString[index] <= 'Z') ||
-                         (dateString[index] >= 'a' && dateString[index] <= 'z'))
-                {
-                    //
-                    // we have a string, should be a day, month, or GMT
-                    //   lets skim to the end of the string
-                    //
-
-                    dateParseResults[i] = MapDayMonthToDword(dateString, index);
-
-                    iLastLettered = i;
-
-                    // We want to ignore the possibility of a time zone such as PST or EST in a non-standard
-                    // date format such as "Thu Dec 17 16:01:28 PST 1998" (Notice that the year is _after_ the time zone
-                    if ((dateParseResults[i] == DATE_TOKEN_ERROR) &&
-                        !(isANSIDateFormat && (i == DATE_ANSI_INDEX_YEAR)))
-                    {
-                        return false;
-                    }
-
-                    //
-                    // At this point if we have a vaild string
-                    //  at this index, we know for sure that we're
-                    //  looking at a ANSI type DATE format.
-                    //
-
-                    if (i == DATE_ANSI_INDEX_MONTH)
-                    {
-                        isANSIDateFormat = true;
-                    }
-
-                    //
-                    // Read past the end of the current set of alpha characters,
-                    //  as MapDayMonthToDword only peeks at a few characters
-                    //
-
-                    do
-                    {
-                        index++;
-                    } while ((index < dateString.Length) &&
-                             ((dateString[index] >= 'A' && dateString[index] <= 'Z') ||
-                              (dateString[index] >= 'a' && dateString[index] <= 'z')));
-
-                    i++; // next token
-                }
-                else
-                {
-                    //
-                    // For the generic case its either a space, comma, semi-colon, etc.
-                    //  the point is we really don't care, nor do we need to waste time
-                    //  worring about it (the orginal code did).   The point is we
-                    //  care about the actual date information, So we just advance to the
-                    //  next lexume.
-                    //
-
-                    index++;
-                }
+                result = offset.LocalDateTime;
+                return true;
             }
 
-            //
-            // We're finished parsing the string, now take the parsed tokens
-            //  and turn them to the actual structured information we care about.
-            //  So we build lpSysTime from the Array, using a local if none is passed in.
-            //
-
-            int year;
-            int month;
-            int day;
-            int hour;
-            int minute;
-            int second;
-            int millisecond;
-
-            millisecond = 0;
-
-            if (isANSIDateFormat)
-            {
-                day = dateParseResults[DATE_ANSI_INDEX_DAY];
-                month = dateParseResults[DATE_ANSI_INDEX_MONTH];
-                hour = dateParseResults[DATE_ANSI_INDEX_HRS];
-                minute = dateParseResults[DATE_ANSI_INDEX_MINS];
-                second = dateParseResults[DATE_ANSI_INDEX_SECS];
-                if (iLastLettered != DATE_ANSI_INDEX_YEAR)
-                {
-                    year = dateParseResults[DATE_ANSI_INDEX_YEAR];
-                }
-                else
-                {
-                    // This is a fix to get around toString/toGMTstring (where the timezone is
-                    // appended at the end. (See above)
-                    year = dateParseResults[DATE_INDEX_TZ];
-                }
-            }
-            else
-            {
-                day = dateParseResults[DATE_1123_INDEX_DAY];
-                month = dateParseResults[DATE_1123_INDEX_MONTH];
-                year = dateParseResults[DATE_1123_INDEX_YEAR];
-                hour = dateParseResults[DATE_1123_INDEX_HRS];
-                minute = dateParseResults[DATE_1123_INDEX_MINS];
-                second = dateParseResults[DATE_1123_INDEX_SECS];
-            }
-
-            //
-            // Normalize the year, 90 == 1990, handle the year 2000, 02 == 2002
-            //  This is Year 2000 handling folks!!!  We get this wrong and
-            //  we all look bad.
-            //
-
-            if (year < 100)
-            {
-                year += ((year < 80) ? 2000 : 1900);
-            }
-
-            //
-            // if we got misformed time, then plug in the current time
-            // !lpszHrs || !lpszMins || !lpszSec
-            //
-
-            if ((i < 4) ||
-                (day > 31) ||
-                (hour > 23) ||
-                (minute > 59) ||
-                (second > 59))
-            {
-                return false;
-            }
-
-            //
-            // Now do the DateTime conversion
-            //
-
-            result = new DateTime(year, month, day, hour, minute, second, millisecond);
-
-            //
-            // we want the system time to be accurate. This is _suhlow_
-            // The time passed in is in the local time zone; we have to convert this into GMT.
-            //
-
-            if (iLastLettered == DATE_ANSI_INDEX_YEAR)
-            {
-                // this should be an unusual case.
-                result = result.ToUniversalTime();
-            }
-
-            //
-            // If we have an Offset to another Time Zone
-            //   then convert to appropriate GMT time
-            //
-
-            if (i > DATE_INDEX_TZ &&
-                dateParseResults[DATE_INDEX_TZ] != DATE_TOKEN_GMT)
-            {
-
-                //
-                // if we received +/-nnnn as offset (hhmm), modify the output FILETIME
-                //
-
-                double offset = dateParseResults[DATE_INDEX_TZ];
-                result.AddHours(offset);
-            }
-
-            // In the end, we leave it all in LocalTime
-
-            result = result.ToLocalTime();
-
-            return true;
+            return false;
         }
     }
 }

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -76,40 +76,42 @@ namespace System.Net.Tests
                 foreach (var date in dates.SelectMany(d => new[] { d.ToOffset(TimeSpan.FromHours(5)), d.ToOffset(TimeSpan.FromHours(-5)) }))
                 {
                     var formatted = date.ToString(format);
-                    // Should be date.LocalDateTime, but current implementation ignores offsets...
-                    var expected = new DateTimeOffset(date.DateTime, TimeSpan.Zero).LocalDateTime;
+                    var expected = date.LocalDateTime;
                     yield return new object[] { formatted, expected };
                     yield return new object[] { formatted.ToLowerInvariant(), expected };
                 }
             }
+        }
+
+        public static IEnumerable<object[]> Dates_Invalid_Data()
+        {
+            yield return new object[] { "not a valid date here" };
+            yield return new object[] { "Sun, 31 Nov 1234567890 33:77:80 GMT" };
 
             // Should be Sunday...
-            var dayOfWeekMismatch = new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
-            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 GMT", dayOfWeekMismatch };
-            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 UTC", dayOfWeekMismatch };
-            yield return new object[] { "Sat, 25 Mar 2018 21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 GMT", dayOfWeekMismatch };
-            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 UTC", dayOfWeekMismatch };
-            yield return new object[] { "Saturday, 25-Mar-18 21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Sat Mar 25 21:33:01 2018", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-
-            var dayOfWeekAndMonthInvalid = new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
-            yield return new object[] { "Sue, 25 Not 2018 16:33:01 GMT", dayOfWeekAndMonthInvalid };
-            yield return new object[] { "Sue, 25 Not 2018 16:33:01 UTC", dayOfWeekAndMonthInvalid };
-            yield return new object[] { "Sue, 25 Not 2018 21:33:01+05:00", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Surprise, 25-Not-18 16:33:01 GMT", dayOfWeekAndMonthInvalid };
-            yield return new object[] { "Surprise, 25-Not-18 16:33:01 UTC", dayOfWeekAndMonthInvalid };
-            yield return new object[] { "Surprise, 25-Not-18 21:33:01+05:00", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Sue Not 25 21:33:01 2018", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-
-            var strangeSeparators = new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
-            yield return new object[] { "Sun?!25<Mar]2018&16^33(01$GMT", strangeSeparators };
-            yield return new object[] { "Sun$@25^Mar%2018|16-33)01~UTC", strangeSeparators };
-            yield return new object[] { "Sun`;25%Mar{2018=21=33*01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Sunday<>25#Mar!18_16,33@01\tGMT", strangeSeparators };
-            yield return new object[] { "Sunday}{25\\Mar\"18'16?33^01-UTC", strangeSeparators };
-            yield return new object[] { "Sunday$%25.Mar-18=21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Sun+Mar,25/21?33[01{2018", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 GMT" };
+            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 UTC" };
+            yield return new object[] { "Sat, 25 Mar 2018 21:33:01+05:00" };
+            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 GMT" };
+            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 UTC" };
+            yield return new object[] { "Saturday, 25-Mar-18 21:33:01+05:00" };
+            yield return new object[] { "Sat Mar 25 21:33:01 2018" };
+            // Invalid day-of-week/month values
+            yield return new object[] { "Sue, 25 Not 2018 16:33:01 GMT" };
+            yield return new object[] { "Sue, 25 Not 2018 16:33:01 UTC" };
+            yield return new object[] { "Sue, 25 Not 2018 21:33:01+05:00" };
+            yield return new object[] { "Surprise, 25-Not-18 16:33:01 GMT" };
+            yield return new object[] { "Surprise, 25-Not-18 16:33:01 UTC" };
+            yield return new object[] { "Surprise, 25-Not-18 21:33:01+05:00" };
+            yield return new object[] { "Sue Not 25 21:33:01 2018" };
+            // Strange separators
+            yield return new object[] { "Sun?!25<Mar]2018&16^33(01$GMT" };
+            yield return new object[] { "Sun$@25^Mar%2018|16-33)01~UTC" };
+            yield return new object[] { "Sun`;25%Mar{2018=21=33*01+05:00" };
+            yield return new object[] { "Sunday<>25#Mar!18_16,33@01\tGMT" };
+            yield return new object[] { "Sunday}{25\\Mar\"18'16?33^01-UTC" };
+            yield return new object[] { "Sunday$%25.Mar-18=21:33:01+05:00" };
+            yield return new object[] { "Sun+Mar,25/21?33[01{2018" };
         }
 
         public HttpWebRequestTest(ITestOutputHelper output)
@@ -757,8 +759,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [InlineData("not a valid date here")]
-        [InlineData("Sun, 31 Nov 1234567890 33:77:80 GMT")]
+        [MemberData(nameof(Dates_Invalid_Data))]
         public void IfModifiedSince_InvalidValue(string invalid)
         {
             HttpWebRequest request = WebRequest.CreateHttp("http://localhost");
@@ -800,8 +801,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [InlineData("not a valid date here")]
-        [InlineData("Sun, 31 Nov 1234567890 33:77:80 GMT")]
+        [MemberData(nameof(Dates_Invalid_Data))]
         public void Date_InvalidValue(string invalid)
         {
             HttpWebRequest request = WebRequest.CreateHttp("http://localhost");

--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -27,7 +27,7 @@ namespace System.Net.Tests
                 // RFC850 - UTC
                 "dddd, dd-MMM-yy HH:mm:ss UTC",
                 // ANSI
-                "ddd MMM d HH:mm:ss yyyy"
+                "ddd MMM d HH:mm:ss yyyy",
             };
 
             var offset_formats = new[]
@@ -62,40 +62,42 @@ namespace System.Net.Tests
                 foreach (var date in dates.SelectMany(d => new[] { d.ToOffset(TimeSpan.FromHours(5)), d.ToOffset(TimeSpan.FromHours(-5)) }))
                 {
                     var formatted = date.ToString(format);
-                    // Should be date.LocalDateTime, but current implementation ignores offsets...
-                    var expected = new DateTimeOffset(date.DateTime, TimeSpan.Zero).LocalDateTime;
+                    var expected = date.LocalDateTime;
                     yield return new object[] { formatted, expected };
                     yield return new object[] { formatted.ToLowerInvariant(), expected };
                 }
             }
+        }
+
+        public static IEnumerable<object[]> Dates_Invalid_Data()
+        {
+            yield return new object[] { "not a valid date here" };
+            yield return new object[] { "Sun, 31 Nov 1234567890 33:77:80 GMT" };
 
             // Should be Sunday...
-            var dayOfWeekMismatch = new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
-            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 GMT", dayOfWeekMismatch };
-            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 UTC", dayOfWeekMismatch };
-            yield return new object[] { "Sat, 25 Mar 2018 21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 GMT", dayOfWeekMismatch };
-            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 UTC", dayOfWeekMismatch };
-            yield return new object[] { "Saturday, 25-Mar-18 21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Sat Mar 25 21:33:01 2018", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-
-            var dayOfWeekAndMonthInvalid = new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
-            yield return new object[] { "Sue, 25 Not 2018 16:33:01 GMT", dayOfWeekAndMonthInvalid };
-            yield return new object[] { "Sue, 25 Not 2018 16:33:01 UTC", dayOfWeekAndMonthInvalid };
-            yield return new object[] { "Sue, 25 Not 2018 21:33:01+05:00", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Surprise, 25-Not-18 16:33:01 GMT", dayOfWeekAndMonthInvalid };
-            yield return new object[] { "Surprise, 25-Not-18 16:33:01 UTC", dayOfWeekAndMonthInvalid };
-            yield return new object[] { "Surprise, 25-Not-18 21:33:01+05:00", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Sue Not 25 21:33:01 2018", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-
-            var strangeSeparators = new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
-            yield return new object[] { "Sun?!25<Mar]2018&16^33(01$GMT", strangeSeparators };
-            yield return new object[] { "Sun$@25^Mar%2018|16-33)01~UTC", strangeSeparators };
-            yield return new object[] { "Sun`;25%Mar{2018=21=33*01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Sunday<>25#Mar!18_16,33@01\tGMT", strangeSeparators };
-            yield return new object[] { "Sunday}{25\\Mar\"18'16?33^01-UTC", strangeSeparators };
-            yield return new object[] { "Sunday$%25.Mar-18=21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
-            yield return new object[] { "Sun+Mar,25/21?33[01{2018", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 GMT" };
+            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 UTC" };
+            yield return new object[] { "Sat, 25 Mar 2018 21:33:01+05:00" };
+            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 GMT" };
+            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 UTC" };
+            yield return new object[] { "Saturday, 25-Mar-18 21:33:01+05:00" };
+            yield return new object[] { "Sat Mar 25 21:33:01 2018" };
+            // Invalid day-of-week/month values
+            yield return new object[] { "Sue, 25 Not 2018 16:33:01 GMT" };
+            yield return new object[] { "Sue, 25 Not 2018 16:33:01 UTC" };
+            yield return new object[] { "Sue, 25 Not 2018 21:33:01+05:00" };
+            yield return new object[] { "Surprise, 25-Not-18 16:33:01 GMT" };
+            yield return new object[] { "Surprise, 25-Not-18 16:33:01 UTC" };
+            yield return new object[] { "Surprise, 25-Not-18 21:33:01+05:00" };
+            yield return new object[] { "Sue Not 25 21:33:01 2018" };
+            // Strange separators
+            yield return new object[] { "Sun?!25<Mar]2018&16^33(01$GMT" };
+            yield return new object[] { "Sun$@25^Mar%2018|16-33)01~UTC" };
+            yield return new object[] { "Sun`;25%Mar{2018=21=33*01+05:00" };
+            yield return new object[] { "Sunday<>25#Mar!18_16,33@01\tGMT" };
+            yield return new object[] { "Sunday}{25\\Mar\"18'16?33^01-UTC" };
+            yield return new object[] { "Sunday$%25.Mar-18=21:33:01+05:00" };
+            yield return new object[] { "Sun+Mar,25/21?33[01{2018" };
         }
 
         [Theory]
@@ -156,8 +158,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [InlineData("not a valid date here")]
-        [InlineData("Sun, 31 Nov 1234567890 33:77:80 GMT")]
+        [MemberData(nameof(Dates_Invalid_Data))]
         public async Task LastModified_InvalidValue(string invalid)
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Test.Common;
 using System.Threading.Tasks;
@@ -12,6 +14,90 @@ namespace System.Net.Tests
 {
     public class HttpWebResponseTest
     {
+        public static IEnumerable<object[]> Dates_ReadValue_Data()
+        {
+            var zero_formats = new[]
+            {
+                // RFC1123
+                "R",
+                // RFC1123 - UTC
+                "ddd, dd MMM yyyy HH:mm:ss UTC",
+                // RFC850
+                "dddd, dd-MMM-yy HH:mm:ss G\\MT",
+                // RFC850 - UTC
+                "dddd, dd-MMM-yy HH:mm:ss UTC",
+                // ANSI
+                "ddd MMM d HH:mm:ss yyyy"
+            };
+
+            var offset_formats = new[]
+            {
+                // RFC1123 - Offset
+                "ddd, dd MMM yyyy HH:mm:sszzz",
+                // RFC850 - Offset
+                "dddd, dd-MMM-yy HH:mm:sszzz",
+            };
+
+            var dates = new[]
+            {
+                new DateTimeOffset(2018, 1, 1, 12, 1, 14, TimeSpan.Zero),
+                new DateTimeOffset(2018, 1, 3, 15, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2015, 5, 6, 20, 45, 38, TimeSpan.Zero),
+            };
+
+            foreach (var date in dates)
+            {
+                var expected = date.LocalDateTime;
+
+                foreach (var format in zero_formats.Concat(offset_formats))
+                {
+                    var formatted = date.ToString(format);
+                    yield return new object[] { formatted, expected };
+                    yield return new object[] { formatted.ToLowerInvariant(), expected };
+                }
+            }
+
+            foreach (var format in offset_formats)
+            {
+                foreach (var date in dates.SelectMany(d => new[] { d.ToOffset(TimeSpan.FromHours(5)), d.ToOffset(TimeSpan.FromHours(-5)) }))
+                {
+                    var formatted = date.ToString(format);
+                    // Should be date.LocalDateTime, but current implementation ignores offsets...
+                    var expected = new DateTimeOffset(date.DateTime, TimeSpan.Zero).LocalDateTime;
+                    yield return new object[] { formatted, expected };
+                    yield return new object[] { formatted.ToLowerInvariant(), expected };
+                }
+            }
+
+            // Should be Sunday...
+            var dayOfWeekMismatch = new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
+            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 GMT", dayOfWeekMismatch };
+            yield return new object[] { "Sat, 25 Mar 2018 16:33:01 UTC", dayOfWeekMismatch };
+            yield return new object[] { "Sat, 25 Mar 2018 21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 GMT", dayOfWeekMismatch };
+            yield return new object[] { "Saturday, 25-Mar-18 16:33:01 UTC", dayOfWeekMismatch };
+            yield return new object[] { "Saturday, 25-Mar-18 21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+            yield return new object[] { "Sat Mar 25 21:33:01 2018", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+
+            var dayOfWeekAndMonthInvalid = new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
+            yield return new object[] { "Sue, 25 Not 2018 16:33:01 GMT", dayOfWeekAndMonthInvalid };
+            yield return new object[] { "Sue, 25 Not 2018 16:33:01 UTC", dayOfWeekAndMonthInvalid };
+            yield return new object[] { "Sue, 25 Not 2018 21:33:01+05:00", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+            yield return new object[] { "Surprise, 25-Not-18 16:33:01 GMT", dayOfWeekAndMonthInvalid };
+            yield return new object[] { "Surprise, 25-Not-18 16:33:01 UTC", dayOfWeekAndMonthInvalid };
+            yield return new object[] { "Surprise, 25-Not-18 21:33:01+05:00", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+            yield return new object[] { "Sue Not 25 21:33:01 2018", new DateTimeOffset(2018, 11, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+
+            var strangeSeparators = new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(5)).LocalDateTime;
+            yield return new object[] { "Sun?!25<Mar]2018&16^33(01$GMT", strangeSeparators };
+            yield return new object[] { "Sun$@25^Mar%2018|16-33)01~UTC", strangeSeparators };
+            yield return new object[] { "Sun`;25%Mar{2018=21=33*01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+            yield return new object[] { "Sunday<>25#Mar!18_16,33@01\tGMT", strangeSeparators };
+            yield return new object[] { "Sunday}{25\\Mar\"18'16?33^01-UTC", strangeSeparators };
+            yield return new object[] { "Sunday$%25.Mar-18=21:33:01+05:00", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+            yield return new object[] { "Sun+Mar,25/21?33[01{2018", new DateTimeOffset(2018, 3, 25, 21, 33, 1, TimeSpan.FromHours(0)).LocalDateTime };
+        }
+
         [Theory]
         [InlineData("text/html")]
         [InlineData("text/html; charset=utf-8")]
@@ -45,6 +131,74 @@ namespace System.Net.Tests
                 using (WebResponse response = await getResponse)
                 {
                     Assert.Equal(string.Empty, response.ContentType);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(Dates_ReadValue_Data))]
+        public async Task LastModified_ReadValue(string raw, DateTime expected)
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpWebRequest request = WebRequest.CreateHttp(url);
+                request.Method = HttpMethod.Get.Method;
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK);
+
+                using (WebResponse response = await getResponse)
+                {
+                    response.Headers.Set(HttpRequestHeader.LastModified, raw);
+                    HttpWebResponse httpResponse = Assert.IsType<HttpWebResponse>(response);
+                    Assert.Equal(expected, httpResponse.LastModified);
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData("not a valid date here")]
+        [InlineData("Sun, 31 Nov 1234567890 33:77:80 GMT")]
+        public async Task LastModified_InvalidValue(string invalid)
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpWebRequest request = WebRequest.CreateHttp(url);
+                request.Method = HttpMethod.Get.Method;
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK);
+
+                using (WebResponse response = await getResponse)
+                {
+                    response.Headers.Set(HttpRequestHeader.LastModified, invalid);
+                    HttpWebResponse httpResponse = Assert.IsType<HttpWebResponse>(response);
+                    Assert.Equal(DateTime.MinValue, httpResponse.LastModified);
+                }
+            });
+        }
+
+        [Fact]
+        public async Task LastModified_NotPresent()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpWebRequest request = WebRequest.CreateHttp(url);
+                request.Method = HttpMethod.Get.Method;
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK);
+
+                using (WebResponse response = await getResponse)
+                {
+                    HttpWebResponse httpResponse = Assert.IsType<HttpWebResponse>(response);
+
+                    DateTime lower = DateTime.Now;
+                    DateTime firstCaptured = httpResponse.LastModified;
+                    DateTime middle = DateTime.Now;
+                    Assert.InRange(firstCaptured, lower, middle);
+                    await Task.Delay(10);
+                    DateTime secondCaptured = httpResponse.LastModified;
+                    DateTime upper = DateTime.Now;
+                    Assert.InRange(secondCaptured, middle, upper);
+                    Assert.NotEqual(firstCaptured, secondCaptured);
                 }
             });
         }


### PR DESCRIPTION
fixes #12513

Added exploratory tests, then modified those tests into what DateTime(Offset).Parse can handle.
Also fixes the following bugs in the original:
 - considered ANSI dates to be local (to the _receiver_, no less), instead of UTC/GMT like the spec says.
 - accepted offset values (ie, `+05:00`), but didn't actually use them.
 - would throw `ArrayIndexOutOfBoundsException` if a string token didn't have enough distinguishing characters (ie, `'S'` throws, because it needs to check the next character for `'a'`/`'u'` for Saturday/Sunday)

Retains case insensitivity of the original.
Drops ability to use partially matching day-of-week/month strings (ie, the original parses `"Surprise"` as `"Sunday"`).
Drops ability to use non-matching date/day-of-week strings (ie `"Sat, 25 Mar 2018 16:33:01 GMT"` - the 25th was actually a Sunday)
Drops ability to use arbitrary characters as separators.
Now allows arbitrary amounts of whitespace between tokens.

Attempting to retain any of the previous compatibility changes would require changes to `DateTime.Parse`, which I am somewhat loathe to do.

I'm going to assume these changes represent a performance regression, given the previous implementation was highly optimized (if somewhat buggy).
Additionally, the way the previous code was written makes me think it was pulled from C/C++ somewhere - I don't know whether that should be looked into.
