### PR TITLE
De-duplicate resource ID's to make Mono merge easier

### DIFF
--- a/src/Common/tests/Resources/Strings.resx
+++ b/src/Common/tests/Resources/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Argument_InvalidPathChars" xml:space="preserve">
-    <value>Argument_InvalidPathChars {0}</value>
+    <value>Illegal characters in path '{0}'.</value>
   </data>
   <data name="IO_FileNotFound" xml:space="preserve">
     <value>IO_FileNotFound</value>

--- a/src/Common/tests/Resources/Strings.resx
+++ b/src/Common/tests/Resources/Strings.resx
@@ -118,43 +118,43 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Argument_InvalidPathChars" xml:space="preserve">
-    <value>Illegal characters in path '{0}'.</value>
+    <value>Argument_InvalidPathChars {0}</value>
   </data>
   <data name="IO_FileNotFound" xml:space="preserve">
-    <value>Unable to find the specified file.</value>
+    <value>IO_FileNotFound</value>
   </data>
   <data name="IO_FileNotFound_FileName" xml:space="preserve">
-    <value>Could not find file '{0}'.</value>
+    <value>IO_FileNotFound_FileName {0}</value>
   </data>
   <data name="IO_PathNotFound_NoPathName" xml:space="preserve">
-    <value>Could not find a part of the path.</value>
+    <value>IO_PathNotFound_NoPathName</value>
   </data>
   <data name="IO_PathNotFound_Path" xml:space="preserve">
-    <value>Could not find a part of the path '{0}'.</value>
+    <value>IO_PathNotFound_Path {0}</value>
   </data>
   <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
-    <value>Access to the path is denied.</value>
+    <value>UnauthorizedAccess_IODenied_NoPathName</value>
   </data>
   <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
-    <value>Access to the path '{0}' is denied.</value>
+    <value>UnauthorizedAccess_IODenied_Path {0}</value>
   </data>
   <data name="IO_AlreadyExists_Name" xml:space="preserve">
-    <value>Cannot create '{0}' because a file or directory with the same name already exists.</value>
+    <value>IO_AlreadyExists_Name {0}</value>
   </data>
   <data name="IO_FileExists_Name" xml:space="preserve">
-    <value>The file '{0}' already exists.</value>
+    <value>IO_FileExists_Name {0}</value>
   </data>
   <data name="IO_PathTooLong" xml:space="preserve">
-    <value>The specified file name or path is too long, or a component of the specified path is too long.</value>
+    <value>IO_PathTooLong</value>
   </data>
   <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
-    <value>The process cannot access the file because it is being used by another process.</value>
+    <value>IO_SharingViolation_NoFileName</value>
   </data>
   <data name="IO_SharingViolation_File" xml:space="preserve">
-    <value>The process cannot access the file '{0}' because it is being used by another process.</value>
+    <value>IO_SharingViolation_File {0}</value>
   </data>
   <data name="IO_PathTooLong_Path" xml:space="preserve">
-    <value>The path '{0}' is too long, or a component of the specified path is too long.</value>
+    <value>IO_PathTooLong_Path {0}</value>
   </data>
   <data name="Arg_InvalidSearchPattern" xml:space="preserve">
     <value>Arg_InvalidSearchPattern {0}</value>

--- a/src/Common/tests/Resources/Strings.resx
+++ b/src/Common/tests/Resources/Strings.resx
@@ -121,40 +121,40 @@
     <value>Illegal characters in path '{0}'.</value>
   </data>
   <data name="IO_FileNotFound" xml:space="preserve">
-    <value>IO_FileNotFound</value>
+    <value>Unable to find the specified file.</value>
   </data>
   <data name="IO_FileNotFound_FileName" xml:space="preserve">
-    <value>IO_FileNotFound_FileName {0}</value>
+    <value>Could not find file '{0}'.</value>
   </data>
   <data name="IO_PathNotFound_NoPathName" xml:space="preserve">
-    <value>IO_PathNotFound_NoPathName</value>
+    <value>Could not find a part of the path.</value>
   </data>
   <data name="IO_PathNotFound_Path" xml:space="preserve">
-    <value>IO_PathNotFound_Path {0}</value>
+    <value>Could not find a part of the path '{0}'.</value>
   </data>
   <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
-    <value>UnauthorizedAccess_IODenied_NoPathName</value>
+    <value>Access to the path is denied.</value>
   </data>
   <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
-    <value>UnauthorizedAccess_IODenied_Path {0}</value>
+    <value>Access to the path '{0}' is denied.</value>
   </data>
   <data name="IO_AlreadyExists_Name" xml:space="preserve">
-    <value>IO_AlreadyExists_Name {0}</value>
+    <value>Cannot create '{0}' because a file or directory with the same name already exists.</value>
   </data>
   <data name="IO_FileExists_Name" xml:space="preserve">
-    <value>IO_FileExists_Name {0}</value>
+    <value>The file '{0}' already exists.</value>
   </data>
   <data name="IO_PathTooLong" xml:space="preserve">
-    <value>IO_PathTooLong</value>
+    <value>The specified file name or path is too long, or a component of the specified path is too long.</value>
   </data>
   <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
-    <value>IO_SharingViolation_NoFileName</value>
+    <value>The process cannot access the file because it is being used by another process.</value>
   </data>
   <data name="IO_SharingViolation_File" xml:space="preserve">
-    <value>IO_SharingViolation_File {0}</value>
+    <value>The process cannot access the file '{0}' because it is being used by another process.</value>
   </data>
   <data name="IO_PathTooLong_Path" xml:space="preserve">
-    <value>IO_PathTooLong_Path {0}</value>
+    <value>The path '{0}' is too long, or a component of the specified path is too long.</value>
   </data>
   <data name="Arg_InvalidSearchPattern" xml:space="preserve">
     <value>Arg_InvalidSearchPattern {0}</value>

--- a/src/FindResourceDuplicates.ps1
+++ b/src/FindResourceDuplicates.ps1
@@ -1,6 +1,11 @@
-﻿Write-Host "Running..."
+﻿# Xamarin ingests much of CoreFX code into Mono. Because they use .NET Framework assembly factoring they
+# must merge some of our resx files. If the same resource ID is used for different strings, they cannot be merged.
+# This script can be run periodically to detect any such collisions. They can then be resolved either by changing to
+# use the same string, or by de-duplicating the ID's.
+
+Write-Host "Running..."
 $currentPath = Get-Location
