### PR TITLE
Fix ipv6 address format in Host header

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -269,7 +269,8 @@ namespace System.Net.Http
             else
             {
                 Debug.Assert(_pool.UsingProxy);
-                await WriteAsciiStringAsync(uri.IdnHost).ConfigureAwait(false);
+                await WriteAsciiStringAsync(uri.HostNameType == UriHostNameType.IPv6 ?
+                    "[" + uri.IdnHost + "]" : uri.IdnHost).ConfigureAwait(false);
 
                 if (!uri.IsDefaultPort)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -269,8 +269,12 @@ namespace System.Net.Http
             else
             {
                 Debug.Assert(_pool.UsingProxy);
+
+                // If the hostname is an IPv6 address, uri.IdnHost will return the address without enclosing [].
+                // In this case, use uri.Host instead, which will correctly enclose with [].
+                // Note we don't need punycode encoding if it's an IP address, so using uri.Host is fine.
                 await WriteAsciiStringAsync(uri.HostNameType == UriHostNameType.IPv6 ?
-                    "[" + uri.IdnHost + "]" : uri.IdnHost).ConfigureAwait(false);
+                    uri.Host : uri.IdnHost).ConfigureAwait(false);
 
                 if (!uri.IsDefaultPort)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -117,7 +117,8 @@ namespace System.Net.Http
 
             if (_host != null)
             {
-                bool isHostTypeIPv6 = _host.Split(':').Length - 1 > 1;
+                int posColon = -1;
+                bool isHostTypeIPv6 = (-1 != (posColon = _host.IndexOf(':')) && -1 != (posColon = _host.IndexOf(':', posColon)));
                 string hostAddress = isHostTypeIPv6 ? "[" + _host + "]" : _host;
 
                 // Precalculate ASCII bytes for Host header

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -117,12 +117,15 @@ namespace System.Net.Http
 
             if (_host != null)
             {
+                bool isHostTypeIPv6 = _host.Split(':').Length - 1 > 1;
+                string hostAddress = isHostTypeIPv6 ? "[" + _host + "]" : _host;
+
                 // Precalculate ASCII bytes for Host header
                 // Note that if _host is null, this is a (non-tunneled) proxy connection, and we can't cache the hostname.
                 string hostHeader =
                     (_port != (_sslOptions == null ? DefaultHttpPort : DefaultHttpsPort)) ?
-                    $"{_host}:{_port}" :
-                    _host;
+                    $"{hostAddress}:{_port}" :
+                    hostAddress;
 
                 // Note the IDN hostname should always be ASCII, since it's already been IDNA encoded.
                 _hostHeaderValueBytes = Encoding.ASCII.GetBytes(hostHeader);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -118,7 +118,7 @@ namespace System.Net.Http
             if (_host != null)
             {
                 int posColon = -1;
-                bool isHostTypeIPv6 = (-1 != (posColon = _host.IndexOf(':')) && -1 != (posColon = _host.IndexOf(':', posColon)));
+                bool isHostTypeIPv6 = (posColon = _host.IndexOf(':')) != -1 && _host.IndexOf(':', posColon+1) != -1;
                 string hostAddress = isHostTypeIPv6 ? "[" + _host + "]" : _host;
 
                 // Precalculate ASCII bytes for Host header

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -117,16 +117,12 @@ namespace System.Net.Http
 
             if (_host != null)
             {
-                int posColon = -1;
-                bool isHostTypeIPv6 = (posColon = _host.IndexOf(':')) != -1 && _host.IndexOf(':', posColon+1) != -1;
-                string hostAddress = isHostTypeIPv6 ? "[" + _host + "]" : _host;
-
                 // Precalculate ASCII bytes for Host header
                 // Note that if _host is null, this is a (non-tunneled) proxy connection, and we can't cache the hostname.
                 string hostHeader =
                     (_port != (_sslOptions == null ? DefaultHttpPort : DefaultHttpsPort)) ?
-                    $"{hostAddress}:{_port}" :
-                    hostAddress;
+                    $"{_host}:{_port}" :
+                    _host;
 
                 // Note the IDN hostname should always be ASCII, since it's already been IDNA encoded.
                 _hostHeaderValueBytes = Encoding.ASCII.GetBytes(hostHeader);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -140,11 +140,12 @@ namespace System.Net.Http
         private static HttpConnectionKey GetConnectionKey(HttpRequestMessage request, Uri proxyUri, bool isProxyConnect)
         {
             Uri uri = request.RequestUri;
+            bool isIPv6Address = uri.HostNameType == UriHostNameType.IPv6;
 
             if (isProxyConnect)
             {
                 Debug.Assert(uri == proxyUri);
-                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, uri.IdnHost, uri.Port, null, proxyUri);
+                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, null, proxyUri);
             }
 
             string sslHostName = null;
@@ -170,7 +171,7 @@ namespace System.Net.Http
                     if (HttpUtilities.IsNonSecureWebSocketScheme(uri.Scheme))
                     {
                         // Non-secure websocket connection through proxy to the destination.
-                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, uri.IdnHost, uri.Port, null, proxyUri);
+                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, null, proxyUri);
                     }
                     else
                     {
@@ -183,16 +184,16 @@ namespace System.Net.Http
                 else
                 {
                     // Tunnel SSL connection through proxy to the destination.
-                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, uri.IdnHost, uri.Port, sslHostName, proxyUri);
+                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, sslHostName, proxyUri);
                 }
             }
             else if (sslHostName != null)
             {
-                return new HttpConnectionKey(HttpConnectionKind.Https, uri.IdnHost, uri.Port, sslHostName, null);
+                return new HttpConnectionKey(HttpConnectionKind.Https, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, sslHostName, null);
             }
             else
             {
-                return new HttpConnectionKey(HttpConnectionKind.Http, uri.IdnHost, uri.Port, null, null);
+                return new HttpConnectionKey(HttpConnectionKind.Http, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, null, null);
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -140,12 +140,16 @@ namespace System.Net.Http
         private static HttpConnectionKey GetConnectionKey(HttpRequestMessage request, Uri proxyUri, bool isProxyConnect)
         {
             Uri uri = request.RequestUri;
+
+            // If the hostname is an IPv6 address, uri.IdnHost will return the address without enclosing [].
+            // In this case, use uri.Host instead, which will correctly enclose with [].
+            // Note we don't need punycode encoding if it's an IP address, so using uri.Host is fine.
             bool isIPv6Address = uri.HostNameType == UriHostNameType.IPv6;
 
             if (isProxyConnect)
             {
                 Debug.Assert(uri == proxyUri);
-                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, null, proxyUri);
+                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, isIPv6Address ? uri.Host : uri.IdnHost, uri.Port, null, proxyUri);
             }
 
             string sslHostName = null;
