### PR TITLE
Fix CS0177 when compiled on Mono

### DIFF
--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
@@ -44,6 +44,7 @@ namespace System.ServiceModel.Syndication
 
         private static bool Rfc3339DateTimeParser(string dateTimeString, out DateTimeOffset dto)
         {
+            dto = default(DateTimeOffset);
             dateTimeString = dateTimeString.Trim();
             if (dateTimeString.Length < 20)
             {
@@ -67,6 +68,7 @@ namespace System.ServiceModel.Syndication
 
         private static bool Rfc822DateTimeParser(string dateTimeString, out DateTimeOffset dto)
         {
+            dto = default(DateTimeOffset);
             StringBuilder dateTimeStringBuilder = new StringBuilder(dateTimeString.Trim());
             if (dateTimeStringBuilder.Length < 18)
             {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -55,6 +55,7 @@ namespace System.ServiceModel.Syndication
 
         private bool NotImplementedDateTimeParser(XmlDateTimeData XmlDateTimeData, out DateTimeOffset dateTimeOffset)
         {
+            dateTimeOffset = default(DateTimeOffset);
             return false;
         }
 
@@ -430,7 +431,7 @@ namespace System.ServiceModel.Syndication
         {
             try
             {
-                DateTimeOffset dateTimeOffset;
+                DateTimeOffset dateTimeOffset = default(DateTimeOffset);
                 var elementQualifiedName = new XmlQualifiedName(reader.LocalName, reader.NamespaceURI);
                 var xmlDateTimeData = new XmlDateTimeData(dateTimeString, elementQualifiedName);
                 object[] args = new object[] { xmlDateTimeData, dateTimeOffset };


### PR DESCRIPTION
Since .NET Core compiles code using reference assemblies where all structs are empty so the following usages are fine:
```
bool Foo(out Guid id)
{
   return true; //id is not set but it's okay for empty structs
}
```

But it doesn't work on Mono (and .NET Framework). Similar to https://github.com/dotnet/corefx/pull/17432



