### PR TITLE
Refactoring ReadOnlySequence tests

### DIFF
--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Memory.Tests
 {
-    public abstract class ReadOnlySequenceTestsByte
+    public abstract class ReadOnlySequenceTestsByte: ReadOnlySequenceTests<byte>
     {
         public class Array : ReadOnlySequenceTestsByte
         {
@@ -36,29 +36,7 @@ namespace System.Memory.Tests
             public SplitInThreeSegments() : base(ReadOnlySequenceFactory<byte>.SplitInThree) { }
         }
 
-        internal ReadOnlySequenceFactory<byte> Factory { get; }
-
-        internal ReadOnlySequenceTestsByte(ReadOnlySequenceFactory<byte> factory)
-        {
-            Factory = factory;
-        }
-
-        [Fact]
-        public void EmptyIsCorrect()
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(0);
-            Assert.Equal(0, buffer.Length);
-            Assert.True(buffer.IsEmpty);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        [InlineData(8)]
-        public void LengthIsCorrect(int length)
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(length);
-            Assert.Equal(length, buffer.Length);
-        }
+        internal ReadOnlySequenceTestsByte(ReadOnlySequenceFactory<byte> factory): base(factory) { }
 
         [Theory]
         [InlineData(1)]
@@ -85,56 +63,6 @@ namespace System.Memory.Tests
             ReadOnlySequence<byte> buffer = Factory.CreateWithContent(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
             ReadOnlySequence<byte> slice = func(buffer);
             Assert.Equal(new byte[] { 5, 6, 7, 8, 9 }, slice.ToArray());
-        }
-
-        [Theory]
-        [MemberData(nameof(OutOfRangeSliceCases))]
-        public void ReadOnlyBufferDoesNotAllowSlicingOutOfRange(Action<ReadOnlySequence<byte>> fail)
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(100);
-            Assert.Throws<ArgumentOutOfRangeException>(() => fail(buffer));
-        }
-
-        [Fact]
-        public void ReadOnlyBufferGetPosition_MovesPosition()
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(100);
-
-            SequencePosition position = buffer.GetPosition(65);
-            Assert.Equal(buffer.Slice(position).Length, 35);
-
-            position = buffer.GetPosition(65, buffer.Start);
-            Assert.Equal(buffer.Slice(position).Length, 35);
-        }
-
-        [Fact]
-        public void ReadOnlyBufferGetPosition_ChecksBounds()
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(100);
-            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(101));
-            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(101, buffer.Start));
-        }
-
-        [Fact]
-        public void ReadOnlyBufferGetPosition_DoesNotAlowNegative()
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(20);
-            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(-1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(-1, buffer.Start));
-        }
-
-        [Fact]
-        public void ReadOnlyBufferSlice_ChecksEnd()
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(100);
-            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Slice(70, buffer.Start));
-        }
-
-        [Fact]
-        public void SliceToTheEndWorks()
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(10);
-            Assert.True(buffer.Slice(buffer.End).IsEmpty);
         }
 
         [Theory]
@@ -168,142 +96,5 @@ namespace System.Memory.Tests
 
             Assert.Null(result);
         }
