### PR TITLE
build-native.sh fails when using 'uname -p' to determine arch.

### DIFF
--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -173,12 +173,7 @@ __ClangMinorVersion=0
 __StaticLibLink=0
 __PortableBuild=0
 
-CPUName=$(uname -p)
-# Some Linux platforms report unknown for processor, but the arch for machine.
-if [ "$CPUName" == "unknown" ]; then
-    CPUName=$(uname -m)
-fi
-
+CPUName=$(uname -m)
 if [ "$CPUName" == "i686" ]; then
     __BuildArch=x86
 fi

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -174,12 +174,12 @@ __StaticLibLink=0
 __PortableBuild=0
 
 CPUName=$(uname -p)
-# Some Linux platforms report unknown for platform, but the arch for machine.
-if [ $CPUName == "unknown" ]; then
+# Some Linux platforms report unknown for processor, but the arch for machine.
+if [ "$CPUName" == "unknown" ]; then
     CPUName=$(uname -m)
 fi
 
-if [ $CPUName == "i686" ]; then
+if [ "$CPUName" == "i686" ]; then
     __BuildArch=x86
 fi
 


### PR DESCRIPTION
uname -p actually returns the processor type, not the 'platform' as the comment suggested.
Quote the $CPUName variable when referencing it as the processor type returned via 'uname -p' can contain spaces.

Examples:
> uname -p
Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz
> uname -p
Intel(R) Core(TM)2 Duo CPU E6750 @ 2.66GHz

This fixes #28761