### PR TITLE
change sync timeout handling back to use actual sync timeouts

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -157,14 +157,6 @@ namespace System.Net.Sockets
             set
             {
                 Debug.Assert(value == -1 || value > 0, $"Unexpected value: {value}");
-
-                // We always implement timeouts using nonblocking I/O and AsyncContext,
-                // to avoid issues when switching from blocking I/O to nonblocking.
-                if (value != -1)
-                {
-                    SetHandleNonBlocking();
-                }
-
                 _receiveTimeout = value;
             }
         }
@@ -178,14 +170,6 @@ namespace System.Net.Sockets
             set
             {
                 Debug.Assert(value == -1 || value > 0, $"Unexpected value: {value}");
-
-                // We always implement timeouts using nonblocking I/O and AsyncContext,
-                // to avoid issues when switching from blocking I/O to nonblocking.
-                if (value != -1)
-                {
-                    SetHandleNonBlocking();
-                }
-
                 _sendTimeout = value;
             }
         }
@@ -349,7 +333,7 @@ namespace System.Net.Sockets
                 IntPtr acceptedFd;
                 if (!socketHandle.IsNonBlocking)
                 {
-                    errorCode = socketHandle.AsyncContext.Accept(socketAddress, ref socketAddressLen, -1, out acceptedFd);
+                    errorCode = socketHandle.AsyncContext.Accept(socketAddress, ref socketAddressLen, out acceptedFd);
                 }
                 else
                 {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1246,7 +1246,7 @@ namespace System.Net.Sockets
         {
             if (_nonBlockingSet)
             {
-                errorCode = SocketError.Success;
+                errorCode = SocketError.Success;    // Will be ignored
                 return true;
             }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1242,11 +1242,23 @@ namespace System.Net.Sockets
             }
         }
 
-        public SocketError Accept(byte[] socketAddress, ref int socketAddressLen, int timeout, out IntPtr acceptedFd)
+        private bool ShouldRetrySyncOperation(out SocketError errorCode)
+        {
+            if (_nonBlockingSet)
+            {
+                errorCode = SocketError.Success;
+                return true;
+            }
+
+            // We are in blocking mode, so the EAGAIN we received indicates a timeout.
+            errorCode = SocketError.TimedOut;
+            return false;
+        }
+
+        public SocketError Accept(byte[] socketAddress, ref int socketAddressLen, out IntPtr acceptedFd)
         {
             Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
             Debug.Assert(socketAddressLen > 0, $"Unexpected socketAddressLen: {socketAddressLen}");
-            Debug.Assert(timeout == -1 || timeout > 0, $"Unexpected timeout: {timeout}");
 
             SocketError errorCode;
             int observedSequenceNumber;
@@ -1263,7 +1275,7 @@ namespace System.Net.Sockets
                 SocketAddressLen = socketAddressLen,
             };
 
-            PerformSyncOperation(ref _receiveQueue, operation, timeout, observedSequenceNumber);
+            PerformSyncOperation(ref _receiveQueue, operation, -1, observedSequenceNumber);
 
             socketAddressLen = operation.SocketAddressLen;
             acceptedFd = operation.AcceptedFileDescriptor;
@@ -1307,11 +1319,10 @@ namespace System.Net.Sockets
             return SocketError.IOPending;
         }
 
-        public SocketError Connect(byte[] socketAddress, int socketAddressLen, int timeout)
+        public SocketError Connect(byte[] socketAddress, int socketAddressLen)
         {
             Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
             Debug.Assert(socketAddressLen > 0, $"Unexpected socketAddressLen: {socketAddressLen}");
-            Debug.Assert(timeout == -1 || timeout > 0, $"Unexpected timeout: {timeout}");
 
             // Connect is different than the usual "readiness" pattern of other operations.
             // We need to call TryStartConnect to initiate the connect with the OS, 
@@ -1332,7 +1343,7 @@ namespace System.Net.Sockets
                 SocketAddressLen = socketAddressLen
             };
 
-            PerformSyncOperation(ref _sendQueue, operation, timeout, observedSequenceNumber);
+            PerformSyncOperation(ref _sendQueue, operation, -1, observedSequenceNumber);
 
             return operation.ErrorCode;
         }