@@ -171,7 +175,7 @@ namespace System.Net.Http
                     if (HttpUtilities.IsNonSecureWebSocketScheme(uri.Scheme))
                     {
                         // Non-secure websocket connection through proxy to the destination.
-                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, null, proxyUri);
+                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, isIPv6Address ? uri.Host : uri.IdnHost, uri.Port, null, proxyUri);
                     }
                     else
                     {
@@ -184,16 +188,16 @@ namespace System.Net.Http
                 else
                 {
                     // Tunnel SSL connection through proxy to the destination.
-                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, sslHostName, proxyUri);
+                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, isIPv6Address ? uri.Host : uri.IdnHost, uri.Port, sslHostName, proxyUri);
                 }
             }
             else if (sslHostName != null)
             {
-                return new HttpConnectionKey(HttpConnectionKind.Https, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, sslHostName, null);
+                return new HttpConnectionKey(HttpConnectionKind.Https, isIPv6Address ? uri.Host : uri.IdnHost, uri.Port, sslHostName, null);
             }
             else
             {
-                return new HttpConnectionKey(HttpConnectionKind.Http, isIPv6Address ? uri.Host: uri.IdnHost, uri.Port, null, null);
+                return new HttpConnectionKey(HttpConnectionKind.Http, isIPv6Address ? uri.Host : uri.IdnHost, uri.Port, null, null);
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -140,11 +140,12 @@ namespace System.Net.Http
         private static HttpConnectionKey GetConnectionKey(HttpRequestMessage request, Uri proxyUri, bool isProxyConnect)
         {
             Uri uri = request.RequestUri;
+            string host = uri.HostNameType == UriHostNameType.IPv6 ? "[" + uri.IdnHost + "]" : uri.IdnHost;
 
             if (isProxyConnect)
             {
                 Debug.Assert(uri == proxyUri);
-                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, uri.IdnHost, uri.Port, null, proxyUri);
+                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, host, uri.Port, null, proxyUri);
             }
 
             string sslHostName = null;
