### PR TITLE
[1.1] Make native packages filterable on non-full build

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -38,31 +38,27 @@
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
     <Project Include="Native\pkg\runtime.native.System\runtime.native.System.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
-      <BuildAllOSGroups>true</BuildAllOSGroups>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>
     <Project Include="Native\pkg\runtime.native.System.IO.Compression\runtime.native.System.IO.Compression.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
-      <BuildAllOSGroups>true</BuildAllOSGroups>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>
     <Project Include="Native\pkg\runtime.native.System.Net.Http\runtime.native.System.Net.Http.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
-      <BuildAllOSGroups>true</BuildAllOSGroups>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>
     <Project Include="Native\pkg\runtime.native.System.Net.Security\runtime.native.System.Net.Security.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
-      <BuildAllOSGroups>true</BuildAllOSGroups>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>
     <Project Include="Native\pkg\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
-      <BuildAllOSGroups>true</BuildAllOSGroups>
-    </Project>
-    <Project Include="Native\pkg\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.builds">
-      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
-      <BuildAllOSGroups>true</BuildAllOSGroups>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>
     <Project Include="Native\pkg\runtime.native.System.Security.Cryptography.OpenSsl\runtime.native.System.Security.Cryptography.OpenSsl.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
-      <BuildAllOSGroups>true</BuildAllOSGroups>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>
   </ItemGroup>
 


### PR DESCRIPTION
Allows setting BuildAllOSGroups properly as an input parameter, and removes a second project inclusion of the crypto native package.