### PR TITLE
Add more logging to SocketsHttpHandler

### DIFF
--- a/src/Common/tests/Scripts/Tools/net_startlog.cmd
+++ b/src/Common/tests/Scripts/Tools/net_startlog.cmd
@@ -1,2 +1,2 @@
-logman create trace SystemNetTrace -o net.etl -pf net_providers.txt
+logman create trace SystemNetTrace -o net.etl -pf net_providers.txt -max 1000
 logman start SystemNetTrace

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -50,7 +50,10 @@ namespace System.Net.Http
             if (digestResponse.Parameters.TryGetValue(Algorithm, out algorithm))
             {
                 if (algorithm != Sha256 && algorithm != Md5 && algorithm != Sha256Sess && algorithm != MD5Sess)
+                {
+                    if (NetEventSource.IsEnabled) NetEventSource.Error(digestResponse, "Algorithm not supported: {algorithm}");
                     return null;
+                }
             }
             else
             {
@@ -61,6 +64,7 @@ namespace System.Net.Http
             string nonce;
             if (!digestResponse.Parameters.TryGetValue(Nonce, out nonce))
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Error(digestResponse, "Nonce missing");
                 return null;
             }
 
@@ -71,6 +75,7 @@ namespace System.Net.Http
             string realm;
             if (!digestResponse.Parameters.TryGetValue(Realm, out realm))
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Error(digestResponse, "Realm missing");
                 return null;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -44,6 +44,10 @@ namespace System.Net.Http
             if (!isProxyAuth && connection.UsingProxy && !ProxySupportsConnectionAuth(response))
             {
                 // Proxy didn't indicate that it supports connection-based auth, so we can't proceed.
+                if (NetEventSource.IsEnabled)
+                {
+                    NetEventSource.Error(connection, $"Proxy doesn't support connection-based auth, uri={authUri}");
+                }
                 return response;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -159,6 +159,7 @@ namespace System.Net.Http
             // Any errors in obtaining parameter return false and we don't proceed with auth
             if (string.IsNullOrEmpty(parameter))
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Error(null, "Null parameter");
                 return false;
             }
 
@@ -251,11 +252,19 @@ namespace System.Net.Http
                                     {
                                         try
                                         {
+                                            if (NetEventSource.IsEnabled)
+                                            {
+                                                NetEventSource.Info(pool.PreAuthCredentials, $"Adding Basic credential to cache, uri={authUri}, username={challenge.Credential.UserName}");
+                                            }
                                             pool.PreAuthCredentials.Add(authUri, BasicScheme, challenge.Credential);
                                         }
                                         catch (ArgumentException)
                                         {
                                             // The credential already existed.
+                                            if (NetEventSource.IsEnabled)
+                                            {
+                                                NetEventSource.Info(pool.PreAuthCredentials, $"Basic credential present in cache, uri={authUri}, username={challenge.Credential.UserName}");
+                                            }
                                         }
                                     }
                                     break;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -159,7 +159,6 @@ namespace System.Net.Http
             // Any errors in obtaining parameter return false and we don't proceed with auth
             if (string.IsNullOrEmpty(parameter))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, "Null parameter");
                 return false;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -309,6 +309,11 @@ namespace System.Net.Http
                         default:
                         case ParsingState.Done: // shouldn't be called once we're done
                             Debug.Fail($"Unexpected state: {_state}");
+                            if (NetEventSource.IsEnabled)
+                            {
+                                NetEventSource.Error(this, $"Unexpected state: {_state}");
+                            }
+                            
                             return default;
                     }
                 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CookieHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CookieHelper.cs
@@ -31,7 +31,7 @@ namespace System.Net.Http
                         // Ignore invalid Set-Cookie header and continue processing.
                         if (NetEventSource.IsEnabled)
                         {
-                            NetEventSource.Info(response, $"Invalid Set-Cookie '{valuesArray[i]}' ignored.");
+                            NetEventSource.Error(response, $"Invalid Set-Cookie '{valuesArray[i]}' ignored.");
                         }
                     }
                 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -154,6 +154,10 @@ namespace System.Net.Http
             // pretends they're part of the default when running on Win7/2008R2.
             if (s_isWindows7Or2008R2 && sslOptions.EnabledSslProtocols == SslProtocols.None)
             {
+                if (NetEventSource.IsEnabled)
+                {
+                    NetEventSource.Info(poolManager, $"Win7OrWin2K8R2 platform, Changing default TLS protocols to {SecurityProtocol.DefaultSecurityProtocols}");
+                }
                 sslOptions.EnabledSslProtocols = SecurityProtocol.DefaultSecurityProtocols;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -262,12 +262,11 @@ namespace System.Net.Http
             {
                 // Eat any exception from the IWebProxy and just treat it as no proxy.
                 // This matches the behavior of other handlers.
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, ex);
+                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Exception from IWebProxy.GetProxy({request.RequestUri}): {ex}");
             }
 
             if (proxyUri != null && proxyUri.Scheme != UriScheme.Http)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.net_http_invalid_proxy_scheme);
                 throw new NotSupportedException(SR.net_http_invalid_proxy_scheme);
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -258,14 +258,16 @@ namespace System.Net.Http
                     proxyUri = _proxy.GetProxy(request.RequestUri);
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // Eat any exception from the IWebProxy and just treat it as no proxy.
                 // This matches the behavior of other handlers.
