### PR TITLE
Port fixes to remove use of unsafe in ReadOnlySequence APIs and fix bounds checks on Slice

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -281,12 +281,12 @@ namespace System.Buffers
 
             if (startRange + (ulong)start > sliceRange)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
 
             int currentLength = startSegment.Memory.Length - (int)startIndex;
 
-            // Position in startSegment
+            // Position not in startSegment
             if (currentLength <= start)
             {
                 if (currentLength < 0)
@@ -357,13 +357,13 @@ namespace System.Buffers
 
             if (sliceRange + (ulong)length > endRange)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
 
             int currentLength = sliceStartSegment.Memory.Length - (int)sliceStartIndex;
 
-            // Position in startSegment
-            if (currentLength <= length)
+            // Position not in startSegment
+            if (currentLength < length)
             {
                 if (currentLength < 0)
                     ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -510,17 +510,6 @@ namespace System.Buffers
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void GetTypeAndIndices(int start, int end, out SequenceType sequenceType, out int startIndex, out int endIndex)
-        {
-            startIndex = start & ReadOnlySequence.IndexBitMask;
-            endIndex = end & ReadOnlySequence.IndexBitMask;
-            // We take high order bits of two indexes index and move them
-            // to a first and second position to convert to BufferType
-            // Masking with 2 is required to only keep the second bit of Start.GetInteger()
-            sequenceType = Start.GetObject() == null ? SequenceType.Empty : (SequenceType)((((uint)Start.GetInteger() >> 30) & 2) | (uint)End.GetInteger() >> 31);
-        }
-
         /// <summary>
         /// An enumerator over the <see cref="ReadOnlySequence{T}"/>
         /// </summary>

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence_helpers.cs
@@ -150,20 +150,18 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, int offset) => Seek(start, end, (long)offset);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal SequencePosition Seek(in SequencePosition start, in SequencePosition end, long offset)
+        private SequencePosition Seek(in SequencePosition start, in SequencePosition end, long offset, ExceptionArgument argument)
         {
-            GetTypeAndIndices(start.GetInteger(), end.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);
+            int startIndex = GetIndex(start);
+            int endIndex = GetIndex(end);
 
             object startObject = start.GetObject();
             object endObject = end.GetObject();
 
-            if (type == SequenceType.MultiSegment && startObject != endObject)
+            if (startObject != endObject)
             {
-                Debug.Assert(startObject is ReadOnlySequenceSegment<T>);
-                var startSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject);
+                Debug.Assert(startObject != null);
+                var startSegment = (ReadOnlySequenceSegment<T>)startObject;
 
                 int currentLength = startSegment.Memory.Length - startIndex;
 
@@ -171,22 +169,25 @@ namespace System.Buffers
                 if (currentLength > offset)
                     goto IsSingleSegment;
 
+                if (currentLength < 0)
+                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+
                 // End of segment. Move to start of next.
-                return SeekMultiSegment(startSegment.Next, endObject, endIndex, offset - currentLength);
+                return SeekMultiSegment(startSegment.Next, endObject, endIndex, offset - currentLength, argument);
             }
 
             Debug.Assert(startObject == endObject);
 
             if (endIndex - startIndex < offset)
-                ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
+                ThrowHelper.ThrowArgumentOutOfRangeException(argument);
 
-            // Single segment Seek
+        // Single segment Seek
         IsSingleSegment:
             return new SequencePosition(startObject, startIndex + (int)offset);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static SequencePosition SeekMultiSegment(ReadOnlySequenceSegment<T> currentSegment, object endObject, int endPosition, long offset)
+        private static SequencePosition SeekMultiSegment(ReadOnlySequenceSegment<T> currentSegment, object endObject, int endIndex, long offset, ExceptionArgument argument)
         {
             Debug.Assert(currentSegment != null);
             Debug.Assert(offset >= 0);
@@ -205,91 +206,161 @@ namespace System.Buffers
             }
 
             // Hit the end of the segments but didn't reach the count
-            if (currentSegment == null || (currentSegment == endObject && endPosition < offset))
-                ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
+            if (currentSegment == null || endIndex < offset)
+                ThrowHelper.ThrowArgumentOutOfRangeException(argument);
 
         FoundSegment:
             return new SequencePosition(currentSegment, (int)offset);
         }
 
