### PR TITLE
Enable faster invoke in interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <IsInterpreting Condition="'$(TargetGroup)' == 'uapaot'">true</IsInterpreting>
+    <DefineConstants> $(DefineConstants);FEATURE_DLG_INVOKE</DefineConstants>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <IsInterpreting Condition="'$(TargetGroup)' == 'uapaot'">true</IsInterpreting>
-    <DefineConstants> $(DefineConstants);FEATURE_DLG_INVOKE</DefineConstants>
+    <DefineConstants> $(DefineConstants);FEATURE_DLG_INVOKE;FEATURE_FAST_CREATE</DefineConstants>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -24,6 +24,7 @@ namespace System.Dynamic.Utils
 
 #if !FEATURE_DYNAMIC_DELEGATE
 
+        private static readonly CacheDict<Type, DynamicMethod> s_thunks = new CacheDict<Type, DynamicMethod>(256);
         private static readonly MethodInfo s_FuncInvoke = typeof(Func<object[], object>).GetMethod("Invoke");
         private static readonly MethodInfo s_ArrayEmpty = typeof(Array).GetMethod(nameof(Array.Empty)).MakeGenericMethod(typeof(object));
 
@@ -42,107 +43,113 @@ namespace System.Dynamic.Utils
         // return (TRet)ret;
         private static Delegate CreateObjectArrayDelegateRefEmit(Type delegateType, Func<object[], object> handler)
         {
-            MethodInfo delegateInvokeMethod = delegateType.GetInvokeMethod();
+            DynamicMethod thunkMethod;
 
-            Type returnType = delegateInvokeMethod.ReturnType;
-            bool hasReturnValue = returnType != typeof(void);
-
-            ParameterInfo[] parameters = delegateInvokeMethod.GetParametersCached();
-            Type[] paramTypes = new Type[parameters.Length + 1];
-            paramTypes[0] = typeof(Func<object[], object>);
-            for (int i = 0; i < parameters.Length; i++)
+            if (!s_thunks.TryGetValue(delegateType, out thunkMethod))
             {
-                paramTypes[i + 1] = parameters[i].ParameterType;
-            }
+                MethodInfo delegateInvokeMethod = delegateType.GetInvokeMethod();
 
-            DynamicMethod thunkMethod = new DynamicMethod("Thunk", returnType, paramTypes);
-            ILGenerator ilgen = thunkMethod.GetILGenerator();
+                Type returnType = delegateInvokeMethod.ReturnType;
+                bool hasReturnValue = returnType != typeof(void);
 
-            LocalBuilder argArray = ilgen.DeclareLocal(typeof(object[]));
-            LocalBuilder retValue = ilgen.DeclareLocal(typeof(object));
-
-            // create the argument array
-            if (parameters.Length == 0)
-            {
-                ilgen.Emit(OpCodes.Call, s_ArrayEmpty);
-            }
-            else
-            {
-                ilgen.Emit(OpCodes.Ldc_I4, parameters.Length);
-                ilgen.Emit(OpCodes.Newarr, typeof(object));
-            }
-            ilgen.Emit(OpCodes.Stloc, argArray);
-
-            // populate object array
-            bool hasRefArgs = false;
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                bool paramIsByReference = parameters[i].ParameterType.IsByRef;
-                Type paramType = parameters[i].ParameterType;
-                if (paramIsByReference)
-                    paramType = paramType.GetElementType();
-
-                hasRefArgs = hasRefArgs || paramIsByReference;
-
-                ilgen.Emit(OpCodes.Ldloc, argArray);
-                ilgen.Emit(OpCodes.Ldc_I4, i);
-                ilgen.Emit(OpCodes.Ldarg, i + 1);
-
-                if (paramIsByReference)
-                {
-                    ilgen.Emit(OpCodes.Ldobj, paramType);
-                }
-                Type boxType = ConvertToBoxableType(paramType);
-                ilgen.Emit(OpCodes.Box, boxType);
-                ilgen.Emit(OpCodes.Stelem_Ref);
-            }
-
-            if (hasRefArgs)
-            {
-                ilgen.BeginExceptionBlock();
-            }
-
-            // load delegate
-            ilgen.Emit(OpCodes.Ldarg_0);
-
-            // load array
-            ilgen.Emit(OpCodes.Ldloc, argArray);
-
-            // invoke Invoke
-            ilgen.Emit(OpCodes.Callvirt, s_FuncInvoke);
-            ilgen.Emit(OpCodes.Stloc, retValue);
-
-            if (hasRefArgs)
-            {
-                // copy back ref/out args
-                ilgen.BeginFinallyBlock();
+                ParameterInfo[] parameters = delegateInvokeMethod.GetParametersCached();
+                Type[] paramTypes = new Type[parameters.Length + 1];
+                paramTypes[0] = typeof(Func<object[], object>);
                 for (int i = 0; i < parameters.Length; i++)
                 {
-                    if (parameters[i].ParameterType.IsByRef)
-                    {
-                        Type byrefToType = parameters[i].ParameterType.GetElementType();
-
-                        // update parameter
-                        ilgen.Emit(OpCodes.Ldarg, i + 1);
-                        ilgen.Emit(OpCodes.Ldloc, argArray);
-                        ilgen.Emit(OpCodes.Ldc_I4, i);
-                        ilgen.Emit(OpCodes.Ldelem_Ref);
-                        ilgen.Emit(OpCodes.Unbox_Any, byrefToType);
-                        ilgen.Emit(OpCodes.Stobj, byrefToType);
-                    }
+                    paramTypes[i + 1] = parameters[i].ParameterType;
                 }
-                ilgen.EndExceptionBlock();
+
+                thunkMethod = new DynamicMethod("Thunk", returnType, paramTypes);
+                ILGenerator ilgen = thunkMethod.GetILGenerator();
+
+                LocalBuilder argArray = ilgen.DeclareLocal(typeof(object[]));
+                LocalBuilder retValue = ilgen.DeclareLocal(typeof(object));
+
+                // create the argument array
+                if (parameters.Length == 0)
+                {
+                    ilgen.Emit(OpCodes.Call, s_ArrayEmpty);
+                }
+                else
+                {
+                    ilgen.Emit(OpCodes.Ldc_I4, parameters.Length);
+                    ilgen.Emit(OpCodes.Newarr, typeof(object));
+                }
+                ilgen.Emit(OpCodes.Stloc, argArray);
+
+                // populate object array
+                bool hasRefArgs = false;
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    bool paramIsByReference = parameters[i].ParameterType.IsByRef;
+                    Type paramType = parameters[i].ParameterType;
+                    if (paramIsByReference)
+                        paramType = paramType.GetElementType();
+
+                    hasRefArgs = hasRefArgs || paramIsByReference;
+
+                    ilgen.Emit(OpCodes.Ldloc, argArray);
+                    ilgen.Emit(OpCodes.Ldc_I4, i);
+                    ilgen.Emit(OpCodes.Ldarg, i + 1);
+
+                    if (paramIsByReference)
+                    {
+                        ilgen.Emit(OpCodes.Ldobj, paramType);
+                    }
+                    Type boxType = ConvertToBoxableType(paramType);
+                    ilgen.Emit(OpCodes.Box, boxType);
+                    ilgen.Emit(OpCodes.Stelem_Ref);
+                }
+
+                if (hasRefArgs)
+                {
+                    ilgen.BeginExceptionBlock();
+                }
+
+                // load delegate
+                ilgen.Emit(OpCodes.Ldarg_0);
+
+                // load array
+                ilgen.Emit(OpCodes.Ldloc, argArray);
+
+                // invoke Invoke
+                ilgen.Emit(OpCodes.Callvirt, s_FuncInvoke);
+                ilgen.Emit(OpCodes.Stloc, retValue);
+
+                if (hasRefArgs)
+                {
+                    // copy back ref/out args
+                    ilgen.BeginFinallyBlock();
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        if (parameters[i].ParameterType.IsByRef)
+                        {
+                            Type byrefToType = parameters[i].ParameterType.GetElementType();
+
+                            // update parameter
+                            ilgen.Emit(OpCodes.Ldarg, i + 1);
+                            ilgen.Emit(OpCodes.Ldloc, argArray);
+                            ilgen.Emit(OpCodes.Ldc_I4, i);
+                            ilgen.Emit(OpCodes.Ldelem_Ref);
+                            ilgen.Emit(OpCodes.Unbox_Any, byrefToType);
+                            ilgen.Emit(OpCodes.Stobj, byrefToType);
+                        }
+                    }
+                    ilgen.EndExceptionBlock();
+                }
+
+                if (hasReturnValue)
+                {
+                    ilgen.Emit(OpCodes.Ldloc, retValue);
+                    ilgen.Emit(OpCodes.Unbox_Any, ConvertToBoxableType(returnType));
+                }
+
+                ilgen.Emit(OpCodes.Ret);
+
+                s_thunks[delegateType] = thunkMethod;
             }
 
