### PR TITLE
Fix perf hit from WinHttpGetProxyForUrl

### DIFF
--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
@@ -221,6 +221,12 @@ internal partial class Interop
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WinHttpDetectAutoProxyConfigUrl(
+            AutoDetectType autoDetectFlags,
+            out IntPtr autoConfigUrl);
+
+        [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool WinHttpGetIEProxyConfigForCurrentUser(
             out WINHTTP_CURRENT_USER_IE_PROXY_CONFIG proxyConfig);
 

--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
@@ -222,7 +222,7 @@ internal partial class Interop
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool WinHttpDetectAutoProxyConfigUrl(
-            AutoDetectType autoDetectFlags,
+            uint autoDetectFlags,
             out IntPtr autoConfigUrl);
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
@@ -310,5 +310,13 @@ internal partial class Interop
             public uint dwBytesTransferred;
             public WINHTTP_WEB_SOCKET_BUFFER_TYPE eBufferType;
         }
+
+        [Flags]
+        internal enum AutoDetectType
+        {
+            None = 0x0,
+            Dhcp = 0x1, // WINHTTP_AUTO_DETECT_TYPE_DHCP
+            DnsA = 0x2, // WINHTTP_AUTO_DETECT_TYPE_DNS_A
+        }
     }
 }

--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
@@ -312,7 +312,7 @@ internal partial class Interop
         }
 
         [Flags]
-        internal enum AutoDetectType
+        public enum AutoDetectType
         {
             None = 0x0,
             Dhcp = 0x1, // WINHTTP_AUTO_DETECT_TYPE_DHCP

--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
@@ -310,13 +310,5 @@ internal partial class Interop
             public uint dwBytesTransferred;
             public WINHTTP_WEB_SOCKET_BUFFER_TYPE eBufferType;
         }
-
-        [Flags]
-        public enum AutoDetectType
-        {
-            None = 0x0,
-            Dhcp = 0x1, // WINHTTP_AUTO_DETECT_TYPE_DHCP
-            DnsA = 0x2, // WINHTTP_AUTO_DETECT_TYPE_DNS_A
-        }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1014,6 +1014,7 @@ namespace System.Net.Http
                             proxyInfo.Proxy = Marshal.StringToHGlobalUni(proxyString);
                         }
                     }
+                    // If AutoDetect is not set, the result is cached in AutoSettingsUsed.
                     else if (_proxyHelper != null && _proxyHelper.AutoSettingsUsed)
                     {
                         if (_proxyHelper.GetProxyForUrl(_sessionHandle, uri, out proxyInfo))

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
@@ -172,6 +172,10 @@ namespace System.Net.Http
                 }
                 else
                 {
+                    // We match behavior of WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY and ignore errors.
+                    int lastError = Marshal.GetLastWin32Error();
+                    WinHttpTraceHelper.Trace("WinInetProxyHelper.DetectScriptLocation: error={0}", lastError);
+
                     if (AutoConfigUrl == null)
                     {
                         WinHttpTraceHelper.Trace("WinInetProxyHelper.DetectScriptLocation: Auto discovery failed.");
@@ -206,7 +210,7 @@ namespace System.Net.Http
                     ProxyBypass = Marshal.PtrToStringUni(proxyConfig.ProxyBypass);
 
                     WinHttpTraceHelper.Trace(
-                        "WinInetProxyHelper.ctor: AutoConfigUrl={0}, AutoDetect={1}, Proxy={2}, ProxyBypass={3}",
+                        "WinInetProxyHelper.GetIEProxySetting: AutoConfigUrl={0}, AutoDetect={1}, Proxy={2}, ProxyBypass={3}",
                         AutoConfigUrl,
                         AutoDetect,
                         Proxy,
@@ -218,10 +222,10 @@ namespace System.Net.Http
                 {
                     // We match behavior of WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY and ignore errors.
                     int lastError = Marshal.GetLastWin32Error();
-                    WinHttpTraceHelper.Trace("WinInetProxyHelper.ctor: error={0}", lastError);
+                    WinHttpTraceHelper.Trace("WinInetProxyHelper.GetIEProxySetting: error={0}", lastError);
                 }
 
-                WinHttpTraceHelper.Trace("WinInetProxyHelper.ctor: _useProxy={0}", _useProxy);
+                WinHttpTraceHelper.Trace("WinInetProxyHelper.GetIEProxySetting: _useProxy={0}", _useProxy);
             }
             finally
             {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
@@ -162,16 +162,16 @@ namespace System.Net.Http
             }
 
             WinHttpTraceHelper.Trace("WinInetProxyHelper.DetectScriptLocation: Attempting discovery PROXY_AUTO_DETECT_TYPE_DHCP.");
-            AutoConfigUrl = SafeDetectAutoProxyUrl(Interop.WinHttp.AutoDetectType.Dhcp);
+            AutoConfigUrl = GetAutoProxyConfigUrl(Interop.WinHttp.AutoDetectType.Dhcp);
 
             if (AutoConfigUrl == null)
             {
                 WinHttpTraceHelper.Trace("WinInetProxyHelper.DetectScriptLocation: Attempting discovery AUTO_DETECT_TYPE_DNS_A.");
-                AutoConfigUrl = SafeDetectAutoProxyUrl(Interop.WinHttp.AutoDetectType.DnsA);
+                AutoConfigUrl = GetAutoProxyConfigUrl(Interop.WinHttp.AutoDetectType.DnsA);
             }
             else
             {
-                // Auto-detect succeed.
+                // Auto-detect succeeded.
                 return;
             }
 
@@ -183,7 +183,7 @@ namespace System.Net.Http
             }
         }
 
