### PR TITLE
Add basic GET SocketsHttpHandler perf tests

### DIFF
--- a/src/System.Net.Http/tests/Performance/Configurations.props
+++ b/src/System.Net.Http/tests/Performance/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netcoreapp;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Net.Http/tests/Performance/Perf.SocketsHttpHandler.cs
+++ b/src/System.Net.Http/tests/Performance/Perf.SocketsHttpHandler.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Xunit.Performance;
+using Xunit;
+
+namespace System.Net.Http.Tests
+{
+    public sealed class SocketsHttpHandlerPerfTest
+    {
+        const int InnerIterationCount = 1000;
+
+        public static IEnumerable<object[]> Get_MemberData() =>
+            from ssl in new[] { false, true }
+            from connectionPerRequest in new[] { false, true }
+            from chunkedResponse in new[] { false, true }
+            from responseLength in new[] { 1, 100_000 }
+            select new object[] { ssl, connectionPerRequest, chunkedResponse, responseLength };
+
+        [Benchmark(InnerIterationCount = InnerIterationCount)]
+        [MemberData(nameof(Get_MemberData))]
+        public async Task Get(bool ssl, bool connectionPerRequest, bool chunkedResponse, int responseLength)
+        {
+            using (var serverCert = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate())
+            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                #region Server
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(int.MaxValue);
+                ReadOnlyMemory<byte> responseBytes = Encoding.UTF8.GetBytes(chunkedResponse ?
+                    $"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n{responseLength.ToString("X")}\r\n{new string('a', responseLength)}\r\n0\r\n\r\n" :
+                    $"HTTP/1.1 200 OK\r\nContent-Length: {responseLength}\r\n\r\n{new string('a', responseLength)}");
+
+                Task serverTask = Task.Run(async () =>
+                {
+                    try
+                    {
+                        while (true)
+                        {
+                            using (Socket s = await listener.AcceptAsync())
+                            {
+                                try
+                                {
+                                    Stream stream = new NetworkStream(s);
+                                    if (ssl)
+                                    {
+                                        var sslStream = new SslStream(stream, false, delegate { return true; });
+                                        await sslStream.AuthenticateAsServerAsync(serverCert, false, SslProtocols.None, false);
+                                        stream = sslStream;
+                                    }
+
+                                    using (var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 100))
+                                    {
+                                        while (true)
+                                        {
+                                            while (!string.IsNullOrEmpty(await reader.ReadLineAsync()));
+                                            await stream.WriteAsync(responseBytes);
+                                            if (connectionPerRequest)
+                                            {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                catch (SocketException e) when (e.SocketErrorCode == SocketError.ConnectionAborted) { }
+                            }
+                        }
+                    }
+                    catch { }
+                });
+                #endregion
+
+                var ep = (IPEndPoint)listener.LocalEndPoint;
+                var uri = new Uri($"http{(ssl?"s":"")}://{ep.Address}:{ep.Port}/");
+                using (var handler = new SocketsHttpHandler())
+                using (var invoker = new HttpMessageInvoker(handler))
+                {
+                    if (ssl)
+                    {
+                        handler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
+                    }
+
+                    var req = new HttpRequestMessage(HttpMethod.Get, uri);
+                    if (connectionPerRequest)
+                    {
+                        req.Headers.ConnectionClose = true;
+                    }
+
+                    foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+                    {
+                        using (iteration.StartMeasurement())
+                        {
+                            for (int i = 0; i < InnerIterationCount; i++)
+                            {
+                                using (HttpResponseMessage resp = await invoker.SendAsync(req, CancellationToken.None))
+                                using (Stream respStream = await resp.Content.ReadAsStreamAsync())
+                                {
+                                    await respStream.CopyToAsync(Stream.Null);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                listener.Dispose();
+                await serverTask;
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/Performance/Perf.SocketsHttpHandler.cs
+++ b/src/System.Net.Http/tests/Performance/Perf.SocketsHttpHandler.cs
@@ -37,9 +37,11 @@ namespace System.Net.Http.Tests
                 #region Server
                 listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
                 listener.Listen(int.MaxValue);
-                ReadOnlyMemory<byte> responseBytes = Encoding.UTF8.GetBytes(chunkedResponse ?
-                    $"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n{responseLength.ToString("X")}\r\n{new string('a', responseLength)}\r\n0\r\n\r\n" :
-                    $"HTTP/1.1 200 OK\r\nContent-Length: {responseLength}\r\n\r\n{new string('a', responseLength)}");
+                string responseText = 
+                    "HTTP/1.1 200 OK\r\n" + (connectionPerRequest ? "Connection: close\r\n" : "") + (chunkedResponse ?
+                    $"Transfer-Encoding: chunked\r\n\r\n{responseLength.ToString("X")}\r\n{new string('a', responseLength)}\r\n0\r\n\r\n" :
+                    $"Content-Length: {responseLength}\r\n\r\n{new string('a', responseLength)}");
+                ReadOnlyMemory<byte> responseBytes = Encoding.UTF8.GetBytes(responseText);
 
                 Task serverTask = Task.Run(async () =>
                 {

--- a/src/System.Net.Http/tests/Performance/System.Net.Http.Performance.Tests.csproj
+++ b/src/System.Net.Http/tests/Performance/System.Net.Http.Performance.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
+    <ProjectGuid>{981FC867-9071-444D-9388-BC5826609F76}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <ItemGroup>
+    <Compile Include="Perf.SocketsHttpHandler.cs" />
+    <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
+      <Link>Common\System\PerfUtils.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
+      <Link>Common\System\Net\Configuration.Certificates.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CommonPath)\..\perf\PerfRunner\PerfRunner.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>PerfRunner</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.0-prerelease\content\**\*.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Tests for:
- http vs https
- connection: close vs keep-alive
- chunked vs content-length response
- various response lengths

These are not meant to be end-to-end tests, just basic perf tests to help get a quick read on regressions and the like.

cc: @geoffkizer, @wfurt, @davidsh

Example output on my machine (with a bunch of other stuff going on, so don't pay too much attention to the numbers):

 System.Net.Http.Performance.Tests.dll                                                                                                         | Metric   | Unit | Iterations |  Average | STDEV.S |      Min |      Max
:--------------------------------------------------------------------------------------------------------------------------------------------- |:-------- |:----:|:----------:| --------:| -------:| --------:| --------:
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, connectionPerRequest: False, chunkedResponse: False, responseLength: 1)      | Duration | msec |    100     |   83.455 |   6.179 |   74.239 |  128.440
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, connectionPerRequest: False, chunkedResponse: False, responseLength: 100000) | Duration | msec |     21     |  491.563 |  43.112 |  421.577 |  592.187
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, connectionPerRequest: False, chunkedResponse: True, responseLength: 1)       | Duration | msec |    100     |   79.547 |   7.700 |   65.360 |  105.538
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, connectionPerRequest: False, chunkedResponse: True, responseLength: 100000)  | Duration | msec |     22     |  463.553 |  13.256 |  433.116 |  498.969
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, connectionPerRequest: True, chunkedResponse: False, responseLength: 1)       | Duration | msec |     18     |  586.871 |  63.070 |  489.314 |  719.751
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, connectionPerRequest: True, chunkedResponse: False, responseLength: 100000)  | Duration | msec |     7      | 1448.363 | 295.026 | 1220.242 | 2023.730
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, connectionPerRequest: True, chunkedResponse: True, responseLength: 1)        | Duration | msec |     18     |  560.555 |  50.207 |  472.637 |  671.757
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, connectionPerRequest: True, chunkedResponse: True, responseLength: 100000)   | Duration | msec |     8      | 1309.533 |  39.894 | 1257.887 | 1372.492
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: True, connectionPerRequest: False, chunkedResponse: False, responseLength: 1)       | Duration | msec |     78     |  128.654 |  25.640 |  101.723 |  248.124
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: True, connectionPerRequest: False, chunkedResponse: False, responseLength: 100000)  | Duration | msec |     19     |  530.344 |  13.028 |  504.011 |  556.610
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: True, connectionPerRequest: False, chunkedResponse: True, responseLength: 1)        | Duration | msec |     93     |  108.198 |  13.686 |   90.941 |  166.983
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: True, connectionPerRequest: False, chunkedResponse: True, responseLength: 100000)   | Duration | msec |     18     |  570.010 |  49.106 |  527.718 |  711.297
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: True, connectionPerRequest: True, chunkedResponse: False, responseLength: 1)        | Duration | msec |     3      | 3726.067 | 207.902 | 3553.084 | 3956.715
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: True, connectionPerRequest: True, chunkedResponse: False, responseLength: 100000)   | Duration | msec |     2      | 5714.703 | 577.583 | 5306.290 | 6123.116
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: True, connectionPerRequest: True, chunkedResponse: True, responseLength: 1)         | Duration | msec |     3      | 3467.903 |  34.445 | 3446.754 | 3507.649
 System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: True, connectionPerRequest: True, chunkedResponse: True, responseLength: 100000)    | Duration | msec |     3      | 4173.551 |  46.385 | 4122.404 | 4212.891
