### PR TITLE
Enable DCS_TypeWithPrimitiveKnownTypes test on uapaot

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4015,9 +4015,9 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-#if !ReflectionOnly
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "dotnet-corefx #24265")]
-#endif
+//#if !ReflectionOnly
+//    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "dotnet-corefx #24265")]
+//#endif
     public static void DCS_TypeWithPrimitiveKnownTypes()
     {
         var list = new TypeWithPrimitiveKnownTypes();

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4015,9 +4015,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-//#if !ReflectionOnly
-//    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "dotnet-corefx #24265")]
-//#endif
     public static void DCS_TypeWithPrimitiveKnownTypes()
     {
         var list = new TypeWithPrimitiveKnownTypes();


### PR DESCRIPTION
Enable DCS_TypeWithPrimitiveKnownTypes on Uapaot  since the original issue #24265 has been fixed.
Fix #28978 

@mconnew @zhenlan @yujayee @Lxiamail 