### PR TITLE
ReadOnlyMemory Start.GetObject() never equal to null

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -338,7 +338,7 @@ namespace System.Buffers
             // We take high order bits of two indexes index and move them
             // to a first and second position to convert to BufferType
             // Masking with 2 is required to only keep the second bit of Start.GetInteger()
-            sequenceType = Start.GetObject() == null ? SequenceType.Empty : (SequenceType)((((uint)Start.GetInteger() >> 30) & 2) | (uint)End.GetInteger() >> 31);
+            sequenceType = (SequenceType)((((uint)Start.GetInteger() >> 30) & 2) | (uint)End.GetInteger() >> 31);
         }
 
         /// <summary>


### PR DESCRIPTION
I removed unreachable code because `Start.GetObject() == null` always equal to false because Start.GetObject() never equal to null (this is tested in constructors).