### PR TITLE
When a new binder is exactly the same as existing one, just use the old instance instead.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
+++ b/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="Microsoft\CSharp\RuntimeBinder\ArgumentObject.cs" />
     <Compile Include="Microsoft\CSharp\RuntimeBinder\Binder.cs" />
+    <Compile Include="Microsoft\CSharp\RuntimeBinder\BinderEquivalence.cs" />
     <Compile Include="Microsoft\CSharp\RuntimeBinder\BinderHelper.cs" />
     <Compile Include="Microsoft\CSharp\RuntimeBinder\CSharpArgumentInfo.cs" />
     <Compile Include="Microsoft\CSharp\RuntimeBinder\CSharpArgumentInfoFlags.cs" />
@@ -159,6 +160,9 @@
     <Compile Include="Microsoft\CSharp\RuntimeBinder\Syntax\PredefinedType.cs" />
     <Compile Include="Microsoft\CSharp\RuntimeBinder\Syntax\TokenFacts.cs" />
     <Compile Include="Microsoft\CSharp\RuntimeBinder\Syntax\TokenKind.cs" />
+    <Compile Include="$(CommonPath)\System\Numerics\Hashing\HashHelpers.cs">
+      <Link>Common\System\Collections\HashHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Binder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Binder.cs
@@ -41,9 +41,8 @@ namespace Microsoft.CSharp.RuntimeBinder
                 binaryOperationFlags |= CSharpBinaryOperationFlags.LogicalOperation;
             }
 
-            return new CSharpBinaryOperationBinder(operation, isChecked, binaryOperationFlags, context, argumentInfo);
+            return new CSharpBinaryOperationBinder(operation, isChecked, binaryOperationFlags, context, argumentInfo).TryGetExisting();
         }
-
 
         //////////////////////////////////////////////////////////////////////
 
@@ -67,7 +66,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                         CSharpConversionKind.ImplicitConversion;
             bool isChecked = (flags & CSharpBinderFlags.CheckedContext) != 0;
 
-            return new CSharpConvertBinder(type, conversionKind, isChecked, context);
+            return new CSharpConvertBinder(type, conversionKind, isChecked, context).TryGetExisting();
         }
 
 
@@ -85,7 +84,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             Type context,
             IEnumerable<CSharpArgumentInfo> argumentInfo)
         {
-            return new CSharpGetIndexBinder(context, argumentInfo);
+            return new CSharpGetIndexBinder(context, argumentInfo).TryGetExisting();
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -105,7 +104,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             IEnumerable<CSharpArgumentInfo> argumentInfo)
         {
             bool allowCallables = (flags & CSharpBinderFlags.ResultIndexed) != 0;
-            return new CSharpGetMemberBinder(name, allowCallables, context, argumentInfo);
+            return new CSharpGetMemberBinder(name, allowCallables, context, argumentInfo).TryGetExisting();
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -130,7 +129,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 callFlags |= CSharpCallFlags.ResultDiscarded;
             }
 
-            return new CSharpInvokeBinder(callFlags, context, argumentInfo);
+            return new CSharpInvokeBinder(callFlags, context, argumentInfo).TryGetExisting();
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -169,7 +168,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 callFlags |= CSharpCallFlags.ResultDiscarded;
             }
 
