### PR TITLE
System.Net.Http.Native: correct hex for libcurl versions

### DIFF
--- a/src/Native/Unix/System.Net.Http.Native/pal_multi.cpp
+++ b/src/Native/Unix/System.Net.Http.Native/pal_multi.cpp
@@ -84,7 +84,7 @@ extern "C" int32_t HttpNative_MultiWait(CURLM* multiHandle,
         // passed to curl_multi_wait.  See https://github.com/dotnet/corefx/issues/9751.  So if we have a libcurl
         // prior to that version, we need to do our own poll to get the status of the extra file descriptor.
         //
-        if (curl_version_info(CURLVERSION_NOW)->version_num >= 0x073200)
+        if (curl_version_info(CURLVERSION_NOW)->version_num >= 0x072000)
         {
             *isExtraFileDescriptorActive = (extraFds.revents & CURL_WAIT_POLLIN) != 0;
         }

--- a/src/Native/Unix/System.Net.Http.Native/pal_versioninfo.cpp
+++ b/src/Native/Unix/System.Net.Http.Native/pal_versioninfo.cpp
@@ -43,7 +43,7 @@ static_assert(PAL_CURL_VERSION_PSL == CURL_VERSION_PSL, "");
 // Based on docs/libcurl/symbols-in-versions in libcurl source tree,
 // the CURL_VERSION_HTTP2 was introduced in libcurl 7.33.0 and
 // the CURLPIPE_MULTIPLEX was introduced in libcurl 7.43.0.
-#define MIN_VERSION_WITH_CURLPIPE_MULTIPLEX 0x074300
+#define MIN_VERSION_WITH_CURLPIPE_MULTIPLEX 0x072B00
 
 extern "C" int32_t HttpNative_GetSupportedFeatures()
 {


### PR DESCRIPTION
I encountered a bug in native bindings for libcurl. 

Sometimes there is a version check to know if an option (for example h2 multiplexing support) is available. In code version constants are specified as hex values. However they are converted to hex in a wrong way: 7.43.0 becomes 0x074300 but it should be 0x072B00.

I found two places affected by this issue, but maybe there are more. @janvorli please take a look.