-$resouces = New-Object 'System.Collections.Generic.Dictionary[String,Collections.Generic.List[ResouceRecord]]'
+$resouces = New-Object 'System.Collections.Generic.Dictionary[String,Collections.Generic.List[ResourceRecord]]'
 foreach ($resourceFile in Get-ChildItem $currentPath  -recurse -include Strings.resx)
 {
     if ($resourceFile -like "*\tests\*")
@@ -15,11 +20,11 @@ foreach ($resourceFile in Get-ChildItem $currentPath  -recurse -include Strings.
     {
         if(!$resouces.ContainsKey($resource.name))
         {
-            $resourceList = New-Object Collections.Generic.List[ResouceRecord]            
+            $resourceList = New-Object Collections.Generic.List[ResourceRecord]            
             $resouces.Add($resource.name,$resourceList)
         }    
             
-        $record = New-Object ResouceRecord
+        $record = New-Object ResourceRecord
         $record.value = $resource.value
         $record.fileName = $resourceFile
 
@@ -61,7 +66,7 @@ else
     Write-Host "No duplicates found."
 }          
    
-class ResouceRecord
+class ResourceRecord
 {
     [String]$value
     [String]$fileName

--- a/src/FindResourceDuplicates.ps1
+++ b/src/FindResourceDuplicates.ps1
@@ -1,0 +1,50 @@
+﻿Write-Host "Running..."
+$currentPath = Get-Location
+$resouces = New-Object 'System.Collections.Generic.Dictionary[String,Collections.Generic.List[string]]'
+foreach ($resourceFile in Get-ChildItem $currentPath  -recurse -include Strings.resx)
+{
+    if ($resourceFile -like "*\tests\*")
+    {
+        continue
+    }
+
+    #Write-Host "Analyzing  $($resourceFile)"
+
+    [xml]$XDocument = Get-Content -Path $resourceFile    
+    foreach($resource in $XDocument.SelectNodes("//root/data"))
+    {
+        if(!$resouces.ContainsKey($resource.name))
+        {
+            $resourceList = New-Object Collections.Generic.List[string]
+            $resouces.Add($resource.name,$resourceList)
+        }        
+        $resouces[$resource.name].Add($resource.value);
+    }                       
+}
+
+$duplicates = New-Object 'Collections.Generic.List[string]'
+
+foreach($resouce in $resouces.GetEnumerator())
+{
+    $count = ($resouce.value | Get-Unique).count
+    if($count -gt 1)
+    {       
+        foreach($value in $resouce.value.GetEnumerator())
+        {
+            $duplicates.Add("$($resouce.key) $($value)")
+        }
+    }
+}
+     
+if($duplicates.Count -gt 0)
+{
+    foreach($dup in $duplicates.GetEnumerator())
+    {
+        Write-Host $($dup)
+    }
+}
+else
+{
+    Write-Host "No duplicates found."
+}            
+   

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ExceptionUtils.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ExceptionUtils.vb
@@ -71,7 +71,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
         ' default constructor
         Public Sub New()
-            MyBase.New(GetResourceString(SR.InternalError))
+            MyBase.New(GetResourceString(SR.InternalError_VisualBasicRuntime))
         End Sub
 
     End Class

--- a/src/Microsoft.VisualBasic/src/Resources/Strings.resx
+++ b/src/Microsoft.VisualBasic/src/Resources/Strings.resx
@@ -71,7 +71,7 @@
     <value>Loop control variable of type '{1}' does not implement the 'System.IComparable' interface.</value>
   </data>
   <data name="Argument_InvalidValue" xml:space="preserve">
-    <value>Arguments are not valid.</value>
+    <value>Value was invalid.</value>
   </data>
   <data name="ForLoop_CommonType2" xml:space="preserve">
     <value>Cannot convert start value of type '{0}' and step value of type '{1}' to a common numeric type.</value>
@@ -91,7 +91,7 @@
   <data name="ForLoop_UnacceptableRelOperator2" xml:space="preserve">
     <value>Parameter types of '{0}' must be of type '{1}' to be used in a 'For' statement.</value>
   </data>
-  <data name="InternalError" xml:space="preserve">
+  <data name="InternalError_VisualBasicRuntime" xml:space="preserve">
     <value>Internal error in the Microsoft Visual Basic runtime.</value>
   </data>
   <data name="Argument_InvalidNullValue1" xml:space="preserve">

--- a/src/System.Collections.NonGeneric/src/Resources/Strings.resx
+++ b/src/System.Collections.NonGeneric/src/Resources/Strings.resx
@@ -61,6 +61,9 @@
   <data name="Argument_AddingDuplicate" xml:space="preserve">
     <value>An item with the same key has already been added. Key: {0}</value>
   </data>
+  <data name="Argument_AddingDuplicate_OldAndNewKeys " xml:space="preserve">
+    <value>Item has already been added. Key in dictionary: '{0}'  Key being added: '{1}'</value>
+  </data>
   <data name="Argument_ImplementIComparable" xml:space="preserve">
     <value>At least one object must implement IComparable.</value>
   </data>

--- a/src/System.Collections.NonGeneric/src/Resources/Strings.resx
+++ b/src/System.Collections.NonGeneric/src/Resources/Strings.resx
@@ -58,8 +58,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Argument_AddingDuplicate__" xml:space="preserve">
-    <value>Item has already been added. Key in dictionary: '{0}'  Key being added: '{1}'</value>
+  <data name="Argument_AddingDuplicate" xml:space="preserve">
+    <value>An item with the same key has already been added. Key: {0}</value>
   </data>
   <data name="Argument_ImplementIComparable" xml:space="preserve">
     <value>At least one object must implement IComparable.</value>
@@ -110,7 +110,7 @@
     <value>Enumeration already finished.</value>
   </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
-    <value>Collection was modified; enumeration operation may not execute.</value>
+    <value>Collection was modified after the enumerator was instantiated.</value>
   </data>
   <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
     <value>Enumeration has not started. Call MoveNext.</value>

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -192,7 +192,7 @@ namespace System.Collections
 
             int i = Array.BinarySearch(keys, 0, _size, key, comparer);
             if (i >= 0)
-                throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate__, GetKey(i), key));
+                throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate, key));
             Insert(~i, key, value);
         }
 

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -192,7 +192,7 @@ namespace System.Collections
 
             int i = Array.BinarySearch(keys, 0, _size, key, comparer);
             if (i >= 0)
-                throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate, key));
+                throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate_OldAndNewKeys, GetKey(i), key));
             Insert(~i, key, value);
         }
 

--- a/src/System.Collections.Specialized/src/Resources/Strings.resx
+++ b/src/System.Collections.Specialized/src/Resources/Strings.resx
@@ -68,10 +68,10 @@
     <value>Index is less than zero.</value>
   </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
-    <value>Collection was modified after the enumerator was instantiated.</value>
+    <value>Collection was modified; enumeration operation may not execute.</value>
   </data>
   <data name="InvalidOperation_EnumOpCantHappen" xml:space="preserve">
-    <value>Enumerator is positioned before the first element or after the last element of the collection.</value>
+    <value>Enumeration has either not started or has already finished.</value>
   </data>
   <data name="Arg_MultiRank" xml:space="preserve">
     <value>Multi dimension array is not supported on this operation.</value>

--- a/src/System.Collections.Specialized/src/Resources/Strings.resx
+++ b/src/System.Collections.Specialized/src/Resources/Strings.resx
@@ -68,7 +68,7 @@
     <value>Index is less than zero.</value>
   </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
-    <value>Collection was modified; enumeration operation may not execute.</value>
+    <value>Collection was modified after the enumerator was instantiated.</value>
   </data>
   <data name="InvalidOperation_EnumOpCantHappen" xml:space="preserve">
     <value>Enumeration has either not started or has already finished.</value>

--- a/src/System.Collections.Specialized/src/Resources/Strings.resx
+++ b/src/System.Collections.Specialized/src/Resources/Strings.resx
@@ -61,10 +61,10 @@
   <data name="Argument_AddingDuplicate" xml:space="preserve">
     <value>An item with the same key has already been added. Key: {0}</value>
   </data>
-  <data name="Argument_InvalidValue" xml:space="preserve">
+  <data name="Argument_InvalidValue_TooSmall" xml:space="preserve">
     <value>Argument {0} should be larger than {1}.</value>
   </data>
-  <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
+  <data name="ArgumentOutOfRange_NeedNonNegNum_Index" xml:space="preserve">
     <value>Index is less than zero.</value>
   </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
@@ -174,7 +174,7 @@ namespace System.Collections.Specialized
         {
             if (maxValue < 1)
             {
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidValue, nameof(maxValue), 1), nameof(maxValue));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidValue_TooSmall, nameof(maxValue), 1), nameof(maxValue));
             }
 
             short offset = (short)(priorOffset + CountBitsSet(priorMask));

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
@@ -228,7 +228,7 @@ namespace System.Collections.Specialized
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
             if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum_Index);
 
             if (array.Length - index < count)
                 throw new ArgumentException(SR.Arg_InsufficientSpace);
@@ -388,7 +388,7 @@ namespace System.Collections.Specialized
                 if (array == null)
                     throw new ArgumentNullException(nameof(array));
                 if (index < 0)
-                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum_Index);
 
                 for (DictionaryNode node = _list.head; node != null; node = node.next)
                 {

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -372,7 +372,7 @@ namespace System.Collections.Specialized
 
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum_Index);
             }
 
             if (array.Length - index < _entriesArray.Count)
@@ -620,7 +620,7 @@ namespace System.Collections.Specialized
 
                 if (index < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum_Index);
                 }
 
                 if (array.Length - index < _coll.Count)

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
@@ -208,7 +208,7 @@ namespace System.Collections.Specialized
 
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum_Index);
             }
 
             if (dest.Length - index < Count)

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -541,7 +541,7 @@ namespace System.Collections.Specialized
                 if (array == null)
                     throw new ArgumentNullException(nameof(array));
                 if (index < 0)
-                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum_Index);
                 foreach (object o in _objects)
                 {
                     array.SetValue(_isKeys ? ((DictionaryEntry)o).Key : ((DictionaryEntry)o).Value, index);

--- a/src/System.Collections/src/Resources/Strings.resx
+++ b/src/System.Collections/src/Resources/Strings.resx
@@ -89,7 +89,7 @@
     <value>Enumeration has either not started or has already finished.</value>
   </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
-    <value>Collection was modified; enumeration operation may not execute.</value>
+    <value>Collection was modified after the enumerator was instantiated.</value>
   </data>
   <data name="InvalidOperation_EmptyStack" xml:space="preserve">
     <value>Stack empty.</value>

--- a/src/System.ComponentModel.Composition/src/Resources/Strings.resx
+++ b/src/System.ComponentModel.Composition/src/Resources/Strings.resx
@@ -79,7 +79,7 @@
   <data name="CardinalityMismatch_NoExports" xml:space="preserve">
     <value>No exports were found that match the constraint: {0}</value>
   </data>
-  <data name="CardinalityMismatch_TooManyExports" xml:space="preserve">
+  <data name="CardinalityMismatch_TooManyExports_Constraint" xml:space="preserve">
     <value>More than one export was found that matches the constraint: {0}</value>
   </data>
   <data name="ImportEngine_ComposeTookTooManyIterations" xml:space="preserve">

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ExportProvider.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ExportProvider.cs
@@ -111,7 +111,7 @@ namespace System.ComponentModel.Composition.Hosting
                     throw new ImportCardinalityMismatchException(string.Format(CultureInfo.CurrentCulture, SR.CardinalityMismatch_NoExports, definition.ToString()));
                 default:
                     Assumes.IsTrue(result == ExportCardinalityCheckResult.TooManyExports);
-                    throw new ImportCardinalityMismatchException(string.Format(CultureInfo.CurrentCulture, SR.CardinalityMismatch_TooManyExports, definition.ToString()));
+                    throw new ImportCardinalityMismatchException(string.Format(CultureInfo.CurrentCulture, SR.CardinalityMismatch_TooManyExports_Constraint, definition.ToString()));
             }
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
+++ b/src/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
@@ -181,8 +181,8 @@
   <data name="ErrorServiceExists" xml:space="preserve">
     <value>The service {0} already exists in the service container.</value>
   </data>
