### PR TITLE
Ensure LocalCertificateSelectionCallback is still called with AuthenticateAsServerAsync

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -635,7 +635,9 @@ namespace System.Net.Security
             // There are three options for selecting the server certificate. When 
             // selecting which to use, we prioritize the new ServerCertSelectionDelegate
             // API. If the new API isn't used we call LocalCertSelectionCallback, and if 
-            // neither is set we fall back to using ServerCertificate.
+            // neither is set we fall back to using ServerCertificate. When choosing
+            // from multiple certificates ServerCertSelectionDelegate is the preferred
+            // API. LocalCertSelectionCallback is maintained only for compat reasons.
             if (_sslAuthenticationOptions.ServerCertSelectionDelegate != null)
             {
                 string serverIdentity = SniHelper.GetServerName(clientHello);

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -632,6 +632,10 @@ namespace System.Net.Security
             X509Certificate localCertificate = null;
             bool cachedCred = false;
 
+            // There are three options for selecting the server certificate. When 
+            // selecting which to use, we prioritize the new ServerCertSelectionDelegate
+            // API. If the new API isn't used we call LocalCertSelectionCallback, and if 
+            // neither is set we fall back to using ServerCertificate.
             if (_sslAuthenticationOptions.ServerCertSelectionDelegate != null)
             {
                 string serverIdentity = SniHelper.GetServerName(clientHello);
@@ -642,7 +646,6 @@ namespace System.Net.Security
                     throw new AuthenticationException(SR.net_ssl_io_no_server_cert);
                 }
             }
-            // This probably never gets called as this is a client options delegate
             else if (_sslAuthenticationOptions.CertSelectionDelegate != null)
             {
                 X509CertificateCollection tempCollection = new X509CertificateCollection();

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -634,10 +634,8 @@ namespace System.Net.Security
 
             // There are three options for selecting the server certificate. When 
             // selecting which to use, we prioritize the new ServerCertSelectionDelegate
-            // API. If the new API isn't used we call LocalCertSelectionCallback, and if 
-            // neither is set we fall back to using ServerCertificate. When choosing
-            // from multiple certificates ServerCertSelectionDelegate is the preferred
-            // API. LocalCertSelectionCallback is maintained only for compat reasons.
+            // API. If the new API isn't used we call LocalCertSelectionCallback (for compat
+            // with .NET Framework), and if neither is set we fall back to using ServerCertificate.
             if (_sslAuthenticationOptions.ServerCertSelectionDelegate != null)
             {
                 string serverIdentity = SniHelper.GetServerName(clientHello);

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -650,6 +650,7 @@ namespace System.Net.Security
             {
                 X509CertificateCollection tempCollection = new X509CertificateCollection();
                 tempCollection.Add(_sslAuthenticationOptions.ServerCertificate);
+                // We pass string.Empty here to maintain strict compatability with .NET Framework.
                 localCertificate = _sslAuthenticationOptions.CertSelectionDelegate(string.Empty, tempCollection, null, Array.Empty<string>());
                 if (NetEventSource.IsEnabled)
                     NetEventSource.Info(this, "Use delegate selected Cert");

--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -24,15 +24,15 @@ namespace System.Net.Security
             RemoteCertRequired = true;
             RemoteCertificateValidationCallback = sslClientAuthenticationOptions.RemoteCertificateValidationCallback;
             TargetHost = sslClientAuthenticationOptions.TargetHost;
+            CertSelectionDelegate = localCallback;
 
             // Client specific options.
-            CertSelectionDelegate = localCallback;
             CertificateRevocationCheckMode = sslClientAuthenticationOptions.CertificateRevocationCheckMode;
             ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
             LocalCertificateSelectionCallback = sslClientAuthenticationOptions.LocalCertificateSelectionCallback;
         }
 
-        internal SslAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions)
+        internal SslAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions, LocalCertSelectionCallback localCallback)
         {
             // Common options.
             AllowRenegotiation = sslServerAuthenticationOptions.AllowRenegotiation;
@@ -44,6 +44,7 @@ namespace System.Net.Security
             RemoteCertRequired = sslServerAuthenticationOptions.ClientCertificateRequired;
             RemoteCertificateValidationCallback = sslServerAuthenticationOptions.RemoteCertificateValidationCallback;
             TargetHost = string.Empty;
+            CertSelectionDelegate = localCallback;
 
             // Server specific options.
             CertificateRevocationCheckMode = sslServerAuthenticationOptions.CertificateRevocationCheckMode;

--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -24,15 +24,15 @@ namespace System.Net.Security
             RemoteCertRequired = true;
             RemoteCertificateValidationCallback = sslClientAuthenticationOptions.RemoteCertificateValidationCallback;
             TargetHost = sslClientAuthenticationOptions.TargetHost;
-            CertSelectionDelegate = localCallback;
 
             // Client specific options.
+            CertSelectionDelegate = localCallback;            
             CertificateRevocationCheckMode = sslClientAuthenticationOptions.CertificateRevocationCheckMode;
             ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
             LocalCertificateSelectionCallback = sslClientAuthenticationOptions.LocalCertificateSelectionCallback;
         }
 
