### PR TITLE
Enable a thread pool bound handle test on uap

### DIFF
--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_AllocateNativeOverlappedTests.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_AllocateNativeOverlappedTests.cs
@@ -200,7 +200,6 @@ public partial class ThreadPoolBoundHandleTests
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
-    [ActiveIssue("https://github.com/dotnet/corefx/issues/18058", TargetFrameworkMonikers.Uap)]
     public unsafe void AllocateNativeOverlapped_PreAllocated_ReusedReturnedNativeOverlapped_OffsetLowAndOffsetHighSetToZero()
     {   // The CLR reuses NativeOverlapped underneath, check to make sure that they reset fields back to zero
 


### PR DESCRIPTION
The test was failing sometimes, some debugging info was added as part of https://github.com/dotnet/corefx/issues/18058 to help with failure investigation. The test remained disabled though.

Closes https://github.com/dotnet/corefx/issues/18058 until another failure occurs