### PR TITLE
Cut string allocations for filtered watcher files

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.FileOperations.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.FileOperations.cs
@@ -17,12 +17,6 @@ internal partial class Interop
             internal const int OPEN_EXISTING = 3;
             internal const int COPY_FILE_FAIL_IF_EXISTS = 0x00000001;
 
-            internal const int FILE_ACTION_ADDED = 1;
-            internal const int FILE_ACTION_REMOVED = 2;
-            internal const int FILE_ACTION_MODIFIED = 3;
-            internal const int FILE_ACTION_RENAMED_OLD_NAME = 4;
-            internal const int FILE_ACTION_RENAMED_NEW_NAME = 5;
-
             internal const int FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
             internal const int FILE_FLAG_FIRST_PIPE_INSTANCE = 0x00080000;
             internal const int FILE_FLAG_OVERLAPPED = 0x40000000;

--- a/src/Common/src/Interop/Windows/kernel32/Interop.ReadDirectoryChangesW.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.ReadDirectoryChangesW.cs
@@ -12,14 +12,39 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, EntryPoint = "ReadDirectoryChangesW", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern unsafe bool ReadDirectoryChangesW(
-            SafeFileHandle hDirectory, 
-            byte[] lpBuffer, 
-            int nBufferLength, 
-            [MarshalAs(UnmanagedType.Bool)] bool bWatchSubtree, 
-            int dwNotifyFilter, 
-            out int lpBytesReturned,
-            NativeOverlapped* lpOverlapped, 
-            IntPtr lpCompletionRoutine);
+        internal static unsafe extern bool ReadDirectoryChangesW(
+            SafeFileHandle hDirectory,
+            byte[] lpBuffer,
+            uint nBufferLength,
+            bool bWatchSubtree,
+            uint dwNotifyFilter,
+            uint* lpBytesReturned,
+            NativeOverlapped* lpOverlapped,
+            void* lpCompletionRoutine);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct FILE_NOTIFY_INFORMATION
+        {
+            internal uint NextEntryOffset;
+            internal FileAction Action;
+
+            // Note that the file name is not null terminated
+            private uint FileNameLength;
+            private char _FileName;
+
+            internal unsafe ReadOnlySpan<char> FileName
+            {
+                get { fixed (char* c = &_FileName) { return new ReadOnlySpan<char>(c, (int)FileNameLength / sizeof(char)); } }
+            }
+        }
+
+        internal enum FileAction : uint
+        {
+            FILE_ACTION_ADDED = 0x00000001,
+            FILE_ACTION_REMOVED = 0x00000002,
+            FILE_ACTION_MODIFIED = 0x00000003,
+            FILE_ACTION_RENAMED_OLD_NAME = 0x00000004,
+            FILE_ACTION_RENAMED_NEW_NAME = 0x00000005
+        }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -246,12 +246,11 @@ namespace System.IO
             Debug.Assert(buffer != null);
             Debug.Assert(buffer.Length > 0);
 
-            ReadOnlySpan<char> oldName = ReadOnlySpan<char>.Empty;
-
-            Interop.Kernel32.FILE_NOTIFY_INFORMATION* info;
             fixed (byte* b = buffer)
             {
-                info = (Interop.Kernel32.FILE_NOTIFY_INFORMATION*)b;
+                Interop.Kernel32.FILE_NOTIFY_INFORMATION* info = (Interop.Kernel32.FILE_NOTIFY_INFORMATION*)b;
+
+                ReadOnlySpan<char> oldName = ReadOnlySpan<char>.Empty;
 
                 // Parse each event from the buffer and notify appropriate delegates
                 do

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.IO
 {
@@ -143,16 +143,15 @@ namespace System.IO
 
                 // Get the overlapped pointer to use for this iteration.
                 overlappedPointer = state.ThreadPoolBinding.AllocateNativeOverlapped(state.PreAllocatedOverlapped);
-                int size;
                 continueExecuting = Interop.Kernel32.ReadDirectoryChangesW(
                     state.DirectoryHandle,
                     state.Buffer, // the buffer is kept pinned for the duration of the sync and async operation by the PreAllocatedOverlapped
                     _internalBufferSize,
                     _includeSubdirectories,
-                    (int)_notifyFilters,
-                    out size,
+                    (uint)_notifyFilters,
+                    null,
                     overlappedPointer,
-                    IntPtr.Zero);
+                    null);
             }
             catch (ObjectDisposedException)
             {
@@ -242,123 +241,97 @@ namespace System.IO
             }
         }
 
