### PR TITLE
Test that AsyncLocal<class> changed event is not raised multiple times for one change in value

### DIFF
--- a/src/System.Threading/tests/AsyncLocalTests.cs
+++ b/src/System.Threading/tests/AsyncLocalTests.cs
@@ -154,6 +154,60 @@ namespace System.Threading.Tests
         }
 
         [Fact]
+        public static void NotifyCountOnObjectValueChange()
+        {
+            var obj0 = new object();
+            var obj1 = new object();
+            var obj2 = new object();
+
+            int asyncLocal0ChangeCount = 0;
+            int asyncLocal1ChangeCount = 0;
+            void VerifyChangeCounts(int expectedAsyncLocal0ChangeCount, int expectedAsyncLocal1ChangeCount)
+            {
+                Assert.Equal(expectedAsyncLocal0ChangeCount, asyncLocal0ChangeCount);
+                Assert.Equal(expectedAsyncLocal1ChangeCount, asyncLocal1ChangeCount);
+            }
+
+            Action<AsyncLocalValueChangedArgs<object>> onAsyncLocal0Changed = e =>
+            {
+                Assert.Null(e.PreviousValue);
+                Assert.Same(obj0, e.CurrentValue);
+                ++asyncLocal0ChangeCount;
+            };
+            VerifyChangeCounts(0, 0);
+            var asyncLocal0 = new AsyncLocal<object>(onAsyncLocal0Changed);
+            VerifyChangeCounts(0, 0);
+            asyncLocal0.Value = obj0;
+            VerifyChangeCounts(1, 0);
+            var executionContext = ExecutionContext.Capture();
+
+            Action<AsyncLocalValueChangedArgs<object>> onAsyncLocal1Changed = e =>
+            {
+                if (e.PreviousValue == null)
+                {
+                    Assert.True(e.CurrentValue == obj1 || e.CurrentValue == obj2);
+                }
+                else
+                {
+                    Assert.Null(e.CurrentValue);
+                }
+                ++asyncLocal1ChangeCount;
+            };
+            VerifyChangeCounts(1, 0);
+            var asyncLocal1 = new AsyncLocal<object>(onAsyncLocal1Changed);
+            VerifyChangeCounts(1, 0);
+            asyncLocal1.Value = obj1;
+            VerifyChangeCounts(1, 1);
+            asyncLocal1.Value = null;
+            VerifyChangeCounts(1, 2);
+            asyncLocal1.Value = obj2;
+            VerifyChangeCounts(1, 3);
+
+            ExecutionContext.Run(executionContext, data => VerifyChangeCounts(1, 4), null);
+            VerifyChangeCounts(1, 5);
+        }
+
+        [Fact]
         public static async Task NotifyOnThreadContextChange()
         {
             bool expectThreadContextChange = false;

--- a/src/System.Threading/tests/AsyncLocalTests.cs
+++ b/src/System.Threading/tests/AsyncLocalTests.cs
@@ -154,7 +154,7 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        public static void NotifyCountOnObjectValueChange()
+        public static async Task NotifyCountOnObjectValueChange()
         {
             var obj0 = new object();
             var obj1 = new object();

--- a/src/System.Threading/tests/AsyncLocalTests.cs
+++ b/src/System.Threading/tests/AsyncLocalTests.cs
@@ -170,8 +170,9 @@ namespace System.Threading.Tests
 
             Action<AsyncLocalValueChangedArgs<object>> onAsyncLocal0Changed = e =>
             {
-                Assert.Null(e.PreviousValue);
-                Assert.Same(obj0, e.CurrentValue);
+                Assert.True(e.PreviousValue == null || e.CurrentValue == null);
+                object nonNullValue = e.PreviousValue ?? e.CurrentValue;
+                Assert.Same(obj0, nonNullValue);
                 ++asyncLocal0ChangeCount;
             };
             VerifyChangeCounts(0, 0);
@@ -183,14 +184,9 @@ namespace System.Threading.Tests
 
             Action<AsyncLocalValueChangedArgs<object>> onAsyncLocal1Changed = e =>
             {
-                if (e.PreviousValue == null)
-                {
-                    Assert.True(e.CurrentValue == obj1 || e.CurrentValue == obj2);
-                }
-                else
-                {
-                    Assert.Null(e.CurrentValue);
-                }
+                Assert.True(e.PreviousValue == null || e.CurrentValue == null);
+                object nonNullValue = e.PreviousValue ?? e.CurrentValue;
+                Assert.True(nonNullValue == obj1 || nonNullValue == obj2);
                 ++asyncLocal1ChangeCount;
             };
             VerifyChangeCounts(1, 0);


### PR DESCRIPTION
- Depends on and tests https://github.com/dotnet/coreclr/pull/17767
- Tests for and closes https://github.com/dotnet/coreclr/issues/17758