-  <data name="InvalidArgument" xml:space="preserve">
-    <value>'{1}' is not a valid value for '{0}'.</value>
+  <data name="InvalidArgumentValue" xml:space="preserve">
+    <value>Value of '{1}' is not valid for '{0}'.</value>
   </data>
   <data name="InvalidNullArgument" xml:space="preserve">
     <value>Null is not a valid value for {0}.</value>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -53,7 +53,7 @@ namespace System.ComponentModel.Design
 
             if (name.Length == 0)
             {
-                throw new ArgumentException(SR.Format(SR.InvalidArgument, name.Length.ToString(CultureInfo.CurrentCulture), (0).ToString(CultureInfo.CurrentCulture)), "name.Length");
+                throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, name.Length.ToString(CultureInfo.CurrentCulture), (0).ToString(CultureInfo.CurrentCulture)), "name.Length");
             }
 
             return new DesignerOptionCollection(this, parent, name, value);

--- a/src/System.Composition.Hosting/src/Resources/Strings.resx
+++ b/src/System.Composition.Hosting/src/Resources/Strings.resx
@@ -87,7 +87,7 @@
     <value>Metadata value circularity not possible, use lazy initialization.</value>
   </data>
   <data name="CardinalityMismatch_TooManyExports" xml:space="preserve">
-    <value>"Only one export for the contract '{0}' is allowed, multiple implementations were found."</value>
+    <value>More than one export was found that matches the constraint: {0}</value>
   </data>
   <data name="Diagnostic_ThrowingException" xml:space="preserve">
     <value>Exception Thrown: {0}\r\n</value>

--- a/src/System.Composition.Hosting/src/Resources/Strings.resx
+++ b/src/System.Composition.Hosting/src/Resources/Strings.resx
@@ -87,7 +87,7 @@
     <value>Metadata value circularity not possible, use lazy initialization.</value>
   </data>
   <data name="CardinalityMismatch_TooManyExports" xml:space="preserve">
-    <value>More than one export was found that matches the constraint: {0}</value>
+    <value>"Only one export for the contract '{0}' is allowed, multiple implementations were found."</value>
   </data>
   <data name="Diagnostic_ThrowingException" xml:space="preserve">
     <value>Exception Thrown: {0}\r\n</value>

--- a/src/System.Configuration.ConfigurationManager/src/Resources/Strings.resx
+++ b/src/System.Configuration.ConfigurationManager/src/Resources/Strings.resx
@@ -594,7 +594,7 @@
     <value>The machine.config file '{0}' was not found.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="Unable_to_convert_type_from_string" xml:space="preserve">
     <value>Could not find a type-converter to convert object if type '{0}' from string.</value>

--- a/src/System.Configuration.ConfigurationManager/src/Resources/Strings.resx
+++ b/src/System.Configuration.ConfigurationManager/src/Resources/Strings.resx
@@ -94,10 +94,7 @@
   </data>
   <!--
     other exceptions
-  -->
-  <data name="Argument_AddingDuplicate" xml:space="preserve">
-    <value>An entry with the same key already exists.</value>
-  </data>
+  -->  
   <data name="Config_add_configurationsection_already_added" xml:space="preserve">
     <value>Cannot add a ConfigurationSection that already belongs to the Configuration.</value>
   </data>

--- a/src/System.Data.Common/src/Resources/Strings.resx
+++ b/src/System.Data.Common/src/Resources/Strings.resx
@@ -101,7 +101,7 @@
   <data name="Xml_MissingTable" xml:space="preserve"><value>Cannot load diffGram. Table '{0}' is missing in the destination dataset.</value></data>
   <data name="Xml_MissingSQL" xml:space="preserve"><value>Cannot load diffGram. The 'sql' node is missing.</value></data>
   <data name="Xml_ColumnConflict" xml:space="preserve"><value>Column name '{0}' is defined for different mapping types.</value></data>
-  <data name="Xml_InvalidPrefix" xml:space="preserve"><value>Prefix '{0}' is not valid, because it contains special characters.</value></data>
+  <data name="Xml_InvalidPrefix_SpecialCharacters" xml:space="preserve"><value>Prefix '{0}' is not valid, because it contains special characters.</value></data>
   <data name="Xml_NestedCircular" xml:space="preserve"><value>Circular reference in self-nested table '{0}'.</value></data>
   <data name="Xml_FoundEntity" xml:space="preserve"><value>DataSet cannot expand entities. Use XmlValidatingReader and set the EntityHandling property accordingly.</value></data>
   <data name="Xml_PolymorphismNotSupported" xml:space="preserve"><value>Type '{0}' does not implement IXmlSerializable interface therefore can not proceed with serialization.</value></data>
@@ -370,7 +370,7 @@
   <data name="Range_Argument" xml:space="preserve"><value>Min ({0}) must be less than or equal to max ({1}) in a Range object.</value></data>
   <data name="Range_NullRange" xml:space="preserve"><value>This is a null range.</value></data>
   <data name="RecordManager_MinimumCapacity" xml:space="preserve"><value>MinimumCapacity must be non-negative.</value></data>
-  <data name="SqlConvert_ConvertFailed" xml:space="preserve"><value> Cannot convert object of type '{0}' to object of type '{1}'.</value></data>
+  <data name="SqlConvert_ConvertFailed" xml:space="preserve"><value>Cannot convert object of type '{0}' to object of type '{1}'.</value></data>
   <data name="DataSet_DefaultDataException" xml:space="preserve"><value>Data Exception.</value></data>
   <data name="DataSet_DefaultConstraintException" xml:space="preserve"><value>Constraint Exception.</value></data>
   <data name="DataSet_DefaultDeletedRowInaccessibleException" xml:space="preserve"><value>Deleted rows inaccessible.</value></data>

--- a/src/System.Data.Common/src/Resources/Strings.resx
+++ b/src/System.Data.Common/src/Resources/Strings.resx
@@ -418,9 +418,9 @@
   <data name="ADP_NoQuoteChange" xml:space="preserve"><value>The QuotePrefix and QuoteSuffix properties cannot be changed once an Insert, Update, or Delete command has been generated.</value></data>
   <data name="ADP_MissingSourceCommand" xml:space="preserve"><value>The DataAdapter.SelectCommand property needs to be initialized.</value></data>
   <data name="ADP_MissingSourceCommandConnection" xml:space="preserve"><value>The DataAdapter.SelectCommand.Connection property needs to be initialized;</value></data>
-  <data name="ADP_InvalidMultipartName" xml:space="preserve"><value>{0} "{1}".</value></data>
-  <data name="ADP_InvalidMultipartNameQuoteUsage" xml:space="preserve"><value>{0} "{1}", incorrect usage of quotes.</value></data>
-  <data name="ADP_InvalidMultipartNameToManyParts" xml:space="preserve"><value>{0} "{1}", the current limit of "{2}" is insufficient.</value></data>
+  <data name="ADP_InvalidMultipartName" xml:space="preserve"><value>{0} '{1}'.</value></data>
+  <data name="ADP_InvalidMultipartNameQuoteUsage" xml:space="preserve"><value>{0} '{1}', incorrect usage of quotes.</value></data>
+  <data name="ADP_InvalidMultipartNameToManyParts" xml:space="preserve"><value>{0} '{1}', the current limit of '{2}' is insufficient.</value></data>
   <data name="ADP_ColumnSchemaExpression" xml:space="preserve"><value>The column mapping from SourceColumn '{0}' failed because the DataColumn '{1}' is a computed column.</value></data>
   <data name="ADP_ColumnSchemaMismatch" xml:space="preserve"><value>Inconvertible type mismatch between SourceColumn '{0}' of {1} and the DataColumn '{2}' of {3}.</value></data>
   <data name="ADP_ColumnSchemaMissing1" xml:space="preserve"><value>Missing the DataColumn '{0}' for the SourceColumn '{2}'.</value></data>

--- a/src/System.Data.Common/src/System/Data/DataException.cs
+++ b/src/System.Data.Common/src/System/Data/DataException.cs
@@ -679,7 +679,7 @@ namespace System.Data
         public static Exception ColumnTypeConflict(string name) => _Data(SR.Format(SR.Xml_ColumnConflict, name));
         public static Exception CannotConvert(string name, string type) => _Data(SR.Format(SR.Xml_CannotConvert, name, type));
         public static Exception MissingRefer(string name) => _Data(SR.Format(SR.Xml_MissingRefer, Keywords.REFER, Keywords.XSD_KEYREF, name));
-        public static Exception InvalidPrefix(string name) => _Data(SR.Format(SR.Xml_InvalidPrefix, name));
+        public static Exception InvalidPrefix(string name) => _Data(SR.Format(SR.Xml_InvalidPrefix_SpecialCharacters, name));
         public static Exception CanNotDeserializeObjectType() => _InvalidOperation(SR.Xml_CanNotDeserializeObjectType);
         public static Exception IsDataSetAttributeMissingInSchema() => _Data(SR.Xml_IsDataSetAttributeMissingInSchema);
         public static Exception TooManyIsDataSetAtributeInSchema() => _Data(SR.Xml_TooManyIsDataSetAtributeInSchema);

--- a/src/System.Data.Odbc/src/Resources/Strings.resx
+++ b/src/System.Data.Odbc/src/Resources/Strings.resx
@@ -328,7 +328,7 @@
     <value>There is already an open DataReader associated with this Command which must be closed first.</value>
   </data>
   <data name="ADP_DeriveParametersNotSupported" xml:space="preserve">
