### PR TITLE
Address some SocketsHttpHandler feedback

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -288,7 +288,7 @@ namespace System.Net.Http
             {
                 await WriteAsciiStringAsync(HttpKnownHeaderNames.Cookie).ConfigureAwait(false);
                 await WriteTwoBytesAsync((byte)':', (byte)' ').ConfigureAwait(false);
-                await WriteAsciiStringAsync(cookiesFromContainer).ConfigureAwait(false);
+                await WriteStringAsync(cookiesFromContainer).ConfigureAwait(false);
                 await WriteTwoBytesAsync((byte)'\r', (byte)'\n').ConfigureAwait(false);
             }
         }
@@ -484,7 +484,7 @@ namespace System.Net.Http
                 }
 
                 // Start to read response.
-                _allowedReadLineBytes = _pool.Settings._maxResponseHeadersLength * 1024;
+                _allowedReadLineBytes = (int)Math.Min(int.MaxValue, _pool.Settings._maxResponseHeadersLength * 1024L);
 
                 // We should not have any buffered data here; if there was, it should have been treated as an error
                 // by the previous request handling.  (Note we do not support HTTP pipelining.)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -640,7 +640,10 @@ namespace System.Net.Http
             }
         }
 
-        /// <summary>Disposes the </summary>
+        /// <summary>
+        /// Disposes the connection pool.  This is only needed when the pool currently contains
+        /// or has associated connections.
+        /// </summary>
         public void Dispose()
         {
             List<CachedConnection> list = _idleConnections;
@@ -679,7 +682,7 @@ namespace System.Net.Http
 
                 // Get the current time.  This is compared against each connection's last returned
                 // time to determine whether a connection is too old and should be closed.
-                DateTimeOffset now = DateTimeOffset.Now;
+                DateTimeOffset now = DateTimeOffset.UtcNow;
 
                 // Find the first item which needs to be removed.
                 int freeIndex = 0;
@@ -882,17 +885,8 @@ namespace System.Net.Http
             }
 
             /// <summary>Creates a connection.</summary>
-            public ValueTask<(HttpConnection, HttpResponseMessage)> CreateConnectionAsync()
-            {
-                try
-                {
-                    return _pool.CreateConnectionAsync(_request, _cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    return new ValueTask<(HttpConnection, HttpResponseMessage)>(Threading.Tasks.Task.FromException<(HttpConnection, HttpResponseMessage)>(e));
-                }
-            }
+            public ValueTask<(HttpConnection, HttpResponseMessage)> CreateConnectionAsync() =>
+                _pool.CreateConnectionAsync(_request, _cancellationToken);
         }
     }
 }


### PR DESCRIPTION
- We were using WriteAsciiStringAsync in one place we shouldn't have been.  Change it to WriteStringAsync.
- We were potentially overflowing in a multiplication on MaxResponseHeadersLength if it was set to a very large value.  Changed it to use long multiplication and to cap the max length at int.MaxValue.
- We were accidentally using DateTimeOffset.Now instead of UtcNow when getting the current time during stale pool removal.  Change to UtcNow.
- We had an unnecessary/unreachable catch block.  Remove it.
- In a race condition where the handler and thus its pool manager was disposed while the cleaning timer callback was in flight (either already queued or already running), we could potentially dispose of the timer and then the callback attempt to change the timer and incur an ObjectDisposedException that would go unhandled on a thread pool thread.  One fix would be to track disposal under the same lock that's used to mutate the cleaning timer, but that incurs the cost of tracking disposal and taking a lock on disposal in order to deal with a rare race condition (that we've never actually seen happen).  Instead, I opt to simply catch and eat any ODEs that occur.
- If either of the connection lifetime values are set at 0, we avoid putting connections back into a pool and thus also avoid creating the cleaning timer.  But we're still putting the created pool into the pools collection, which in theory in an extreme case could be a leak.  The fix is simply to not store the pool into the pools in this case.

cc: @GrabYourPitchforks, @geoffkizer, @davidsh