### PR TITLE
FontFamily.Equals in Linux use .Name instead of NativeFamily pointer which is not a singleton

### DIFF
--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -214,6 +214,7 @@
     <Compile Include="System\Drawing\Drawing2D\CustomLineCap.Windows.cs" />
     <Compile Include="System\Drawing\Drawing2D\GraphicsPath.Windows.cs" />
     <Compile Include="System\Drawing\Font.Windows.cs" />
+    <Compile Include="System\Drawing\FontFamily.Windows.cs" />
     <Compile Include="System\Drawing\GdiplusNative.Windows.cs" />
     <Compile Include="System\Drawing\Graphics.Windows.cs" />
     <Compile Include="System\Drawing\GraphicsContext.cs" />
@@ -314,6 +315,7 @@
     <Compile Include="System\Drawing\BufferedGraphicsContext.Unix.cs" />
     <Compile Include="System\Drawing\macFunctions.cs" />
     <Compile Include="System\Drawing\Font.Unix.cs" />
+    <Compile Include="System\Drawing\FontFamily.Unix.cs" />
     <Compile Include="System\Drawing\GdiplusNative.Unix.cs" />
     <Compile Include="System\Drawing\GdiPlusStreamHelper.Unix.cs" />
     <Compile Include="System\Drawing\LibX11Functions.cs" />

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.Unix.cs
@@ -16,6 +16,7 @@ namespace System.Drawing
                 return true;
             }
 
+            // if obj = null then (obj is FontFamily) = false.
             if (!(obj is FontFamily otherFamily))
             {
                 return false;
@@ -23,7 +24,7 @@ namespace System.Drawing
 
             // In unix FontFamily objects are not singleton so they don't share the same native pointer,
             // the best we have to know if they are the same is FontFamily.Name which gets resolved from the native pointer.
-            return string.Compare(otherFamily.Name, Name, StringComparison.Ordinal) == 0;
+            return Name.Equals(otherFamily.Name, StringComparison.Ordinal);
         }
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.Unix.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Drawing
+{
+    /// <summary>
+    /// Abstracts a group of type faces having a similar basic design but having certain variation in styles.
+    /// </summary>
+    public sealed partial class FontFamily : MarshalByRefObject, IDisposable
+    {
+        public override bool Equals(object obj)
+        {
+            if (obj == this)
+            {
+                return true;
+            }
+
+            if (!(obj is FontFamily otherFamily))
+            {
+                return false;
+            }
+
+            // In unix FontFamily objects are not singleton so they don't share the same native pointer,
+            // the best we have to know if they are the same is FontFamily.Name which gets resolved from the native pointer.
+            return string.Compare(otherFamily.Name, Name, StringComparison.Ordinal) == 0;
+        }
+    }
+}

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.Windows.cs
@@ -16,6 +16,7 @@ namespace System.Drawing
                 return true;
             }
 
