### PR TITLE
Collapse leftover AsSpan().Slice(...) into AsSpan(...)

### DIFF
--- a/src/Common/src/CoreLib/System/IO/PathInternal.cs
+++ b/src/Common/src/CoreLib/System/IO/PathInternal.cs
@@ -134,7 +134,7 @@ namespace System.IO
             // at the end.
             if (skip > 0)
             {
-                sb.Append(path.AsSpan().Slice(0, skip));
+                sb.Append(path.AsSpan(0, skip));
             }
 
             for (int i = skip; i < path.Length; i++)

--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -836,7 +836,7 @@ namespace System.IO
                     int n = await fs.ReadAsync(rentedArray.AsMemory(bytesRead), cancellationToken).ConfigureAwait(false);
                     if (n == 0)
                     {
-                        return rentedArray.AsSpan().Slice(0, bytesRead).ToArray();
+                        return rentedArray.AsSpan(0, bytesRead).ToArray();
                     }
                     bytesRead += n;
                 }

--- a/src/System.Memory/tests/ReadOnlySpan/Overlaps.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/Overlaps.cs
@@ -31,7 +31,7 @@ namespace System.SpanTests
             {
                 int[] a = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
 
-                ReadOnlySpan<int> source = a.AsSpan().Slice(7, 5);
+                ReadOnlySpan<int> source = a.AsSpan(7, 5);
 
                 Span<int> expected = new int[a.Length].AsSpan(i, 5);
                 Span<int> actual = a.AsSpan(i, 5);
@@ -93,7 +93,7 @@ namespace System.SpanTests
             {
                 int[] a = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
 
-                ReadOnlySpan<int> source = a.AsSpan().Slice(7, 5);
+                ReadOnlySpan<int> source = a.AsSpan(7, 5);
 
                 Span<int> expected = new int[a.Length].AsSpan(i, 5);
                 Span<int> actual = a.AsSpan(i, 5);

--- a/src/System.Memory/tests/Span/Overlaps.cs
+++ b/src/System.Memory/tests/Span/Overlaps.cs
@@ -31,7 +31,7 @@ namespace System.SpanTests
             {
                 int[] a = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
 
-                Span<int> source = a.AsSpan().Slice(7, 5);
+                Span<int> source = a.AsSpan(7, 5);
 
                 Span<int> expected = new int[a.Length].AsSpan(i, 5);
                 Span<int> actual = a.AsSpan(i, 5);
@@ -93,7 +93,7 @@ namespace System.SpanTests
             {
                 int[] a = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
 
-                Span<int> source = a.AsSpan().Slice(7, 5);
+                Span<int> source = a.AsSpan(7, 5);
 
                 Span<int> expected = new int[a.Length].AsSpan(i, 5);
                 Span<int> actual = a.AsSpan(i, 5);
@@ -138,7 +138,7 @@ namespace System.SpanTests
         {
             byte[] a = new byte[16];
 
-            Assert.True(a.AsSpan().Slice(0, 12).Overlaps(a.AsSpan().Slice(8, 8), out int elementOffset));
+            Assert.True(a.AsSpan(0, 12).Overlaps(a.AsSpan(8, 8), out int elementOffset));
             Assert.Equal(8, elementOffset);
         }
 
@@ -147,7 +147,7 @@ namespace System.SpanTests
         {
             Guid[] a = new Guid[16];
 
-            Assert.True(a.AsSpan().Slice(0, 12).Overlaps(a.AsSpan().Slice(8, 8), out int elementOffset));
+            Assert.True(a.AsSpan(0, 12).Overlaps(a.AsSpan(8, 8), out int elementOffset));
             Assert.Equal(8, elementOffset);
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -227,7 +227,7 @@ namespace System.Net.Http
             else
             {
                 host = value.Substring(0, separatorIndex);
-                if (!UInt16.TryParse(value.AsSpan().Slice(separatorIndex + 1), out port))
+                if (!UInt16.TryParse(value.AsSpan(separatorIndex + 1), out port))
                 {
                     return null;
                 }

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -448,7 +448,7 @@ namespace System.Tests
             Assert.Equal(expected, dst);
 
             Span<char> dstSpan = new char[expected.Length];
-            s.AsSpan().Slice(sourceIndex, count).CopyTo(dstSpan.Slice(destinationIndex, count));
+            s.AsSpan(sourceIndex, count).CopyTo(dstSpan.Slice(destinationIndex, count));
             Assert.Equal(expected, dstSpan.ToArray());
         }
 
@@ -2608,11 +2608,11 @@ namespace System.Tests
             if (startIndex + length == s.Length)
             {
                 Assert.Equal(expected, s.Substring(startIndex));
-                Assert.Equal(expected, s.AsSpan().Slice(startIndex).ToString());
+                Assert.Equal(expected, s.AsSpan(startIndex).ToString());
             }
             Assert.Equal(expected, s.Substring(startIndex, length));
 
-            Assert.Equal(expected, s.AsSpan().Slice(startIndex, length).ToString());
+            Assert.Equal(expected, s.AsSpan(startIndex, length).ToString());
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBMPString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBMPString.cs
@@ -542,7 +542,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(1000, bytesWritten);
 
             Assert.Equal(
-                input.AsSpan().Slice(4).ByteArrayToHex(),
+                input.AsSpan(4).ByteArrayToHex(),
                 output.ByteArrayToHex());
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBitString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBitString.cs
@@ -247,7 +247,7 @@ namespace System.Security.Cryptography.Tests.Asn1
 
             Assert.True(didRead, "reader.TryCopyBitStringBytes");
             Assert.Equal(expectedUnusedBitCount, unusedBitCount);
-            Assert.Equal(expectedHex, output.AsSpan().Slice(0, bytesWritten).ByteArrayToHex());
+            Assert.Equal(expectedHex, output.AsSpan(0, bytesWritten).ByteArrayToHex());
         }
 
         private static void TryCopyBitStringBytes_Throws(
@@ -453,7 +453,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(999, bytesWritten);
 
             Assert.Equal(
-                input.AsSpan().Slice(5).ByteArrayToHex(),
+                input.AsSpan(5).ByteArrayToHex(),
                 output.ByteArrayToHex());
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadIA5String.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadIA5String.cs
@@ -506,7 +506,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(1000, bytesWritten);
 
             Assert.Equal(
-                input.AsSpan().Slice(4).ByteArrayToHex(),
+                input.AsSpan(4).ByteArrayToHex(),
                 output.ByteArrayToHex());
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadOctetString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadOctetString.cs
@@ -204,7 +204,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                 out int bytesWritten);
 
             Assert.True(didRead, "reader.TryCopyOctetStringBytes");
-            Assert.Equal(expectedHex, output.AsSpan().Slice(0, bytesWritten).ByteArrayToHex());
+            Assert.Equal(expectedHex, output.AsSpan(0, bytesWritten).ByteArrayToHex());
         }
 
         private static void TryCopyOctetStringBytes_Throws(
@@ -359,7 +359,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(1000, bytesWritten);
 
             Assert.Equal(
-                input.AsSpan().Slice(4).ByteArrayToHex(),
+                input.AsSpan(4).ByteArrayToHex(),
                 output.ByteArrayToHex());
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadUTF8String.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadUTF8String.cs
@@ -522,7 +522,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(1000, bytesWritten);
 
             Assert.Equal(
-                input.AsSpan().Slice(4).ByteArrayToHex(),
+                input.AsSpan(4).ByteArrayToHex(),
                 output.ByteArrayToHex());
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/ComprehensiveWriteTest.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/ComprehensiveWriteTest.cs
@@ -266,7 +266,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                     "C058767D1FF060A609D7E3D4317079AF0CD0A8A49251AB129157F9894A036487" +
                     "090807060504030201").HexToByteArray();
 
-                writer.WriteBitString(containsSignature.AsSpan().Slice(9, 256));
+                writer.WriteBitString(containsSignature.AsSpan(9, 256));
 
                 // certificate
                 writer.PopSequence();

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
@@ -372,8 +372,8 @@ namespace System.Security.Cryptography.Tests.Asn1
 
             byte[] encoded = writer.Encode();
 
-            Assert.Equal(tagHex, encoded.AsSpan().Slice(0, tagHex.Length / 2).ByteArrayToHex());
-            Assert.Equal("0000", encoded.AsSpan().Slice(encoded.Length - 2).ByteArrayToHex());
+            Assert.Equal(tagHex, encoded.AsSpan(0, tagHex.Length / 2).ByteArrayToHex());
+            Assert.Equal("0000", encoded.AsSpan(encoded.Length - 2).ByteArrayToHex());
             Assert.Equal(encodedSize, encoded.Length);
         }
 


### PR DESCRIPTION
Leftover from https://github.com/dotnet/corefx/issues/27330

Mainly updating usage pattern in tests.

cc @tarekgh 