### PR TITLE
Faster ReadOnlySequence First and TryGet methods

### DIFF
--- a/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
+++ b/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
@@ -36,13 +36,14 @@ namespace System.Buffers
         private static SequencePosition? PositionOfMultiSegment<T>(in ReadOnlySequence<T> source, T value) where T : IEquatable<T>
         {
             SequencePosition position = source.Start;
-            while (source.TryGetBuffer(position, out ReadOnlyMemory<T> memory, out SequencePosition next, true))
+            while (source.TryGetBuffer(position, out ReadOnlyMemory<T> memory, out SequencePosition next, trusted: true))
             {
                 int index = memory.Span.IndexOf(value);
                 if (index != -1)
                 {
                     return source.GetPosition(index, position);
                 }
+
                 position = next;
             }
 
@@ -73,7 +74,7 @@ namespace System.Buffers
         private static void CopyToMultiSegment<T>(in ReadOnlySequence<T> source, Span<T> destination)
         {
             SequencePosition position = source.Start;
-            while (source.TryGetBuffer(position, out ReadOnlyMemory<T> memory, out SequencePosition next, true))
+            while (source.TryGetBuffer(position, out ReadOnlyMemory<T> memory, out SequencePosition next, trusted: true))
             {
                 memory.Span.CopyTo(destination);
                 position = next;

--- a/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
+++ b/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
@@ -17,39 +17,15 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static SequencePosition? PositionOf<T>(in this ReadOnlySequence<T> source, T value) where T : IEquatable<T>
         {
-            if (source.IsSingleSegment)
-            {
-                int index = source.First.Span.IndexOf(value);
-                if (index != -1)
-                {
-                    return source.GetPosition(index);
-                }
-
-                return null;
-            }
-            else
-            {
-                return PositionOfMultiSegment(source, value);
-            }
-        }
-
-        private static SequencePosition? PositionOfMultiSegment<T>(in ReadOnlySequence<T> source, T value) where T : IEquatable<T>
-        {
             SequencePosition position = source.Start;
-            SequencePosition result = position;
-            while (source.TryGet(ref position, out ReadOnlyMemory<T> memory))
+            while (source.TryGetBuffer(position, out ReadOnlyMemory<T> memory, out SequencePosition next, true))
             {
                 int index = memory.Span.IndexOf(value);
                 if (index != -1)
                 {
-                    return source.GetPosition(index, result);
+                    return source.GetPosition(index, position);
                 }
-                else if (position.GetObject() == null)
-                {
-                    break;
-                }
-
-                result = position;
+                position = next;
             }
 
             return null;
@@ -66,26 +42,14 @@ namespace System.Buffers
             if (source.Length > destination.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
 
-            if (source.IsSingleSegment)
+            SequencePosition position = source.Start;
+            while (source.TryGetBuffer(position, out ReadOnlyMemory<T> memory, out SequencePosition next, true))
             {
-                source.First.Span.CopyTo(destination);
-            }
-            else
-            {
-                CopyToMultiSegment(source, destination);
-            }
-        }
-
-        private static void CopyToMultiSegment<T>(in ReadOnlySequence<T> sequence, Span<T> destination)
-        {
-            SequencePosition position = sequence.Start;
-            while (sequence.TryGet(ref position, out ReadOnlyMemory<T> memory))
-            {
-                ReadOnlySpan<T> span = memory.Span;
-                span.CopyTo(destination);
+                memory.Span.CopyTo(destination);
+                position = next;
                 if (position.GetObject() != null)
                 {
-                    destination = destination.Slice(span.Length);
+                    destination = destination.Slice(memory.Length);
                 }
                 else
                 {

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -433,7 +433,7 @@ namespace System.Buffers
             /// <returns></returns>
             public bool MoveNext()
             {
-                bool result = _sequence.TryGetBuffer(_next, out _currentMemory, out SequencePosition next, true);
+                bool result = _sequence.TryGetBuffer(_next, out _currentMemory, out SequencePosition next, trusted: true);
                 _next = next;
                 return result;
             }

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -52,7 +52,7 @@ namespace System.Buffers
         /// <summary>
         /// Gets <see cref="ReadOnlyMemory{T}"/> from the first segment.
         /// </summary>
-        public ReadOnlyMemory<T> First => GetFirstBuffer(_sequenceStart, _sequenceEnd);
+        public ReadOnlyMemory<T> First => GetFirstBuffer();
 
         /// <summary>
         /// A position to the start of the <see cref="ReadOnlySequence{T}"/>.
@@ -361,7 +361,7 @@ namespace System.Buffers
         /// </summary>
         public bool TryGet(ref SequencePosition position, out ReadOnlyMemory<T> memory, bool advance = true)
         {
-            bool result = TryGetBuffer(position, End, out memory, out SequencePosition next);
+            bool result = TryGetBuffer(position, out memory, out SequencePosition next);
             if (advance)
             {
                 position = next;
@@ -386,14 +386,22 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private SequenceType GetSequenceType()
+        {
+            // We take high order bits of two indexes and move them
+            // to a first and second position to convert to SequenceType
+            return (SequenceType)(-(2 * (_sequenceStart.GetInteger() >> 31) + (_sequenceEnd.GetInteger() >> 31)));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetIndex(in SequencePosition position) => position.GetInteger() & ReadOnlySequence.IndexBitMask;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void GetTypeAndIndices(int start, int end, out SequenceType sequenceType, out int startIndex, out int endIndex)
         {
             startIndex = start & ReadOnlySequence.IndexBitMask;
             endIndex = end & ReadOnlySequence.IndexBitMask;
-            // We take high order bits of two indexes index and move them
-            // to a first and second position to convert to BufferType
-            // Masking with 2 is required to only keep the second bit of Start.GetInteger()
-            sequenceType = Start.GetObject() == null ? SequenceType.Empty : (SequenceType)((((uint)Start.GetInteger() >> 30) & 2) | (uint)End.GetInteger() >> 31);
+            sequenceType = GetSequenceType();
         }
 
         /// <summary>
@@ -425,12 +433,9 @@ namespace System.Buffers
             /// <returns></returns>
             public bool MoveNext()
             {
-                if (_next.GetObject() == null)
-                {
-                    return false;
-                }
-
-                return _sequence.TryGet(ref _next, out _currentMemory);
+                bool result = _sequence.TryGetBuffer(_next, out _currentMemory, out SequencePosition next, true);
+                _next = next;
+                return result;
             }
         }
 
@@ -439,8 +444,7 @@ namespace System.Buffers
             MultiSegment = 0x00,
             Array = 0x1,
             MemoryManager = 0x2,
-            String = 0x3,
-            Empty = 0x4
+            String = 0x3
         }
     }
 

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -383,9 +383,9 @@ namespace System.Buffers
             Debug.Assert(endObject != null);
 
             int length = endIndex - startIndex;
-            if (startObject != endObject)
+            if (startObject != endObject || startObject == null)
             {
-                // Can't get ReadOnlyMemory from multi-block segments
+                // Can't get ReadOnlyMemory from multi-block segments and default sequence
                 memory = default;
                 return false;
             }

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -421,7 +421,7 @@ namespace System.Buffers
 
         internal bool TryGetString(out string text, out int start, out int length)
         {
-            if (typeof(T) != typeof(char))
+            if (typeof(T) != typeof(char) || GetSequenceType() != SequenceType.String)
             {
                 start = 0;
                 length = 0;
@@ -429,20 +429,11 @@ namespace System.Buffers
                 return false;
             }
 
-            GetTypeAndIndices(Start.GetInteger(), End.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);
+            Debug.Assert(_sequenceStart.GetObject() is string);
 
-            if (type != SequenceType.String)
-            {
-                start = 0;
-                length = 0;
-                text = null;
-                return false;
-            }
-
-            start = startIndex;
-            length = endIndex - startIndex;
-            text = (string)Start.GetObject();
-
+            text = Unsafe.As<string>(_sequenceStart.GetObject());
+            start = GetIndex(_sequenceStart);
+            length = GetIndex(_sequenceEnd) - start;
             return true;
         }
     }


### PR DESCRIPTION
I suggest faster ReadOnlySequence First and TryGet methods.
Performance tests:
![screenshot_13](https://user-images.githubusercontent.com/6407980/38637175-93e3577e-3df4-11e8-9c3d-17c51fa2f96f.png)
