### PR TITLE
Prevent CMake 2.8 tests failing for unused variable (causing millisec to be dropped from stat calls)

### DIFF
--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -30,6 +30,10 @@ endif ()
 # We compile with -Werror, so we need to make sure these code fragments compile without warnings.
 set(CMAKE_REQUIRED_FLAGS -Werror)
 
+# Older CMake versions (3.8) do not assign the result of their tests, causing unused-value errors
+# which are not distinguished from the test failing.
+set(CMAKE_REQUIRED_FLAGS -Wno-error=unused-value)
+
 # This compiler warning will fail code as innocuous as:
 # static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 # Check if the compiler knows about this warning so we can disable it

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -28,11 +28,9 @@ else ()
 endif ()
 
 # We compile with -Werror, so we need to make sure these code fragments compile without warnings.
-set(CMAKE_REQUIRED_FLAGS -Werror)
-
 # Older CMake versions (3.8) do not assign the result of their tests, causing unused-value errors
-# which are not distinguished from the test failing.
-set(CMAKE_REQUIRED_FLAGS -Wno-error=unused-value)
+# which are not distinguished from the test failing. So no error for that one.
+set(CMAKE_REQUIRED_FLAGS "-Werror -Wno-error=unused-value")
 
 # This compiler warning will fail code as innocuous as:
 # static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -231,7 +231,7 @@ check_c_source_compiles(
     int main()
     {
         char buffer[1];
-        char* c = strerror_r(0, buffer, 0);
+        char c = *strerror_r(0, buffer, 0);
         return 0;
     }
     "

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -98,7 +98,6 @@ namespace System.IO.Tests
                     // If it's the OS/Filesystem often returns 0 for the millisecond part, this may
                     // help prove it. This should only be written 1/1000 runs, unless the test is going to
                     // fail.
-                    //Console.WriteLine($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")}");
                     Console.WriteLine($"## TimesIncludeMillisecondPart got a file time of {time.ToString("o")} on {driveFormat}");
 
                     item = GetExistingItem(); // try a new file/directory

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -86,8 +86,8 @@ namespace System.IO.Tests
                     DateTime time = function.Getter(item);
                     msec = time.Millisecond;
 
-                    //if (msec != 0)
-                    //    break;
+                    if (msec != 0)
+                        break;
 
                     // This case should only happen 1/1000 times, unless the OS/Filesystem does
                     // not support millisecond granularity.
@@ -104,8 +104,7 @@ namespace System.IO.Tests
                     item = GetExistingItem(); // try a new file/directory
                 }
 
-                // Temporarily disabled while investigating failures in #27662
-                // Assert.NotEqual(0, msec);
+                Assert.NotEqual(0, msec);
             });
         }
 
@@ -130,11 +129,6 @@ namespace System.IO.Tests
 
                     // If it's 1/1000, or low granularity, this may help:
                     Thread.Sleep(1234);
-
-                    // If it's the OS/Filesystem often returns 0 for the millisecond part, this may
-                    // help prove it. This should only be written 1/1000 runs, unless the test is going to
-                    // fail.
-                    Console.WriteLine($"TimesIncludeMillisecondPart got a file time of {time.ToString("o")}");
 
                     item = GetExistingItem(); // try a new file/directory
                 }


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/27662 which only reproduced with bits built from official build machines.

The millisecond part of the stat structs can appear in several forms or possibly not be available so we probe for it with CMake's such:
```c
check_struct_has_member(
    "struct stat"
    st_atim
    "sys/types.h;sys/stat.h"
    HAVE_STAT_TIM)
```

This was failing on the official build machines even though st_atim is present in the struct. The cause can be found in `corefx/bin/obj/Linux.x64.Debug/native/CMakeFiles/CMakeError.log`
```
Building C object CMakeFiles/cmTryCompileExec161514853.dir/src.c.o
/usr/local/bin/clang-3.9   -std=gnu99 -D_GNU_SOURCE -DHAVE_STAT_TIM -Werror   -o CMakeFiles/cmTryCompileExec161514853.dir/src.c.o   -c /root/corefx/bin/obj/Linux.x64.Debug/native/CMakeFiles/CMakeTmp/src.c
/root/corefx/bin/obj/Linux.x64.Debug/native/CMakeFiles/CMakeTmp/src.c:8:9: error: expression result unused [-Werror,-Wunused-value]
   tmp->st_atim;
   ~~~  ^~~~~~~
1 error generated.
gmake[1]: *** [CMakeFiles/cmTryCompileExec161514853.dir/src.c.o] Error 1 
```

This is because the test code is like this:
```c

#include <sys/types.h>
#include <sys/stat.h>

int main()
{
   struct stat* tmp;
   tmp->st_atim;
  return 0;
}
```

In later versions of CMake it looks like this which avoids the warning/error.
```c
int main()
{
   (void)sizeof(((struct stat *)0)->st_atim);
   return 0;
} 
```

The fix is to specifically disable warning as error for this diagnostic. I verified this fixes it on the build machine:
```
-- Performing Test HAVE_STAT_TIM
-- Performing Test HAVE_STAT_TIM - Success
```

The main reason this took some time to root cause (other than it not reproing locally or in CI) was that I did not realize the official builds build in docker containers in order to achieve a portable build on Centos 7. So when I built on the official build boxes, I was picking up cmake version 3.5.1 rather than 2.8.12.2.