### PR TITLE
Make TripleDESCryptoServiceProvider CreateTransform behave like netfx

### DIFF
--- a/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/Helpers.cs
@@ -44,6 +44,20 @@ namespace Internal.Cryptography
             return null;
         }
 
+        public static byte[] TrimLargeIV(byte[] currentIV, int blockSizeInBits)
+        {
+            int blockSizeBytes = checked((blockSizeInBits + 7) / 8);
+
+            if (currentIV?.Length > blockSizeBytes)
+            {
+                byte[] tmp = new byte[blockSizeBytes];
+                Buffer.BlockCopy(currentIV, 0, tmp, 0, tmp.Length);
+                return tmp;
+            }
+
+            return currentIV;
+        }
+
         public static bool IsLegalSize(this int size, KeySizes[] legalSizes)
         {
             for (int i = 0; i < legalSizes.Length; i++)

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DESCryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DESCryptoServiceProvider.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
@@ -26,9 +27,13 @@ namespace System.Security.Cryptography
         }
 
         public override ICryptoTransform CreateDecryptor() => _impl.CreateDecryptor();
-        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) => _impl.CreateDecryptor(rgbKey, rgbIV);
         public override ICryptoTransform CreateEncryptor() => _impl.CreateEncryptor();
-        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) => _impl.CreateEncryptor(rgbKey, rgbIV);
+
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) =>
+            _impl.CreateEncryptor(rgbKey, Helpers.TrimLargeIV(rgbIV, BlockSize));
+
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) =>
+            _impl.CreateDecryptor(rgbKey, Helpers.TrimLargeIV(rgbIV, BlockSize));
 
         protected override void Dispose(bool disposing)
         {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RC2CryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RC2CryptoServiceProvider.Unix.cs
@@ -29,9 +29,13 @@ namespace System.Security.Cryptography
         }
 
         public override ICryptoTransform CreateDecryptor() => _impl.CreateDecryptor();
-        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) => _impl.CreateDecryptor(rgbKey, rgbIV);
         public override ICryptoTransform CreateEncryptor() => _impl.CreateEncryptor();
-        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) => _impl.CreateEncryptor(rgbKey, rgbIV);
+
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) =>
+            _impl.CreateEncryptor(rgbKey, Helpers.TrimLargeIV(rgbIV, BlockSize));
+
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) =>
+            _impl.CreateDecryptor(rgbKey, Helpers.TrimLargeIV(rgbIV, BlockSize));
 
         protected override void Dispose(bool disposing)
         {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/TripleDESCryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/TripleDESCryptoServiceProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
@@ -67,29 +68,11 @@ namespace System.Security.Cryptography
         public override void GenerateIV() => _impl.GenerateIV();
         public override void GenerateKey() => _impl.GenerateKey();
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "This is the implementation of TripleDES")]
         public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) =>
-            _impl.CreateEncryptor(rgbKey, TrimLargeIV(rgbIV));
+            _impl.CreateEncryptor(rgbKey, Helpers.TrimLargeIV(rgbIV, BlockSize));
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "This is the implementation of TripleDES")]
         public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) =>
-            _impl.CreateDecryptor(rgbKey, TrimLargeIV(rgbIV));
-
-        private byte[] TrimLargeIV(byte[] iv)
-        {
-            // The BlockSize for 3DES is 64, so this is always 8, but let's use
-            // the formula anyways.
-            int blockSizeBytes = (BlockSize + 7) / 8;
-
-            if (iv?.Length > blockSizeBytes)
-            {
-                byte[] tmp = new byte[blockSizeBytes];
-                Buffer.BlockCopy(iv, 0, tmp, 0, tmp.Length);
-                return tmp;
-            }
-
-            return iv;
-        }
+            _impl.CreateDecryptor(rgbKey, Helpers.TrimLargeIV(rgbIV, BlockSize));
 
         protected override void Dispose(bool disposing)
         {

--- a/src/System.Security.Cryptography.Csp/tests/CreateTransformCompat.cs
+++ b/src/System.Security.Cryptography.Csp/tests/CreateTransformCompat.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Csp.Tests
+{
+    public static class CreateTransformCompat
+    {
+        [Theory]
+        [InlineData(typeof(AesCryptoServiceProvider), null)]
+        [InlineData(typeof(DESCryptoServiceProvider), 9)]
+        [InlineData(typeof(DESCryptoServiceProvider), 13)]
+        [InlineData(typeof(RC2CryptoServiceProvider), 9)]
+        [InlineData(typeof(RC2CryptoServiceProvider), 17)]
+        [InlineData(typeof(TripleDESCryptoServiceProvider), 9)]
+        [InlineData(typeof(TripleDESCryptoServiceProvider), 24)]
+        [InlineData(typeof(TripleDESCryptoServiceProvider), 31)]
+        public static void CreateTransform_IVTooBig(Type t, int? ivSizeBytes)
+        {
+            using (SymmetricAlgorithm alg = (SymmetricAlgorithm)Activator.CreateInstance(t))
+            {
+                alg.Mode = CipherMode.CBC;
+                byte[] key = alg.Key;
+
+                // If it isn't supposed to work
+                if (ivSizeBytes == null)
+                {
+                    // badSize is in bytes, BlockSize is in bits.
+                    // So badSize is 8 times as big as it should be.
+                    int badSize = alg.BlockSize;
+                    Assert.Throws<ArgumentException>(() => alg.CreateEncryptor(key, new byte[badSize]));
+                    Assert.Throws<ArgumentException>(() => alg.CreateDecryptor(key, new byte[badSize]));
+
+                    return;
+                }
+
+                int correctSize = alg.BlockSize / 8;
+                byte[] data = { 1, 2, 3, 4, 5 };
+
+                byte[] iv = new byte[ivSizeBytes.Value];
+
+                for (int i = 0; i < iv.Length; i++)
+                {
+                    iv[i] = (byte)((byte.MaxValue - i) ^ correctSize);
+                }
+
+                byte[] correctIV = iv.AsSpan(0, correctSize).ToArray();
+
+                using (ICryptoTransform correctEnc = alg.CreateEncryptor(key, correctIV))
+                using (ICryptoTransform badIvEnc = alg.CreateEncryptor(key, iv))
+                using (ICryptoTransform badIvDec = alg.CreateDecryptor(key, iv))
+                {
+                    byte[] encrypted = badIvEnc.TransformFinalBlock(data, 0, data.Length);
+                    byte[] correctEncrypted = correctEnc.TransformFinalBlock(data, 0, data.Length);
+
+                    Assert.Equal(correctEncrypted, encrypted);
+
+                    byte[] decrypted1 = badIvDec.TransformFinalBlock(correctEncrypted, 0, correctEncrypted.Length);
+
+                    Assert.Equal(data, decrypted1);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -13,6 +13,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="CreateTransformCompat.cs" />
     <Compile Include="CspParametersTests.cs" />
     <Compile Include="RSAImportExportCspBlobTests.cs" />
     <Compile Include="RSACryptoServiceProviderBackCompat.cs" />


### PR DESCRIPTION
.NET Framework's TripleDESCryptoServiceProvider rejects small inputs, but
accepts oversized IVs (effectively truncating them to the block size).  This
change makes the .NET Core type behave the same way, and adds a test to
codify all of the oversized IV relationships with the CryptoServiceProvider
compat types.  (DES and RC2 apparently already allowed it)

Fixes #28553.