### PR TITLE
Pin PlatformAbstraction version to last stable

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -40,7 +40,6 @@
     <MicrosoftNETCoreDotNetHostPackageVersion>2.1.0-preview3-26402-02</MicrosoftNETCoreDotNetHostPackageVersion>
     <MicrosoftNETCoreDotNetHostPolicyPackageVersion>2.1.0-preview3-26402-02</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview3-26402-02</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftDotNetPlatformAbstractionsPackageVersion>2.1.0-preview3-26402-02</MicrosoftDotNetPlatformAbstractionsPackageVersion>
 
     <!-- CoreFX-built SNI identity package -->
     <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
@@ -169,11 +168,6 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>MicrosoftNETCoreAppPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.App</PackageId>
-    </XmlUpdateStep>
-    <XmlUpdateStep Include="CoreSetup">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>MicrosoftDotNetPlatformAbstractionsPackageVersion</ElementName>
-      <PackageId>Microsoft.DotNet.PlatformAbstractions</PackageId>
     </XmlUpdateStep>
     <UpdateStep Include="BuildTools">
       <UpdaterType>File</UpdaterType>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -51,7 +51,7 @@
       <Version>0.10.0-alpha-experimental</Version>
     </PackageReference>
     <PackageReference Condition="'$(TargetGroup)' != 'uapaot'" Include="Microsoft.DotNet.PlatformAbstractions">
-      <Version>$(MicrosoftDotNetPlatformAbstractionsPackageVersion)</Version>
+      <Version>2.0.4</Version>
     </PackageReference>
     <PackageReference Include="CommandLineParser">
       <Version>2.1.1-beta</Version>


### PR DESCRIPTION
We cannot depend on the latest PlatformAbstractions package
which is built from core-setup as it adds a cycle which we cannot
have in our source-build. To fix this temporarily we are pinning
to the last stable version 2.0.4.

See issue https://github.com/dotnet/corefx/issues/28620.

cc @eerhardt @krwq 

Port of change https://github.com/dotnet/corefx/pull/28778 into master