### PR TITLE
PropertyDescriptor - MemberDescriptor.Attributes

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -377,16 +377,20 @@ namespace System.ComponentModel
                     list = new List<Attribute>(_attributes);
                 }
 
-                var set = new HashSet<object>();
+                var map = new Dictionary<object, int>();
 
                 for (int i = 0; i < list.Count;)
                 {
-                    if (set.Add(list[i].TypeId))
+                    int savedIndex = -1;
+                    object typeId = list[i].TypeId;
+                    if (!map.TryGetValue(typeId, out savedIndex))
                     {
-                        ++i;
+                        map.Add(typeId, i);
+                        i++;
                     }
                     else
                     {
+                        list[savedIndex] = list[i];
                         list.RemoveAt(i);
                     }
                 }

--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
@@ -160,6 +160,13 @@ namespace System.ComponentModel.Tests
             Assert.NotEqual(firstAssociatedObject, firstAssociation);
         }
 
+        [Fact]
+        public void DerivedPropertyAttribute() {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(FooBarDerived))["Value"];
+            var descriptionAttribute = (DescriptionAttribute)property.Attributes[typeof(DescriptionAttribute)];
+            Assert.Equal("Derived", descriptionAttribute.Description);
+        }
+
         private class InvocationRecordingTypeDescriptionProvider : TypeDescriptionProvider
         {
             public bool ReceivedCall { get; private set; } = false;
@@ -219,6 +226,18 @@ namespace System.ComponentModel.Tests
                 ReceivedCall = true;
                 return base.IsSupportedType(type);
             }
+        }
+
+        class FooBarBase
+        {
+            [Description("Base")]
+            public virtual int Value { get; set; }
+        }
+
+        class FooBarDerived : FooBarBase 
+        {
+            [Description("Derived")]
+            public override int Value { get; set; }
         }
 
         private static Tuple<Type, Type>[] s_typesWithConverters =


### PR DESCRIPTION
Port the change #26756 into 2.0

Fixes #26600
PropertyDescriptor - MemberDescriptor.Attributes returns base attribute instead of ancestor's attribute