### PR TITLE
Work around occasional IOException using OpenRemoteBaseKey against local machine

### DIFF
--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedUtils.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedUtils.cs
@@ -163,7 +163,11 @@ namespace System.Diagnostics
 
             try
             {
-                baseKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, machineName);
+                if (machineName == ".")
+                    baseKey = Registry.LocalMachine;
+                else
+                    baseKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, machineName);
+
                 if (baseKey == null)
                     throw new InvalidOperationException(SR.Format(SR.RegKeyMissingShort, "HKEY_LOCAL_MACHINE", machineName));
 


### PR DESCRIPTION
RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, ".") " is sporadically hitting an IOException with "Network path not found" because the underlying call to RegConnectRegistry  is returning an error. I am working around the problem by using Registry.LocalMachine when the key requested is against the local machine. I will open the issue to consider whether OpenRemoteBaseKey should do this itself. I will tag the issue here (after I create it)
Fixes https://github.com/dotnet/corefx/issues/29007