### PR TITLE
Fix compat pack publish script to be able to publish and restore for 2.1 with current cli

### DIFF
--- a/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <!-- Setting NETCoreAppMaximumVersion to a high version so that the sdk doesn't complain if we're restoring/publishing for a higher version than the sdk. -->
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
     <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RID).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
     <DisableImplicitFrameworkReferences Condition="$(TargetFramework.Contains('netcoreapp'))">true</DisableImplicitFrameworkReferences>
   </PropertyGroup>


### PR DESCRIPTION
This is to fix: https://devdiv.visualstudio.com/DevDiv/_build?buildId=1531047 since the current cli we're restoring is for .NET Core 2.0

cc: @weshaggard @danmosemsft 