-            return new CSharpInvokeMemberBinder(callFlags, name, context, typeArguments, argumentInfo);
+            return new CSharpInvokeMemberBinder(callFlags, name, context, typeArguments, argumentInfo).TryGetExisting();
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -186,7 +185,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             Type context,
             IEnumerable<CSharpArgumentInfo> argumentInfo)
         {
-            return new CSharpInvokeConstructorBinder(CSharpCallFlags.None, context, argumentInfo);
+            return new CSharpInvokeConstructorBinder(CSharpCallFlags.None, context, argumentInfo).TryGetExisting();
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -203,7 +202,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             string name,
             Type context)
         {
-            return new CSharpIsEventBinder(name, context);
+            return new CSharpIsEventBinder(name, context).TryGetExisting();
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -222,7 +221,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             bool isCompoundAssignment = (flags & CSharpBinderFlags.ValueFromCompoundAssignment) != 0;
             bool isChecked = (flags & CSharpBinderFlags.CheckedContext) != 0;
-            return new CSharpSetIndexBinder(isCompoundAssignment, isChecked, context, argumentInfo);
+            return new CSharpSetIndexBinder(isCompoundAssignment, isChecked, context, argumentInfo).TryGetExisting();
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -243,7 +242,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             bool isCompoundAssignment = (flags & CSharpBinderFlags.ValueFromCompoundAssignment) != 0;
             bool isChecked = (flags & CSharpBinderFlags.CheckedContext) != 0;
-            return new CSharpSetMemberBinder(name, isCompoundAssignment, isChecked, context, argumentInfo);
+            return new CSharpSetMemberBinder(name, isCompoundAssignment, isChecked, context, argumentInfo).TryGetExisting();
         }
 
         //////////////////////////////////////////////////////////////////////
