### PR TITLE
Improve parsing of WinINet default proxy strings in SocketsHttpHandler 

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -190,7 +190,7 @@ namespace System.Net.Http
             }
 
             int idx = value.IndexOf("http://");
-            if( idx >= 0 )
+            if (idx >= 0)
             {
                 int endOfProxy = value.IndexOfAny(_proxyDelimiters, idx);
                 int proxyLength = (endOfProxy == -1) ? value.Length - idx : endOfProxy - idx;
@@ -202,7 +202,7 @@ namespace System.Net.Http
             }
 
             idx = value.IndexOf("http=");
-            if( idx >= 0 )
+            if (idx >= 0)
             {
                 idx += 5; // Skip "http=" so we can replace it with "http://"
                 int endOfProxy = value.IndexOfAny(_proxyDelimiters, idx);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -314,7 +314,7 @@ namespace System.Net.Http
                     }
                 }
 
-                return uri.Scheme == Uri.UriSchemeHttps ? _secureProxyUri : _insecureProxyUri;
+                return (uri.Scheme == UriScheme.Https || uri.Scheme == UriScheme.Wss) ? _secureProxyUri : _insecureProxyUri;
             }
 
             // For anything else ask WinHTTP.

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -13,11 +13,11 @@ namespace System.Net.Http
 {
     internal sealed class HttpSystemProxy : IWebProxy, IDisposable
     {
-        private readonly List<IPAddress> _localIp;
         private readonly Uri _insecureProxyUri;         // URI of the http system proxy if set
         private readonly Uri _secureProxyUri;         // URI of the https system proxy if set
         private readonly List<Regex> _bypass;           // list of domains not to proxy
         private readonly bool _bypassLocal = false;     // we should bypass domain considered local
+        private readonly List<IPAddress> _localIp;
         private ICredentials _credentials;
         private readonly WinInetProxyHelper _proxyHelper;
         private SafeWinHttpHandle _sessionHandle;
@@ -314,6 +314,7 @@ namespace System.Net.Http
                     }
                 }
 
+                // We did not find match on bypass list.
                 return (uri.Scheme == UriScheme.Https || uri.Scheme == UriScheme.Wss) ? _secureProxyUri : _insecureProxyUri;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -225,12 +225,15 @@ namespace System.Net.Http
                 Uri.TryCreate(value.Substring(idx, proxyLength) , UriKind.Absolute, out insecureProxy);
             }
 
-            idx = value.IndexOf("http=");
-            if (idx >= 0)
+            if (insecureProxy == null)
             {
-                idx += 5; // Skip "http=" so we can replace it with "http://"
-                int proxyLength = GetProxySubstringLength(value, idx);
-                Uri.TryCreate("http://" + value.Substring(idx, proxyLength) , UriKind.Absolute, out insecureProxy);
+                idx = value.IndexOf("http=");
+                if (idx >= 0)
+                {
+                    idx += 5; // Skip "http=" so we can replace it with "http://"
+                    int proxyLength = GetProxySubstringLength(value, idx);
+                    Uri.TryCreate("http://" + value.Substring(idx, proxyLength) , UriKind.Absolute, out insecureProxy);
+                }
             }
 
             idx = value.IndexOf("https://");
@@ -241,12 +244,15 @@ namespace System.Net.Http
                 Uri.TryCreate("http://" + value.Substring(idx, proxyLength) , UriKind.Absolute, out secureProxy);
             }
 
