### PR TITLE
Remove use of Unsafe code in ReadOnlySequence GetFirstBuffer (and optimize)

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -52,7 +52,7 @@ namespace System.Buffers
         /// <summary>
         /// Gets <see cref="ReadOnlyMemory{T}"/> from the first segment.
         /// </summary>
-        public ReadOnlyMemory<T> First => GetFirstBuffer(_sequenceStart, _sequenceEnd);
+        public ReadOnlyMemory<T> First => GetFirstBuffer();
 
         /// <summary>
         /// A position to the start of the <see cref="ReadOnlySequence{T}"/>.

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -97,8 +97,7 @@ namespace System.Buffers
             {
                 if (endIndex >= 0)  // SequenceType.MultiSegment
                 {
-                    // TODO: use explicit cast instead of Unsafe.As
-                    ReadOnlyMemory<T> memory = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject).Memory;
+                    ReadOnlyMemory<T> memory = ((ReadOnlySequenceSegment<T>)startObject).Memory;
                     if (isMultiSegment)
                     {
                         return memory.Slice(startIndex);
@@ -110,8 +109,7 @@ namespace System.Buffers
                     if (isMultiSegment)
                         ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
-                    // TODO: use explicit cast instead of Unsafe.As
-                    return new ReadOnlyMemory<T>(Unsafe.As<T[]>(startObject), startIndex, (endIndex & ReadOnlySequence.IndexBitMask) - startIndex);
+                    return new ReadOnlyMemory<T>((T[])startObject, startIndex, (endIndex & ReadOnlySequence.IndexBitMask) - startIndex);
                 }
             }
             else // startIndex < 0
@@ -123,15 +121,13 @@ namespace System.Buffers
                 // the JIT to see when that the code is unreachable and eliminate it.
                 if (typeof(T) == typeof(char) && endIndex < 0)  // SequenceType.String
                 {
-                    // TODO: use explicit cast instead of Unsafe.As
                     // No need to remove the FlagBitMask since (endIndex - startIndex) == (endIndex & ReadOnlySequence.IndexBitMask) - (startIndex & ReadOnlySequence.IndexBitMask)
-                    return (ReadOnlyMemory<T>)(object)(Unsafe.As<string>(startObject)).AsMemory((startIndex & ReadOnlySequence.IndexBitMask), endIndex - startIndex);
+                    return (ReadOnlyMemory<T>)(object)((string)startObject).AsMemory((startIndex & ReadOnlySequence.IndexBitMask), endIndex - startIndex);
                 }
                 else // endIndex >= 0, SequenceType.MemoryManager
                 {
-                    // TODO: use explicit cast instead of Unsafe.As
                     startIndex &= ReadOnlySequence.IndexBitMask;
-                    return Unsafe.As<MemoryManager<T>>(startObject).Memory.Slice(startIndex, endIndex - startIndex);
+                    return ((MemoryManager<T>)startObject).Memory.Slice(startIndex, endIndex - startIndex);
                 }
             }
         }

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -97,7 +97,8 @@ namespace System.Buffers
             {
                 if (endIndex >= 0)  // SequenceType.MultiSegment
                 {
-                    ReadOnlyMemory<T> memory = ((ReadOnlySequenceSegment<T>)startObject).Memory;
+                    // TODO: use explicit cast instead of Unsafe.As
+                    ReadOnlyMemory<T> memory = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject).Memory;
                     if (isMultiSegment)
                     {
                         return memory.Slice(startIndex);
@@ -109,7 +110,8 @@ namespace System.Buffers
                     if (isMultiSegment)
                         ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
-                    return new ReadOnlyMemory<T>((T[])startObject, startIndex, (endIndex & ReadOnlySequence.IndexBitMask) - startIndex);
+                    // TODO: use explicit cast instead of Unsafe.As
+                    return new ReadOnlyMemory<T>(Unsafe.As<T[]>(startObject), startIndex, (endIndex & ReadOnlySequence.IndexBitMask) - startIndex);
                 }
             }
             else // startIndex < 0
@@ -121,13 +123,15 @@ namespace System.Buffers
                 // the JIT to see when that the code is unreachable and eliminate it.
                 if (typeof(T) == typeof(char) && endIndex < 0)  // SequenceType.String
                 {
+                    // TODO: use explicit cast instead of Unsafe.As
                     // No need to remove the FlagBitMask since (endIndex - startIndex) == (endIndex & ReadOnlySequence.IndexBitMask) - (startIndex & ReadOnlySequence.IndexBitMask)
-                    return (ReadOnlyMemory<T>)(object)((string)startObject).AsMemory((startIndex & ReadOnlySequence.IndexBitMask), endIndex - startIndex);
+                    return (ReadOnlyMemory<T>)(object)(Unsafe.As<string>(startObject)).AsMemory((startIndex & ReadOnlySequence.IndexBitMask), endIndex - startIndex);
                 }
                 else // endIndex >= 0, SequenceType.MemoryManager
                 {
+                    // TODO: use explicit cast instead of Unsafe.As
                     startIndex &= ReadOnlySequence.IndexBitMask;
-                    return ((MemoryManager<T>)startObject).Memory.Slice(startIndex, endIndex - startIndex);
+                    return Unsafe.As<MemoryManager<T>>(startObject).Memory.Slice(startIndex, endIndex - startIndex);
                 }
             }
         }


### PR DESCRIPTION
Here are the results if we continue to use Unsafe.As to cast (mainly to showcase performance improvement):
![image](https://user-images.githubusercontent.com/6527137/38654385-e0550822-3dc3-11e8-98df-7419d849720b.png)

cc @pakrym, @AlexRadch, @davidfowl, @KrzysztofCwalina, @krwq 