-            if (hasReturnValue)
-            {
-                ilgen.Emit(OpCodes.Ldloc, retValue);
-                ilgen.Emit(OpCodes.Unbox_Any, ConvertToBoxableType(returnType));
-            }
-
-            ilgen.Emit(OpCodes.Ret);
-
-            // TODO: we need to cache these.
             return thunkMethod.CreateDelegate(delegateType, handler);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -42,7 +42,6 @@ namespace System.Linq.Expressions.Interpreter
                 return new ActionCallInstruction(target);
             }
 
-            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:
@@ -85,7 +84,6 @@ namespace System.Linq.Expressions.Interpreter
                 return new FuncCallInstruction<T0>(target);
             }
 
-            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:
@@ -128,7 +126,6 @@ namespace System.Linq.Expressions.Interpreter
                 return new FuncCallInstruction<T0, T1>(target);
             }
 
-            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -4,6 +4,8 @@
 
 using System.Reflection;
 using System.Dynamic.Utils;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -19,7 +21,7 @@ namespace System.Linq.Expressions.Interpreter
         public override string InstructionName => "Call";
 
 #if FEATURE_DLG_INVOKE
-        private static readonly Dictionary<MethodInfo, CallInstruction> _cache = new Dictionary<MethodInfo, CallInstruction>();
+         private static readonly ConditionalWeakTable<MethodInfo, CallInstruction> _cache = new ConditionalWeakTable<MethodInfo, CallInstruction>();
 #endif
 
         public static CallInstruction Create(MethodInfo info)
