### PR TITLE
[release/2.1] Ensure framework assemblies have higher version than those applied to previous frameworks when API or type location changes

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2407,10 +2407,10 @@
     },
     "System.Memory": {
       "InboxOn": {
-        "netcoreapp2.1": "4.0.1.0",
+        "netcoreapp2.1": "4.1.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
-        "uap10.0.16300": "4.0.1.0",
+        "uap10.0.16300": "4.1.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -4903,8 +4903,8 @@
       "BaselineVersion": "4.4.0",
       "InboxOn": {
         "netcoreapp2.0": "4.1.1.0",
-        "netcoreapp2.1": "4.2.0.0",
-        "uap10.0.16300": "4.2.0.0"
+        "netcoreapp2.1": "4.3.0.0",
+        "uap10.0.16300": "4.3.0.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",

--- a/pkg/test/frameworkSettings/netcoreapp2.1/settings.targets
+++ b/pkg/test/frameworkSettings/netcoreapp2.1/settings.targets
@@ -6,4 +6,12 @@
     <!-- use the most recent MS.NETCore.App we have from upstack -->
     <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Temporarily suppress checking closure of Memory and Threading.Tasks.Extensions
+         These wil fail until we get an updated Microsoft.NETCore.App.
+         https://github.com/dotnet/corefx/issues/29249 -->
+    <IgnoredReference Include="System.Memory" />
+    <IgnoredReference Include="System.Threading.Tasks.Extensions" />
+  </ItemGroup>
 </Project>

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -3,6 +3,9 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <!-- System.Memory has forwarded types into the runtime on netcoreapp/uap
+         It must win over assemblies versioned at 4.0.* -->
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.1.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Memory/pkg/System.Memory.pkgproj
+++ b/src/System.Memory/pkg/System.Memory.pkgproj
@@ -8,14 +8,8 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.Memory.csproj" />
     <InboxOnTargetFramework  Include="$(AllXamarinFrameworks)" />
-    <!-- Since UAP and .NETCoreApp are package based we still want to enable
-         OOBing libraries that happen to overlap with their framework package.
-         This avoids us having to lock the API in our NuGet packages just
-         to match what shipped inbox: since we can provide a new library
-         we can update it to add API without raising the netstandard version. -->
-    <ValidatePackageSuppression Include="TreatAsOutOfBox">
-      <Value>.NETCoreApp;UAP</Value>
-    </ValidatePackageSuppression>
+    <InboxOnTargetFramework  Include="netcoreapp2.1" />
+    <InboxOnTargetFramework  Include="$(UAPvNextTFM)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Memory/ref/Configurations.props
+++ b/src/System.Memory/ref/Configurations.props
@@ -4,12 +4,11 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
-      netcoreapp;
-      uap10.0.16299;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
       uap;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Memory/ref/System.Memory.csproj
+++ b/src/System.Memory/ref/System.Memory.csproj
@@ -17,16 +17,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Memory.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' and '$(TargetGroup)' != 'uap10.0.16299'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.InteropServices\ref\System.Runtime.InteropServices.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1' Or '$(TargetGroup)' == 'uap10.0.16299'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1'">
     <Reference Include="System.Globalization" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />

--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -4,13 +4,12 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
-      netcoreapp-Windows_NT;
-      netcoreapp-Unix;
-      uap10.0.16299-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
       uap-Windows_NT;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -21,8 +21,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.16299-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\SequencePosition.cs" />
     <Compile Include="System\ThrowHelper.cs" />

--- a/src/System.Threading.Tasks.Extensions/dir.props
+++ b/src/System.Threading.Tasks.Extensions/dir.props
@@ -3,6 +3,9 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <!-- System.Threading.Tasks.Extensions has forwarded types into the runtime on netcoreapp/uap
+         It must win over assemblies versioned at 4.2.* -->
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.3.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>


### PR DESCRIPTION
Now that roll forward is supported we must version our assemblies when surface area changes or when types are moved.

I did a scan of all assemblies that ship an implementation for netcoreapp2.0, have a version >= the version inbox, and the implementation exposes different API or has moved types.

release/2.1 version of #29218 