### PR TITLE
SocketsHttpHandler: if server sends invalid NT auth challenge, don't continue processing

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -62,6 +62,11 @@ namespace System.Net.Http
                         while (true)
                         {
                             string challengeResponse = authContext.GetOutgoingBlob(challengeData);
+                            if (challengeResponse == null)
+                            {
+                                // Server sent something invalid, so stop processing and return current response.
+                                break;
+                            }
 
                             await connection.DrainResponseAsync(response).ConfigureAwait(false);
 


### PR DESCRIPTION
Fixes #28648 

@Tratcher @stephentoub @davidsh @dotnet/ncl 
