### PR TITLE
Port three CoreCLR changes missed by mirror.

### DIFF
--- a/src/Common/src/CoreLib/System/Buffers/IMemoryOwner.cs
+++ b/src/Common/src/CoreLib/System/Buffers/IMemoryOwner.cs
@@ -13,6 +13,5 @@ namespace System.Buffers
         /// Returns a Memory<typeparamref name="T"/>.
         /// </summary>
         Memory<T> Memory { get; }
-
     }
 }

--- a/src/Common/src/CoreLib/System/Double.cs
+++ b/src/Common/src/CoreLib/System/Double.cs
@@ -297,7 +297,7 @@ namespace System
         // PositiveInfinity or NegativeInfinity for a number that is too
         // large or too small.
 
-        public static double Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider provider = null)
+        public static double Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider provider = null)
         {
             NumberFormatInfo.ValidateParseStyleFloatingPoint(style);
             return Number.ParseDouble(s, style, NumberFormatInfo.GetInstance(provider));

--- a/src/Common/src/CoreLib/System/Memory.cs
+++ b/src/Common/src/CoreLib/System/Memory.cs
@@ -174,7 +174,7 @@ namespace System
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="Memory{T}"/>
         /// </summary>
-        public static implicit operator Memory<T>(T[] array) => (array != null) ? new Memory<T>(array) : default;
+        public static implicit operator Memory<T>(T[] array) => new Memory<T>(array);
 
         /// <summary>
         /// Defines an implicit conversion of a <see cref="ArraySegment{T}"/> to a <see cref="Memory{T}"/>

--- a/src/Common/src/CoreLib/System/ReadOnlyMemory.cs
+++ b/src/Common/src/CoreLib/System/ReadOnlyMemory.cs
@@ -102,7 +102,7 @@ namespace System
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="ReadOnlyMemory{T}"/>
         /// </summary>
-        public static implicit operator ReadOnlyMemory<T>(T[] array) => (array != null) ? new ReadOnlyMemory<T>(array) : default;
+        public static implicit operator ReadOnlyMemory<T>(T[] array) => new ReadOnlyMemory<T>(array);
 
         /// <summary>
         /// Defines an implicit conversion of a <see cref="ArraySegment{T}"/> to a <see cref="ReadOnlyMemory{T}"/>

--- a/src/Common/src/CoreLib/System/Single.cs
+++ b/src/Common/src/CoreLib/System/Single.cs
@@ -288,7 +288,7 @@ namespace System
             return Number.ParseSingle(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
-        public static float Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider provider = null)
+        public static float Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider provider = null)
         {
             NumberFormatInfo.ValidateParseStyleFloatingPoint(style);
             return Number.ParseSingle(s, style, NumberFormatInfo.GetInstance(provider));

--- a/src/Common/src/CoreLib/System/TimeZoneInfo.Unix.cs
+++ b/src/Common/src/CoreLib/System/TimeZoneInfo.Unix.cs
@@ -1117,6 +1117,37 @@ namespace System
             return result;
         }
 
+        private static DateTime ParseTimeOfDay(string time)
+        {
+            DateTime timeOfDay;
+            TimeSpan? timeOffset = TZif_ParseOffsetString(time);
+            if (timeOffset.HasValue)
+            {
+                // This logic isn't correct and can't be corrected until https://github.com/dotnet/corefx/issues/2618 is fixed.
+                // Some time zones use time values like, "26", "144", or "-2".
+                // This allows the week to sometimes be week 4 and sometimes week 5 in the month.
+                // For now, strip off any 'days' in the offset, and just get the time of day correct
+                timeOffset = new TimeSpan(timeOffset.Value.Hours, timeOffset.Value.Minutes, timeOffset.Value.Seconds);
+                if (timeOffset.Value < TimeSpan.Zero)
+                {
+                    timeOfDay = new DateTime(1, 1, 2, 0, 0, 0);
+                }
+                else
+                {
+                    timeOfDay = new DateTime(1, 1, 1, 0, 0, 0);
+                }
+
+                timeOfDay += timeOffset.Value;
+            }
+            else
+            {
+                // default to 2AM.
+                timeOfDay = new DateTime(1, 1, 1, 2, 0, 0);
+            }
+
+            return timeOfDay;
+        }
+
         private static TransitionTime TZif_CreateTransitionTimeFromPosixRule(string date, string time)
         {
             if (string.IsNullOrEmpty(date))
@@ -1138,48 +1169,90 @@ namespace System
                     throw new InvalidTimeZoneException(SR.Format(SR.InvalidTimeZone_UnparseablePosixMDateString, date));
                 }
 
