### PR TITLE
[release/2.1] Lock Vectors reference assembly to 4.1.3.0 and don't OOB it on netcoreapp2.0

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -157,6 +157,7 @@
   <!-- Set some shortcuts for more terse conditions in project files -->
   <PropertyGroup>
     <TargetsNetCoreApp Condition="$(TargetGroup.StartsWith('netcoreapp'))">true</TargetsNetCoreApp>
+    <TargetsUap Condition="$(TargetGroup.StartsWith('uap'))">true</TargetsUap>
     <TargetsNetFx Condition="$(TargetGroup.StartsWith('net4')) OR '$(TargetGroup)' == 'netfx'">true</TargetsNetFx>
   </PropertyGroup>
 

--- a/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
+++ b/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
@@ -6,11 +6,11 @@
     <MinClientVersion>2.8.6</MinClientVersion>
   </PropertyGroup>
   <ItemGroup>
+    <HarvestIncludePaths Include="ref\netstandard1.0;ref\netstandard2.0">
+      <SupportedFramework>netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+    </HarvestIncludePaths>
     <ProjectReference Include="..\ref\System.Numerics.Vectors.csproj">
-      <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
-      <!-- Make sure this doesn't get stripped during harvesting.
-           We have an implementation that will work on desktop, thus needs a unique assembly version -->
-      <Preserve>true</Preserve>
+      <SupportedFramework>net45</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Numerics.Vectors.csproj" />
   </ItemGroup>
@@ -21,7 +21,7 @@
     <InboxOnTargetFramework Include="xamarinmac20" />
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
-    <InboxOnTargetFramework Include="netcoreapp2.1" />
+    <InboxOnTargetFramework Include="netcoreapp2.0" />
     <InboxOnTargetFramework Include="uap10.0.16299" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Numerics.Vectors/ref/Configurations.props
+++ b/src/System.Numerics.Vectors/ref/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PackageConfigurations>
       netstandard1.0;
+      net45;
       netstandard;
       net46;
     </PackageConfigurations>

--- a/src/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
+++ b/src/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
@@ -301,7 +301,7 @@ namespace System.Numerics
         public Vector(T value) { throw null; }
         public Vector(T[] values) { throw null; }
         public Vector(T[] values, int index) { throw null; }
-#if netcoreapp
+#if HAS_SPAN
         public Vector(Span<T> values) { throw null; }
 #endif
         public static int Count { get { throw null; } }

--- a/src/System.Numerics.Vectors/ref/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/ref/System.Numerics.Vectors.csproj
@@ -3,11 +3,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{650277B5-9423-4ACE-BB54-2659995B21C7}</ProjectGuid>
-    <IsTargetingNetFx Condition="'$(TargetGroup)'=='netfx' OR '$(TargetGroup)'=='net46'">true</IsTargetingNetFx>
-    <IsTargetingNetCoreApp Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap'">true</IsTargetingNetCoreApp>
-    <IsPartialFacadeAssembly Condition="'$(IsTargetingNetFx)'=='true'">true</IsPartialFacadeAssembly>
-    <DefineConstants Condition="'$(IsTargetingNetCoreApp)'=='true'">$(DefineConstants);netcoreapp</DefineConstants>
+    <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)'=='true' AND '$(TargetGroup)' != 'net45'">true</IsPartialFacadeAssembly>
+    <DefineConstants Condition="'$(TargetsNetCoreApp)'=='true' OR '$(TargetsUap)' == 'true'">$(DefineConstants);HAS_SPAN</DefineConstants>
+    <!-- Must match version supported by frameworks which support 4.1.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.2.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.1.3.0</AssemblyVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
@@ -23,14 +26,14 @@
   <ItemGroup>
     <Compile Include="System.Numerics.Vectors.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsTargetingNetFx)'=='true'">
+  <ItemGroup Condition="'$(TargetsNetFx)'=='true'">
     <Reference Include="mscorlib" />
     <Reference Include="System.Numerics" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
     <Reference Include="System.Runtime" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsTargetingNetCoreApp)'=='true'">
+  <ItemGroup Condition="'$(TargetsNetCoreApp)'=='true' OR '$(TargetsUap)' == 'true'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
System.Numerics.Vectors was made inbox in netcoreapp2.0, we were still allowing distribution
in the package, however the package was applying the netstandard2.0 implementation to
netcoreapp2.0.

Now that we've disabled oobing the netcoreapp2.1 build (since many types were moved into
corelib) it no longer makes sense for us to mantain the ability to oob the netcoreapp2.0 build.

Doing so not only degrades the inbox version (by not using the framework's MathF
implementation) but also creates type-unfication issues on roll forward: app targets 2.0
carries OOB copy of Vectors with higher version than 2.1, rolls forward to 2.1 and host will
use the OOB copy, no longer unifying to the types in corelib.

Fixes #29162 