### PR TITLE
Bump versions for 2.2

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -33,7 +33,7 @@
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">4.5.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">4.6.0</PackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>

--- a/dependencies.props
+++ b/dependencies.props
@@ -48,7 +48,7 @@
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0019</XunitPerfAnalysisPackageVersion>
     <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>
     <XunitNetcoreExtensionsVersion>2.2.0-preview1-02725-03</XunitNetcoreExtensionsVersion>
-    
+
     <!-- Roslyn optimization data package version -->
     <OptimizationDataVersion>2.0.0-rc-61101-17</OptimizationDataVersion>
   </PropertyGroup>
@@ -193,7 +193,7 @@
 
   <PropertyGroup>
     <XUnitPackageVersion>2.3.0-beta1-build3642</XUnitPackageVersion>
-    <CompatibilityShimsPackageVersion>2.0.0</CompatibilityShimsPackageVersion>
+    <CompatibilityShimsPackageVersion>2.1.0</CompatibilityShimsPackageVersion>
   </PropertyGroup>
 
   <!-- Set up dependencies on packages that aren't found in a BuildInfo. -->

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -135,7 +135,7 @@
   <!-- System.Data.SqlClient tests require sni.dll in the test folder -->
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <PackageReference Include="runtime.native.System.Data.SqlClient.sni">
-      <Version>$(PackageVersion)-$(CoreFxExpectedPrerelease)</Version>
+      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion)</Version>
     </PackageReference>
     <PackageToInclude Include="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni"/>
     <PackageToInclude Include="runtime.win-x64.runtime.native.System.Data.SqlClient.sni"/>
@@ -155,7 +155,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
   <!-- Retrieve the UAP Tools to the TestHost folder -->
-  <Target Name="CopyUAPToolsToTestHost" 
+  <Target Name="CopyUAPToolsToTestHost"
           AfterTargets="RestorePackages"
           Condition="'$(TargetGroup)'=='uap'" >
 
@@ -175,12 +175,12 @@
     </ItemGroup>
 
     <Copy Condition="'$(UAPToolsFolder)'!=''"
-          SourceFiles="@(RunnerFolderContents)" 
+          SourceFiles="@(RunnerFolderContents)"
           DestinationFolder="$(TestHostRootPath)\Runner\%(RecursiveDir)"
           SkipUnchangedFiles="true"/>
 
     <Copy Condition="'$(UAPToolsFolder)'!=''"
-          SourceFiles="@(LauncherFolderContents)" 
+          SourceFiles="@(LauncherFolderContents)"
           DestinationFolder="$(TestHostRootPath)\Launcher\%(RecursiveDir)"
           SkipUnchangedFiles="true"/>
   </Target>
@@ -220,7 +220,7 @@
             Text="Error: looks the package $(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion) not restored or missing xunit.console.exe."
     />
     <ItemGroup>
-      <ReferenceCopyLocalPaths 
+      <ReferenceCopyLocalPaths
         Include="$(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\*.*"
         Exclude="$(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\xunit.console.exe.config"
       >

--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -1,14 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <PropertyGroup>
-    <PackageVersion>2.1.0</PackageVersion>
+    <PackageVersion>2.2.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>
   </PropertyGroup>
-
   <ItemGroup>
     <File Include="runtime.json" />
     <!-- make this package installable and noop in a packages.config-based project -->
@@ -16,8 +14,6 @@
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
   </ItemGroup>
-
   <Import Project="runtimeGroups.props" />
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -1,20 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <PropertyGroup>
-    <PackageVersion>2.1.0</PackageVersion>
+    <PackageVersion>2.2.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- make this package installable and noop in a packages.config-based project -->
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
-
     <File Include="runtime.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworkName>netcoreapp</TargetFrameworkName>
-    <TargetFrameworkVersion>2.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>2.2</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
 
     <RefBinDir>$(NETCoreAppPackageRefPath)</RefBinDir>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -1,23 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <PropertyGroup>
-    <PackageVersion>4.6.0</PackageVersion>
+    <PackageVersion>4.7.0</PackageVersion>
     <TargetFrameworkName>uap</TargetFrameworkName>
     <TargetFrameworkVersion>$(UAPvNextVersion)</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
-
     <RefBinDir>$(UAPPackageRefPath)</RefBinDir>
     <LibBinDir>$(UAPPackageRuntimePath)</LibBinDir>
     <LibBinDir Condition="$(PackageTargetRuntime.EndsWith('-aot'))">$(UAPAOTPackageRuntimePath)</LibBinDir>
-
     <IsFrameworkPackage>true</IsFrameworkPackage>
-
     <!-- Private packages need symbols -->
     <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
-
   <ItemGroup>
     <IgnoredReference Include="System.Private.CoreLib" />
     <IgnoredReference Include="Windows" />
@@ -40,9 +35,7 @@
     <ExcludeFromClosure Include="System.ServiceProcess" />
     <ExcludeFromClosure Include="System.Transactions" />
     <ExcludeFromClosure Include="WindowsBase" />
-
     <ExcludeFromDuplicateTypes Include="System.Private.Reflection.Metadata.Ecma335" />
-
     <!-- Permit the following implementation-only assemblies -->
     <ValidatePackageSuppression Condition="'$(PackageTargetRuntime)' != ''" Include="PermitInbox">
       <Value>
@@ -68,11 +61,10 @@
     </ValidatePackageSuppression>
     <!-- Permit missing Inbox since this used to be a shim and it is now OOB -->
     <ValidatePackageSuppression Include="PermitMissingInbox">
-        <Value>
+      <Value>
             System.ComponentModel.Composition;
         </Value>
     </ValidatePackageSuppression>
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
+++ b/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
@@ -1,14 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <PropertyGroup>
-    <PackageVersion>2.2.0</PackageVersion>
+    <PackageVersion>2.3.0</PackageVersion>
     <HarvestStablePackage>false</HarvestStablePackage>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <PackageIndexFileName>packageIndex.json</PackageIndexFileName>
   </PropertyGroup>
-  
   <ItemGroup>
     <File Include="Microsoft.Private.PackageBaseline.props">
       <TargetPath>build</TargetPath>
@@ -17,7 +15,6 @@
       <TargetPath>build</TargetPath>
     </File>
   </ItemGroup>
