### PR TITLE
Stable test for both type of dateStyles. (dd\MM\yyyy and MM\dd\yyyy)

### DIFF
--- a/src/System.Runtime.Extensions/tests/Performance/System/Perf.Convert.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/System/Perf.Convert.cs
@@ -101,8 +101,8 @@ namespace System
         [InlineData("Fri, 27 Feb 2009 03:11:21 GMT")]
         [InlineData("Thursday, February 26, 2009")]
         [InlineData("February 26, 2009")]
-        [InlineData("12/31/1999 11:59:59 PM")]
-        [InlineData("12/31/1999")]
+        [InlineData("12/12/1999 11:59:59 PM")]
+        [InlineData("12/12/1999")]
         public void ToDateTime_String(string value)
         {
             int innerIterationCount = (int)Benchmark.InnerIterationCount;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28879