### PR TITLE
Reduce buffering in ManagedWebSocket.ReceiveAsync

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -26,7 +26,7 @@ namespace System.Net.Http
                     return 0;
                 }
 
-                ValueTask<int> readTask = _connection.ReadAsync(buffer);
+                ValueTask<int> readTask = _connection.ReadBufferedAsync(buffer);
                 int bytesRead;
                 if (readTask.IsCompletedSuccessfully)
                 {

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -204,12 +204,12 @@ namespace System.Net.WebSockets
                 }
 
                 // Get or create the buffer to use
-                const int MinBufferSize = 14; // from ManagedWebSocket.MaxMessageHeaderLength
+                const int MinBufferSize = 125; // from ManagedWebSocket.MaxControlPayloadLength
                 ArraySegment<byte> optionsBuffer = options.Buffer.GetValueOrDefault();
                 Memory<byte> buffer =
                     optionsBuffer.Count >= MinBufferSize ? optionsBuffer : // use the provided buffer if it's big enough
-                    options.ReceiveBufferSize >= MinBufferSize ? new byte[options.ReceiveBufferSize] : // or use the requested size if it's big enough
-                    Memory<byte>.Empty; // or let WebSocket.CreateFromStream use its default
+                    default; // or let WebSocket.CreateFromStream use its default
+                    // options.ReceiveBufferSize is ignored, as we rely on the buffer inside the SocketsHttpHandler stream
 
                 // Get the response stream and wrap it in a web socket.
                 Stream connectedStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);


### PR DESCRIPTION
Today we use a big-ish receive buffer (4K) in ManagedWebSocket, reading all data into the receive buffer and then copying from there into the caller-provided destination buffer.  With this change, we assume that the underlying stream is providing the desired level of buffering, and thus only use a 125-byte buffer, just big enough to handle message headers and control payloads (the latter for simplicity, as no caller-supplied buffer is available there).

Fixes https://github.com/dotnet/corefx/issues/28445
cc: @davidfowl, @geoffkizer, @anurse 