### PR TITLE
Remap EBADF in SocketErrorPal.Unix.cs to OperationAborted

### DIFF
--- a/src/Common/src/System/Net/Sockets/SocketErrorPal.Unix.cs
+++ b/src/Common/src/System/Net/Sockets/SocketErrorPal.Unix.cs
@@ -40,7 +40,7 @@ namespace System.Net.Sockets
             { Interop.Error.EAFNOSUPPORT, SocketError.AddressFamilyNotSupported },
             { Interop.Error.EAGAIN, SocketError.WouldBlock },
             { Interop.Error.EALREADY, SocketError.AlreadyInProgress },
-            { Interop.Error.EBADF, SocketError.InvalidArgument },
+            { Interop.Error.EBADF, SocketError.OperationAborted },
             { Interop.Error.ECANCELED, SocketError.OperationAborted },
             { Interop.Error.ECONNABORTED, SocketError.ConnectionAborted },
             { Interop.Error.ECONNREFUSED, SocketError.ConnectionRefused },
@@ -101,7 +101,7 @@ namespace System.Net.Sockets
             { SocketError.HostUnreachable, Interop.Error.EHOSTUNREACH },
             { SocketError.InProgress, Interop.Error.EINPROGRESS },
             { SocketError.Interrupted, Interop.Error.EINTR },
-            { SocketError.InvalidArgument, Interop.Error.EINVAL }, // could also have been EBADF, though that's logically an invalid argument
+            { SocketError.InvalidArgument, Interop.Error.EINVAL },
             { SocketError.IOPending, Interop.Error.EINPROGRESS },
             { SocketError.IsConnected, Interop.Error.EISCONN },
             { SocketError.MessageSize, Interop.Error.EMSGSIZE },


### PR DESCRIPTION
Due to the way async operations on Socket are implemented on Unix, it's possible that a socket file descriptor could be closed and subsequent calls to methods like recvmsg as part of the async operation could report EBADF, meaning "The argument sockfd is an invalid descriptor."  As part of our PAL layer, we currently map this error to SocketError.InvalidArgument, as that's the most direct equivalent, but in practice since this only ever occurs when the socket file descriptor was valid and has been closed to become invalid, it's more logically associated with OperationAborted, with the operation having been effectively canceled due to the socket having been closed.  This matters for two reasons: 1) the resulting error message is more informative to the developer to help track down the cause ("Invalid argument" can be misleading), and 2) code in various places checks for OperationAborted as a signal of cancellation / socket closure and would end up missing these cases.  This commit just updates that mapping.

Fixes https://github.com/dotnet/corefx/issues/29075
Related to https://github.com/dotnet/corefx/issues/24677
cc: @tmds, @geoffkizer, @benaadams 