-        internal SslAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions, LocalCertSelectionCallback localCallback)
+        internal SslAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
             // Common options.
             AllowRenegotiation = sslServerAuthenticationOptions.AllowRenegotiation;
@@ -44,7 +44,6 @@ namespace System.Net.Security
             RemoteCertRequired = sslServerAuthenticationOptions.ClientCertificateRequired;
             RemoteCertificateValidationCallback = sslServerAuthenticationOptions.RemoteCertificateValidationCallback;
             TargetHost = string.Empty;
-            CertSelectionDelegate = localCallback;
 
             // Server specific options.
             CertificateRevocationCheckMode = sslServerAuthenticationOptions.CertificateRevocationCheckMode;

--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -26,7 +26,7 @@ namespace System.Net.Security
             TargetHost = sslClientAuthenticationOptions.TargetHost;
 
             // Client specific options.
-            CertSelectionDelegate = localCallback;            
+            CertSelectionDelegate = localCallback;
             CertificateRevocationCheckMode = sslClientAuthenticationOptions.CertificateRevocationCheckMode;
             ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
             LocalCertificateSelectionCallback = sslClientAuthenticationOptions.LocalCertificateSelectionCallback;

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -162,12 +162,13 @@ namespace System.Net.Security
                 throw new InvalidOperationException(SR.Format(SR.net_conflicting_options, nameof(ServerCertificateSelectionCallback)));
             }
 
-            var authOptions = new SslAuthenticationOptions(sslServerAuthenticationOptions, _certSelectionDelegate);
+            var authOptions = new SslAuthenticationOptions(sslServerAuthenticationOptions);
 
             _userServerCertificateSelectionCallback = sslServerAuthenticationOptions.ServerCertificateSelectionCallback;
             authOptions.ServerCertSelectionDelegate = _userServerCertificateSelectionCallback == null ? null : new ServerCertSelectionCallback(ServerCertSelectionCallbackWrapper);
 
             authOptions.CertValidationDelegate = _certValidationDelegate;
+            authOptions.CertSelectionDelegate = _certSelectionDelegate;
 
             return authOptions;
         }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -152,17 +152,17 @@ namespace System.Net.Security
 
         private SslAuthenticationOptions CreateAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
-            if (sslServerAuthenticationOptions.ServerCertificate == null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback == null)
+            if (sslServerAuthenticationOptions.ServerCertificate == null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback == null && _certSelectionDelegate == null)
             {
                 throw new ArgumentNullException(nameof(sslServerAuthenticationOptions.ServerCertificate));
             }
 
-            if (sslServerAuthenticationOptions.ServerCertificate != null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null)
+            if (sslServerAuthenticationOptions.ServerCertificate != null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null  && _certSelectionDelegate == null)
             {
                 throw new InvalidOperationException(SR.Format(SR.net_conflicting_options, nameof(ServerCertificateSelectionCallback)));
             }
 
-            var authOptions = new SslAuthenticationOptions(sslServerAuthenticationOptions);
+            var authOptions = new SslAuthenticationOptions(sslServerAuthenticationOptions, _certSelectionDelegate);
 
             _userServerCertificateSelectionCallback = sslServerAuthenticationOptions.ServerCertificateSelectionCallback;
             authOptions.ServerCertSelectionDelegate = _userServerCertificateSelectionCallback == null ? null : new ServerCertSelectionCallback(ServerCertSelectionCallbackWrapper);

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -157,7 +157,7 @@ namespace System.Net.Security
                 throw new ArgumentNullException(nameof(sslServerAuthenticationOptions.ServerCertificate));
             }
 
