### PR TITLE
Disable Selectedsites test by default

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClient.SelectedSitesTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClient.SelectedSitesTest.cs
@@ -13,8 +13,14 @@ namespace System.Net.Http.Functional.Tests
 {
     public abstract class HttpClient_SelectedSites_Test : HttpClientTestBase
     {
-        [Theory]
-        [OuterLoop]
+        public static bool IsSelectedSitesTestEnabled() 
+        {
+            string envVar = Environment.GetEnvironmentVariable("CORFX_NET_HTTP_SELECTED_SITES");
+            return envVar != null &&
+                (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1"));
+        }
+
+        [ConditionalTheory(nameof(IsSelectedSitesTestEnabled))]
         [Trait("SelectedSites", "true")]
         [MemberData(nameof(GetSelectedSites))]
         public async Task RetrieveSite_Succeeds(string site)
@@ -42,8 +48,7 @@ namespace System.Net.Http.Functional.Tests
             throw new Exception("Not expected to reach here");
         }
 
-        [Theory]
-        [OuterLoop]
+        [ConditionalTheory(nameof(IsSelectedSitesTestEnabled))]
         [Trait("SiteInvestigation", "true")]
         [InlineData("http://microsoft.com")]
         public async Task RetrieveSite_Debug_Helper(string site)


### PR DESCRIPTION
These tests were not intended to be enabled by default, control them via a env var.