### PR TITLE
Increase iteration counts in threading perf tests

### DIFF
--- a/src/System.Threading/tests/Performance/Perf.EventWaitHandle.cs
+++ b/src/System.Threading/tests/Performance/Perf.EventWaitHandle.cs
@@ -9,18 +9,21 @@ namespace System.Threading.Tests
 {
     public class Perf_EventWaitHandle
     {
-        [Benchmark]
+        [Benchmark(InnerIterationCount = 100_000)]
         public void Set_Reset()
         {
-            foreach (var iteration in Benchmark.Iterations)
+            using (EventWaitHandle are = new EventWaitHandle(false, EventResetMode.AutoReset))
             {
-                using (EventWaitHandle are = new EventWaitHandle(false, EventResetMode.AutoReset))
-                using (iteration.StartMeasurement())
+                foreach (var iteration in Benchmark.Iterations)
                 {
-                    are.Set(); are.Reset(); are.Set(); are.Reset();
-                    are.Set(); are.Reset(); are.Set(); are.Reset();
-                    are.Set(); are.Reset(); are.Set(); are.Reset();
-                    are.Set(); are.Reset(); are.Set(); are.Reset();
+                    using (iteration.StartMeasurement())
+                    {
+                        for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        {
+                            are.Set();
+                            are.Reset();
+                        }
+                    }
                 }
             }
         }

--- a/src/System.Threading/tests/Performance/Perf.Interlocked.cs
+++ b/src/System.Threading/tests/Performance/Perf.Interlocked.cs
@@ -8,7 +8,9 @@ namespace System.Threading.Tests
 {
     public class Perf_Interlocked
     {
-        [Benchmark(InnerIterationCount = 1000)]
+        private const int IterationCount = 10_000_000;
+
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void Increment_int()
         {
             int location = 0;
@@ -25,7 +27,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 1000)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void Decrement_int()
         {
             int location = 0;
@@ -42,7 +44,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 1000)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void Increment_long()
         {
             long location = 0;
@@ -59,7 +61,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 1000)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void Decrement_long()
         {
             long location = 0;
@@ -76,7 +78,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 1000)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void Add_int()
         {
             int location = 0;
@@ -93,7 +95,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 1000)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void Add_long()
         {
             long location = 0;
@@ -110,7 +112,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 1000)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void Exchange_int()
         {
             int location = 0;
@@ -128,7 +130,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 1000)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void Exchange_long()
         {
             long location = 0;
@@ -146,7 +148,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 500)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void CompareExchange_int()
         {
             int location = 0;
@@ -165,7 +167,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 500)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void CompareExchange_long()
         {
             long location = 0;

--- a/src/System.Threading/tests/Performance/Perf.Lock.cs
+++ b/src/System.Threading/tests/Performance/Perf.Lock.cs
@@ -9,7 +9,7 @@ namespace System.Threading.Tests
 {
     public class Perf_Lock
     {
-        [Benchmark(InnerIterationCount = 100)]
+        [Benchmark(InnerIterationCount = 2_000_000)]
         public static void ReaderWriterLockSlimPerf()
         {
             ReaderWriterLockSlim rwLock = new ReaderWriterLockSlim();

--- a/src/System.Threading/tests/Performance/Perf.Monitor.cs
+++ b/src/System.Threading/tests/Performance/Perf.Monitor.cs
@@ -8,7 +8,9 @@ namespace System.Threading.Tests
 {
     public class Perf_Monitor
     {
-        [Benchmark(InnerIterationCount = 250)]
+        private const int IterationCount = 4_000_000;
+
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void EnterExit()
         {
             object sync = new object();
@@ -26,7 +28,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 100)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void TryEnterExit()
         {
             object sync = new object();

--- a/src/System.Threading/tests/Performance/Perf.SpinLock.cs
+++ b/src/System.Threading/tests/Performance/Perf.SpinLock.cs
@@ -8,7 +8,9 @@ namespace System.Threading.Tests
 {
     public class Perf_SpinLock
     {
-        [Benchmark(InnerIterationCount = 100)]
+        private const int IterationCount = 1_000_000;
+
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void EnterExit()
         {
             SpinLock spinLock = new SpinLock();
@@ -28,7 +30,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 100)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void TryEnterExit()
         {
             SpinLock spinLock = new SpinLock();

--- a/src/System.Threading/tests/Performance/Perf.Volatile.cs
+++ b/src/System.Threading/tests/Performance/Perf.Volatile.cs
@@ -8,7 +8,9 @@ namespace System.Threading.Tests
 {
     public class Perf_Volatile
     {
-        [Benchmark(InnerIterationCount = 2000)]
+        private const int IterationCount = 100_000_000;
+
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void Read_double()
         {
             double location = 0;
@@ -25,7 +27,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 2000)]
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void Write_double()
         {
             double location = 0;


### PR DESCRIPTION
Relevant to https://github.com/dotnet/coreclr/issues/17345

```
Before:

   System.Threading.Performance.Tests.dll                       | Metric   | Unit | Iterations | Average |    STDEV.S |   Min |   Max
  :------------------------------------------------------------ |:-------- |:----:|:----------:| -------:| ----------:| -----:| -----:
   System.Threading.Tests.Perf_EventWaitHandle.Set_Reset        | Duration | msec |    1000    |   0.006 |      0.003 | 0.005 | 0.053
   System.Threading.Tests.Perf_Interlocked.Add_int              | Duration | msec |    100     |   0.007 | 1.856E-004 | 0.007 | 0.008
   System.Threading.Tests.Perf_Interlocked.Add_long             | Duration | msec |    100     |   0.007 |      0.003 | 0.006 | 0.026
   System.Threading.Tests.Perf_Interlocked.CompareExchange_int  | Duration | msec |    100     |   0.004 |      0.003 | 0.004 | 0.021
   System.Threading.Tests.Perf_Interlocked.CompareExchange_long | Duration | msec |    100     |   0.004 |      0.002 | 0.004 | 0.021
   System.Threading.Tests.Perf_Interlocked.Decrement_int        | Duration | msec |    100     |   0.007 | 1.495E-004 | 0.007 | 0.007
   System.Threading.Tests.Perf_Interlocked.Decrement_long       | Duration | msec |    100     |   0.008 |      0.005 | 0.006 | 0.049
   System.Threading.Tests.Perf_Interlocked.Exchange_int         | Duration | msec |    100     |   0.007 |      0.002 | 0.007 | 0.023
   System.Threading.Tests.Perf_Interlocked.Exchange_long        | Duration | msec |    100     |   0.007 | 2.119E-004 | 0.007 | 0.009
   System.Threading.Tests.Perf_Interlocked.Increment_int        | Duration | msec |    100     |   0.007 | 1.134E-004 | 0.007 | 0.007
   System.Threading.Tests.Perf_Interlocked.Increment_long       | Duration | msec |    100     |   0.007 |      0.002 | 0.007 | 0.025
   System.Threading.Tests.Perf_Lock.ReaderWriterLockSlimPerf    | Duration | msec |    100     |   0.003 | 1.681E-004 | 0.003 | 0.004
   System.Threading.Tests.Perf_Monitor.EnterExit                | Duration | msec |    100     |   0.005 |      0.002 | 0.005 | 0.021
   System.Threading.Tests.Perf_Monitor.TryEnterExit             | Duration | msec |    100     |   0.002 | 2.455E-004 | 0.002 | 0.004
   System.Threading.Tests.Perf_SpinLock.EnterExit               | Duration | msec |    100     |   0.010 |      0.006 | 0.008 | 0.048
   System.Threading.Tests.Perf_SpinLock.TryEnterExit            | Duration | msec |    100     |   0.008 |      0.003 | 0.008 | 0.026
   System.Threading.Tests.Perf_Volatile.Read_double             | Duration | msec |    100     |   0.002 |      0.002 | 0.001 | 0.018
   System.Threading.Tests.Perf_Volatile.Write_double            | Duration | msec |    100     |   0.002 | 2.533E-004 | 0.002 | 0.004

After:

   System.Threading.Performance.Tests.dll                       | Metric   | Unit | Iterations | Average | STDEV.S |    Min |    Max
  :------------------------------------------------------------ |:-------- |:----:|:----------:| -------:| -------:| ------:| ------:
   System.Threading.Tests.Perf_EventWaitHandle.Set_Reset        | Duration | msec |    100     |  61.277 |   0.771 | 60.692 | 66.405
   System.Threading.Tests.Perf_Interlocked.Add_int              | Duration | msec |    100     |  63.767 |   1.554 | 63.182 | 77.342
   System.Threading.Tests.Perf_Interlocked.Add_long             | Duration | msec |    100     |  63.669 |   1.059 | 63.160 | 70.719
   System.Threading.Tests.Perf_Interlocked.CompareExchange_int  | Duration | msec |    100     |  63.805 |   1.669 | 63.180 | 74.795
   System.Threading.Tests.Perf_Interlocked.CompareExchange_long | Duration | msec |    100     |  63.465 |   0.169 | 63.182 | 63.934
   System.Threading.Tests.Perf_Interlocked.Decrement_int        | Duration | msec |    100     |  66.444 |   3.587 | 63.206 | 77.222
   System.Threading.Tests.Perf_Interlocked.Decrement_long       | Duration | msec |    100     |  63.867 |   2.026 | 63.178 | 77.969
   System.Threading.Tests.Perf_Interlocked.Exchange_int         | Duration | msec |    100     |  68.325 |   3.153 | 59.724 | 79.176
   System.Threading.Tests.Perf_Interlocked.Exchange_long        | Duration | msec |    100     |  63.486 |   0.439 | 63.100 | 66.889
   System.Threading.Tests.Perf_Interlocked.Increment_int        | Duration | msec |    100     |  63.503 |   0.334 | 63.175 | 64.845
   System.Threading.Tests.Perf_Interlocked.Increment_long       | Duration | msec |    100     |  63.544 |   0.400 | 63.204 | 65.800
   System.Threading.Tests.Perf_Lock.ReaderWriterLockSlimPerf    | Duration | msec |    100     |  55.961 |   0.338 | 55.576 | 57.365
   System.Threading.Tests.Perf_Monitor.EnterExit                | Duration | msec |    100     |  67.236 |   0.462 | 66.876 | 71.239
   System.Threading.Tests.Perf_Monitor.TryEnterExit             | Duration | msec |    100     |  67.323 |   0.441 | 66.852 | 69.791
   System.Threading.Tests.Perf_SpinLock.EnterExit               | Duration | msec |    100     |  72.317 |   2.919 | 71.308 | 91.634
   System.Threading.Tests.Perf_SpinLock.TryEnterExit            | Duration | msec |    100     |  71.845 |   0.978 | 71.207 | 78.743
   System.Threading.Tests.Perf_Volatile.Read_double             | Duration | msec |    100     |  37.493 |   0.524 | 37.116 | 40.922
   System.Threading.Tests.Perf_Volatile.Write_double            | Duration | msec |    100     |  50.883 |   0.284 | 50.519 | 52.009
```