### PR TITLE
Clear SSL error queue after MultiDestroy and MultiRemoveHandle

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Multi.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Multi.cs
@@ -92,6 +92,10 @@ internal static partial class Interop
             {
                 bool result = MultiDestroy(handle) == CURLMcode.CURLM_OK;
                 SetHandle(IntPtr.Zero);
+
+#if !SYSNETHTTP_NO_OPENSSL
+                Interop.Crypto.ErrClearError(); // Ensure that no SSL errors were left on the queue by libcurl.
+#endif
                 return result;
             }
         }

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Multi.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Multi.cs
@@ -96,6 +96,7 @@ internal static partial class Interop
 #if !SYSNETHTTP_NO_OPENSSL
                 Interop.Crypto.ErrClearError(); // Ensure that no SSL errors were left on the queue by libcurl.
 #endif
+
                 return result;
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.MultiAgent.cs
@@ -753,6 +753,10 @@ namespace System.Net.Http
                     CURLMcode removeResult = Interop.Http.MultiRemoveHandle(_multiHandle, activeRequest.EasyHandle);
                     Debug.Assert(removeResult == CURLMcode.CURLM_OK, "Failed to remove easy handle"); // ignore cleanup errors in release
 
+#if !SYSNETHTTP_NO_OPENSSL
+                    Interop.Crypto.ErrClearError(); // Ensure that no SSL errors were left on the queue by libcurl.
+#endif
+
                     // Release the associated GCHandle so that it's not kept alive forever
                     if (gcHandlePtr != IntPtr.Zero)
                     {


### PR DESCRIPTION
Part 3 of separating PR #28862: Clear SSL error queue after MultiDestroy and MultiRemoveHandle (CurlHandler).

These methods wrap calls to SSL_shutdown that can leave unwanted errors on the SSL error queue. 

There is no return to indicate if an error happened, so whenever MultiDestroy and MultiRemoveHandle are called a corresponding call to ErrClearError was added.