### PR TITLE
Make HttpWebResponse.LastModified throw when invalid date is provided

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpDateParse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpDateParse.cs
@@ -399,18 +399,7 @@ namespace System.Net
             return true;
         }
 
-        // parse String to DateTime format.
-        public static DateTime StringToDate(String S)
-        {
-            DateTime dtOut;
-            if (HttpDateParse.ParseHttpDate(S, out dtOut))
-            {
-                return dtOut;
-            }
-            else
-            {
-                throw new ProtocolViolationException(SR.net_baddate);
-            }
-        }
+        public static DateTime StringToDate(string S) =>
+            HttpDateParse.ParseHttpDate(S, out DateTime dtOut) ? dtOut : throw new ProtocolViolationException(SR.net_baddate);
     }
 }

--- a/src/System.Net.Requests/src/System/Net/HttpDateParse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpDateParse.cs
@@ -399,7 +399,7 @@ namespace System.Net
             return true;
         }
 
-        public static DateTime StringToDate(string S) =>
-            HttpDateParse.ParseHttpDate(S, out DateTime dtOut) ? dtOut : throw new ProtocolViolationException(SR.net_baddate);
+        public static DateTime StringToDate(string s) =>
+            HttpDateParse.ParseHttpDate(s, out DateTime dtOut) ? dtOut : throw new ProtocolViolationException(SR.net_baddate);
     }
 }

--- a/src/System.Net.Requests/src/System/Net/HttpDateParse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpDateParse.cs
@@ -398,5 +398,19 @@ namespace System.Net
 
             return true;
         }
+
+        // parse String to DateTime format.
+        public static DateTime StringToDate(String S)
+        {
+            DateTime dtOut;
+            if (HttpDateParse.ParseHttpDate(S, out dtOut))
+            {
+                return dtOut;
+            }
+            else
+            {
+                throw new ProtocolViolationException(SR.net_baddate);
+            }
+        }
     }
 }

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1450,7 +1450,7 @@ namespace System.Net
                 {
                     return DateTime.MinValue; // MinValue means header is not present
                 }
-                return StringToDate(headerValue);
+                return HttpDateParse.StringToDate(headerValue);
 #if DEBUG
             }
 #endif
@@ -1469,20 +1469,6 @@ namespace System.Net
 #if DEBUG
             }
 #endif
-        }
-
-        // parse String to DateTime format.
-        private static DateTime StringToDate(String S)
-        {
-            DateTime dtOut;
-            if (HttpDateParse.ParseHttpDate(S, out dtOut))
-            {
-                return dtOut;
-            }
-            else
-            {
-                throw new ProtocolViolationException(SR.net_baddate);
-            }
         }
 
         // convert Date to String using RFC 1123 pattern

--- a/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -150,12 +150,10 @@ namespace System.Net
                 {
                     return DateTime.Now;
                 }
-                DateTime dtOut;
-                HttpDateParse.ParseHttpDate(lastmodHeaderValue, out dtOut);
-                return dtOut;
+
+                return HttpDateParse.StringToDate(lastmodHeaderValue);
             }
         }
-
 
         /// <devdoc>
         ///    <para>

--- a/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -94,42 +94,36 @@ namespace System.Net.Tests
             });
         }
 
-        [OuterLoop]
         [Fact]
-        public async Task HttpHeader_LastModifiedDate_Success()
+        public async Task LastModified_ValidDate_Success()
         {
             DateTime expected = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2018, 4, 10, 3, 4, 5, DateTimeKind.Utc), TimeZoneInfo.Local);
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 HttpWebRequest request = WebRequest.CreateHttp(url);
-                request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, "Last-Modified: Tue, 10 Apr 2018 03:04:05 GMT\r\n", "12345");
 
-                using (WebResponse response = await getResponse)
+                using (HttpWebResponse response = (HttpWebResponse)(await getResponse))
                 {
-                    HttpWebResponse httpResponse = (HttpWebResponse)response;
-                    Assert.Equal(expected, httpResponse.LastModified);
+                    Assert.Equal(expected, response.LastModified);
                 }
             });
         }
 
-        [OuterLoop]
         [Fact]
-        public async Task HttpHeader_LastModifiedDate_Throws()
+        public async Task LastModified_InvalidDate_Throws()
         {
             DateTime expected = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2018, 4, 10, 3, 4, 5, DateTimeKind.Utc), TimeZoneInfo.Local);
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 HttpWebRequest request = WebRequest.CreateHttp(url);
-                request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
                 await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, "Last-Modified: invalid date\r\n", "12345");
 
-                using (WebResponse response = await getResponse)
+                using (HttpWebResponse response = (HttpWebResponse)(await getResponse))
                 {
-                    HttpWebResponse httpResponse = (HttpWebResponse)response;
-                    Assert.Throws<ProtocolViolationException>(() => httpResponse.LastModified);
+                    Assert.Throws<ProtocolViolationException>(() => response.LastModified);
                 }
             });
         }
@@ -165,6 +159,6 @@ namespace System.Net.Tests
                     }
                 }
             });
-        } 
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28941

cc: @Clockwork-Muse 