### PR TITLE
Speed up regex FindFirstChar when there are exactly 2 possible match start characters

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -714,6 +714,12 @@ namespace System.Text.RegularExpressions
             return set[SETSTART];
         }
 
+        public static (char, char) DoubletonChars(string set)
+        {
+            Debug.Assert(IsDoubleton(set), "Tried to get the singleton char out of a non singleton character class");
+            return (set[SETSTART], set[SETSTART + 2]);
+        }
+
         public static bool IsMergeable(string charClass)
         {
             return (!IsNegated(charClass) && !IsSubtraction(charClass));
@@ -731,6 +737,19 @@ namespace System.Text.RegularExpressions
         {
             if (set[FLAGS] == 0 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
                 (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]))
+                return true;
+            else
+                return false;
+        }
+
+        /// <summary>
+        /// <c>true</c> if the set contains a single character only
+        /// </summary>
+        public static bool IsDoubleton(string set)
+        {
+            if (set[FLAGS] == 0 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 4 && !IsSubtraction(set) &&
+                ((set[SETSTART] + 1 == set[SETSTART + 1]) &&   // if the class only has one member eg., "T", it is stored as "TU"
+                (set[SETSTART + 2] == LastChar || set[SETSTART + 2] + 1 == set[SETSTART + 3])))
                 return true;
             else
                 return false;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -587,7 +587,7 @@ namespace System.Text.RegularExpressions
 
             for (i = 0, iMax = s_lcTable.Length; i < iMax;)
             {
-                iMid = (i + iMax) / 2;
+                iMid = (i & iMax) + ((i ^ iMax) >> 1); // Faster than (i + iMax) / 2;
                 if (s_lcTable[iMid].ChMax < chMin)
                     i = iMid + 1;
                 else
@@ -816,7 +816,7 @@ namespace System.Text.RegularExpressions
 
             while (min != max)
             {
-                mid = (min + max) / 2;
+                mid = (min & max) + ((min ^ max) >> 1); // Faster than (min + max) / 2
                 if (ch < set[mid])
                     max = mid;
                 else
@@ -1119,7 +1119,7 @@ namespace System.Text.RegularExpressions
             int max = s_propTable.Length;
             while (min != max)
             {
-                int mid = (min + max) / 2;
+                int mid = (min & max) + ((min ^ max) >> 1); // Faster than (min + max) / 2;
                 int res = string.Compare(capname, s_propTable[mid][0], StringComparison.Ordinal);
                 if (res < 0)
                     max = mid;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -716,7 +716,7 @@ namespace System.Text.RegularExpressions
 
         public static (char, char) DoubletonChars(string set)
         {
-            Debug.Assert(IsDoubleton(set), "Tried to get the singleton char out of a non singleton character class");
+            Debug.Assert(IsDoubleton(set), "Tried to get the doubleton char out of a non doubleton character class");
             return (set[SETSTART], set[SETSTART + 2]);
         }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -747,9 +747,12 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public static bool IsDoubleton(string set)
         {
-            if (set[FLAGS] == 0 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 4 && !IsSubtraction(set) &&
-                ((set[SETSTART] + 1 == set[SETSTART + 1]) &&   // if the class only has one member eg., "T", it is stored as "TU"
-                (set[SETSTART + 2] == LastChar || set[SETSTART + 2] + 1 == set[SETSTART + 3])))
+            if (set[FLAGS] == 0 && // it's not negated. [a-z^aeiuo] shows negation
+                set[CATEGORYLENGTH] == 0 && // there are no categories (like "punctuation") only raw ranges
+                set[SETLENGTH] == 4 && // negation + count + start and end of range = 4
+                !IsSubtraction(set) && // not a subtraction. [a-z-[aeiuo]] shows subtraction
+                ((set[SETSTART] + 1 == set[SETSTART + 1]) &&   // first range is a single character (note that end stored is one past actual end, so 'T' is stored as 'TU')
+                (set[SETSTART + 2] == LastChar || set[SETSTART + 2] + 1 == set[SETSTART + 3]))) // second range is a single character (LastChar check is for \uFFFF: the end could not be incremented in that case)
                 return true;
             else
                 return false;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1419,6 +1419,7 @@ namespace System.Text.RegularExpressions
                 Mvfldloc(s_textposF, _textposV);
                 Mvfldloc(s_textF, _textV);
 
+                // Forwardchars() {
                 if (!_code.RightToLeft)
                 {
                     Ldthisfld(s_textendF);
@@ -1431,18 +1432,23 @@ namespace System.Text.RegularExpressions
                 }
                 Sub();
                 Stloc(cV);
+                // }
 
+                // check i > 0 else return false
                 Ldloc(cV);
                 Ldc(0);
                 BleFar(l4);
 
+                // loop begin
                 MarkLabel(l1);
 
+                // i--
                 Ldloc(cV);
                 Ldc(1);
                 Sub();
                 Stloc(cV);
 
+                // Forwardcharnext() {
                 if (_code.RightToLeft)
                     Leftcharnext();
                 else
@@ -1450,20 +1456,22 @@ namespace System.Text.RegularExpressions
 
                 if (_fcPrefix.GetValueOrDefault().CaseInsensitive)
                     CallToLower();
+                // }
 
                 if (!RegexCharClass.IsSingleton(_fcPrefix.GetValueOrDefault().Prefix))
                 {
                     Ldstr(_fcPrefix.GetValueOrDefault().Prefix);
                     Call(s_charInSetM);
 
-                    BrtrueFar(l2);
+                    BrtrueFar(l2); // Backwardnext(); return true;
                 }
                 else
                 {
                     Ldc(RegexCharClass.SingletonChar(_fcPrefix.GetValueOrDefault().Prefix));
-                    Beq(l2);
+                    Beq(l2); // Backwardnext(); return true;
                 }
 
+                // if i > 0 continue loop
                 MarkLabel(l5);
 
                 Ldloc(cV);
@@ -1473,52 +1481,20 @@ namespace System.Text.RegularExpressions
                 else
                     Bgt(l1);
 
+                // return false, setting runtextpos
                 Ldc(0);
                 BrFar(l3);
 
+                // Backwardnext() {
                 MarkLabel(l2);
-
-                /*          // CURRENTLY DISABLED
-                            // If for some reason we have a prefix we didn't use, use it now.
-                
-                            if (_bmPrefix != null) {
-                                if (!_code._rightToLeft) {
-                                    Ldthisfld(_textendF);
-                                    Ldloc(_textposV);
-                                }
-                                else {
-                                    Ldloc(_textposV);
-                                    Ldthisfld(_textbegF);
-                                }
-                                Sub();
-                                Ldc(_bmPrefix._pattern.Length - 1);
-                                BltFar(l5);
-                                
-                                for (int i = 1; i < _bmPrefix._pattern.Length; i++) {
-                                    Ldloc(_textV);
-                                    Ldloc(_textposV);
-                                    if (!_code._rightToLeft) {
-                                        Ldc(i - 1);
-                                        Add();
-                                    }
-                                    else {
-                                        Ldc(i);
-                                        Sub();
-                                    }
-                                    Callvirt(_getcharM);
-                                    if (!_code._rightToLeft)
-                                        Ldc(_bmPrefix._pattern[i]);
-                                    else
-                                        Ldc(_bmPrefix._pattern[_bmPrefix._pattern.Length - 1 - i]);
-                                    BneFar(l5);
-                                }
-                            }
-                */
 
                 Ldloc(_textposV);
                 Ldc(1);
                 Sub(_code.RightToLeft);
                 Stloc(_textposV);
+                // }
+
+                // return true, setting runtextpos
                 Ldc(1);
 
                 MarkLabel(l3);
@@ -1526,6 +1502,7 @@ namespace System.Text.RegularExpressions
                 Mvlocfld(_textposV, s_textposF);
                 Ret();
 
+                // return false
                 MarkLabel(l4);
                 Ldc(0);
                 Ret();

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -430,6 +430,20 @@ namespace System.Text.RegularExpressions
                     }
                 }
             }
+            else if (RegexCharClass.IsDoubleton(set))
+            {
+                (char a, char b) chars = RegexCharClass.DoubletonChars(set);
+
+                for (i = Forwardchars(); i > 0; i--)
+                {
+                    char ch = Forwardcharnext();
+                    if (ch == chars.a || ch == chars.b)
+                    {
+                        Backwardnext();
+                        return true;
+                    }
+                }
+            }
             else
             {
                 for (int i = Forwardchars(); i > 0; i--)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -434,7 +434,7 @@ namespace System.Text.RegularExpressions
             {
                 (char a, char b) chars = RegexCharClass.DoubletonChars(set);
 
-                for (i = Forwardchars(); i > 0; i--)
+                for (int i = Forwardchars(); i > 0; i--)
                 {
                     char ch = Forwardcharnext();
                     if (ch == chars.a || ch == chars.b)


### PR DESCRIPTION
Regex-Redux spends much of its time scanning its huge input string to find the first character of a match ([see perf analysis here](https://github.com/dotnet/corefx/issues/27124) - this is the 20% or more time noted in CharInClassInternal)

This scan is the job of FindFirstChar(). In general character classes are complicated objects because they must store possibly several valid ranges, which may be character classes, as well as some options such as negating. They are packed objects and a binary search is used to check whether a candidate character matches the class. See http://www.moserware.com/2009/03/how-net-regular-expressions-really-work.html for a breakdown of how they work.

We do some optimizations to avoid this binary search for every character. First is Boyer-Moore which helps for long fixed prefix. Second is [IsSingleton](https://github.com/dotnet/corefx/blob/master/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs#L420), which special cases for positive match of a single specific character.

RegexRedux doesn't benefit much from either of these. It has no long prefix and in many cases there are several possible first characters. For example [here](https://github.com/dotnet/corefx/blob/master/src/System.Text.RegularExpressions/tests/Performance/Perf.RegexRedux.cs#L56) in `"agggt[cgt]aa|tt[acg]accct"` much of the time it is scanning for either `a` or `t`. In some cases there are some more options for example in `"agggtaa[cgt]|[acg]ttaccct"` it would start looking for `a`, `c` or `g` to begin the match. However two characters is the key case.

At this point we are looking for localized low risk changes.

Firstly I made a small speedup to the binary search by replacing `(min + max) / 2` with ` (min & max) + ((min ^ max) >> 1)` (apparently from Knuth .. it can be intuitively seen that halving the sum will retain all the bits they have in common, and half of all the bits they do not have in common). It is nice that it avoids overflow but that is not relevant in this case. This gave only a small improvement: I measured ~1% on an artificial test case and within noise on the full test. Nevertheless it is low harm so I retained it and used it in the other two binary searches in the file.

Secondly I special cased the "two possible characters" as IsDoubleton in the same pattern as existing IsSingleton. This gave a larger benefit, with no measureable hit on the generic test case:

## before
two runs:

  System.Text.RegularExpressions.Performance.Tests.dll                               | Metric         | Unit  | Iterations |    Average |   STDEV.S |        Min |        Max
  :--------------------------------------------------------------------------------- |:-------------- |:-----:|:----------:| ----------:| ---------:| ----------:| ----------:
   System.Text.RegularExpressions.Tests.Perf_Regex.Match                             | Duration       | msec  |     44     |    229.951 |    11.146 |    219.932 |    258.559
   System.Text.RegularExpressions.Tests.Perf_Regex.Match                             | GC Allocations | bytes |     44     | 1.871E+008 | 48478.158 | 1.870E+008 | 1.872E+008
   System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: Compiled) | Duration       | msec  |     27     |    377.521 |    20.081 |    335.727 |    419.947
   System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: None)     | Duration       | msec  |     15     |    709.439 |    31.986 |    655.717 |    765.097


   System.Text.RegularExpressions.Performance.Tests.dll                              | Metric         | Unit  | Iterations |    Average |   STDEV.S |        Min |        Max
  :--------------------------------------------------------------------------------- |:-------------- |:-----:|:----------:| ----------:| ---------:| ----------:| ----------:
   System.Text.RegularExpressions.Tests.Perf_Regex.Match                             | Duration       | msec  |     45     |    226.408 |    13.236 |    212.146 |    262.963
   System.Text.RegularExpressions.Tests.Perf_Regex.Match                             | GC Allocations | bytes |     45     | 1.871E+008 | 46358.265 | 1.869E+008 | 1.872E+008
   System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: Compiled) | Duration       | msec  |     28     |    366.970 |    17.217 |    337.323 |    407.299
   System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: None)     | Duration       | msec  |     15     |    700.781 |    35.247 |    653.294 |    790.779

## after
two runs:

  System.Text.RegularExpressions.Performance.Tests.dll                              | Metric         | Unit  | Iterations |    Average |   STDEV.S |        Min |        Max
  :--------------------------------------------------------------------------------- |:-------------- |:-----:|:----------:| ----------:| ---------:| ----------:| ----------:
   System.Text.RegularExpressions.Tests.Perf_Regex.Match                             | Duration       | msec  |     46     |    220.359 |     7.715 |    213.496 |    247.767
   System.Text.RegularExpressions.Tests.Perf_Regex.Match                             | GC Allocations | bytes |     46     | 1.871E+008 | 48166.588 | 1.870E+008 | 1.872E+008
   System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: Compiled) | Duration       | msec  |     29     |    345.858 |    22.669 |    318.472 |    412.110
   System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: None)     | Duration       | msec  |     15     |    667.597 |    33.483 |    624.545 |    745.706

  System.Text.RegularExpressions.Performance.Tests.dll                              | Metric         | Unit  | Iterations |    Average |   STDEV.S |        Min |        Max
  :--------------------------------------------------------------------------------- |:-------------- |:-----:|:----------:| ----------:| ---------:| ----------:| ----------:
   System.Text.RegularExpressions.Tests.Perf_Regex.Match                             | Duration       | msec  |     45     |    226.161 |    15.460 |    212.438 |    300.492
   System.Text.RegularExpressions.Tests.Perf_Regex.Match                             | GC Allocations | bytes |     45     | 1.871E+008 | 59941.718 | 1.869E+008 | 1.872E+008
   System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: Compiled) | Duration       | msec  |     29     |    354.753 |    22.682 |    310.074 |    390.565
   System.Text.RegularExpressions.Tests.RegexRedux.RegexReduxMini(options: None)     | Duration       | msec  |     15     |    666.738 |    30.583 |    621.243 |    709.226 


The RegexReduxMini not compiled improves by 6% (a little better than 1 std dev).  Compiled improves by about 6% but this is within noise: I would only expect the division to help and then slightly. The regular Match case also remains the same within noise.

At this point I only made the change in the interpreted mode. I annotated the relevant compiled mode code which demonstrates it is not a simple transliteration into IL. That is future work. Meantime I believe the risk of this change diverging behavior is low because it is an extension of existing singleton behavior.
