### PR TITLE
Clean up GetConsoleTitle

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -5,68 +5,54 @@
 using System.Diagnostics;
 using System.Text;
 using System.Runtime.InteropServices;
+using System;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "GetConsoleTitleW")]
-        private static extern int GetConsoleTitle([Out]StringBuilder title, int nSize);
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+        private static extern uint GetConsoleTitleW(ref char title, uint nSize);
 
-        private const int InitialBufferSizeInChars = 256;
-
-        // Although msdn states that the max allowed limit is 65K,
-        // desktop limits this to 24500 as buffer sizes greater than it
-        // throw.
-        private const int MaxAllowedBufferSizeInChars = 24500;
-
-        // GetConsoleTitle sometimes interprets the second parameter (nSize) as number of bytes and sometimes as the number of chars.
-        // Instead of doing complicated and dangerous logic to determine if this may or may not occur,
-        // we simply assume the worst and reserve a bigger buffer. This way we may use a bit more memory,
-        // but we will always be safe.
-        private static int CharCountToByteCount(int numChars)
+        internal static string GetConsoleTitle(out int error)
         {
-            return numChars * 2;
-        }
+            error = Errors.ERROR_SUCCESS;
 
-        // 1. We first try to call the GetConsoleTitle with an InitialBufferSizeInChars of 256.
-        // 2. Then based on the return value either increase the capacity or return failure.
-        internal static int GetConsoleTitle(out string title, out int titleLength)
-        {
-            int lastError = 0;
-            StringBuilder sb = new StringBuilder(CharCountToByteCount(InitialBufferSizeInChars + 1));
-            int len = GetConsoleTitle(sb, sb.Capacity);
+            Span<char> initialBuffer = stackalloc char[256];
+            ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
 
-            if (len <= 0)
+            do
             {
-                lastError = Marshal.GetLastWin32Error();
-            }
-            else if (len > MaxAllowedBufferSizeInChars)
-            {
-                // Title is greater than the allowed buffer so we do not read the title and only pass the length to the caller.
-                title = string.Empty;
-                titleLength = len;
-                return 0;
-            }
-            else
-            {
-                if (len > InitialBufferSizeInChars)
+                // The documentation asserts that the console's title is stored in a shared 64KB buffer.
+                // The magic number that used to exist here (24500), is likely related to that.
+                // A full UNICODE_STRING is 32K chars...
+                Debug.Assert(builder.Capacity <= short.MaxValue, "shouldn't be possible to grow beyond UNICODE_STRING size");
+                uint result = GetConsoleTitleW(ref builder.GetPinnableReference(), (uint)builder.Capacity);
+
+                if (result == 0)
                 {
-                    // We need to increase the sb capacity and retry.
-                    sb.Capacity = CharCountToByteCount(len + 1);
-                    len = GetConsoleTitle(sb, sb.Capacity);
-                    if (len <= 0)
+                    error = Marshal.GetLastWin32Error();
+                    if (error == Errors.ERROR_INSUFFICIENT_BUFFER)
                     {
-                        lastError = Marshal.GetLastWin32Error();
+                        // Typically this API truncates, but there was a bug in RS2 so we'll make an attempt to handle
+                        builder.EnsureCapacity(builder.Capacity * 2);
+                    }
+                    else
+                    {
+                        return string.Empty;
                     }
                 }
-            }
-
-            // If the call succeeds the size must be less than or equal to sb capacity as retrieved from the first call.
-            Debug.Assert(lastError != 0 || len + 1 <= sb.Capacity);
-            title = len > 0 ? sb.ToString() : string.Empty;
-            titleLength = title.Length;
-            return lastError;
+                else if (result >= builder.Capacity - 1)
+                {
+                    // Our buffer was full. As this API truncates we need to increase our size and reattempt.
+                    builder.EnsureCapacity(builder.Capacity * 2);
+                }
+                else
+                {
+                    builder.Length = (int)result;
+                    return builder.ToString();
+                }
+            } while (true);
         }
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
@@ -9,6 +10,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        internal static extern uint GetConsoleTitleW(ref char title, uint nSize);
+        internal unsafe static extern uint GetConsoleTitleW(char* title, uint nSize);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -26,7 +26,7 @@ internal partial class Interop
                 uint result = GetConsoleTitleW(ref builder.GetPinnableReference(), (uint)builder.Capacity);
 
                 // The documentation asserts that the console's title is stored in a shared 64KB buffer.
