### PR TITLE
Populate the original path when creating directories

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -37,7 +37,7 @@ namespace System.IO
 
             FileSystem.CreateDirectory(fullPath);
 
-            return new DirectoryInfo(fullPath, null);
+            return new DirectoryInfo(path, fullPath, isNormalized: true);
         }
 
         // Tests if the given path refers to an existing DirectoryInfo on disk.

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -47,7 +47,7 @@ namespace System.IO
                 // but don't mangle the root.
                 string parentName = Path.GetDirectoryName(PathInternal.IsRoot(FullPath) ? FullPath : PathInternal.TrimEndingDirectorySeparator(FullPath));
                 return parentName != null ? 
-                    new DirectoryInfo(parentName, null) :
+                    new DirectoryInfo(parentName, isNormalized: true) :
                     null;
             }
         }

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -20,6 +20,37 @@ namespace System.IO.Tests
         #endregion
 
         #region UniversalTests
+
+        [Fact]
+        public void FileNameIsToString_NotFullPath()
+        {
+            // We're checking that we're maintaining the original path
+            RemoteInvoke(() =>
+            {
+                Environment.CurrentDirectory = TestDirectory;
+                string subdir = Path.GetRandomFileName();
+                DirectoryInfo info = Create(subdir);
+                Assert.Equal(subdir, info.ToString());
+            }).Dispose();
+        }
+
+        [Fact]
+        public void FileNameIsToString_FullPath()
+        {
+            string subdir = Path.GetRandomFileName();
+            string fullPath = Path.Join(TestDirectory, subdir);
+            DirectoryInfo info = Create(fullPath);
+            if (PlatformDetection.IsFullFramework)
+            {
+                // I think this was accidental. In Core we want to be consistent with constructing
+                // an Info manually then calling Create on it.
+                Assert.Equal(subdir, info.ToString());
+            }
+            else
+            {
+                Assert.Equal(fullPath, info.ToString());
+            }
+        }
 
         [Fact]
         public void NullAsPath_ThrowsArgumentNullException()

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -38,7 +38,7 @@ namespace System.IO.Tests
         public void FileNameIsToString_FullPath()
         {
             string subdir = Path.GetRandomFileName();
-            string fullPath = Path.Join(TestDirectory, subdir);
+            string fullPath = Path.Combine(TestDirectory, subdir);
             DirectoryInfo info = Create(fullPath);
             if (PlatformDetection.IsFullFramework)
             {

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -17,6 +17,8 @@ namespace System.IO.Tests
             return Directory.CreateDirectory(path);
         }
 
+        public virtual bool IsDirectoryCreate => true;
+
         #endregion
 
         #region UniversalTests
@@ -40,7 +42,7 @@ namespace System.IO.Tests
             string subdir = Path.GetRandomFileName();
             string fullPath = Path.Combine(TestDirectory, subdir);
             DirectoryInfo info = Create(fullPath);
-            if (PlatformDetection.IsFullFramework)
+            if (PlatformDetection.IsFullFramework && IsDirectoryCreate)
             {
                 // I think this was accidental. In Core we want to be consistent with constructing
                 // an Info manually then calling Create on it.

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -17,6 +17,8 @@ namespace System.IO.Tests
             return result;
         }
 
+        public override bool IsDirectoryCreate => false;
+
         #endregion
 
         [Fact]


### PR DESCRIPTION
The DirectoryInfo class should be the same when calling Directory.Create() as
it would be creating DirectoryInfo directly then calling create on it.