### PR TITLE
CurlHandler is deadlocking like WinHttpHandler

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2942,7 +2942,9 @@ namespace System.Net.Http.Functional.Tests
         {
             if (IsWinHttpHandler || IsNetfxHandler || IsCurlHandler)
             {
-                // Issue #27746: WinHttpHandler and netfx hang on this test
+                // Issue #27746: WinHttpHandler and netfx hang on this test. 
+                // The same happens consistently on macOS 10.13 Release and with some
+                // frequency on some Linux flavors, disabling the test for curl handler due to that.
                 return;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2940,7 +2940,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task Proxy_UseSecureProxyTunnel_Success()
         {
-            if (IsWinHttpHandler || IsNetfxHandler)
+            if (IsWinHttpHandler || IsNetfxHandler || IsCurlHandler)
             {
                 // Issue #27746: WinHttpHandler and netfx hang on this test
                 return;


### PR DESCRIPTION
This repros consistently for Release on High Sierra. Issue #27746 already tracks it.

Issue tracking the hanging in macOS is #28116 