@@ -170,7 +171,7 @@ namespace System.Net.Http
                     if (HttpUtilities.IsNonSecureWebSocketScheme(uri.Scheme))
                     {
                         // Non-secure websocket connection through proxy to the destination.
-                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, uri.IdnHost, uri.Port, null, proxyUri);
+                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, host, uri.Port, null, proxyUri);
                     }
                     else
                     {
@@ -183,16 +184,16 @@ namespace System.Net.Http
                 else
                 {
                     // Tunnel SSL connection through proxy to the destination.
-                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, uri.IdnHost, uri.Port, sslHostName, proxyUri);
+                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, host, uri.Port, sslHostName, proxyUri);
                 }
             }
             else if (sslHostName != null)
             {
-                return new HttpConnectionKey(HttpConnectionKind.Https, uri.IdnHost, uri.Port, sslHostName, null);
+                return new HttpConnectionKey(HttpConnectionKind.Https, host, uri.Port, sslHostName, null);
             }
             else
             {
-                return new HttpConnectionKey(HttpConnectionKind.Http, uri.IdnHost, uri.Port, null, null);
+                return new HttpConnectionKey(HttpConnectionKind.Http, host, uri.Port, null, null);
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -140,12 +140,11 @@ namespace System.Net.Http
         private static HttpConnectionKey GetConnectionKey(HttpRequestMessage request, Uri proxyUri, bool isProxyConnect)
         {
             Uri uri = request.RequestUri;
-            string host = uri.HostNameType == UriHostNameType.IPv6 ? "[" + uri.IdnHost + "]" : uri.IdnHost;
 
             if (isProxyConnect)
             {
                 Debug.Assert(uri == proxyUri);
-                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, host, uri.Port, null, proxyUri);
+                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, uri.IdnHost, uri.Port, null, proxyUri);
             }
 
             string sslHostName = null;
@@ -171,7 +170,7 @@ namespace System.Net.Http
                     if (HttpUtilities.IsNonSecureWebSocketScheme(uri.Scheme))
                     {
                         // Non-secure websocket connection through proxy to the destination.
-                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, host, uri.Port, null, proxyUri);
+                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, uri.IdnHost, uri.Port, null, proxyUri);
                     }
                     else
                     {
@@ -184,16 +183,16 @@ namespace System.Net.Http
                 else
                 {
                     // Tunnel SSL connection through proxy to the destination.
-                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, host, uri.Port, sslHostName, proxyUri);
+                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, uri.IdnHost, uri.Port, sslHostName, proxyUri);
                 }
             }
             else if (sslHostName != null)
             {
-                return new HttpConnectionKey(HttpConnectionKind.Https, host, uri.Port, sslHostName, null);
+                return new HttpConnectionKey(HttpConnectionKind.Https, uri.IdnHost, uri.Port, sslHostName, null);
             }
             else
             {
-                return new HttpConnectionKey(HttpConnectionKind.Http, host, uri.Port, null, null);
+                return new HttpConnectionKey(HttpConnectionKind.Http, uri.IdnHost, uri.Port, null, null);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -472,11 +472,11 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData("http://", "[::1234]")]
-        [InlineData("http://", "[::1234]:8080")]
-        public async Task GetAsync_IPv6AddressInHostHeader_CorrectlyFormatted(string scheme, string host)
+        [InlineData("[::1234]")]
+        [InlineData("[::1234]:8080")]
+        public async Task GetAsync_IPv6AddressInHostHeader_CorrectlyFormatted(string host)
         {
-            string ipv6Address = scheme + host;
+            string ipv6Address = "http://" + host;
             bool connectionAccepted = false;
 
             await LoopbackServer.CreateClientAndServerAsync(async proxyUri =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -502,13 +502,13 @@ namespace System.Net.Http.Functional.Tests
             from useSsl in new[] { true, false }
             select new object[] { address, useSsl };
 
-        [OuterLoop]
         [Theory]
         [MemberData(nameof(SecureAndNonSecure_IPBasedUri_MemberData))]
         public async Task GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(IPAddress address, bool useSsl)
         {
             if (IsCurlHandler)
             {
+                // Issue: #28703.
                 return;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -518,7 +518,12 @@ namespace System.Net.Http.Functional.Tests
                 {
                     if (useSsl)
                     {
-                        handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                        handler.ServerCertificateCustomValidationCallback =
+#if netcoreapp
+                            HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+#else // .NET Framework doesn't contain a definition for DangerousAcceptAnyServerCertificateValidator.
+                            delegate { return true; };
+#endif
                     }
                     try { await client.GetAsync(url); } catch { }
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -471,11 +471,12 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Fact]
-        public async Task GetAsync_IPv6AddressInHostHeader_CorrectlyFormatted()
+        [Theory]
+        [InlineData("http://", "[::1234]")]
+        [InlineData("http://", "[::1234]:8080")]
+        public async Task GetAsync_IPv6AddressInHostHeader_CorrectlyFormatted(string scheme, string host)
         {
-            string host = "[::1234]:8080";
-            string ipv6Address = "http://" + host;
+            string ipv6Address = scheme + host;
             bool connectionAccepted = false;
 
             await LoopbackServer.CreateClientAndServerAsync(async proxyUri =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -507,6 +507,11 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(SecureAndNonSecure_IPBasedUri_MemberData))]
         public async Task GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(IPAddress address, bool useSsl)
         {
+            if (IsCurlHandler)
+            {
+                return;
+            }
+
             var options = new LoopbackServer.Options { Address = address, UseSsl= useSsl };
             bool connectionAccepted = false;
             string host = "";

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -518,12 +518,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     if (useSsl)
                     {
-                        handler.ServerCertificateCustomValidationCallback =
-#if netcoreapp
-                            HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-#else // .NET Framework doesn't contain a definition for DangerousAcceptAnyServerCertificateValidator.
-                            delegate { return true; };
-#endif
+                        handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
                     }
                     try { await client.GetAsync(url); } catch { }
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -502,6 +502,7 @@ namespace System.Net.Http.Functional.Tests
             from useSsl in new[] { true, false }
             select new object[] { address, useSsl };
 
+        [OuterLoop]
         [Theory]
         [MemberData(nameof(SecureAndNonSecure_IPBasedUri_MemberData))]
         public async Task GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(IPAddress address, bool useSsl)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -497,6 +497,42 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(connectionAccepted);
         }
 
+        public static IEnumerable<object[]> SecureAndNonSecure_IPBasedUri_MemberData() =>
+            from address in new[] { IPAddress.Loopback, IPAddress.IPv6Loopback }
+            from useSsl in new[] { true, false }
+            select new object[] { address, useSsl };
+
+        [Theory]
+        [MemberData(nameof(SecureAndNonSecure_IPBasedUri_MemberData))]
+        public async Task GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(IPAddress address, bool useSsl)
+        {
+            var options = new LoopbackServer.Options { Address = address, UseSsl= useSsl };
+            bool connectionAccepted = false;
+            string host = "";
+
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
+            {
+                host = $"{url.Host}:{url.Port}";
+                using (HttpClientHandler handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    if (useSsl)
+                    {
+                        handler.ServerCertificateCustomValidationCallback = delegate { return true; };
+                        handler.ClientCertificateOptions = ClientCertificateOption.Automatic;
+                    }
+                    try { await client.GetAsync(url); } catch { }
+                }
+            }, server => server.AcceptConnectionAsync(async connection =>
+            {
+                connectionAccepted = true;
+                List<string> headers = await connection.ReadRequestHeaderAndSendResponseAsync();
+                Assert.Contains($"Host: {host}", headers);
+            }), options);
+
+            Assert.True(connectionAccepted);
+        }
+
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(CompressedServers))]
         public async Task GetAsync_SetAutomaticDecompression_HeadersRemoved(Uri server)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -506,12 +506,6 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(SecureAndNonSecure_IPBasedUri_MemberData))]
         public async Task GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(IPAddress address, bool useSsl)
         {
-            if (IsCurlHandler)
-            {
-                // Issue: #28703.
-                return;
-            }
-
             var options = new LoopbackServer.Options { Address = address, UseSsl= useSsl };
             bool connectionAccepted = false;
             string host = "";
@@ -524,8 +518,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     if (useSsl)
                     {
-                        handler.ServerCertificateCustomValidationCallback = delegate { return true; };
-                        handler.ClientCertificateOptions = ClientCertificateOption.Automatic;
+                        handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
                     }
                     try { await client.GetAsync(url); } catch { }
                 }


### PR DESCRIPTION
Per discussion in [#28557](https://github.com/dotnet/corefx/issues/28557). If this change looks ok, I will fix the WinHttp as well.

Fix: [#28557](https://github.com/dotnet/corefx/issues/28557) (moved to https://github.com/dotnet/runtime/issues/25661)