-        private static void CheckEndReachable(object startSegment, object endSegment)
+        private void BoundsCheck(in SequencePosition position)
         {
-            Debug.Assert(startSegment != null);
-            Debug.Assert(startSegment is ReadOnlySequenceSegment<T>);
-            Debug.Assert(endSegment != null);
+            uint sliceStartIndex = (uint)GetIndex(position);
+            uint startIndex = (uint)GetIndex(_sequenceStart);
+            uint endIndex = (uint)GetIndex(_sequenceEnd);
 
-            var current = Unsafe.As<ReadOnlySequenceSegment<T>>(startSegment);
+            object startObject = _sequenceStart.GetObject();
+            object endObject = _sequenceEnd.GetObject();
 
-            while (current.Next != null)
+            // Single-Segment Sequence
+            if (startObject == endObject)
             {
-                current = current.Next;
-                if (current == endSegment)
+                if (!InRange(sliceStartIndex, startIndex, endIndex))
                 {
-                    // Found end
-                    return;
+                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
                 }
             }
+            else
+            {
+                // Multi-Segment Sequence
+                // Storing this in a local since it is used twice within InRange()
+                ulong startRange = (ulong)(((ReadOnlySequenceSegment<T>)startObject).RunningIndex + startIndex);
+                if (!InRange(
+                    (ulong)(((ReadOnlySequenceSegment<T>)position.GetObject()).RunningIndex + sliceStartIndex),
+                    startRange,
+                    (ulong)(((ReadOnlySequenceSegment<T>)endObject).RunningIndex + endIndex)))
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                }
+            }
+        }
 