-    <value>{0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType.{1}.</value>
+    <value>{0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType. {1}.</value>
   </data>
   <data name="ADP_InvalidCommandTimeout" xml:space="preserve">
     <value>Invalid CommandTimeout value {0}; the value must be &gt;= 0.</value>

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1186,7 +1186,7 @@
     <value>Server implementation is not supported</value>
   </data>
   <data name="net_nego_protection_level_not_supported" xml:space="preserve">
-    <value>Requested protection level is not supported with the gssapi implementation currently installed.</value>
+    <value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
   </data>
   <data name="net_context_buffer_too_small" xml:space="preserve">
     <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -220,7 +220,7 @@
     <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
   </data>
   <data name="SqlConvert_ConvertFailed" xml:space="preserve">
-    <value> Cannot convert object of type '{0}' to object of type '{1}'.</value>
+    <value>Cannot convert object of type '{0}' to object of type '{1}'.</value>
   </data>
   <data name="SQL_WrongType" xml:space="preserve">
     <value>Expecting argument of type {1}, but received type {0}.</value>
@@ -1180,13 +1180,13 @@
     <value>NTLM authentication is not possible with default credentials on this platform.</value>
   </data>
   <data name="net_nego_not_supported_empty_target_with_defaultcreds" xml:space="preserve">
-    <value>Target name should be non-empty if default credentials are passed.</value>
+    <value>Target name should be non empty if default credentials are passed.</value>
   </data>
   <data name="net_nego_server_not_supported" xml:space="preserve">
-    <value>Server implementation is not supported.</value>
+    <value>Server implementation is not supported</value>
   </data>
   <data name="net_nego_protection_level_not_supported" xml:space="preserve">
-    <value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
+    <value>Requested protection level is not supported with the gssapi implementation currently installed.</value>
   </data>
   <data name="net_context_buffer_too_small" xml:space="preserve">
     <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
@@ -1252,7 +1252,7 @@
     <value>The requested collection ({0}) is not defined.</value>
   </data>
   <data name="MDF_UnsupportedVersion" xml:space="preserve">
-    <value> requested collection ({0}) is not supported by this version of the provider.</value>
+    <value>The requested collection ({0}) is not supported by this version of the provider.</value>
   </data>
   <data name="MDF_MissingRestrictionColumn" xml:space="preserve">
     <value>One or more of the required columns of the restrictions collection is missing.</value>

--- a/src/System.DirectoryServices.Protocols/src/Resources/Strings.resx
+++ b/src/System.DirectoryServices.Protocols/src/Resources/Strings.resx
@@ -120,7 +120,7 @@
   <data name="DsmlNonHttpUri" xml:space="preserve">
     <value>The URI that is supplied must be either "http" or "https".</value>
   </data>
-  <data name="NoNegativeTime" xml:space="preserve">
+  <data name="NoNegativeTimeLimit" xml:space="preserve">
     <value>A negative value is not permitted for the time limit.</value>
   </data>
   <data name="NoNegativeSizeLimit" xml:space="preserve">
@@ -446,9 +446,6 @@
   </data>
   <data name="ValidValueType" xml:space="preserve">
     <value>The value must be a string, byte[], or Uri type.</value>
-  </data>
-  <data name="SupportedPlatforms" xml:space="preserve">
-    <value>System.DirectoryServices.Protocols namespace is only supported on Windows 2000 and later operating systems.</value>
   </data>
   <data name="TLSNotSupported" xml:space="preserve">
     <value>Transport layer security is not supported on Windows 2000.</value>

--- a/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryConnection.cs
+++ b/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryConnection.cs
@@ -28,7 +28,7 @@ namespace System.DirectoryServices.Protocols
             {
                 if (value < TimeSpan.Zero)
                 {
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.NoNegativeTime), nameof(value));
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.NoNegativeTimeLimit), nameof(value));
                 }
 
                 _connectionTimeOut = value;

--- a/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryRequest.cs
+++ b/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryRequest.cs
@@ -311,7 +311,7 @@ namespace System.DirectoryServices.Protocols
             {
                 if (value < TimeSpan.Zero)
                 {
-                    throw new ArgumentException(SR.NoNegativeTime, nameof(value));
+                    throw new ArgumentException(SR.NoNegativeTimeLimit, nameof(value));
                 }
 
                 // Prevent integer overflow.

--- a/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -127,7 +127,7 @@ namespace System.DirectoryServices.Protocols
             {
                 if (value < TimeSpan.Zero)
                 {
-                    throw new ArgumentException(SR.NoNegativeTime, nameof(value));
+                    throw new ArgumentException(SR.NoNegativeTimeLimit, nameof(value));
                 }
 
                 // Prevent integer overflow.

--- a/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
+++ b/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
@@ -237,7 +237,7 @@ namespace System.DirectoryServices.Protocols
             {
                 if (value < TimeSpan.Zero)
                 {
-                    throw new ArgumentException(SR.NoNegativeTime, nameof(value));
+                    throw new ArgumentException(SR.NoNegativeTimeLimit, nameof(value));
                 }
 
                 // Prevent integer overflow.
@@ -276,7 +276,7 @@ namespace System.DirectoryServices.Protocols
             {
                 if (value < TimeSpan.Zero)
                 {
-                    throw new ArgumentException(SR.NoNegativeTime, nameof(value));
+                    throw new ArgumentException(SR.NoNegativeTimeLimit, nameof(value));
                 }
 
                 // Prevent integer overflow.
@@ -418,7 +418,7 @@ namespace System.DirectoryServices.Protocols
             {
                 if (value < TimeSpan.Zero)
                 {
-                    throw new ArgumentException(SR.NoNegativeTime, nameof(value));
+                    throw new ArgumentException(SR.NoNegativeTimeLimit, nameof(value));
                 }
 
                 // Prevent integer overflow.

--- a/src/System.Drawing.Common/src/Resources/Strings.resx
+++ b/src/System.Drawing.Common/src/Resources/Strings.resx
@@ -258,7 +258,7 @@
   <data name="InterpolationColorsLengthsDiffer" xml:space="preserve">
     <value>Colors and positions do not have the same number of elements.</value>
   </data>
-  <data name="InvalidArgument" xml:space="preserve">
+  <data name="InvalidArgumentValue" xml:space="preserve">
     <value>Value of '{1}' is not valid for '{0}'.</value>
   </data>
   <data name="InvalidBoundArgument" xml:space="preserve">

--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.Windows.cs
@@ -80,7 +80,7 @@ namespace System.Drawing
             {
                 if (value.Width <= 0 || value.Height <= 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgument, nameof(MaximumBuffer), value), nameof(value));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(MaximumBuffer), value), nameof(value));
                 }
 
                 // If we've been asked to decrease the size of the maximum buffer,

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -152,7 +152,7 @@ namespace System.Drawing
 
             if (uri.IsUnc)
             {
-                throw new ArgumentException(SR.Format(SR.InvalidArgument, nameof(filePath), filePath));
+                throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(filePath), filePath));
             }
 
             if (!uri.IsFile)

--- a/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
@@ -256,7 +256,7 @@ namespace System.Drawing
         {
             if (firstTabOffset < 0)
             {
-                throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "firstTabOffset", firstTabOffset));
+                throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(firstTabOffset), firstTabOffset));
             }
 
             foreach (float tabStop in tabStops) // Emulate Windows GDI+ behavior.

--- a/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
@@ -256,7 +256,7 @@ namespace System.Drawing
         {
             if (firstTabOffset < 0)
             {
-                throw new ArgumentException(SR.Format(SR.InvalidArgument, "firstTabOffset", firstTabOffset));
+                throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "firstTabOffset", firstTabOffset));
             }
 
             foreach (float tabStop in tabStops) // Emulate Windows GDI+ behavior.

--- a/src/System.IO.Compression.Brotli/src/Resources/Strings.resx
+++ b/src/System.IO.Compression.Brotli/src/Resources/Strings.resx
@@ -128,7 +128,7 @@
     <value>Enum value was out of legal range.</value>
   </data>  
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Can not access a closed Stream.</value>
+    <value>Cannot access a closed Stream.</value>
   </data>  
   <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
     <value>Positive number required.</value>

--- a/src/System.IO.Compression.Brotli/src/Resources/Strings.resx
+++ b/src/System.IO.Compression.Brotli/src/Resources/Strings.resx
@@ -128,7 +128,7 @@
     <value>Enum value was out of legal range.</value>
   </data>  
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>  
   <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
     <value>Positive number required.</value>

--- a/src/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/System.IO.Compression/src/Resources/Strings.resx
@@ -154,7 +154,7 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Can not access a closed Stream.</value>
+    <value>Cannot access a closed Stream.</value>
   </data>
   <data name="UnknownBlockType" xml:space="preserve">
     <value>Unknown block type. Stream might be corrupted.</value>

--- a/src/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/System.IO.Compression/src/Resources/Strings.resx
@@ -157,7 +157,7 @@
     <value>Cannot access a closed stream.</value>
   </data>
   <data name="UnknownBlockType" xml:space="preserve">
-    <value>Unknown block type. stream might be corrupted.</value>
+    <value>Unknown block type. Stream might be corrupted.</value>
   </data>
   <data name="UnknownState" xml:space="preserve">
     <value>Decoder is in some unknown state. This might be caused by corrupted data.</value>

--- a/src/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/System.IO.Compression/src/Resources/Strings.resx
@@ -154,10 +154,10 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="UnknownBlockType" xml:space="preserve">
-    <value>Unknown block type. Stream might be corrupted.</value>
+    <value>Unknown block type. stream might be corrupted.</value>
   </data>
   <data name="UnknownState" xml:space="preserve">
     <value>Decoder is in some unknown state. This might be caused by corrupted data.</value>

--- a/src/System.IO.FileSystem/src/Resources/Strings.resx
+++ b/src/System.IO.FileSystem/src/Resources/Strings.resx
@@ -274,7 +274,7 @@
     <value>Access to the path '{0}' is denied.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="PlatformNotSupported_FileEncryption" xml:space="preserve">
     <value>File encryption is not supported on this platform.</value>

