### PR TITLE
Add private, parameterless constructor

### DIFF
--- a/src/System.Security.Claims/src/System/Security/Claims/Claim.cs
+++ b/src/System.Security.Claims/src/System/Security/Claims/Claim.cs
@@ -38,6 +38,12 @@ namespace System.Security.Claims
         private readonly string _value;
         private readonly string _valueType;
 
+        /// <summary>Prevents a default instance of the <see cref="Claim"/> class from being created</summary>
+        /// <remarks>To assist with serialization</remarks>
+        private Claim()
+        {
+        }
+
         /// <summary>
         /// Initializes an instance of <see cref="Claim"/> using a <see cref="BinaryReader"/>.
         /// Normally the <see cref="BinaryReader"/> is constructed using the bytes from <see cref="WriteTo(BinaryWriter)"/> and initialized in the same way as the <see cref="BinaryWriter"/>.


### PR DESCRIPTION
Most serializers require classes to have parameterless constructors. During de-serialization an empty class is created and then populated. By keeping the constructor private misuse should be minimal.