-                // The magic number that used to exist here (24500), is likely related to that.
+                // The magic number that used to exist here (24500) is likely related to that.
                 // A full UNICODE_STRING is 32K chars...
                 Debug.Assert(result <= short.MaxValue, "shouldn't be possible to grow beyond UNICODE_STRING size");
 
@@ -35,7 +35,7 @@ internal partial class Interop
                     error = Marshal.GetLastWin32Error();
                     if (error == Errors.ERROR_INSUFFICIENT_BUFFER)
                     {
-                        // Typically this API truncates, but there was a bug in RS2 so we'll make an attempt to handle
+                        // Typically this API truncates but there was a bug in RS2 so we'll make an attempt to handle
                         builder.EnsureCapacity(builder.Capacity * 2);
                     }
                     else

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -2,69 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Text;
 using System.Runtime.InteropServices;
-using System;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        private static extern uint GetConsoleTitleW(ref char title, uint nSize);
-
-        private static bool s_isWindows7 = GetIsWindows7();
-
-        private static bool GetIsWindows7()
-        {
-            // Version lies from the OS kick in starting with Windows 8 (6.2)
-            Version version = Environment.OSVersion.Version;
-            return version.Major == 6 && version.Minor == 1;
-        }
-
-        internal static string GetConsoleTitle(out int error)
-        {
-            error = Errors.ERROR_SUCCESS;
-
-            Span<char> initialBuffer = stackalloc char[256];
-            ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
-
-            do
-            {
-                // Windows 7 copies count of bytes into the output buffer but returns count of chars.
-                uint result = GetConsoleTitleW(ref builder.GetPinnableReference(), (uint)builder.Capacity * (uint)(s_isWindows7 ? sizeof(char) : 1));
-
-                // The documentation asserts that the console's title is stored in a shared 64KB buffer.
-                // The magic number that used to exist here (24500) is likely related to that.
-                // A full UNICODE_STRING is 32K chars...
-                Debug.Assert(result <= short.MaxValue, "shouldn't be possible to grow beyond UNICODE_STRING size");
-
-                if (result == 0)
-                {
-                    error = Marshal.GetLastWin32Error();
-                    if (error == Errors.ERROR_INSUFFICIENT_BUFFER)
-                    {
-                        // Typically this API truncates but there was a bug in RS2 so we'll make an attempt to handle
-                        builder.EnsureCapacity(builder.Capacity * 2);
-                        error = Errors.ERROR_SUCCESS;
-                    }
-                    else
-                    {
-                        return string.Empty;
-                    }
-                }
-                else if (result >= builder.Capacity - 1)
-                {
-                    // Our buffer was full. As this API truncates we need to increase our size and reattempt.
-                    builder.EnsureCapacity(builder.Capacity * 2);
-                }
-                else
-                {
-                    builder.Length = (int)result;
-                    return builder.ToString();
-                }
-            } while (true);
-        }
+        internal static extern uint GetConsoleTitleW(ref char title, uint nSize);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -23,11 +23,12 @@ internal partial class Interop
 
             do
             {
+                uint result = GetConsoleTitleW(ref builder.GetPinnableReference(), (uint)builder.Capacity);
+
                 // The documentation asserts that the console's title is stored in a shared 64KB buffer.
                 // The magic number that used to exist here (24500), is likely related to that.
                 // A full UNICODE_STRING is 32K chars...
-                Debug.Assert(builder.Capacity <= short.MaxValue, "shouldn't be possible to grow beyond UNICODE_STRING size");
-                uint result = GetConsoleTitleW(ref builder.GetPinnableReference(), (uint)builder.Capacity);
+                Debug.Assert(result <= short.MaxValue, "shouldn't be possible to grow beyond UNICODE_STRING size");
 
                 if (result == 0)
                 {

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -63,6 +63,7 @@ internal partial class Interop
                         s_sizeMultiplier = 2;
                         return GetConsoleTitle(out error);
                     }
+                    return title;
                 }
             } while (true);
         }

--- a/src/System.Console/src/Resources/Strings.resx
+++ b/src/System.Console/src/Resources/Strings.resx
@@ -207,9 +207,6 @@
   <data name="ArgumentOutOfRange_ConsoleKey" xml:space="preserve">
     <value>Console key values must be between 0 and 255 inclusive.</value>
   </data>
