### PR TITLE
Produce Windows PDBs when building for netfx and in a Windows OS

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -174,6 +174,8 @@
   <!-- Set the kind of PDB to Portable and turn on SourceLink (fetching source from GitHub) -->
   <PropertyGroup>
     <DebugType Condition="'$(DebugType)' == ''">Portable</DebugType>
+    <!-- Empty DebugType when building for netfx and in windows so that it is set to full or pdbonly later -->
+    <DebugType Condition="('$(_bc_TargetGroup)'=='netfx' OR $(_bc_TargetGroup.StartsWith('net4'))) AND '$(_runtimeOSFamily)' == 'win'"></DebugType>
     <UseSourceLink>true</UseSourceLink>
   </PropertyGroup>
 


### PR DESCRIPTION
From: https://github.com/dotnet/corefx/pull/28059/files

When testing in NETFX we need to produce Windows PDBs to get detailed stack traces with file name and line numbers.

cc: @weshaggard @danmosemsft 