### PR TITLE
Replaced ReadOnlySequence unsafe casting to safe casting in Seek method

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -315,15 +315,7 @@ namespace System.Buffers
                 if (Length < int.MaxValue)
                 {
 #if !FEATURE_PORTABLE_SPAN
-                    return string.Create((int)Length, charSequence, (span, sequence) =>
-                    {
-                        foreach (ReadOnlyMemory<char> readOnlyMemory in sequence)
-                        {
-                            ReadOnlySpan<char> sourceSpan = readOnlyMemory.Span;
-                            sourceSpan.CopyTo(span);
-                            span = span.Slice(sourceSpan.Length);
-                        }
-                    });
+                    return string.Create((int)Length, charSequence, (span, sequence) => sequence.CopyTo(span));
 #else
                     return new string(charSequence.ToArray());
 #endif

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -145,15 +145,14 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, long offset)
         {
-            GetTypeAndIndices(start.GetInteger(), end.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);
-
+            int startIndex = GetIndex(start);
+            int endIndex = GetIndex(end);
             object startObject = start.GetObject();
             object endObject = end.GetObject();
-
-            if (type == SequenceType.MultiSegment && startObject != endObject)
+            if (startObject != endObject)
             {
-                Debug.Assert(startObject is ReadOnlySequenceSegment<T>);
-                var startSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject);
+                Debug.Assert(startObject != null);
+                var startSegment = (ReadOnlySequenceSegment<T>)startObject;
 
                 int currentLength = startSegment.Memory.Length - startIndex;
 
@@ -165,8 +164,6 @@ namespace System.Buffers
                 return SeekMultiSegment(startSegment.Next, endObject, endIndex, offset - currentLength);
             }
 
-            Debug.Assert(startObject == endObject);
-
             if (endIndex - startIndex < offset)
                 ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
 
@@ -176,9 +173,8 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static SequencePosition SeekMultiSegment(ReadOnlySequenceSegment<T> currentSegment, object endObject, int endPosition, long offset)
+        private static SequencePosition SeekMultiSegment(ReadOnlySequenceSegment<T> currentSegment, object endObject, int endIndex, long offset)
         {
-            Debug.Assert(currentSegment != null);
             Debug.Assert(offset >= 0);
 
             while (currentSegment != null && currentSegment != endObject)
@@ -195,7 +191,7 @@ namespace System.Buffers
             }
 
             // Hit the end of the segments but didn't reach the count
-            if (currentSegment == null || (currentSegment == endObject && endPosition < offset))
+            if (currentSegment == null || endIndex < offset)
                 ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
 
         FoundSegment:


### PR DESCRIPTION
Replaced ReadOnlySequence unsafe casting to safe casting in Seek method. Part of #28920