### PR TITLE
Fix bin placing when building all configurations and there is a placeholder configuration present in BuildConfigurations

### DIFF
--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -105,8 +105,23 @@
           Condition="'$(FilterProjectsByBuildConfiguration)' != 'false'"
           DependsOnTargets="ExpandAllBuildConfigurations;FilterBuildConfiguration" />
 
+  <!-- When building all configurations we don't want to have any place holder configuration, so remove them
+  before we return all configurations when calling GetBuildConfigurations to not affect bin placing -->
+  <Target Name="FilterPlaceHolderConfigurations"
+          Condition="'$(BuildAllConfigurations)' == 'true' AND '$(BuildConfigurations)' != ''">
+    <ItemGroup>
+      <_allConfigurations Include="$(BuildConfigurations)" />
+      <_allConfigurations Remove="@(_allConfigurations)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <BuildConfigurations>@(_allConfigurations)</BuildConfigurations>
+    </PropertyGroup>
+  </Target>
+
   <!-- Runs in a leaf project (eg: csproj) to determine all configurations -->
   <Target Name="GetBuildConfigurations"
+          DependsOnTargets="FilterPlaceHolderConfigurations"
           Returns="$(_AllBuildConfigurations)">
     <PropertyGroup>
       <_AllBuildConfigurations>$(BuildConfigurations)</_AllBuildConfigurations>


### PR DESCRIPTION
While changing netfx to target .NET 4.7 I had to add a placeholder configuration (_netfx) to System.ValueTuple since it is already inbox in mscorlib.dll 

When I built all configurations I noticed that it wouldn't bin place System.ValueTuple in the ref/runtime folders for any of the configurations. This happened because when we populate _bestBinPlaceConfigurationwe call to find the best configuration with all the project configuration's and all the possible configurations in the traversal, so this means that we're passing a placeholder configuration (_netfx) which will match with the netfx configuration passed with all the traversal configurations and we will return an empty ItemGroup for _bestBinPlaceConfigurations.

What I'm doing here is to filter the project BuildConfigurations to not have a placeholder configuration present when we call GetBuildConfigurations and we're building the all configurations traversal.

cc: @weshaggard @danmosemsft @ericstj 