-  <data name="ArgumentOutOfRange_ConsoleTitleTooLong" xml:space="preserve">
-    <value>The console title is too long.</value>
-  </data>
   <data name="ArgumentOutOfRange_ConsoleBufferBoundaries" xml:space="preserve">
     <value>The value must be greater than or equal to zero and less than the console's buffer size in that dimension.</value>
   </data>

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -170,6 +170,9 @@
     <Compile Include="$(CommonPath)\CoreLib\System\IO\Win32Marshal.cs">
       <Link>Common\CoreLib\System\IO\Win32Marshal.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\System\Text\ValueStringBuilder.cs">
+      <Link>Common\CoreLib\System\Text\ValueStringBuilder.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Unix -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
@@ -272,6 +275,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.IO;
-using System.Text;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace System
 {
@@ -271,24 +269,12 @@ namespace System
             set { SetCursorPosition(CursorLeft, value); }
         }
 
-        private const int MaxConsoleTitleLength = 24500; // same value as in .NET Framework
-
         public static string Title
         {
             get { return ConsolePal.Title; }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                if (value.Length > MaxConsoleTitleLength)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_ConsoleTitleTooLong);
-                }
-
-                ConsolePal.Title = value;
+                ConsolePal.Title = value ?? throw new ArgumentNullException(nameof(value));
             }
         }
 

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -606,7 +606,7 @@ namespace System
             {
                 string title = Interop.Kernel32.GetConsoleTitle(out int error);
                 if (error != Interop.Errors.ERROR_SUCCESS)
-                    throw new IOException($"Error: {error}");
+                    throw Win32Marshal.GetExceptionForWin32Error(error, string.Empty);
 
                 return title;
             }

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -606,7 +606,7 @@ namespace System
             {
                 string title = Interop.Kernel32.GetConsoleTitle(out int error);
                 if (error != Interop.Errors.ERROR_SUCCESS)
-                    throw Win32Marshal.GetExceptionForWin32Error(error, $"Error: {error}");
+                    throw new IOException($"Error: {error}");
 
                 return title;
             }

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -606,7 +606,7 @@ namespace System
             {
                 string title = Interop.Kernel32.GetConsoleTitle(out int error);
                 if (error != Interop.Errors.ERROR_SUCCESS)
-                    throw Win32Marshal.GetExceptionForWin32Error(error, string.Empty);
+                    throw Win32Marshal.GetExceptionForWin32Error(error, $"Error: {error}");
 
                 return title;
             }

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -616,7 +616,7 @@ namespace System
                 Span<char> initialBuffer = stackalloc char[256];
                 ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
 
-                do
+                while (true)
                 {
                     uint result = Interop.Errors.ERROR_SUCCESS;
 
@@ -638,9 +638,10 @@ namespace System
                             case Interop.Errors.ERROR_INSUFFICIENT_BUFFER:
                                 // Typically this API truncates but there was a bug in RS2 so we'll make an attempt to handle
                                 builder.EnsureCapacity(builder.Capacity * 2);
-                                break;
+                                continue;
                             case Interop.Errors.ERROR_SUCCESS:
-                                return string.Empty;
+                                // The title is empty.
+                                break;
                             default:
                                 throw Win32Marshal.GetExceptionForWin32Error(error, string.Empty);
                         }
@@ -654,13 +655,14 @@ namespace System
                         // (If we're Windows 10 with a version lie to 7 this will be inefficient so we'll want to remove
                         //  this workaround when we no longer support Windows 7)
                         builder.EnsureCapacity(builder.Capacity * 2);
+                        continue;
                     }
-                    else
-                    {
-                        builder.Length = (int)result;
-                        return builder.ToString();
-                    }
-                } while (true);
+
+                    builder.Length = (int)result;
+                    break;
+                }
+
+                return builder.ToString();
             }
             set
             {

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -609,7 +609,7 @@ namespace System
             }
         }
 
