### PR TITLE
Handle User-Agent/Server writing similarly to HttpHeaders.GetHeaderString

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -263,6 +263,7 @@ namespace System.Net.Http
                         cookiesFromContainer = null;
                     }
 
+                    // Some headers such as User-Agent and Server use space as a separator (see: ProductInfoHeaderParser)
                     HttpHeaderParser parser = header.Key.Parser;
                     string separator = HttpHeaderParser.DefaultSeparator;
                     if (parser != null && parser.SupportsMultipleValues)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -263,9 +263,16 @@ namespace System.Net.Http
                         cookiesFromContainer = null;
                     }
 
+                    HttpHeaderParser parser = header.Key.Parser;
+                    string separator = HttpHeaderParser.DefaultSeparator;
+                    if (parser != null && parser.SupportsMultipleValues)
+                    {
+                        separator = parser.Separator;
+                    }
+
                     for (int i = 1; i < header.Value.Length; i++)
                     {
-                        await WriteTwoBytesAsync((byte)',', (byte)' ').ConfigureAwait(false);
+                        await WriteAsciiStringAsync(separator).ConfigureAwait(false);
                         await WriteStringAsync(header.Value[i]).ConfigureAwait(false);
                     }
                 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -264,17 +264,20 @@ namespace System.Net.Http
                     }
 
                     // Some headers such as User-Agent and Server use space as a separator (see: ProductInfoHeaderParser)
-                    HttpHeaderParser parser = header.Key.Parser;
-                    string separator = HttpHeaderParser.DefaultSeparator;
-                    if (parser != null && parser.SupportsMultipleValues)
+                    if (header.Value.Length > 1)
                     {
-                        separator = parser.Separator;
-                    }
+                        HttpHeaderParser parser = header.Key.Parser;
+                        string separator = HttpHeaderParser.DefaultSeparator;
+                        if (parser != null && parser.SupportsMultipleValues)
+                        {
+                            separator = parser.Separator;
+                        }
 
-                    for (int i = 1; i < header.Value.Length; i++)
-                    {
-                        await WriteAsciiStringAsync(separator).ConfigureAwait(false);
-                        await WriteStringAsync(header.Value[i]).ConfigureAwait(false);
+                        for (int i = 1; i < header.Value.Length; i++)
+                        {
+                            await WriteAsciiStringAsync(separator).ConfigureAwait(false);
+                            await WriteStringAsync(header.Value[i]).ConfigureAwait(false);
+                        }
                     }
                 }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Test.Common;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -396,6 +398,34 @@ namespace System.Net.Http.Functional.Tests
                 Task<HttpResponseMessage>[] tasks = Enumerable.Range(0, 3).Select(_ => client.GetAsync(CreateFakeUri())).ToArray();
                 Assert.All(tasks, task => Assert.Throws<TaskCanceledException>(() => task.GetAwaiter().GetResult()));
             }
+        }
+
+        [Fact]
+        public async Task SendAsync_UserAgent_CorrectlyWritten()
+        {
+            string userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.18 Safari/537.36";
+            string requestUri = "http://[::1234]";
+            bool connectionAccepted = false;
+
+            await LoopbackServer.CreateClientAndServerAsync(async proxyUri =>
+            {
+                using (HttpClientHandler handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    handler.Proxy = new WebProxy(proxyUri);
+                    var message = new HttpRequestMessage(HttpMethod.Post, requestUri);
+                    message.Headers.TryAddWithoutValidation("User-Agent", userAgent);
+                    try { await client.SendAsync(message).ConfigureAwait(false); }
+                    catch { }
+                }
+            }, server => server.AcceptConnectionAsync(async connection =>
+            {
+                connectionAccepted = true;
+                List<string> headers = await connection.ReadRequestHeaderAndSendResponseAsync();
+                Assert.Contains($"User-Agent: {userAgent}", headers);
+            }));
+
+            Assert.True(connectionAccepted);
         }
 
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -404,19 +404,16 @@ namespace System.Net.Http.Functional.Tests
         public async Task SendAsync_UserAgent_CorrectlyWritten()
         {
             string userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.18 Safari/537.36";
-            string requestUri = "http://[::1234]";
             bool connectionAccepted = false;
 
-            await LoopbackServer.CreateClientAndServerAsync(async proxyUri =>
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
                 using (HttpClientHandler handler = CreateHttpClientHandler())
                 using (var client = new HttpClient(handler))
                 {
-                    handler.Proxy = new WebProxy(proxyUri);
-                    var message = new HttpRequestMessage(HttpMethod.Post, requestUri);
+                    var message = new HttpRequestMessage(HttpMethod.Post, uri);
                     message.Headers.TryAddWithoutValidation("User-Agent", userAgent);
-                    try { await client.SendAsync(message).ConfigureAwait(false); }
-                    catch { }
+                    await client.SendAsync(message).ConfigureAwait(false);
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -404,25 +404,20 @@ namespace System.Net.Http.Functional.Tests
         public async Task SendAsync_UserAgent_CorrectlyWritten()
         {
             string userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.18 Safari/537.36";
-            bool connectionAccepted = false;
 
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
-                using (HttpClientHandler handler = CreateHttpClientHandler())
-                using (var client = new HttpClient(handler))
+                using (var client = CreateHttpClient())
                 {
                     var message = new HttpRequestMessage(HttpMethod.Post, uri);
                     message.Headers.TryAddWithoutValidation("User-Agent", userAgent);
-                    await client.SendAsync(message).ConfigureAwait(false);
+                    (await client.SendAsync(message).ConfigureAwait(false)).Dispose();
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {
-                connectionAccepted = true;
                 List<string> headers = await connection.ReadRequestHeaderAndSendResponseAsync();
                 Assert.Contains($"User-Agent: {userAgent}", headers);
             }));
-
-            Assert.True(connectionAccepted);
         }
 
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -409,7 +409,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (var client = CreateHttpClient())
                 {
-                    var message = new HttpRequestMessage(HttpMethod.Post, uri);
+                    var message = new HttpRequestMessage(HttpMethod.Get, uri);
                     message.Headers.TryAddWithoutValidation("User-Agent", userAgent);
                     (await client.SendAsync(message).ConfigureAwait(false)).Dispose();
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28951

(Tests pending)

This changes writing headers similarly to what we do here:
https://github.com/dotnet/corefx/blob/d5351fe933f0f4682ac465b656b2a438b076c24e/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs#L309-L329