### PR TITLE
Always use DnsEndPoint in SocketHttpHandler's ConnectAsync

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -54,9 +54,7 @@ namespace System.Net.Http
                 saea.Initialize(cancellationToken);
 
                 // Configure which server to which to connect.
-                saea.RemoteEndPoint = IPAddress.TryParse(host, out IPAddress address) ?
-                    (EndPoint)new IPEndPoint(address, port) :
-                    new DnsEndPoint(host, port);
+                saea.RemoteEndPoint = new DnsEndPoint(host, port);
 
                 // Initiate the connection.
                 if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, saea))


### PR DESCRIPTION
We had a minor optimization here, but there's a long-standing issue with Socket.ConnectAsync where it's leaving for finalization a socket when the connect with an IP address fails.  It's more important to address that issue, and using DnsEndPoint does so (it's also the code we want, anyway).

Contributes to https://github.com/dotnet/corefx/issues/26517
Contributes to https://github.com/dotnet/corefx/issues/29285

cc: @geoffkizer, @davidsh 