### PR TITLE
* NO MERGE * example of tactical changes to ensure SSL error queue is kept clean

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -35,9 +35,6 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1BitStringFree")]
         internal static extern void Asn1BitStringFree(IntPtr o);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeAsn1OctetString")]
-        internal static extern SafeAsn1OctetStringHandle DecodeAsn1OctetString(byte[] buf, int len);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1OctetStringNew")]
         internal static extern SafeAsn1OctetStringHandle Asn1OctetStringNew();
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -210,7 +210,7 @@ internal static partial class Interop
                     if (sendCount <= 0)
                     {
                         // Make sure we clear out the error that is stored in the queue
-                        Crypto.ErrGetError();
+                        Crypto.ErrClearError();
                         sendBuf = null;
                         sendCount = 0;
                     }
@@ -267,7 +267,7 @@ internal static partial class Interop
                 if (retVal <= 0)
                 {
                     // Make sure we clear out the error that is stored in the queue
-                    Crypto.ErrGetError();
+                    Crypto.ErrClearError();
                 }
             }
 
@@ -505,7 +505,8 @@ internal static partial class Interop
 
         internal static SslException CreateSslException(string message)
         {
-            ulong errorVal = Crypto.ErrGetError();
+            ulong errorVal = Crypto.ErrGetLastError();
+            Crypto.ErrClearError();
             string msg = SR.Format(message, Marshal.PtrToStringAnsi(Crypto.ErrReasonErrorString(errorVal)));
             return new SslException(msg, (int)errorVal);
         }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -505,7 +505,7 @@ internal static partial class Interop
 
         internal static SslException CreateSslException(string message)
         {
-            ulong errorVal = Crypto.ErrGetLastError();
+            ulong errorVal = Crypto.ErrPeekLastError();
             Crypto.ErrClearError();
             string msg = SR.Format(message, Marshal.PtrToStringAnsi(Crypto.ErrReasonErrorString(errorVal)));
             return new SslException(msg, (int)errorVal);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -237,6 +237,7 @@ namespace Microsoft.Win32.SafeHandles
                 readBio.Dispose();
                 writeBio.Dispose();
                 handle.Dispose(); // will make IsInvalid==true if it's not already
+                Interop.Crypto.ErrClearError();
                 return handle;
             }
             handle._isServer = isServer;

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -67,16 +67,6 @@ extern "C" void CryptoNative_Asn1BitStringFree(ASN1_STRING* a)
     ASN1_BIT_STRING_free(a);
 }
 
-extern "C" ASN1_OCTET_STRING* CryptoNative_DecodeAsn1OctetString(const uint8_t* buf, int32_t len)
-{
-    if (!buf || !len)
-    {
-        return nullptr;
-    }
-
-    return d2i_ASN1_OCTET_STRING(nullptr, &buf, len);
-}
-
 extern "C" ASN1_OCTET_STRING* CryptoNative_Asn1OctetStringNew()
 {
     ASN1_OCTET_STRING *r = ASN1_OCTET_STRING_new();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -79,12 +79,24 @@ extern "C" ASN1_OCTET_STRING* CryptoNative_DecodeAsn1OctetString(const uint8_t* 
 
 extern "C" ASN1_OCTET_STRING* CryptoNative_Asn1OctetStringNew()
 {
-    return ASN1_OCTET_STRING_new();
+    ASN1_OCTET_STRING *r = ASN1_OCTET_STRING_new();
+    if (r == nullptr)
+    {
+        ERR_clear_error();
+    }
+
+    return r;
 }
 
 extern "C" int32_t CryptoNative_Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len)
 {
-    return ASN1_OCTET_STRING_set(s, data, len);
+    int32_t r = ASN1_OCTET_STRING_set(s, data, len)
+    if (r == 0)
+    {
+        ERR_clear_error();
+    }
+
+    return
 }
 
 extern "C" void CryptoNative_Asn1OctetStringFree(ASN1_STRING* a)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -86,7 +86,7 @@ extern "C" int32_t CryptoNative_Asn1OctetStringSet(ASN1_OCTET_STRING* s, const u
         ERR_clear_error();
     }
 
-    return
+    return r;
 }
 
 extern "C" void CryptoNative_Asn1OctetStringFree(ASN1_STRING* a)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -80,7 +80,7 @@ extern "C" ASN1_OCTET_STRING* CryptoNative_Asn1OctetStringNew()
 
 extern "C" int32_t CryptoNative_Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len)
 {
-    int32_t r = ASN1_OCTET_STRING_set(s, data, len)
+    int32_t r = ASN1_OCTET_STRING_set(s, data, len);
     if (r == 0)
     {
         ERR_clear_error();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_bio.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_bio.cpp
@@ -18,7 +18,13 @@ extern "C" BIO* CryptoNative_BioNewFile(const char* filename, const char* mode)
 
 extern "C" int32_t CryptoNative_BioDestroy(BIO* a)
 {
-    return BIO_free(a);
+    int32_t r = BIO_free(a);
+    if (r == 0)
+    {
+        ERR_clear_error();
+    }
+
+    return r;
 }
 
 extern "C" int32_t CryptoNative_BioGets(BIO* b, char* buf, int32_t size)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
@@ -64,6 +64,7 @@ namespace Internal.Cryptography.Pal
                 }
             }
 
+            Interop.Crypto.ErrClearError(); 
             return null;
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
@@ -118,7 +118,10 @@ namespace Internal.Cryptography.Pal
             // 
             // Use BioSeek directly for the last seek attempt, because any failure here should instead
             // report the already created (but not yet thrown) exception.
-            Interop.Crypto.BioSeek(bio, bioPosition);
+            if (Interop.Crypto.BioSeek(bio, bioPosition) < 0)
+            {
+                Interop.Crypto.ErrClearError();
+            }
 
             Debug.Assert(openSslException != null);
             throw openSslException;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -120,7 +120,10 @@ namespace Internal.Cryptography.Pal
             // 
             // Use BioSeek directly for the last seek attempt, because any failure here should instead
             // report the already created (but not yet thrown) exception.
-            Interop.Crypto.BioSeek(bio, bioPosition);
+            if (Interop.Crypto.BioSeek(bio, bioPosition) < 0)
+            {
+                Interop.Crypto.ErrClearError();
+            }
             
             Debug.Assert(openSslException != null);
             throw openSslException;


### PR DESCRIPTION
Addressed the following native calls that were pending from initial list:

CryptoNative_Asn1OctetStringNew
CryptoNative_Asn1OctetStringSet
CryptoNative_BigNumFromBinary
CryptoNative_BioDestroy
CryptoNative_BioNewFile
CryptoNative_BioRead
CryptoNative_BioSeek
CryptoNative_BioTell
CryptoNative_BioWrite
CryptoNative_CreateMemoryBio
CryptoNative_DecodeAsn1OctetString
CryptoNative_DecodeAsn1TypeBytes

If the native failure is ignored on managed I opted to clear the queue on native.
Some of the functions, typically set or related may actually have no chance of returning error assuming we pass good parameters.