-            if (sslServerAuthenticationOptions.ServerCertificate != null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null)
+            if ((sslServerAuthenticationOptions.ServerCertificate != null || _certSelectionDelegate != null) && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null)
             {
                 throw new InvalidOperationException(SR.Format(SR.net_conflicting_options, nameof(ServerCertificateSelectionCallback)));
             }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -157,7 +157,7 @@ namespace System.Net.Security
                 throw new ArgumentNullException(nameof(sslServerAuthenticationOptions.ServerCertificate));
             }
 
-            if (sslServerAuthenticationOptions.ServerCertificate != null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null  && _certSelectionDelegate == null)
+            if (sslServerAuthenticationOptions.ServerCertificate != null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null)
             {
                 throw new InvalidOperationException(SR.Format(SR.net_conflicting_options, nameof(ServerCertificateSelectionCallback)));
             }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -53,7 +53,7 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(HostNameData))]
-        public void SslStream_ServerCallbackNotSet_UsesLocalCertificateSelection(string hostName)
+        public void SslStream_ServerCallbackSet_UsesServerCallback(string hostName)
         {
             X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
 
@@ -100,19 +100,19 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(HostNameData))]
-        public void SslStream_ServerCallbackSet_UsesServerCallback(string hostName)
+        public void SslStream_ServerCallbackNotSet_UsesLocalCertificateSelection(string hostName)
         {
             X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
 
             int timesCallbackCalled = 0;
 
-            var selectionCallback = new LocalCertificateSelectionCallback((a, targetHost, c, d, e) =>
+            var selectionCallback = new LocalCertificateSelectionCallback((object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] issuers) =>
             {
                 timesCallbackCalled++;
                 return serverCert;
             });
 
-            vvar validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+            var validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
             {
                 Assert.Equal(serverCert, certificate);
                 return true; 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -105,7 +105,7 @@ namespace System.Net.Security.Tests
 
             var selectionCallback = new LocalCertificateSelectionCallback((object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] issuers) =>
             {
-                Assert.Equal(targetHost, string.Empty);
+                Assert.Equal(string.Empty, targetHost);
                 Assert.True(localCertificates.Contains(serverCert));
                 timesCallbackCalled++;
                 return serverCert;

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -51,6 +51,90 @@ namespace System.Net.Security.Tests
                 });
         }
 
+        [Theory]
+        [MemberData(nameof(HostNameData))]
+        public void SslStream_ServerCallbackNotSet_UsesLocalCertificateSelection(string hostName)
+        {
+            X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
+
+            int timesCallbackCalled = 0;
+
+            var selectionCallback = new LocalCertificateSelectionCallback((object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] issuers) =>
+            {
+                Assert.True(false, "LocalCertificateSelectionCallback called instead of RemoteCertificateValidationCallback.");
+                return null;
+            });
+
+            var validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+            {
+                Assert.Equal(serverCert, certificate);
+                return true; 
+            });
+
+            VirtualNetwork vn = new VirtualNetwork();
+            using (VirtualNetworkStream serverStream = new VirtualNetworkStream(vn, isServer: true),
+                                        clientStream = new VirtualNetworkStream(vn, isServer: false))
+            using (SslStream server = new SslStream(serverStream, false, null, selectionCallback),
+                             client = new SslStream(clientStream, leaveInnerStreamOpen: false, validationCallback))
+            {
+                Task clientJob = Task.Run(() => {
+                    client.AuthenticateAsClient(hostName);
+                });
+
+                SslServerAuthenticationOptions options = DefaultServerOptions();
+                options.ServerCertificate = serverCert;
+                options.ServerCertificateSelectionCallback = (sender, actualHostName) =>
+                {
+                    timesCallbackCalled++;
+                    Assert.Equal(hostName, actualHostName);
+                    return serverCert;
+                };
+
+                var cts = new CancellationTokenSource();
+                server.AuthenticateAsServerAsync(options, cts.Token).Wait();
+
+                Assert.Equal(1, timesCallbackCalled);
+                clientJob.Wait();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(HostNameData))]
+        public void SslStream_ServerCallbackSet_UsesServerCallback(string hostName)
+        {
+            X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
+
+            int timesCallbackCalled = 0;
+
+            var selectionCallback = new LocalCertificateSelectionCallback((a, targetHost, c, d, e) =>
+            {
+                timesCallbackCalled++;
+                return serverCert;
+            });
+
+            var validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) => { Assert.Equal(serverCert, certificate); return true; });
+
+            VirtualNetwork vn = new VirtualNetwork();
+            using (VirtualNetworkStream serverStream = new VirtualNetworkStream(vn, isServer: true),
+                                        clientStream = new VirtualNetworkStream(vn, isServer: false))
+            using (SslStream server = new SslStream(serverStream, false, null, selectionCallback),
+                             client = new SslStream(clientStream, leaveInnerStreamOpen: false, validationCallback))
+            {
+                Task clientJob = Task.Run(() => {
+                    client.AuthenticateAsClient(hostName);
+                });
+
+                SslServerAuthenticationOptions options = DefaultServerOptions();
+                options.ServerCertificate = serverCert;
+
+                var cts = new CancellationTokenSource();
+                server.AuthenticateAsServerAsync(options, cts.Token).Wait();
+
+                Assert.Equal(1, timesCallbackCalled);
+                clientJob.Wait();
+            }
+        }
+
         [Fact]
         public void SslStream_NoSniFromClient_CallbackReturnsNull()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -112,7 +112,11 @@ namespace System.Net.Security.Tests
                 return serverCert;
             });
 
