### PR TITLE
Fix TraceSource handling of GetEntryAssembly

### DIFF
--- a/src/Common/src/System/Reflection/Emit/IgnoreAccessChecksToAttributeBuilder.cs
+++ b/src/Common/src/System/Reflection/Emit/IgnoreAccessChecksToAttributeBuilder.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+
+namespace System.Reflection.Emit
+{
+    internal static class IgnoreAccessChecksToAttributeBuilder
+    {
+        /// <summary>
+        /// Generate the declaration for the IgnoresAccessChecksToAttribute type.
+        /// This attribute will be both defined and used in the dynamic assembly.
+        /// Each usage identifies the name of the assembly containing non-public
+        /// types the dynamic assembly needs to access.  Normally those types
+        /// would be inaccessible, but this attribute allows them to be visible.
+        /// It works like a reverse InternalsVisibleToAttribute.
+        /// This method returns the ConstructorInfo of the generated attribute.
+        /// </summary>
+        public static ConstructorInfo AddToModule(ModuleBuilder mb)
+        {
+            TypeBuilder attributeTypeBuilder =
+                mb.DefineType("System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute",
+                               TypeAttributes.Public | TypeAttributes.Class,
+                               typeof(Attribute));
+
+            // Create backing field as:
+            // private string assemblyName;
+            FieldBuilder assemblyNameField =
+                attributeTypeBuilder.DefineField("assemblyName", typeof(String), FieldAttributes.Private);
+
+            // Create ctor as:
+            // public IgnoresAccessChecksToAttribute(string)
+            ConstructorBuilder constructorBuilder = attributeTypeBuilder.DefineConstructor(MethodAttributes.Public,
+                                                         CallingConventions.HasThis,
+                                                         new Type[] { assemblyNameField.FieldType });
+
+            ILGenerator il = constructorBuilder.GetILGenerator();
+
+            // Create ctor body as:
+            // this.assemblyName = {ctor parameter 0}
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg, 1);
+            il.Emit(OpCodes.Stfld, assemblyNameField);
+
+            // return
+            il.Emit(OpCodes.Ret);
+
+            // Define property as:
+            // public string AssemblyName {get { return this.assemblyName; } }
+            PropertyBuilder getterPropertyBuilder = attributeTypeBuilder.DefineProperty(
+                                                   "AssemblyName",
+                                                   PropertyAttributes.None,
+                                                   CallingConventions.HasThis,
+                                                   returnType: typeof(String),
+                                                   parameterTypes: null);
+
+            MethodBuilder getterMethodBuilder = attributeTypeBuilder.DefineMethod(
+                                                   "get_AssemblyName",
+                                                   MethodAttributes.Public,
+                                                   CallingConventions.HasThis,
+                                                   returnType: typeof(String),
+                                                   parameterTypes: null);
+
+            // Generate body:
+            // return this.assemblyName;
+            il = getterMethodBuilder.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, assemblyNameField);
+            il.Emit(OpCodes.Ret);
+
+            // Generate the AttributeUsage attribute for this attribute type:
+            // [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+            TypeInfo attributeUsageTypeInfo = typeof(AttributeUsageAttribute).GetTypeInfo();
+
+            // Find the ctor that takes only AttributeTargets
+            ConstructorInfo attributeUsageConstructorInfo =
+                attributeUsageTypeInfo.DeclaredConstructors
+                    .Single(c => c.GetParameters().Count() == 1 &&
+                                 c.GetParameters()[0].ParameterType == typeof(AttributeTargets));
+
+            // Find the property to set AllowMultiple
+            PropertyInfo allowMultipleProperty =
+                attributeUsageTypeInfo.DeclaredProperties
+                    .Single(f => string.Equals(f.Name, "AllowMultiple"));
+
+            // Create a builder to construct the instance via the ctor and property
+            CustomAttributeBuilder customAttributeBuilder =
+                new CustomAttributeBuilder(attributeUsageConstructorInfo,
+                                            new object[] { AttributeTargets.Assembly },
+                                            new PropertyInfo[] { allowMultipleProperty },
+                                            new object[] { true });
+
+            // Attach this attribute instance to the newly defined attribute type
+            attributeTypeBuilder.SetCustomAttribute(customAttributeBuilder);
+
+            // Make the TypeInfo real so the constructor can be used.
+            return attributeTypeBuilder.CreateTypeInfo().DeclaredConstructors.Single();
+        }
+    }
+}

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -56,7 +56,7 @@ namespace System.Diagnostics
             {
                 if (s_appName == null)
                 {
-                    s_appName = Assembly.GetEntryAssembly().GetName().Name;
+                    s_appName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
                 }
                 return s_appName;
             }

