### PR TITLE
Remove agent cleanup steps

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -264,27 +264,6 @@
         "workingFolder": "",
         "failOnStandardError": "false"
       }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": false,
-      "displayName": "Cleanup VSTS Agent",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
-      "refName": "Task13",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(PB_GitDirectory)/Tools/msbuild.sh",
-        "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
-        "workingFolder": "$(Build.SourcesDirectory)/corefx/Tools/scripts/vstsagent/",
-        "failOnStandardError": "false"
-      }
     }
   ],
   "options": [

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -328,27 +328,6 @@
         "workingFolder": "",
         "failOnStandardError": "false"
       }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": false,
-      "displayName": "Cleanup VSTS Agent",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
-      "refName": "Task15",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(DockerHost_ToolsDirectory)/msbuild.sh",
-        "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
-        "workingFolder": "$(DockerHost_ToolsDirectory)/scripts/vstsagent/",
-        "failOnStandardError": "false"
-      }
     }
   ],
   "options": [

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
@@ -295,36 +295,6 @@
       "environment": {},
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": false,
-      "displayName": "Build solution corefx\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
-      "refName": "Task14",
-      "task": {
-        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "solution": "corefx\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "14.0",
-        "msbuildArchitecture": "x86",
-        "msbuildLocation": "",
-        "platform": "",
-        "configuration": "",
-        "msbuildArguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
-        "clean": "false",
-        "maximumCpuCount": "false",
-        "restoreNugetPackages": "false",
-        "logProjectEvents": "false",
-        "createLogFile": "false"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Run AgentTools/End.ps1",
       "timeoutInMinutes": 0,

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -346,36 +346,6 @@
       "environment": {},
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": false,
-      "displayName": "Build solution corefx\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
-      "refName": "Task16",
-      "task": {
-        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "solution": "corefx\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "14.0",
-        "msbuildArchitecture": "x86",
-        "msbuildLocation": "",
-        "platform": "",
-        "configuration": "",
-        "msbuildArguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
-        "clean": "false",
-        "maximumCpuCount": "false",
-        "restoreNugetPackages": "false",
-        "logProjectEvents": "false",
-        "createLogFile": "false"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Run AgentTools/End.ps1",
       "timeoutInMinutes": 0,


### PR DESCRIPTION
These steps are no longer necessary, as agent cleanup is run nightly by VSTS.