+            // if obj = null then (obj is FontFamily) = false.
             if (!(obj is FontFamily otherFamily))
             {
                 return false;

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.Windows.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Drawing
+{
+    /// <summary>
+    /// Abstracts a group of type faces having a similar basic design but having certain variation in styles.
+    /// </summary>
+    public sealed partial class FontFamily : MarshalByRefObject, IDisposable
+    {
+        public override bool Equals(object obj)
+        {
+            if (obj == this)
+            {
+                return true;
+            }
+
+            if (!(obj is FontFamily otherFamily))
+            {
+                return false;
+            }
+
+            // We can safely use the ptr to the native GDI+ FontFamily because in windows it is common to 
+            // all objects of the same family (singleton RO object).
+            return otherFamily.NativeFamily == NativeFamily;
+        }
+    }
+}

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -14,7 +14,7 @@ namespace System.Drawing
     /// <summary>
     /// Abstracts a group of type faces having a similar basic design but having certain variation in styles.
     /// </summary>
-    public sealed class FontFamily : MarshalByRefObject, IDisposable
+    public sealed partial class FontFamily : MarshalByRefObject, IDisposable
     {
         private const int NeutralLanguage = 0;
         private IntPtr _nativeFamily;
@@ -75,6 +75,7 @@ namespace System.Drawing
 
             int status = SafeNativeMethods.Gdip.GdipCreateFontFamilyFromName(name, new HandleRef(fontCollection, nativeFontCollection), out fontfamily);
 
+
             if (status != SafeNativeMethods.Gdip.Ok)
             {
                 if (_createDefaultOnFail)
@@ -131,23 +132,6 @@ namespace System.Drawing
         ~FontFamily() => Dispose(false);
 
         internal IntPtr NativeFamily => _nativeFamily;
-
-        public override bool Equals(object obj)
-        {
-            if (obj == this)
-            {
-                return true;
-            }
-
-            if (!(obj is FontFamily otherFamily))
-            {
-                return false;
-            }
-
-            // We can safely use the ptr to the native GDI+ FontFamily because it is common to 
-            // all objects of the same family (singleton RO object).
-            return otherFamily.NativeFamily == NativeFamily;
-        }
 
         /// <summary>
         /// Converts this <see cref='FontFamily'/> to a human-readable string.

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -75,7 +75,6 @@ namespace System.Drawing
 
             int status = SafeNativeMethods.Gdip.GdipCreateFontFamilyFromName(name, new HandleRef(fontCollection, nativeFontCollection), out fontfamily);
 
-
             if (status != SafeNativeMethods.Gdip.Ok)
             {
                 if (_createDefaultOnFail)

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -48,8 +48,17 @@ namespace System.Drawing.Tests
             using (var font1 = new Font(fontFamily1, 9))
             using (var font2 = new Font(fontFamily2, 9))
             {
-                Assert.False(font1.Equals(font2));
+                // In some Linux distros all the default fonts live under the same family (Fedora, Centos, Redhat)
+                if (font1.FontFamily.GetHashCode() != font2.FontFamily.GetHashCode())
+                    Assert.False(font1.Equals(font2));
             }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FontFamily_Equals_NullObject()
+        {
+            FontFamily nullFamily = null;
+            Assert.False(FontFamily.GenericMonospace.Equals(nullFamily));
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -16,6 +16,42 @@ namespace System.Drawing.Tests
             yield return new object[] { FontFamily.GenericSerif, float.MaxValue };
         }
 
+        public static IEnumerable<object[]> FontFamily_Equals_SameFamily_TestData()
+        {
+            yield return new object[] { FontFamily.GenericMonospace, 1 };
+            yield return new object[] { FontFamily.GenericSerif, float.MaxValue };
+            yield return new object[] { FontFamily.GenericSansSerif, 10 };
+        }
+
+        public static IEnumerable<object[]> FontFamily_Equals_DifferentFamily_TestData()
+        {
+            yield return new object[] { FontFamily.GenericMonospace, FontFamily.GenericSerif };
+            yield return new object[] { FontFamily.GenericSansSerif, FontFamily.GenericSerif };
+            yield return new object[] { FontFamily.GenericSansSerif, FontFamily.GenericMonospace };
+        }
+
+        [ConditionalTheory(Helpers.GdiplusIsAvailable)]
+        [MemberData(nameof(FontFamily_Equals_SameFamily_TestData))]
+        public void Font_Equals_SameFontFamily(FontFamily fontFamily, float size)
+        {
+            using (var font1 = new Font(fontFamily, size))
+            using (var font2 = new Font(fontFamily, size))
+            {
+                Assert.True(font1.Equals(font2));
+            }
+        }
+
+        [ConditionalTheory(Helpers.GdiplusIsAvailable)]
+        [MemberData(nameof(FontFamily_Equals_DifferentFamily_TestData))]
+        public void Font_Equals_DifferentFontFamily(FontFamily fontFamily1, FontFamily fontFamily2)
+        {
+            using (var font1 = new Font(fontFamily1, 9))
+            using (var font2 = new Font(fontFamily2, 9))
+            {
+                Assert.False(font1.Equals(font2));
+            }
+        }
+
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(Ctor_Family_Size_TestData))]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/28052

In linux FontFamily objects are not treated as singleton so their NativeFamily pointers can change from object to object. However, when getting the FontFamily.Name from the native pointer we would get the same value if the FontFamily is the same. 

However since we depend on the different font families across operative systems and Linux distros, we can have results where 2 fonts in linux are part of the same font family and in windows they are part of different families.

cc: @danmosemsft @qmfrederik 