--- a/src/System.IO.FileSystem/src/Resources/Strings.resx
+++ b/src/System.IO.FileSystem/src/Resources/Strings.resx
@@ -131,10 +131,7 @@
   </data>
   <data name="Arg_InvalidHandle" xml:space="preserve">
     <value>Invalid handle.</value>
-  </data>
-  <data name="Arg_InvalidSearchPattern" xml:space="preserve">
-    <value>Search pattern cannot contain '..' to move up directories and can be contained only internally in file/directory names, as in 'a..b'.</value>
-  </data>
+  </data>  
   <data name="Arg_Path2IsRooted" xml:space="preserve">
     <value>Second path fragment must not be a drive or UNC name.</value>
   </data>

--- a/src/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
+++ b/src/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>Non-negative number required.</value>
   </data>
   <data name="IO_FileNotFound" xml:space="preserve">
     <value>Unable to find the specified file.</value>

--- a/src/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
+++ b/src/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
@@ -127,7 +127,7 @@
     <value>Could not find file '{0}'.</value>
   </data>
   <data name="IO_AlreadyExists_Name" xml:space="preserve">
-    <value>Cannot create \"{0}\" because a file or directory with the same name already exists.</value>
+    <value>Cannot create '{0}' because a file or directory with the same name already exists.</value>
   </data>
   <data name="IO_FileExists_Name" xml:space="preserve">
     <value>The file '{0}' already exists.</value>

--- a/src/System.IO.Packaging/src/Resources/Strings.resx
+++ b/src/System.IO.Packaging/src/Resources/Strings.resx
@@ -130,7 +130,7 @@
   <data name="InvalidRelationshipType" xml:space="preserve">
     <value>Relationship Type cannot contain only spaces or be empty.</value>
   </data>
-  <data name="InvalidToken" xml:space="preserve">
+  <data name="InvalidToken_ContentType" xml:space="preserve">
     <value>A token is not valid. Refer to RFC 2616 for correct grammar of content types.</value>
   </data>
   <data name="InvalidTypeSubType" xml:space="preserve">

--- a/src/System.IO.Packaging/src/System/IO/Packaging/ContentType.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/ContentType.cs
@@ -430,13 +430,13 @@ namespace System.IO.Packaging
         private static string ValidateToken(string token)
         {
             if (String.IsNullOrEmpty(token))
-                throw new ArgumentException(SR.InvalidToken);
+                throw new ArgumentException(SR.InvalidToken_ContentType);
 
             for (int i = 0; i < token.Length; i++)
             {
                 if (!IsAsciiLetterOrDigit(token[i]) && !IsAllowedCharacter(token[i]))
                 {
-                    throw new ArgumentException(SR.InvalidToken);
+                    throw new ArgumentException(SR.InvalidToken_ContentType);
                 }
             }
 

--- a/src/System.IO.Pipes.AccessControl/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes.AccessControl/src/Resources/Strings.resx
@@ -59,7 +59,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedValidPipeAccessRights" xml:space="preserve">
-    <value>Need valid PipeAccessRights value.</value>
+    <value>Invalid PipeAccessRights value.</value>
   </data>
   <data name="Argument_NonContainerInvalidAnyFlag" xml:space="preserve">
     <value>This flag may not be set on a pipe.</value>

--- a/src/System.IO.Pipes.AccessControl/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes.AccessControl/src/Resources/Strings.resx
@@ -65,7 +65,7 @@
     <value>This flag may not be set on a pipe.</value>
   </data>
   <data name="InvalidOperation_PipeNotYetConnected" xml:space="preserve">
-    <value>Pipe is not connected.</value>
+    <value>Pipe hasn't been connected yet.</value>
   </data>
   <data name="IO_IO_PipeBroken" xml:space="preserve">
     <value>Pipe is broken.</value>

--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>Non-negative number required.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidPipeAccessRights" xml:space="preserve">
     <value>Invalid PipeAccessRights value.</value>
@@ -136,7 +136,7 @@
     <value>serverName cannot be an empty string.  Use \\\".\\\" for current machine.</value>
   </data>
   <data name="Argument_InvalidHandle" xml:space="preserve">
-    <value>Invalid handle.</value>
+    <value>'handle' has been disposed or is an invalid handle.</value>
   </data>
   <data name="ArgumentNull_Buffer" xml:space="preserve">
     <value>Buffer cannot be null.</value>

--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -136,7 +136,7 @@
     <value>serverName cannot be an empty string.  Use \\\".\\\" for current machine.</value>
   </data>
   <data name="Argument_InvalidHandle" xml:space="preserve">
-    <value>'handle' has been disposed or is an invalid handle.</value>
+    <value>Handle has been disposed or is invalid.</value>
   </data>
   <data name="ArgumentNull_Buffer" xml:space="preserve">
     <value>Buffer cannot be null.</value>
@@ -271,7 +271,7 @@
     <value>The name of a pipe on this platform must be a valid file name or a valid absolute path to a file name.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="PlatformNotSupported_OperatingSystemError" xml:space="preserve">
     <value>The operating system returned error '{0}' indicating that the operation is not supported.</value>

--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -202,7 +202,7 @@
     <value>Could not find file '{0}'.</value>
   </data>
   <data name="IO_AlreadyExists_Name" xml:space="preserve">
-    <value>Cannot create \"{0}\" because a file or directory with the same name already exists.</value>
+    <value>Cannot create '{0}' because a file or directory with the same name already exists.</value>
   </data>
   <data name="IO_FileExists_Name" xml:space="preserve">
     <value>The file '{0}' already exists.</value>
@@ -210,7 +210,7 @@
   <data name="IO_IO_PipeBroken" xml:space="preserve">
     <value>Pipe is broken.</value>
   </data>
-  <data name="IO_OperationAborted" xml:space="preserve">
+  <data name="IO_OperationAborted_Unexpected" xml:space="preserve">
     <value>IO operation was aborted unexpectedly.</value>
   </data>
   <data name="IO_SharingViolation_File" xml:space="preserve">

--- a/src/System.IO.Pipes/src/System/IO/Error.cs
+++ b/src/System.IO.Pipes/src/System/IO/Error.cs
@@ -34,7 +34,7 @@ namespace System.IO
 
         internal static Exception GetOperationAborted()
         {
-            return new IOException(SR.IO_OperationAborted);
+            return new IOException(SR.IO_OperationAborted_Unexpected);
         }
     }
 }

--- a/src/System.IO.Ports/src/Resources/Strings.resx
+++ b/src/System.IO.Ports/src/Resources/Strings.resx
@@ -187,7 +187,7 @@
     <value>Stream does not support seeking.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Can not access a closed Stream.</value>
+    <value>Cannot access a closed Stream.</value>
   </data>
   <data name="InvalidNullEmptyArgument" xml:space="preserve">
     <value>Argument {0} cannot be null or zero-length.</value>
@@ -207,19 +207,19 @@
   <data name="IO_PortNotFoundFileName" xml:space="preserve">
     <value>The port '{0}' does not exist.</value>
   </data>
-  <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
+  <data name="UnauthorizedAccess_IODenied_NoPortName" xml:space="preserve">
     <value>Access to the port is denied.</value>
   </data>
-  <data name="IO_PathTooLong" xml:space="preserve">
+  <data name="IO_PathTooLong_PortName" xml:space="preserve">
     <value>The specified port name is too long.  The port name must be less than 260 characters.</value>
   </data>
-  <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
+  <data name="IO_SharingViolation_NoPortName" xml:space="preserve">
     <value>The process cannot access the port because it is being used by another process.</value>
   </data>
-  <data name="IO_SharingViolation_File" xml:space="preserve">
+  <data name="IO_SharingViolation_Port" xml:space="preserve">
     <value>The process cannot access the port '{0}' because it is being used by another process.</value>
   </data>
-  <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
+  <data name="UnauthorizedAccess_IODenied_Port" xml:space="preserve">
     <value>Access to the port '{0}' is denied.</value>
   </data>
   <data name="PlatformNotSupported_IOPorts" xml:space="preserve">
@@ -228,7 +228,7 @@
   <data name="PlatformNotSupported_SerialPort_GetPortNames" xml:space="preserve">
     <value>Enumeration of serial port names is not supported on the current platform.</value>
   </data>
-  <data name="IO_PathTooLong_Path" xml:space="preserve">
+  <data name="IO_PathTooLong_Path_PortName" xml:space="preserve">
     <value>The specified port name '{0}' is too long.  The port name must be less than 260 characters.</value>
   </data>
 </root>

--- a/src/System.IO.Ports/src/Resources/Strings.resx
+++ b/src/System.IO.Ports/src/Resources/Strings.resx
@@ -178,7 +178,7 @@
     <value>The timeout must be either a positive number or -1.</value>
   </data>
   <data name="IndexOutOfRange_IORaceCondition" xml:space="preserve">
-    <value>Probable I/O race condition detected while copying memory.  The I/O package is not thread safe by default.  In multithreaded applications, a stream must be accessed in a thread-safe way, such as a thread-safe wrapper returned by TextReader's or TextWriter's Synchronized methods.  This also applies to classes like StreamWriter and StreamReader.</value>
+    <value>Probable I/O race condition detected while copying memory. The I/O package is not thread safe by default. In multithreaded applications, a stream must be accessed in a thread-safe way, such as a thread-safe wrapper returned by TextReader's or TextWriter's Synchronized methods. This also applies to classes like StreamWriter and StreamReader.</value>
   </data>
   <data name="IO_OperationAborted" xml:space="preserve">
     <value>The I/O operation has been aborted because of either a thread exit or an application request.</value>