-            var validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) => { Assert.Equal(serverCert, certificate); return true; });
+            vvar validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+            {
+                Assert.Equal(serverCert, certificate);
+                return true; 
+            });
 
             VirtualNetwork vn = new VirtualNetwork();
             using (VirtualNetworkStream serverStream = new VirtualNetworkStream(vn, isServer: true),

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -83,7 +83,6 @@ namespace System.Net.Security.Tests
                 });
 
                 SslServerAuthenticationOptions options = DefaultServerOptions();
-                options.ServerCertificate = serverCert;
                 options.ServerCertificateSelectionCallback = (sender, actualHostName) =>
                 {
                     timesCallbackCalled++;

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -60,6 +60,29 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        public async Task SslStream_RemoteCertificateValidationCallbackReturnsNull_Throws()
+        {
+            VirtualNetwork network = new VirtualNetwork();
+
+            var selectionCallback = new LocalCertificateSelectionCallback((object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] issuers) =>
+            {
+                return null;
+            });
+
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            using (var server = new SslStream(serverStream, false, null, selectionCallback))
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                Task t1 = client.AuthenticateAsClientAsync(certificate.GetNameInfo(X509NameType.SimpleName, false));
+                Task t2 = server.AuthenticateAsServerAsync(certificate);
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () => await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2));
+            }
+        }
+
+        [Fact]
         public async Task SslStream_StreamToStream_Successive_ClientWrite_Sync_Success()
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -75,10 +75,9 @@ namespace System.Net.Security.Tests
             using (var server = new SslStream(serverStream, false, null, selectionCallback))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
             {
-                Task t1 = client.AuthenticateAsClientAsync(certificate.GetNameInfo(X509NameType.SimpleName, false));
-                Task t2 = server.AuthenticateAsServerAsync(certificate);
-
-                await Assert.ThrowsAsync<NotSupportedException>(async () => await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2));
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                    await TestConfiguration.WhenAllOrAnyFailedWithTimeout(client.AuthenticateAsClientAsync(certificate.GetNameInfo(X509NameType.SimpleName, false)), server.AuthenticateAsServerAsync(certificate))
+                );
             }
         }
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -60,7 +60,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        public async Task SslStream_RemoteCertificateValidationCallbackReturnsNull_Throws()
+        public async Task SslStream_ServerLocalCertificateSelectionCallbackReturnsNull_Throw()
         {
             VirtualNetwork network = new VirtualNetwork();
 


### PR DESCRIPTION
In .NET Core 2.0, we call `LocalCertificateSelectionCallback` to choose the certificate during `AuthenticateAsServerAsync`. As part of adding support for SNI, this functionality was removed. However, some users have already implemented SNI using `LocalCertificateSelectionCallback`, and we should aim to maintain compatibility for them.

This change ensures that we maintain the old behavior of `LocalCertificateSelectionCallback` when the new SNI callback is not set. When both are set, we default to the new behavior. I also added two tests to verify this behavior.

Fixes: #29110