### PR TITLE
Stop artificially rooting SocketAsyncEventArgs

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -536,7 +536,11 @@ namespace System.Net.Sockets
             {
                 _context = ExecutionContext.Capture();
             }
+
+            StartOperationCommonCore();
         }
+
+        partial void StartOperationCommonCore();
 
         internal void StartOperationAccept()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.netcoreapp.cs
@@ -4,7 +4,10 @@
 
 using System.Buffers;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Xunit;
 
 namespace System.Net.Sockets.Tests
@@ -191,6 +194,55 @@ namespace System.Net.Sockets.Tests
                 Assert.Equal(m.Length, saea.Count);
                 Assert.Null(saea.Buffer);
             }
+        }
+
+        [OuterLoop("Involves GC and finalization")]
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Finalizer_InvokedWhenNoLongerReferenced(bool afterAsyncOperation)
+        {
+            var cwt = new ConditionalWeakTable<object, object>();
+
+            for (int i = 0; i < 5; i++) // create several SAEA instances, stored into cwt
+            {
+                CreateSocketAsyncEventArgs();
+
+                void CreateSocketAsyncEventArgs() // separated out so that JIT doesn't extend lifetime of SAEA instances
+                {
+                    var saea = new SocketAsyncEventArgs();
+                    cwt.Add(saea, saea);
+
+                    if (afterAsyncOperation)
+                    {
+                        using (Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                        {
+                            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                            listener.Listen(1);
+
+                            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                            {
+                                saea.RemoteEndPoint = listener.LocalEndPoint;
+                                using (var mres = new ManualResetEventSlim())
+                                {
+                                    saea.Completed += (s, e) => mres.Set();
+                                    if (client.ConnectAsync(saea))
+                                    {
+                                        mres.Wait();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                return cwt.Count() == 0; // validate that the cwt becomes empty
+            }, 30_000));
         }
     }
 }


### PR DESCRIPTION
SocketAsyncEventArgs creates an overlapped object that references the SAEA.  That overlapped object creates an async pinning handle in the runtime, which roots the SocketAsyncEventArgs.  The cycle from SAEA->Overlapped->handle->SAEA involving the root means that a dropped SAEA that's not Dispose'd will end up leaking.

This commit fixes that by adding a level of indirection between the handle and the SAEA.  Rather than wrapping the SAEA directly, the handle is given an intermediate object that references the SAEA, and the SAEA then stores itself as a reference into that object only while an active operation is in progress.  Once the operation completes, the reference in that object is nulled out, and the SAEA will no longer be kept alive by the pinning handle.

Fixes https://github.com/dotnet/corefx/issues/28746
cc: @geoffkizer, @davidsh, @halter73 