### PR TITLE
Make it clear that the default proxy cannot by set via environment variable on Windows

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -89,16 +89,12 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
+        [PlatformSpecific(TestPlatforms.AnyUnix)] // The default proxy is resolved via WinINet on Windows.
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed(bool useProxy)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return; // The default proxy is resolved via WinINet on Windows.
-            }
-
             const string ExpectedUsername = "rightusername";
             const string ExpectedPassword = "rightpassword";
             LoopbackServer.Options options = new LoopbackServer.Options { IsProxy = true, Username = ExpectedUsername, Password = ExpectedPassword };

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -92,9 +92,13 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [ActiveIssue(25640, TestPlatforms.Windows)] // TODO It should be enabled for SocketsHttpHandler on all platforms
         public async Task ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed(bool useProxy)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return; // The default proxy is resolved via WinINet on Windows.
+            }
+
             const string ExpectedUsername = "rightusername";
             const string ExpectedPassword = "rightpassword";
             LoopbackServer.Options options = new LoopbackServer.Options { IsProxy = true, Username = ExpectedUsername, Password = ExpectedPassword };


### PR DESCRIPTION
This test was tagged with an active issue disabling it on Windows, but the behavior is actually by design. 

Quoting @davidsh:
> The default for .NET Framework is to use WinINET-style (IE registry setttings) to find the default proxy. There has never been a concept for using environment variables on Windows. It might be an interesting idea to add environment variables which could override the WinINET-style proxy settings. But that seems like a new feature for .NET Core. We would want to have those variables be appropriately named. In some ways, this would provide the ability for easier machine-wide proxy settings which has been requested by users in the past. WinINET-style settings are only available for interactive user accounts on Windows, i.e. those accounts with those registry settings. Background service accounts like those used in NT-style services don't have those settings by default. So, adding environment variables might be a useful thing.

I agree that we should look into adding support for default proxies set via environment variable, but for now I think we should just make it clear this isn't a bug.

Fixes: #25640