@@ -72,12 +74,9 @@ namespace System.Linq.Expressions.Interpreter
             CallInstruction res;
             if (ShouldCache(info))
             {
-                lock (_cache)
+                if (_cache.TryGetValue(info, out res))
                 {
-                    if (_cache.TryGetValue(info, out res))
-                    {
-                        return res;
-                    }
+                    return res;
                 }
             }
 
@@ -116,10 +115,7 @@ namespace System.Linq.Expressions.Interpreter
             // cache it for future users if it's a reasonable method to cache
             if (ShouldCache(info))
             {
-                lock (_cache)
-                {
-                    _cache[info] = res;
-                }
+                _cache.AddOrUpdate(info, res);
             }
 
             return res;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -21,7 +21,7 @@ namespace System.Linq.Expressions.Interpreter
         public override string InstructionName => "Call";
 
 #if FEATURE_DLG_INVOKE
-         private static readonly ConditionalWeakTable<MethodInfo, CallInstruction> _cache = new ConditionalWeakTable<MethodInfo, CallInstruction>();
+        private static readonly CacheDict<MethodInfo, CallInstruction> s_cache = new CacheDict<MethodInfo, CallInstruction>(256);
 #endif
 
         public static CallInstruction Create(MethodInfo info)
@@ -74,7 +74,7 @@ namespace System.Linq.Expressions.Interpreter
             CallInstruction res;
             if (ShouldCache(info))
             {
-                if (_cache.TryGetValue(info, out res))
+                if (s_cache.TryGetValue(info, out res))
                 {
                     return res;
                 }
@@ -115,7 +115,7 @@ namespace System.Linq.Expressions.Interpreter
             // cache it for future users if it's a reasonable method to cache
             if (ShouldCache(info))
             {
-                _cache.AddOrUpdate(info, res);
+                s_cache[info] = res;
             }
 
             return res;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NullCheckInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NullCheckInstruction.cs
@@ -16,11 +16,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            if (frame.Peek() == null)
-            {
-                throw new NullReferenceException();
-            }
-
+            NullCheck(frame.Peek());
             return 1;
         }
     }

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -90,7 +90,6 @@ namespace System.Linq.Expressions.Tests
             MethodCallExpression call = Expression.Call(typeof(NonGenericClass).GetMethod("FooEnum"), p);
             Func<NonGenericClass.E1, NonGenericClass.E2> lambda = Expression.Lambda<Func<NonGenericClass.E1, NonGenericClass.E2>>(call, p).Compile(useInterpreter);
 
