### PR TITLE
Remove long running option from MARS

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
@@ -56,7 +56,7 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         /// <param name="packet">SNI packet</param>
         /// <returns>SNI error code</returns>
-        public abstract uint ReceiveAsync(ref SNIPacket packet, bool isMars = false);
+        public abstract uint ReceiveAsync(ref SNIPacket packet);
 
         /// <summary>
         /// Enable SSL

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -108,7 +108,7 @@ namespace System.Data.SqlClient.SNI
         {
             lock (this)
             {
-                return _lowerHandle.ReceiveAsync(ref packet, isMars: true);
+                return _lowerHandle.ReceiveAsync(ref packet);
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -272,7 +272,7 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         /// <param name="packet">SNI packet</param>
         /// <returns>SNI error code</returns>
-        public override uint ReceiveAsync(ref SNIPacket packet, bool isMars = true)
+        public override uint ReceiveAsync(ref SNIPacket packet)
         {
             lock (_receivedPacketQueue)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -172,13 +172,13 @@ namespace System.Data.SqlClient.SNI
             }
         }
 
-        public override uint ReceiveAsync(ref SNIPacket packet, bool isMars = false)
+        public override uint ReceiveAsync(ref SNIPacket packet)
         {
             packet = new SNIPacket(_bufferSize);
             
             try
             {
-                packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
+                packet.ReadFromStreamAsync(_stream, _receiveCallback);
                 return TdsEnums.SNI_SUCCESS_IO_PENDING;
             }
             catch (ObjectDisposedException ode)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -443,7 +443,7 @@ namespace System.Data.SqlClient.SNI
         /// <param name="handle">SNI handle</param>
         /// <param name="packet">Packet</param>
         /// <returns>SNI error status</returns>
-        public uint ReadAsync(SNIHandle handle, out SNIPacket packet, bool isMars = false)
+        public uint ReadAsync(SNIHandle handle, out SNIPacket packet)
         {
             packet = null;
             return handle.ReceiveAsync(ref packet);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -537,13 +537,13 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         /// <param name="packet">SNI packet</param>
         /// <returns>SNI error code</returns>
-        public override uint ReceiveAsync(ref SNIPacket packet, bool isMars = false)
+        public override uint ReceiveAsync(ref SNIPacket packet)
         {
             packet = new SNIPacket(_bufferSize);
 
             try
             {
-                packet.ReadFromStreamAsync(_stream, _receiveCallback, isMars);
+                packet.ReadFromStreamAsync(_stream, _receiveCallback);
                 return TdsEnums.SNI_SUCCESS_IO_PENDING;
             }
             catch (Exception e) when (e is ObjectDisposedException || e is SocketException || e is IOException)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -160,7 +160,7 @@ namespace System.Data.SqlClient.SNI
         internal override object ReadAsync(out uint error, ref object handle)
         {
             SNIPacket packet;
-            error = SNIProxy.Singleton.ReadAsync((SNIHandle)handle, out packet, isMars: _parser.MARSOn);
+            error = SNIProxy.Singleton.ReadAsync((SNIHandle)handle, out packet);
             return packet;
         }
 


### PR DESCRIPTION
Removing the long running task scheduler options.
After running tests for EF and SqlClient manual tests, it is safe to remove the LongRunning options.
The fix from PR https://github.com/dotnet/corefx/pull/28427 alleviated the MARS related hang issues.

Fixes https://github.com/dotnet/corefx/issues/19836 