### PR TITLE
Update download link for PerfView tool

### DIFF
--- a/Documentation/debugging/windows-instructions.md
+++ b/Documentation/debugging/windows-instructions.md
@@ -127,7 +127,7 @@ Logs are going to be placed in %SYSTEMDRIVE%\sockets.etl.
 
 ### Using PerfView
 
-1. Install [PerfView](http://www.microsoft.com/en-us/download/details.aspx?id=28567)
+1. Install [PerfView](https://github.com/Microsoft/perfview/blob/master/documentation/Downloading.md)
 2. Run PerfView as Administrator
 3. Press Alt+C to collect events 
 4. Disable all other collection parameters


### PR DESCRIPTION
The PerfView tool has been moved to open-source. Updating the documentation link to point to the most recent place for downloading the tool.