### PR TITLE
propagate default credentials so we can pick up default kerberos ticket

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -293,6 +293,21 @@ namespace System.Net.Http
                 {
                     _curlHandler.UseDefaultCredentials = value;
                 }
+                else
+                {
+                    if (value)
+                    {
+                        _socketsHttpHandler.Credentials = CredentialCache.DefaultCredentials;
+                    }
+                    else
+                    {
+                        if (_socketsHttpHandler.Credentials == CredentialCache.DefaultCredentials)
+                        {
+                            // Only clear out the Credentials property if it was a DefaultCredentials.
+                            _socketsHttpHandler.Credentials = null;
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
fixes #28963 

This duplicates code from Windows counter part. 
This makes SocketsHttpHandler behave like curl.

Note there is no unit test yet. Kerberos setup will need some more work. 
This was tested manually:

> ~/latest/dotnet run http://toweinfu-iis/test/auth/negotiate/Showidentity.ashx
> result1=StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.HttpConnection+HttpConnectionResponseContent, Headers:
> {
>   Cache-Control: private
>   Server: Microsoft-IIS/10.0
>   X-AspNet-Version: 4.0.30319
>   Persistent-Auth: true
>   X-Powered-By: ASP.NET
>   WWW-Authenticate: Negotiate oRQwEqADCgEAoQsGCSqGSIb3EgECAg==
>   Date: Tue, 10 Apr 2018 03:58:37 GMT
>   Content-Type: application/json; charset=utf-8
>   Content-Length: 60
> }
> result1 lenght = System.Threading.Tasks.Task
> {
>   "Authenticated": "True",
>   "User": "pri\testuser"
> }


