### PR TITLE
IPEndPoint.Port as UInt16

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -35,8 +35,8 @@ namespace System.Net
 
         internal const int AnyPort = MinPort;
 
-        internal static IPEndPoint Any = new IPEndPoint(IPAddress.Any, AnyPort);
-        internal static IPEndPoint IPv6Any = new IPEndPoint(IPAddress.IPv6Any, AnyPort);
+        internal static readonly IPEndPoint Any = new IPEndPoint(IPAddress.Any, AnyPort);
+        internal static readonly IPEndPoint IPv6Any = new IPEndPoint(IPAddress.IPv6Any, AnyPort);
 
         public override AddressFamily AddressFamily
         {

--- a/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -20,7 +20,7 @@ namespace System.Net
         ///       property.
         ///    </para>
         /// </devdoc>
-        public const int MinPort = UInt16.MinValue;
+        public const int MinPort = ushort.MinValue;
 
         /// <devdoc>
         ///    <para>
@@ -28,10 +28,10 @@ namespace System.Net
         ///       property.
         ///    </para>
         /// </devdoc>
-        public const int MaxPort = UInt16.MaxValue;
+        public const int MaxPort = ushort.MaxValue;
 
         private IPAddress _address;
-        private UInt16 _port;
+        private ushort _port;
 
         internal const int AnyPort = MinPort;
 
@@ -58,7 +58,7 @@ namespace System.Net
             {
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
-            _port = Convert.ToUInt16(port);
+            _port = (ushort) port;
             _address = new IPAddress(address);
         }
 
@@ -77,7 +77,7 @@ namespace System.Net
             {
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
-            _port = Convert.ToUInt16(port);
+            _port = (ushort) port;
             _address = address;
         }
 
@@ -107,7 +107,7 @@ namespace System.Net
         {
             get
             {
-                return Convert.ToInt32(_port);
+                return (int) _port;
             }
             set
             {
@@ -115,7 +115,7 @@ namespace System.Net
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
-                _port = Convert.ToUInt16(value);
+                _port = (ushort) value;
             }
         }
 

--- a/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -20,7 +20,7 @@ namespace System.Net
         ///       property.
         ///    </para>
         /// </devdoc>
-        public const int MinPort = 0x00000000;
+        public const int MinPort = UInt16.MinValue;
 
         /// <devdoc>
         ///    <para>
@@ -28,7 +28,7 @@ namespace System.Net
         ///       property.
         ///    </para>
         /// </devdoc>
-        public const int MaxPort = 0x0000FFFF;
+        public const int MaxPort = UInt16.MaxValue;
 
         private IPAddress _address;
         private int _port;

--- a/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -31,7 +31,7 @@ namespace System.Net
         public const int MaxPort = UInt16.MaxValue;
 
         private IPAddress _address;
-        private int _port;
+        private UInt16 _port;
 
         internal const int AnyPort = MinPort;
 
@@ -58,7 +58,7 @@ namespace System.Net
             {
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
-            _port = port;
+            _port = Convert.ToUInt16(port);
             _address = new IPAddress(address);
         }
 
@@ -77,7 +77,7 @@ namespace System.Net
             {
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
-            _port = port;
+            _port = Convert.ToUInt16(port);
             _address = address;
         }
 
@@ -107,7 +107,7 @@ namespace System.Net
         {
             get
             {
-                return _port;
+                return Convert.ToInt32(_port);
             }
             set
             {
@@ -115,7 +115,7 @@ namespace System.Net
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
-                _port = value;
+                _port = Convert.ToUInt16(value);
             }
         }
 

--- a/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -35,9 +35,6 @@ namespace System.Net
 
         internal const int AnyPort = MinPort;
 
-        internal static readonly IPEndPoint Any = new IPEndPoint(IPAddress.Any, AnyPort);
-        internal static readonly IPEndPoint IPv6Any = new IPEndPoint(IPAddress.IPv6Any, AnyPort);
-
         public override AddressFamily AddressFamily
         {
             get


### PR DESCRIPTION
A Port is a unsigned integer of 16 bits, so it have sense to define it internaly as a UInt16