### PR TITLE
Update dependencies for release/uwp6.1

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreReleaseLabel>preview1</PreReleaseLabel>
+    <PreReleaseLabel>uwp61</PreReleaseLabel>
     <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>

--- a/dependencies.props
+++ b/dependencies.props
@@ -21,17 +21,18 @@
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
+    <PlatformPackageVersion>2.0.1</PlatformPackageVersion>
     <CoreFxExpectedPrerelease>preview1-26307-01</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.1.0-b-uwp6-26309-01</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25627-00</ExternalExpectedPrerelease>
     <ProjectNTfsExpectedPrerelease>rel-26323-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>rel-26323-00</ProjectNTfsTestILCExpectedPrerelease>
     <ProjectNTfsTestILCPackageVersion>1.0.0-rel-26323-00</ProjectNTfsTestILCPackageVersion>
-    <NETStandardPackageVersion>2.1.0-preview1-25729-01</NETStandardPackageVersion>
+    <NETStandardPackageVersion>2.0.1</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-25706-01</MicrosoftNETCoreAppPackageVersion>
     <!-- Use the SNI runtime package -->
-    <SniPackageVersion>4.4.0-preview2-25312-01</SniPackageVersion>
+    <SniPackageVersion>4.4.0</SniPackageVersion>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->

--- a/dependencies.props
+++ b/dependencies.props
@@ -9,30 +9,29 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</CoreFxCurrentRef>
-    <CoreClrCurrentRef>3a037b925fac2dfab6ca2f587099b45bb8413f5f</CoreClrCurrentRef>
+    <CoreFxCurrentRef>9bd62fa21bf4815effc5aa1906e32d4680a16a57</CoreFxCurrentRef>
+    <CoreClrCurrentRef>5cce8ebd18593f26147fcd04eb7183ae7fb87358</CoreClrCurrentRef>
     <CoreSetupCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</CoreSetupCurrentRef>
     <ExternalCurrentRef>1fe3c36279b702b526ca9441412d441f1b6a4821</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>62bbc1ed21d32925454339e1bb0a17590029c9d4</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>d55da128c5ce03e979a3c2e3f5ecd91da24e259c</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>97059fa979a3c8fb8b9fba127c526f15e48c9dde</SniCurrentRef>
     <StandardCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</StandardCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <PlatformPackageVersion>2.1.0-preview1-25631-01</PlatformPackageVersion>
-    <CoreFxExpectedPrerelease>preview1-25801-01</CoreFxExpectedPrerelease>
-    <CoreClrPackageVersion>2.1.0-b-uwp6-25707-02</CoreClrPackageVersion>
+    <CoreFxExpectedPrerelease>preview1-26307-01</CoreFxExpectedPrerelease>
+    <CoreClrPackageVersion>2.1.0-b-uwp6-26309-01</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25627-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>rel-25728-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>rel-25728-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-rel-25728-00</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsExpectedPrerelease>rel-26323-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>rel-26323-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-rel-26323-00</ProjectNTfsTestILCPackageVersion>
     <NETStandardPackageVersion>2.1.0-preview1-25729-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-25706-01</MicrosoftNETCoreAppPackageVersion>
     <!-- Use the SNI runtime package -->
-    <SniPackageVersion>4.4.0</SniPackageVersion>
+    <SniPackageVersion>4.4.0-preview2-25312-01</SniPackageVersion>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
@@ -47,7 +46,7 @@
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
     <DependencyBranch>master</DependencyBranch>
-    <Uwp6ReleaseDependencyBranch>release/uwp6.0</Uwp6ReleaseDependencyBranch>
+    <Uwp6ReleaseDependencyBranch>release/uwp6.1</Uwp6ReleaseDependencyBranch>
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>
 
@@ -61,7 +60,7 @@
       <CurrentRef>$(CoreClrCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="CoreSetup">
-      <BuildInfoPath>$(BaseDotNetBuildInfo)core-setup/$(Uwp6ReleaseDependencyBranch)</BuildInfoPath>
+      <BuildInfoPath>$(BaseDotNetBuildInfo)core-setup/release/uwp6.0</BuildInfoPath>
       <CurrentRef>$(CoreSetupCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="External">
@@ -93,11 +92,6 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>CoreFxExpectedPrerelease</ElementName>
       <BuildInfoName>CoreFx</BuildInfoName>
-    </XmlUpdateStep>
-    <XmlUpdateStep Include="CoreFx">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>PlatformPackageVersion</ElementName>
-      <PackageId>Microsoft.NETCore.Platforms</PackageId>
     </XmlUpdateStep>
     <XmlUpdateStep Include="CoreClr">
       <Path>$(MSBuildThisFileFullPath)</Path>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,9 +3,9 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "TestILC.amd64ret": "1.0.0-rel-25728-00",
-        "TestILC.armret": "1.0.0-rel-25728-00",
-        "TestILC.x86ret": "1.0.0-rel-25728-00"
+        "TestILC.amd64ret": "1.0.0-rel-26323-00",
+        "TestILC.armret": "1.0.0-rel-26323-00",
+        "TestILC.x86ret": "1.0.0-rel-26323-00"
       }
     }
   }

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -36,12 +36,12 @@
     <Compile Include="System\OperatingSystem.cs" />
     <Compile Include="System\PlatformID.cs" />
     <Compile Include="System\IO\EncodingCache.cs" />