-            ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+        private void BoundsCheck(uint sliceStartIndex, object sliceStartObject, uint sliceEndIndex, object sliceEndObject)
+        {
+            uint startIndex = (uint)GetIndex(_sequenceStart);
+            uint endIndex = (uint)GetIndex(_sequenceEnd);
+
+            object startObject = _sequenceStart.GetObject();
+            object endObject = _sequenceEnd.GetObject();
+
+            // Single-Segment Sequence
+            if (startObject == endObject)
+            {
+                if (sliceStartObject != sliceEndObject ||
+                    sliceStartObject != startObject ||
+                    sliceStartIndex > sliceEndIndex ||
+                    sliceStartIndex < startIndex ||
+                    sliceEndIndex > endIndex)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                }
+            }
+            else
+            {
+                // Multi-Segment Sequence
+                // This optimization works because we know sliceStartIndex, sliceEndIndex, startIndex, and endIndex are all >= 0
+                Debug.Assert(sliceStartIndex >= 0 && startIndex >= 0 && endIndex >= 0);
+
+                ulong sliceStartRange = (ulong)(((ReadOnlySequenceSegment<T>)sliceStartObject).RunningIndex + sliceStartIndex);
+                ulong sliceEndRange = (ulong)(((ReadOnlySequenceSegment<T>)sliceEndObject).RunningIndex + sliceEndIndex);
+
+                if (sliceStartRange > sliceEndRange)
+                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+
+                if (sliceStartRange < (ulong)(((ReadOnlySequenceSegment<T>)startObject).RunningIndex + startIndex)
+                    || sliceEndRange > (ulong)(((ReadOnlySequenceSegment<T>)endObject).RunningIndex + endIndex))
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                }
+            }
+        }
+
+        private static SequencePosition GetEndPosition(ReadOnlySequenceSegment<T> startSegment, object startObject, int startIndex, object endObject, int endIndex, long length)
+        {
+            int currentLength = startSegment.Memory.Length - startIndex;
+
+            if (currentLength > length)
+            {
+                return new SequencePosition(startObject, startIndex + (int)length);
+            }
+
+            if (currentLength < 0)
+                ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+
+            return SeekMultiSegment(startSegment.Next, endObject, endIndex, length - currentLength, ExceptionArgument.length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private long GetLength(in SequencePosition start, in SequencePosition end)
+        private SequenceType GetSequenceType()
         {
-            GetTypeAndIndices(start.GetInteger(), end.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);
+            // We take high order bits of two indexes and move them
+            // to a first and second position to convert to SequenceType
 
-            object startObject = start.GetObject();
-            object endObject = end.GetObject();
-            if (type == SequenceType.MultiSegment && startObject != endObject)
+            // if (start < 0  and end < 0)
+            // start >> 31 = -1, end >> 31 = -1
+            // 2 * (-1) + (-1) = -3, result = (SequenceType)3
+
+            // if (start < 0  and end >= 0)
+            // start >> 31 = -1, end >> 31 = 0
+            // 2 * (-1) + 0 = -2, result = (SequenceType)2
+
+            // if (start >= 0  and end >= 0)
+            // start >> 31 = 0, end >> 31 = 0
+            // 2 * 0 + 0 = 0, result = (SequenceType)0
+
+            // if (start >= 0  and end < 0)
+            // start >> 31 = 0, end >> 31 = -1
+            // 2 * 0 + (-1) = -1, result = (SequenceType)1
+
+            return (SequenceType)(-(2 * (_sequenceStart.GetInteger() >> 31) + (_sequenceEnd.GetInteger() >> 31)));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetIndex(in SequencePosition position) => position.GetInteger() & ReadOnlySequence.IndexBitMask;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ReadOnlySequence<T> SliceImpl(in SequencePosition start, in SequencePosition end)
+        {
+            // In this method we reset high order bits from indices
+            // of positions that were passed in
+            // and apply type bits specific for current ReadOnlySequence type
+
+            return new ReadOnlySequence<T>(
+                start.GetObject(),
+                GetIndex(start) | (_sequenceStart.GetInteger() & ReadOnlySequence.FlagBitMask),
+                end.GetObject(),
+                GetIndex(end) | (_sequenceEnd.GetInteger() & ReadOnlySequence.FlagBitMask)
+            );
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private long GetLength()
+        {
+            int startIndex = GetIndex(_sequenceStart);
+            int endIndex = GetIndex(_sequenceEnd);
+            object startObject = _sequenceStart.GetObject();
+            object endObject = _sequenceEnd.GetObject();
+
+            if (startObject != endObject)
             {
-                Debug.Assert(startObject != null);
-                Debug.Assert(startObject is ReadOnlySequenceSegment<T>);
-                Debug.Assert(endObject != null);
-                Debug.Assert(endObject is ReadOnlySequenceSegment<T>);
-
-                var startSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject);
-                var endSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(endObject);
-                // (end.RunningIndex + endIndex) - (start.RunningIndex + startIndex) // (End offset) - (start offset)
-                return endSegment.RunningIndex - startSegment.RunningIndex - startIndex + endIndex; // Rearranged to avoid overflow
+                var startSegment = (ReadOnlySequenceSegment<T>)startObject;
+                var endSegment = (ReadOnlySequenceSegment<T>)endObject;
+                // (End offset) - (start offset)
+                return (endSegment.RunningIndex + endIndex) - (startSegment.RunningIndex + startIndex);
             }
 
-            Debug.Assert(startObject == endObject);
             // Single segment length
             return endIndex - startIndex;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void BoundsCheck(in SequencePosition start, in SequencePosition end)
-        {
-            GetTypeAndIndices(start.GetInteger(), end.GetInteger(), out SequenceType type, out int startIndex, out int endIndex);
-
-            object startObject = start.GetObject();
-            object endObject = end.GetObject();
-            if (type == SequenceType.MultiSegment && startObject != endObject)
-            {
-                Debug.Assert(startObject != null);
-                Debug.Assert(startObject is ReadOnlySequenceSegment<T>);
-                Debug.Assert(endObject != null);
-                Debug.Assert(endObject is ReadOnlySequenceSegment<T>);
-
-                var startSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(startObject);
-                var endSegment = Unsafe.As<ReadOnlySequenceSegment<T>>(endObject);
-
-                // start.RunningIndex + startIndex <= end.RunningIndex + endIndex
-                if (startSegment.RunningIndex - endIndex <= endSegment.RunningIndex - startIndex) // Rearranged to avoid overflow
-                {
-                    // Mult-segment in bounds
-                    return;
-                }
-            }
-            else if (startIndex <= endIndex)
-            {
-                Debug.Assert(startObject == endObject);
-                // Single segment in bounds
-                return;
-            }
-
-            ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
         }
 
         internal bool TryGetReadOnlySequenceSegment(out ReadOnlySequenceSegment<T> startSegment, out int startIndex, out ReadOnlySequenceSegment<T> endSegment, out int endIndex)
@@ -402,6 +473,58 @@ namespace System.Buffers
             text = (string)Start.GetObject();
 
             return true;
+        }
+
+        private static bool InRange(uint value, uint start, uint end)
+        {
+            // _sequenceStart and _sequenceEnd must be well-formed
+            Debug.Assert(start <= int.MaxValue);
+            Debug.Assert(end <= int.MaxValue);
+            Debug.Assert(start <= end);
+
+            // The case, value > int.MaxValue, is invalid, and hence it shouldn't be in the range.
+            // If value > int.MaxValue, it is invariably greater than both 'start' and 'end'.
+            // In that case, the experession simplifies to value <= end, which will return false.
+
+            // The case, value < start, is invalid.
+            // In that case, (value - start) would underflow becoming larger than int.MaxValue.
+            // (end - start) can never underflow and hence must be within 0 and int.MaxValue. 
+            // So, we will correctly return false.
+
+            // The case, value > end, is invalid.
+            // In that case, the expression simplifies to value <= end, which will return false.
+            // This is because end > start & value > end implies value > start as well.
+
+            // In all other cases, value is valid, and we return true.
+
+            // Equivalent to: return (start <= value && value <= start)
+            return (value - start) <= (end - start);
+        }
+
+        private static bool InRange(ulong value, ulong start, ulong end)
+        {
+            // _sequenceStart and _sequenceEnd must be well-formed
+            Debug.Assert(start <= long.MaxValue);
+            Debug.Assert(end <= long.MaxValue);
+            Debug.Assert(start <= end);
+
+            // The case, value > long.MaxValue, is invalid, and hence it shouldn't be in the range.
+            // If value > long.MaxValue, it is invariably greater than both 'start' and 'end'.
+            // In that case, the experession simplifies to value <= end, which will return false.
+
+            // The case, value < start, is invalid.
+            // In that case, (value - start) would underflow becoming larger than long.MaxValue.
+            // (end - start) can never underflow and hence must be within 0 and long.MaxValue. 
+            // So, we will correctly return false.
+
+            // The case, value > end, is invalid.
+            // In that case, the expression simplifies to value <= end, which will return false.
+            // This is because end > start & value > end implies value > start as well.
+
+            // In all other cases, value is valid, and we return true.
+
+            // Equivalent to: return (start <= value && value <= start)
+            return (value - start) <= (end - start);
         }
     }
 }

--- a/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
+++ b/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
@@ -39,7 +39,14 @@ namespace System.Runtime.InteropServices
         /// </summary>
         public static bool TryGetReadOnlyMemory<T>(ReadOnlySequence<T> sequence, out ReadOnlyMemory<T> memory)
         {
-            return sequence.TryGetReadOnlyMemory(out memory);
+            if (!sequence.IsSingleSegment)
+            {
+                memory = default;
+                return false;
+            }
+
+            memory = sequence.First;
+            return true;
         }
 
         /// <summary>

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Common.byte.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Common.byte.cs
@@ -72,5 +72,41 @@ namespace System.Memory.Tests
             Assert.Equal("Hello", Encoding.ASCII.GetString(helloBytes));
             Assert.Equal(" World", Encoding.ASCII.GetString(worldBytes));
         }