-  
   <!-- Stamp the packageIndex with pre-release version for this build -->
   <Target Name="StampPackageIndex" BeforeTargets="GenerateNuSpec">
     <MakeDir Directories="$(IntermediateOutputPath)" />
@@ -26,7 +23,6 @@
     <UpdatePackageIndex PackageIndexFile="$(IntermediateOutputPath)$(PackageIndexFileName)"
                         PreRelease="$(VersionSuffix)" />
   </Target>
-  
   <Target Name="UpdateFromLocalBuild">
     <ItemGroup>
       <AllPackages Include="$(PackageOutputPath)\*.nupkg" Exclude="$(PackageOutputPath)\*Microsoft.Private.*.nupkg" />
@@ -48,6 +44,5 @@
                         Packages="@(AllPackages)"
                         InboxFrameworkLayoutFolders="@(FrameworkLayout)" />
   </Target>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
+++ b/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageVersion>2.3.0</PackageVersion>
     <HarvestStablePackage>false</HarvestStablePackage>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <PackageIndexFileName>packageIndex.json</PackageIndexFileName>
@@ -19,7 +18,7 @@
   <Target Name="StampPackageIndex" BeforeTargets="GenerateNuSpec">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <Copy SourceFiles="$(PackageIndexFileName)" DestinationFolder="$(IntermediateOutputPath)" OverwriteReadOnlyFiles="true" />
-    
+
     <UpdatePackageIndex PackageIndexFile="$(IntermediateOutputPath)$(PackageIndexFileName)"
                         PreRelease="$(VersionSuffix)" />
   </Target>

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -8,7 +8,8 @@
     "CoreFx.Private.TestUtilities": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "1.0.0.0": "4.5.0"
