### PR TITLE
More SSL error queue cleaning

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.Initialization.cs
@@ -25,6 +25,11 @@ internal static partial class Interop
 
             //Call ssl specific initializer
             Ssl.EnsureLibSslInitialized();
+            if (Interop.Crypto.ErrPeekLastError() != 0)
+            {
+                // It is going to be wrapped in a type load exception but will have the error information
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
+            }
         }
 #endif
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -24,7 +24,6 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator(null, null, null, SslPolicyErrors.None));
         }
 
-        [ActiveIssue(25676, TestPlatforms.Linux)]
         [Theory]
         [InlineData(SslProtocols.Tls, false)] // try various protocols to ensure we correctly set versions even when accepting all certs
         [InlineData(SslProtocols.Tls, true)]

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
@@ -22,27 +22,17 @@ namespace Internal.Cryptography.Pal
             _pkcs12Handle = pkcs12Handle;
         }
 
-        public static bool TryRead(byte[] data, out OpenSslPkcs12Reader pkcs12Reader)
-        {
-            Exception ignored;
-            return TryRead(data, out pkcs12Reader, out ignored, captureException: false);
-        }
+        public static bool TryRead(byte[] data, out OpenSslPkcs12Reader pkcs12Reader) =>
+            TryRead(data, out pkcs12Reader, out _, captureException: false);
 
-        public static bool TryRead(byte[] data, out OpenSslPkcs12Reader pkcs12Reader, out Exception openSslException)
-        {
-            return TryRead(data, out pkcs12Reader, out openSslException, captureException: true);
-        }
+        public static bool TryRead(byte[] data, out OpenSslPkcs12Reader pkcs12Reader, out Exception openSslException) =>
+            TryRead(data, out pkcs12Reader, out openSslException, captureException: true);
 
-        public static bool TryRead(SafeBioHandle fileBio, out OpenSslPkcs12Reader pkcs12Reader)
-        {
-            Exception ignored;
-            return TryRead(fileBio, out pkcs12Reader, out ignored, captureException: false);
-        }
+        public static bool TryRead(SafeBioHandle fileBio, out OpenSslPkcs12Reader pkcs12Reader) =>
+            TryRead(fileBio, out pkcs12Reader, out _, captureException: false);
 
-        public static bool TryRead(SafeBioHandle fileBio, out OpenSslPkcs12Reader pkcs12Reader, out Exception openSslException)
-        {
-            return TryRead(fileBio, out pkcs12Reader, out openSslException, captureException: true);
-        }
+        public static bool TryRead(SafeBioHandle fileBio, out OpenSslPkcs12Reader pkcs12Reader, out Exception openSslException) =>
+            TryRead(fileBio, out pkcs12Reader, out openSslException, captureException: true);
 
         public void Dispose()
         {
@@ -158,7 +148,6 @@ namespace Internal.Cryptography.Pal
             if (!p12.IsInvalid)
             {
                 pkcs12Reader = new OpenSslPkcs12Reader(p12);
-                openSslException = null;                
                 return true;
             }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
@@ -52,9 +52,10 @@ namespace Internal.Cryptography.Pal
                 if (pkcs7.IsInvalid)
                 {
                     Interop.Crypto.ErrClearError();
+                    return false;
                 }
 
-                return !pkcs7.IsInvalid;
+                return true;
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
@@ -15,10 +15,15 @@ namespace Internal.Cryptography.Pal
         {
             using (SafePkcs7Handle pkcs7 = Interop.Crypto.DecodePkcs7(rawData, rawData.Length))
             {
-                if (!pkcs7.IsInvalid)
+                if (pkcs7.IsInvalid)
+                {
+                    Interop.Crypto.ErrClearError();
+                }
+                else
                 {
                     return true;
                 }
+
             }
 
             using (SafeBioHandle bio = Interop.Crypto.CreateMemoryBio())
@@ -29,7 +34,13 @@ namespace Internal.Cryptography.Pal
 
                 using (SafePkcs7Handle pkcs7 = Interop.Crypto.PemReadBioPkcs7(bio))
                 {
-                    return !pkcs7.IsInvalid;
+                    if (pkcs7.IsInvalid)
+                    {
+                        Interop.Crypto.ErrClearError();
+                        return false;
+                    }
+
+                    return true;
                 }
             }
         }
@@ -38,6 +49,11 @@ namespace Internal.Cryptography.Pal
         {
             using (SafePkcs7Handle pkcs7 = Interop.Crypto.D2IPkcs7Bio(fileBio))
             {
+                if (pkcs7.IsInvalid)
+                {
+                    Interop.Crypto.ErrClearError();
+                }
+
                 return !pkcs7.IsInvalid;
             }
         }
@@ -46,7 +62,13 @@ namespace Internal.Cryptography.Pal
         {
             using (SafePkcs7Handle pkcs7 = Interop.Crypto.PemReadBioPkcs7(fileBio))
             {
-                return !pkcs7.IsInvalid;
+                if (pkcs7.IsInvalid)
+                {
+                    Interop.Crypto.ErrClearError();
+                    return false;
+                }
+
+                return true;
             }
         }
 