--- a/src/System.IO.Ports/src/Resources/Strings.resx
+++ b/src/System.IO.Ports/src/Resources/Strings.resx
@@ -187,7 +187,7 @@
     <value>Stream does not support seeking.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="InvalidNullEmptyArgument" xml:space="preserve">
     <value>Argument {0} cannot be null or zero-length.</value>

--- a/src/System.IO.Ports/src/System/IO/Ports/InternalResources.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/InternalResources.cs
@@ -72,22 +72,22 @@ namespace System.IO.Ports
 
                 case Interop.Errors.ERROR_ACCESS_DENIED:
                     if (str.Length == 0)
-                        throw new UnauthorizedAccessException(SR.UnauthorizedAccess_IODenied_NoPathName);
+                        throw new UnauthorizedAccessException(SR.UnauthorizedAccess_IODenied_NoPortName);
                     else
-                        throw new UnauthorizedAccessException(string.Format(SR.UnauthorizedAccess_IODenied_Path, str));
+                        throw new UnauthorizedAccessException(string.Format(SR.UnauthorizedAccess_IODenied_Port, str));
 
                 case Interop.Errors.ERROR_FILENAME_EXCED_RANGE:
                     if (string.IsNullOrEmpty(str))
-                        throw new PathTooLongException(SR.IO_PathTooLong);
+                        throw new PathTooLongException(SR.IO_PathTooLong_PortName);
                     else
-                        throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, str));
+                        throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path_PortName, str));
 
                 case Interop.Errors.ERROR_SHARING_VIOLATION:
                     // error message.
                     if (str.Length == 0)
-                        throw new IOException(SR.IO_SharingViolation_NoFileName);
+                        throw new IOException(SR.IO_SharingViolation_NoPortName);
                     else
-                        throw new IOException(string.Format(SR.IO_SharingViolation_File, str));
+                        throw new IOException(string.Format(SR.IO_SharingViolation_Port, str));
 
                 default:
                     throw new IOException(GetMessage(errorCode), MakeHRFromErrorCode(errorCode));

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -481,7 +481,7 @@
   <data name="PdbGeneratorNeedsExpressionCompiler" xml:space="preserve">
     <value>DebugInfoGenerator created by CreatePdbGenerator can only be used with LambdaExpression.CompileToMethod.</value>
   </data>
-  <data name="InvalidArgumentValue" xml:space="preserve">
+  <data name="InvalidArgumentValue_ParamName" xml:space="preserve">
     <value>Invalid argument value</value>
   </data>
   <data name="NonEmptyCollectionRequired" xml:space="preserve">

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1368,7 +1368,7 @@ namespace System.Linq.Expressions
 
         internal static Exception InvalidArgumentValue(string paramName)
         {
-            return new ArgumentException(Strings.InvalidArgumentValue, paramName);
+            return new ArgumentException(Strings.InvalidArgumentValue_ParamName, paramName);
         }
 
         internal static Exception NonEmptyCollectionRequired(string paramName)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -815,7 +815,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// A string like "Invalid argument value"
         /// </summary>
-        internal static string InvalidArgumentValue => SR.InvalidArgumentValue;
+        internal static string InvalidArgumentValue_ParamName => SR.InvalidArgumentValue_ParamName;
 
         /// <summary>
         /// A string like "Non-empty collection required"

--- a/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -116,7 +116,7 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="net_http_content_stream_already_read" xml:space="preserve">
     <value>The stream was already consumed. It cannot be read again.</value>

--- a/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -116,7 +116,7 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Can not access a closed Stream.</value>
+    <value>Cannot access a closed Stream.</value>
   </data>
   <data name="net_http_content_stream_already_read" xml:space="preserve">
     <value>The stream was already consumed. It cannot be read again.</value>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -349,7 +349,7 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="net_http_libcurl_callback_notsupported_sslbackend" xml:space="preserve">
     <value>The handler does not support custom handling of certificates with this combination of libcurl ({0}) and its SSL backend ("{1}"). An SSL backend based on "{2}" is required. Consider using System.Net.Http.SocketsHttpHandler.</value>
@@ -433,7 +433,7 @@
     <value>Server implementation is not supported</value>
   </data>
   <data name="net_nego_protection_level_not_supported" xml:space="preserve">
-    <value>Requested protection level is not supported with the gssapi implementation currently installed.</value>
+    <value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
   </data>
   <data name="net_context_buffer_too_small" xml:space="preserve">
     <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -349,7 +349,7 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Can not access a closed Stream.</value>
+    <value>Cannot access a closed Stream.</value>
   </data>
   <data name="net_http_libcurl_callback_notsupported_sslbackend" xml:space="preserve">
     <value>The handler does not support custom handling of certificates with this combination of libcurl ({0}) and its SSL backend ("{1}"). An SSL backend based on "{2}" is required. Consider using System.Net.Http.SocketsHttpHandler.</value>

--- a/src/System.Net.Mail/src/Resources/Strings.resx
+++ b/src/System.Net.Mail/src/Resources/Strings.resx
@@ -99,7 +99,7 @@
     <value>Server implementation is not supported</value>
   </data>
   <data name="net_nego_protection_level_not_supported" xml:space="preserve">
-    <value>Requested protection level is not supported with the gssapi implementation currently installed.</value>
+    <value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
   </data>
   <data name="SSPIInvalidHandleType" xml:space="preserve">
     <value>'{0}' is not a supported handle type.</value>

--- a/src/System.Net.Primitives/src/Resources/Strings.resx
+++ b/src/System.Net.Primitives/src/Resources/Strings.resx
@@ -107,7 +107,7 @@
     <value>Default credentials cannot be supplied for the {0} authentication scheme.</value>
   </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
-    <value>Collection was modified; enumeration operation may not execute.</value>
+    <value>Collection was modified after the enumerator was instantiated.</value>
   </data>
   <data name="InvalidOperation_EnumOpCantHappen" xml:space="preserve">
     <value>Enumeration has either not started or has already finished.</value>

--- a/src/System.Net.Primitives/src/Resources/Strings.resx
+++ b/src/System.Net.Primitives/src/Resources/Strings.resx
@@ -107,9 +107,9 @@
     <value>Default credentials cannot be supplied for the {0} authentication scheme.</value>
   </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
-    <value>Collection was modified after the enumerator was instantiated.</value>
+    <value>Collection was modified; enumeration operation may not execute.</value>
   </data>
   <data name="InvalidOperation_EnumOpCantHappen" xml:space="preserve">
-    <value>Enumerator is positioned before the first element or after the last element of the collection.</value>
+    <value>Enumeration has either not started or has already finished.</value>
   </data>
 </root>

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -406,7 +406,7 @@
     <value>Server implementation is not supported</value>
   </data>
   <data name="net_nego_protection_level_not_supported" xml:space="preserve">
-    <value>Requested protection level is not supported with the gssapi implementation currently installed.</value>
+    <value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
   </data>
   <data name="net_nego_not_supported_empty_target_with_defaultcreds" xml:space="preserve">
     <value>Target name should be non empty if default credentials are passed.</value>

--- a/src/System.Net.Security/tests/FunctionalTests/Resources/Strings.resx
+++ b/src/System.Net.Security/tests/FunctionalTests/Resources/Strings.resx
@@ -59,10 +59,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="net_gssapi_operation_failed_detailed" xml:space="preserve">
-    <value>Gss api operation failed with error : {0} ({1}).</value>
+    <value>GSSAPI operation failed with error - {0} ({1}).</value>
   </data>
   <data name="net_gssapi_operation_failed" xml:space="preserve">
-    <value>GSSAPI operation failed with status: {0} (Minor status: {1})</value>
+    <value>GSSAPI operation failed with status: {0} (Minor status: {1}).</value>
   </data>
   <data name="net_context_establishment_failed" xml:space="preserve">
     <value>GSSAPI security context establishment failed with status: {0} (Minor status: {1})</value>
@@ -74,6 +74,6 @@
     <value>GSSAPI decryption or signature verification failed with status: {0} (Minor status: {1})</value>
   </data>
   <data name="net_context_buffer_too_small" xml:space="preserve">
-    <value>Insufficient buffer space. Required: {0} Actual: {1}</value>
+    <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
   </data>
 </root>

--- a/src/System.Net.Security/tests/FunctionalTests/Resources/Strings.resx
+++ b/src/System.Net.Security/tests/FunctionalTests/Resources/Strings.resx
@@ -59,10 +59,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="net_gssapi_operation_failed_detailed" xml:space="preserve">
-    <value>GSSAPI operation failed with error - {0} ({1}).</value>
+    <value>Gss api operation failed with error : {0} ({1}).</value>
   </data>
   <data name="net_gssapi_operation_failed" xml:space="preserve">
-    <value>GSSAPI operation failed with status: {0} (Minor status: {1}).</value>
+    <value>GSSAPI operation failed with status: {0} (Minor status: {1})</value>
   </data>
   <data name="net_context_establishment_failed" xml:space="preserve">
     <value>GSSAPI security context establishment failed with status: {0} (Minor status: {1})</value>
@@ -74,6 +74,6 @@
     <value>GSSAPI decryption or signature verification failed with status: {0} (Minor status: {1})</value>
   </data>
   <data name="net_context_buffer_too_small" xml:space="preserve">
-    <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
+    <value>Insufficient buffer space. Required: {0} Actual: {1}</value>
   </data>
 </root>

