### PR TITLE
Stop nulling out fields in SafeDeleteSslContext dispose

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -114,11 +114,6 @@ namespace System.Net
                     _sslContext.Dispose();
                     _sslContext = null;
                 }
-
-                _toConnection = null;
-                _fromConnection = null;
-                _writeCallback = null;
-                _readCallback = null;
             }
 
             base.Dispose(disposing);


### PR DESCRIPTION
Nulling out these fields in SafeDeleteSslContext.Dispose causes occasional difficult to reproduce exceptions in CI:
```
Unhandled Exception: System.ArgumentNullException: Value cannot be null.
   at System.Threading.Monitor.ReliableEnter(Object obj, Boolean& lockTaken)
   at System.Net.SafeDeleteSslContext.WriteToConnection(Void* connection, Byte* data, Void** dataLength)
   at Interop.AppleCrypto.SslHandshake(SafeSslHandle sslHandle)
   at System.Net.Security.SslStreamPal.PerformHandshake(SafeSslHandle sslHandle)
   at System.Net.Security.SslStreamPal.HandshakeInternal(SafeFreeCredentials credential, SafeDeleteContext& context, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, Boolean isServer, Boolean remoteCertRequired, String targetName)
```

The fix is to stop nulling out these fields in the dispose method, and to allow the garbage collector to take care of them instead.

Fixes: #28759