-    <Compile Include="System\IO\StreamReader.cs" />
-    <Compile Include="System\IO\StreamWriter.cs" />
+    <Compile Include="System\IO\StreamReader.cs" Condition="'$(TargetGroup)' != 'uapaot'" />
+    <Compile Include="System\IO\StreamWriter.cs" Condition="'$(TargetGroup)' != 'uapaot'" />
     <Compile Include="System\IO\StringReader.cs" />
     <Compile Include="System\IO\StringWriter.cs" />
-    <Compile Include="System\IO\TextReader.cs" />
-    <Compile Include="System\IO\TextWriter.cs" />
+    <Compile Include="System\IO\TextReader.cs" Condition="'$(TargetGroup)' != 'uapaot'" />
+    <Compile Include="System\IO\TextWriter.cs" Condition="'$(TargetGroup)' != 'uapaot'" />
     <Compile Include="System\IO\BufferedStream.cs" />
     <Compile Include="System\IO\InvalidDataException.cs" />
     <Compile Include="System\Net\WebUtility.cs" />
@@ -55,7 +55,7 @@
     <Compile Include="System\Runtime\Versioning\VersioningHelper.cs" />
     <Compile Include="System\StringNormalizationExtensions.cs" />
     <Compile Include="System\Collections\ArrayList.cs" />
-    <Compile Include="System\Collections\Comparer.cs" />
+    <Compile Include="System\Collections\Comparer.cs" Condition="'$(TargetGroup)' != 'uapaot'" />
     <Compile Include="System\Collections\Hashtable.cs" />
     <Compile Include="$(CommonPath)\System\Collections\CompatibleComparer.cs">
       <Link>Common\System\Collections\CompatibleComparer.cs</Link>

--- a/src/shims/ApiCompatBaseline.netfx.netstandard20.txt
+++ b/src/shims/ApiCompatBaseline.netfx.netstandard20.txt
@@ -163,4 +163,7 @@ MembersMustExist : Member 'System.Text.RegularExpressions.Regex.CapNames.get()' 
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.CapNames.set(System.Collections.IDictionary)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.Caps.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.Caps.set(System.Collections.IDictionary)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Caching.MemoryCache..ctor(System.String, System.Collections.Specialized.NameValueCollection, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Caching.MemoryCache.GetLastSize(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Caching.MemoryCache.Remove(System.String, System.Runtime.Caching.CacheEntryRemovedReason, System.String)' does not exist in the implementation but it does exist in the contract.
 Total Issues: 151

--- a/src/shims/ApiCompatBaseline.uapaot.netstandard20.txt
+++ b/src/shims/ApiCompatBaseline.uapaot.netstandard20.txt
@@ -5,4 +5,10 @@ Compat issues with assembly System.Core:
 TypesMustExist : Type 'System.Security.Cryptography.ECCurve' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.ECParameters' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.ECPoint' does not exist in the implementation but it does exist in the contract.
-Total Issues: 5
+MembersMustExist : Member 'System.ReadOnlySpan<T>..ctor(T[], System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ReadOnlySpan<T>.DangerousCreate(System.Object, T, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ReadOnlySpan<T>.DangerousGetPinnableReference()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Span<T>..ctor(T[], System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Span<T>.DangerousCreate(System.Object, T, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Span<T>.DangerousGetPinnableReference()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 11

--- a/src/shims/ApiCompatBaseline.uapaot.netstandard20Only.txt
+++ b/src/shims/ApiCompatBaseline.uapaot.netstandard20Only.txt
@@ -1,1 +1,7 @@
-Total Issues: 0
+MembersMustExist : Member 'System.ReadOnlySpan<T>..ctor(T[], System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ReadOnlySpan<T>.DangerousCreate(System.Object, T, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ReadOnlySpan<T>.DangerousGetPinnableReference()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Span<T>..ctor(T[], System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Span<T>.DangerousCreate(System.Object, T, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Span<T>.DangerousGetPinnableReference()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 6

--- a/src/shims/manual/mscorlib.csproj
+++ b/src/shims/manual/mscorlib.csproj
@@ -23,6 +23,16 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+
+  <ItemGroup>
+    <SeedTypePreference Include="System.Diagnostics.DebuggerStepperBoundaryAttribute">
+      <Assembly>System.Diagnostics.Debug</Assembly>
+    </SeedTypePreference>
+    <SeedTypePreference Include="System.Diagnostics.DebuggerVisualizerAttribute">
+      <Assembly>System.Diagnostics.Debug</Assembly>
+    </SeedTypePreference>
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="mscorlib.forwards.cs" />
     <ReferencePath Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.*.dll" Exclude="$(RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll" />


### PR DESCRIPTION
Update dependencies for release/uwp6.1 to use dependencies from uwp61 branches instead of uwp6.0 branches. This also removes the PlatformPackageVersion property because it is not produced in corefx:release/uwp6.1 like it was in corefx:release/uwp6.0