### PR TITLE
Added AssociatedMetadataTypeTypeDescriptionProvider & MetadataTypeAttribute to C.CM.DA

### DIFF
--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -8,6 +8,12 @@
 
 namespace System.ComponentModel.DataAnnotations
 {
+    public partial class AssociatedMetadataTypeTypeDescriptionProvider : System.ComponentModel.TypeDescriptionProvider
+    {
+        public AssociatedMetadataTypeTypeDescriptionProvider(System.Type type) { }
+        public AssociatedMetadataTypeTypeDescriptionProvider(System.Type type, System.Type associatedMetadataType) { }
+        public override System.ComponentModel.ICustomTypeDescriptor GetTypeDescriptor(System.Type objectType, object instance) { throw null; }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), AllowMultiple = false, Inherited = true)]
     [System.ObsoleteAttribute("This attribute is no longer in use and will be ignored if applied.")]
     public sealed partial class AssociationAttribute : System.Attribute
@@ -183,6 +189,12 @@ namespace System.ComponentModel.DataAnnotations
         public int Length { get { throw null; } }
         public override string FormatErrorMessage(string name) { throw null; }
         public override bool IsValid(object value) { throw null; }
+    }
+    [System.AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed partial class MetadataTypeAttribute : System.Attribute
+    {
+        public System.Type MetadataClassType { get { throw null; } }
+        public MetadataTypeAttribute(System.Type metadataClassType) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(2432), AllowMultiple = false)]
     public partial class MinLengthAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute

--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
@@ -18,6 +18,10 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="mscorlib" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'netcoreapp2.0'">
+    <Reference Include="System.ComponentModel.TypeConverter" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.Annotations/src/Resources/Strings.resx
+++ b/src/System.ComponentModel.Annotations/src/Resources/Strings.resx
@@ -61,6 +61,9 @@
   <data name="ArgumentIsNullOrWhitespace" xml:space="preserve">
     <value>The argument '{0}' cannot be null, empty or contain only whitespace.</value>
   </data>
+  <data name="AssociatedMetadataTypeTypeDescriptor_MetadataTypeContainsUnknownProperties" xml:space="preserve">
+    <value>The associated metadata type for type '{0}' contains the following unknown properties or fields: {1}. Please make sure that the names of these members match the names of the properties on the main type.</value>
+  </data>
   <data name="AttributeStore_Unknown_Property" xml:space="preserve">
     <value>The type '{0}' does not contain a public property named '{1}'.</value>
   </data>
@@ -126,6 +129,9 @@
   </data>
   <data name="MaxLengthAttribute_ValidationError" xml:space="preserve">
     <value>The field {0} must be a string or array type with a maximum length of '{1}'.</value>
+  </data>
+  <data name="MetadataTypeAttribute_TypeCannotBeNull" xml:space="preserve">
+    <value>MetadataClassType cannot be null.</value>
   </data>
   <data name="MinLengthAttribute_InvalidMinLength" xml:space="preserve">
     <value>MinLengthAttribute must have a Length value that is zero or greater.</value>