-
-        [Fact]
-        public void CopyTo_ThrowsWhenSourceLargerThenDestination()
-        {
-            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(10);
-
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                Span<byte> span = new byte[5];
-                buffer.CopyTo(span);
-            });
-        }
-
-        public static TheoryData<Func<ReadOnlySequence<byte>, ReadOnlySequence<byte>>> ValidSliceCases => new TheoryData<Func<ReadOnlySequence<byte>, ReadOnlySequence<byte>>>
-        {
-            b => b.Slice(5),
-            b => b.Slice(0).Slice(5),
-            b => b.Slice(5, 5),
-            b => b.Slice(b.GetPosition(5), 5),
-            b => b.Slice(5, b.GetPosition(10)),
-            b => b.Slice(b.GetPosition(5), b.GetPosition(10)),
-            b => b.Slice(b.GetPosition(5, b.Start), 5),
-            b => b.Slice(5, b.GetPosition(10, b.Start)),
-            b => b.Slice(b.GetPosition(5, b.Start), b.GetPosition(10, b.Start)),
-
-            b => b.Slice((long)5),
-            b => b.Slice((long)5, 5),
-            b => b.Slice(b.GetPosition(5), (long)5),
-            b => b.Slice((long)5, b.GetPosition(10)),
-            b => b.Slice(b.GetPosition(5, b.Start), (long)5),
-            b => b.Slice((long)5, b.GetPosition(10, b.Start)),
-        };
-
-        public static TheoryData<Action<ReadOnlySequence<byte>>> OutOfRangeSliceCases => new TheoryData<Action<ReadOnlySequence<byte>>>
-        {
-            // negative start	
-            b => b.Slice(-1), // no length
-            b => b.Slice(-1, -1), // negative length
-            b => b.Slice(-1, 0), // zero length
-            b => b.Slice(-1, 1), // positive length
-            b => b.Slice(-1, 101), // after end length
-            b => b.Slice(-1, b.Start), // to start
-            b => b.Slice(-1, b.End), // to end
-
-            // zero start
-            b => b.Slice(0, -1), // negative length
-            b => b.Slice(0, 101), // after end length
-
-            // end start
-            b => b.Slice(100, -1), // negative length
-            b => b.Slice(100, 1), // after end length
-            b => b.Slice(100, b.Start), // to start
-
-            // After end start
-            b => b.Slice(101), // no length
-            b => b.Slice(101, -1), // negative length
-            b => b.Slice(101, 0), // zero length
-            b => b.Slice(101, 1), // after end length
-            b => b.Slice(101, b.Start), // to start
-            b => b.Slice(101, b.End), // to end
-
-            // At Start start
-            b => b.Slice(b.Start, -1), // negative length
-            b => b.Slice(b.Start, 101), // after end length
-
-            // At End start
-            b => b.Slice(b.End, -1), // negative length
-            b => b.Slice(b.End, 1), // after end length
-            b => b.Slice(b.End, b.Start), // to start
-
-            // Slice at begin
-            b => b.Slice(0, 70).Slice(0, b.End), // to after end
-            b => b.Slice(0, 70).Slice(b.Start, b.End), // to after end
-            // from after end
-            b => b.Slice(0, 70).Slice(b.End),
-            b => b.Slice(0, 70).Slice(b.End, -1), // negative length
-            b => b.Slice(0, 70).Slice(b.End, 0), // zero length
-            b => b.Slice(0, 70).Slice(b.End, 1), // after end length
-            b => b.Slice(0, 70).Slice(b.End, b.Start), // to start
-            b => b.Slice(0, 70).Slice(b.End, b.End), // to after end
-
-            // Slice at begin
-            b => b.Slice(b.Start, 70).Slice(0, b.End), // to after end
-            b => b.Slice(b.Start, 70).Slice(b.Start, b.End), // to after end
-            // from after end
-            b => b.Slice(b.Start, 70).Slice(b.End),
-            b => b.Slice(b.Start, 70).Slice(b.End, -1), // negative length
-            b => b.Slice(b.Start, 70).Slice(b.End, 0), // zero length
-            b => b.Slice(b.Start, 70).Slice(b.End, 1), // after end length
-            b => b.Slice(b.Start, 70).Slice(b.End, b.Start), // to start
-            b => b.Slice(b.Start, 70).Slice(b.End, b.End), // to after end
-
-            // Slice at middle
-            b => b.Slice(30, 40).Slice(0, b.Start), // to before start
-            b => b.Slice(30, 40).Slice(0, b.End), // to after end
-            // from before start
-            b => b.Slice(30, 40).Slice(b.Start),
-            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
-            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
-            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
-            b => b.Slice(30, 40).Slice(b.Start, 41), // after end length
-            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
-            b => b.Slice(30, 40).Slice(b.Start, b.End), // to after end
-            // from after end
-            b => b.Slice(30, 40).Slice(b.End),
-            b => b.Slice(b.Start, 70).Slice(b.End, -1), // negative length
-            b => b.Slice(b.Start, 70).Slice(b.End, 0), // zero length
-            b => b.Slice(b.Start, 70).Slice(b.End, 1), // after end length
-            b => b.Slice(30, 40).Slice(b.End, b.Start), // to before start
-            b => b.Slice(30, 40).Slice(b.End, b.End), // to after end
-
-            // Slice at end
-            b => b.Slice(70, 30).Slice(0, b.Start), // to before start
-            // from before start
-            b => b.Slice(30, 40).Slice(b.Start),
-            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
-            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
-            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
-            b => b.Slice(30, 40).Slice(b.Start, 31), // after end length
-            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
-            b => b.Slice(30, 40).Slice(b.Start, b.End), // to end
-            // from end
-            b => b.Slice(70, 30).Slice(b.End, b.Start), // to before start
-
-            // Slice at end
-            b => b.Slice(70, 30).Slice(0, b.Start), // to before start
-            // from before start
-            b => b.Slice(30, 40).Slice(b.Start),
-            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
-            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
-            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
-            b => b.Slice(30, 40).Slice(b.Start, 31), // after end length
-            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
-            b => b.Slice(30, 40).Slice(b.Start, b.End), // to end
-            // from end
-            b => b.Slice(70, 30).Slice(b.End, b.Start), // to before start
-        };
     }
 }

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.cs
@@ -1,0 +1,223 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using Xunit;
+
+namespace System.Memory.Tests
+{
+    public abstract class ReadOnlySequenceTests<T>
+    {
+        internal ReadOnlySequenceFactory<T> Factory { get; }
+
+        internal ReadOnlySequenceTests(ReadOnlySequenceFactory<T> factory)
+        {
+            Factory = factory;
+        }
+
+        [Fact]
+        public void EmptyIsCorrect()
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(0);
+            Assert.Equal(0, buffer.Length);
+            Assert.True(buffer.IsEmpty);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(8)]
+        public void LengthIsCorrect(int length)
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(length);
+            Assert.Equal(length, buffer.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(OutOfRangeSliceCases))]
+        public void ReadOnlyBufferDoesNotAllowSlicingOutOfRange(Action<ReadOnlySequence<T>> fail)
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(100);
+            Assert.Throws<ArgumentOutOfRangeException>(() => fail(buffer));
+        }
+
+        [Fact]
+        public void ReadOnlyBufferGetPosition_MovesPosition()
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(100);
+
+            SequencePosition position = buffer.GetPosition(65);
+            Assert.Equal(buffer.Slice(position).Length, 35);
+
+            position = buffer.GetPosition(65, buffer.Start);
+            Assert.Equal(buffer.Slice(position).Length, 35);
+        }
+
+        [Fact]
+        public void ReadOnlyBufferGetPosition_ChecksBounds()
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(100);
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(101));
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(101, buffer.Start));
+        }
+
+        [Fact]
+        public void ReadOnlyBufferGetPosition_DoesNotAlowNegative()
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(20);
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.GetPosition(-1, buffer.Start));
+        }
+
+        [Fact]
+        public void ReadOnlyBufferSlice_ChecksEnd()
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(100);
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Slice(70, buffer.Start));
+        }
+
+        [Fact]
+        public void SliceToTheEndWorks()
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(10);
+            Assert.True(buffer.Slice(buffer.End).IsEmpty);
+        }
+
+        [Fact]
+        public void CopyTo_ThrowsWhenSourceLargerThenDestination()
+        {
+            ReadOnlySequence<T> buffer = Factory.CreateOfSize(10);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Span<T> span = new T[5];
+                buffer.CopyTo(span);
+            });
+        }
+
+        public static TheoryData<Func<ReadOnlySequence<T>, ReadOnlySequence<T>>> ValidSliceCases => new TheoryData<Func<ReadOnlySequence<T>, ReadOnlySequence<T>>>
+        {
+            b => b.Slice(5),
+            b => b.Slice(0).Slice(5),
+            b => b.Slice(5, 5),
+            b => b.Slice(b.GetPosition(5), 5),
+            b => b.Slice(5, b.GetPosition(10)),
+            b => b.Slice(b.GetPosition(5), b.GetPosition(10)),
+            b => b.Slice(b.GetPosition(5, b.Start), 5),
+            b => b.Slice(5, b.GetPosition(10, b.Start)),
+            b => b.Slice(b.GetPosition(5, b.Start), b.GetPosition(10, b.Start)),
+
+            b => b.Slice((long)5),
+            b => b.Slice((long)5, 5),
+            b => b.Slice(b.GetPosition(5), (long)5),
+            b => b.Slice((long)5, b.GetPosition(10)),
+            b => b.Slice(b.GetPosition(5, b.Start), (long)5),
+            b => b.Slice((long)5, b.GetPosition(10, b.Start)),
+        };
+
+        public static TheoryData<Action<ReadOnlySequence<T>>> OutOfRangeSliceCases => new TheoryData<Action<ReadOnlySequence<T>>>
+        {
+            // negative start	
+            b => b.Slice(-1), // no length
+            b => b.Slice(-1, -1), // negative length
+            b => b.Slice(-1, 0), // zero length
+            b => b.Slice(-1, 1), // positive length
+            b => b.Slice(-1, 101), // after end length
+            b => b.Slice(-1, b.Start), // to start
+            b => b.Slice(-1, b.End), // to end
+
+            // zero start
+            b => b.Slice(0, -1), // negative length
+            b => b.Slice(0, 101), // after end length
+
+            // end start
+            b => b.Slice(100, -1), // negative length
+            b => b.Slice(100, 1), // after end length
+            b => b.Slice(100, b.Start), // to start
+
+            // After end start
+            b => b.Slice(101), // no length
+            b => b.Slice(101, -1), // negative length
+            b => b.Slice(101, 0), // zero length
+            b => b.Slice(101, 1), // after end length
+            b => b.Slice(101, b.Start), // to start
+            b => b.Slice(101, b.End), // to end
+
+            // At Start start
+            b => b.Slice(b.Start, -1), // negative length
+            b => b.Slice(b.Start, 101), // after end length
+
+            // At End start
+            b => b.Slice(b.End, -1), // negative length
+            b => b.Slice(b.End, 1), // after end length
+            b => b.Slice(b.End, b.Start), // to start
+
+            // Slice at begin
+            b => b.Slice(0, 70).Slice(0, b.End), // to after end
+            b => b.Slice(0, 70).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(0, 70).Slice(b.End),
+            b => b.Slice(0, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(0, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(0, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(0, 70).Slice(b.End, b.Start), // to start
+            b => b.Slice(0, 70).Slice(b.End, b.End), // to after end
+
+            // Slice at begin
+            b => b.Slice(b.Start, 70).Slice(0, b.End), // to after end
+            b => b.Slice(b.Start, 70).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(b.Start, 70).Slice(b.End),
+            b => b.Slice(b.Start, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(b.Start, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(b.Start, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(b.Start, 70).Slice(b.End, b.Start), // to start
+            b => b.Slice(b.Start, 70).Slice(b.End, b.End), // to after end
+
+            // Slice at middle
+            b => b.Slice(30, 40).Slice(0, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(0, b.End), // to after end
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 41), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to after end
+            // from after end
+            b => b.Slice(30, 40).Slice(b.End),
+            b => b.Slice(b.Start, 70).Slice(b.End, -1), // negative length
+            b => b.Slice(b.Start, 70).Slice(b.End, 0), // zero length
+            b => b.Slice(b.Start, 70).Slice(b.End, 1), // after end length
+            b => b.Slice(30, 40).Slice(b.End, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.End, b.End), // to after end
+
+            // Slice at end
+            b => b.Slice(70, 30).Slice(0, b.Start), // to before start
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 31), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to end
+            // from end
+            b => b.Slice(70, 30).Slice(b.End, b.Start), // to before start
+
+            // Slice at end
+            b => b.Slice(70, 30).Slice(0, b.Start), // to before start
+            // from before start
+            b => b.Slice(30, 40).Slice(b.Start),
+            b => b.Slice(30, 40).Slice(b.Start, -1), // negative length
+            b => b.Slice(30, 40).Slice(b.Start, 0), // zero length
+            b => b.Slice(30, 40).Slice(b.Start, 1), // positive length
+            b => b.Slice(30, 40).Slice(b.Start, 31), // after end length
+            b => b.Slice(30, 40).Slice(b.Start, b.Start), // to before start
+            b => b.Slice(30, 40).Slice(b.Start, b.End), // to end
+            // from end
+            b => b.Slice(70, 30).Slice(b.End, b.Start), // to before start
+        };
+    }
+}

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.char.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.byte.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Default.cs" />


### PR DESCRIPTION
I refactored ReadOnlySequence tests to remove code duplicates and to not duplicate tests in future. It was part of https://github.com/dotnet/corefx/pull/29231 PR