-        private string SafeDetectAutoProxyUrl(Interop.WinHttp.AutoDetectType discoveryMethod)
+        private string GetAutoProxyConfigUrl(Interop.WinHttp.AutoDetectType discoveryMethod)
         {
             string url = null;
             IntPtr autoProxyUrl = new IntPtr();

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -612,7 +612,7 @@ internal static partial class Interop
         }
 
         public static bool WinHttpDetectAutoProxyConfigUrl(
-            AutoDetectType autoDetectFlags,
+            uint autoDetectFlags,
             out IntPtr autoConfigUrl)
         {
             if (FakeRegistry.WinInetProxySettings.AutoDetect)

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -611,6 +611,24 @@ internal static partial class Interop
             return true;
         }
 
+        public static bool WinHttpDetectAutoProxyConfigUrl(
+            AutoDetectType autoDetectFlags,
+            out IntPtr autoConfigUrl)
+        {
+            if (FakeRegistry.WinInetProxySettings.AutoDetect)
+            {
+                autoConfigUrl = Marshal.StringToHGlobalUni(FakeRegistry.WinInetProxySettings.AutoConfigUrl);
+                return true;
+            }
+            else
+            {
+                autoConfigUrl = IntPtr.Zero;
+
+                TestControl.LastWin32Error = (int)Interop.WinHttp.ERROR_FILE_NOT_FOUND;
+                return false;
+            }
+        }
+
         public static IntPtr WinHttpSetStatusCallback(
             SafeWinHttpHandle handle,
             Interop.WinHttp.WINHTTP_STATUS_CALLBACK callback,


### PR DESCRIPTION
This PR optimizes some scenarios which we need to call `WinHttpGetProxyForUrl`.

1. Introduce the `WinHttpDetectAutoProxyConfigUrl` function, which implements a subset of the WPAD protocol: it attempts to auto-detect the URL for the proxy auto-config file, without downloading or executing the PAC file.

- If not able to find the script location. It is possible that there is no proxy auto-configuration file because the client has a direct Internet connection, and does not need a proxy server. Or a proxy server may be required, but the local network may not support WPAD. In both cases, the proxy configuration has to be obtained from the user or found somewhere on the client machine. We will use the information from calling into `WinHttpGetIEProxyConfigForCurrentUser` to see whether a proxy server is listed in Internet Explorer's settings. Cache the information.

- If able to find the script location, the AutoDetect setting has precedence over the other settings. So if there is already a automatic configuration script location (from `WinHttpGetIEProxyConfigForCurrentUser`), this value will be overridden. We will cache the related information and provide it to `WinHttpGetProxyForUrl`.

2. If there is no proxy, the information has been cached from the above procedures, we will stop calling into `WinHttpGetProxyForUrl`.

We have exhaustive test cases verifying behaviors with different proxy settings. Please let me know if there are special cases we care about, and I will add tests for them.

https://github.com/dotnet/corefx/blob/85062446c4e5af0c205f646e0ae720e160b20e85/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs#L641-L832

Fix: #28543