### PR TITLE
Account for source-build in our package build filtering

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.builds
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.builds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <ItemGroup Condition="'$(OfficialBuildId)' == '' Or '$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true'">
     <Project Include="Microsoft.NETCore.Platforms.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.builds
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.builds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <ItemGroup Condition="'$(OfficialBuildId)' == '' Or '$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true'">
     <Project Include="Microsoft.NETCore.Targets.pkgproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -2,6 +2,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
 
+  <PropertyGroup>
+    <!-- Used to determine if we should build some packages only once across multiple official build legs.
+         For offline builds we still set OfficialBuildId but we need to build all the packages for a single
+         leg only, so we also take DotNetBuildOffline into account. -->
+    <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' AND '$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
+  </PropertyGroup>
+
   <!-- Packages opt-in to automatic RID-specific builds by placing a *.RID.props next to their project
        that defines the OfficialBuildRID item: all RIDs targeted by the package -->
   <Import Project="$(MSBuildProjectDirectory)\*.rids.props" />
@@ -16,7 +23,7 @@
     </BuildRID>
   </ItemGroup>
 
-  <!-- create the "Project" item which is the current $(MSBuildProjectName).pkgproj with meta-data for all 
+  <!-- create the "Project" item which is the current $(MSBuildProjectName).pkgproj with meta-data for all
        supported RIDs -->
   <ItemGroup>
     <_project Include="@(BuildRID)">
@@ -48,10 +55,10 @@
     <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
     <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
   </ItemGroup>
-  
+
   <PropertyGroup>
     <!-- BlockStable on private packages by default -->
     <BlockStable Condition="'$(BlockStable)' == '' and $(MSBuildProjectName.Contains('Private'))">true</BlockStable>
   </PropertyGroup>
-  
+
 </Project>

--- a/pkg/dir.traversal.targets
+++ b/pkg/dir.traversal.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="..\dir.traversal.targets" />
-  
-  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+
+  <PropertyGroup Condition="'$(BuildingAnOfficialBuildLeg)' == 'true'">
     <!-- During an official build, only build identity packages in the AllConfigurations build -->
     <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>
 


### PR DESCRIPTION
We need to account for source-build which sets the
OfficialBuildId property to replicate the official builds,
so we also look at the DotNetBuildOffline property to
determine that we should still build the all the packages.

cc @dseefeld 