### PR TITLE
Delete faulty assert in SslStreamInternal

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -182,7 +182,6 @@ namespace System.Net.Security
         private void ResetReadBuffer()
         {
             Debug.Assert(_decryptedBytesCount == 0);
-            Debug.Assert(_internalBuffer == null || _internalBufferCount > 0);
 
             if (_internalBuffer == null)
             {


### PR DESCRIPTION
We're hitting an assert when a ReadAsync call is made on SslStream after the underlying stream encounters EOF.  When calling FillBufferAsync, we've already allocated the read buffer, and we may not have any data in the buffer; if we then hit EOF, we've still not got any data in the buffer and we return.  Then when ReadAsync is called again, the assert trips over the buffer being allocated and also being empty.

The fix is to call ReturnReadBufferIfEmpty when we hit EOF, so that we promptly free the buffer.  But I'm also deleting the failing assert, as it seems like we could hit this in other situations as well.

Fixes https://github.com/dotnet/corefx/issues/29127
cc: @geoffkizer, @Drawaes, @davidsh 