### PR TITLE
Update WhenAllOrAnyFailed test helper with aggregation timeout

### DIFF
--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -36,6 +36,9 @@
     <Compile Include="PipeTest.Read.cs" />
     <Compile Include="PipeTest.Write.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+      <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="NamedPipeTests\NamedPipeTest.CurrentUserOnly.netcoreapp.cs" />


### PR DESCRIPTION
I suspect that some of the sporadic failures we've seen in CI in networking tests have included misleading exceptions.  This is an attempt to address that.

A bunch of our tests use a WhenAllOrAnyFailed helper.  It's used in situations where we have a client task and server task, and we want to wait for both of them to complete, but because they interact with each other, we don't want to deadlock in a situation where one of them failing means the other will never complete.  However, since the helper ends up propagating the exception from whichever completes first, it also means in some situations, for example, the client might fail with an exception that highlights the real reason for the overall failure, but we could end up recording the exception the server then incurs due to the client tearing down the connection.

This commit modifies the helper.  On the success path where both tasks complete successfully, nothing is different.  On the failure path, though, rather than just immediately propagating the first exception we got, we wait for up to 3 seconds for additional tasks to complete.  Once either they've all completed or we've reached the timeout, we then loop through all of the tasks and gather up all of the exceptions, and propagate those in an aggregate, hopefully providing more details for the real reason the test failed.

cc: @geoffkizer, @wfurt, @pjanotti 