@@ -263,7 +262,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             IEnumerable<CSharpArgumentInfo> argumentInfo)
         {
             bool isChecked = (flags & CSharpBinderFlags.CheckedContext) != 0;
-            return new CSharpUnaryOperationBinder(operation, isChecked, context, argumentInfo);
+            return new CSharpUnaryOperationBinder(operation, isChecked, context, argumentInfo).TryGetExisting();
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderEquivalence.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderEquivalence.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         //    typical C# binders, once created, are rooted to their callsites, which are stored in static fields.
         //    the cache is unlikely to extend the life time of the binders.
         //    the limit here is just to have assurance on how large the cache may get.
-        private const int BINDER_CACHE_LIMIT = 4096;
+        private const uint BINDER_CACHE_LIMIT = 4096;
 
         // keep a separate count because it is cheaper than calling CD.Count()
         // it does not need to be very precise either
@@ -43,7 +43,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                 // a simple eviction policy -
                 // if cache grows too big, just flush it and start over.
-                if (count > BINDER_CACHE_LIMIT)
+                if ((uint)count > BINDER_CACHE_LIMIT)
                 {
                     binderEquivalenceCache.Clear();
                     cachedBinderCount = 0;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderEquivalence.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderEquivalence.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.CSharp.RuntimeBinder
+{
+    internal static class BinderEquivalence
+    {
+        // An upper bound on the size of binder cache.
+        // We do not need to catch all the binders, 4K should be enough for most cases.
+        //
+        // For the perspective: the dynamic testsuite has a lot of dynamic operations, 
+        // but ends up needing only ~500 binders once caching is enabled.
+        //
+        // NOTE:
+        //    typical C# binders, once created, are rooted to their callsites, which are stored in static fields.
+        //    the cache is unlikely to extend the life time of the binders.
+        //    the limit here is just to have assurance on how large the cache may get.
+        private const int BINDER_CACHE_LIMIT = 4096;
+
+        // keep a separate count because it is cheaper than calling CD.Count()
+        // it does not need to be very precise either
+        private static int cachedBinderCount;
+
+        // it is unlikely to see a lot of contention on the binder cache.
+        // creating binders is not a very frequent operation.
+        // typically a dynamic operation in the source will create just one binder lazily when first executed.
+        private static readonly ConcurrentDictionary<ICSharpBinder, ICSharpBinder> binderEquivalenceCache = 
+            new ConcurrentDictionary<ICSharpBinder, ICSharpBinder>(concurrencyLevel:2, capacity: 32, new BinderEqualityComparer());
+
+        internal static T TryGetExisting<T>(this T binder)
+            where T: ICSharpBinder
+        {
+            var fromCache = binderEquivalenceCache.GetOrAdd(binder, binder);
+            if (fromCache == (object)binder)
+            {
+                var count = Interlocked.Increment(ref cachedBinderCount);
+
+                // a simple eviction policy -
+                // if cache grows too big, just flush it and start over.
+                if (count > BINDER_CACHE_LIMIT)
+                {
+                    binderEquivalenceCache.Clear();
+                    cachedBinderCount = 0;
+                }
+            }
+
+            return (T)fromCache;
+        }
+
+        internal class BinderEqualityComparer : IEqualityComparer<ICSharpBinder>
+        {
+            public bool Equals(ICSharpBinder x, ICSharpBinder y) => x.IsEquivalentTo(y);
+            public int GetHashCode(ICSharpBinder obj) => obj.BinderEqivalenceHash;
+        }
+    }
+}

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderEquivalence.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderEquivalence.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CSharp.RuntimeBinder
     internal static class BinderEquivalence
     {
         // An upper bound on the size of binder cache.
-        // We do not need to catch all the binders, 4K should be enough for most cases.
+        // We do not need to cache all the binders, 4K should be enough for most cases.
         //
         // For the perspective: the dynamic testsuite has a lot of dynamic operations, 
         // but ends up needing only ~500 binders once caching is enabled.
@@ -56,7 +56,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         internal class BinderEqualityComparer : IEqualityComparer<ICSharpBinder>
         {
             public bool Equals(ICSharpBinder x, ICSharpBinder y) => x.IsEquivalentTo(y);
-            public int GetHashCode(ICSharpBinder obj) => obj.BinderEqivalenceHash;
+            public int GetHashCode(ICSharpBinder obj) => obj.GetGetBinderEquivalenceHash();
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpArgumentInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpArgumentInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Numerics.Hashing;
 
 namespace Microsoft.CSharp.RuntimeBinder
 {
@@ -19,7 +20,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         /// <summary>
         /// The flags for the argument.
         /// </summary>
-        private CSharpArgumentInfoFlags Flags { get; }
+        internal CSharpArgumentInfoFlags Flags { get; }
 
         /// <summary>
         /// The name of the argument, if named; otherwise null.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpBinaryOperationBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpBinaryOperationBinder.cs
@@ -83,21 +83,18 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext, isChecked);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            hash = HashHelpers.Combine(hash, (int)_binopFlags);
+            if (IsChecked)
             {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                hash = HashHelpers.Combine(hash, (int)_binopFlags);
-                if (IsChecked)
-                {
-                    hash = HashHelpers.Combine(hash, 1);
-                }
-                hash = HashHelpers.Combine(hash, (int)Operation);
-                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
-
-                return hash;
+                hash = HashHelpers.Combine(hash, 1);
             }
+            hash = HashHelpers.Combine(hash, (int)Operation);
+            hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
+using System.Numerics.Hashing;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -51,6 +52,10 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private readonly RuntimeBinder _binder;
 
+        private readonly Type _callingContext;
+
+        private bool IsChecked => _binder.IsChecked;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CSharpConvertBinder" />.
         /// </summary>
@@ -66,7 +71,43 @@ namespace Microsoft.CSharp.RuntimeBinder
             base(type, conversionKind == CSharpConversionKind.ExplicitConversion)
         {
             ConversionKind = conversionKind;
+            _callingContext = callingContext;
             _binder = new RuntimeBinder(callingContext, isChecked);
+        }
+
+        public int BinderEqivalenceHash
+        {
+            get
+            {
+                int hash = _callingContext?.GetHashCode() ?? 0;
+                hash = HashHelpers.Combine(hash, (int)ConversionKind);
+                if (IsChecked)
+                {
+                    hash = HashHelpers.Combine(hash, 1);
+                }
+
+                hash = HashHelpers.Combine(hash, Type.GetHashCode());
+                return hash;
+            }
+        }
+
+        public bool IsEquivalentTo(ICSharpBinder other)
+        {
+            var otherBinder = other as CSharpConvertBinder;
+            if (otherBinder == null)
+            {
+                return false;
+            }
+
+            if (ConversionKind != otherBinder.ConversionKind ||
+                IsChecked != otherBinder.IsChecked ||
+                _callingContext != otherBinder._callingContext ||
+                Type != otherBinder.Type)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
@@ -75,20 +75,17 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext, isChecked);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            hash = HashHelpers.Combine(hash, (int)ConversionKind);
+            if (IsChecked)
             {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                hash = HashHelpers.Combine(hash, (int)ConversionKind);
-                if (IsChecked)
-                {
-                    hash = HashHelpers.Combine(hash, 1);
-                }
-
-                hash = HashHelpers.Combine(hash, Type.GetHashCode());
-                return hash;
+                hash = HashHelpers.Combine(hash, 1);
             }
+
+            hash = HashHelpers.Combine(hash, Type.GetHashCode());
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
@@ -53,15 +53,12 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
-            {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
 
-                return hash;
-            }
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
@@ -36,6 +36,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private readonly RuntimeBinder _binder;
 
+        private readonly Type _callingContext;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CSharpGetIndexBinder" />.
         /// </summary>
@@ -47,7 +49,36 @@ namespace Microsoft.CSharp.RuntimeBinder
             base(BinderHelper.CreateCallInfo(ref argumentInfo, 1)) // discard 1 argument: the target object
         {
             _argumentInfo = argumentInfo as CSharpArgumentInfo[];
+            _callingContext = callingContext;
             _binder = new RuntimeBinder(callingContext);
+        }
+
+        public int BinderEqivalenceHash
+        {
+            get
+            {
+                int hash = _callingContext?.GetHashCode() ?? 0;
+                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+                return hash;
+            }
+        }
+
+        public bool IsEquivalentTo(ICSharpBinder other)
+        {
+            var otherBinder = other as CSharpGetIndexBinder;
+            if (otherBinder == null)
+            {
+                return false;
+            }
+
+            if (_callingContext != otherBinder._callingContext ||
+                _argumentInfo.Length != otherBinder._argumentInfo.Length)
+            {
+                return false;
+            }
+
+            return BinderHelper.CompareArgInfos(_argumentInfo, otherBinder._argumentInfo);
         }
 
         /// <summary>

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetMemberBinder.cs
@@ -62,20 +62,17 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            if (ResultIndexed)
             {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                if (ResultIndexed)
-                {
-                    hash = HashHelpers.Combine(hash, 1);
-                }
-                hash = HashHelpers.Combine(hash, Name.GetHashCode());
-                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
-
-                return hash;
+                hash = HashHelpers.Combine(hash, 1);
             }
+            hash = HashHelpers.Combine(hash, Name.GetHashCode());
+            hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetMemberBinder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
+using System.Numerics.Hashing;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -39,6 +40,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private readonly RuntimeBinder _binder;
 
+        private readonly Type _callingContext;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CSharpGetMemberBinder" />.
         /// </summary>
@@ -55,7 +58,43 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             ResultIndexed = resultIndexed;
             _argumentInfo = BinderHelper.ToArray(argumentInfo);
+            _callingContext = callingContext;
             _binder = new RuntimeBinder(callingContext);
+        }
+
+        public int BinderEqivalenceHash
+        {
+            get
+            {
+                int hash = _callingContext?.GetHashCode() ?? 0;
+                if (ResultIndexed)
+                {
+                    hash = HashHelpers.Combine(hash, 1);
+                }
+                hash = HashHelpers.Combine(hash, Name.GetHashCode());
+                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+                return hash;
+            }
+        }
+
+        public bool IsEquivalentTo(ICSharpBinder other)
+        {
+            var otherBinder = other as CSharpGetMemberBinder;
+            if (otherBinder == null)
+            {
+                return false;
+            }
+
+            if (Name != otherBinder.Name ||
+                ResultIndexed != otherBinder.ResultIndexed ||
+                _callingContext != otherBinder._callingContext ||
+                _argumentInfo.Length != otherBinder._argumentInfo.Length)
+            {
+                return false;
+            }
+
+            return BinderHelper.CompareArgInfos(_argumentInfo, otherBinder._argumentInfo);
         }
 
         /// <summary>

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
@@ -64,16 +64,13 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
-            {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                hash = HashHelpers.Combine(hash, (int)_flags);
-                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            hash = HashHelpers.Combine(hash, (int)_flags);
+            hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
 
-                return hash;
-            }
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Numerics.Hashing;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -43,6 +44,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private readonly RuntimeBinder _binder;
 
+        private readonly Type _callingContext;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CSharpInvokeBinder" />.
         /// </summary>
@@ -56,8 +59,39 @@ namespace Microsoft.CSharp.RuntimeBinder
             base(BinderHelper.CreateCallInfo(ref argumentInfo, 1)) // discard 1 argument: the target object (even if static, arg is type)
         {
             _flags = flags;
+            _callingContext = callingContext;
             _argumentInfo = argumentInfo as CSharpArgumentInfo[];
             _binder = new RuntimeBinder(callingContext);
+        }
+
+        public int BinderEqivalenceHash
+        {
+            get
+            {
+                int hash = _callingContext?.GetHashCode() ?? 0;
+                hash = HashHelpers.Combine(hash, (int)_flags);
+                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+                return hash;
+            }
+        }
+
+        public bool IsEquivalentTo(ICSharpBinder other)
+        {
+            var otherBinder = other as CSharpInvokeBinder;
+            if (otherBinder == null)
+            {
+                return false;
+            }
+
+            if (_flags != otherBinder._flags ||
+                _callingContext != otherBinder._callingContext ||
+                _argumentInfo.Length != otherBinder._argumentInfo.Length)
+            {
+                return false;
+            }
+
+            return BinderHelper.CompareArgInfos(_argumentInfo, otherBinder._argumentInfo);
         }
 
         /// <summary>

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeConstructorBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeConstructorBinder.cs
@@ -51,18 +51,15 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
-            {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                hash = HashHelpers.Combine(hash, (int)Flags);
-                hash = HashHelpers.Combine(hash, Name.GetHashCode());
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            hash = HashHelpers.Combine(hash, (int)Flags);
+            hash = HashHelpers.Combine(hash, Name.GetHashCode());
 
-                hash = BinderHelper.AddArgHashes(hash, TypeArguments, _argumentInfo);
+            hash = BinderHelper.AddArgHashes(hash, TypeArguments, _argumentInfo);
 
-                return hash;
-            }
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeConstructorBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeConstructorBinder.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Numerics.Hashing;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -37,14 +38,51 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private readonly RuntimeBinder _binder;
 
+        private readonly Type _callingContext;
+
         public CSharpInvokeConstructorBinder(
             CSharpCallFlags flags,
             Type callingContext,
             IEnumerable<CSharpArgumentInfo> argumentInfo)
         {
             Flags = flags;
+            _callingContext = callingContext;
             _argumentInfo = BinderHelper.ToArray(argumentInfo);
             _binder = new RuntimeBinder(callingContext);
+        }
+
+        public int BinderEqivalenceHash
+        {
+            get
+            {
+                int hash = _callingContext?.GetHashCode() ?? 0;
+                hash = HashHelpers.Combine(hash, (int)Flags);
+                hash = HashHelpers.Combine(hash, Name.GetHashCode());
+
+                hash = BinderHelper.AddArgHashes(hash, TypeArguments, _argumentInfo);
+
+                return hash;
+            }
+        }
+
+        public bool IsEquivalentTo(ICSharpBinder other)
+        {
+            var otherBinder = other as CSharpInvokeConstructorBinder;
+            if (otherBinder == null)
+            {
+                return false;
+            }
+
+            if (Flags != otherBinder.Flags ||
+                _callingContext != otherBinder._callingContext ||
+                Name != otherBinder.Name ||
+                TypeArguments.Length != otherBinder.TypeArguments.Length ||
+                _argumentInfo.Length != otherBinder._argumentInfo.Length)
+            {
+                return false;
+            }
+
+            return BinderHelper.CompareArgInfos(TypeArguments, otherBinder.TypeArguments, _argumentInfo, otherBinder._argumentInfo);
         }
 
         public override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeMemberBinder.cs
@@ -73,18 +73,15 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
-            {
-                int hash = CallingContext?.GetHashCode() ?? 0;
-                hash = HashHelpers.Combine(hash, (int)Flags);
-                hash = HashHelpers.Combine(hash, Name.GetHashCode());
+            int hash = CallingContext?.GetHashCode() ?? 0;
+            hash = HashHelpers.Combine(hash, (int)Flags);
+            hash = HashHelpers.Combine(hash, Name.GetHashCode());
 
-                hash = BinderHelper.AddArgHashes(hash, TypeArguments, _argumentInfo);
+            hash = BinderHelper.AddArgHashes(hash, TypeArguments, _argumentInfo);
 
-                return hash;
-            }
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpIsEventBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpIsEventBinder.cs
@@ -46,14 +46,11 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
-            {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                hash = HashHelpers.Combine(hash, Name.GetHashCode());
-                return hash;
-            }
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            hash = HashHelpers.Combine(hash, Name.GetHashCode());
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpIsEventBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpIsEventBinder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Dynamic;
+using System.Numerics.Hashing;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -29,6 +30,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private readonly RuntimeBinder _binder;
 
+        private readonly Type _callingContext;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CSharpIsEventBinder"/> class.
         /// </summary>
@@ -39,7 +42,35 @@ namespace Microsoft.CSharp.RuntimeBinder
             Type callingContext)
         {
             Name = name;
+            _callingContext = callingContext;
             _binder = new RuntimeBinder(callingContext);
+        }
+
+        public int BinderEqivalenceHash
+        {
+            get
+            {
+                int hash = _callingContext?.GetHashCode() ?? 0;
+                hash = HashHelpers.Combine(hash, Name.GetHashCode());
+                return hash;
+            }
+        }
+
+        public bool IsEquivalentTo(ICSharpBinder other)
+        {
+            var otherBinder = other as CSharpIsEventBinder;
+            if (otherBinder == null)
+            {
+                return false;
+            }
+
+            if (_callingContext != otherBinder._callingContext ||
+                Name != otherBinder.Name)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
@@ -62,23 +62,20 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext, isChecked);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            if (IsChecked)
             {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                if (IsChecked)
-                {
-                    hash = HashHelpers.Combine(hash, 1);
-                }
-                if (IsCompoundAssignment)
-                {
-                    hash = HashHelpers.Combine(hash, 1);
-                }
-                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
-
-                return hash;
+                hash = HashHelpers.Combine(hash, 1);
             }
+            if (IsCompoundAssignment)
+            {
+                hash = HashHelpers.Combine(hash, 1);
+            }
+            hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Numerics.Hashing;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -35,6 +36,10 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private readonly RuntimeBinder _binder;
 
+        private readonly Type _callingContext;
+
+        private bool IsChecked => _binder.IsChecked;
+
         //////////////////////////////////////////////////////////////////////
 
         /// <summary>
@@ -53,7 +58,46 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             IsCompoundAssignment = isCompoundAssignment;
             _argumentInfo = argumentInfo as CSharpArgumentInfo[];
+            _callingContext = callingContext;
             _binder = new RuntimeBinder(callingContext, isChecked);
+        }
+
+        public int BinderEqivalenceHash
+        {
+            get
+            {
+                int hash = _callingContext?.GetHashCode() ?? 0;
+                if (IsChecked)
+                {
+                    hash = HashHelpers.Combine(hash, 1);
+                }
+                if (IsCompoundAssignment)
+                {
+                    hash = HashHelpers.Combine(hash, 1);
+                }
+                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+                return hash;
+            }
+        }
+
+        public bool IsEquivalentTo(ICSharpBinder other)
+        {
+            var otherBinder = other as CSharpSetIndexBinder;
+            if (otherBinder == null)
+            {
+                return false;
+            }
+
+            if (_callingContext != otherBinder._callingContext ||
+                IsChecked != otherBinder.IsChecked ||
+                IsCompoundAssignment != otherBinder.IsCompoundAssignment ||
+                _argumentInfo.Length != otherBinder._argumentInfo.Length)
+            {
+                return false;
+            }
+
+            return BinderHelper.CompareArgInfos(_argumentInfo, otherBinder._argumentInfo);
         }
 
         /// <summary>

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetMemberBinder.cs
@@ -61,24 +61,21 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext, isChecked);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            if (IsChecked)
             {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                if (IsChecked)
-                {
-                    hash = HashHelpers.Combine(hash, 1);
-                }
-                if (IsCompoundAssignment)
-                {
-                    hash = HashHelpers.Combine(hash, 1);
-                }
-                hash = HashHelpers.Combine(hash, Name.GetHashCode());
-                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
-
-                return hash;
+                hash = HashHelpers.Combine(hash, 1);
             }