-        public static string Title
+        public unsafe static string Title
         {
             get
             {
@@ -618,7 +618,12 @@ namespace System
 
                 do
                 {
-                    uint result = Interop.Kernel32.GetConsoleTitleW(ref builder.GetPinnableReference(), (uint)builder.Capacity);
+                    uint result = Interop.Errors.ERROR_SUCCESS;
+
+                    fixed (char* c = &builder.GetPinnableReference())
+                    {
+                        result = Interop.Kernel32.GetConsoleTitleW(c, (uint)builder.Capacity);
+                    }
 
                     // The documentation asserts that the console's title is stored in a shared 64KB buffer.
                     // The magic number that used to exist here (24500) is likely related to that.

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -600,31 +600,16 @@ namespace System
             }
         }
 
-        // Although msdn states that the max allowed limit is 65K,
-        // desktop limits this to 24500 as buffer sizes greater than it
-        // throw.
-        private const int MaxConsoleTitleLength = 24500;
-
         public static string Title
         {
             get
             {
-                string title = null;
-                int titleLength = -1;
-                int r = Interop.Kernel32.GetConsoleTitle(out title, out titleLength);
+                string title = Interop.Kernel32.GetConsoleTitle(out int error);
+                if (error != Interop.Errors.ERROR_SUCCESS)
+                    throw Win32Marshal.GetExceptionForWin32Error(error, string.Empty);
 
-                if (0 != r)
-                {
-                    throw Win32Marshal.GetExceptionForWin32Error(r, string.Empty);
-                }
-
-                if (titleLength > MaxConsoleTitleLength)
-                    throw new InvalidOperationException(SR.ArgumentOutOfRange_ConsoleTitleTooLong);
-
-                Debug.Assert(title.Length == titleLength);
                 return title;
             }
-
             set
             {
                 if (!Interop.Kernel32.SetConsoleTitle(value))

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -144,8 +144,15 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     public static void Title_Get_Windows_NoNulls()
     {
         string title = Console.Title;
-        string trimmedTitle = title.TrimEnd('\0');
-        Assert.Equal(trimmedTitle, title);
+        if (PlatformDetection.IsWindowsNanoServer)
+        {
+            Assert.NotNull(title);
+        }
+        else
+        {
+            string trimmedTitle = title.TrimEnd('\0');
+            Assert.Equal(trimmedTitle, title);
+        }
     }
 
     [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Nano currently ignores set title
@@ -169,7 +176,7 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
             string newTitle = new string('a', int.Parse(lengthOfTitleString));
             Console.Title = newTitle;
 
-            if (newTitle.Length > 513 && PlatformDetection.IsWindows10Version1703OrGreater && !PlatformDetection.IsWindows10Version1709OrGreater)
+            if (newTitle.Length >= 511 && !PlatformDetection.IsNetCore && PlatformDetection.IsWindows10Version1703OrGreater && !PlatformDetection.IsWindows10Version1709OrGreater)
             {
                 // RS2 has a bug when getting the window title when the title length is longer than 513 character
                 Assert.Throws<IOException>(() => Console.Title);

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -132,11 +131,21 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior specific to Windows
+    [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // In appcontainer, the stream cannot be opened: there is no Console
     public static void Title_Get_Windows()
     {
         Assert.NotNull(Console.Title);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // In appcontainer, the stream cannot be opened: there is no Console
+    public static void Title_Get_Windows_NoNulls()
+    {
+        string title = Console.Title;
+        string trimmedTitle = title.TrimEnd('\0');
+        Assert.Equal(trimmedTitle, title);
     }
 
     [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Nano currently ignores set title
@@ -150,7 +159,7 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     [InlineData(512)]
     [InlineData(513)]
     [InlineData(1024)]
-    [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior specific to Windows
+    [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // In appcontainer, the stream cannot be opened: there is no Console
     public static void Title_Set_Windows(int lengthOfTitle)
     {

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -142,8 +142,13 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Nano currently ignores set title
     [InlineData(0)]
     [InlineData(1)]
+    [InlineData(254)]
     [InlineData(255)]
     [InlineData(256)]
+    [InlineData(257)]
+    [InlineData(511)]
+    [InlineData(512)]
+    [InlineData(513)]
     [InlineData(1024)]
     [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior specific to Windows
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // In appcontainer, the stream cannot be opened: there is no Console
@@ -187,8 +192,10 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     }
 
     [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
     public static void Title_Set_Windows_GreaterThan24500Chars_ThrowsArgumentOutOfRangeException()
     {
+        // We don't explicitly throw on Core as this isn't technically correct
         string newTitle = new string('a', 24501);
         AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => Console.Title = newTitle);
     }

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -144,13 +144,15 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     public static void Title_Get_Windows_NoNulls()
     {
         string title = Console.Title;
+        string trimmedTitle = title.TrimEnd('\0');
+
         if (PlatformDetection.IsWindowsNanoServer)
         {
-            Assert.NotNull(title);
+            // Nano server titles are currently broken
+            Assert.NotEqual(trimmedTitle, title);
         }
         else
         {
-            string trimmedTitle = title.TrimEnd('\0');
             Assert.Equal(trimmedTitle, title);
         }
     }


### PR DESCRIPTION
The Windows interop code for GetConsoleTitle was way more convoluted than it needed to be.
It also isn't accurate and overallocates. I've removed things that date back to 9x and allowed
for a case that showed up in RS2.