### PR TITLE
Run docker commands in a container without a local filesystem mounted volume

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -5,45 +5,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Change permissions to agent folder for cleanup steps",
-      "timeoutInMinutes": 0,
-      "refName": "Task1",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "sudo",
-        "arguments": "chmod 777 -R .",
-        "workingFolder": "$(Agent.WorkFolder)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Delete files from $(PB_GitDirectory)",
-      "timeoutInMinutes": 0,
-      "refName": "Task2",
-      "task": {
-        "id": "b7e8b412-0437-4065-9371-edc5881de25b",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "SourceFolder": "$(PB_GitDirectory)",
-        "Contents": "**\n.gitignore\n.editorconfig\n.gitattributes\n.gitmirrorall\n.git/**\n.git"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "git clone",
+      "displayName": "Local git clone",
       "timeoutInMinutes": 0,
       "refName": "Task3",
       "task": {
@@ -63,7 +25,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "git checkout",
+      "displayName": "Local git checkout",
       "timeoutInMinutes": 0,
       "refName": "Task4",
       "task": {
@@ -83,9 +45,9 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Initialize tools",
+      "displayName": "Local initialize tools",
       "timeoutInMinutes": 0,
-      "refName": "Task5",
+      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -94,7 +56,7 @@
       "inputs": {
         "filename": "$(PB_GitDirectory)/init-tools.sh",
         "arguments": "",
-        "workingFolder": "$(PB_GitDirectory)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },
@@ -103,9 +65,9 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Initialize Docker",
+      "displayName": "Local initialize Docker",
       "timeoutInMinutes": 0,
-      "refName": "Task6",
+      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -123,7 +85,47 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Generate Version Assets",
+      "displayName": "Docker git clone",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) git clone $(PB_VsoCorefxGitUrl) $(PB_DockerVolumeName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Docker git checkout",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) git checkout $(SourceVersion)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Docker generate version assets",
       "timeoutInMinutes": 0,
       "refName": "Task7",
       "task": {
@@ -133,7 +135,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-managed.sh -OfficialBuildId=$(OfficialBuildId) -- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-managed.sh -OfficialBuildId=$(OfficialBuildId) -- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -143,7 +145,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run sync.sh",
+      "displayName": "Docker run sync.sh",
       "timeoutInMinutes": 0,
       "refName": "Task8",
       "task": {
@@ -153,7 +155,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/sync.sh $(PB_SyncArguments)",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/sync.sh $(PB_SyncArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -163,7 +165,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build-native.sh",
+      "displayName": "Docker run build-native.sh",
       "timeoutInMinutes": 0,
       "refName": "Task9",
       "task": {
@@ -173,7 +175,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-native.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildNativeArguments)",
+        "arguments": "run --rm -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-native.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildNativeArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -183,7 +185,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build-managed.sh",
+      "displayName": "Docker run build-managed.sh",
       "timeoutInMinutes": 0,
       "refName": "Task10",
       "task": {
@@ -193,7 +195,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-managed.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildManagedArguments)",
+        "arguments": "run --rm -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-managed.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildManagedArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -203,7 +205,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build-packages.sh",
+      "displayName": "Docker run build-packages.sh",
       "timeoutInMinutes": 0,
       "refName": "Task11",
       "task": {
@@ -213,7 +215,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-packages.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildPackagesArguments)",
+        "arguments": "run --rm -e ROOTFS_DIR=$(ROOTFS_DIR) $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-packages.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildPackagesArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -223,7 +225,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run publish-packages.sh",
+      "displayName": "Docker run publish-packages.sh",
       "timeoutInMinutes": 0,
       "refName": "Task12",
       "task": {
@@ -233,7 +235,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/publish-packages.sh -AzureAccount=$(PB_CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_Label) -verbose -- /p:OverwriteOnPublish=false",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/publish-packages.sh -AzureAccount=$(PB_CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_Label) -verbose -- /p:OverwriteOnPublish=false",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -243,19 +245,58 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
-      "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",
+      "displayName": "Local create container from volume for exposing logs",
       "timeoutInMinutes": 0,
       "condition": "succeededOrFailed()",
-      "refName": "CopyFiles1",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run $(PB_DockerCommonRunArgs) echo",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Local expose Docker container for publishing",
+      "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "cp -L $(PB_DockerContainerName):$(PB_DockerVolumeName) $(PB_DockerCopyDest)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Local copy log files to: $(PB_DockerCopyDest)\\DockerBuildLogs",
+      "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
         "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "SourceFolder": "$(PB_GitDirectory)",
-        "Contents": "*.log",
-        "TargetFolder": "$(Build.StagingDirectory)\\BuildLogs",
+        "SourceFolder": "$(PB_DockerCopyDest)",
+        "Contents": "**/*.log",
+        "TargetFolder": "$(PB_DockerCopyDest)\\DockerBuildLogs",
         "CleanTargetFolder": "false",
         "OverWrite": "false",
         "flattenFolders": "false"
@@ -266,7 +307,7 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
-      "displayName": "Publish Artifact: BuildLogs",
+      "displayName": "Local publish artifact: BuildLogs",
       "timeoutInMinutes": 0,
       "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts2",
@@ -276,7 +317,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "PathtoPublish": "$(Build.StagingDirectory)\\BuildLogs",
+        "PathtoPublish": "$(Build.StagingDirectory)\\DockerBuildLogs",
         "ArtifactName": "BuildLogs",
         "ArtifactType": "Container",
         "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)",
@@ -289,7 +330,7 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": false,
-      "displayName": "Cleanup Docker",
+      "displayName": "Local cleanup Docker",
       "timeoutInMinutes": 0,
       "condition": "always()",
       "refName": "Task14",
@@ -327,15 +368,6 @@
         "assignToRequestor": "true",
         "additionalFields": "{}"
       }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
     }
   ],
   "variables": {
@@ -352,13 +384,16 @@
     "PB_Architecture": {
       "value": "arm"
     },
+    "PB_AssetRootUrl": {
+      "value": ""
+    },
     "PB_BuildArguments": {
       "value": "-BuildArch=$(PB_Architecture)"
     },
-    "PB_BuildNativeArguments": {
+    "PB_BuildManagedArguments": {
       "value": "$(PB_BuildArguments)"
     },
-    "PB_BuildManagedArguments": {
+    "PB_BuildNativeArguments": {
       "value": "$(PB_BuildArguments)"
     },
     "PB_BuildPackagesArguments": {
@@ -374,13 +409,13 @@
       "value": "Release"
     },
     "PB_DockerCommonRunArgs": {
-      "value": "--rm --name $(PB_DockerContainerName) -v \"$(PB_GitDirectory):$(PB_DockerVolumeName)\" -w=\"$(PB_DockerVolumeName)\" -e \"PACKAGEVERSIONPROPSURL=$(PB_PackageVersionPropsUrl)\" $(PB_DockerImageName)"
+      "value": "--name $(PB_DockerContainerName) -v \"$(PB_DockerContainerName):$(PB_DockerVolumeName)\" -w=\"$(PB_DockerVolumeName)\" -e \"PACKAGEVERSIONPROPSURL=$(PB_PackageVersionPropsUrl)\" $(PB_DockerImageName)"
     },
     "PB_DockerContainerName": {
       "value": "corefx-cross-$(Build.BuildId)"
     },
     "PB_DockerCopyDest": {
-      "value": "$(Build.BinariesDirectory)/docker_repo"
+      "value": "$(Build.StagingDirectory)"
     },
     "PB_DockerImageName": {
       "value": "$(PB_DockerRepository):$(PB_DockerTag)"
@@ -400,6 +435,13 @@
     },
     "PB_Label": {
       "value": "$(Build.BuildNumber)"
+    },
+    "PB_PackageVersionPropsUrl": {
+      "value": ""
+    },
+    "PB_SyncArguments": {
+      "value": "-p -- /p:ArchGroup=$(PB_Architecture)",
+      "allowOverride": true
     },
     "PB_VsoAccountName": {
       "value": "dn-bot"
@@ -428,16 +470,6 @@
     "VsoPassword": {
       "value": null,
       "isSecret": true
-    },
-    "PB_SyncArguments": {
-      "value": "-p -- /p:ArchGroup=$(PB_Architecture)",
-      "allowOverride": true
-    },
-    "PB_PackageVersionPropsUrl": {
-      "value": ""
-    },
-    "PB_AssetRootUrl": {
-      "value": ""
     }
   },
   "demands": [
@@ -470,7 +502,7 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
-      "cleanOptions": "0",
+      "cleanOptions": "3",
       "checkoutNestedSubmodules": "false",
       "labelSourcesFormat": "$(build.buildNumber)"
     },
@@ -479,15 +511,21 @@
     "name": "DotNet-CoreFX-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-CoreFX-Trusted",
     "defaultBranch": "refs/heads/master",
-    "clean": "false",
+    "clean": "true",
     "checkoutSubmodules": false
   },
   "processParameters": {},
   "quality": "definition",
   "drafts": [],
   "queue": {
+    "_links": {
+      "self": {
+        "href": "https://devdiv.visualstudio.com/DefaultCollection/_apis/build/Queues/36"
+      }
+    },
     "id": 36,
     "name": "DotNet-Build",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/build/Queues/36",
     "pool": {
       "id": 39,
       "name": "DotNet-Build"
@@ -501,10 +539,10 @@
   "project": {
     "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "name": "DevDiv",
-    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items for Visual Studio and most active DevDiv products are in this account.",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098432,
+    "revision": 418099070,
     "visibility": "organization"
   }
 }

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -5,45 +5,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Change permissions to agent folder for cleanup steps",
-      "timeoutInMinutes": 0,
-      "refName": "Task1",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "sudo",
-        "arguments": "chmod 777 -R .",
-        "workingFolder": "$(Agent.WorkFolder)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": false,
-      "displayName": "Delete files from $(PB_GitDirectory)",
-      "timeoutInMinutes": 0,
-      "refName": "Task2",
-      "task": {
-        "id": "b7e8b412-0437-4065-9371-edc5881de25b",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "SourceFolder": "$(PB_GitDirectory)",
-        "Contents": "**\n.gitignore\n.editorconfig\n.gitattributes\n.gitmirrorall\n.git/**\n.git"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "git clone",
+      "displayName": "Local git clone",
       "timeoutInMinutes": 0,
       "refName": "Task3",
       "task": {
@@ -63,7 +25,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "git checkout",
+      "displayName": "Local git checkout",
       "timeoutInMinutes": 0,
       "refName": "Task4",
       "task": {
@@ -83,29 +45,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Create host machine tools sandbox",
-      "timeoutInMinutes": 0,
-      "refName": "Task5",
-      "task": {
-        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
-        "versionSpec": "2.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "SourceFolder": "$(PB_GitDirectory)",
-        "Contents": "init-tools.sh\nBuildToolsVersion.txt\nDotnetCLIVersion.txt\ninit-tools.msbuild\ndependencies.props",
-        "TargetFolder": "$(DockerHost_Sandbox)",
-        "CleanTargetFolder": "false",
-        "OverWrite": "false",
-        "flattenFolders": "false"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Initialize tools in sandbox for host machine",
+      "displayName": "Local initialize tools",
       "timeoutInMinutes": 0,
       "refName": "Task6",
       "task": {
@@ -114,7 +54,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(DockerHost_Sandbox)/init-tools.sh",
+        "filename": "$(PB_GitDirectory)/init-tools.sh",
         "arguments": "",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -125,7 +65,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Initialize Docker",
+      "displayName": "Local initialize Docker",
       "timeoutInMinutes": 0,
       "refName": "Task7",
       "task": {
@@ -134,7 +74,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(DockerHost_ToolsDirectory)/scripts/docker/init-docker.sh",
+        "filename": "$(PB_GitDirectory)/Tools/scripts/docker/init-docker.sh",
         "arguments": "$(PB_DockerImageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -145,7 +85,47 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Generate version assets",
+      "displayName": "Docker git clone",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker ",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) git clone $(PB_VsoCorefxGitUrl) $(PB_DockerVolumeName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Docker git checkout",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) git checkout $(SourceVersion)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Docker generate version assets",
       "timeoutInMinutes": 0,
       "refName": "Task8",
       "task": {
@@ -155,7 +135,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-managed.sh -OfficialBuildId=$(OfficialBuildId) -- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-managed.sh -OfficialBuildId=$(OfficialBuildId) -- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -165,7 +145,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run sync",
+      "displayName": "Docker run sync",
       "timeoutInMinutes": 0,
       "refName": "Task9",
       "task": {
@@ -175,7 +155,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/sync.sh $(PB_SyncArguments)",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/sync.sh $(PB_SyncArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -185,7 +165,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build.sh",
+      "displayName": "Docker run build.sh",
       "timeoutInMinutes": 0,
       "refName": "Task10",
       "task": {
@@ -195,7 +175,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -205,7 +185,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Build tests",
+      "displayName": "Docker build tests",
       "timeoutInMinutes": 0,
       "condition": "and(succeeded(), ne(variables.PB_SkipTests, 'true'), ne(variables.PB_SkipTestBuild, 'true'))",
       "refName": "Task11",
@@ -216,7 +196,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-tests.sh $(PB_BuildTestsArguments)",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/build-tests.sh $(PB_BuildTestsArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -226,7 +206,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Create Helix Test Jobs",
+      "displayName": "Docker create helix test jobs",
       "timeoutInMinutes": 0,
       "condition": "and(succeeded(), ne(variables.PB_SkipTests, 'true'), ne(variables.PB_EnableCloudTest, 'false'))",
       "refName": "Task12",
@@ -237,7 +217,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/Tools/msbuild.sh $(PB_DockerVolumeName)/src/upload-tests.proj $(PB_CreateHelixArguments) /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(PB_CloudResultsAccessToken)\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint) /p:\"Branch=$(SourceBranch)\" /p:TargetQueues=$(PB_TargetQueue) /p:\"OfficialBuildId=$(OfficialBuildId)\" /p:\"ProductBuildId=$(ProductBuildId)\"",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/Tools/msbuild.sh $(PB_DockerVolumeName)/src/upload-tests.proj $(PB_CreateHelixArguments) /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(PB_CloudResultsAccessToken)\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint) /p:\"Branch=$(SourceBranch)\" /p:TargetQueues=$(PB_TargetQueue) /p:\"OfficialBuildId=$(OfficialBuildId)\" /p:\"ProductBuildId=$(ProductBuildId)\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -247,7 +227,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Push packages to Azure",
+      "displayName": "Docker push packages to Azure",
       "timeoutInMinutes": 0,
       "refName": "Task13",
       "task": {
@@ -257,7 +237,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/publish-packages.sh -AzureAccount=$(PB_CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_Label) -verbose -- /p:OverwriteOnPublish=false",
+        "arguments": "run --rm $(PB_DockerCommonRunArgs) $(PB_DockerVolumeName)/publish-packages.sh -AzureAccount=$(PB_CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_Label) -verbose -- /p:OverwriteOnPublish=false",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -267,19 +247,58 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
-      "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",
+      "displayName": "Local create container from volume for exposing logs",
       "timeoutInMinutes": 0,
       "condition": "succeededOrFailed()",
-      "refName": "CopyFiles1",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run $(PB_DockerCommonRunArgs) echo",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Local expose Docker container for publishing",
+      "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker ",
+        "arguments": "cp -L $(PB_DockerContainerName):$(PB_DockerVolumeName) $(PB_DockerCopyDest)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Local copy log files to: $(PB_DockerCopyDest)\\DockerBuildLogs",
+      "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
         "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "SourceFolder": "$(PB_GitDirectory)",
-        "Contents": "*.log",
-        "TargetFolder": "$(Build.StagingDirectory)\\BuildLogs",
+        "SourceFolder": "$(PB_DockerCopyDest)",
+        "Contents": "**/*.log",
+        "TargetFolder": "$(PB_DockerCopyDest)\\DockerBuildLogs",
         "CleanTargetFolder": "false",
         "OverWrite": "false",
         "flattenFolders": "false"
@@ -290,7 +309,7 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
-      "displayName": "Publish Artifact: BuildLogs",
+      "displayName": "Local publish artifact: BuildLogs",
       "timeoutInMinutes": 0,
       "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts2",
@@ -300,7 +319,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "PathtoPublish": "$(Build.StagingDirectory)\\BuildLogs",
+        "PathtoPublish": "$(Build.StagingDirectory)\\DockerBuildLogs",
         "ArtifactName": "BuildLogs",
         "ArtifactType": "Container",
         "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)",
@@ -313,7 +332,7 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": false,
-      "displayName": "Cleanup Docker",
+      "displayName": "Local cleanup Docker",
       "timeoutInMinutes": 0,
       "condition": "always()",
       "refName": "Task14",
@@ -323,7 +342,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(DockerHost_ToolsDirectory)/scripts/docker/cleanup-docker.sh",
+        "filename": "$(PB_GitDirectory)/Tools/scripts/docker/cleanup-docker.sh",
         "arguments": "",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -351,15 +370,6 @@
         "assignToRequestor": "true",
         "additionalFields": "{}"
       }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
     }
   ],
   "variables": {
@@ -367,19 +377,16 @@
       "value": null,
       "isSecret": true
     },
-    "DockerHost_Sandbox": {
-      "value": "$(Build.StagingDirectory)/HostSandbox"
-    },
-    "DockerHost_ToolsDirectory": {
-      "value": "$(DockerHost_Sandbox)/Tools"
+    "HelixApiAccessKey": {
+      "value": null,
+      "isSecret": true
     },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
-    "ProductBuildId": {
-      "value": "",
-      "allowOverride": true
+    "PB_AssetRootUrl": {
+      "value": ""
     },
     "PB_BuildArguments": {
       "value": "-buildArch=x64 -Release -stripSymbols",
@@ -399,10 +406,6 @@
       "value": null,
       "isSecret": true
     },
-    "HelixApiAccessKey": {
-      "value": null,
-      "isSecret": true
-    },
     "PB_CloudResultsAccountName": {
       "value": "dotnetjobresult"
     },
@@ -411,13 +414,13 @@
       "allowOverride": true
     },
     "PB_DockerCommonRunArgs": {
-      "value": "--rm --name $(PB_DockerContainerName) -v \"$(PB_GitDirectory):$(PB_DockerVolumeName)\" -w=\"$(PB_DockerVolumeName)\" -e \"PACKAGEVERSIONPROPSURL=$(PB_PackageVersionPropsUrl)\" $(PB_DockerImageName)"
+      "value": "--name $(PB_DockerContainerName) -v \"$(PB_DockerContainerName):$(PB_DockerVolumeName)\" -w=\"$(PB_DockerVolumeName)\" -e \"PACKAGEVERSIONPROPSURL=$(PB_PackageVersionPropsUrl)\" $(PB_DockerImageName)"
     },
     "PB_DockerContainerName": {
       "value": "corefx-$(Build.BuildId)"
     },
     "PB_DockerCopyDest": {
-      "value": "$(Build.BinariesDirectory)/docker_repo"
+      "value": "$(Build.StagingDirectory)"
     },
     "PB_DockerImageName": {
       "value": "$(PB_DockerRepository):$(PB_DockerTag)"
@@ -439,6 +442,13 @@
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
+    "PB_PackageVersionPropsUrl": {
+      "value": ""
+    },
+    "PB_SkipTests": {
+      "value": "false",
+      "allowOverride": true
+    },
     "PB_SyncArguments": {
       "value": "-p -- /p:ArchGroup=x64",
       "allowOverride": true
@@ -455,6 +465,10 @@
     "PB_VsoRepositoryName": {
       "value": "DotNet-CoreFX-Trusted"
     },
+    "ProductBuildId": {
+      "value": "",
+      "allowOverride": true
+    },
     "SourceVersion": {
       "value": "HEAD",
       "allowOverride": true
@@ -466,16 +480,6 @@
     "VsoPassword": {
       "value": null,
       "isSecret": true
-    },
-    "PB_SkipTests": {
-      "value": "false",
-      "allowOverride": true
-    },
-    "PB_PackageVersionPropsUrl": {
-      "value": ""
-    },
-    "PB_AssetRootUrl": {
-      "value": ""
     }
   },
   "demands": [
@@ -507,7 +511,7 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "true",
-      "cleanOptions": "0",
+      "cleanOptions": "3",
       "checkoutNestedSubmodules": "false",
       "labelSourcesFormat": "$(build.buildNumber)"
     },
@@ -516,15 +520,21 @@
     "name": "DotNet-CoreFX-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-CoreFX-Trusted",
     "defaultBranch": "refs/heads/master",
-    "clean": "false",
+    "clean": "true",
     "checkoutSubmodules": false
   },
   "processParameters": {},
   "quality": "definition",
   "drafts": [],
   "queue": {
+    "_links": {
+      "self": {
+        "href": "https://devdiv.visualstudio.com/DefaultCollection/_apis/build/Queues/36"
+      }
+    },
     "id": 36,
     "name": "DotNet-Build",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/build/Queues/36",
     "pool": {
       "id": 39,
       "name": "DotNet-Build"
@@ -538,10 +548,10 @@
   "project": {
     "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "name": "DevDiv",
-    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items for Visual Studio and most active DevDiv products are in this account.",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098432,
+    "revision": 418099051,
     "visibility": "organization"
   }
 }

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -5,6 +5,11 @@
     "Type": "VSTS",
     "BaseUrl": "https://devdiv.visualstudio.com/DefaultCollection"
   },
+  "PrivateRun": {
+    "property-overrides": {
+      "PB_PublishType": ""
+    }
+  },  
   "Pipelines": [
     {
       "Name": "Trusted-All-Linux",


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/3224

Note, It's possible that this could cause build failures if it's submitted before some manual agent cleanup occurs.  ie, This change enables VSTS build agent cleanup, and that step will fail (Permission Denied) if it tries to cleanup any build which was run using the previous model. 

@weshaggard @mmitche I'd like to manually cleanup all the current Corefx builds off of the Linux agents before submitting this change.  The alternative way to deal with this is to leave in the previous cleanup model (change permissions and then delete) for about a week after the rest of this change goes in and then transition to using VSTS's cleanup system.