### PR TITLE
Fix crossfs build for armel jessie

### DIFF
--- a/cross/armel/sources.list.jessie
+++ b/cross/armel/sources.list.jessie
@@ -1,7 +1,3 @@
 deb http://ftp.debian.org/debian/ jessie main contrib non-free
 deb-src http://ftp.debian.org/debian/ jessie main contrib non-free
 
-# Stable repo is the only repo that has llvm for armel
-deb http://ftp.debian.org/debian/ stable main contrib non-free
-deb-src http://ftp.debian.org/debian/ stable main contrib non-free
-


### PR DESCRIPTION
The source list was incorrectly containing stable/main sources in addition
to the jessie/main. That caused the openssl 1.1 to creep in and the
build with such crossfs was failing since we were trying to compile
against ssl 1.1 headers.
The reason why it was working in the past is that the stable branch used
to be something older and so it didn't have this issue.
The stable repo reference most likely came from coreclr where it was 
needed to get the lldb-dev package.