### PR TITLE
[release/2.1] Ensure LocalCertificateSelectionCallback is still called with AuthenticateAsServerAsync

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -632,6 +632,10 @@ namespace System.Net.Security
             X509Certificate localCertificate = null;
             bool cachedCred = false;
 
+            // There are three options for selecting the server certificate. When 
+            // selecting which to use, we prioritize the new ServerCertSelectionDelegate
+            // API. If the new API isn't used we call LocalCertSelectionCallback (for compat
+            // with .NET Framework), and if neither is set we fall back to using ServerCertificate.
             if (_sslAuthenticationOptions.ServerCertSelectionDelegate != null)
             {
                 string serverIdentity = SniHelper.GetServerName(clientHello);
@@ -642,11 +646,11 @@ namespace System.Net.Security
                     throw new AuthenticationException(SR.net_ssl_io_no_server_cert);
                 }
             }
-            // This probably never gets called as this is a client options delegate
             else if (_sslAuthenticationOptions.CertSelectionDelegate != null)
             {
                 X509CertificateCollection tempCollection = new X509CertificateCollection();
                 tempCollection.Add(_sslAuthenticationOptions.ServerCertificate);
+                // We pass string.Empty here to maintain strict compatability with .NET Framework.
                 localCertificate = _sslAuthenticationOptions.CertSelectionDelegate(string.Empty, tempCollection, null, Array.Empty<string>());
                 if (NetEventSource.IsEnabled)
                     NetEventSource.Info(this, "Use delegate selected Cert");

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -152,12 +152,12 @@ namespace System.Net.Security
 
         private SslAuthenticationOptions CreateAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
-            if (sslServerAuthenticationOptions.ServerCertificate == null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback == null)
+            if (sslServerAuthenticationOptions.ServerCertificate == null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback == null && _certSelectionDelegate == null)
             {
                 throw new ArgumentNullException(nameof(sslServerAuthenticationOptions.ServerCertificate));
             }
 
-            if (sslServerAuthenticationOptions.ServerCertificate != null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null)
+            if ((sslServerAuthenticationOptions.ServerCertificate != null || _certSelectionDelegate != null) && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null)
             {
                 throw new InvalidOperationException(SR.Format(SR.net_conflicting_options, nameof(ServerCertificateSelectionCallback)));
             }
@@ -168,6 +168,7 @@ namespace System.Net.Security
             authOptions.ServerCertSelectionDelegate = _userServerCertificateSelectionCallback == null ? null : new ServerCertSelectionCallback(ServerCertSelectionCallbackWrapper);
 
             authOptions.CertValidationDelegate = _certValidationDelegate;
+            authOptions.CertSelectionDelegate = _certSelectionDelegate;
 
             return authOptions;
         }


### PR DESCRIPTION
In .NET Core 2.0, we call LocalCertificateSelectionCallback to choose the certificate during AuthenticateAsServerAsync. As part of adding support for SNI, this functionality was removed. However, some users have already implemented SNI using LocalCertificateSelectionCallback, and we should aim to maintain compatibility for them.

This change ensures that we maintain the old behavior of LocalCertificateSelectionCallback when the new SNI callback is not set.

The fix has been merged into master in [this commit](https://github.com/dotnet/corefx/commit/eeea6babf28188887f99aa0b459dc5877b39f31e).

See issue #29110 for details.

cc: @karelz 

