### PR TITLE
Add config to force OpenSsl error queue cleanup before Encrypt/Decrypt

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -26,6 +26,21 @@ internal static partial class Interop
         private unsafe static readonly Ssl.SslCtxSetAlpnCallback s_alpnServerCallback = AlpnServerSelectCallback;
         private static readonly IdnMapping s_idnMapping = new IdnMapping();
 
+        static OpenSsl()
+        {
+            if (!AppContext.TryGetSwitch("System.Net.Security.SslStream.ForceOpenSslErrorQueueCleanupBeforeEncryptDecrypt", out bool forceErrorQueueCleanup))
+            {
+                // AppContext wasn't used, try the environment variable.
+                string envVar = Environment.GetEnvironmentVariable("DOTNET_FORCE_OPENSSL_ERROR_QUEUE_CLEANUP_BEFORE_ENCRYPT_DECRYPT");
+                forceErrorQueueCleanup = envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1"));
+            }
+
+            if (forceErrorQueueCleanup)
+            {
+                Ssl.ForceOpenSslErrorQueueCleanupBeforeWriteRead();
+            }
+        }
+
         #region internal methods
         internal static SafeChannelBindingHandle QueryChannelBinding(SafeSslHandle context, ChannelBindingKind bindingType)
         {

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -28,16 +28,16 @@ internal static partial class Interop
 
         static OpenSsl()
         {
-            if (!AppContext.TryGetSwitch("System.Net.Security.SslStream.ForceOpenSslErrorQueueCleanupBeforeEncryptDecrypt", out bool forceErrorQueueCleanup))
+            if (!AppContext.TryGetSwitch("System.Net.Security.SslStream.ForceClearOpenSslErrorQueue", out bool forceErrorQueueCleanup))
             {
                 // AppContext wasn't used, try the environment variable.
-                string envVar = Environment.GetEnvironmentVariable("DOTNET_FORCE_OPENSSL_ERROR_QUEUE_CLEANUP_BEFORE_ENCRYPT_DECRYPT");
+                string envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_SECURITY_SSLSTREAM_FORCECLEAROPENSSLERRORQUEUE");
                 forceErrorQueueCleanup = envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1"));
             }
 
             if (forceErrorQueueCleanup)
             {
-                Ssl.ForceOpenSslErrorQueueCleanupBeforeWriteRead();
+                Ssl.ForceErrorQueueCleanupBeforeWriteRead();
             }
         }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -82,8 +82,8 @@ internal static partial class Interop
             out int dataKeySize,
             out int hashKeySize);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ForceOpenSslErrorQueueCleanupBeforeWriteRead")]
-        internal static extern void ForceOpenSslErrorQueueCleanupBeforeWriteRead();
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ForceErrorQueueCleanupBeforeWriteRead")]
+        internal static extern void ForceErrorQueueCleanupBeforeWriteRead();
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslWrite")]
         internal static extern unsafe int SslWrite(SafeSslHandle ssl, byte* buf, int num);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -82,6 +82,9 @@ internal static partial class Interop
             out int dataKeySize,
             out int hashKeySize);
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ForceOpenSslErrorQueueCleanupBeforeWriteRead")]
+        internal static extern void ForceOpenSslErrorQueueCleanupBeforeWriteRead();
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslWrite")]
         internal static extern unsafe int SslWrite(SafeSslHandle ssl, byte* buf, int num);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -415,25 +415,29 @@ err:
 }
 
 // Controls if ERR_clear_error is going to be called before SSL_write/SSL_read
-static bool g_forceOpenSslErrorQueueCleanupBeforeWriteRead = false;
+static bool g_forceErrorQueueCleanupBeforeWriteRead = false;
 
-extern "C" void CryptoNative_ForceOpenSslErrorQueueCleanupBeforeWriteRead()
+extern "C" void CryptoNative_ForceErrorQueueCleanupBeforeWriteRead()
 {
-    g_forceOpenSslErrorQueueCleanupBeforeWriteRead = true;
+    g_forceErrorQueueCleanupBeforeWriteRead = true;
 }
 
 extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
-    if (g_forceOpenSslErrorQueueCleanupBeforeWriteRead)
+    if (g_forceErrorQueueCleanupBeforeWriteRead)
+    {
         ERR_clear_error();
+    }
 
     return SSL_write(ssl, buf, num);
 }
 
 extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
 {
-    if (g_forceOpenSslErrorQueueCleanupBeforeWriteRead)
+    if (g_forceErrorQueueCleanupBeforeWriteRead)
+    {
         ERR_clear_error();
+    }
 
     return SSL_read(ssl, buf, num);
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -414,13 +414,27 @@ err:
     return 0;
 }
 
+// Controls if ERR_clear_error is going to be called before SSL_write/SSL_read
+static bool g_forceOpenSslErrorQueueCleanupBeforeWriteRead = false;
+
+extern "C" void CryptoNative_ForceOpenSslErrorQueueCleanupBeforeWriteRead()
+{
+    g_forceOpenSslErrorQueueCleanupBeforeWriteRead = true;
+}
+
 extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
+    if (g_forceOpenSslErrorQueueCleanupBeforeWriteRead)
+        ERR_clear_error();
+
     return SSL_write(ssl, buf, num);
 }
 
 extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
 {
+    if (g_forceOpenSslErrorQueueCleanupBeforeWriteRead)
+        ERR_clear_error();
+
     return SSL_read(ssl, buf, num);
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -131,6 +131,12 @@ Ensures that libssl is correctly initialized and ready to use.
 extern "C" void CryptoNative_EnsureLibSslInitialized();
 
 /*
+Calling this function causes the calls to CryptoNative_SslWrite and CryptoNative_SslRead to always
+call ERR_clear_error() before calling SSL_write/SSL_read.
+*/
+extern "C" void CryptoNative_ForceErrorQueueCleanupBeforeWriteRead();
+
+/*
 Shims the SSLv23_method method.
 
 Returns the requested SSL_METHOD.


### PR DESCRIPTION
This is an escape valve in case the optimization of removing the calls to ERR_clear_error() for each SSL_write/SSL_read causes troubles. There will be a performance impact but depending on the scenario it can be a desired trade-off.

The AppContext switch is "System.Net.Security.SslStream.ForceOpenSslErrorQueueCleanupBeforeEncryptDecrypt"
The env var is "DOTNET_FORCE_OPENSSL_ERROR_QUEUE_CLEANUP_BEFORE_ENCRYPT_DECRYPT"

Any naming suggestion is appreciated... 