+
+        [Fact]
+        public static void SliceStartPositionAndLength()
+        {
+            var segment1 = new BufferSegment<byte>(new byte[10]);
+            BufferSegment<byte> segment2 = segment1.Append(new byte[10]);
+
+            var buffer = new ReadOnlySequence<byte>(segment1, 0, segment2, 10);
+
+            ReadOnlySequence<byte> sliced = buffer.Slice(buffer.GetPosition(10), 10);
+            Assert.Equal(10, sliced.Length);
+
+            Assert.Equal(segment2, sliced.Start.GetObject());
+            Assert.Equal(segment2, sliced.End.GetObject());
+
+            Assert.Equal(0, sliced.Start.GetInteger());
+            Assert.Equal(10, sliced.End.GetInteger());
+        }
+
+        [Fact]
+        public static void SliceStartAndEndPosition()
+        {
+            var segment1 = new BufferSegment<byte>(new byte[10]);
+            BufferSegment<byte> segment2 = segment1.Append(new byte[10]);
+
+            var buffer = new ReadOnlySequence<byte>(segment1, 0, segment2, 10);
+
+            ReadOnlySequence<byte> sliced = buffer.Slice(10, buffer.GetPosition(20));
+            Assert.Equal(10, sliced.Length);
+
+            Assert.Equal(segment2, sliced.Start.GetObject());
+            Assert.Equal(segment2, sliced.End.GetObject());
+
+            Assert.Equal(0, sliced.Start.GetInteger());
+            Assert.Equal(10, sliced.End.GetInteger());
+        }
     }
 }

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Default.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Default.cs
@@ -80,12 +80,12 @@ namespace System.Memory.Tests
         public void Default_SlicePositiveStart()
         {
             ReadOnlySequence<byte> buffer = default;
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1, buffer.End));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1L, 0L));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1L, buffer.End));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1, buffer.End));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1L, 0L));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1L, buffer.End));
         }
 
         [Fact]
@@ -105,10 +105,10 @@ namespace System.Memory.Tests
         public void Default_SlicePositiveLength()
         {
             ReadOnlySequence<byte> buffer = default;
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(0, 1));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(0L, 1L));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(buffer.Start, 1));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(buffer.Start, 1L));
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(0L, 1L));
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(buffer.Start, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(buffer.Start, 1L));
         }
 
         [Fact]

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Empty.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Empty.cs
@@ -81,12 +81,12 @@ namespace System.Memory.Tests
         public void Empty_SlicePositiveStart()
         {
             ReadOnlySequence<byte> buffer = ReadOnlySequence<byte>.Empty;
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1, buffer.End));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1L, 0L));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(1L, buffer.End));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1, buffer.End));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1L, 0L));
+            Assert.Throws<ArgumentOutOfRangeException>("start", () => buffer.Slice(1L, buffer.End));
         }
 
         [Fact]
@@ -106,10 +106,10 @@ namespace System.Memory.Tests
         public void Empty_SlicePositiveLength()
         {
             ReadOnlySequence<byte> buffer = ReadOnlySequence<byte>.Empty;
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(0, 1));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(0L, 1L));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(buffer.Start, 1));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => buffer.Slice(buffer.Start, 1L));
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(0L, 1L));
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(buffer.Start, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(buffer.Start, 1L));
         }
 
         [Fact]

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
@@ -203,12 +203,107 @@ namespace System.Memory.Tests
 
         public static TheoryData<Action<ReadOnlySequence<byte>>> OutOfRangeSliceCases => new TheoryData<Action<ReadOnlySequence<byte>>>
         {
-            b => b.Slice(101),
-            b => b.Slice(0, 101),
-            b => b.Slice(b.Start, 101),
-            b => b.Slice(0, 70).Slice(b.End, b.End),
-            b => b.Slice(0, 70).Slice(b.Start, b.End),
-            b => b.Slice(0, 70).Slice(0, b.End)
+            // negative start	
+            b => b.Slice(-1), // no length
+            b => b.Slice(-1, -1), // negative length
+            b => b.Slice(-1, 0), // zero length
+            b => b.Slice(-1, 1), // positive length
+            b => b.Slice(-1, 101), // after end length
+            b => b.Slice(-1, b.Start), // to start
+            b => b.Slice(-1, b.End), // to end
+
+            // zero start
+            b => b.Slice(0, -1), // negative length
+            b => b.Slice(0, 101), // after end length
+
+            // end start
+            b => b.Slice(100, -1), // negative length
+            b => b.Slice(100, 1), // after end length
+            b => b.Slice(100, b.Start), // to start
+
+            // After end start
+            b => b.Slice(101), // no length
+            b => b.Slice(101, -1), // negative length
+            b => b.Slice(101, 0), // zero length
+            b => b.Slice(101, 1), // after end length
+            b => b.Slice(101, b.Start), // to start
+            b => b.Slice(101, b.End), // to end
+
+            // At Start start
+            b => b.Slice(b.Start, -1), // negative length
+            b => b.Slice(b.Start, 101), // after end length
+
+            // At End start
+            b => b.Slice(b.End, -1), // negative length
+            b => b.Slice(b.End, 1), // after end length
+            b => b.Slice(b.End, b.Start), // to start
+
+            // Slice at begin
+            b => b.Slice(0, 70).Slice(0, b.End), // to after end
+            b => b.Slice(0, 70).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(0, 70).Slice(b.End),
+            b => b.Slice(0, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(0, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(0, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(0, 70).Slice(b.End, b.Start), // to start
+            b => b.Slice(0, 70).Slice(b.End, b.End), // to after end
+
+            // Slice at begin
+            b => b.Slice(b.Start, 70).Slice(0, b.End), // to after end
+            b => b.Slice(b.Start, 70).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(b.Start, 70).Slice(b.End),
+            b => b.Slice(b.Start, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(b.Start, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(b.Start, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(b.Start, 70).Slice(b.End, b.Start), // to start
+            b => b.Slice(b.Start, 70).Slice(b.End, b.End), // to after end
+
+            // Slice at middle
+            b => b.Slice(30, 40).Slice(0, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(0, b.End), // to after end
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 41), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(30, 40).Slice(b.End),
+            b => b.Slice(b.Start, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(b.Start, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(b.Start, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(30, 40).Slice(b.End, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.End, b.End), // to after end
+
+            // Slice at end
+            b => b.Slice(70, 30).Slice(0, b.Start), // to before start
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 31), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to end
+            // from end
+            b => b.Slice(70, 30).Slice(b.End, b.Start), // to before start
+
+            // Slice at end
+            b => b.Slice(70, 30).Slice(0, b.Start), // to before start
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 31), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to end
+            // from end
+            b => b.Slice(70, 30).Slice(b.End, b.Start), // to before start
         };
     }
 }

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.char.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.char.cs
@@ -206,12 +206,107 @@ namespace System.Memory.Tests
 
         public static TheoryData<Action<ReadOnlySequence<char>>> OutOfRangeSliceCases => new TheoryData<Action<ReadOnlySequence<char>>>
         {
-            b => b.Slice(101),
-            b => b.Slice(0, 101),
-            b => b.Slice(b.Start, 101),
-            b => b.Slice(0, 70).Slice(b.End, b.End),
-            b => b.Slice(0, 70).Slice(b.Start, b.End),
-            b => b.Slice(0, 70).Slice(0, b.End)
+            // negative start	
+            b => b.Slice(-1), // no length
+            b => b.Slice(-1, -1), // negative length
+            b => b.Slice(-1, 0), // zero length
+            b => b.Slice(-1, 1), // positive length
+            b => b.Slice(-1, 101), // after end length
+            b => b.Slice(-1, b.Start), // to start
+            b => b.Slice(-1, b.End), // to end
+
+            // zero start
+            b => b.Slice(0, -1), // negative length
+            b => b.Slice(0, 101), // after end length
+
+            // end start
+            b => b.Slice(100, -1), // negative length
+            b => b.Slice(100, 1), // after end length
+            b => b.Slice(100, b.Start), // to start
+
+            // After end start
+            b => b.Slice(101), // no length
+            b => b.Slice(101, -1), // negative length
+            b => b.Slice(101, 0), // zero length
+            b => b.Slice(101, 1), // after end length
+            b => b.Slice(101, b.Start), // to start
+            b => b.Slice(101, b.End), // to end
+
+            // At Start start
+            b => b.Slice(b.Start, -1), // negative length
+            b => b.Slice(b.Start, 101), // after end length
+
+            // At End start
+            b => b.Slice(b.End, -1), // negative length
+            b => b.Slice(b.End, 1), // after end length
+            b => b.Slice(b.End, b.Start), // to start
+
+            // Slice at begin
+            b => b.Slice(0, 70).Slice(0, b.End), // to after end
+            b => b.Slice(0, 70).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(0, 70).Slice(b.End),
+            b => b.Slice(0, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(0, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(0, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(0, 70).Slice(b.End, b.Start), // to start
+            b => b.Slice(0, 70).Slice(b.End, b.End), // to after end
+
+            // Slice at begin
+            b => b.Slice(b.Start, 70).Slice(0, b.End), // to after end
+            b => b.Slice(b.Start, 70).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(b.Start, 70).Slice(b.End),
+            b => b.Slice(b.Start, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(b.Start, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(b.Start, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(b.Start, 70).Slice(b.End, b.Start), // to start
+            b => b.Slice(b.Start, 70).Slice(b.End, b.End), // to after end
+
+            // Slice at middle
+            b => b.Slice(30, 40).Slice(0, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(0, b.End), // to after end
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 41), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(30, 40).Slice(b.End),
+            b => b.Slice(b.Start, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(b.Start, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(b.Start, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(30, 40).Slice(b.End, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.End, b.End), // to after end
+
+            // Slice at end
+            b => b.Slice(70, 30).Slice(0, b.Start), // to before start
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 31), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to end
+            // from end
+            b => b.Slice(70, 30).Slice(b.End, b.Start), // to before start
+
+            // Slice at end
+            b => b.Slice(70, 30).Slice(0, b.Start), // to before start
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 31), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to end
+            // from end
+            b => b.Slice(70, 30).Slice(b.End, b.Start), // to before start
         };
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28920

Grabbing changes from https://github.com/dotnet/corefx/pull/29135 / https://github.com/dotnet/corefx/pull/29109

As part of the fix to remove use of Unsafe.As and add proper input validation, the goal was to minimize regression to Kestrel and and the HttpParser benchmarks. There should be little to no regression. This was confirmed in https://github.com/dotnet/corefx/pull/29135#issuecomment-381816589.

cc @pakrym, @joshfree 