@@ -90,6 +112,7 @@ namespace Internal.Cryptography.Pal
                 {
                     certPal = null;
                     certPals = null;
+                    Interop.Crypto.ErrClearError();
                     return false;
                 }
 
@@ -109,6 +132,7 @@ namespace Internal.Cryptography.Pal
                 {
                     certPal = null;
                     certPals = null;
+                    Interop.Crypto.ErrClearError();
                     return false;
                 }
 
@@ -172,6 +196,7 @@ namespace Internal.Cryptography.Pal
                 {
                     certPal = null;
                     certPals = null;
+                    Interop.Crypto.ErrClearError();
                     return false;
                 }
 
@@ -218,33 +243,32 @@ namespace Internal.Cryptography.Pal
             return true;
         }
 
-        internal static bool TryReadPkcs12(byte[] rawData, SafePasswordHandle password, out ICertificatePal certPal)
+        internal static bool TryReadPkcs12(byte[] rawData, SafePasswordHandle password, out ICertificatePal certPal, out Exception openSslException)
         {
             List<ICertificatePal> ignored;
 
-            return TryReadPkcs12(rawData, password, true, out certPal, out ignored);
-
+            return TryReadPkcs12(rawData, password, true, out certPal, out ignored, out openSslException);
         }
 
-        internal static bool TryReadPkcs12(SafeBioHandle bio, SafePasswordHandle password, out ICertificatePal certPal)
+        internal static bool TryReadPkcs12(SafeBioHandle bio, SafePasswordHandle password, out ICertificatePal certPal, out Exception openSslException)
         {
             List<ICertificatePal> ignored;
 
-            return TryReadPkcs12(bio, password, true, out certPal, out ignored);
+            return TryReadPkcs12(bio, password, true, out certPal, out ignored, out openSslException);
         }
 
-        internal static bool TryReadPkcs12(byte[] rawData, SafePasswordHandle password, out List<ICertificatePal> certPals)
+        internal static bool TryReadPkcs12(byte[] rawData, SafePasswordHandle password, out List<ICertificatePal> certPals, out Exception openSslException)
         {
             ICertificatePal ignored;
 
-            return TryReadPkcs12(rawData, password, false, out ignored, out certPals);
+            return TryReadPkcs12(rawData, password, false, out ignored, out certPals, out openSslException);
         }
 
-        internal static bool TryReadPkcs12(SafeBioHandle bio, SafePasswordHandle password, out List<ICertificatePal> certPals)
+        internal static bool TryReadPkcs12(SafeBioHandle bio, SafePasswordHandle password, out List<ICertificatePal> certPals, out Exception openSslException)
         {
             ICertificatePal ignored;
 
-            return TryReadPkcs12(bio, password, false, out ignored, out certPals);
+            return TryReadPkcs12(bio, password, false, out ignored, out certPals, out openSslException);
         }
 
         private static bool TryReadPkcs12(
@@ -252,12 +276,13 @@ namespace Internal.Cryptography.Pal
             SafePasswordHandle password,
             bool single,
             out ICertificatePal readPal,
-            out List<ICertificatePal> readCerts)
+            out List<ICertificatePal> readCerts,
+            out Exception openSslException)
         {
             // DER-PKCS12
             OpenSslPkcs12Reader pfx;
 
-            if (!OpenSslPkcs12Reader.TryRead(rawData, out pfx))
+            if (!OpenSslPkcs12Reader.TryRead(rawData, out pfx, out openSslException))
             {
                 readPal = null;
                 readCerts = null;
@@ -275,12 +300,13 @@ namespace Internal.Cryptography.Pal
             SafePasswordHandle password,
             bool single,
             out ICertificatePal readPal,
-            out List<ICertificatePal> readCerts)
+            out List<ICertificatePal> readCerts,
+            out Exception openSslException)
         {
             // DER-PKCS12
             OpenSslPkcs12Reader pfx;
 
-            if (!OpenSslPkcs12Reader.TryRead(bio, out pfx))
+            if (!OpenSslPkcs12Reader.TryRead(bio, out pfx, out openSslException))
             {
                 readPal = null;
                 readCerts = null;


### PR DESCRIPTION
Another batch of cleaning SSL error queue. Trying to be minimize the extension of the changes while ensuring the SSL error queue is clean of typical errors without affecting exceptions currently throw by the code. In interest of keeping the perf unchanged calls to cleanup the queue are ideally only added in case of errors and preferably via ERR_clear_error.

The targets addressed on this change were identified via debugger by selecting calls that were putting errors on the SSL queue. The removal of the active issue is at this point still tentative: I can't be sure that it is going to pass reliable on Outerloop and I do not have any more local repros.

Contributes to [#25676](https://github.com/dotnet/corefx/issues/25676) (moved to https://github.com/dotnet/runtime/issues/24335).