-            idx = value.IndexOf("https=");
-            if (idx >= 0)
+            if (secureProxy == null)
             {
-                idx += 6; // Skip "https=" so we can replace it with "http://"
-                int proxyLength = GetProxySubstringLength(value, idx);
-                Uri.TryCreate("http://" + value.Substring(idx, proxyLength) , UriKind.Absolute, out secureProxy);
+                idx = value.IndexOf("https=");
+                if (idx >= 0)
+                {
+                    idx += 6; // Skip "https=" so we can replace it with "http://"
+                    int proxyLength = GetProxySubstringLength(value, idx);
+                    Uri.TryCreate("http://" + value.Substring(idx, proxyLength) , UriKind.Absolute, out secureProxy);
+                }
             }
         }
 

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -14,6 +14,7 @@ namespace System.Net.Http.Tests
     public class HttpSystemProxyTest : RemoteExecutorTestBase
     {
         private readonly ITestOutputHelper _output;
+        private const string FakeProxyString = "http://proxy.contoso.com";
         private readonly Uri insecureProxyUri = new Uri("http://proxy.insecure.com");
         private readonly Uri secureProxyUri = new Uri("http://proxy.secure.com");
         private readonly Uri fooHttp = new Uri("http://foo.com");

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -39,6 +39,8 @@ namespace System.Net.Http.Tests
         [InlineData(";http=proxy.insecure.com;;", true, false)]
         [InlineData("    http=proxy.insecure.com    ", true, false)]
         [InlineData("http=proxy.insecure.com;http=proxy.wrong.com", true, false)]
+        [InlineData("http=http://proxy.insecure.com", true, false)]
+        [InlineData("https=https://proxy.secure.com", false, true)]
         public void HttpProxy_SystemProxy_Loaded(string proxyString, bool hasInsecureProxy, bool hasSecureProxy)
         {
             IWebProxy p;

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -19,6 +19,8 @@ namespace System.Net.Http.Tests
         private readonly Uri secureProxyUri = new Uri("http://proxy.secure.com");
         private readonly Uri fooHttp = new Uri("http://foo.com");
         private readonly Uri fooHttps = new Uri("https://foo.com");
+        private readonly Uri fooWs = new Uri("ws://foo.com");
+        private readonly Uri fooWss = new Uri("wss://foo.com");
 
         public HttpSystemProxyTest(ITestOutputHelper output)
         {
@@ -52,6 +54,8 @@ namespace System.Net.Http.Tests
 
             Assert.Equal(hasInsecureProxy ? insecureProxyUri : null, p.GetProxy(fooHttp));
             Assert.Equal(hasSecureProxy ? secureProxyUri : null, p.GetProxy(fooHttps));
+            Assert.Equal(hasInsecureProxy ? insecureProxyUri : null, p.GetProxy(fooWs));
+            Assert.Equal(hasSecureProxy ? secureProxyUri : null, p.GetProxy(fooWss));
         }
 
         [Theory]

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -153,6 +153,8 @@ namespace System.Net.Http.Tests
 
             Assert.Equal(null, p.GetProxy(fooHttp));
             Assert.Equal(null, p.GetProxy(fooHttps));
+            Assert.Equal(null, p.GetProxy(fooWs));
+            Assert.Equal(null, p.GetProxy(fooWss));
         }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -15,12 +15,12 @@ namespace System.Net.Http.Tests
     {
         private readonly ITestOutputHelper _output;
         private const string FakeProxyString = "http://proxy.contoso.com";
-        private readonly Uri insecureProxyUri = new Uri("http://proxy.insecure.com");
-        private readonly Uri secureProxyUri = new Uri("http://proxy.secure.com");
-        private readonly Uri fooHttp = new Uri("http://foo.com");
-        private readonly Uri fooHttps = new Uri("https://foo.com");
-        private readonly Uri fooWs = new Uri("ws://foo.com");
-        private readonly Uri fooWss = new Uri("wss://foo.com");
+        private const string insecureProxyUri = "http://proxy.insecure.com";
+        private const string secureProxyUri = "http://proxy.secure.com";
+        private const string fooHttp = "http://foo.com";
+        private const string fooHttps = "https://foo.com";
+        private const string fooWs = "ws://foo.com";
+        private const string fooWss = "wss://foo.com";
 
         public HttpSystemProxyTest(ITestOutputHelper output)
         {
@@ -41,23 +41,27 @@ namespace System.Net.Http.Tests
         [InlineData("http=proxy.insecure.com;http=proxy.wrong.com", true, false)]
         [InlineData("http=http://proxy.insecure.com", true, false)]
         [InlineData("https=https://proxy.secure.com", false, true)]
-        public void HttpProxy_SystemProxy_Loaded(string proxyString, bool hasInsecureProxy, bool hasSecureProxy)
+        public void HttpProxy_SystemProxy_Loaded(string rawProxyString, bool hasInsecureProxy, bool hasSecureProxy)
         {
-            IWebProxy p;
+            RemoteInvoke((proxyString, insecureProxy, secureProxy) =>
+            {
+                IWebProxy p;
 
-            FakeRegistry.Reset();
-            Assert.False(HttpSystemProxy.TryCreate(out p));
+                FakeRegistry.Reset();
+                Assert.False(HttpSystemProxy.TryCreate(out p));
 
-            FakeRegistry.WinInetProxySettings.Proxy = proxyString;
-            WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
+                FakeRegistry.WinInetProxySettings.Proxy = proxyString;
+                WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
 
-            Assert.True(HttpSystemProxy.TryCreate(out p));
-            Assert.NotNull(p);
+                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.NotNull(p);
 
-            Assert.Equal(hasInsecureProxy ? insecureProxyUri : null, p.GetProxy(fooHttp));
-            Assert.Equal(hasSecureProxy ? secureProxyUri : null, p.GetProxy(fooHttps));
-            Assert.Equal(hasInsecureProxy ? insecureProxyUri : null, p.GetProxy(fooWs));
-            Assert.Equal(hasSecureProxy ? secureProxyUri : null, p.GetProxy(fooWss));
+                Assert.Equal(Boolean.Parse(insecureProxy) ? new Uri(insecureProxyUri) : null, p.GetProxy(new Uri(fooHttp)));
+                Assert.Equal(Boolean.Parse(secureProxy) ? new Uri(secureProxyUri) : null, p.GetProxy(new Uri(fooHttps)));
+                Assert.Equal(Boolean.Parse(insecureProxy) ? new Uri(insecureProxyUri) : null, p.GetProxy(new Uri(fooWs)));
+                Assert.Equal(Boolean.Parse(secureProxy) ? new Uri(secureProxyUri) : null, p.GetProxy(new Uri(fooWss)));
+                return SuccessExitCode;
+            }, rawProxyString, hasInsecureProxy.ToString(), hasSecureProxy.ToString()).Dispose();
         }
 
         [Theory]
@@ -86,7 +90,7 @@ namespace System.Net.Http.Tests
                 IWebProxy p;
 
                 FakeRegistry.Reset();
-                FakeRegistry.WinInetProxySettings.Proxy = FakeProxyString;
+                FakeRegistry.WinInetProxySettings.Proxy = insecureProxyUri;
                 FakeRegistry.WinInetProxySettings.ProxyBypass = "23.23.86.44;*.foo.com;<local>;BAR.COM; ; 162*;[2002::11];[*:f8b0:4005:80a::200e]; http://www.xn--mnchhausen-9db.at;http://*.xn--bb-bjab.eu;http://xn--bb-bjab.eu;";
 
                 Assert.True(HttpSystemProxy.TryCreate(out p));
@@ -113,7 +117,7 @@ namespace System.Net.Http.Tests
                 IWebProxy p;
 
                 FakeRegistry.Reset();
-                FakeRegistry.WinInetProxySettings.Proxy = FakeProxyString;
+                FakeRegistry.WinInetProxySettings.Proxy = insecureProxyUri;
                 FakeRegistry.WinInetProxySettings.ProxyBypass = bypassValue;
 
                 Assert.True(HttpSystemProxy.TryCreate(out p));
@@ -134,29 +138,34 @@ namespace System.Net.Http.Tests
            }, bypass, count.ToString()).Dispose();
         }
 
