### PR TITLE
SslStream IDN mapping host name on Windows

### DIFF
--- a/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -5,6 +5,7 @@
 using Microsoft.Win32.SafeHandles;
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 
@@ -444,6 +445,7 @@ namespace System.Net.Security
 #endif
         private const string dummyStr = " ";
         private static readonly byte[] s_dummyBytes = new byte[] { 0 };
+        private static readonly IdnMapping s_idnMapping = new IdnMapping();
 
         protected SafeFreeCredentials _EffectiveCredential;
 
@@ -592,7 +594,8 @@ namespace System.Net.Security
                         targetName = dummyStr;
                     }
 
-                    fixed (char* namePtr = targetName)
+                    string punyCode = s_idnMapping.GetAscii(targetName);
+                    fixed (char* namePtr = punyCode)
                     {
                         errorCode = MustRunInitializeSecurityContext_SECURITY(
                                         ref inCredentials,

--- a/src/System.Net.Security/src/System/Net/Security/SniHelper.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SniHelper.cs
@@ -298,7 +298,10 @@ namespace System.Net.Security
             catch (ArgumentException)
             {
                 // client has not done IDN mapping
-                return idnEncodedString;
+                // TODO: this logic is replaced only for testing various implementations,
+                //       this change should be removed before merging
+                // return idnEncodedString;
+                return null;
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SniHelper.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SniHelper.cs
@@ -298,10 +298,7 @@ namespace System.Net.Security
             catch (ArgumentException)
             {
                 // client has not done IDN mapping
-                // TODO: this logic is replaced only for testing various implementations,
-                //       this change should be removed before merging
-                // return idnEncodedString;
-                return null;
+                return idnEncodedString;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28585

Adding IDN mapping as we do on OpenSsl implementation: https://github.com/dotnet/corefx/blob/c533892f2e57940ec9e66616288bf340b75a9217/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs#L129

First run (commit) was testing if SNI tests will work correctly with the fallback in SniHelper.DecodeString removed (fallback to utf-8 string in case idn unmapping failed)