@@ -1398,7 +1409,8 @@ namespace System.Net.Sockets
             SocketError errorCode;
             int observedSequenceNumber;
             if (_receiveQueue.IsReady(this, out observedSequenceNumber) &&
-                SocketPal.TryCompleteReceiveFrom(_socket, buffer.Span, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+                (SocketPal.TryCompleteReceiveFrom(_socket, buffer.Span, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode)))
             {
                 flags = receivedFlags;
                 return errorCode;
@@ -1425,7 +1437,8 @@ namespace System.Net.Sockets
             SocketError errorCode;
             int observedSequenceNumber;
             if (_receiveQueue.IsReady(this, out observedSequenceNumber) &&
-                SocketPal.TryCompleteReceiveFrom(_socket, buffer, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+                (SocketPal.TryCompleteReceiveFrom(_socket, buffer, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode)))
             {
                 flags = receivedFlags;
                 return errorCode;
@@ -1503,7 +1516,8 @@ namespace System.Net.Sockets
             SocketError errorCode;
             int observedSequenceNumber;
             if (_receiveQueue.IsReady(this, out observedSequenceNumber) &&
-                SocketPal.TryCompleteReceiveFrom(_socket, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+                (SocketPal.TryCompleteReceiveFrom(_socket, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode)))
             {
                 flags = receivedFlags;
                 return errorCode;
@@ -1570,7 +1584,8 @@ namespace System.Net.Sockets
             SocketError errorCode;
             int observedSequenceNumber;
             if (_receiveQueue.IsReady(this, out observedSequenceNumber) &&
-                SocketPal.TryCompleteReceiveMessageFrom(_socket, buffer.Span, buffers, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode))
+                (SocketPal.TryCompleteReceiveMessageFrom(_socket, buffer.Span, buffers, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode)))
             {
                 flags = receivedFlags;
                 return errorCode;
@@ -1657,7 +1672,8 @@ namespace System.Net.Sockets
             SocketError errorCode;
             int observedSequenceNumber;
             if (_sendQueue.IsReady(this, out observedSequenceNumber) &&
-                SocketPal.TryCompleteSendTo(_socket, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+                (SocketPal.TryCompleteSendTo(_socket, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode)))
             {
                 return errorCode;
             }
@@ -1688,7 +1704,8 @@ namespace System.Net.Sockets
             int bufferIndexIgnored = 0, offset = 0, count = buffer.Length;
             int observedSequenceNumber;
             if (_sendQueue.IsReady(this, out observedSequenceNumber) &&
-                SocketPal.TryCompleteSendTo(_socket, buffer, null, ref bufferIndexIgnored, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+                (SocketPal.TryCompleteSendTo(_socket, buffer, null, ref bufferIndexIgnored, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode)))
             {
                 return errorCode;
             }
@@ -1769,7 +1786,8 @@ namespace System.Net.Sockets
             SocketError errorCode;
             int observedSequenceNumber;
             if (_sendQueue.IsReady(this, out observedSequenceNumber) &&
-                SocketPal.TryCompleteSendTo(_socket, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+                (SocketPal.TryCompleteSendTo(_socket, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode)))
             {
                 return errorCode;
             }
@@ -1836,7 +1854,8 @@ namespace System.Net.Sockets
             SocketError errorCode;
             int observedSequenceNumber;
             if (_sendQueue.IsReady(this, out observedSequenceNumber) &&
-                SocketPal.TryCompleteSendFile(_socket, fileHandle, ref offset, ref count, ref bytesSent, out errorCode))
+                (SocketPal.TryCompleteSendFile(_socket, fileHandle, ref offset, ref count, ref bytesSent, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode)))
             {
                 return errorCode;
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -864,7 +864,7 @@ namespace System.Net.Sockets
         {
             if (!handle.IsNonBlocking)
             {
-                return handle.AsyncContext.Connect(socketAddress, socketAddressLen, -1);
+                return handle.AsyncContext.Connect(socketAddress, socketAddressLen);
             }
 
             SocketError errorCode;
@@ -1097,17 +1097,15 @@ namespace System.Net.Sockets
             {
                 if (optionName == SocketOptionName.ReceiveTimeout)
                 {
-                    // Note, setting a non-infinite timeout will force the handle into nonblocking mode
                     handle.ReceiveTimeout = optionValue == 0 ? -1 : optionValue;
-                    handle.TrackOption(optionLevel, optionName);
-                    return SocketError.Success;
+                    err = Interop.Sys.SetReceiveTimeout(handle, optionValue);
+                    return GetErrorAndTrackSetting(handle, optionLevel, optionName, err);
                 }
                 else if (optionName == SocketOptionName.SendTimeout)
                 {
-                    // Note, setting a non-infinite timeout will force the handle into nonblocking mode
                     handle.SendTimeout = optionValue == 0 ? -1 : optionValue;
-                    handle.TrackOption(optionLevel, optionName);
-                    return SocketError.Success;
+                    err = Interop.Sys.SetSendTimeout(handle, optionValue);
+                    return GetErrorAndTrackSetting(handle, optionLevel, optionName, err);
                 }
             }
             else if (optionLevel == SocketOptionLevel.IP)


### PR DESCRIPTION
Fixes #29040 

We made a change in 2.1 (#22588) to force sync operations with timeout to go through the sync-over-async path.  This caused a nontrivial perf hit.  

This change reverts (mostly) the previous change and fixes the original issue by checking explicitly for blocking mode and not retrying when a timeout is exceeded.

Also, remove timeout handling from accept and connect operations since it is never used.

@stephentoub @dotnet/ncl 