--- a/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
@@ -13,6 +13,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+    <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptor.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptionProvider.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\AssociationAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\CompareAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\ConcurrencyCheckAttribute.cs" />
@@ -32,6 +34,8 @@
     <Compile Include="System\ComponentModel\DataAnnotations\KeyAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\LocalizableString.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\MaxLengthAttribute.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\MetadataPropertyDescriptorWrapper.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\MetadataTypeAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\MinLengthAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\PhoneAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\RangeAttribute.cs" />

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptionProvider.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.DataAnnotations
+{
+    public class AssociatedMetadataTypeTypeDescriptionProvider : TypeDescriptionProvider
+    {
+        private Type _associatedMetadataType;
+        public AssociatedMetadataTypeTypeDescriptionProvider(Type type)
+            : base(TypeDescriptor.GetProvider(type))
+        {
+        }
+
+        public AssociatedMetadataTypeTypeDescriptionProvider(Type type, Type associatedMetadataType)
+            : this(type)
+        {
+            if (associatedMetadataType == null)
+            {
+                throw new ArgumentNullException("associatedMetadataType");
+            }
+
+            _associatedMetadataType = associatedMetadataType;
+        }
+
+        public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
+        {
+            ICustomTypeDescriptor baseDescriptor = base.GetTypeDescriptor(objectType, instance);
+            return new AssociatedMetadataTypeTypeDescriptor(baseDescriptor, objectType, _associatedMetadataType);
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptor.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptor.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Collections.Concurrent;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    internal class AssociatedMetadataTypeTypeDescriptor : CustomTypeDescriptor
+    {
+        private Type AssociatedMetadataType
+        {
+            get;
+            set;
+        }
+
+        private bool IsSelfAssociated
+        {
+            get;
+            set;
+        }
+
+        public AssociatedMetadataTypeTypeDescriptor(ICustomTypeDescriptor parent, Type type, Type associatedMetadataType)
+            : base(parent)
+        {
+            AssociatedMetadataType = associatedMetadataType ?? TypeDescriptorCache.GetAssociatedMetadataType(type);
+            IsSelfAssociated = (type == AssociatedMetadataType);
+            if (AssociatedMetadataType != null)
+            {
+                TypeDescriptorCache.ValidateMetadataType(type, AssociatedMetadataType);
+            }
+        }
+
+        public override PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+        {
+            return GetPropertiesWithMetadata(base.GetProperties(attributes));
+        }
+
+        public override PropertyDescriptorCollection GetProperties()
+        {
+            return GetPropertiesWithMetadata(base.GetProperties());
+        }
+
+        private PropertyDescriptorCollection GetPropertiesWithMetadata(PropertyDescriptorCollection originalCollection)
+        {
+            if (AssociatedMetadataType == null)
+            {
+                return originalCollection;
+            }
+
+            bool customDescriptorsCreated = false;
+            List<PropertyDescriptor> tempPropertyDescriptors = new List<PropertyDescriptor>();
+            foreach (PropertyDescriptor propDescriptor in originalCollection)
+            {
+                Attribute[] newMetadata = TypeDescriptorCache.GetAssociatedMetadata(AssociatedMetadataType, propDescriptor.Name);
+                PropertyDescriptor descriptor = propDescriptor;
+                if (newMetadata.Length > 0)
+                {
+                    // Create a metadata descriptor that wraps the property descriptor
+                    descriptor = new MetadataPropertyDescriptorWrapper(propDescriptor, newMetadata);
+                    customDescriptorsCreated = true;
+                }
+
+                tempPropertyDescriptors.Add(descriptor);
+            }
+
+            if (customDescriptorsCreated)
+            {
+                return new PropertyDescriptorCollection(tempPropertyDescriptors.ToArray(), true);
+            }
+            return originalCollection;
+        }
+
+        public override AttributeCollection GetAttributes()
+        {
+            // Since normal TD behavior is to return cached attribute instances on subsequent
+            // calls to GetAttributes, we must be sure below to use the TD APIs to get both
+            // the base and associated attributes
+            AttributeCollection attributes = base.GetAttributes();
+            if (AssociatedMetadataType != null && !IsSelfAssociated)
+            {
+                // Note that the use of TypeDescriptor.GetAttributes here opens up the possibility of
+                // infinite recursion, in the corner case of two Types referencing each other as
+                // metadata types (or a longer cycle), though the second condition above saves an immediate such
+                // case where a Type refers to itself.
+                Attribute[] newAttributes = TypeDescriptor.GetAttributes(AssociatedMetadataType).OfType<Attribute>().ToArray();
+                attributes = AttributeCollection.FromExisting(attributes, newAttributes);
+            }
+            return attributes;
+        }
+
+        private static class TypeDescriptorCache
+        {
+            private static readonly Attribute[] emptyAttributes = new Attribute[0];
+            // Stores the associated metadata type for a type
+            private static readonly ConcurrentDictionary<Type, Type> _metadataTypeCache = new ConcurrentDictionary<Type, Type>();
+
+            // Stores the attributes for a member info
+            private static readonly ConcurrentDictionary<Tuple<Type, string>, Attribute[]> _typeMemberCache = new ConcurrentDictionary<Tuple<Type, string>, Attribute[]>();
+
+            // Stores whether or not a type and associated metadata type has been checked for validity
+            private static readonly ConcurrentDictionary<Tuple<Type, Type>, bool> _validatedMetadataTypeCache = new ConcurrentDictionary<Tuple<Type, Type>, bool>();
+
+            public static void ValidateMetadataType(Type type, Type associatedType)
+            {
+                Tuple<Type, Type> typeTuple = new Tuple<Type, Type>(type, associatedType);
+                if (!_validatedMetadataTypeCache.ContainsKey(typeTuple))
+                {
+                    CheckAssociatedMetadataType(type, associatedType);
+                    _validatedMetadataTypeCache.TryAdd(typeTuple, true);
+                }
+            }
+
+            public static Type GetAssociatedMetadataType(Type type)
+            {
+                Type associatedMetadataType = null;
+                if (_metadataTypeCache.TryGetValue(type, out associatedMetadataType))
+                {
+                    return associatedMetadataType;
+                }
+
+                // Try association attribute
+                MetadataTypeAttribute attribute = (MetadataTypeAttribute)Attribute.GetCustomAttribute(type, typeof(MetadataTypeAttribute));
+                if (attribute != null)
+                {
+                    associatedMetadataType = attribute.MetadataClassType;
+                }
+                _metadataTypeCache.TryAdd(type, associatedMetadataType);
+                return associatedMetadataType;
+            }
+
+            private static void CheckAssociatedMetadataType(Type mainType, Type associatedMetadataType)
+            {
+                // Only properties from main type
+                HashSet<string> mainTypeMemberNames = new HashSet<string>(mainType.GetProperties().Select(p => p.Name));
+
+                // Properties and fields from buddy type
+                var buddyFields = associatedMetadataType.GetFields().Select(f => f.Name);
+                var buddyProperties = associatedMetadataType.GetProperties().Select(p => p.Name);
+                HashSet<string> buddyTypeMembers = new HashSet<string>(buddyFields.Concat(buddyProperties), StringComparer.Ordinal);
+
+                // Buddy members should be a subset of the main type's members
+                if (!buddyTypeMembers.IsSubsetOf(mainTypeMemberNames))
+                {
+                    // Reduce the buddy members to the set not contained in the main members
+                    buddyTypeMembers.ExceptWith(mainTypeMemberNames);
+
+                    throw new InvalidOperationException(String.Format(
+                        CultureInfo.CurrentCulture,
+                        SR.AssociatedMetadataTypeTypeDescriptor_MetadataTypeContainsUnknownProperties,
+                        mainType.FullName,
+                        String.Join(", ", buddyTypeMembers.ToArray())));
+                }
+            }
+
+            public static Attribute[] GetAssociatedMetadata(Type type, string memberName)
+            {
+                var memberTuple = new Tuple<Type, string>(type, memberName);
+                Attribute[] attributes;
+                if (_typeMemberCache.TryGetValue(memberTuple, out attributes))
+                {
+                    return attributes;
+                }
+
+                // Allow fields and properties
+                MemberTypes allowedMemberTypes = MemberTypes.Property | MemberTypes.Field;
+                // Only public static/instance members
+                BindingFlags searchFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
+                // Try to find a matching member on type
+                MemberInfo matchingMember = type.GetMember(memberName, allowedMemberTypes, searchFlags).FirstOrDefault();
+                if (matchingMember != null)
+                {
+                    attributes = Attribute.GetCustomAttributes(matchingMember, true /* inherit */);
+                }
+                else
+                {
+                    attributes = emptyAttributes;
+                }
+
+                _typeMemberCache.TryAdd(memberTuple, attributes);
+                return attributes;
+            }
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MetadataPropertyDescriptorWrapper.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MetadataPropertyDescriptorWrapper.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.ComponentModel;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    internal class MetadataPropertyDescriptorWrapper : PropertyDescriptor
+    {
+        private PropertyDescriptor _descriptor;
+        private bool _isReadOnly;
+
+        public MetadataPropertyDescriptorWrapper(PropertyDescriptor descriptor, Attribute[] newAttributes)
+            : base(descriptor, newAttributes)
+        {
+            _descriptor = descriptor;
+            var readOnlyAttribute = newAttributes.OfType<ReadOnlyAttribute>().FirstOrDefault();
+            _isReadOnly = (readOnlyAttribute != null ? readOnlyAttribute.IsReadOnly : false);
+        }
+
+        public override void AddValueChanged(object component, EventHandler handler) { _descriptor.AddValueChanged(component, handler); }
+
+        public override bool CanResetValue(object component) { return _descriptor.CanResetValue(component); }
+
+        public override Type ComponentType { get { return _descriptor.ComponentType; } }
+
+        public override object GetValue(object component) { return _descriptor.GetValue(component); }
+
+        public override bool IsReadOnly
+        {
+            get
+            {
+                // Dev10 Bug 594083
+                // It's not enough to call the wrapped _descriptor because it does not know anything about
+                // new attributes passed into the constructor of this class.
+                return _isReadOnly || _descriptor.IsReadOnly;
+            }
+        }
+
+        public override Type PropertyType { get { return _descriptor.PropertyType; } }
+
+        public override void RemoveValueChanged(object component, EventHandler handler) { _descriptor.RemoveValueChanged(component, handler); }
+
+        public override void ResetValue(object component) { _descriptor.ResetValue(component); }
+
+        public override void SetValue(object component, object value) { _descriptor.SetValue(component, value); }
+
+        public override bool ShouldSerializeValue(object component) { return _descriptor.ShouldSerializeValue(component); }
+
+        public override bool SupportsChangeEvents { get { return _descriptor.SupportsChangeEvents; } }
+    }
+}

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MetadataTypeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MetadataTypeAttribute.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    /// <summary>
+    /// Used for associating a metadata class with the entity class.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class MetadataTypeAttribute : Attribute {
+ 
+        private Type _metadataClassType;
+ 
+        public Type MetadataClassType {
+            get {
+                if (_metadataClassType == null) {
+                    throw new InvalidOperationException(SR.MetadataTypeAttribute_TypeCannotBeNull);
+                }
+ 
+                return _metadataClassType;
+            }
+        }
+ 
+        public MetadataTypeAttribute(Type metadataClassType) {
+            _metadataClassType = metadataClassType;
+        }
+ 
+    }
+}

--- a/src/System.ComponentModel.Annotations/tests/AssociatedMetadataTypeTypeDescriptionProviderTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/AssociatedMetadataTypeTypeDescriptionProviderTests.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.ComponentModel.DataAnnotations.Tests
+{
+    public class AssociatedMetadataTypeTypeDescriptionProviderTests
+    {
+        [Fact]
+        public static void Constructor_NullType_ThrowsArgumentNullException()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("type", () => new AssociatedMetadataTypeTypeDescriptionProvider(null));
+        }
+
+        [Fact]
+        public static void Constructor_NullAssociatedMetadataType_ThrowsArgumentNullException()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("associatedMetadataType", () => new AssociatedMetadataTypeTypeDescriptionProvider(typeof(string), null));
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/tests/MetadataTypeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/MetadataTypeAttributeTests.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.ComponentModel.DataAnnotations.Tests
+{
+    public class MetadataTypeAttributeTests
+    {
+        
+    }
+}

--- a/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="AssociatedMetadataTypeTypeDescriptionProviderTests.cs" />
     <Compile Include="UIHintAttributeTests.cs" />
     <Compile Include="FilterUIHintAttributeTests.cs" />
     <Compile Include="DisplayAttributeTests.cs" />
@@ -26,6 +27,7 @@
     <Compile Include="EnumDataTypeAttributeTests.cs" />
     <Compile Include="FileExtensionsAttributeTests.cs" />
     <Compile Include="MaxLengthAttributeTests.cs" />
+    <Compile Include="MetadataTypeAttributeTests.cs" />
     <Compile Include="MinLengthAttributeTests.cs" />
     <Compile Include="PhoneAttributeTests.cs" />
     <Compile Include="RangeAttributeTests.cs" />


### PR DESCRIPTION
This PR brings all remaining types under System.ComponentModel.DataAnnotations namespace of .net framework to .net core.

This helps following issues:

This closes **.NET Core 2 type load exception for "AssociatedMetadataTypeTypeDescriptionProvider" when using full .net framework dll in web api owin** #22469

This closes **Port more of System.ComponentModel.DataAnnotations types** #16101

Let me know if any change is required.
Thanks for your efforts (-: