### PR TITLE
Fix intermittent test failure in System.Buffers

### DIFF
--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -406,8 +406,12 @@ namespace System.Buffers.ArrayPool.Tests
                 int count = 0;
                 listener.RunWithCallback(e =>
                 {
-                    Interlocked.Increment(ref count);
-                    callback(e);
+                    // Don't bother tracking the GC polling event- it isn't deterministic
+                    if (e.EventId != 5)
+                    {
+                        Interlocked.Increment(ref count);
+                        callback(e);
+                    }
                 }, body);
                 return count;
             }


### PR DESCRIPTION
The new event that tracks GC callbacks was causing tests to fail
intermittently. Just ignore it for the purposes of the existing tests.

`ArrayPoolUnitTests`