### PR TITLE
Silent the warning on XCode 9.3's clang

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.cpp
+++ b/src/Native/Unix/System.Native/pal_process.cpp
@@ -369,6 +369,7 @@ static rlim_t ConvertFromManagedRLimitInfinityToPalIfNecessary(uint64_t value)
     // rlim_t type can vary per platform, so we also treat anything outside its range as infinite.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
     if (value == UINT64_MAX || value > std::numeric_limits<rlim_t>::max())
 #pragma clang diagnostic pop


### PR DESCRIPTION
Based on the discussion at https://github.com/dotnet/corefx/pull/28919#issuecomment-380155615.
@janvorli, @pjanotti