+            if (IsCompoundAssignment)
+            {
+                hash = HashHelpers.Combine(hash, 1);
+            }
+            hash = HashHelpers.Combine(hash, Name.GetHashCode());
+            hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpUnaryOperationBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpUnaryOperationBinder.cs
@@ -70,20 +70,17 @@ namespace Microsoft.CSharp.RuntimeBinder
             _binder = new RuntimeBinder(callingContext, isChecked);
         }
 
-        public int BinderEqivalenceHash
+        public int GetGetBinderEquivalenceHash()
         {
-            get
+            int hash = _callingContext?.GetHashCode() ?? 0;
+            hash = HashHelpers.Combine(hash, (int)Operation);
+            if (IsChecked)
             {
-                int hash = _callingContext?.GetHashCode() ?? 0;
-                hash = HashHelpers.Combine(hash, (int)Operation);
-                if (IsChecked)
-                {
-                    hash = HashHelpers.Combine(hash, 1);
-                }
-                hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
-
-                return hash;
+                hash = HashHelpers.Combine(hash, 1);
             }
+            hash = BinderHelper.AddArgHashes(hash, _argumentInfo);
+
+            return hash;
         }
 
         public bool IsEquivalentTo(ICSharpBinder other)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ICSharpBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ICSharpBinder.cs
