### PR TITLE
Reenable SetHdevmode_IntPtr_Success test

### DIFF
--- a/src/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
@@ -578,19 +578,42 @@ namespace System.Drawing.Printing.Tests
             Assert.NotEqual(IntPtr.Zero, handle);
         }
 
-        [ActiveIssue(26637)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
-        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        [ConditionalFact(typeof(PrinterSettingsTests), nameof(CanTestSetHdevmode_IntPtr_Success))]
         public void SetHdevmode_IntPtr_Success()
         {
-            var printerSettings = new PrinterSettings() { Copies = 3 };
-            var newPrinterSettings = new PrinterSettings() { Copies = 6 };
+            string printerName = GetNameOfTestPrinterSuitableForDevModeTesting();
+            var printerSettings = new PrinterSettings() { PrinterName = printerName, Copies = 3 };
+            var newPrinterSettings = new PrinterSettings() { PrinterName = printerName, Copies = 6 };
+
             IntPtr handle = printerSettings.GetHdevmode();
             newPrinterSettings.SetHdevmode(handle);
             Assert.Equal(printerSettings.Copies, newPrinterSettings.Copies);
             Assert.Equal(printerSettings.Collate, newPrinterSettings.Collate);
             Assert.Equal(printerSettings.Duplex, newPrinterSettings.Duplex);
         }
+
+        public static bool CanTestSetHdevmode_IntPtr_Success => Helpers.GetGdiplusIsAvailable() && GetNameOfTestPrinterSuitableForDevModeTesting() != null;
+
+        private static string GetNameOfTestPrinterSuitableForDevModeTesting()
+        {
+            foreach (string candidate in s_TestPrinterNames)
+            {
+                PrinterSettings printerSettings = new PrinterSettings() { PrinterName = candidate };
+                if (printerSettings.IsValid)
+                    return candidate;
+            }
+            return null;
+        }
+
+        private static readonly string[] s_TestPrinterNames =
+        {
+            // Our method of testing this api requires a printer that supports multi-copy printing, collating and duplex settings. Not all printers
+            // support these so rather than trust the machine running the test to have configured such a printer as the default, use the name of 
+            // a known compliant printer that ships with Windows 10.
+            "Microsoft Print to PDF",
+            "Microsoft XPS Document Writer", // Backup for older Windows
+        };
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/26637

This test normally passes unless the machine's
default printer is set to something that
doesn't support multiple copies (or duplex
or collate settings.) In that case, the
printer serves up a DEVMODE structure
whose "dmFields" flags indicate the absence
of those fields and thus, the meaningless property
does not get populated in the DEVMODE.

Given that

1. this is the existing NETFX behavior.

2. there's no other obvious value to put in these
   properties when the printer doesn't support them.
   Perhaps these properties should have been nullable
   properties but that horse has long left the barn.

3. The purpose of the Hdevmode_IntPtr apis is not cloning
   PrinterSettings (PrinterSettings explicitly supports
   a Clone() method for that purpose.) The test is
   just using it that way as a way of validating
   the HDevMode_IntPtr apis in the best way it can
   in a generic unit test run on uncontrolled
   machines.

I'm just changing the test to use a known
printer type that works rather than trusting
the default.