### PR TITLE
Making types listed in #27980 internal

### DIFF
--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/CachingSectionGroup.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/CachingSectionGroup.cs
@@ -7,7 +7,7 @@ using System.Configuration;
 
 namespace System.Runtime.Caching.Configuration
 {
-    public sealed class CachingSectionGroup : ConfigurationSectionGroup
+    internal sealed class CachingSectionGroup : ConfigurationSectionGroup
     {
         public CachingSectionGroup()
         {

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheElement.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheElement.cs
@@ -8,7 +8,7 @@ using System.Configuration;
 
 namespace System.Runtime.Caching.Configuration
 {
-    public sealed class MemoryCacheElement : ConfigurationElement
+    internal sealed class MemoryCacheElement : ConfigurationElement
     {
         private static ConfigurationPropertyCollection s_properties;
         private static readonly ConfigurationProperty s_propName;

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSection.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSection.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.Caching.Configuration
        </system.caching>
     */
 
-    public sealed class MemoryCacheSection : ConfigurationSection
+    internal sealed class MemoryCacheSection : ConfigurationSection
     {
         private static ConfigurationPropertyCollection s_properties;
         private static readonly ConfigurationProperty s_propNamedCaches;

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSettingsCollection.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSettingsCollection.cs
@@ -9,7 +9,7 @@ namespace System.Runtime.Caching.Configuration
 {
     [ConfigurationCollection(typeof(MemoryCacheElement),
     CollectionType = ConfigurationElementCollectionType.AddRemoveClearMap)]
-    public sealed class MemoryCacheSettingsCollection : ConfigurationElementCollection
+    internal sealed class MemoryCacheSettingsCollection : ConfigurationElementCollection
     {
         private static ConfigurationPropertyCollection s_properties;
 


### PR DESCRIPTION
These types are used by the cache config and are not supposed to be used by the end user. Therefore they are excluded from the reference assembly and are changed to be internal in the implementation assembly. 

I ad hoc tested the change in a simple core app to check if the config still works correctly with the types being internal. 