### PR TITLE
Use cached IdnMapping instances

### DIFF
--- a/src/Common/src/System/Net/Security/CertificateValidation.Unix.cs
+++ b/src/Common/src/System/Net/Security/CertificateValidation.Unix.cs
@@ -11,6 +11,8 @@ namespace System.Net.Security
 {
     internal static class CertificateValidation
     {
+        private static readonly IdnMapping s_idnMapping = new IdnMapping();
+
         internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, string hostName)
         {
             SslPolicyErrors errors = chain.Build(remoteCertificate) ?
@@ -41,8 +43,7 @@ namespace System.Net.Security
                     // The IdnMapping converts Unicode input into the IDNA punycode sequence.
                     // It also does host case normalization.  The bypass logic would be something
                     // like "all characters being within [a-z0-9.-]+"
-                    // Since it's not documented as being thread safe, create a new one each time.
-                    string matchName = new IdnMapping().GetAscii(hostName);
+                    string matchName = s_idnMapping.GetAscii(hostName);
                     hostNameMatch = Interop.Crypto.CheckX509Hostname(certHandle, matchName, matchName.Length);
                 }
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/GeneralNameEncoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/GeneralNameEncoder.cs
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography.X509Certificates
             RegisteredId = DerSequenceReader.ContextSpecificTagFlag | 8,
         }
 
-        private readonly IdnMapping _idnMapping = new IdnMapping();
+        private static readonly IdnMapping s_idnMapping = new IdnMapping();
 
         internal byte[][] EncodeEmailAddress(string emailAddress)
         {
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         internal byte[][] EncodeDnsName(string dnsName)
         {
-            string idnaName = _idnMapping.GetAscii(dnsName);
+            string idnaName = s_idnMapping.GetAscii(dnsName);
             byte[][] dnsNameTlv = DerEncoder.SegmentedEncodeIA5String(idnaName.ToCharArray());
             dnsNameTlv[0][0] = (byte)GeneralNameTag.DnsName;
 


### PR DESCRIPTION
IdnMapping isn't currently documented to be thread-safe, but other than the properties which these uses don't change, it is.  Since all of this is part of netcoreapp, it's fine to rely on that implementation detail, and we can avoid allocating a new IdnMapping instance per use. (We already do this in other places, too.)

cc: @krwq, @bartonjs, @tarekgh 