+                if (NetEventSource.IsEnabled) NetEventSource.Error(this, ex);
             }
 
             if (proxyUri != null && proxyUri.Scheme != UriScheme.Http)
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.net_http_invalid_proxy_scheme);
                 throw new NotSupportedException(SR.net_http_invalid_proxy_scheme);
             }
 
@@ -291,6 +293,8 @@ namespace System.Net.Http
         /// <summary>Removes unusable connections from each pool, and removes stale pools entirely.</summary>
         private void RemoveStalePools()
         {
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+
             Debug.Assert(_cleaningTimer != null);
 
             // Iterate through each pool in the set of pools.  For each, ask it to clear out
@@ -325,6 +329,8 @@ namespace System.Net.Http
             // than reused.  This should be a rare occurrence, so for now we don't worry about it.  In the
             // future, there are a variety of possible ways to address it, such as allowing connections to
             // be returned to pools they weren't associated with.
+
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
         }
 
         internal readonly struct HttpConnectionKey : IEquatable<HttpConnectionKey>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentDuplexStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentDuplexStream.cs
@@ -12,6 +12,7 @@ namespace System.Net.Http
     {
         public HttpContentDuplexStream(HttpConnection connection) : base(connection)
         {
+            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
         }
 
         public sealed override bool CanRead => true;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -39,6 +39,7 @@ namespace System.Net.Http
 
             if (proxyHelper.AutoSettingsUsed)
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Info(proxyHelper, $"AutoSettingsUsed, calling {nameof(Interop.WinHttp.WinHttpOpen)}");
                 sessionHandle = Interop.WinHttp.WinHttpOpen(
                     IntPtr.Zero,
                     Interop.WinHttp.WINHTTP_ACCESS_TYPE_NO_PROXY,
@@ -49,6 +50,7 @@ namespace System.Net.Http
                 if (sessionHandle.IsInvalid)
                 {
                     // Proxy failures are currently ignored by managed handler.
+                    if (NetEventSource.IsEnabled) NetEventSource.Error(proxyHelper, $"{nameof(Interop.WinHttp.WinHttpOpen)} returned invalid handle");
                     return false;
                 }
             }
@@ -135,11 +137,11 @@ namespace System.Net.Http
                                             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
                             _bypass.Add(re);
                         }
-                        catch
+                        catch (Exception ex)
                         {
                             if (NetEventSource.IsEnabled)
                             {
-                                NetEventSource.Info(this, "Failed to process " + tmp + " from bypass list.");
+                                NetEventSource.Error(this, ex, "Failed to process " + tmp + " from bypass list.");
                             }
                         }
                     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -141,7 +141,7 @@ namespace System.Net.Http
                         {
                             if (NetEventSource.IsEnabled)
                             {
-                                NetEventSource.Error(this, ex, "Failed to process " + tmp + " from bypass list.");
+                                NetEventSource.Error(this, $"Failed to process {tmp} from bypass list: {ex}");
                             }
                         }
                     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -27,6 +27,8 @@ namespace System.Net.Http
 
         protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, request, cancellationToken);
+
             HttpResponseMessage response = await _initialInnerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             uint redirectCount = 0;
@@ -41,7 +43,7 @@ namespace System.Net.Http
                     // then just return the 3xx response.
                     if (NetEventSource.IsEnabled)
                     {
-                        NetEventSource.Info(this, $"Exceeded max number of redirects. Redirect from {request.RequestUri} to {redirectUri} blocked.");
+                        NetEventSource.Error(this, $"Exceeded max number of redirects. Redirect from {request.RequestUri} to {redirectUri} blocked.");
                     }
 
                     break;
@@ -64,6 +66,8 @@ namespace System.Net.Http
                 // Issue the redirected request.
                 response = await _redirectInnerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
+
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
 
             return response;
         }
@@ -112,7 +116,7 @@ namespace System.Net.Http
             {
                 if (NetEventSource.IsEnabled)
                 {
-                    NetEventSource.Info(this, $"Insecure https to http redirect from '{requestUri}' to '{location}' blocked.");
+                    NetEventSource.Error(this, $"Insecure https to http redirect from '{requestUri}' to '{location}' blocked.");
                 }
 
                 return null;


### PR DESCRIPTION
As part of looking at the usability of .NET Core network logging (compared to
.NET Framework), I did a walkthru of the current logging in SocketsHttpHandler.
I noticed some inconsistencies in how the NetEventSource logging is being used.

For the 2.1 release, I wanted to at least add more logging to some key areas
including places where we ignore errors/exceptions.

There is still more work to do to improve the logging to make it useful for
developers. This includes doing a better job at logging for System.Net.Sockets
as well as looking into other tool options besides PerfView to look at the traces.

I also fixed the sample script for using starting the traces using Windows logman.
The default log buffer size is too small even for for simple traces. Now, using PerfView
on all the System.Net.* traces no longer shows an error about traces being dropped.