### PR TITLE
Avoid unnecessarily propagating ExecutionContext in SocketAsyncEngine

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -266,7 +266,7 @@ namespace System.Net.Sockets
                     // we can't pool the object, as ProcessQueue may still have a reference to it, due to
                     // using a pattern whereby it takes the lock to grab an item, but then releases the lock
                     // to do further processing on the item that's still in the list.
-                    ThreadPool.QueueUserWorkItem(o => ((AsyncOperation)o).InvokeCallback(allowPooling: false), this);
+                    ThreadPool.UnsafeQueueUserWorkItem(o => ((AsyncOperation)o).InvokeCallback(allowPooling: false), this);
                 }
 
                 Trace("Exit");
@@ -837,7 +837,7 @@ namespace System.Net.Sockets
 
                 // We just transitioned from Waiting to Processing.
                 // Spawn a work item to do the actual processing.
-                ThreadPool.QueueUserWorkItem(s_processingCallback, context);
+                ThreadPool.UnsafeQueueUserWorkItem(s_processingCallback, context);
             }
 
             // Called on the threadpool when data may be available.
@@ -968,7 +968,7 @@ namespace System.Net.Sockets
                         Debug.Assert(_state == QueueState.Processing);
 
                         // Spawn a new work item to continue processing the queue.
-                        ThreadPool.QueueUserWorkItem(s_processingCallback, context);
+                        ThreadPool.UnsafeQueueUserWorkItem(s_processingCallback, context);
                     }
 
                     // At this point, the operation has completed and it's no longer

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -286,11 +286,21 @@ namespace System.Net.Sockets
                 //
                 // Start the event loop on its own thread.
                 //
-                Task.Factory.StartNew(
-                    EventLoop,
-                    CancellationToken.None,
-                    TaskCreationOptions.LongRunning,
-                    TaskScheduler.Default);
+                bool suppressFlow = !ExecutionContext.IsFlowSuppressed();
+                try
+                {
+                    if (suppressFlow) ExecutionContext.SuppressFlow();
+                    Task.Factory.StartNew(
+                        s => ((SocketAsyncEngine)s).EventLoop(),
+                        this,
+                        CancellationToken.None,
+                        TaskCreationOptions.LongRunning,
+                        TaskScheduler.Default);
+                }
+                finally
+                {
+                    if (suppressFlow) ExecutionContext.RestoreFlow();
+                }
             }
             catch
             {


### PR DESCRIPTION
SocketAsyncEngines are created lazily on-demand.  If we happen to create one at a point where there's a non-default ExecutionContext, we end up capturing that context onto the event loop thread, such that all subsequent dispatches capture and restore that ExecutionContext.

Fixes https://github.com/dotnet/corefx/issues/28482
cc: @benaadams, @geoffkizer, @tmds