### PR TITLE
Add regression test for Task handling of suppressed ExecutionContext flow

### DIFF
--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="MethodCoverage.cs" />
     <Compile Include="CESchedulerPairTests.cs" />
     <!-- Task -->
+    <Compile Include="Task\ExecutionContextFlowTest.cs" />
     <Compile Include="Task\RunContinuationsAsynchronouslyTests.cs" />
     <Compile Include="Task\TPLTestException.cs" />
     <Compile Include="Task\TaskRunSyncTests.cs" />

--- a/src/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests
+{
+    public class ExecutionContextFlowTest
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SuppressFlow_TaskCapturesContextAccordingly(bool suppressFlow)
+        {
+            Assert.False(ExecutionContext.IsFlowSuppressed());
+            if (suppressFlow) ExecutionContext.SuppressFlow();
+            try
+            {
+                var asyncLocal = new AsyncLocal<int>();
+                Task.Factory.StartNew(() => asyncLocal.Value = 42, CancellationToken.None, TaskCreationOptions.None, new InlineTaskScheduler()).Wait();
+                Assert.Equal(suppressFlow ? 42 : 0, asyncLocal.Value);
+            }
+            finally
+            {
+                if (suppressFlow) ExecutionContext.RestoreFlow();
+            }
+        }
+
+        private sealed class InlineTaskScheduler : TaskScheduler
+        {
+            protected override void QueueTask(Task task) => TryExecuteTask(task);
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => TryExecuteTask(task);
+            protected override IEnumerable<Task> GetScheduledTasks() => null;
+        }
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/17407 (one of the cases won't pass until that change is consumed into corefx)
Contributes to https://github.com/dotnet/coreclr/issues/17403
cc: @sdmaclea, @kouvel 