-        private void ParseEventBufferAndNotifyForEach(byte[] buffer)
+        private unsafe void ParseEventBufferAndNotifyForEach(byte[] buffer)
         {
             Debug.Assert(buffer != null);
             Debug.Assert(buffer.Length > 0);
 
+            ReadOnlySpan<char> oldName = ReadOnlySpan<char>.Empty;
+
+            // Note that the buffer is pinned for the lifetime of the watcher.
+            // We have to pin again here to get the pointer.
+            Interop.Kernel32.FILE_NOTIFY_INFORMATION* info;
+            fixed (byte* b = buffer)
+            {
+                info = (Interop.Kernel32.FILE_NOTIFY_INFORMATION*)b;
+            }
+
             // Parse each event from the buffer and notify appropriate delegates
-
-            /******
-                Format for the buffer is the following C struct:
-
-                typedef struct _FILE_NOTIFY_INFORMATION {
-                   DWORD NextEntryOffset;
-                   DWORD Action;
-                   DWORD FileNameLength;
-                   WCHAR FileName[1];
-                } FILE_NOTIFY_INFORMATION;
-
-                NOTE1: FileNameLength is length in bytes.
-                NOTE2: The Filename is a Unicode string that's NOT NULL terminated.
-                NOTE3: A NextEntryOffset of zero means that it's the last entry
-            *******/
-
-            // Parse the file notify buffer:
-            int offset = 0;
-            int nextOffset, action, nameLength;
-            string oldName = null;
-            string name = null;
-
             do
             {
-                unsafe
+                // A slightly convoluted piece of code follows.  Here's what's happening:
+                //
+                // We wish to collapse the poorly done rename notifications from the
+                // ReadDirectoryChangesW API into a nice rename event. So to do that,
+                // it's assumed that a FILE_ACTION_RENAMED_OLD_NAME will be followed
+                // immediately by a FILE_ACTION_RENAMED_NEW_NAME in the buffer, which is
+                // all that the following code is doing.
+                //
+                // On a FILE_ACTION_RENAMED_OLD_NAME, it asserts that no previous one existed
+                // and saves its name.  If there are no more events in the buffer, it'll
+                // assert and fire a RenameEventArgs with the Name field null.
+                //
+                // If a NEW_NAME action comes in with no previous OLD_NAME, we assert and fire
+                // a rename event with the OldName field null.
+                //
+                // If the OLD_NAME and NEW_NAME actions are indeed there one after the other,
+                // we'll fire the RenamedEventArgs normally and clear oldName.
+                //
+                // If the OLD_NAME is followed by another action, we assert and then fire the
+                // rename event with the Name field null and then fire the next action.
+                //
+                // In case it's not a OLD_NAME or NEW_NAME action, we just fire the event normally.
+                //
+                // (Phew!)
+
+                switch (info->Action)
                 {
-                    fixed (byte* buffPtr = &buffer[0])
-                    {
-                        // Get next offset:
-                        nextOffset = *((int*)(buffPtr + offset));
+                    case Interop.Kernel32.FileAction.FILE_ACTION_RENAMED_OLD_NAME:
+                        // Action is renamed from, save the name of the file
+                        oldName = info->FileName;
+                        break;
+                    case Interop.Kernel32.FileAction.FILE_ACTION_RENAMED_NEW_NAME:
+                        // oldName may be empty if we didn't receive FILE_ACTION_RENAMED_OLD_NAME first
+                        NotifyRenameEventArgs(
+                            WatcherChangeTypes.Renamed,
+                            info->FileName,
+                            oldName);
+                        oldName = ReadOnlySpan<char>.Empty;
+                        break;
+                    default:
+                        if (!oldName.IsEmpty)
+                        {
+                            // Previous FILE_ACTION_RENAMED_OLD_NAME with no new name
+                            NotifyRenameEventArgs(WatcherChangeTypes.Renamed, ReadOnlySpan<char>.Empty, oldName);
+                            oldName = ReadOnlySpan<char>.Empty;
+                        }
 
-                        // Get change flag:
-                        action = *((int*)(buffPtr + offset + 4));
+                        switch (info->Action)
+                        {
+                            case Interop.Kernel32.FileAction.FILE_ACTION_ADDED:
+                                NotifyFileSystemEventArgs(WatcherChangeTypes.Created, info->FileName);
+                                break;
+                            case Interop.Kernel32.FileAction.FILE_ACTION_REMOVED:
+                                NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, info->FileName);
+                                break;
+                            case Interop.Kernel32.FileAction.FILE_ACTION_MODIFIED:
+                                NotifyFileSystemEventArgs(WatcherChangeTypes.Changed, info->FileName);
+                                break;
+                            default:
+                                Debug.Fail($"Unknown FileSystemEvent action type!  Value: {info->Action}");
+                                break;
+                        }
 
-                        // Get filename length (in bytes):
-                        nameLength = *((int*)(buffPtr + offset + 8));
-                        name = new string((char*)(buffPtr + offset + 12), 0, nameLength / 2);
-                    }
+                        break;
                 }
 
-                /* A slightly convoluted piece of code follows.  Here's what's happening:
+                info = info->NextEntryOffset == 0 ? null : (Interop.Kernel32.FILE_NOTIFY_INFORMATION*)((byte*)info + info->NextEntryOffset);
+            } while (info != null);
 
-                   We wish to collapse the poorly done rename notifications from the
-                   ReadDirectoryChangesW API into a nice rename event. So to do that,
-                   it's assumed that a FILE_ACTION_RENAMED_OLD_NAME will be followed
-                   immediately by a FILE_ACTION_RENAMED_NEW_NAME in the buffer, which is
-                   all that the following code is doing.
-
-                   On a FILE_ACTION_RENAMED_OLD_NAME, it asserts that no previous one existed
-                   and saves its name.  If there are no more events in the buffer, it'll
-                   assert and fire a RenameEventArgs with the Name field null.
-
-                   If a NEW_NAME action comes in with no previous OLD_NAME, we assert and fire
-                   a rename event with the OldName field null.
-
-                   If the OLD_NAME and NEW_NAME actions are indeed there one after the other,
-                   we'll fire the RenamedEventArgs normally and clear oldName.
-
-                   If the OLD_NAME is followed by another action, we assert and then fire the
-                   rename event with the Name field null and then fire the next action.
-
-                   In case it's not a OLD_NAME or NEW_NAME action, we just fire the event normally.
-
-                   (Phew!)
-                 */
-
-                // If the action is RENAMED_FROM, save the name of the file
-                if (action == Interop.Kernel32.FileOperations.FILE_ACTION_RENAMED_OLD_NAME)
-                {
-                    oldName = name;
-                }
-                else if (action == Interop.Kernel32.FileOperations.FILE_ACTION_RENAMED_NEW_NAME)
-                {
-                    // oldName may be null here if we received a FILE_ACTION_RENAMED_NEW_NAME with no old name
-                    NotifyRenameEventArgs(WatcherChangeTypes.Renamed, name, oldName);
-                    oldName = null;
-                }
-                else
-                {
-                    if (oldName != null)
-                    {
-                        // Previous FILE_ACTION_RENAMED_OLD_NAME with no new name
-                        NotifyRenameEventArgs(WatcherChangeTypes.Renamed, null, oldName);
-                        oldName = null;
-                    }
-
-                    switch (action)
-                    {
-                        case Interop.Kernel32.FileOperations.FILE_ACTION_ADDED:
-                            NotifyFileSystemEventArgs(WatcherChangeTypes.Created, name);
-                            break;
-                        case Interop.Kernel32.FileOperations.FILE_ACTION_REMOVED:
-                            NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, name);
-                            break;
-                        case Interop.Kernel32.FileOperations.FILE_ACTION_MODIFIED:
-                            NotifyFileSystemEventArgs(WatcherChangeTypes.Changed, name);
-                            break;
-                        default:
-                            Debug.Fail("Unknown FileSystemEvent action type!  Value: " + action);
-                            break;
-                    }
-                }
-
-                offset += nextOffset;
-            } while (nextOffset != 0);
-
-            if (oldName != null)
+            if (!oldName.IsEmpty)
             {
                 // Previous FILE_ACTION_RENAMED_OLD_NAME with no new name
-                NotifyRenameEventArgs(WatcherChangeTypes.Renamed, null, oldName);
-                oldName = null;
+                NotifyRenameEventArgs(WatcherChangeTypes.Renamed, ReadOnlySpan<char>.Empty, oldName);
             }
         }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -475,8 +475,8 @@ namespace System.IO.Tests
 
                 fsw.Renamed += (o, e) =>
                 {
-                    Assert.Equal(e.OldFullPath, file.Path);
-                    Assert.Equal(e.FullPath, newPath);
+                    Assert.Equal(file.Path, e.OldFullPath);
+                    Assert.Equal(newPath, e.FullPath);
                 };
 
                 fsw.EnableRaisingEvents = true;
@@ -485,9 +485,9 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]                        
+        [Fact]
         public void FileSystemWatcher_Path()
-        {            
+        {
             FileSystemWatcher watcher = new FileSystemWatcher();
             Assert.Equal(String.Empty, watcher.Path);
 


### PR DESCRIPTION
This changes the Win32 watcher code to not allocate strings until after we've matched the name and know that we're going to actually fire an event.

Unix code can be changed to encode into a temporary buffer to get a similar reduction. I'll open an up-for-grabs issue on it.

Flip a test to have expected in the expected argument.

cc: @danmosemsft, @Anipik 