--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -215,7 +215,7 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Can not access a closed Stream.</value>
+    <value>Cannot access a closed Stream.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
     <value>Positive number required.</value>

--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -215,7 +215,7 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
     <value>Positive number required.</value>

--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -123,7 +123,7 @@
   <data name="ArrayExceededSizeAttribute" xml:space="preserve">
     <value>Array length '{0}' provided by Size attribute is not equal to the number of array elements '{1}' from namespace '{2}' found.</value>
   </data>
-  <data name="ArrayTypeIsNotSupported" xml:space="preserve">
+  <data name="ArrayTypeIsNotSupported_GeneratingCode" xml:space="preserve">
     <value>An internal error has occurred. '{0}[]' is not supported when generating code for serialization.</value>
   </data>
   <data name="CannotDeserializeRefAtTopLevel" xml:space="preserve">

--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -333,7 +333,7 @@
   <data name="InvalidNonNullReturnValueByIsAny" xml:space="preserve">
     <value>Method '{0}.{1}()' returns a non-null value. The return value must be null since IsAny</value>
   </data>
-  <data name="InvalidPrimitiveType" xml:space="preserve">
+  <data name="InvalidPrimitiveType_Serialization" xml:space="preserve">
     <value>Type '{0}' is not a valid serializable type.</value>
   </data>
   <data name="InvalidReturnTypeOnGetSchemaMethod" xml:space="preserve">
@@ -535,7 +535,7 @@
     <value>Unexpected end of file.</value>
   </data>
   <data name="UnknownConstantType" xml:space="preserve">
-    <value>Unrecognized constant type '{0}'.</value>
+    <value>Internal Error: Unrecognized constant type {0}.</value>
   </data>
   <data name="ValueMustBeNonNegative" xml:space="preserve">
     <value>The value of this argument must be non-negative.</value>
@@ -732,7 +732,7 @@
   <data name="XmlInvalidDepth" xml:space="preserve">
     <value>Cannot call '{0}' while Depth is '{1}'.</value>
   </data>
-  <data name="XmlInvalidEncoding" xml:space="preserve">
+  <data name="XmlInvalidEncoding_UTF8" xml:space="preserve">
     <value>XML encoding must be 'UTF-8'.</value>
   </data>
   <data name="XmlInvalidFFFE" xml:space="preserve">

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
@@ -1230,7 +1230,7 @@ namespace System.Runtime.Serialization
             {
                 OpCode opCode = GetLdelemOpCode(arrayElementType.GetTypeCode());
                 if (opCode.Equals(OpCodes.Nop))
-                    throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ArrayTypeIsNotSupported, DataContract.GetClrTypeFullName(arrayElementType))));
+                    throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ArrayTypeIsNotSupported_GeneratingCode, DataContract.GetClrTypeFullName(arrayElementType))));
                 if (_codeGenTrace != CodeGenTrace.None)
                     EmitSourceInstruction(opCode.ToString());
                 _ilGen.Emit(opCode);
@@ -1292,7 +1292,7 @@ namespace System.Runtime.Serialization
             {
                 OpCode opCode = GetStelemOpCode(arrayElementType.GetTypeCode());
                 if (opCode.Equals(OpCodes.Nop))
-                    throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ArrayTypeIsNotSupported, DataContract.GetClrTypeFullName(arrayElementType))));
+                    throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ArrayTypeIsNotSupported_GeneratingCode, DataContract.GetClrTypeFullName(arrayElementType))));
                 if (_codeGenTrace != CodeGenTrace.None)
                     EmitSourceInstruction(opCode.ToString());
                 EmitStackTop(arrayElementType);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlReaderDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlReaderDelegator.cs
@@ -227,7 +227,7 @@ namespace System.Runtime.Serialization
         private Exception CreateInvalidPrimitiveTypeException(Type type)
         {
             return new InvalidDataContractException(SR.Format(
-                type.IsInterface ? SR.InterfaceTypeCannotBeCreated : SR.InvalidPrimitiveType,
+                type.IsInterface ? SR.InterfaceTypeCannotBeCreated : SR.InvalidPrimitiveType_Serialization,
                 DataContract.GetClrTypeFullName(type)));
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
@@ -286,7 +286,7 @@ namespace System.Runtime.Serialization
 
         private Exception CreateInvalidPrimitiveTypeException(Type type)
         {
-            return new InvalidDataContractException(SR.Format(SR.InvalidPrimitiveType, DataContract.GetClrTypeFullName(type)));
+            return new InvalidDataContractException(SR.Format(SR.InvalidPrimitiveType_Serialization, DataContract.GetClrTypeFullName(type)));
         }
 
         internal void WriteAnyType(object value)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
@@ -153,7 +153,7 @@ namespace System.Xml
             // We only validate that they are the only attributes that exist.  Encoding can have any value.
             if (_attributeCount > 1)
             {
-                if (CheckDeclAttribute(1, "encoding", null, true, SR.XmlInvalidEncoding))
+                if (CheckDeclAttribute(1, "encoding", null, true, SR.XmlInvalidEncoding_UTF8))
                 {
                     if (_attributeCount == 3 && !CheckStandalone(2))
                         XmlExceptionHelper.ThrowXmlException(this, new XmlException(SR.Format(SR.XmlMalformedDecl)));

--- a/src/System.Private.Reflection.Metadata.Ecma335/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/Resources/Strings.resx
@@ -299,7 +299,7 @@
     <value>Unexpected PDB Checksum data signature value.</value>
   </data>
   <data name="InvalidPdbChecksumDataFormat" xml:space="preserve">
-    <value>Invalid PDB Checksum data data format.</value>
+    <value>Invalid PDB Checksum data format.</value>
   </data>
   <data name="UnexpectedSignatureHeader" xml:space="preserve">
     <value>Expected signature header for '{0}', but found '{1}' (0x{2:x2}).</value>

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -281,7 +281,7 @@
     <value>Unexpected Embedded Portable PDB data signature value.</value>
   </data>
   <data name="InvalidPdbChecksumDataFormat" xml:space="preserve">
-    <value>Invalid PDB Checksum data data format.</value>
+    <value>Invalid PDB Checksum data format.</value>
   </data>
   <data name="UnexpectedSignatureHeader" xml:space="preserve">
     <value>Expected signature header for '{0}', but found '{1}' (0x{2:x2}).</value>

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -281,7 +281,7 @@
     <value>Unexpected Embedded Portable PDB data signature value.</value>
   </data>
   <data name="InvalidPdbChecksumDataFormat" xml:space="preserve">
-    <value>Invalid PDB Checksum data format.</value>
+    <value>Invalid PDB Checksum data data format.</value>
   </data>
   <data name="UnexpectedSignatureHeader" xml:space="preserve">
     <value>Expected signature header for '{0}', but found '{1}' (0x{2:x2}).</value>

--- a/src/System.Runtime.Extensions/src/Resources/Strings.resx
+++ b/src/System.Runtime.Extensions/src/Resources/Strings.resx
@@ -139,14 +139,11 @@
     <value>The parameter '{0}' cannot be an empty string.</value>
   </data>
   <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
-    <value>Array is not long enough. Check array index and length.</value>
+    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
   </data>
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
     <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
-  </data>
-  <data name="ArgumentOutOfRange_GenericPositive" xml:space="preserve">
-    <value>Value must be positive.</value>
-  </data>
+  </data>  
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
@@ -196,7 +193,7 @@
     <value>The file '{0}' already exists.</value>
   </data>
   <data name="Arg_EnumIllegalVal" xml:space="preserve">
-    <value>Illegal enum value: {0}</value>
+    <value>Illegal enum value: {0}.</value>
   </data>
   <data name="InvalidOperation_ComputerName" xml:space="preserve">
     <value>Computer name could not be obtained.</value>
@@ -265,7 +262,7 @@
     <value>Insertion index was out of range. Must be non-negative and less than or equal to size.</value>
   </data>
   <data name="ArgumentOutOfRange_BiggerThanCollection" xml:space="preserve">
-    <value>Larger than collection size.</value>
+    <value>Must be less than or equal to the size of the collection.</value>
   </data>
   <data name="ArgumentOutOfRange_Count" xml:space="preserve">
     <value>Count must be positive and count must refer to a location within the string/array/collection.</value>

--- a/src/System.Runtime.Extensions/src/Resources/Strings.resx
+++ b/src/System.Runtime.Extensions/src/Resources/Strings.resx
@@ -275,10 +275,7 @@
   </data>
   <data name="ArgumentOutOfRange_SmallCapacity" xml:space="preserve">
     <value>capacity was less than the current size.</value>
-  </data>
-  <data name="Argument_AddingDuplicate__" xml:space="preserve">
-    <value>Item has already been added. Key in dictionary: '{0}'  Key being added: '{1}'</value>
-  </data>
+  </data>  
   <data name="Argument_InvalidOffLen" xml:space="preserve">
     <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
   </data>
@@ -295,7 +292,7 @@
     <value>Enumeration already finished.</value>
   </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
-    <value>Collection was modified; enumeration operation may not execute.</value>
+    <value>Collection was modified after the enumerator was instantiated.</value>
   </data>
   <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
     <value>Enumeration has not started. Call MoveNext.</value>
@@ -355,7 +352,7 @@
     <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="Argument_EmptyPath" xml:space="preserve">
     <value>Empty path name is not legal.</value>

--- a/src/System.Runtime.Extensions/src/Resources/Strings.resx
+++ b/src/System.Runtime.Extensions/src/Resources/Strings.resx
@@ -237,7 +237,7 @@
   <data name="EntryPointNotFound" xml:space="preserve">
     <value>Entry point not found in assembly</value>
   </data>
-  <data name="NotSupported" xml:space="preserve">
+  <data name="NotSupported_Platform" xml:space="preserve">
     <value>Not supported on this platform.</value>
   </data>
   <data name="Arg_ContextMarshalException" xml:space="preserve">
@@ -324,10 +324,10 @@
   <data name="Serialization_KeyValueDifferentSizes" xml:space="preserve">
     <value>The keys and values arrays have different sizes.</value>
   </data>
-  <data name="Serialization_MissingKeys" xml:space="preserve">
+  <data name="Serialization_MissingKeys_Hashtable" xml:space="preserve">
     <value>The Keys for this Hashtable are missing.</value>
   </data>
-  <data name="Serialization_MissingValues" xml:space="preserve">
+  <data name="Serialization_MissingValues_Hashtable" xml:space="preserve">
     <value>The Values for this Hashtable are missing.</value>
   </data>
   <data name="Serialization_NullKey" xml:space="preserve">

--- a/src/System.Runtime.Extensions/src/Resources/Strings.resx
+++ b/src/System.Runtime.Extensions/src/Resources/Strings.resx
@@ -120,6 +120,9 @@
   <data name="Argument_AddingDuplicate" xml:space="preserve">
     <value>An item with the same key has already been added. Key: {0}</value>
   </data>
+  <data name="Argument_AddingDuplicate_OldAndNewKeys" xml:space="preserve">
+    <value>Item has already been added. Key in dictionary: '{0}'  Key being added: '{1}'</value>
+  </data>
   <data name="Argument_EmptyApplicationName" xml:space="preserve">
     <value>ApplicationId cannot have an empty string for the name.</value>
   </data>

--- a/src/System.Runtime.Extensions/src/System/AppDomain.cs
+++ b/src/System.Runtime.Extensions/src/System/AppDomain.cs
@@ -174,7 +174,7 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(domain));
             }
-            throw new CannotUnloadAppDomainException(SR.NotSupported);
+            throw new CannotUnloadAppDomainException(SR.NotSupported_Platform);
         }
 
         public Assembly Load(byte[] rawAssembly) => Assembly.Load(rawAssembly);

