### PR TITLE
Fix getting shortname of file for Attachment class

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/Attachment.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/Attachment.cs
@@ -12,7 +12,6 @@ namespace System.Net.Mail
     {
         internal bool disposed = false;
         private MimePart _part = new MimePart();
-        private static readonly char[] s_fileShortNameIndicators = new char[] { '\\', ':' };
         private static readonly char[] s_contentCIDInvalidChars = new char[] { '<', '>' };
 
         internal AttachmentBase()
@@ -66,22 +65,6 @@ namespace System.Net.Mail
                 disposed = true;
                 _part.Dispose();
             }
-        }
-
-        internal static string ShortNameFromFile(string fileName)
-        {
-            string name;
-            int start = fileName.LastIndexOfAny(s_fileShortNameIndicators, fileName.Length - 1, fileName.Length);
-
-            if (start > 0)
-            {
-                name = fileName.Substring(start + 1, fileName.Length - start - 1);
-            }
-            else
-            {
-                name = fileName;
-            }
-            return name;
         }
 
         internal void SetContentFromFile(string fileName, ContentType contentType)
@@ -341,14 +324,14 @@ namespace System.Net.Mail
 
         public Attachment(string fileName) : base(fileName)
         {
-            Name = ShortNameFromFile(fileName);
+            Name = Path.GetFileName(fileName);
             MimePart.ContentDisposition = new ContentDisposition();
         }
 
         public Attachment(string fileName, string mediaType) :
             base(fileName, mediaType)
         {
-            Name = ShortNameFromFile(fileName);
+            Name = Path.GetFileName(fileName);
             MimePart.ContentDisposition = new ContentDisposition();
         }
 
@@ -357,7 +340,7 @@ namespace System.Net.Mail
         {
             if (contentType.Name == null || contentType.Name == string.Empty)
             {
-                Name = ShortNameFromFile(fileName);
+                Name = Path.GetFileName(fileName);
             }
             else
             {

--- a/src/System.Net.Mail/tests/Functional/AttachmentTest.cs
+++ b/src/System.Net.Mail/tests/Functional/AttachmentTest.cs
@@ -36,16 +36,38 @@ namespace System.Net.Mail.Tests
         public void ConstructorPathName()
         {
             string attachFile = Path.GetTempFileName();
-            try
+            using(var tempFile = new TempFile(attachFile))
             {
-                var fileStream = File.Create(attachFile);
-                fileStream.Close();
-                Attachment attach = new Attachment(attachFile);
-                Assert.Equal(Path.GetFileName(attachFile), attach.Name);
+                Attachment attach = new Attachment(tempFile.Path);
+                Assert.Equal(Path.GetFileName(tempFile.Path), attach.Name);
             }
-            finally
+        }
+
+        [Fact]
+        public void ConstructorPathNameMediaType()
+        {
+            string attachFile = Path.GetTempFileName();
+            using(var tempFile = new TempFile(attachFile))
             {
-                File.Delete(attachFile);
+                const string mediaType = "application/octet-stream";
+                string shortName = Path.GetFileName(tempFile.Path);
+                Attachment attach = new Attachment(tempFile.Path, mediaType);
+                Assert.Equal(shortName, attach.Name);
+                Assert.Equal(mediaType, attach.ContentType.MediaType);
+            }
+        }
+
+        [Fact]
+        public void ConstructorPathNameContentType()
+        {
+            string attachFile = Path.GetTempFileName();
+            using(var tempFile = new TempFile(attachFile))
+            {
+                const string mediaType = "application/octet-stream";
+                string shortName = Path.GetFileName(tempFile.Path);
+                Attachment attach = new Attachment(tempFile.Path, new Mime.ContentType(mediaType));
+                Assert.Equal(shortName, attach.Name);
+                Assert.Equal(mediaType, attach.ContentType.MediaType);
             }
         }
 

--- a/src/System.Net.Mail/tests/Functional/AttachmentTest.cs
+++ b/src/System.Net.Mail/tests/Functional/AttachmentTest.cs
@@ -33,6 +33,23 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        public void ConstructorPathName()
+        {
+            string attachFile = Path.GetTempFileName();
+            try
+            {
+                var fileStream = File.Create(attachFile);
+                fileStream.Close();
+                Attachment attach = new Attachment(attachFile);
+                Assert.Equal(Path.GetFileName(attachFile), attach.Name);
+            }
+            finally
+            {
+                File.Delete(attachFile);
+            }
+        }
+
+        [Fact]
         public void CreateAttachmentFromStringNullName()
         {
             Attachment attach = Attachment.CreateAttachmentFromString("", null, Encoding.ASCII, "application/octet-stream");

--- a/src/System.Net.Mail/tests/Functional/AttachmentTest.cs
+++ b/src/System.Net.Mail/tests/Functional/AttachmentTest.cs
@@ -35,39 +35,42 @@ namespace System.Net.Mail.Tests
         [Fact]
         public void ConstructorPathName()
         {
-            string attachFile = Path.GetTempFileName();
-            using(var tempFile = new TempFile(attachFile))
+            using (var tempFile = TempFile.Create(new byte[0]))
             {
-                Attachment attach = new Attachment(tempFile.Path);
-                Assert.Equal(Path.GetFileName(tempFile.Path), attach.Name);
+                using (Attachment attach = new Attachment(tempFile.Path))
+                {
+                    Assert.Equal(Path.GetFileName(tempFile.Path), attach.Name);
+                }
             }
         }
 
         [Fact]
         public void ConstructorPathNameMediaType()
         {
-            string attachFile = Path.GetTempFileName();
-            using(var tempFile = new TempFile(attachFile))
+            using (var tempFile = TempFile.Create(new byte[0]))
             {
                 const string mediaType = "application/octet-stream";
                 string shortName = Path.GetFileName(tempFile.Path);
-                Attachment attach = new Attachment(tempFile.Path, mediaType);
-                Assert.Equal(shortName, attach.Name);
-                Assert.Equal(mediaType, attach.ContentType.MediaType);
+                using (Attachment attach = new Attachment(tempFile.Path, mediaType))
+                {
+                    Assert.Equal(shortName, attach.Name);
+                    Assert.Equal(mediaType, attach.ContentType.MediaType);
+                }
             }
         }
 
         [Fact]
         public void ConstructorPathNameContentType()
         {
-            string attachFile = Path.GetTempFileName();
-            using(var tempFile = new TempFile(attachFile))
+            using (var tempFile = TempFile.Create(new byte[0]))
             {
                 const string mediaType = "application/octet-stream";
                 string shortName = Path.GetFileName(tempFile.Path);
-                Attachment attach = new Attachment(tempFile.Path, new Mime.ContentType(mediaType));
-                Assert.Equal(shortName, attach.Name);
-                Assert.Equal(mediaType, attach.ContentType.MediaType);
+                using (Attachment attach = new Attachment(tempFile.Path, new Mime.ContentType(mediaType)))
+                {
+                    Assert.Equal(shortName, attach.Name);
+                    Assert.Equal(mediaType, attach.ContentType.MediaType);
+                }
             }
         }
 


### PR DESCRIPTION
The shortname for a file path is incorrectly calculated on non-Windows systems as the seperators are NTFS specific.

Fix is to use System.IO.Path::GetFileName() instead of custom method.

Fixes https://github.com/PowerShell/PowerShell/issues/6564