### PR TITLE
Disable SSL3 test case on RedHat 6

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -80,7 +80,10 @@ namespace System.Net.Http.Functional.Tests
                 yield return new object[] { protocol, true };
             }
 
-            // These protocols are disabled by default, so we can only connect with them explicitly
+            // These protocols are disabled by default, so we can only connect with them explicitly.
+            // Some linux distributions intentionally misreport the current OpenSsl version for
+            // compatability reasons, and so the default behavior may vary from what we expect.
+            // Since we cannot detect the actual OpenSSL version, we have to skip this case.
 #pragma warning disable 0618
             if (PlatformDetection.IsWindows ||
                 PlatformDetection.IsOSX ||

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -84,7 +84,10 @@ namespace System.Net.Http.Functional.Tests
 #pragma warning disable 0618
             if (PlatformDetection.IsWindows ||
                 PlatformDetection.IsOSX ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PlatformDetection.OpenSslVersion < new Version(1, 0, 2) && !PlatformDetection.IsDebian))
+                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+                 PlatformDetection.OpenSslVersion < new Version(1, 0, 2) &&
+                 !PlatformDetection.IsDebian &&
+                 !PlatformDetection.IsRedHatFamily6))
             {
                 yield return new object[] { SslProtocols.Ssl3, true };
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -82,7 +82,7 @@ namespace System.Net.Http.Functional.Tests
 
             // These protocols are disabled by default, so we can only connect with them explicitly.
             // Some linux distributions intentionally misreport the current OpenSsl version for
-            // compatability reasons, and so the default behavior may vary from what we expect.
+            // compatibility reasons, and so the default behavior may vary from what we expect.
             // Since we cannot detect the actual OpenSSL version, we have to skip this case.
 #pragma warning disable 0618
             if (PlatformDetection.IsWindows ||

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -81,9 +81,7 @@ namespace System.Net.Http.Functional.Tests
             }
 
             // These protocols are disabled by default, so we can only connect with them explicitly.
-            // Some linux distributions intentionally misreport the current OpenSsl version for
-            // compatibility reasons, and so the default behavior may vary from what we expect.
-            // Since we cannot detect the actual OpenSSL version, we have to skip this case.
+            // On certain platforms these are completely disabled and cannot be used at all.
 #pragma warning disable 0618
             if (PlatformDetection.IsWindows ||
                 PlatformDetection.IsOSX ||
@@ -92,6 +90,7 @@ namespace System.Net.Http.Functional.Tests
                  !PlatformDetection.IsDebian &&
                  !PlatformDetection.IsRedHatFamily6))
             {
+                // TODO #28790: SSLv3 is supported on RHEL 6, but this test case still fails.
                 yield return new object[] { SslProtocols.Ssl3, true };
             }
             if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10Version1607OrGreater)


### PR DESCRIPTION
Because of [this issue](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html-single/6.9_release_notes/index#known_issues_security), one of our SSL tests consistently fails on RedHat 6.9.

The test tries to detect what version of OpenSsl is loaded in order to decide which test cases are valid. The call we're actually using to do that is `SSLEay`. As documented in the RedHat 6.9 known issues, that value is not reported correctly:
```
Because certain applications perform incorrect version check of the OpenSSL version, the actual 
runtime version of OpenSSL is masked and the build-time version is reported instead. Consequently,
it is impossible to detect the currently running OpenSSL version using the SSLeay() function.
```

The misreported version causes us to use a test case we would not otherwise, which then fails. This fix disables the test case on RedHat.