--- a/src/System.Runtime.Extensions/src/System/Collections/Hashtable.cs
+++ b/src/System.Runtime.Extensions/src/System/Collections/Hashtable.cs
@@ -1236,11 +1236,11 @@ namespace System.Collections
 
             if (serKeys == null)
             {
-                throw new SerializationException(SR.Serialization_MissingKeys);
+                throw new SerializationException(SR.Serialization_MissingKeys_Hashtable);
             }
             if (serValues == null)
             {
-                throw new SerializationException(SR.Serialization_MissingValues);
+                throw new SerializationException(SR.Serialization_MissingValues_Hashtable);
             }
             if (serKeys.Length != serValues.Length)
             {

--- a/src/System.Runtime.Extensions/src/System/Collections/Hashtable.cs
+++ b/src/System.Runtime.Extensions/src/System/Collections/Hashtable.cs
@@ -953,7 +953,7 @@ namespace System.Collections
                 {
                     if (add)
                     {
-                        throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate__, _buckets[bucketNumber].key, key));
+                        throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate, key));
                     }
                     _isWriterInProgress = true;
                     _buckets[bucketNumber].val = nvalue;

--- a/src/System.Runtime.Extensions/src/System/Collections/Hashtable.cs
+++ b/src/System.Runtime.Extensions/src/System/Collections/Hashtable.cs
@@ -953,7 +953,7 @@ namespace System.Collections
                 {
                     if (add)
                     {
-                        throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate, key));
+                        throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate_OldAndNewKeys , _buckets[bucketNumber].key, key));
                     }
                     _isWriterInProgress = true;
                     _buckets[bucketNumber].val = nvalue;

--- a/src/System.Runtime.Serialization.Formatters/src/Resources/Strings.resx
+++ b/src/System.Runtime.Serialization.Formatters/src/Resources/Strings.resx
@@ -59,7 +59,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Arg_HTCapacityOverflow" xml:space="preserve">
-    <value>Capacity overflowed and went negative.</value>
+    <value>Hashtable's capacity overflowed and went negative. Check load factor, capacity and the current size of the table.</value>
   </data>
   <data name="Serialization_NonSerType" xml:space="preserve">
     <value>Type '{0}' in Assembly '{1}' is not marked as serializable.</value>

--- a/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
+++ b/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
@@ -271,7 +271,7 @@
     <value>An error has occurred.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Cannot access a closed Stream.</value>
+    <value>Cannot access a closed stream.</value>
   </data>
   <data name="NotSupported_UnseekableStream" xml:space="preserve">
     <value>Stream does not support seeking.</value>

--- a/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -134,7 +134,7 @@
     <value>The specified curve '{0}' or its parameters are not valid for this platform.</value>
   </data>
   <data name="Cryptography_InvalidCurveOid" xml:space="preserve">
-    <value>The specified Oid is not valid. The Oid.FriendlyName property must be set, or be determined from Oid.Value.</value>
+    <value>The specified Oid is not valid. The Oid.FriendlyName or Oid.Value property must be set.</value>
   </data>
   <data name="Cryptography_InvalidIVSize" xml:space="preserve">
     <value>Specified initialization vector (IV) does not match the block size for this algorithm.</value>

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -71,7 +71,7 @@
     <value>The OID value was invalid.</value>
   </data>
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
-    <value>Index was out of range.  Must be non-negative and less than the size of the collection.</value>
+    <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
   </data>
   <data name="Cryptography_Asn_EnumeratedValueRequiresNonFlagsEnum" xml:space="preserve">
     <value>ASN.1 Enumerated values only apply to enum types without the [Flags] attribute.</value>

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -269,7 +269,7 @@
       <value>The platform does not have a definition for an X509 certificate store named '{0}' with a StoreLocation of '{1}', and does not support creating it.</value>
   </data>
   <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
-    <value>Enumeration has not started.  Call MoveNext.</value>
+    <value>Enumeration has not started. Call MoveNext.</value>
   </data>
   <data name="NotSupported_ECDsa_Csp" xml:space="preserve">
     <value>CryptoApi ECDsa keys are not supported.</value>

--- a/src/System.Security.Cryptography.Xml/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Xml/src/Resources/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
-    <value>Index was out of range.  Must be non-negative and less than the size of the collection.</value>
+    <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
   </data>
   <data name="Arg_EmptyOrNullString" xml:space="preserve">
     <value>String cannot be empty or null.</value>

--- a/src/System.ServiceProcess.ServiceController/src/Resources/Strings.resx
+++ b/src/System.ServiceProcess.ServiceController/src/Resources/Strings.resx
@@ -71,7 +71,7 @@
     <value>The value of argument '{0}' ({1}) is invalid for Enum type '{2}'.</value>
   </data>
   <data name="InvalidParameter" xml:space="preserve">
-    <value>Invalid value {1} for parameter {0}.</value>
+    <value>Invalid value '{1}' for parameter '{0}'.</value>
   </data>
   <data name="NoMachineName" xml:space="preserve">
     <value>MachineName was not set.</value>

--- a/src/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -103,7 +103,7 @@
   <data name="IncompleteSlashP" xml:space="preserve">
     <value>Incomplete \\p{X} character escape.</value>
   </data>
-  <data name="InternalError" xml:space="preserve">
+  <data name="InternalError_ScanRegex" xml:space="preserve">
     <value>Internal error in ScanRegex.</value>
   </data>
   <data name="InvalidGroupName" xml:space="preserve">

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -356,7 +356,7 @@ namespace System.Text.RegularExpressions
                         break;
 
                     default:
-                        throw MakeException(SR.InternalError);
+                        throw MakeException(SR.InternalError_ScanRegex);
                 }
 
                 ScanBlank();
@@ -420,7 +420,7 @@ namespace System.Text.RegularExpressions
                             break;
 
                         default:
-                            throw MakeException(SR.InternalError);
+                            throw MakeException(SR.InternalError_ScanRegex);
                     }
 
                     ScanBlank();

--- a/src/System.Threading.Overlapped/src/Resources/Strings.resx
+++ b/src/System.Threading.Overlapped/src/Resources/Strings.resx
@@ -62,7 +62,7 @@
     <value>'handle' has already been bound to the thread pool, or was not opened for asynchronous I/O.</value>
   </data>
   <data name="Argument_InvalidHandle" xml:space="preserve">
-    <value>'handle' has been disposed or is an invalid handle.</value>
+    <value>Handle has been disposed or is invalid.</value>
   </data>
   <data name="Argument_NativeOverlappedAlreadyFree" xml:space="preserve">
     <value>'overlapped' has already been freed.</value>


### PR DESCRIPTION
closes  #29226 

@danmosemsft  some of this changes could be "subjective".

```
PS ...\ .\FindResourceDuplicates.ps1 ...\corefx\src
InvalidArgumentValue Value of '{1}' is not valid for '{0}'.
InvalidArgumentValue Value of '{1}' is not valid for '{0}'.
InvalidArgumentValue Invalid argument value
ADP_DeriveParametersNotSupported {0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType.{1}.
ADP_DeriveParametersNotSupported {0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType. {1}.
```
I created a powershell script [here](https://gist.github.com/MarcoRossignoli/84edeb15828de2af89f045badd549816) and found other duplicates. Where i can put script?

PS. I'm not so fluent with powershell, i think that an expert could do this check with less code, i did my best.