### PR TITLE
Marking tests affected by 27740 in XmlSchemaValidatorApi as active issue

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -85,6 +85,7 @@ namespace System.Xml.Tests
             Assert.True(false);
         }
 
+        [ActiveIssue(27740, TestPlatforms.AnyUnix)]
         [Fact]
         //[Variation(Desc = "TFS_470021 Unexpected local particle qualified name when chameleon schema is added to set")]
         public void TFS_470021()

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -893,6 +893,7 @@ namespace System.Xml.Tests
         }
 
         //TFS_538324
+        [ActiveIssue(27740, TestPlatforms.AnyUnix)]
         [Fact]
         public void XSDValidationGeneratesInvalidError_1()
         {
@@ -919,6 +920,7 @@ namespace System.Xml.Tests
         }
 
         //TFS_538324
+        [ActiveIssue(27740, TestPlatforms.AnyUnix)]
         [Fact]
         public void XSDValidationGeneratesInvalidError_2()
         {


### PR DESCRIPTION
The root cause of #27740 does not seem to be in the tests themselves but in my Ubuntu VM the 2 tests hitting it are being disabled in this PR. Later I will provide the crashing stacks but I want to test the other exit code 134 before doing that.