### PR TITLE
Removing System.Runtime.Caching/src/MatchingRefApiCompatBaseline.txt

### DIFF
--- a/src/System.Runtime.Caching/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.Caching/src/MatchingRefApiCompatBaseline.txt
@@ -1,6 +1,0 @@
-Compat issues with assembly System.Runtime.Caching:
-TypesMustExist : Type 'System.Runtime.Caching.Configuration.CachingSectionGroup' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Runtime.Caching.Configuration.MemoryCacheElement' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Runtime.Caching.Configuration.MemoryCacheSection' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Runtime.Caching.Configuration.MemoryCacheSettingsCollection' does not exist in the implementation but it does exist in the contract.
-Total Issues: 4


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/28636 made the API match. Now removing the baseline file.

Fixes #27980