### PR TITLE
[release/2.1] Always use DnsEndPoint in SocketHttpHandler's ConnectAsync (#29286)

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -54,9 +54,7 @@ namespace System.Net.Http
                 saea.Initialize(cancellationToken);
 
                 // Configure which server to which to connect.
-                saea.RemoteEndPoint = IPAddress.TryParse(host, out IPAddress address) ?
-                    (EndPoint)new IPEndPoint(address, port) :
-                    new DnsEndPoint(host, port);
+                saea.RemoteEndPoint = new DnsEndPoint(host, port);
 
                 // Initiate the connection.
                 if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, saea))


### PR DESCRIPTION
Port of #29286