### PR TITLE
Fix ImplicitMachineConfigHost parameter checking

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
@@ -309,7 +309,7 @@ namespace System.Configuration
         public override Stream OpenStreamForWrite(string streamName, string templateStreamName, ref object writeContext)
         {
             // only support files, not URIs
-            if (!IsFile(streamName)) throw ExceptionUtil.UnexpectedError("ClientConfigurationHost::OpenStreamForWrite");
+            if (!IsFile(streamName)) throw ExceptionUtil.UnexpectedError($"ClientConfigurationHost::OpenStreamForWrite '{streamName}' '{templateStreamName}'");
 
             return Host.OpenStreamForWrite(streamName, templateStreamName, ref writeContext);
         }

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
@@ -23,15 +23,25 @@ namespace System.Configuration
             out string locationConfigPath, IInternalConfigRoot configRoot, params object[] hostInitConfigurationParams)
         {
             // Stash the filemap so we can see if the machine config was explicitly specified
-            _fileMap = hostInitConfigurationParams[0] as ConfigurationFileMap;
+            GetFileMap(hostInitConfigurationParams);
             base.InitForConfiguration(ref locationSubPath, out configPath, out locationConfigPath, configRoot, hostInitConfigurationParams);
         }
 
         public override void Init(IInternalConfigRoot configRoot, params object[] hostInitParams)
         {
             // Stash the filemap so we can see if the machine config was explicitly specified
-            _fileMap = hostInitParams[0] as ConfigurationFileMap;
+            GetFileMap(hostInitParams);
             base.Init(configRoot, hostInitParams);
+        }
+
+        private void GetFileMap(object[] parameters)
+        {
+            foreach (object parameter in parameters)
+            {
+                _fileMap = parameter as ConfigurationFileMap;
+                if (_fileMap != null)
+                    return;
+            }
         }
 
         public override string GetStreamName(string configPath)

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -42,6 +42,10 @@ namespace System.ConfigurationTests
             }
         }
 
+        private class PersistedSimpleSettings : SimpleSettings
+        {
+        }
+
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp)),
             InlineData(true),
             InlineData(false)
@@ -82,7 +86,7 @@ namespace System.ConfigurationTests
                 ? (SimpleSettings)SettingsBase.Synchronized(new SimpleSettings()) 
                 : new SimpleSettings();
 
-            Assert.Equal(default(string), settings.StringProperty);
+            Assert.Equal(default, settings.StringProperty);
             settings.StringProperty = "Foo";
             Assert.Equal("Foo", settings.StringProperty);
         }
@@ -103,12 +107,59 @@ namespace System.ConfigurationTests
             Assert.Equal(10, settings.IntProperty);
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp)),
+            InlineData(true),
+            InlineData(false)
+            ]
+        [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
+        public void Save_SimpleSettings_Ok(bool isSynchronized)
+        {
+            PersistedSimpleSettings settings = isSynchronized
+                ? (PersistedSimpleSettings)SettingsBase.Synchronized(new PersistedSimpleSettings())
+                : new PersistedSimpleSettings();
+
+            // Make sure we're clean
+            settings.Reset();
+            settings.Save();
+            Assert.Equal(DefaultIntPropertyValue, settings.IntProperty);
+            Assert.Equal(default, settings.StringProperty);
+
+            // Change settings and save
+            settings.IntProperty = 12;
+            settings.StringProperty = "Bar";
+            Assert.Equal("Bar", settings.StringProperty);
+            Assert.Equal(12, settings.IntProperty);
+            settings.Save();
+
+            // Create a new instance and validate persisted settings
+            settings = isSynchronized
+                            ? (PersistedSimpleSettings)SettingsBase.Synchronized(new PersistedSimpleSettings())
+                            : new PersistedSimpleSettings();
+            Assert.Equal(default, settings.StringProperty); // [ApplicationScopedSetting] isn't persisted
+            Assert.Equal(12, settings.IntProperty);
+
+            // Reset and save
+            settings.Reset();
+            settings.Save();
+            Assert.Equal(DefaultIntPropertyValue, settings.IntProperty);
+            Assert.Equal(default, settings.StringProperty);
+
+            // Create a new instance and validate persisted settings
+            settings = isSynchronized
+                            ? (PersistedSimpleSettings)SettingsBase.Synchronized(new PersistedSimpleSettings())
+                            : new PersistedSimpleSettings();
+            Assert.Equal(default, settings.StringProperty); // [ApplicationScopedSetting] isn't persisted
+            Assert.Equal(DefaultIntPropertyValue, settings.IntProperty);
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void Reload_SimpleSettings_Ok()
         {
-            var settings = new SimpleSettings();
-            settings.IntProperty = 10;
+            var settings = new SimpleSettings
+            {
+                IntProperty = 10
+            };
 
             Assert.NotEqual(DefaultIntPropertyValue, settings.IntProperty);
             settings.Reload();

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -107,11 +107,11 @@ namespace System.ConfigurationTests
             Assert.Equal(10, settings.IntProperty);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp)),
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer)),
             InlineData(true),
-            InlineData(false)
-            ]
+            InlineData(false)]
         [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/35668", TestPlatforms.AnyUnix)]
         public void Save_SimpleSettings_Ok(bool isSynchronized)
         {
             PersistedSimpleSettings settings = isSynchronized


### PR DESCRIPTION
Don't assume index of the ConfigurationFileMap in params

Fixes: #28784