### PR TITLE
Enable digest test runs on CurlHandler.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -18,6 +18,7 @@ namespace System.Net.Http.Functional.Tests
         private const string Domain = "testdomain";
 
         private static readonly NetworkCredential s_credentials = new NetworkCredential(Username, Password, Domain);
+        private static readonly NetworkCredential s_credentialsNoDomain = new NetworkCredential(Username, Password);
 
         private static readonly Func<HttpClientHandler, Uri, HttpStatusCode, ICredentials, Task> s_createAndValidateRequest = async (handler, url, expectedStatusCode, credentials) =>
         {
@@ -34,11 +35,16 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(Authentication_TestData))]
         public async Task HttpClientHandler_Authentication_Succeeds(string authenticateHeader, bool result)
         {
-            if (PlatformDetection.IsWindowsNanoServer || (IsCurlHandler && authenticateHeader.ToLowerInvariant().Contains("digest")))
+            if (PlatformDetection.IsWindowsNanoServer)
             {
                 // TODO: #28065: Fix failing authentication test cases on different httpclienthandlers.
                 return;
             }
+
+            // Digest authentication does not work with domain credentials on CurlHandler. This is blocked by bugs in LibCurl.
+            NetworkCredential credentials = (IsCurlHandler && authenticateHeader.ToLowerInvariant().Contains("digest")) ?
+                s_credentialsNoDomain :
+                s_credentials;
 
             var options = new LoopbackServer.Options { Domain = Domain, Username = Username, Password = Password };
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -50,7 +56,7 @@ namespace System.Net.Http.Functional.Tests
                     server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.Unauthorized, serverAuthenticateHeader);
 
                 await TestHelper.WhenAllCompletedOrAnyFailedWithTimeout(TestHelper.PassingTestTimeoutMilliseconds,
-                    s_createAndValidateRequest(handler, url, result ? HttpStatusCode.OK : HttpStatusCode.Unauthorized, s_credentials), serverTask);
+                    s_createAndValidateRequest(handler, url, result ? HttpStatusCode.OK : HttpStatusCode.Unauthorized, credentials), serverTask);
             }, options);
         }
 
@@ -139,9 +145,6 @@ namespace System.Net.Http.Functional.Tests
             yield return new object[] { "bAsiC ", true };
             yield return new object[] { "basic", true };
 
-            // Add digest tests fail on CurlHandler.
-            // TODO: #28065: Fix failing authentication test cases on different httpclienthandlers.
-            yield return new object[] { "Digest realm=\"testrealm\" nonce=\"testnonce\"", false };
             yield return new object[] { $"Digest realm=\"testrealm\", nonce=\"{Convert.ToBase64String(Encoding.UTF8.GetBytes($"{DateTimeOffset.UtcNow}:XMh;z+$5|`i6Hx}}\", qop=auth-int, algorithm=MD5"))}\"", true };
             yield return new object[] { "Digest realm=\"api@example.org\", qop=\"auth\", algorithm=MD5-sess, nonce=\"5TsQWLVdgBdmrQ0XsxbDODV+57QdFR34I9HAbC/RVvkK\", " +
                     "opaque=\"HRPCssKJSGjCrkzDg8OhwpzCiGPChXYjwrI2QmXDnsOS\", charset=UTF-8, userhash=true", true };
@@ -153,7 +156,6 @@ namespace System.Net.Http.Functional.Tests
             if (PlatformDetection.IsNetCore)
             {
                 // TODO: #28060: Fix failing authentication test cases on Framework run.
-                yield return new object[] { "Digest realm=\"testrealm1\", nonce=\"testnonce1\" Digest realm=\"testrealm2\", nonce=\"testnonce2\"", false };
                 yield return new object[] { "Basic something, Digest something", false };
                 yield return new object[] { $"Digest realm=\"testrealm\", nonce=\"testnonce\", algorithm=MD5 " +
                     $"Basic realm=\"testrealm\"", false };

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -41,7 +41,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            // Digest authentication does not work with domain credentials on CurlHandler. This is blocked by bugs in LibCurl.
+            // Digest authentication does not work with domain credentials on CurlHandler. This is blocked by the behavior of LibCurl.
             NetworkCredential credentials = (IsCurlHandler && authenticateHeader.ToLowerInvariant().Contains("digest")) ?
                 s_credentialsNoDomain :
                 s_credentials;

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -568,13 +568,21 @@ namespace System.Net.Http.Functional.Tests
 
         public static IEnumerable<object[]> Authentication_SocketsHttpHandler_TestData()
         {
-            // These test cases pass on SocketsHttpHandler, fail everywhere else.
-            // TODO: #28065: Investigate failing authentication test cases on WinHttpHandler & CurlHandler.
+            // These test cases successfully authenticate on SocketsHttpHandler but fail on the other handlers.
+            // These are legal as per the the RFC, so authenticating is the expected behavior. See #28521 for details.
             yield return new object[] { "Basic realm=\"testrealm1\" basic realm=\"testrealm1\"", true };
             yield return new object[] { "Basic something digest something", true };
+
+            // These cases fail on WinHttpHandler because of a behavior in WinHttp that causes requests to be duplicated
+            // when the digest header has certain parameters. See #28522 for details.
             yield return new object[] { "Digest ", false };
-            yield return new object[] { "Digest realm=withoutquotes, nonce=withoutquotes", false };
             yield return new object[] { "Digest realm=\"testrealm\", nonce=\"testnonce\", algorithm=\"myown\"", false };
+
+            // These cases fail to authenticate on SocketsHttpHandler, but succeed on the other handlers.
+            // they are all invalid as per the RFC, so failing is the expected behavior. See #28523 for details.
+            yield return new object[] { "Digest realm=withoutquotes, nonce=withoutquotes", false };
+            yield return new object[] { "Digest realm=\"testrealm\" nonce=\"testnonce\"", false };
+            yield return new object[] { "Digest realm=\"testrealm1\", nonce=\"testnonce1\" Digest realm=\"testrealm2\", nonce=\"testnonce2\"", false };
         }
     }
 


### PR DESCRIPTION
Now that the authentication test failures have been diagnosed, re-enable most of the Digest authentication test cases on CurlHandler. Two additional cases had to be moved to the SocketsHttpHandler only tests, since they fail on CurlHandler and do not have fixes yet.

The digest test cases have to use credentials without a domain when run against CurlHandler. This is because Curl does not allow us to set the realm parameter used to send the domain along with a digest authorization header. We could alternatively try to use the down level login name as the username, but it appears that there is a bug in the Curl escaping logic that causes backslashes in the username to be duplicated. I plan to open an issue in the Curl repo once things are a bit less busy.

All of the test cases that are SocketsHttpHandler only are now tracked by individual issues, so I think with this we can close #28065.
