### PR TITLE
Modify test to only try open file with vi not nano

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -155,7 +155,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Theory, InlineData("nano"), InlineData("vi")]
+        [Theory, InlineData("vi")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [OuterLoop("Opens program")]
         public void ProcessStart_OpenFileOnLinux_UsesSpecifiedProgram(string programToOpenWith)
@@ -178,7 +178,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Theory, InlineData("nano"), InlineData("vi")]
+        [Theory, InlineData("vi")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [OuterLoop("Opens program")]
         public void ProcessStart_OpenFileOnLinux_UsesSpecifiedProgramUsingArgumentList(string programToOpenWith)
@@ -186,7 +186,7 @@ namespace System.Diagnostics.Tests
             if (IsProgramInstalled(programToOpenWith))
             {
                 string fileToOpen = GetTestFilePath() + ".txt";
-                File.WriteAllText(fileToOpen, $"{nameof(ProcessStart_OpenFileOnLinux_UsesSpecifiedProgram)}");
+                File.WriteAllText(fileToOpen, $"{nameof(ProcessStart_OpenFileOnLinux_UsesSpecifiedProgramUsingArgumentList)}");
                 ProcessStartInfo psi = new ProcessStartInfo(programToOpenWith);
                 psi.ArgumentList.Add(fileToOpen);
                 using (var px = Process.Start(psi))


### PR DESCRIPTION
Fixes: #28668

As explained in #28668, the test failure in `System.Diagnostics.Tests.ProcessTests/ProcessStart_OpenFileOnLinux_UsesSpecifiedProgram(programToOpenWith: \"nano\")` seems due to nano exiting when stdin is not a terminal.

This PR changes this test and test `ProcessStart_OpenFileOnLinux_UsesSpecifiedProgramUsingArgumentList` to only use vi.

cc: @danmosemsft @tmds 