### PR TITLE
Removing SequenceMarshal.TryGetMemoryManager for ReadOnlySequence

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -532,7 +532,6 @@ namespace System.Runtime.InteropServices
     public static partial class SequenceMarshal
     {
         public static bool TryGetArray<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ArraySegment<T> segment) { throw null; }
-        public static bool TryGetMemoryManager<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.Buffers.MemoryManager<T> manager, out int start, out int length) { throw null; }
         public static bool TryGetReadOnlyMemory<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ReadOnlyMemory<T> memory) { throw null; }
         public static bool TryGetReadOnlySequenceSegment<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.Buffers.ReadOnlySequenceSegment<T> startSegment, out int startIndex, out System.Buffers.ReadOnlySequenceSegment<T> endSegment, out int endIndex) { throw null; }
     }

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -322,25 +322,6 @@ namespace System.Buffers
             return true;
         }
 
-        internal bool TryGetMemoryManager(out MemoryManager<T> manager, out int start, out int length)
-        {
-            GetTypeAndIndices(Start.GetInteger(), End.GetInteger(), out SequenceType type, out start, out int endIndex);
-
-            if (type != SequenceType.MemoryManager)
-            {
-                manager = default;
-                length = 0;
-                return false;
-            }
-
-            Debug.Assert(Start.GetObject() != null);
-            Debug.Assert(Start.GetObject() is MemoryManager<T>);
-
-            manager = Unsafe.As<MemoryManager<T>>(Start.GetObject());
-            length = endIndex - start;
-            return true;
-        }
-
         internal bool TryGetReadOnlyMemory(out ReadOnlyMemory<T> memory)
         {
             GetTypeAndIndices(Start.GetInteger(), End.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);

--- a/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
+++ b/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
@@ -34,15 +34,6 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>
-        /// Get <see cref="MemoryManager{T}"/> from the underlying <see cref="ReadOnlySequence{T}"/>.
-        /// If unable to get the <see cref="MemoryManager{T}"/>, return false.
-        /// </summary>
-        public static bool TryGetMemoryManager<T>(ReadOnlySequence<T> sequence, out MemoryManager<T> manager, out int start, out int length)
-        {
-            return sequence.TryGetMemoryManager(out manager, out start, out length);
-        }
-
-        /// <summary>
         /// Get <see cref="ReadOnlyMemory{T}"/> from the underlying <see cref="ReadOnlySequence{T}"/>.
         /// If unable to get the <see cref="ReadOnlyMemory{T}"/>, return false.
         /// </summary>

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.TryGet.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.TryGet.cs
@@ -21,7 +21,6 @@ namespace System.Memory.Tests
             Assert.Equal(3, array.Count);
 
             Assert.False(SequenceMarshal.TryGetReadOnlySequenceSegment(buffer, out _, out _, out _, out _));
-            Assert.False(SequenceMarshal.TryGetMemoryManager(buffer, out _, out _, out _));
 
             // Array can be retrieved with TryGetReadOnlyMemory
             Assert.True(SequenceMarshal.TryGetReadOnlyMemory(buffer, out ReadOnlyMemory<byte> newMemory));
@@ -38,7 +37,6 @@ namespace System.Memory.Tests
             Assert.Equal(new byte[] { 3, 4, 5 }, newMemory.ToArray());
 
             Assert.False(SequenceMarshal.TryGetReadOnlySequenceSegment(buffer, out ReadOnlySequenceSegment<byte> startSegment, out int startIndex, out ReadOnlySequenceSegment<byte> endSegment, out int endIndex));
-            Assert.False(SequenceMarshal.TryGetMemoryManager(buffer, out _, out _, out _));
 
             // Memory is internally decomposed to its container so it would be accessible via TryGetArray
             Assert.True(SequenceMarshal.TryGetArray(buffer, out ArraySegment<byte> array));
@@ -58,7 +56,6 @@ namespace System.Memory.Tests
             Assert.Equal(text.Substring(2, 3).ToCharArray(), newMemory.ToArray());
 
             Assert.False(SequenceMarshal.TryGetReadOnlySequenceSegment(buffer, out ReadOnlySequenceSegment<char> startSegment, out int startIndex, out ReadOnlySequenceSegment<char> endSegment, out int endIndex));
-            Assert.False(SequenceMarshal.TryGetMemoryManager(buffer, out _, out _, out _));
             Assert.False(SequenceMarshal.TryGetArray(buffer, out _));
         }
 
@@ -77,7 +74,6 @@ namespace System.Memory.Tests
             Assert.Equal(5, endIndex);
 
             Assert.False(SequenceMarshal.TryGetArray(buffer, out _));
-            Assert.False(SequenceMarshal.TryGetMemoryManager(buffer, out _, out _, out _));
 
             // Single block can be retrieved with TryGetReadOnlyMemory
             Assert.True(SequenceMarshal.TryGetReadOnlyMemory(buffer, out ReadOnlyMemory<byte> newMemory));
@@ -100,7 +96,6 @@ namespace System.Memory.Tests
             Assert.Equal(1, endIndex);
 
             Assert.False(SequenceMarshal.TryGetArray(buffer, out _));
-            Assert.False(SequenceMarshal.TryGetMemoryManager(buffer, out _, out _, out _));
 
             // Multi-block can't be retrieved with TryGetReadOnlyMemory
             Assert.False(SequenceMarshal.TryGetReadOnlyMemory(buffer, out _));


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28959

cc @pakrym, @KrzysztofCwalina, @davidfowl 