-            object boxed = new Mutable();
             Assert.Equal(NonGenericClass.E2.One, lambda(NonGenericClass.E1.One));
             Assert.Equal(NonGenericClass.E2.Two, lambda(NonGenericClass.E1.Two));
         }

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -84,6 +84,19 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
+        public static void EnumArgAndReturn(bool useInterpreter)
+        {
+            ParameterExpression p = Expression.Parameter(typeof(NonGenericClass.E1));
+            MethodCallExpression call = Expression.Call(typeof(NonGenericClass).GetMethod("FooEnum"), p);
+            Func<NonGenericClass.E1, NonGenericClass.E2> lambda = Expression.Lambda<Func<NonGenericClass.E1, NonGenericClass.E2>>(call, p).Compile(useInterpreter);
+
+            object boxed = new Mutable();
+            Assert.Equal(NonGenericClass.E2.One, lambda(NonGenericClass.E1.One));
+            Assert.Equal(NonGenericClass.E2.Two, lambda(NonGenericClass.E1.Two));
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
         public static void MultiRankArrayWriteBack(bool useInterpreter)
         {
             ParameterExpression p = Expression.Parameter(typeof(Mutable[,]));
@@ -699,6 +712,23 @@ namespace System.Linq.Expressions.Tests
             public void InstanceMethod3(int i1, int i2, int i3) { }
             public void InstanceMethod4(int i1, int i2, int i3, int i4) { }
             public static void StaticMethod1(int i1) { }
+
+            public enum E1 : byte
+            {
+                One,
+                Two
+            }
+
+            public enum E2 : int
+            {
+                One,
+                Two
+            }
+
+            public static E2 FooEnum(E1 arg)
+            {
+                return (E2)arg;
+            }
         }
 
         public interface Interface1


### PR DESCRIPTION
The change follows up on several TODOs and commented out unfinished implementation.

In cases where it is possible, we can avoid expensive calls via reflection and use more efficient delegate-based thunks. These are also the most common scenarios. 
When optimized invocations are not possible (too many arguments, byref arguments, etc..) we still use reflection.

For the cases where we create thunks, there are small caches to hold the recently used ones - just to opportunistically avoid costs of creating thunk delegates again. That is particularly important when the thunks are created via Ref.Emit.

- [x] enable fast invoke pass
- [x] enable caching on reverse invoke (at the entry points to the interpreter lambdas)
- [x] enable fast invoker creation


