### PR TITLE
Fix perf hit from WinHttpGetProxyForUrl

### DIFF
--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
@@ -221,6 +221,12 @@ internal partial class Interop
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WinHttpDetectAutoProxyConfigUrl(
+            uint autoDetectFlags,
+            out IntPtr autoConfigUrl);
+
+        [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool WinHttpGetIEProxyConfigForCurrentUser(
             out WINHTTP_CURRENT_USER_IE_PROXY_CONFIG proxyConfig);
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
@@ -191,10 +191,10 @@ namespace System.Net.Http
             int currentTimeStamp = Environment.TickCount;
 
             // Environment.TickCount will increment from zero to Int32.MaxValue for approximately 24.9 days, then jump to
-            // Int32.MinValue. When that happens, we may skip doing WinHttpDetectAutoProxyConfigUrl for one request which we
-            // suppose to do. Since _previousTimeStampTicks will get updated in that request, susequent requests in next 24.9
-            // days period will behave correctly.
-            doAutoDetect = currentTimeStamp - _previousTimeStampTicks > TimerPeriodInMilliseconds ? true : false;
+            // Int32.MinValue. When that happens, we may skip calling WinHttpDetectAutoProxyConfigUrl for one request which we
+            // otherwise will call. Since _previousTimeStampTicks will get updated in that request, subsequent requests in
+            // next 24.9 days period will behave correctly.
+            doAutoDetect = currentTimeStamp - _previousTimeStampTicks > TimerPeriodInMilliseconds;
             _previousTimeStampTicks = currentTimeStamp;
 
             if (doAutoDetect)

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -611,6 +611,24 @@ internal static partial class Interop
             return true;
         }
 
+        public static bool WinHttpDetectAutoProxyConfigUrl(
+            uint autoDetectFlags,
+            out IntPtr autoConfigUrl)
+        {
+            if (FakeRegistry.WinInetProxySettings.AutoDetect)
+            {
+                autoConfigUrl = Marshal.StringToHGlobalUni(FakeRegistry.WinInetProxySettings.AutoConfigUrl);
+                return true;
+            }
+            else
+            {
+                autoConfigUrl = IntPtr.Zero;
+
+                TestControl.LastWin32Error = (int)Interop.WinHttp.ERROR_FILE_NOT_FOUND;
+                return false;
+            }
+        }
+
         public static IntPtr WinHttpSetStatusCallback(
             SafeWinHttpHandle handle,
             Interop.WinHttp.WINHTTP_STATUS_CALLBACK callback,

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -328,9 +328,17 @@ namespace System.Net.Http
             var proxyInfo = new Interop.WinHttp.WINHTTP_PROXY_INFO();
             try
             {
-                if (_proxyHelper.GetProxyForUrl(_sessionHandle, uri, out proxyInfo))
+                // When not able to find script using WPAD protocol, and there is no explicit
+                // PAC file set, we can avoid calling WinHttpGetProxyForUrl for each request.
+                bool skipGetProxyForUrl = string.IsNullOrEmpty(_proxyHelper.AutoConfigUrl) &&
+                    _proxyHelper.AutoDetectScriptSuccess() == false;
+
+                if (!skipGetProxyForUrl)
                 {
-                    return GetUriFromString(Marshal.PtrToStringUni(proxyInfo.Proxy));
+                    if (_proxyHelper.GetProxyForUrl(_sessionHandle, uri, out proxyInfo))
+                    {
+                        return GetUriFromString(Marshal.PtrToStringUni(proxyInfo.Proxy));
+                    }
                 }
             }
             finally


### PR DESCRIPTION
Per offline discussion, here is the summary of optimization approach:

1. We don't want to modify existing WinHttpHandler code. Only improve the perf hit from SocketsHttpHandler side.
2. Introduce `WinHttpDetectAutoProxyConfigUrl`. When "Automatic detect settings" is checked, we will call into this function to see if we can auto detect config file.
3. If we are not able to auto detect config file and "Use automatic configuration script" is turned off, we can safely skip calling into WinHttpGetProxyForUrl.
4. Add timer optimization for calling `WinHttpDetectAutoProxyConfigUrl`. We don't call it per request, instead call it every 2 minutes, cache/update the info, to improve performance.

Replace: #28859
Fix: #28543