### PR TITLE
Aggressive Inline fast-path of BuffersExtensions split methods

### DIFF
--- a/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
+++ b/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Buffers
 {
     /// <summary>
@@ -12,6 +14,7 @@ namespace System.Buffers
         /// <summary>
         /// Returns position of first occurrence of item in the <see cref="ReadOnlySequence{T}"/>
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static SequencePosition? PositionOf<T>(in this ReadOnlySequence<T> source, T value) where T : IEquatable<T>
         {
             if (source.IsSingleSegment)
@@ -57,6 +60,7 @@ namespace System.Buffers
         /// </summary>
         /// <param name="source">The source <see cref="ReadOnlySequence{T}"/>.</param>
         /// <param name="destination">The destination <see cref="Span{Byte}"/>.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyTo<T>(in this ReadOnlySequence<T> source, Span<T> destination)
         {
             if (source.Length > destination.Length)
@@ -103,6 +107,7 @@ namespace System.Buffers
         /// <summary>
         /// Writes contents of <paramref name="value"/> to <paramref name="writer"/>
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Write<T>(this IBufferWriter<T> writer, ReadOnlySpan<T> value)
         {
             Span<T> destination = writer.GetSpan();


### PR DESCRIPTION
Methods are split into a fast-path inline part and a slower non-inline part. Aggressively inline the fast-path.

from https://github.com/aspnet/SignalR/pull/1907#issuecomment-379589824

/cc @ahsonkhan @pakrym @davidfowl @JamesNK 