### PR TITLE
[System.Private.Xml.Linq] Remove SILVERLIGHT define

### DIFF
--- a/src/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
+++ b/src/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{BAC347A3-9841-44FC-B1E3-2344D1152C23}</ProjectGuid>
     <AssemblyName>System.Private.Xml.Linq</AssemblyName>
     <RootNamespace>System.Xml</RootNamespace>
-    <DefineConstants>$(DefineConstants);SILVERLIGHT</DefineConstants>
+    <DefineConstants>$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XHashtable.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XHashtable.cs
@@ -109,17 +109,7 @@ namespace System.Xml.Linq
                 lock (this)
                 {
                     XHashtableState newState = _state.Resize();
-
-                    // Use memory barrier to ensure that the resized XHashtableState object is fully constructed before it is assigned
-#if !SILVERLIGHT 
-                    Thread.MemoryBarrier();
-#else // SILVERLIGHT
-                    // The MemoryBarrier method usage is probably incorrect and should be removed.
-
-                    // Replacing with Interlocked.CompareExchange for now (with no effect)
-                    //   which will do a very similar thing to MemoryBarrier (it's just slower)
                     System.Threading.Interlocked.CompareExchange<XHashtableState>(ref _state, null, null);
-#endif // SILVERLIGHT
                     _state = newState;
                 }
             }


### PR DESCRIPTION
This changes removes the SILVERLIGHT define from System.Private.Xml.Linq.
Required for https://github.com/mono/mono/issues/8122 