--- a/src/System.Diagnostics.TraceSource/tests/Configurations.props
+++ b/src/System.Diagnostics.TraceSource/tests/Configurations.props
@@ -2,6 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
       netstandard-Unix;
       netstandard-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Diagnostics.TraceSourceTests
 {
-    public class DefaultTraceListenerClassTests : FileCleanupTestBase
+    public partial class DefaultTraceListenerClassTests : RemoteExecutorTestBase
     {
         private class TestDefaultTraceListener : DefaultTraceListener
         {

--- a/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.netcoreapp.cs
+++ b/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.netcoreapp.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Linq;
+using Xunit;
+
+namespace System.Diagnostics.TraceSourceTests
+{
+    public partial class DefaultTraceListenerClassTests : RemoteExecutorTestBase
+    {
+        [Fact]
+        public void EntryAssemblyName_Default_IncludedInTrace()
+        {
+            RemoteInvoke(() =>
+            {
+                var listener = new TestDefaultTraceListener();
+                Trace.Listeners.Add(listener);
+                Trace.TraceError("hello world");
+                Assert.Equal(Assembly.GetEntryAssembly()?.GetName().Name + " Error: 0 : hello world", listener.Output.Trim());
+            }).Dispose();
+        }
+
+        [Fact]
+        public void EntryAssemblyName_Null_NotIncludedInTrace()
+        {
+            RemoteInvoke(() =>
+            {
+                MakeAssemblyGetEntryAssemblyReturnNull();
+
+                var listener = new TestDefaultTraceListener();
+                Trace.Listeners.Add(listener);
+                Trace.TraceError("hello world");
+                Assert.Equal("Error: 0 : hello world", listener.Output.Trim());
+            }).Dispose();
+        }
+
+        /// <summary>
+        /// Makes Assembly.GetEntryAssembly() return null by generating an AppDomainManager-derived type
+        /// with private reflection and reflection emit, and then again using private reflection to
+        /// store that instance as the current domain manager.  It overrides EntryAssembly to return
+        /// null, simulating the situation of a custom host that doesn't have a managed .exe.
+        /// </summary>
+        private static void MakeAssemblyGetEntryAssemblyReturnNull()
+        {
+            Type appDomainType = typeof(object).Assembly.GetType("System.AppDomain", true, false);
+            Assert.NotNull(appDomainType);
+
+            Type appDomainManagerType = typeof(object).Assembly.GetType("System.AppDomainManager", true, false);
+            Assert.NotNull(appDomainManagerType);
+
+            var asmName = new AssemblyName("CustomAppDomainManager");
+            AssemblyBuilder asmBuilder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+            ModuleBuilder modBuilder = asmBuilder.DefineDynamicModule(asmName.Name);
+            asmBuilder.SetCustomAttribute(new CustomAttributeBuilder(
+                IgnoreAccessChecksToAttributeBuilder.AddToModule(modBuilder), // allow deriving from the internal AppDomainManager in coreclr
+                new object[] { typeof(object).Assembly.GetName().Name }));
+
+            TypeBuilder typeBuilder = modBuilder.DefineType("DerivedAppDomainManager", TypeAttributes.Class | TypeAttributes.Public, appDomainManagerType);
+            PropertyBuilder propBuilder = typeBuilder.DefineProperty("EntryAssembly", PropertyAttributes.None, appDomainType, Type.EmptyTypes);
+            MethodBuilder methodBuilder = typeBuilder.DefineMethod("get_EntryAssembly", MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.Virtual, CallingConventions.HasThis, typeof(Assembly), Type.EmptyTypes);
+            ILGenerator il = methodBuilder.GetILGenerator();
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+            propBuilder.SetGetMethod(methodBuilder);
+
+            appDomainType
+                .GetField("_domainManager", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(appDomainType.GetProperty("CurrentDomain").GetValue(null),
+                Activator.CreateInstance(typeBuilder.CreateType()));
+        }
+    }
+}

--- a/src/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests.csproj
+++ b/src/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>System.Diagnostics.TraceSource.Tests</AssemblyName>
     <ProjectGuid>{7B32D24D-969A-4F7F-8461-B43E15E5D553}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Debug|AnyCPU'" />
@@ -30,6 +32,18 @@
     <Compile Include="TraceSwitchClassTests.cs" />
     <Compile Include="TraceTestHelper.cs" />
     <Compile Include="CorrelationManagerTests.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="DefaultTraceListenerClassTests.netcoreapp.cs" />
+    <Compile Include="$(CommonPath)\System\Reflection\Emit\IgnoreAccessChecksToAttributeBuilder.cs">
+      <Link>Common\System\Reflection\Emit\IgnoreAccessChecksToAttributeBuilder.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -29,6 +29,9 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(TargetGroup)' != 'netstandard'">
     <Compile Include="System\Reflection\DispatchProxy.cs" />
     <Compile Include="System\Reflection\DispatchProxyGenerator.cs" />
+    <Compile Include="$(CommonPath)\System\Reflection\Emit\IgnoreAccessChecksToAttributeBuilder.cs">
+      <Link>Common\System\Reflection\Emit\IgnoreAccessChecksToAttributeBuilder.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="mscorlib" />

--- a/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -214,8 +214,7 @@ namespace System.Reflection
                 {
                     if (_ignoresAccessChecksToAttributeConstructor == null)
                     {
-                        TypeInfo attributeTypeInfo = GenerateTypeInfoOfIgnoresAccessChecksToAttribute();
-                        _ignoresAccessChecksToAttributeConstructor = attributeTypeInfo.DeclaredConstructors.Single();
+                        _ignoresAccessChecksToAttributeConstructor = IgnoreAccessChecksToAttributeBuilder.AddToModule(_mb);
                     }
 
                     return _ignoresAccessChecksToAttributeConstructor;
@@ -226,94 +225,6 @@ namespace System.Reflection
                 int nextId = Interlocked.Increment(ref _typeId);
                 TypeBuilder tb = _mb.DefineType(name + "_" + nextId, TypeAttributes.Public, proxyBaseType);
                 return new ProxyBuilder(this, tb, proxyBaseType);
-            }
-
-            // Generate the declaration for the IgnoresAccessChecksToAttribute type.
-            // This attribute will be both defined and used in the dynamic assembly.
-            // Each usage identifies the name of the assembly containing non-public
-            // types the dynamic assembly needs to access.  Normally those types
-            // would be inaccessible, but this attribute allows them to be visible.
-            // It works like a reverse InternalsVisibleToAttribute.
-            // This method returns the TypeInfo of the generated attribute.
-            private TypeInfo GenerateTypeInfoOfIgnoresAccessChecksToAttribute()
-            {
-                TypeBuilder attributeTypeBuilder = 
-                    _mb.DefineType("System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute", 
-                                   TypeAttributes.Public | TypeAttributes.Class, 
-                                   typeof(Attribute));
-
-                // Create backing field as:
-                // private string assemblyName;
-                FieldBuilder assemblyNameField = 
-                    attributeTypeBuilder.DefineField("assemblyName", typeof(String), FieldAttributes.Private);
-
-                // Create ctor as:
-                // public IgnoresAccessChecksToAttribute(string)
-                ConstructorBuilder constructorBuilder = attributeTypeBuilder.DefineConstructor(MethodAttributes.Public, 
-                                                             CallingConventions.HasThis, 
-                                                             new Type[] { assemblyNameField.FieldType });
-
-                ILGenerator il = constructorBuilder.GetILGenerator();
-
-                // Create ctor body as:
-                // this.assemblyName = {ctor parameter 0}
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldarg, 1);
-                il.Emit(OpCodes.Stfld, assemblyNameField);
-
-                // return
-                il.Emit(OpCodes.Ret);
-
-                // Define property as:
-                // public string AssemblyName {get { return this.assemblyName; } }
-                PropertyBuilder getterPropertyBuilder = attributeTypeBuilder.DefineProperty(
-                                                       "AssemblyName",
-                                                       PropertyAttributes.None,
-                                                       CallingConventions.HasThis,
-                                                       returnType: typeof(String),
-                                                       parameterTypes: null);
-
-                MethodBuilder getterMethodBuilder = attributeTypeBuilder.DefineMethod(
-                                                       "get_AssemblyName",
-                                                       MethodAttributes.Public,
-                                                       CallingConventions.HasThis,
-                                                       returnType: typeof(String),
-                                                       parameterTypes: null);
-
-                // Generate body:
-                // return this.assemblyName;
-                il = getterMethodBuilder.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, assemblyNameField);
-                il.Emit(OpCodes.Ret);
-
-                // Generate the AttributeUsage attribute for this attribute type:
-                // [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-                TypeInfo attributeUsageTypeInfo = typeof(AttributeUsageAttribute).GetTypeInfo();
-
-                // Find the ctor that takes only AttributeTargets
-                ConstructorInfo attributeUsageConstructorInfo =
-                    attributeUsageTypeInfo.DeclaredConstructors
-                        .Single(c => c.GetParameters().Count() == 1 &&
-                                     c.GetParameters()[0].ParameterType == typeof(AttributeTargets));
-
-                // Find the property to set AllowMultiple
-                PropertyInfo allowMultipleProperty =
-                    attributeUsageTypeInfo.DeclaredProperties
-                        .Single(f => String.Equals(f.Name, "AllowMultiple"));
-
-                // Create a builder to construct the instance via the ctor and property
-                CustomAttributeBuilder customAttributeBuilder = 
-                    new CustomAttributeBuilder(attributeUsageConstructorInfo,
-                                                new object[] { AttributeTargets.Assembly },
-                                                new PropertyInfo[] { allowMultipleProperty },
-                                                new object[] { true });
-
-                // Attach this attribute instance to the newly defined attribute type
-                attributeTypeBuilder.SetCustomAttribute(customAttributeBuilder);
-
-                // Make the TypeInfo real so the constructor can be used.
-                return attributeTypeBuilder.CreateTypeInfo();
             }
 
             // Generates an instance of the IgnoresAccessChecksToAttribute to


### PR DESCRIPTION
Check that GetEntryAssembly doesn't return null before dereferencing it.

Fixes https://github.com/dotnet/corefx/issues/29196

@jkotas, I tried to trace through the source to see why GetEntryAssembly might return null, but the conditions that would cause that weren't clear to me.  I'd like to write a test for this.  Suggestions?

cc: @brianrob, @valenis