### PR TITLE
Registry Test SetValueWithEnvironmentVariable disabled

### DIFF
--- a/src/Microsoft.Win32.Registry/tests/Registry/Registry_SetValue_str_str_obj.cs
+++ b/src/Microsoft.Win32.Registry/tests/Registry/Registry_SetValue_str_str_obj.cs
@@ -116,6 +116,9 @@ namespace Microsoft.Win32.RegistryTests
         [MemberData(nameof(TestEnvironment))]
         public void SetValueWithEnvironmentVariable(string valueName, string envVariableName, string expectedVariableValue)
         {
+            if (envVariableName == "ProgramFiles" && PlatformDetection.IsArmProcess)
+                return;
+
             string value = "%" + envVariableName + "%";
             Registry.SetValue(TestRegistryKey.Name, valueName, value);
 

--- a/src/Microsoft.Win32.Registry/tests/Registry/Registry_SetValue_str_str_obj.cs
+++ b/src/Microsoft.Win32.Registry/tests/Registry/Registry_SetValue_str_str_obj.cs
@@ -116,8 +116,9 @@ namespace Microsoft.Win32.RegistryTests
         [MemberData(nameof(TestEnvironment))]
         public void SetValueWithEnvironmentVariable(string valueName, string envVariableName, string expectedVariableValue)
         {
+            // ExpandEnvironmentStrings is converting "C:\Program Files (Arm)" to "C:\Program Files (x86)".
             if (envVariableName == "ProgramFiles" && PlatformDetection.IsArmProcess)
-                return;
+                return; // [ActiveIssue(https://github.com/dotnet/corefx/issues/28856)]
 
             string value = "%" + envVariableName + "%";
             Registry.SetValue(TestRegistryKey.Name, valueName, value);


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/issues/28856