### PR TITLE
Update to a xUnit Performance Api that has a bigger Etw buffer size.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -45,7 +45,7 @@
     <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
 
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
-    <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0018</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0019</XunitPerfAnalysisPackageVersion>
     <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>
     <XunitNetcoreExtensionsVersion>2.2.0-preview1-02719-03</XunitNetcoreExtensionsVersion>
     


### PR DESCRIPTION
These change is to alleviate the frequent failures on the Concurrent tests due to the lost of events, which blocks uploading any data on Windows.