+        [Theory]
         [InlineData("http://")]
         [InlineData("http=")]
         [InlineData("http://;")]
         [InlineData("http=;")]
         [InlineData("  ;  ")]
         [InlineData("proxy.contoso.com")]
-        public void HttpProxy_InvalidSystemProxy_Null(string proxyString)
+        public void HttpProxy_InvalidSystemProxy_Null(string rawProxyString)
         {
-            IWebProxy p;
+            RemoteInvoke((proxyString) =>
+            {
+                IWebProxy p;
 
-            FakeRegistry.Reset();
-            Assert.False(HttpSystemProxy.TryCreate(out p));
+                FakeRegistry.Reset();
+                Assert.False(HttpSystemProxy.TryCreate(out p));
 
-            FakeRegistry.WinInetProxySettings.Proxy = proxyString;
-            WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
+                FakeRegistry.WinInetProxySettings.Proxy = proxyString;
+                WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
 
-            Assert.True(HttpSystemProxy.TryCreate(out p));
-            Assert.NotNull(p);
+                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.NotNull(p);
 
-            Assert.Equal(null, p.GetProxy(fooHttp));
-            Assert.Equal(null, p.GetProxy(fooHttps));
-            Assert.Equal(null, p.GetProxy(fooWs));
-            Assert.Equal(null, p.GetProxy(fooWss));
+                Assert.Equal(null, p.GetProxy(new Uri(fooHttp)));
+                Assert.Equal(null, p.GetProxy(new Uri(fooHttps)));
+                Assert.Equal(null, p.GetProxy(new Uri(fooWs)));
+                Assert.Equal(null, p.GetProxy(new Uri(fooWss)));
+                return SuccessExitCode;
+            }, rawProxyString).Dispose();
         }
     }
 }


### PR DESCRIPTION
WinINet default proxy strings consist of a semicolon or whitespace separated list of proxies, each with the following format:
```
([<scheme>=][<scheme>"://"]<server>[":"<port>])
```
For example:
```
http=127.0.0.1:8888;https=127.0.0.1:8888
```
Our current implementation can only handle a single proxy in the list, and expects that "://" will be used instead of "=". This breaks proxies for users with valid proxy configurations, and applications that configure multiple default proxies (such as Fiddler). In making the fix I tried to write the code to make as few allocations as possible, since the default proxy is checked frequently. Let me know if I should go back to the easy to read fix involving String.Split :)

I made the following assumptions when writing this fix:
- SocketsHttpHandler only supports http proxies.
- When a user provides multiple proxies with the same scheme, we can choose to use the first.

This PR also significantly increases the number of test cases for the relevant code.

See #28603 for more info.