### PR TITLE
Disable StartInfo_TextFile_ShellExecute for NETFX

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -985,8 +985,7 @@ namespace System.Diagnostics.Tests
                                                     nameof(PlatformDetection.IsNotWindows8x))] // https://github.com/dotnet/corefx/issues/20388
         [OuterLoop("Launches notepad")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        // Re-enabling with extra diagnostic info
-        // [ActiveIssue("https://github.com/dotnet/corefx/issues/20388")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20388", TargetFrameworkMonikers.NetFramework)]
         // We don't have the ability yet for UseShellExecute in UAP
         [ActiveIssue("https://github.com/dotnet/corefx/issues/20204", TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void StartInfo_TextFile_ShellExecute()


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/issues/20388

It's now disabled for several platforms, and for 3 frameworks, but still has value running for netcoreapp where it seems to be stable currently.

Multiple ActiveIssue attributes are allowed.