+        "1.0.0.0": "4.5.0",
+        "1.0.1.0": "4.6.0"
       }
     },
     "CustomMarshalers": {
@@ -96,7 +97,7 @@
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
         "4.0.3.0": "4.4.0",
-        "4.0.4.0": "4.5.0"
+        "4.0.4.0": "4.6.0"
       }
     },
     "Microsoft.Devices.Sensors": {
@@ -111,7 +112,8 @@
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "2.0.0.0": "2.0.0",
-        "2.0.1.0": "2.0.1"
+        "2.0.1.0": "2.0.1",
+        "2.0.2.0": "2.1.0"
       }
     },
     "Microsoft.JScript": {
@@ -203,7 +205,7 @@
         "10.0.1.0": "10.0.1",
         "10.0.2.0": "10.1.0",
         "10.0.3.0": "10.2.0",
-        "10.0.4.0": "10.3.0"
+        "10.0.4.0": "10.4.0"
       }
     },
     "Microsoft.VisualBasic.Compatibility": {
@@ -264,7 +266,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.1.0.0": "4.4.0",
-        "4.1.1.0": "4.5.0"
+        "4.1.1.0": "4.5.0",
+        "4.1.2.0": "4.6.0"
       }
     },
     "Microsoft.Win32.Registry.AccessControl": {
@@ -279,13 +282,15 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "Microsoft.Win32.SystemEvents": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "Microsoft.Windows.Compatibility": {
@@ -301,7 +306,8 @@
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.0.0": "1.0.0",
-        "1.0.1.0": "1.1.0"
+        "1.0.1.0": "1.1.0",
+        "2.0.0.0": "2.0.0"
       }
     },
     "Microsoft.Xna.Framework": {
@@ -455,7 +461,7 @@
         "4.3.0",
         "4.4.0"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.6.0",
       "InboxOn": {}
     },
     "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni": {
@@ -583,13 +589,16 @@
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
-        "uap10.0.16299": "4.0.3.0"
+        "netcoreapp2.2": "4.0.4.0",
+        "uap10.0.16299": "4.0.3.0",
+        "uap10.0.16300": "4.0.4.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.CodeDom": {
@@ -600,7 +609,8 @@
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
-        "4.0.1.0": "4.5.0"
+        "4.0.1.0": "4.5.0",
+        "4.0.2.0": "4.6.0"
       }
     },
     "System.Collections": {
@@ -693,7 +703,9 @@
       "InboxOn": {
         "netcoreapp2.0": "1.2.2.0",
         "netcoreapp2.1": "1.2.3.0",
-        "uap10.0.16299": "1.2.3.0"
+        "netcoreapp2.2": "1.2.4.0",
+        "uap10.0.16299": "1.2.3.0",
+        "uap10.0.16300": "1.2.4.0"
       },
       "AssemblyVersionInPackageVersion": {
         "1.1.36.0": "1.1.36",
@@ -701,7 +713,8 @@
         "1.2.0.0": "1.2.0",
         "1.2.1.0": "1.3.0",
         "1.2.2.0": "1.4.0",
-        "1.2.3.0": "1.5.0"
+        "1.2.3.0": "1.5.0",
+        "1.2.4.0": "1.6.0"
       }
     },
     "System.Collections.NonGeneric": {
@@ -807,6 +820,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.2.0.0",
         "netcoreapp2.1": "4.2.1.0",
+        "netcoreapp2.2": "4.2.2.0",
         "net45": "4.0.0.0",
         "net46": "4.0.10.0",
         "portable46-net451+win81": "4.0.0.0",
@@ -814,6 +828,7 @@
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.2.1.0",
+        "uap10.0.16300": "4.2.2.0",
         "win8": "4.0.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
@@ -826,7 +841,8 @@
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0",
         "4.2.0.0": "4.4.0",
-        "4.2.1.0": "4.5.0"
+        "4.2.1.0": "4.5.0",
+        "4.2.2.0": "4.6.0"
       }
     },
     "System.ComponentModel.Composition": {
@@ -841,7 +857,7 @@
         "xamarinwatchos10": "Any"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.6.0"
       }
     },
     "System.ComponentModel.Composition.Registration": {
@@ -978,7 +994,8 @@
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
         "1.0.32.0": "1.1.0",
-        "1.0.33.0": "1.2.0"
+        "1.0.33.0": "1.2.0",
+        "1.0.34.0": "1.3.0"
       }
     },
     "System.Composition.Convention": {
@@ -991,7 +1008,8 @@
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
         "1.0.32.0": "1.1.0",
-        "1.0.33.0": "1.2.0"
+        "1.0.33.0": "1.2.0",
+        "1.0.34.0": "1.3.0"
       }
     },
     "System.Composition.Hosting": {
@@ -1004,7 +1022,8 @@
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
         "1.0.32.0": "1.1.0",
-        "1.0.33.0": "1.2.0"
+        "1.0.33.0": "1.2.0",
+        "1.0.34.0": "1.3.0"
       }
     },
     "System.Composition.Runtime": {
@@ -1017,7 +1036,8 @@
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
         "1.0.32.0": "1.1.0",
-        "1.0.33.0": "1.2.0"
+        "1.0.33.0": "1.2.0",
+        "1.0.34.0": "1.3.0"
       }
     },
     "System.Composition.TypedParts": {
@@ -1030,7 +1050,8 @@
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
         "1.0.32.0": "1.1.0",
-        "1.0.33.0": "1.2.0"
+        "1.0.33.0": "1.2.0",
+        "1.0.34.0": "1.3.0"
       }
     },
     "System.Configuration": {
@@ -1048,7 +1069,8 @@
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
-        "4.0.1.0": "4.5.0"
+        "4.0.1.0": "4.5.0",
+        "4.0.2.0": "4.6.0"
       }
     },
     "System.Configuration.Install": {
@@ -1153,7 +1175,7 @@
         "net45": "4.0.0.0"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.6.0"
       }
     },
     "System.Data.Entity": {
@@ -1175,7 +1197,8 @@
     "System.Data.Odbc": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.Data.OracleClient": {
@@ -1216,7 +1239,7 @@
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.3.0.0",
-        "uap10.0.16300": "4.4.0.0",
+        "uap10.0.16300": "4.4.1.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -1227,7 +1250,8 @@
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0",
         "4.2.0.0": "4.4.0",
-        "4.4.0.0": "4.5.0"
+        "4.4.0.0": "4.5.0",
+        "4.4.1.0": "4.6.0"
       }
     },
     "System.Data.SqlXml": {
@@ -1342,20 +1366,23 @@
       "BaselineVersion": "4.4.1",
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.1",
-        "netcoreapp2.1": "4.0.3.0"
+        "netcoreapp2.1": "4.0.3.0",
+        "netcoreapp2.2": "4.0.4.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
         "4.0.2.1": "4.4.1",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.Diagnostics.EventLog": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.Diagnostics.FileVersionInfo": {
@@ -1392,7 +1419,8 @@
         "xamarinwatchos10": "Any"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.Diagnostics.Process": {
@@ -1592,7 +1620,7 @@
         "net45": "4.0.0.0"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.6.0"
       }
     },
     "System.DirectoryServices.AccountManagement": {
@@ -1600,7 +1628,7 @@
         "net45": "4.0.0.0"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.6.0"
       }
     },
     "System.DirectoryServices.Protocols": {
@@ -1608,7 +1636,7 @@
         "net45": "4.0.0.0"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.6.0"
       }
     },
     "System.Drawing": {
@@ -1629,7 +1657,8 @@
         "xamarinwatchos10": "Any"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.Drawing.Design": {
@@ -1993,7 +2022,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.IO.FileSystem.DriveInfo": {
@@ -2137,13 +2167,15 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.IO.Pipelines": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.IO.Pipes": {
@@ -2171,12 +2203,13 @@
       ],
       "BaselineVersion": "4.4.0",
       "InboxOn": {
-        "uap10.0.16300": "4.0.3.0"
+        "uap10.0.16300": "4.0.4.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.IO.Ports": {
@@ -2185,11 +2218,13 @@
       ],
       "BaselineVersion": "4.4.0",
       "InboxOn": {
-        "uap10.0.16299": "4.0.1.0"
+        "uap10.0.16299": "4.0.1.0",
+        "uap10.0.16300": "4.0.2.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
-        "4.0.1.0": "4.5.0"
+        "4.0.1.0": "4.6.0",
+        "4.0.2.0": "4.6.0"
       }
     },
     "System.IO.UnmanagedMemoryStream": {
@@ -2233,7 +2268,8 @@
       },
       "AssemblyVersionInPackageVersion": {
         "2.0.5.0": "4.4.0",
-        "2.0.6.0": "4.5.0"
+        "2.0.6.0": "4.5.0",
+        "2.0.7.0": "4.6.0"
       }
     },
     "System.Linq": {
@@ -2397,7 +2433,7 @@
         "net45": "4.0.0.0"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.6.0"
       }
     },
     "System.Management.Instrumentation": {
@@ -2408,6 +2444,7 @@
     "System.Memory": {
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0",
+        "netcoreapp2.2": "4.1.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16300": "4.1.0.0",
@@ -2418,7 +2455,8 @@
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
-        "4.0.1.0": "4.5.0"
+        "4.0.1.0": "4.5.0",
+        "4.0.2.0": "4.6.0"
       }
     },
     "System.Messaging": {
@@ -2556,7 +2594,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.Net.HttpListener": {
@@ -2930,7 +2969,8 @@
     "System.Net.WebSockets.WebSocketProtocol": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.Numerics": {
@@ -2966,11 +3006,13 @@
       "InboxOn": {
         "netcoreapp2.0": "4.1.3.0",
         "netcoreapp2.1": "4.1.4.0",
+        "netcoreapp2.2": "4.1.5.0",
         "net46": "4.0.0.0",
         "net461": "4.1.2.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.1.4.0",
+        "uap10.0.16300": "4.1.5.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -2982,7 +3024,8 @@
         "4.1.1.0": "4.1.1",
         "4.1.2.0": "4.3.0",
         "4.1.3.0": "4.4.0",
-        "4.1.4.0": "4.5.0"
+        "4.1.4.0": "4.5.0",
+        "4.1.5.0": "4.6.0"
       }
     },
     "System.Numerics.Vectors.WindowsRuntime": {
@@ -3157,9 +3200,11 @@
       "InboxOn": {
         "netcoreapp2.0": "4.0.3.0",
         "netcoreapp2.1": "4.0.4.0",
+        "netcoreapp2.2": "4.0.5.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.0.4.0",
+        "uap10.0.16300": "4.0.5.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -3170,7 +3215,8 @@
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
         "4.0.3.0": "4.4.0",
-        "4.0.4.0": "4.5.0"
+        "4.0.4.0": "4.5.0",
+        "4.0.5.0": "4.6.0"
       }
     },
     "System.Reflection.Emit": {
@@ -3297,7 +3343,9 @@
       "InboxOn": {
         "netcoreapp2.0": "1.4.2.0",
         "netcoreapp2.1": "1.4.3.0",
-        "uap10.0.16299": "1.4.3.0"
+        "netcoreapp2.2": "1.4.4.0",
+        "uap10.0.16299": "1.4.3.0",
+        "uap10.0.16300": "1.4.4.0"
       },
       "AssemblyVersionInPackageVersion": {
         "1.0.22.0": "1.0.22",
@@ -3306,7 +3354,8 @@
         "1.3.0.0": "1.3.0",
         "1.4.1.0": "1.4.1",
         "1.4.2.0": "1.5.0",
-        "1.4.3.0": "1.6.0"
+        "1.4.3.0": "1.6.0",
+        "1.4.4.0": "1.7.0"
       }
     },
     "System.Reflection.Primitives": {
@@ -3360,9 +3409,11 @@
       "InboxOn": {
         "netcoreapp2.0": "4.1.2.0",
         "netcoreapp2.1": "4.1.3.0",
+        "netcoreapp2.2": "4.1.4.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.1.3.0",
+        "uap10.0.16300": "4.1.4.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -3373,7 +3424,8 @@
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0",
         "4.1.2.0": "4.4.0",
-        "4.1.3.0": "4.5.0"
+        "4.1.3.0": "4.5.0",
+        "4.1.4.0": "4.6.0"
       }
     },
     "System.Resources.Reader": {
@@ -3521,15 +3573,19 @@
         "xamarinwatchos10": "Any"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.6.0"
       }
     },
     "System.Runtime.CompilerServices.Unsafe": {
+      "StableVersions": [
+        "4.4.0"
+      ],
       "InboxOn": {
-        "uap10.0.16300": "4.0.4.0"
+        "uap10.0.16300": "4.0.5.0"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.4.0": "4.5.0"
+        "4.0.4.0": "4.5.0",
+        "4.0.5.0": "4.6.0"
       }
     },
     "System.Runtime.CompilerServices.VisualC": {
@@ -3736,7 +3792,8 @@
     "System.Runtime.Intrinsics.Experimental": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.Runtime.Loader": {
@@ -4048,7 +4105,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.1.0.0": "4.4.0",
-        "4.1.1.0": "4.5.0"
+        "4.1.1.0": "4.6.0",
+        "4.1.2.0": "4.6.0"
       }
     },
     "System.Security.Claims": {
@@ -4114,6 +4172,7 @@
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.3.1.0",
+        "uap10.0.16300": "4.3.2.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -4125,7 +4184,8 @@
         "4.2.0.0": "4.2.0",
         "4.2.1.0": "4.3.0",
         "4.3.0.0": "4.4.0",
-        "4.3.1.0": "4.5.0"
+        "4.3.1.0": "4.5.0",
+        "4.3.2.0": "4.6.0"
       }
     },
     "System.Security.Cryptography.Csp": {
@@ -4188,7 +4248,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.1.0.0": "4.4.0",
-        "4.1.1.0": "4.5.0"
+        "4.1.1.0": "4.5.0",
+        "4.1.2.0": "4.6.0"
       }
     },
     "System.Security.Cryptography.Pkcs": {
@@ -4203,7 +4264,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.Security.Cryptography.Primitives": {
@@ -4249,7 +4311,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.Security.Cryptography.X509Certificates": {
@@ -4285,7 +4348,8 @@
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
-        "4.0.1.0": "4.5.0"
+        "4.0.1.0": "4.5.0",
+        "4.0.2.0": "4.6.0"
       }
     },
     "System.Security.Permissions": {
@@ -4296,7 +4360,8 @@
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
-        "4.0.1.0": "4.5.0"
+        "4.0.1.0": "4.5.0",
+        "4.0.2.0": "4.6.0"
       }
     },
     "System.Security.Principal": {
@@ -4353,7 +4418,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.1.0.0": "4.4.0",
-        "4.1.1.0": "4.5.0"
+        "4.1.1.0": "4.6.0",
+        "4.1.2.0": "4.6.0"
       }
     },
     "System.Security.SecureString": {
@@ -4519,7 +4585,8 @@
     "System.ServiceModel.Syndication": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.ServiceModel.Web": {
@@ -4568,7 +4635,8 @@
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0",
         "4.2.0.0": "4.4.0",
-        "4.2.1.0": "4.5.0"
+        "4.2.1.0": "4.5.0",
+        "4.2.2.0": "4.6.0"
       }
     },
     "System.Speech": {
@@ -4631,6 +4699,7 @@
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.1.1.0",
+        "uap10.0.16300": "4.1.2.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -4641,7 +4710,8 @@
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
         "4.1.0.0": "4.4.0",
-        "4.1.1.0": "4.5.0"
+        "4.1.1.0": "4.5.0",
+        "4.1.2.0": "4.6.0"
       }
     },
     "System.Text.Encoding.Extensions": {
@@ -4699,7 +4769,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.Text.RegularExpressions": {
@@ -4801,13 +4872,15 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.Threading.Channels": {
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.6.0"
       }
     },
     "System.Threading.Overlapped": {
@@ -4884,14 +4957,17 @@
       "InboxOn": {
         "netcoreapp2.0": "4.6.2.0",
         "netcoreapp2.1": "4.6.3.0",
-        "uap10.0.16299": "4.6.3.0"
+        "netcoreapp2.2": "4.6.4.0",
+        "uap10.0.16299": "4.6.3.0",
+        "uap10.0.16300": "4.6.4.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.5.25.0": "4.5.25",
         "4.6.0.0": "4.6.0",
         "4.6.1.0": "4.7.0",
         "4.6.2.0": "4.8.0",
-        "4.6.3.0": "4.9.0"
+        "4.6.3.0": "4.9.0",
+        "4.6.4.0": "4.10.0"
       }
     },
     "System.Threading.Tasks.Extensions": {
@@ -4904,13 +4980,15 @@
       "InboxOn": {
         "netcoreapp2.0": "4.1.1.0",
         "netcoreapp2.1": "4.3.0.0",
+        "netcoreapp2.2": "4.3.0.0",
         "uap10.0.16300": "4.3.0.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.3.0",
         "4.1.1.0": "4.4.0",
-        "4.2.0.0": "4.5.0"
+        "4.2.0.0": "4.5.0",
+        "4.2.1.0": "4.6.0"
       }
     },
     "System.Threading.Tasks.Parallel": {
@@ -5054,10 +5132,12 @@
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
+        "netcoreapp2.2": "4.0.4.0",
         "netstandard2.0": "4.0.2.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.0.3.0",
+        "uap10.0.16300": "4.0.4.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -5066,7 +5146,8 @@
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.6.0"
       }
     },
     "System.Web": {

--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -1,22 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.1.0</PackageVersion>
     <ServiceModelVersion>4.4.1</ServiceModelVersion>
   </PropertyGroup>
-
   <ItemDefinitionGroup>
     <PrereleaseLibraryPackage>
       <Version>4.5.0</Version>
     </PrereleaseLibraryPackage>
   </ItemDefinitionGroup>
-
   <ItemGroup>
     <PackageIndex Include="$(MSBuildThisFileDirectory)externalIndex.json" />
   </ItemGroup>
-
   <ItemGroup>
     <PrereleaseLibraryPackage Include="Microsoft.Win32.Registry" />
     <PrereleaseLibraryPackage Include="Microsoft.Win32.Registry.AccessControl" />
@@ -50,7 +46,6 @@
     <PrereleaseLibraryPackage Include="System.ServiceProcess.ServiceController" />
     <PrereleaseLibraryPackage Include="System.Text.Encoding.CodePages" />
     <PrereleaseLibraryPackage Include="System.Threading.AccessControl" />
-
     <!-- Service model packages -->
     <LibraryPackage Include="System.ServiceModel.Primitives">
       <Version>$(ServiceModelVersion)</Version>
@@ -68,16 +63,13 @@
       <Version>$(ServiceModelVersion)</Version>
     </LibraryPackage>
   </ItemGroup>
-
   <ItemGroup>
     <Dependency Include="@(LibraryPackage)" />
     <Dependency Include="@(PrereleaseLibraryPackage)" />
-
     <!-- Include dependency to shims package -->
     <Dependency Include="Microsoft.Windows.Compatibility.Shims">
       <Version>$(CompatibilityShimsPackageVersion)</Version>
     </Dependency>
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/pkg/test/frameworkSettings/netcoreapp2.2/settings.targets
+++ b/pkg/test/frameworkSettings/netcoreapp2.2/settings.targets
@@ -12,10 +12,19 @@
          https://github.com/dotnet/corefx/issues/29249 -->
     <IgnoredReference Include="System.Memory" />
     <IgnoredReference Include="System.Threading.Tasks.Extensions" />
+
     <!-- Temporarily suppress until System.Collections.Hashtable move propagates into Microsoft.NETCore.App
          https://github.com/dotnet/corefx/issues/29322 -->
     <IgnoredReference Include="System.Runtime.Extensions" />
     <IgnoredTypes Include="System.Collections.Hashtable" />
     <IgnoredTypes Include="System.Collections.IHashCodeProvider" />
+
+    <!-- Temporarily suppress checking closure of these assemblies as
+         they will fail to run on Microsoft.NETCore.App until they are
+         ingested into core-setup.
+         https://github.com/dotnet/corefx/issues/29382
+     -->
+    <IgnoredReference Include="System.Diagnostics.DiagnosticSource" />
+    <IgnoredReference Include="System.Collections.Immutable" />
   </ItemGroup>
 </Project>

--- a/src/CoreFx.Private.TestUtilities/dir.props
+++ b/src/CoreFx.Private.TestUtilities/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
     <AssemblyKey>Test</AssemblyKey>
     <!-- DO NOT ship this as stable for .NET Core 2.0. -->
     <BlockStable>true</BlockStable>

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/dir.props
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <PackageVersion>2.0.1</PackageVersion>
+    <PackageVersion>2.1.0</PackageVersion>
     <AssemblyVersion>2.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/dir.props
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <PackageVersion>2.0.1</PackageVersion>
-    <AssemblyVersion>2.0.1.0</AssemblyVersion>
+    <AssemblyVersion>2.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualBasic/dir.props
+++ b/src/Microsoft.VisualBasic/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <PackageVersion>10.3.0</PackageVersion>
+    <PackageVersion>10.4.0</PackageVersion>
     <AssemblyVersion>10.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/Microsoft.Win32.Registry.AccessControl/dir.props
+++ b/src/Microsoft.Win32.Registry.AccessControl/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Win32.Registry/dir.props
+++ b/src/Microsoft.Win32.Registry/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/Microsoft.Win32.SystemEvents/dir.props
+++ b/src/Microsoft.Win32.SystemEvents/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Buffers/dir.props
+++ b/src/System.Buffers/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.CodeDom/dir.props
+++ b/src/System.CodeDom/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Collections.Immutable/dir.props
+++ b/src/System.Collections.Immutable/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <PackageVersion>1.5.0</PackageVersion>
+    <PackageVersion>1.6.0</PackageVersion>
     <AssemblyVersion>1.2.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Collections.Immutable/dir.props
+++ b/src/System.Collections.Immutable/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <PackageVersion>1.5.0</PackageVersion>
-    <AssemblyVersion>1.2.3.0</AssemblyVersion>
+    <AssemblyVersion>1.2.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.ComponentModel.Annotations/dir.props
+++ b/src/System.ComponentModel.Annotations/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.2.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.ComponentModel.Annotations/pkg/System.ComponentModel.Annotations.pkgproj
+++ b/src/System.ComponentModel.Annotations/pkg/System.ComponentModel.Annotations.pkgproj
@@ -3,15 +3,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.Annotations.csproj">
-      <SupportedFramework>net461;netcoreapp2.1;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net461</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Annotations.csproj" />
     <HarvestIncludePaths Include="ref/netcore50;lib/netcore50" />
     <HarvestIncludePaths Include="ref/netstandard1.1" />
     <HarvestIncludePaths Include="ref/netstandard1.3" />
     <HarvestIncludePaths Include="ref/netstandard1.4;lib/netstandard1.4" />
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <InboxOnTargetFramework Include="net45">
       <FrameworkReference>System.ComponentModel.DataAnnotations</FrameworkReference>
     </InboxOnTargetFramework>
@@ -19,10 +18,6 @@
     <InboxOnTargetFramework Include="uap10.0.16299" />
     <InboxOnTargetFramework Include="win8" />
     <InboxOnTargetFramework Include="portable-net45+win8" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
     <ValidatePackageSuppression Include="PermitMissingImplementation">
       <!-- Supported inbox by all ns1.1-1.3 frameworks -->
       <Value>.NETStandard,Version=v1.1;.NETStandard,Version=v1.2;.NETStandard,Version=v1.3</Value>

--- a/src/System.Composition.AttributedModel/dir.props
+++ b/src/System.Composition.AttributedModel/dir.props
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\dir.props" />
-  <PropertyGroup>
-    <PackageVersion>1.2.0</PackageVersion>
-    <AssemblyVersion>1.0.33.0</AssemblyVersion>
-    <AssemblyKey>MSFT</AssemblyKey>
-  </PropertyGroup>
+  <Import Project="..\System.Composition\dir.props" />
 </Project>

--- a/src/System.Composition.Convention/dir.props
+++ b/src/System.Composition.Convention/dir.props
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\dir.props" />
-  <PropertyGroup>
-    <PackageVersion>1.2.0</PackageVersion>
-    <AssemblyVersion>1.0.33.0</AssemblyVersion>
-    <AssemblyKey>MSFT</AssemblyKey>
-  </PropertyGroup>
+  <Import Project="..\System.Composition\dir.props" />
 </Project>

--- a/src/System.Composition.Hosting/dir.props
+++ b/src/System.Composition.Hosting/dir.props
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\dir.props" />
-  <PropertyGroup>
-    <PackageVersion>1.2.0</PackageVersion>
-    <AssemblyVersion>1.0.33.0</AssemblyVersion>
-    <AssemblyKey>MSFT</AssemblyKey>
-  </PropertyGroup>
+  <Import Project="..\System.Composition\dir.props" />
 </Project>

--- a/src/System.Composition.Runtime/dir.props
+++ b/src/System.Composition.Runtime/dir.props
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\dir.props" />
-  <PropertyGroup>
-    <PackageVersion>1.2.0</PackageVersion>
-    <AssemblyVersion>1.0.33.0</AssemblyVersion>
-    <AssemblyKey>MSFT</AssemblyKey>
-  </PropertyGroup>
+  <Import Project="..\System.Composition\dir.props" />
 </Project>

--- a/src/System.Composition.TypedParts/dir.props
+++ b/src/System.Composition.TypedParts/dir.props
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\dir.props" />
-  <PropertyGroup>
-    <PackageVersion>1.2.0</PackageVersion>
-    <AssemblyVersion>1.0.33.0</AssemblyVersion>
-    <AssemblyKey>MSFT</AssemblyKey>
-  </PropertyGroup>
+  <Import Project="..\System.Composition\dir.props" />
 </Project>

--- a/src/System.Composition/dir.props
+++ b/src/System.Composition/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.0.34.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition/dir.props
+++ b/src/System.Composition/dir.props
@@ -3,6 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <PackageVersion>1.2.0</PackageVersion>
-    <AssemblyVersion>1.0.33.0</AssemblyVersion>
+    <AssemblyVersion>1.0.34.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Configuration.ConfigurationManager/dir.props
+++ b/src/System.Configuration.ConfigurationManager/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.Odbc/dir.props
+++ b/src/System.Data.Odbc/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/dir.props
+++ b/src/System.Data.SqlClient/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.4.0.0</AssemblyVersion>
+    <AssemblyVersion>4.4.1.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.Diagnostics.DiagnosticSource/dir.props
+++ b/src/System.Diagnostics.DiagnosticSource/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Diagnostics.EventLog/dir.props
+++ b/src/System.Diagnostics.EventLog/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.PerformanceCounter/dir.props
+++ b/src/System.Diagnostics.PerformanceCounter/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/dir.props
+++ b/src/System.Drawing.Common/dir.props
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
@@ -119,6 +119,13 @@ namespace System.Drawing
                 if (img == null)
                 {
                     img = s_defaultComponent.GetImage(type, large);
+
+                    // We don't want to hand out the static shared image 
+                    // because otherwise it might get disposed. 
+                    if (img != null)
+                    {
+                        img = (Image)img.Clone();
+                    }
                 }
 
                 if (large)

--- a/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
+++ b/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
@@ -13,9 +13,29 @@ namespace System.Drawing.Tests
 
     public class ToolboxBitmapAttributeTests : RemoteExecutorTestBase
     {
+        private static Size DefaultSize = new Size(16, 16);
+        private void AssertDefaultSize(Image image)
+        {
+            try
+            {
+                Assert.Equal(DefaultSize, image.Size);
+            }
+            catch (Exception ex)
+            {
+                // On .NET Framework sometimes the size might be default or it might
+                // be disposed in which case Size property throws an ArgumentException
+                // so allow both cases see https://github.com/dotnet/corefx/issues/27361. 
+                if (PlatformDetection.IsFullFramework && ex is ArgumentException)
+                {
+                    return;
+                }
+                throw;
+            }
+        }
+
         public static IEnumerable<object[]> Ctor_FileName_TestData()
         {
-            yield return new object[] { null, new Size(16, 16) };
+            yield return new object[] { null, new Size(0, 0) };
             yield return new object[] { Helpers.GetTestBitmapPath("bitmap_173x183_indexed_8bit.bmp"), new Size(173, 183) };
             yield return new object[] { Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"), new Size(16, 16) };
             yield return new object[] { Helpers.GetTestBitmapPath("invalid.ico"), new Size(0, 0) };
@@ -32,7 +52,7 @@ namespace System.Drawing.Tests
             {
                 if (size == Size.Empty)
                 {
-                    Assert.Throws<ArgumentException>(null, () => image.Size);
+                    AssertDefaultSize(image);
                 }
                 else
                 {
@@ -54,7 +74,7 @@ namespace System.Drawing.Tests
             {
                 if (width == -1 && height == -1)
                 {
-                    AssertExtensions.Throws<ArgumentException>(null, () => image.Size);   
+                    AssertDefaultSize(image);
                 }
                 else
                 {
@@ -84,7 +104,7 @@ namespace System.Drawing.Tests
             {
                 if (width == -1 && height == -1)
                 {
-                    Assert.Throws<ArgumentException>(null, () => image.Size);
+                    AssertDefaultSize(image);
                 }
                 else
                 {

--- a/src/System.IO.FileSystem.AccessControl/dir.props
+++ b/src/System.IO.FileSystem.AccessControl/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/System.IO.Packaging/dir.props
+++ b/src/System.IO.Packaging/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipelines/dir.props
+++ b/src/System.IO.Pipelines/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipes.AccessControl/dir.props
+++ b/src/System.IO.Pipes.AccessControl/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
+++ b/src/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.Pipes.AccessControl.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net461</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
     <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
@@ -12,8 +12,8 @@
     </HarvestIncludePaths>
     <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
     <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
-    <File Include="$(PlaceHolderFile)">  
-      <TargetPath>runtimes/win/lib/$(UAPvNextTFM)</TargetPath>  
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/$(UAPvNextTFM)</TargetPath>
     </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO.Ports/dir.props
+++ b/src/System.IO.Ports/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.IO.Ports/pkg/System.IO.Ports.pkgproj
+++ b/src/System.IO.Ports/pkg/System.IO.Ports.pkgproj
@@ -3,12 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.Ports.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;$(AllXamarinFrameworks);$(UAPvNextTFM)</SupportedFramework>
+      <SupportedFramework>net461</SupportedFramework>
     </ProjectReference>
-    <File Include="$(PlaceHolderFile)"> 
-      <TargetPath>runtimes/win/lib/uap10.0.16299</TargetPath> 
-    </File> 
-    <InboxOnTargetFramework Include="uap10.0.16299" /> 
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/uap10.0.16299</TargetPath>
+    </File>
+    <InboxOnTargetFramework Include="uap10.0.16299" />
     <ProjectReference Include="..\src\System.IO.Ports.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Json/dir.props
+++ b/src/System.Json/dir.props
@@ -2,11 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <!-- 
-         This version needs to stay as 2.0.5.0 in order to match Xamarin version.
-         Having it like this enables people to build targetting netstandard and use the
-         built assembly in Xamarin.
-     -->
     <AssemblyVersion>2.0.7.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>

--- a/src/System.Json/dir.props
+++ b/src/System.Json/dir.props
@@ -7,7 +7,7 @@
          Having it like this enables people to build targetting netstandard and use the
          built assembly in Xamarin.
      -->
-    <AssemblyVersion>2.0.6.0</AssemblyVersion>
+    <AssemblyVersion>2.0.7.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <!-- System.Memory has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.0.* -->
-    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.1.1.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.1.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -2,10 +2,10 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <!-- System.Memory has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.0.* -->
-    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.1.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Net.Http.WinHttpHandler/dir.props
+++ b/src/System.Net.Http.WinHttpHandler/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/dir.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Numerics.Vectors/dir.props
+++ b/src/System.Numerics.Vectors/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.4.0</AssemblyVersion>
+    <AssemblyVersion>4.1.5.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
+++ b/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
@@ -15,12 +15,7 @@
     <ProjectReference Include="..\src\System.Numerics.Vectors.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+    <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <InboxOnTargetFramework Include="netcoreapp2.0" />
     <InboxOnTargetFramework Include="uap10.0.16299" />
   </ItemGroup>

--- a/src/System.Reflection.DispatchProxy/dir.props
+++ b/src/System.Reflection.DispatchProxy/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.4.0</AssemblyVersion>
+    <AssemblyVersion>4.0.5.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Reflection.Metadata/dir.props
+++ b/src/System.Reflection.Metadata/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <PackageVersion>1.6.0</PackageVersion>
+    <PackageVersion>1.7.0</PackageVersion>
     <AssemblyVersion>1.4.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Reflection.Metadata/dir.props
+++ b/src/System.Reflection.Metadata/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <PackageVersion>1.6.0</PackageVersion>
-    <AssemblyVersion>1.4.3.0</AssemblyVersion>
+    <AssemblyVersion>1.4.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Reflection.TypeExtensions/dir.props
+++ b/src/System.Reflection.TypeExtensions/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.3.0</AssemblyVersion>
+    <AssemblyVersion>4.1.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.TypeExtensions.csproj">
-      <SupportedFramework>net461;netcoreapp2.1;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net461</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Reflection.TypeExtensions.csproj" />
     <HarvestIncludePaths Include="ref/net46;lib/net46" />
@@ -21,12 +21,7 @@
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/aot/lib/uap10.0.16299</TargetPath>
     </File>
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+    <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />

--- a/src/System.Runtime.CompilerServices.Unsafe/dir.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.4.0</AssemblyVersion>
+    <AssemblyVersion>4.0.5.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
@@ -4,7 +4,7 @@
   <ItemGroup>
     <PackageIndex Include="$(ProjectDir)\pkg\baseline\packageBaseline.1.1.json" />
     <ProjectReference Include="..\ref\System.Runtime.CompilerServices.Unsafe.csproj">
-      <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net45;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
 

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
@@ -37,7 +37,7 @@
     01 00 00 00 00
   ) // false
   .hash algorithm 0x00008004
-  .ver 4:0:4:0
+  .ver 4:0:5:0
 }
 .module System.Runtime.CompilerServices.Unsafe.dll
 // MVID: {1E97D84A-565B-49C5-B60A-F31A1A4ACE13}

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -242,7 +242,7 @@ namespace System.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework does not have dotnet/coreclr#16622")]
         [Fact]
         public void FailFast_ExceptionStackTrace_InnerException()
-        { 
+        {
             // Test if inner exception details are also logged
             var psi = new ProcessStartInfo();
             psi.RedirectStandardError = true;
@@ -431,7 +431,7 @@ namespace System.Tests
         [InlineData(Environment.SpecialFolder.StartMenu)]
         [InlineData(Environment.SpecialFolder.Startup)]
         [InlineData(Environment.SpecialFolder.System)]
-        [InlineData(Environment.SpecialFolder.Templates)]
+        //[InlineData(Environment.SpecialFolder.Templates)]
         [InlineData(Environment.SpecialFolder.DesktopDirectory)]
         [InlineData(Environment.SpecialFolder.Personal)]
         [InlineData(Environment.SpecialFolder.ProgramFiles)]
@@ -450,7 +450,7 @@ namespace System.Tests
         [InlineData(Environment.SpecialFolder.CommonTemplates)]
         [InlineData(Environment.SpecialFolder.CommonVideos)]
         [InlineData(Environment.SpecialFolder.Fonts)]
-        [InlineData(Environment.SpecialFolder.NetworkShortcuts)]
+        //[InlineData(Environment.SpecialFolder.NetworkShortcuts)]
         // [InlineData(Environment.SpecialFolder.PrinterShortcuts)]
         [InlineData(Environment.SpecialFolder.UserProfile)]
         [InlineData(Environment.SpecialFolder.CommonProgramFilesX86)]

--- a/src/System.Runtime.Intrinsics.Experimental/dir.props
+++ b/src/System.Runtime.Intrinsics.Experimental/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <!-- DO NOT ship this as stable. It contains preview-only APIs that will be stable in a future version. -->
     <BlockStable>true</BlockStable>

--- a/src/System.Security.AccessControl/dir.props
+++ b/src/System.Security.AccessControl/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
+++ b/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.AccessControl.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net461</SupportedFramework>
     </ProjectReference>
     <File Include="$(PlaceHolderFile)">
       <TargetPath>runtimes/win/lib/uap10.0.16299</TargetPath>

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.3.1.0</AssemblyVersion>
+    <AssemblyVersion>4.3.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -3,8 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Cng.csproj">
-      <!-- Removing AllXamarianFrameworks from validation because of https://github.com/dotnet/corefx/issues/25924 -->
-      <SupportedFramework>net461;netcoreapp2.1;$(UAPvNextTFM)</SupportedFramework>
+      <SupportedFramework>net461</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Cng.csproj" />
     <File Include="$(PlaceHolderFile)">

--- a/src/System.Security.Cryptography.OpenSsl/dir.props
+++ b/src/System.Security.Cryptography.OpenSsl/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/System.Security.Cryptography.Pkcs/dir.props
+++ b/src/System.Security.Cryptography.Pkcs/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.ProtectedData/dir.props
+++ b/src/System.Security.Cryptography.ProtectedData/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Xml/dir.props
+++ b/src/System.Security.Cryptography.Xml/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Permissions/dir.props
+++ b/src/System.Security.Permissions/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Principal.Windows/dir.props
+++ b/src/System.Security.Principal.Windows/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/System.Security.Principal.Windows/pkg/System.Security.Principal.Windows.pkgproj
+++ b/src/System.Security.Principal.Windows/pkg/System.Security.Principal.Windows.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Principal.Windows.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net461</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Principal.Windows.csproj" />
     <File Include="$(PlaceHolderFile)">

--- a/src/System.ServiceModel.Syndication/dir.props
+++ b/src/System.ServiceModel.Syndication/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.ServiceProcess.ServiceController/dir.props
+++ b/src/System.ServiceProcess.ServiceController/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.2.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.Encoding.CodePages/dir.props
+++ b/src/System.Text.Encoding.CodePages/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.Text.Encodings.Web/dir.props
+++ b/src/System.Text.Encodings.Web/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.AccessControl/dir.props
+++ b/src/System.Threading.AccessControl/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Channels/dir.props
+++ b/src/System.Threading.Channels/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Tasks.Dataflow/dir.props
+++ b/src/System.Threading.Tasks.Dataflow/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <PackageVersion>4.9.0</PackageVersion>
+    <PackageVersion>4.10.0</PackageVersion>
     <AssemblyVersion>4.6.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Threading.Tasks.Dataflow/dir.props
+++ b/src/System.Threading.Tasks.Dataflow/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <PackageVersion>4.9.0</PackageVersion>
-    <AssemblyVersion>4.6.3.0</AssemblyVersion>
+    <AssemblyVersion>4.6.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Threading.Tasks.Extensions/dir.props
+++ b/src/System.Threading.Tasks.Extensions/dir.props
@@ -2,10 +2,10 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion>4.2.1.0</AssemblyVersion>
     <!-- System.Threading.Tasks.Extensions has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.2.* -->
-    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.3.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.3.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Threading.Tasks.Extensions/dir.props
+++ b/src/System.Threading.Tasks.Extensions/dir.props
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.2.1.0</AssemblyVersion>
     <!-- System.Threading.Tasks.Extensions has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.2.* -->
-    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.3.1.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.3.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
+++ b/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Tasks.Extensions.csproj">
-      <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;wp8;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net45</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Tasks.Extensions.csproj" />
 
@@ -19,4 +19,15 @@
     <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <ItemGroup>
+    <!--
+      All frameworks except net45 support the frozen 4.2.0.0 api version. Need to include this after dir.targets to
+      have DefaultValidateionFramework defined. Normally this wouldn't be necessary but the harvested supported
+      frameworks all complain if we don't lift the version of the assembly they support. This won't be any issue
+      once the 4.5.0 package is stable and we can harvest it.
+    -->
+    <SupportedFramework Include="@(DefaultValidateFramework)">
+      <Version>4.2.0.0</Version>
+    </SupportedFramework>
+  </ItemGroup>
 </Project>

--- a/src/System.ValueTuple/dir.props
+++ b/src/System.ValueTuple/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.ValueTuple/pkg/System.ValueTuple.pkgproj
+++ b/src/System.ValueTuple/pkg/System.ValueTuple.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ValueTuple.csproj">
-      <SupportedFramework>net45;netcore45;netcoreapp2.1;wp8;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net45</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ValueTuple.csproj" />
     <InboxOnTargetFramework Include="netstandard2.0" />

--- a/src/System.ValueTuple/ref/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/ref/System.ValueTuple.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>System</RootNamespace>
     <!-- Must match version supported by frameworks which support 4.0.* inbox.
          Can be removed when API is added and this assembly is versioned to 4.1.* -->
-    <AssemblyVersion Condition="'$(TargetGroup)' != 'netfx'">4.0.3.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true' and '$(TargetGroup)' != 'portable_net40+sl4+win8+wp8'">4.0.3.0</AssemblyVersion>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />


### PR DESCRIPTION
PTAL @ericstj 

This change bumps the minor version of all the packages we produce as well as bumps the patch version of all the assemblies that ship in an individual package. 

If a library only ships in the platform package (aka Microsoft.NETCore.App/UAP) then we aren't bumping the assembly version at this time. 
