### PR TITLE
Remove use of Unsafe code in ReadOnlySequence TryGet (and optimize)

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -14,71 +14,72 @@ namespace System.Buffers
     public readonly partial struct ReadOnlySequence<T>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool TryGetBuffer(in SequencePosition start, in SequencePosition end, out ReadOnlyMemory<T> data, out SequencePosition next)
+        internal bool TryGetBuffer(in SequencePosition position, out ReadOnlyMemory<T> memory, out SequencePosition next)
         {
-            SequenceType type;
-            int startIndex = 0;
-            int endIndex = 0;
+            object positionObject = position.GetObject();
             next = default;
-            object startObject = start.GetObject();
-            if (startObject != null)
+
+            if (positionObject == null)
             {
-                GetTypeAndIndices(start.GetInteger(), end.GetInteger(), out type, out startIndex, out endIndex);
-            }
-            else
-            {
-                type = SequenceType.Empty;
+                memory = default;
+                return false;
             }
 
-            int length = endIndex - startIndex;
-            object endObject = end.GetObject();
-
-            if (type != SequenceType.MultiSegment && type != SequenceType.Empty && startObject != endObject)
-                ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+            SequenceType type = GetSequenceType();
+            object endObject = _sequenceEnd.GetObject();
+            int startIndex = GetIndex(position);
+            int endIndex = GetIndex(_sequenceEnd);
 
             if (type == SequenceType.MultiSegment)
             {
-                Debug.Assert(startObject is ReadOnlySequenceSegment<T>);
-                ReadOnlySequenceSegment<T> startSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject);
+                Debug.Assert(positionObject is ReadOnlySequenceSegment<T>);
 
-                data = startSegment.Memory;
+                ReadOnlySequenceSegment<T> startSegment = (ReadOnlySequenceSegment<T>)positionObject;
 
                 if (startSegment != endObject)
                 {
                     ReadOnlySequenceSegment<T> nextSegment = startSegment.Next;
 
-                    if (nextSegment == null && startSegment != endObject)
+                    if (nextSegment == null)
                         ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
                     next = new SequencePosition(nextSegment, 0);
-                    length = data.Length - startIndex;
+                    memory = startSegment.Memory.Slice(startIndex);
+                }
+                else
+                {
+                    memory = startSegment.Memory.Slice(startIndex, endIndex - startIndex);
                 }
             }
             else if (type == SequenceType.Array)
             {
-                Debug.Assert(startObject is T[]);
+                if (positionObject != endObject)
+                    ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
-                data = new ReadOnlyMemory<T>(Unsafe.As<T[]>(startObject));
-            }
-            else if (type == SequenceType.MemoryManager)
-            {
-                Debug.Assert(startObject is MemoryManager<T>);
+                Debug.Assert(positionObject is T[]);
 
-                data = (Unsafe.As<MemoryManager<T>>(startObject)).Memory;
+                memory = new ReadOnlyMemory<T>((T[])positionObject, startIndex, endIndex - startIndex);
             }
             else if (typeof(T) == typeof(char) && type == SequenceType.String)
             {
-                Debug.Assert(startObject is string);
+                if (positionObject != endObject)
+                    ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
-                data = (ReadOnlyMemory<T>)(object)(Unsafe.As<string>(startObject)).AsMemory();
+                Debug.Assert(positionObject is string);
+
+                memory = (ReadOnlyMemory<T>)(object)((string)positionObject).AsMemory(startIndex, endIndex - startIndex);
             }
-            else
+            else // type == SequenceType.MemoryManager
             {
-                data = default;
-                return false;
+                if (positionObject != endObject)
+                    ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+
+                Debug.Assert(type == SequenceType.MemoryManager);
+                Debug.Assert(positionObject is MemoryManager<T>);
+
+                memory = ((MemoryManager<T>)positionObject).Memory.Slice(startIndex, endIndex - startIndex);
             }
 
-            data = data.Slice(startIndex, length);
             return true;
         }
 

--- a/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
+++ b/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
@@ -9,24 +9,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="Perf.Base64EncodeDecode.cs" />
-    <Compile Include="Perf.Memory.Slice.cs" />
-    <Compile Include="Perf.Memory.Span.cs" />
-    <Compile Include="Perf.ReadOnlySequence.Enumerator.cs" />
-    <Compile Include="Perf.ReadOnlySequence.First.cs" />
-    <Compile Include="Perf.ReadOnlySequence.GetPosition.cs" />
-    <Compile Include="Perf.ReadOnlySequence.Slice.cs" />
     <Compile Include="Perf.ReadOnlySequence.TryGet.cs" />
-    <Compile Include="Perf.Span.BinaryReadAndWrite.cs" />
-    <Compile Include="Perf.Span.BinarySearch.cs" />
-    <Compile Include="Perf.Span.Clear.cs" />
-    <Compile Include="Perf.Span.Fill.cs" />
-    <Compile Include="Perf.Span.IndexOf.cs" />
-    <Compile Include="Perf.Span.IndexOfAny.cs" />
-    <Compile Include="Perf.Span.SequenceCompareTo.cs" />
-    <Compile Include="Perf.Span.StartsWith.cs" />
-    <Compile Include="Perf.Utf8Formatter.cs" />
-    <Compile Include="Perf.Utf8Parser.cs" />
     <Compile Include="..\Base64\Base64TestHelper.cs" />
     <Compile Include="..\TestHelpers.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">

--- a/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
+++ b/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
@@ -9,7 +9,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="Perf.Base64EncodeDecode.cs" />
+    <Compile Include="Perf.Memory.Slice.cs" />
+    <Compile Include="Perf.Memory.Span.cs" />
+    <Compile Include="Perf.ReadOnlySequence.Enumerator.cs" />
+    <Compile Include="Perf.ReadOnlySequence.First.cs" />
+    <Compile Include="Perf.ReadOnlySequence.GetPosition.cs" />
+    <Compile Include="Perf.ReadOnlySequence.Slice.cs" />
     <Compile Include="Perf.ReadOnlySequence.TryGet.cs" />
+    <Compile Include="Perf.Span.BinaryReadAndWrite.cs" />
+    <Compile Include="Perf.Span.BinarySearch.cs" />
+    <Compile Include="Perf.Span.Clear.cs" />
+    <Compile Include="Perf.Span.Fill.cs" />
+    <Compile Include="Perf.Span.IndexOf.cs" />
+    <Compile Include="Perf.Span.IndexOfAny.cs" />
+    <Compile Include="Perf.Span.SequenceCompareTo.cs" />
+    <Compile Include="Perf.Span.StartsWith.cs" />
+    <Compile Include="Perf.Utf8Formatter.cs" />
+    <Compile Include="Perf.Utf8Parser.cs" />
     <Compile Include="..\Base64\Base64TestHelper.cs" />
     <Compile Include="..\TestHelpers.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">


### PR DESCRIPTION
Part of https://github.com/dotnet/corefx/issues/28920

![image](https://user-images.githubusercontent.com/6527137/38640370-eb60818c-3d88-11e8-8b77-eb61a215a687.png)

cc @pakrym, @AlexRadch, @davidfowl, @KrzysztofCwalina, @stephentoub, @GrabYourPitchforks, @krwq 