### PR TITLE
React to X509Chain changes in macOS 10.13.4

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
@@ -154,7 +154,8 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
     CFStringRef keyString = reinterpret_cast<CFStringRef>(key);
 
     if (CFEqual(keyString, CFSTR("NotValidBefore")) || CFEqual(keyString, CFSTR("ValidLeaf")) ||
-        CFEqual(keyString, CFSTR("ValidIntermediates")) || CFEqual(keyString, CFSTR("ValidRoot")))
+        CFEqual(keyString, CFSTR("ValidIntermediates")) || CFEqual(keyString, CFSTR("ValidRoot")) ||
+        CFEqual(keyString, CFSTR("TemporalValidity")))
         *pStatus |= PAL_X509ChainNotTimeValid;
     else if (CFEqual(keyString, CFSTR("Revocation")))
         *pStatus |= PAL_X509ChainRevoked;
@@ -168,8 +169,10 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
         *pStatus |= PAL_X509ChainExplicitDistrust;
     else if (CFEqual(keyString, CFSTR("RevocationResponseRequired")))
         *pStatus |= PAL_X509ChainRevocationStatusUnknown;
+    else if (CFEqual(keyString, CFSTR("MissingIntermediate")))
+        *pStatus |= PAL_X509ChainPartialChain;
     else if (CFEqual(keyString, CFSTR("WeakLeaf")) || CFEqual(keyString, CFSTR("WeakIntermediates")) ||
-             CFEqual(keyString, CFSTR("WeakRoot")))
+             CFEqual(keyString, CFSTR("WeakRoot")) || CFEqual(keyString, CFSTR("WeakKeySize")))
     {
         // Because we won't report this out of a chain built by .NET on Windows,
         // don't report it here.


### PR DESCRIPTION
10.13.4 changed some of the detail codes for building the X509ChainStatusFlag values.

"ValidLeaf" (etc) => "TemporalValidity"
"WeakLeaf" (etc) => "WeakKeySize"
new "MissingIntermediate" when the chain didn't complete instead of "AnchorTrusted" lower down.

We'll need to port this to release/2.0.0 as well.
Addresses #28652 (for vNext).