### PR TITLE
 Clear SSL error queue after SSL_shutdown calls

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -12,6 +12,9 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrClearError")]
+        internal static extern ulong ErrClearError();
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrGetError")]
         internal static extern ulong ErrGetError();
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -319,8 +319,11 @@ namespace Microsoft.Win32.SafeHandles
                 retVal = Interop.Ssl.SslShutdown(handle);
             }
 
-            // Clean up the errors
-            Interop.Crypto.ErrClearError();
+            if (retVal == -1)
+            {
+                // Clean up the errors
+                Interop.Crypto.ErrClearError();
+            }
         }
 
         private SafeSslHandle() : base(IntPtr.Zero, true)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -318,6 +318,9 @@ namespace Microsoft.Win32.SafeHandles
                 // Do a bi-directional shutdown.
                 retVal = Interop.Ssl.SslShutdown(handle);
             }
+
+            // Clean up the errors
+            Interop.Crypto.ErrClearError();
         }
 
         private SafeSslHandle() : base(IntPtr.Zero, true)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Win32.SafeHandles
                 retVal = Interop.Ssl.SslShutdown(handle);
             }
 
-            if (retVal == -1)
+            if (retVal < 0)
             {
                 // Clean up the errors
                 Interop.Crypto.ErrClearError();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_err.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_err.cpp
@@ -5,6 +5,11 @@
 #include "pal_err.h"
 #include "pal_utilities.h"
 
+extern "C" void CryptoNative_ErrClearError()
+{
+    ERR_clear_error();
+}
+
 extern "C" uint64_t CryptoNative_ErrGetError()
 {
     return ERR_get_error();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_err.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_err.h
@@ -6,6 +6,11 @@
 #include "opensslshim.h"
 
 /*
+Shims the ERR_clear_error method.
+*/
+extern "C" void CryptoNative_ErrClearError();
+
+/*
 Shims the ERR_get_error method.
 */
 extern "C" uint64_t CryptoNative_ErrGetError();


### PR DESCRIPTION
Part 1 of separating PR #28862 into smaller parts. This one covers the calls to SSL_shutdown explicitly made in CoreFx sources.

The other location of [SSL_shutdown call](https://github.com/dotnet/corefx/blob/275752f322defe4e4d0d6e9ccb4330df146d57f1/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs#L242-261) is already covered by the SSL_ERROR_SSL case. 