@@ -27,8 +27,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         Type ReturnType { get; }
 
-        int BinderEqivalenceHash { get; }
-
+        int GetGetBinderEquivalenceHash();
         bool IsEquivalentTo(ICSharpBinder other);
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ICSharpBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ICSharpBinder.cs
@@ -26,5 +26,9 @@ namespace Microsoft.CSharp.RuntimeBinder
         string Name { get; }
 
         Type ReturnType { get; }
+
+        int BinderEqivalenceHash { get; }
+
+        bool IsEquivalentTo(ICSharpBinder other);
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private readonly ExpressionBinder _binder;
 
+        internal bool IsChecked => _binder.Context.Checked;
+
         public RuntimeBinder(Type contextType, bool isChecked = false)
         {
             AggregateSymbol context;
@@ -160,14 +162,14 @@ namespace Microsoft.CSharp.RuntimeBinder
                 if (swt != null && swt.Sym.getKind() != SYMKIND.SK_MethodSymbol)
                 {
                     // The GetMember only has one argument, and we need to just take the first arg info.
-                    CSharpGetMemberBinder getMember = new CSharpGetMemberBinder(callPayload.Name, false, callPayload.CallingContext, new CSharpArgumentInfo[] { callPayload.GetArgumentInfo(0) });
+                    CSharpGetMemberBinder getMember = new CSharpGetMemberBinder(callPayload.Name, false, callPayload.CallingContext, new CSharpArgumentInfo[] { callPayload.GetArgumentInfo(0) }).TryGetExisting();
 
                     // The Invoke has the remaining argument infos. However, we need to redo the first one
                     // to correspond to the GetMember result.
                     CSharpArgumentInfo[] argInfos = callPayload.ArgumentInfoArray();
 
                     argInfos[0] = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null);
-                    CSharpInvokeBinder invoke = new CSharpInvokeBinder(callPayload.Flags, callPayload.CallingContext, argInfos);
+                    CSharpInvokeBinder invoke = new CSharpInvokeBinder(callPayload.Flags, callPayload.CallingContext, argInfos).TryGetExisting();
 
                     DynamicMetaObject[] newArgs = new DynamicMetaObject[args.Length - 1];
                     Array.Copy(args, 1, newArgs, 0, args.Length - 1);


### PR DESCRIPTION
When a new binder is exactly the same as existing one, just use the old instance instead.

The reason is that DLR associates L2 cache with binder instances. The older binder, while equivalent, may already have some bindings in its cache. It makes sense to reuse them. This is the whole point of L2 cache.
I.E. If the second callsite happens to bind the same operation (say a dynamic addition that turns out to be adding ints), it can simply reuse the results of the previous binding - as long as these "+" callsites use the same binder instance.

Dynamic binding is a relatively expensive reflection-heavy operation. It is nice to be able to reuse the results.