### PR TITLE
Enable connection pooling for requests that use different client certificates…

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
@@ -49,4 +49,15 @@ namespace System.Net.Http
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
+    public partial class WinHttpRequestMessage : HttpRequestMessage
+    {
+        public WinHttpRequestMessage() { }
+        public WinHttpRequestMessage(HttpMethod method, Uri requestUri) { }
+        public WinHttpRequestMessage(HttpMethod method, string requestUri) { }
+        public DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
+        public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> ServerCertificateValidationCallback { get { throw null; } set { } }
+        public bool CheckCertificateRevocationList { get { throw null; } set { } }
+        public System.Net.Http.ClientCertificateOption ClientCertificateOption { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection ClientCertificates { get { throw null; } }
+    }
 }

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -35,6 +35,7 @@
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpException.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpHandler.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestCallback.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestMessage.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestState.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestStream.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpResponseHeaderReader.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestMessage.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestMessage.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Http
+{
+    public class WinHttpRequestMessage : HttpRequestMessage
+    {
+        private DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
+        private Func<
+            HttpRequestMessage,
+            X509Certificate2,
+            X509Chain,
+            SslPolicyErrors,
+            bool> _serverCertificateValidationCallback = null;
+        private bool _checkCertificateRevocationList = false;
+        private ClientCertificateOption _clientCertificateOption = ClientCertificateOption.Manual;
+        private X509Certificate2Collection _clientCertificates = null; // Only create collection when required.
+
+        public WinHttpRequestMessage() : base()
+        {
+        }
+        
+        public WinHttpRequestMessage(HttpMethod method, Uri requestUri) : base(method, requestUri)
+        {
+        }
+        
+        public WinHttpRequestMessage(HttpMethod method, string requestUri) : base(method, requestUri)
+        {
+        }
+
+        public DecompressionMethods AutomaticDecompression
+        {
+            get
+            {
+                return _automaticDecompression;
+            }
+
+            set
+            {
+                _automaticDecompression = value;
+            }
+        }
+
+        public Func<
+            HttpRequestMessage,
+            X509Certificate2,
+            X509Chain,
+            SslPolicyErrors,
+            bool> ServerCertificateValidationCallback
+        {
+            get
+            {
+                return _serverCertificateValidationCallback;
+            }
+
+            set
+            {
+                _serverCertificateValidationCallback = value;
+            }
+        }
+
+        public bool CheckCertificateRevocationList
+        {
+            get
+            {
+                return _checkCertificateRevocationList;
+            }
+
+            set
+            {
+                _checkCertificateRevocationList = value;
+            }
+        }
+
+        public ClientCertificateOption ClientCertificateOption
+        {
+            get
+            {
+                return _clientCertificateOption;
+            }
+
+            set
+            {
+                if (value != ClientCertificateOption.Manual
+                    && value != ClientCertificateOption.Automatic)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _clientCertificateOption = value;
+            }
+        }
+
+        public X509Certificate2Collection ClientCertificates
+        {
+            get
+            {
+                if (_clientCertificateOption != ClientCertificateOption.Manual)
+                {
+                    throw new InvalidOperationException(SR.Format(SR.net_http_invalid_enable_first, "ClientCertificateOptions", "Manual"));
+                }
+
+                if (_clientCertificates == null)
+                {
+                    _clientCertificates = new X509Certificate2Collection();
+                }
+
+                return _clientCertificates;
+            }
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -109,6 +109,9 @@
     <Compile Include="..\..\src\System\Net\Http\WinHttpRequestCallback.cs">
       <Link>ProductionCode\WinHttpRequestCallback.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpRequestMessage.cs">
+      <Link>ProductionCode\WinHttpRequestMessage.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpRequestState.cs">
       <Link>ProductionCode\WinHttpRequestState.cs</Link>
     </Compile>


### PR DESCRIPTION
Enable connection pooling for requests that use different client certificates or server certificate callbacks. This allows setting these options on a per-request basis, which has much better perf for scenarios that want to share a session between requests that use different options for these.

#28841 