### PR TITLE
Fix NetFx package testing

### DIFF
--- a/pkg/test/frameworkSettings/net/settings.targets
+++ b/pkg/test/frameworkSettings/net/settings.targets
@@ -19,14 +19,13 @@
     <IgnoredTypes Include="System.ServiceModel.Channels.HttpRequestMessageExtensionMethods" />
   </ItemGroup>
 
-  <!-- this target must run before ResolvePackageDependenciesForBuild so
+  <!-- this target must run before ResolveLockFileReferences so
        that the SDK targets de-dup the References it adds against those
        that come from packages -->
   <Target Name="ReferenceEntireFramework" 
-          BeforeTargets="ResolvePackageDependenciesForBuild" 
-          DependsOnTargets="GetReferenceAssemblyPaths" 
-          Condition="'$(TargetFrameworkDirectory)' != ''">
-    <ItemGroup>
+          BeforeTargets="ResolveLockFileReferences" 
+          DependsOnTargets="GetFrameworkPaths;GetReferenceAssemblyPaths">
+    <ItemGroup Condition="'$(TargetFrameworkDirectory)' != ''">
       <!-- TargetFrameworkDirectory may contain many paths -->
       <_frameworkDirectoriesToInclude Include="$(TargetFrameworkDirectory)" />
 


### PR DESCRIPTION
SDK did some target refactoring and it broke how we auto-ref the .NET framework.

This fixes that and adds a suppression for one package which is broken.