### PR TITLE
Switch threading perf tests to use constant instead of Benchmark.InnerIteration

### DIFF
--- a/src/System.Threading/tests/Performance/Perf.EventWaitHandle.cs
+++ b/src/System.Threading/tests/Performance/Perf.EventWaitHandle.cs
@@ -9,7 +9,9 @@ namespace System.Threading.Tests
 {
     public class Perf_EventWaitHandle
     {
-        [Benchmark(InnerIterationCount = 100_000)]
+        private const int IterationCount = 100_000;
+
+        [Benchmark(InnerIterationCount = IterationCount)]
         public void Set_Reset()
         {
             using (EventWaitHandle are = new EventWaitHandle(false, EventResetMode.AutoReset))
@@ -18,7 +20,7 @@ namespace System.Threading.Tests
                 {
                     using (iteration.StartMeasurement())
                     {
-                        for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        for (int i = 0; i < IterationCount; i++)
                         {
                             are.Set();
                             are.Reset();

--- a/src/System.Threading/tests/Performance/Perf.Interlocked.cs
+++ b/src/System.Threading/tests/Performance/Perf.Interlocked.cs
@@ -19,7 +19,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.Increment(ref location);
                     }
@@ -36,7 +36,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.Decrement(ref location);
                     }
@@ -53,7 +53,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.Increment(ref location);
                     }
@@ -70,7 +70,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.Decrement(ref location);
                     }
@@ -87,7 +87,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.Add(ref location, 2);
                     }
@@ -104,7 +104,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.Add(ref location, 2);
                     }
@@ -122,7 +122,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.Exchange(ref location, newValue);
                     }
@@ -140,7 +140,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.Exchange(ref location, newValue);
                     }
@@ -159,7 +159,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.CompareExchange(ref location, newValue, comparand);
                     }
@@ -178,7 +178,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Interlocked.CompareExchange(ref location, newValue, comparand);
                     }

--- a/src/System.Threading/tests/Performance/Perf.Lock.cs
+++ b/src/System.Threading/tests/Performance/Perf.Lock.cs
@@ -9,7 +9,9 @@ namespace System.Threading.Tests
 {
     public class Perf_Lock
     {
-        [Benchmark(InnerIterationCount = 2_000_000)]
+        private const int IterationCount = 2_000_000;
+
+        [Benchmark(InnerIterationCount = IterationCount)]
         public static void ReaderWriterLockSlimPerf()
         {
             ReaderWriterLockSlim rwLock = new ReaderWriterLockSlim();
@@ -17,7 +19,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         rwLock.EnterReadLock();
                         rwLock.ExitReadLock();

--- a/src/System.Threading/tests/Performance/Perf.Monitor.cs
+++ b/src/System.Threading/tests/Performance/Perf.Monitor.cs
@@ -19,7 +19,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Monitor.Enter(sync);
                         Monitor.Exit(sync);
@@ -37,7 +37,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Monitor.TryEnter(sync, 0);
                         Monitor.Exit(sync);

--- a/src/System.Threading/tests/Performance/Perf.SpinLock.cs
+++ b/src/System.Threading/tests/Performance/Perf.SpinLock.cs
@@ -19,7 +19,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         bool lockTaken = false;
 
@@ -39,7 +39,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         bool lockTaken = false;
 

--- a/src/System.Threading/tests/Performance/Perf.Volatile.cs
+++ b/src/System.Threading/tests/Performance/Perf.Volatile.cs
@@ -19,7 +19,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Volatile.Read(ref location);
                     }
@@ -37,7 +37,7 @@ namespace System.Threading.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < IterationCount; i++)
                     {
                         Volatile.Write(ref location, newValue);
                     }


### PR DESCRIPTION
Followup to https://github.com/dotnet/corefx/pull/28712