-                DateTime timeOfDay;
-                TimeSpan? timeOffset = TZif_ParseOffsetString(time);
-                if (timeOffset.HasValue)
-                {
-                    // This logic isn't correct and can't be corrected until https://github.com/dotnet/corefx/issues/2618 is fixed.
-                    // Some time zones use time values like, "26", "144", or "-2".
-                    // This allows the week to sometimes be week 4 and sometimes week 5 in the month.
-                    // For now, strip off any 'days' in the offset, and just get the time of day correct
-                    timeOffset = new TimeSpan(timeOffset.Value.Hours, timeOffset.Value.Minutes, timeOffset.Value.Seconds);
-                    if (timeOffset.Value < TimeSpan.Zero)
-                    {
-                        timeOfDay = new DateTime(1, 1, 2, 0, 0, 0);
-                    }
-                    else
-                    {
-                        timeOfDay = new DateTime(1, 1, 1, 0, 0, 0);
-                    }
-
-                    timeOfDay += timeOffset.Value;
-                }
-                else
-                {
-                    // default to 2AM.
-                    timeOfDay = new DateTime(1, 1, 1, 2, 0, 0);
-                }
-
-                return TransitionTime.CreateFloatingDateRule(timeOfDay, month, week, day);
+                return TransitionTime.CreateFloatingDateRule(ParseTimeOfDay(time), month, week, day);
             }
             else
             {
-                // Jn
-                // This specifies the Julian day, with n between 1 and 365.February 29 is never counted, even in leap years.
+                if (date[0] != 'J')
+                {
+                    // should be n Julian day format which we don't support.
+                    //
+                    // This specifies the Julian day, with n between 0 and 365. February 29 is counted in leap years.
+                    //
+                    // n would be a relative number from the begining of the year. which should handle if the
+                    // the year is a leap year or not.
+                    //
+                    // In leap year, n would be counted as:
+                    //
+                    // 0                30 31              59 60              90      335            365
+                    // |-------Jan--------|-------Feb--------|-------Mar--------|....|-------Dec--------|
+                    //
+                    // while in non leap year we'll have
+                    //
+                    // 0                30 31              58 59              89      334            364
+                    // |-------Jan--------|-------Feb--------|-------Mar--------|....|-------Dec--------|
+                    //
+                    //
+                    // For example if n is specified as 60, this means in leap year the rule will start at Mar 1,
+                    // while in non leap year the rule will start at Mar 2.
+                    //
+                    // If we need to support n format, we'll have to have a floating adjustment rule support this case.
 
-                // n
-                // This specifies the Julian day, with n between 0 and 365.February 29 is counted in leap years.
+                    throw new InvalidTimeZoneException(SR.InvalidTimeZone_NJulianDayNotSupported);
+                }
 
-                // These two rules cannot be expressed with the current AdjustmentRules
-                // One of them *could* be supported if we relaxed the TransitionTime validation rules, and allowed
-                // "IsFixedDateRule = true, Month = 0, Day = n" to mean the nth day of the year, picking one of the rules above
-
-                throw new InvalidTimeZoneException(SR.InvalidTimeZone_JulianDayNotSupported);
+                // Julian day
+                TZif_ParseJulianDay(date, out int month, out int day);
+                return TransitionTime.CreateFixedDateRule(ParseTimeOfDay(time), month, day);
             }
+        }
+
+        /// <summary>
+        /// Parses a string like Jn or n into month and day values.
+        /// </summary>
+        /// <returns>
+        /// true if the parsing succeeded; otherwise, false.
+        /// </returns>
+        private static void TZif_ParseJulianDay(string date, out int month, out int day)
+        {
+            // Jn
+            // This specifies the Julian day, with n between 1 and 365.February 29 is never counted, even in leap years.
+            Debug.Assert(date[0] == 'J');
+            Debug.Assert(!String.IsNullOrEmpty(date));
+            month = day = 0;
+
+            int index = 1;
+
+            if (index >= date.Length || ((uint)(date[index] - '0') > '9'-'0'))
+            {
+                throw new InvalidTimeZoneException(SR.InvalidTimeZone_InvalidJulianDay);
+            }
+
+            int julianDay = 0;
+
+            do
+            {
+                julianDay = julianDay * 10 + (int) (date[index] - '0');
+                index++;
+            } while (index < date.Length && ((uint)(date[index] - '0') <= '9'-'0'));
+
+            int[] days = GregorianCalendarHelper.DaysToMonth365;
+
+            if (julianDay == 0 || julianDay > days[days.Length - 1])
+            {
+                throw new InvalidTimeZoneException(SR.InvalidTimeZone_InvalidJulianDay);
+            }
+
+            int i = 1;
+            while (i < days.Length && julianDay > days[i])
+            {
+                i++;
+            }
+
+            Debug.Assert(i > 0 && i < days.Length);
+
+            month = i;
+            day = julianDay - days[i - 1];
         }
 
         /// <summary>


### PR DESCRIPTION
At least part of this one (although it's old, CoreCLR change is older)

https://github.com/dotnet/coreclr/commit/4456cc99ba0fbe3c02be3a9f54c34282caeb7218
Author: Ahson Khan <ahkha@microsoft.com>
Date:   Fri Feb 2 19:30:25 2018 -0800

Changing Span/Memory to return default on null instead of throwing. (#16186)
Additional changes based on feedback (bounds checks)
Adding remaining bounds checks

M       src/mscorlib/shared/System/Memory.cs
M       src/mscorlib/shared/System/ReadOnlyMemory.cs
M       src/mscorlib/shared/System/ReadOnlySpan.Fast.cs
M       src/mscorlib/shared/System/ReadOnlySpan.cs
M       src/mscorlib/shared/System/Span.Fast.cs
M       src/mscorlib/shared/System/Span.NonGeneric.cs
M       src/mscorlib/shared/System/Span.cs

and two that are only in code not built in CoreFX, porting so we can start the mirror up without issues:

https://github.com/dotnet/coreclr/commit/3b3ef2add7b99d8acc3f0a156527d45a6f9e295b
Author: Tarek Mahmoud Sayed <tarekms@microsoft.com>
Date:   Thu Apr 19 13:14:12 2018 -0700

Fix reading Time zone rules using Julian days (#17672)

M       src/mscorlib/Resources/Strings.resx
M       src/mscorlib/shared/System/TimeZoneInfo.Unix.cs

https://github.com/dotnet/coreclr/commit/3db838482038472ee9d75e3a204a77542d30b82b
Author: Stephen Toub <stoub@microsoft.com>
Date:   Fri Apr 13 19:07:34 2018 -0400

Fix default style argument to Double/Single/Decimal.Parse (#17556)

M       src/mscorlib/shared/System/Double.cs
M       src/mscorlib/shared/System/Single.cs
M       src/mscorlib/src/System/Decimal.cs

Reconciliation on other side is in https://github.com/dotnet/coreclr/pull/17713