### PR TITLE
Fix build with xcode 9.3 on OSX

### DIFF
--- a/src/Native/Unix/Common/pal_compiler.h
+++ b/src/Native/Unix/Common/pal_compiler.h
@@ -15,6 +15,8 @@
 
 #ifdef static_assert
 #define c_static_assert(e) static_assert((e),"")
+#elif defined(__has_extension) && __has_extension(c_static_assert)
+#define c_static_assert(e) _Static_assert((e), "")
 #else
 #define c_static_assert(e) typedef char __c_static_assert__[(e)?1:-1]
 #endif


### PR DESCRIPTION
The c_static_assert definition is causing build problems on OSX.
The compiler complains about the typedef we use to implement the
c_static_assert:
`declaration shadows a typedef in the global scope [-Werror,-Wshadow]`
This is due to multiple static asserts

To fix it, I have modified the c_static_assert to use _Static_assert
C feature that's available in clang.