### PR TITLE
Fix proxied ipv6 address request formatting and fix port handling for proxied IP address on SocketsHttpHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -375,7 +375,18 @@ namespace System.Net.Http
                         // Proxied requests contain full URL
                         Debug.Assert(request.RequestUri.Scheme == Uri.UriSchemeHttp);
                         await WriteBytesAsync(s_httpSchemeAndDelimiter).ConfigureAwait(false);
-                        await WriteAsciiStringAsync(request.RequestUri.IdnHost).ConfigureAwait(false);
+
+                        // If the hostname is an IPv6 address, uri.IdnHost will return the address without enclosing [].
+                        // In this case, use uri.Host instead, which will correctly enclose with [].
+                        // Note we don't need punycode encoding if it's an IP address, so using uri.Host is fine.
+                        await WriteAsciiStringAsync(request.RequestUri.HostNameType == UriHostNameType.IPv6 ?
+                            request.RequestUri.Host : request.RequestUri.IdnHost).ConfigureAwait(false);
+
+                        if (!request.RequestUri.IsDefaultPort)
+                        {
+                            await WriteByteAsync((byte)':').ConfigureAwait(false);
+                            await WriteDecimalInt32Async(request.RequestUri.Port).ConfigureAwait(false);
+                        }
                     }
                     await WriteStringAsync(request.RequestUri.GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.UriEscaped)).ConfigureAwait(false);
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -499,13 +499,13 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData("321.123.456.789")]
-        [InlineData("321.123.456.789:8080")]
+        [InlineData("1.2.3.4")]
+        [InlineData("1.2.3.4:8080")]
         [InlineData("[::1234]")]
         [InlineData("[::1234]:8080")]
         public async Task ProxiedIPAddressRequest_NotDefaultPort_CorrectlyFormatted(string host)
         {
-            string ipAddress = "http://" + host;
+            string uri = "http://" + host;
             bool connectionAccepted = false;
 
             await LoopbackServer.CreateClientAndServerAsync(async proxyUri =>
@@ -514,13 +514,13 @@ namespace System.Net.Http.Functional.Tests
                 using (var client = new HttpClient(handler))
                 {
                     handler.Proxy = new WebProxy(proxyUri);
-                    try { await client.GetAsync(ipAddress); } catch { }
+                    try { await client.GetAsync(uri); } catch { }
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {
                 connectionAccepted = true;
                 List<string> headers = await connection.ReadRequestHeaderAndSendResponseAsync();
-                Assert.Contains($"GET {ipAddress}/ HTTP/1.1", headers);
+                Assert.Contains($"GET {uri}/ HTTP/1.1", headers);
             }));
 
             Assert.True(connectionAccepted);
@@ -529,7 +529,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [OuterLoop] // Test uses azure endpoint.
         [InlineData("corefx-net.cloudapp.net")]
-        [InlineData("321.123.456.789")]
+        [InlineData("1.2.3.4")]
         [InlineData("[::1234]")]
         public async Task ProxiedRequest_DefaultPort_PortStrippedOffInUri(string host)
         {


### PR DESCRIPTION
1. Fix IPv6 missing `[]` in proxied request.
2. Fix missing port number in the request.

If default ports 80 (for http connection) and 443 (for https connection) are specified for proxied request, 80 will be stripped off, while 443 will not. Because for https scheme, it will try to tunnel through the proxy (`CONNECT`), and port will not be stripped off.

Tests are added to document the behavior.

Fix: [#28609](https://github.com/dotnet/corefx/issues/28609) (moved to https://github.com/dotnet/runtime/issues/25677)