### PR TITLE
Add perf tests for {U}Int32/64 ToString/TryFormat/Parse

### DIFF
--- a/src/System.Runtime/tests/Performance/Perf.Int64.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Int64.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using Xunit;
+
+namespace System.Tests
+{
+    public class Perf_Int64
+    {
+        private const int InnerCount = 500_000;
+
+        private static string s_resultString;
+        private static int s_resultInt32;
+        private static long s_resultInt64;
+
+        public static object[][] Int64Values => new[]
+        {
+            new object[] { 214748364L },
+            new object[] { 2L },
+            new object[] { 21474836L },
+            new object[] { 21474L },
+            new object[] { 214L },
+            new object[] { 2147L },
+            new object[] { 214748L },
+            new object[] { 21L },
+            new object[] { 2147483L },
+            new object[] { 922337203685477580L },
+            new object[] { 92233720368547758L },
+            new object[] { 9223372036854775L },
+            new object[] { 922337203685477L },
+            new object[] { 92233720368547L },
+            new object[] { 9223372036854L },
+            new object[] { 922337203685L },
+            new object[] { 92233720368L },
+            new object[] { -214748364L },
+            new object[] { -2L },
+            new object[] { -21474836L },
+            new object[] { -21474L },
+            new object[] { -214L },
+            new object[] { -2147L },
+            new object[] { -214748L },
+            new object[] { -21L },
+            new object[] { -2147483L },
+            new object[] { -922337203685477580L },
+            new object[] { -92233720368547758L },
+            new object[] { -9223372036854775L },
+            new object[] { -922337203685477L },
+            new object[] { -92233720368547L },
+            new object[] { -9223372036854L },
+            new object[] { -922337203685L },
+            new object[] { -92233720368L },
+            new object[] { 0L },
+            new object[] { -9223372036854775808L }, // min value
+            new object[] { 9223372036854775807L }, // max value
+            new object[] { -2147483648L }, // int32 min value
+            new object[] { 2147483647L }, // int32 max value
+            new object[] { -4294967295000000000L }, // -(uint.MaxValue * Billion)
+            new object[] { 4294967295000000000L }, // uint.MaxValue * Billion
+            new object[] { -4294967295000000001L }, // -(uint.MaxValue * Billion + 1)
+            new object[] { 4294967295000000001L }, // uint.MaxValue * Billion + 1
+        };
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [MemberData(nameof(Int64Values))]
+        public void ToString(long value)
+        {
+            Span<char> destination = new char[value.ToString().Length];
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < InnerCount; i++)
+                    {
+                        s_resultString = value.ToString();
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [MemberData(nameof(Int64Values))]
+        public void TryFormat(long value)
+        {
+            Span<char> destination = new char[value.ToString().Length];
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < InnerCount; i++)
+                    {
+                        value.TryFormat(destination, out s_resultInt32);
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [MemberData(nameof(Int64Values))]
+        public void Parse(long value)
+        {
+            ReadOnlySpan<char> valueSpan = value.ToString();
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < InnerCount; i++)
+                    {
+                        s_resultInt64 = long.Parse(valueSpan);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.UInt32.cs
+++ b/src/System.Runtime/tests/Performance/Perf.UInt32.cs
@@ -3,23 +3,76 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Xunit.Performance;
+using Xunit;
 
 namespace System.Tests
 {
     public class Perf_UInt32
     {
-        [Benchmark]
-        public void ToString_()
+        private const int InnerCount = 500_000;
+
+        private static string s_resultString;
+        private static int s_resultInt32;
+        private static uint s_resultUInt32;
+
+        public static object[][] UInt32Values => new[]
         {
-            uint testint = new uint();
-            foreach (var iteration in Benchmark.Iterations)
+            new object[] { 0u },
+            new object[] { 1u },
+            new object[] { 1283u },
+            new object[] { 12837467u },
+            new object[] { 4294967295u },
+        };
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [MemberData(nameof(UInt32Values))]
+        public void ToString(uint value)
+        {
+            Span<char> destination = new char[value.ToString().Length];
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
                 using (iteration.StartMeasurement())
-                    for (int i = 0; i < 10000; i++)
+                {
+                    for (int i = 0; i < InnerCount; i++)
                     {
-                        testint.ToString(); testint.ToString(); testint.ToString();
-                        testint.ToString(); testint.ToString(); testint.ToString();
-                        testint.ToString(); testint.ToString(); testint.ToString();
+                        s_resultString = value.ToString();
                     }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [MemberData(nameof(UInt32Values))]
+        public void TryFormat(uint value)
+        {
+            Span<char> destination = new char[value.ToString().Length];
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < InnerCount; i++)
+                    {
+                        value.TryFormat(destination, out s_resultInt32);
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [MemberData(nameof(UInt32Values))]
+        public void Parse(uint value)
+        {
+            ReadOnlySpan<char> valueSpan = value.ToString();
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < InnerCount; i++)
+                    {
+                        s_resultUInt32 = uint.Parse(valueSpan);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.UInt64.cs
+++ b/src/System.Runtime/tests/Performance/Perf.UInt64.cs
@@ -7,29 +7,45 @@ using Xunit;
 
 namespace System.Tests
 {
-    public class Perf_Int32
+    public class Perf_UInt64
     {
-        private const int InnerCount = 500_000;
+        private const int InnerCount = 100_000;
 
         private static string s_resultString;
         private static int s_resultInt32;
+        private static ulong s_resultUInt64;
 
-        public static object[][] Int32Values => new[]
+        public static object[][] UInt64Values => new[]
         {
-            new object[] { 0 },
-            new object[] { -1 },
-            new object[] { 1 },
-            new object[] { -1283 },
-            new object[] { 1283 },
-            new object[] { -12837467 },
-            new object[] { 12837467 },
-            new object[] { -2147483648 },
-            new object[] { 2147483647 },
+            new object[] { 214748364LU },
+            new object[] { 2LU },
+            new object[] { 21474836LU },
+            new object[] { 21474LU },
+            new object[] { 214LU },
+            new object[] { 2147LU },
+            new object[] { 214748LU },
+            new object[] { 21LU },
+            new object[] { 2147483LU },
+            new object[] { 922337203685477580LU },
+            new object[] { 92233720368547758LU },
+            new object[] { 9223372036854775LU },
+            new object[] { 922337203685477LU },
+            new object[] { 92233720368547LU },
+            new object[] { 9223372036854LU },
+            new object[] { 922337203685LU },
+            new object[] { 92233720368LU },
+            new object[] { 0LU }, // min value
+            new object[] { 18446744073709551615LU }, // max value
+            new object[] { 2147483647LU }, // int32 max value
+            new object[] { 9223372036854775807LU }, // int64 max value
+            new object[] { 1000000000000000000LU }, // quintillion
+            new object[] { 4294967295000000000LU }, // uint.MaxValue * Billion
+            new object[] { 4294967295000000001LU }, // uint.MaxValue * Billion + 1
         };
 
         [Benchmark(InnerIterationCount = InnerCount)]
-        [MemberData(nameof(Int32Values))]
-        public void ToString(int value)
+        [MemberData(nameof(UInt64Values))]
+        public void ToString(ulong value)
         {
             Span<char> destination = new char[value.ToString().Length];
             foreach (BenchmarkIteration iteration in Benchmark.Iterations)
@@ -45,8 +61,8 @@ namespace System.Tests
         }
 
         [Benchmark(InnerIterationCount = InnerCount)]
-        [MemberData(nameof(Int32Values))]
-        public void TryFormat(int value)
+        [MemberData(nameof(UInt64Values))]
+        public void TryFormat(ulong value)
         {
             Span<char> destination = new char[value.ToString().Length];
             foreach (BenchmarkIteration iteration in Benchmark.Iterations)
@@ -62,8 +78,8 @@ namespace System.Tests
         }
 
         [Benchmark(InnerIterationCount = InnerCount)]
-        [MemberData(nameof(Int32Values))]
-        public void Parse(int value)
+        [MemberData(nameof(UInt64Values))]
+        public void Parse(ulong value)
         {
             ReadOnlySpan<char> valueSpan = value.ToString();
             foreach (BenchmarkIteration iteration in Benchmark.Iterations)
@@ -72,7 +88,7 @@ namespace System.Tests
                 {
                     for (int i = 0; i < InnerCount; i++)
                     {
-                        s_resultInt32 = int.Parse(valueSpan);
+                        s_resultUInt64 = ulong.Parse(valueSpan);
                     }
                 }
             }

--- a/src/System.Runtime/tests/Performance/System.Runtime.Performance.Tests.csproj
+++ b/src/System.Runtime/tests/Performance/System.Runtime.Performance.Tests.csproj
@@ -12,19 +12,21 @@
   <ItemGroup>
     <Compile Include="Perf.Boolean.cs" />
     <Compile Include="Perf.Char.cs" />
+    <Compile Include="Perf.DateTime.cs" />
     <Compile Include="Perf.Double.cs" />
     <Compile Include="Perf.Enum.cs" />
     <Compile Include="Perf.Guid.cs" />
     <Compile Include="Perf.HashCode.cs" />
+    <Compile Include="Perf.Int32.cs" />
+    <Compile Include="Perf.Int64.cs" />
+    <Compile Include="Perf.IntPtr.cs" />
     <Compile Include="Perf.Object.cs" />
     <Compile Include="Perf.String.cs" />
+    <Compile Include="Perf.StringBuilder.cs" />
     <Compile Include="Perf.TimeSpan.cs" />
     <Compile Include="Perf.Type.cs" />
     <Compile Include="Perf.UInt32.cs" />
-    <Compile Include="Perf.DateTime.cs" />
-    <Compile Include="Perf.Int32.cs" />
-    <Compile Include="Perf.IntPtr.cs" />
-    <Compile Include="Perf.StringBuilder.cs" />
+    <Compile Include="Perf.UInt64.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>


### PR DESCRIPTION
These are ports of the equivalent tests from the Utf8Formatter tests in System.Memory.

Contributes to https://github.com/dotnet/coreclr/issues/15364
cc: @ahsonkhan 