### PR TITLE
[1.1] Fix some packaging bugs

### DIFF
--- a/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
@@ -6,7 +6,6 @@
     <WinVersion Condition="'$(PackagePlatform)'=='arm64'">win10</WinVersion>
     <WinVersion Condition="'$(PackagePlatform)'=='x86' OR '$(PackagePlatform)'=='x64'">win7</WinVersion>
     <PackageTargetRuntime>$(WinVersion)-$(PackagePlatform)</PackageTargetRuntime>
-    <PackageVersion>4.3.1</PackageVersion>
     <!-- the native compression packages require nuget >3.5 for nativeassets support -->
     <MinClientVersion3>3.5</MinClientVersion3>    
   </PropertyGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -36,7 +36,31 @@
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >   
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
-    <Project Include="Native\pkg\**\*.builds">
+    <Project Include="Native\pkg\runtime.native.System\runtime.native.System.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>true</BuildAllOSGroups>
+    </Project>
+    <Project Include="Native\pkg\runtime.native.System.IO.Compression\runtime.native.System.IO.Compression.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>true</BuildAllOSGroups>
+    </Project>
+    <Project Include="Native\pkg\runtime.native.System.Net.Http\runtime.native.System.Net.Http.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>true</BuildAllOSGroups>
+    </Project>
+    <Project Include="Native\pkg\runtime.native.System.Net.Security\runtime.native.System.Net.Security.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>true</BuildAllOSGroups>
+    </Project>
+    <Project Include="Native\pkg\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>true</BuildAllOSGroups>
+    </Project>
+    <Project Include="Native\pkg\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>true</BuildAllOSGroups>
+    </Project>
+    <Project Include="Native\pkg\runtime.native.System.Security.Cryptography.OpenSsl\runtime.native.System.Security.Cryptography.OpenSsl.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
       <BuildAllOSGroups>true</BuildAllOSGroups>
     </Project>


### PR DESCRIPTION
Bugs:
- native compression win7 package had its own packageverson overwriting the parent dir.props one
- we dont need or want to ship the sni package, so I removed the wildcard inclusion of all native packages and added just the ones we want. 
- Also removed the apple crypto package form the version bump.

PTAL: @weshaggard @bartonjs 
FYI: @janvorli 