### PR TITLE
Add {ReadOnly}Memory.Span tests when memory contains invalid values

### DIFF
--- a/src/System.Memory/tests/Memory/Span.cs
+++ b/src/System.Memory/tests/Memory/Span.cs
@@ -106,5 +106,28 @@ namespace System.MemoryTests
             Assert.True(spanObject.SequenceEqual(default));
         }
 
+        [Fact]
+        public static void TornMemory_Array_SpanThrowsIfOutOfBounds()
+        {
+            Memory<int> memory;
+
+            memory = TestHelpers.DangerousCreateMemory<int>(new int[4], 0, 5);
+            Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
+
+            memory = TestHelpers.DangerousCreateMemory<int>(new int[4], 3, 2);
+            Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
+        }
+
+        [Fact]
+        public static void TornMemory_String_SpanThrowsIfOutOfBounds()
+        {
+            Memory<char> memory;
+
+            memory = TestHelpers.DangerousCreateMemory<char>("1234", 0, 5);
+            Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
+
+            memory = TestHelpers.DangerousCreateMemory<char>("1234", 3, 2);
+            Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
+        }
     }
 }

--- a/src/System.Memory/tests/ReadOnlyMemory/Span.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Span.cs
@@ -106,5 +106,28 @@ namespace System.MemoryTests
             Assert.True(spanObject.SequenceEqual(default));
         }
 
+        [Fact]
+        public static void TornMemory_Array_SpanThrowsIfOutOfBounds()
+        {
+            ReadOnlyMemory<int> memory;
+
+            memory = TestHelpers.DangerousCreateReadOnlyMemory<int>(new int[4], 0, 5);
+            Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
+
+            memory = TestHelpers.DangerousCreateReadOnlyMemory<int>(new int[4], 3, 2);
+            Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
+        }
+
+        [Fact]
+        public static void TornMemory_String_SpanThrowsIfOutOfBounds()
+        {
+            ReadOnlyMemory<char> memory;
+
+            memory = TestHelpers.DangerousCreateReadOnlyMemory<char>("1234", 0, 5);
+            Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
+
+            memory = TestHelpers.DangerousCreateReadOnlyMemory<char>("1234", 3, 2);
+            Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
+        }
     }
 }

--- a/src/System.Memory/tests/TestHelpers.cs
+++ b/src/System.Memory/tests/TestHelpers.cs
@@ -413,7 +413,7 @@ namespace System
             return (Memory<T>)boxedMemory;
         }
 
-        /// <summary>Creates a <see cref="Memory{T}"/> with the specified values in its backing field.</summary>
+        /// <summary>Creates a <see cref="ReadOnlyMemory{T}"/> with the specified values in its backing field.</summary>
         public static ReadOnlyMemory<T> DangerousCreateReadOnlyMemory<T>(object obj, int offset, int length) =>
             DangerousCreateMemory<T>(obj, offset, length).AsReadOnlyMemory();
     }

--- a/src/System.Memory/tests/TestHelpers.cs
+++ b/src/System.Memory/tests/TestHelpers.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 
 using static System.Buffers.Binary.BinaryPrimitives;
 using System.Text;
+using System.Reflection;
 
 namespace System
 {
@@ -398,6 +399,22 @@ namespace System
         public static ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) => new ReadOnlySpan<T>(array);
         public static ReadOnlySpan<T> AsReadOnlySpan<T>(this ArraySegment<T> segment) => new ReadOnlySpan<T>(segment.Array, segment.Offset, segment.Count);
         public static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this Memory<T> memory) => memory;
+
+        /// <summary>Creates a <see cref="Memory{T}"/> with the specified values in its backing field.</summary>
+        public static Memory<T> DangerousCreateMemory<T>(object obj, int offset, int length)
+        {
+            Memory<T> mem = default;
+            object boxedMemory = mem;
+
+            typeof(Memory<T>).GetField("_object", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(boxedMemory, obj);
+            typeof(Memory<T>).GetField("_index", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(boxedMemory, offset);
+            typeof(Memory<T>).GetField("_length", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(boxedMemory, length);
+
+            return (Memory<T>)boxedMemory;
+        }
+
+        /// <summary>Creates a <see cref="Memory{T}"/> with the specified values in its backing field.</summary>
+        public static ReadOnlyMemory<T> DangerousCreateReadOnlyMemory<T>(object obj, int offset, int length) =>
+            DangerousCreateMemory<T>(obj, offset, length).AsReadOnlyMemory();
     }
 }
-


### PR DESCRIPTION
Related to https://github.com/dotnet/coreclr/pull/17452#discussion_r179748571
cc: @ahsonkhan, @jkotas 