### PR TITLE
[System.Private.Xml.Linq] Rename FunctionalTests classes

### DIFF
--- a/src/System.Private.Xml.Linq/tests/Properties/FunctionalTests.cs
+++ b/src/System.Private.Xml.Linq/tests/Properties/FunctionalTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class PropertiesFunctionalTests : TestModule
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         [Fact]
@@ -16,7 +16,7 @@ namespace CoreXml.Test.XLinq
         public static void RunTests()
         {
             TestInput.CommandLine = "";
-            FunctionalTests module = new FunctionalTests();
+            PropertiesFunctionalTests module = new PropertiesFunctionalTests();
             module.Init();
 
             //for class PropertiesTests
@@ -28,42 +28,43 @@ namespace CoreXml.Test.XLinq
             Assert.Equal(0, module.FailCount);
         }
         #region Class
-        public partial class PropertiesTests : XLinqTestCase
+        public class PropertiesTests : XLinqTestCase
         {
             // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests
             // Test Case
             public override void AddChildren()
             {
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - XmlConvert conformance      (SetValue)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.XmlConvert, NodeCreateType.SetValue } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - XmlConvert conformance        (constructor)", Params = new object[] { typeof(XElement), ExplicitCastTestType.XmlConvert, NodeCreateType.Constructor } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - value conversion round trip   (constructor)", Params = new object[] { typeof(XElement), ExplicitCastTestType.RoundTrip, NodeCreateType.Constructor } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - value conversion round trip (constructor)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.RoundTrip, NodeCreateType.Constructor } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - value conversion round trip   (SetValue)", Params = new object[] { typeof(XElement), ExplicitCastTestType.RoundTrip, NodeCreateType.SetValue } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - XmlConvert conformance        (SetValue)", Params = new object[] { typeof(XElement), ExplicitCastTestType.XmlConvert, NodeCreateType.SetValue } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - XmlConvert conformance      (constructor)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.XmlConvert, NodeCreateType.Constructor } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - value conversion round trip (SetValue)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.RoundTrip, NodeCreateType.SetValue } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - XmlConvert conformance      (SetValue)", Params = new object[] { typeof(XAttribute), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.XmlConvert, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.SetValue } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - XmlConvert conformance        (constructor)", Params = new object[] { typeof(XElement), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.XmlConvert, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.Constructor } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - value conversion round trip   (constructor)", Params = new object[] { typeof(XElement), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.RoundTrip, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.Constructor } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - value conversion round trip (constructor)", Params = new object[] { typeof(XAttribute), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.RoundTrip, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.Constructor } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - value conversion round trip   (SetValue)", Params = new object[] { typeof(XElement), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.RoundTrip, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.SetValue } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - XmlConvert conformance        (SetValue)", Params = new object[] { typeof(XElement), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.XmlConvert, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.SetValue } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - XmlConvert conformance      (constructor)", Params = new object[] { typeof(XAttribute), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.XmlConvert, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.Constructor } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - value conversion round trip (SetValue)", Params = new object[] { typeof(XAttribute), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.RoundTrip, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.SetValue } } });
                 this.AddChild(new XElement_Op_Eplicit_Null() { Attribute = new TestCaseAttribute() { Name = "XElement - explicit cast, null", Params = new object[] { typeof(XElement) } } });
                 this.AddChild(new XElement_Op_Eplicit_Null() { Attribute = new TestCaseAttribute() { Name = "XAttribute - explicit cast, null", Params = new object[] { typeof(XAttribute) } } });
                 this.AddChild(new XElementName() { Attribute = new TestCaseAttribute() { Name = "XElement.Name with Events", Params = new object[] { true } } });
                 this.AddChild(new XElementName() { Attribute = new TestCaseAttribute() { Name = "XElement.Name", Params = new object[] { false } } });
                 this.AddChild(new XElementValue() { Attribute = new TestCaseAttribute() { Name = "XElement.Value", Params = new object[] { false } } });
             }
-            public partial class XElement_Op_Eplicit : XLinqTestCase
+            public class XElement_Op_Eplicit : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests+XElement_Op_Eplicit
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = null } });
-                    this.AddChild(new TestVariation(SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = "" } });
-                    this.AddChild(new TestVariation(SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = "text" } });
-                    this.AddChild(new TestVariation(SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = typeof(XElement) } });
-                    this.AddChild(new TestVariation(SetValueNullAttr) { Attribute = new VariationAttribute("XAttribute.SetValue(null)") });
-                    this.AddChild(new TestVariation(ConversionoBool) { Attribute = new VariationAttribute("Conversion to bool overloads (0,False,false)") { Params = new object[] { false, new string[] { "0", "False", "false", "FALSE", " FalsE " } } } });
-                    this.AddChild(new TestVariation(ConversionoBool) { Attribute = new VariationAttribute("Conversion to bool overloads (1,True,true)") { Params = new object[] { true, new string[] { "1", "True", "true", "TRUE", " TRue " } } } });
+                    var xElement_Op_Eplicit = new ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.XElement_Op_Eplicit();
+                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = null } });
+                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = "" } });
+                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = "text" } });
+                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = typeof(XElement) } });
+                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNullAttr) { Attribute = new VariationAttribute("XAttribute.SetValue(null)") });
+                    this.AddChild(new TestVariation(xElement_Op_Eplicit.ConversionoBool) { Attribute = new VariationAttribute("Conversion to bool overloads (0,False,false)") { Params = new object[] { false, new string[] { "0", "False", "false", "FALSE", " FalsE " } } } });
+                    this.AddChild(new TestVariation(xElement_Op_Eplicit.ConversionoBool) { Attribute = new VariationAttribute("Conversion to bool overloads (1,True,true)") { Params = new object[] { true, new string[] { "1", "True", "true", "TRUE", " TRue " } } } });
                 }
             }
-            public partial class XElement_Op_Eplicit_Null : XLinqTestCase
+            public class XElement_Op_Eplicit_Null : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests+XElement_Op_Eplicit_Null
                 // Test Case
@@ -71,66 +72,68 @@ namespace CoreXml.Test.XLinq
                 {
                 }
             }
-            public partial class XElementName : XLinqTestCase
+            public class XElementName : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests+XElementName
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - same name") { Params = new object[] { "<element>value</element>", "element" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - name with namespace") { Params = new object[] { "<element>value</element>", "{a}newElement" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - name with xml namespace") { Params = new object[] { "<element>value</element>", "{http://www.w3.org/XML/1998/namespace}newElement" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - element with namespace") { Params = new object[] { "<p:element xmlns:p='mynamespace'><p:child>value</p:child></p:element>", "{a}newElement" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - different name") { Params = new object[] { "<element>value</element>", "newElement" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(InValidVariation) { Attribute = new VariationAttribute("XElement - empty string name") { Params = new object[] { "<element>value</element>", "" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(InValidVariation) { Attribute = new VariationAttribute("XElement - null name") { Params = new object[] { "<element>value</element>", null }, Priority = 0 } });
-                    this.AddChild(new TestVariation(InValidVariation) { Attribute = new VariationAttribute("XElement - space character name") { Params = new object[] { "<element>value</element>", " " }, Priority = 0 } });
-                    this.AddChild(new TestVariation(ValidPIVariation) { Attribute = new VariationAttribute("XProcessingInstruction - Valid Name") { Priority = 0 } });
-                    this.AddChild(new TestVariation(InvalidPIVariation) { Attribute = new VariationAttribute("XProcessingInstruction - Invalid Name") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ValidDocTypeVariation) { Attribute = new VariationAttribute("XDocumentType - Valid Name") { Priority = 0 } });
-                    this.AddChild(new TestVariation(InvalidDocTypeVariation) { Attribute = new VariationAttribute("XDocumentType - Invalid Name") { Priority = 0 } });
+                    var xelementName = new XElementValueFunctionalTests.PropertiesTests.XElementName();
+                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - same name") { Params = new object[] { "<element>value</element>", "element" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - name with namespace") { Params = new object[] { "<element>value</element>", "{a}newElement" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - name with xml namespace") { Params = new object[] { "<element>value</element>", "{http://www.w3.org/XML/1998/namespace}newElement" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - element with namespace") { Params = new object[] { "<p:element xmlns:p='mynamespace'><p:child>value</p:child></p:element>", "{a}newElement" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - different name") { Params = new object[] { "<element>value</element>", "newElement" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.InValidVariation) { Attribute = new VariationAttribute("XElement - empty string name") { Params = new object[] { "<element>value</element>", "" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.InValidVariation) { Attribute = new VariationAttribute("XElement - null name") { Params = new object[] { "<element>value</element>", null }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.InValidVariation) { Attribute = new VariationAttribute("XElement - space character name") { Params = new object[] { "<element>value</element>", " " }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.ValidPIVariation) { Attribute = new VariationAttribute("XProcessingInstruction - Valid Name") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.InvalidPIVariation) { Attribute = new VariationAttribute("XProcessingInstruction - Invalid Name") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.ValidDocTypeVariation) { Attribute = new VariationAttribute("XDocumentType - Valid Name") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementName.InvalidDocTypeVariation) { Attribute = new VariationAttribute("XDocumentType - Invalid Name") { Priority = 0 } });
                 }
             }
-            public partial class XElementValue : XLinqTestCase
+            public class XElementValue : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests+XElementValue
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: String content") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Empty string node") { Params = new object[] { "<X>t0<A/>t00</X>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[t2]]></B><C>t3</C></A>t00</X>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - empty CDATA") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[]]></B><C>t3</C></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - empty XText") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[]]></B><C></C></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - whitespace") { Params = new object[] { "<X>t0<A>t1\n<B/><B xmlns='a'>\t<![CDATA[]]> </B>\n<C></C></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - no text nodes") { Params = new object[] { "<X>t0<A Id='a0'><B/><B xmlns='a'><?Pi c?></B><!--commm--><C></C></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Empty string node") { Params = new object[] { "<X>t0<A></A>t00</X>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(APIModified1) { Attribute = new VariationAttribute("GET: Adjacent text nodes II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(APIModified1) { Attribute = new VariationAttribute("GET: Adjacent text nodes I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(APIModified2) { Attribute = new VariationAttribute("GET: Adjacent text nodes III.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(APIModified3) { Attribute = new VariationAttribute("GET: Concatenated text I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(APIModified3) { Attribute = new VariationAttribute("GET: Concatenated text II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(APIModified4) { Attribute = new VariationAttribute("GET: Removed node.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: String content, Empty string content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: Empty element, String content") { Params = new object[] { "<X>t0<A/>t00</X>", "\nt1 " }, Priority = 0 } });
-                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: Empty element, Empty string content") { Params = new object[] { "<X>t0<A/>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: Empty string content, String content") { Params = new object[] { "<X>t0<A></A>t00</X>", "\nt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: Empty string content, Empty string content") { Params = new object[] { "<X>t0<A></A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: String content, String content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "\nt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  XText content, string content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "\tt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content (PI only), string content") { Params = new object[] { "<X>t0<A is='is'><?PI aaa?></A>t00</X>", "\tt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  XText content, Empty string content") { Params = new object[] { "<X>t0<A xml:space='preserve'>orig</A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  CDATA content, Empty string content") { Params = new object[] { "<X>t0<A><![CDATA[cdata]]></A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  CDATA content, string content") { Params = new object[] { "<X>t0<A><![CDATA[cdata]]></A>t00</X>", "\tt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content, Empty string content") { Params = new object[] { "<X>t0<A xmlns:p='p'>t1<p:Y/></A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content, string content") { Params = new object[] { "<X>t0<A is='is'><![CDATA[cdata]]>orig<C/><!--comment--></A>t00</X>", "\tt1 " }, Priority = 0 } });
-                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content (comment only), string content") { Params = new object[] { "<X>t0<A is='is'><!--comment--></A>t00</X>", "\tt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(set_APIModified1) { Attribute = new VariationAttribute("SET: Adjacent text nodes II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(set_APIModified1) { Attribute = new VariationAttribute("SET: Adjacent text nodes I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(set_APIModified2) { Attribute = new VariationAttribute("SET: Adjacent text nodes III.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(set_APIModified3) { Attribute = new VariationAttribute("SET: Concatenated text I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(set_APIModified3) { Attribute = new VariationAttribute("SET: Concatenated text II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(set_APIModified4) { Attribute = new VariationAttribute("SET: Removed node.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>", "tn\n" }, Priority = 2 } });
+                    var xelementValue = new XElementValueFunctionalTests.PropertiesTests.XElementValue();
+                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: String content") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Empty string node") { Params = new object[] { "<X>t0<A/>t00</X>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[t2]]></B><C>t3</C></A>t00</X>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - empty CDATA") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[]]></B><C>t3</C></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - empty XText") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[]]></B><C></C></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - whitespace") { Params = new object[] { "<X>t0<A>t1\n<B/><B xmlns='a'>\t<![CDATA[]]> </B>\n<C></C></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - no text nodes") { Params = new object[] { "<X>t0<A Id='a0'><B/><B xmlns='a'><?Pi c?></B><!--commm--><C></C></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Empty string node") { Params = new object[] { "<X>t0<A></A>t00</X>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementValue.APIModified1) { Attribute = new VariationAttribute("GET: Adjacent text nodes II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.APIModified1) { Attribute = new VariationAttribute("GET: Adjacent text nodes I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.APIModified2) { Attribute = new VariationAttribute("GET: Adjacent text nodes III.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.APIModified3) { Attribute = new VariationAttribute("GET: Concatenated text I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.APIModified3) { Attribute = new VariationAttribute("GET: Concatenated text II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.APIModified4) { Attribute = new VariationAttribute("GET: Removed node.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: String content, Empty string content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: Empty element, String content") { Params = new object[] { "<X>t0<A/>t00</X>", "\nt1 " }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: Empty element, Empty string content") { Params = new object[] { "<X>t0<A/>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: Empty string content, String content") { Params = new object[] { "<X>t0<A></A>t00</X>", "\nt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: Empty string content, Empty string content") { Params = new object[] { "<X>t0<A></A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: String content, String content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "\nt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  XText content, string content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "\tt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content (PI only), string content") { Params = new object[] { "<X>t0<A is='is'><?PI aaa?></A>t00</X>", "\tt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  XText content, Empty string content") { Params = new object[] { "<X>t0<A xml:space='preserve'>orig</A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  CDATA content, Empty string content") { Params = new object[] { "<X>t0<A><![CDATA[cdata]]></A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  CDATA content, string content") { Params = new object[] { "<X>t0<A><![CDATA[cdata]]></A>t00</X>", "\tt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content, Empty string content") { Params = new object[] { "<X>t0<A xmlns:p='p'>t1<p:Y/></A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content, string content") { Params = new object[] { "<X>t0<A is='is'><![CDATA[cdata]]>orig<C/><!--comment--></A>t00</X>", "\tt1 " }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content (comment only), string content") { Params = new object[] { "<X>t0<A is='is'><!--comment--></A>t00</X>", "\tt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xelementValue.set_APIModified1) { Attribute = new VariationAttribute("SET: Adjacent text nodes II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xelementValue.set_APIModified1) { Attribute = new VariationAttribute("SET: Adjacent text nodes I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xelementValue.set_APIModified2) { Attribute = new VariationAttribute("SET: Adjacent text nodes III.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xelementValue.set_APIModified3) { Attribute = new VariationAttribute("SET: Concatenated text I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xelementValue.set_APIModified3) { Attribute = new VariationAttribute("SET: Concatenated text II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xelementValue.set_APIModified4) { Attribute = new VariationAttribute("SET: Removed node.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>", "tn\n" }, Priority = 2 } });
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/tests/Properties/FunctionalTests.cs
+++ b/src/System.Private.Xml.Linq/tests/Properties/FunctionalTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public class PropertiesFunctionalTests : TestModule
+    public partial class PropertiesFunctionalTests : TestModule
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         [Fact]
@@ -28,43 +28,42 @@ namespace CoreXml.Test.XLinq
             Assert.Equal(0, module.FailCount);
         }
         #region Class
-        public class PropertiesTests : XLinqTestCase
+        public partial class PropertiesTests : XLinqTestCase
         {
             // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests
             // Test Case
             public override void AddChildren()
             {
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - XmlConvert conformance      (SetValue)", Params = new object[] { typeof(XAttribute), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.XmlConvert, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.SetValue } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - XmlConvert conformance        (constructor)", Params = new object[] { typeof(XElement), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.XmlConvert, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.Constructor } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - value conversion round trip   (constructor)", Params = new object[] { typeof(XElement), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.RoundTrip, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.Constructor } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - value conversion round trip (constructor)", Params = new object[] { typeof(XAttribute), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.RoundTrip, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.Constructor } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - value conversion round trip   (SetValue)", Params = new object[] { typeof(XElement), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.RoundTrip, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.SetValue } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - XmlConvert conformance        (SetValue)", Params = new object[] { typeof(XElement), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.XmlConvert, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.SetValue } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - XmlConvert conformance      (constructor)", Params = new object[] { typeof(XAttribute), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.XmlConvert, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.Constructor } } });
-                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - value conversion round trip (SetValue)", Params = new object[] { typeof(XAttribute), ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.ExplicitCastTestType.RoundTrip, ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.NodeCreateType.SetValue } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - XmlConvert conformance      (SetValue)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.XmlConvert, NodeCreateType.SetValue } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - XmlConvert conformance        (constructor)", Params = new object[] { typeof(XElement), ExplicitCastTestType.XmlConvert, NodeCreateType.Constructor } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - value conversion round trip   (constructor)", Params = new object[] { typeof(XElement), ExplicitCastTestType.RoundTrip, NodeCreateType.Constructor } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - value conversion round trip (constructor)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.RoundTrip, NodeCreateType.Constructor } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - value conversion round trip   (SetValue)", Params = new object[] { typeof(XElement), ExplicitCastTestType.RoundTrip, NodeCreateType.SetValue } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XElement - XmlConvert conformance        (SetValue)", Params = new object[] { typeof(XElement), ExplicitCastTestType.XmlConvert, NodeCreateType.SetValue } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - XmlConvert conformance      (constructor)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.XmlConvert, NodeCreateType.Constructor } } });
+                this.AddChild(new XElement_Op_Eplicit() { Attribute = new TestCaseAttribute() { Name = "XAttribute - value conversion round trip (SetValue)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.RoundTrip, NodeCreateType.SetValue } } });
                 this.AddChild(new XElement_Op_Eplicit_Null() { Attribute = new TestCaseAttribute() { Name = "XElement - explicit cast, null", Params = new object[] { typeof(XElement) } } });
                 this.AddChild(new XElement_Op_Eplicit_Null() { Attribute = new TestCaseAttribute() { Name = "XAttribute - explicit cast, null", Params = new object[] { typeof(XAttribute) } } });
                 this.AddChild(new XElementName() { Attribute = new TestCaseAttribute() { Name = "XElement.Name with Events", Params = new object[] { true } } });
                 this.AddChild(new XElementName() { Attribute = new TestCaseAttribute() { Name = "XElement.Name", Params = new object[] { false } } });
                 this.AddChild(new XElementValue() { Attribute = new TestCaseAttribute() { Name = "XElement.Value", Params = new object[] { false } } });
             }
-            public class XElement_Op_Eplicit : XLinqTestCase
+            public partial class XElement_Op_Eplicit : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests+XElement_Op_Eplicit
                 // Test Case
                 public override void AddChildren()
                 {
-                    var xElement_Op_Eplicit = new ImplicitConversionsRoundTripFunctionalTests.PropertiesTests.XElement_Op_Eplicit();
-                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = null } });
-                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = "" } });
-                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = "text" } });
-                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = typeof(XElement) } });
-                    this.AddChild(new TestVariation(xElement_Op_Eplicit.SetValueNullAttr) { Attribute = new VariationAttribute("XAttribute.SetValue(null)") });
-                    this.AddChild(new TestVariation(xElement_Op_Eplicit.ConversionoBool) { Attribute = new VariationAttribute("Conversion to bool overloads (0,False,false)") { Params = new object[] { false, new string[] { "0", "False", "false", "FALSE", " FalsE " } } } });
-                    this.AddChild(new TestVariation(xElement_Op_Eplicit.ConversionoBool) { Attribute = new VariationAttribute("Conversion to bool overloads (1,True,true)") { Params = new object[] { true, new string[] { "1", "True", "true", "TRUE", " TRue " } } } });
+                    this.AddChild(new TestVariation(SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = null } });
+                    this.AddChild(new TestVariation(SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = "" } });
+                    this.AddChild(new TestVariation(SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = "text" } });
+                    this.AddChild(new TestVariation(SetValueNull) { Attribute = new VariationAttribute("XElement.SetValue(null)") { Param = typeof(XElement) } });
+                    this.AddChild(new TestVariation(SetValueNullAttr) { Attribute = new VariationAttribute("XAttribute.SetValue(null)") });
+                    this.AddChild(new TestVariation(ConversionoBool) { Attribute = new VariationAttribute("Conversion to bool overloads (0,False,false)") { Params = new object[] { false, new string[] { "0", "False", "false", "FALSE", " FalsE " } } } });
+                    this.AddChild(new TestVariation(ConversionoBool) { Attribute = new VariationAttribute("Conversion to bool overloads (1,True,true)") { Params = new object[] { true, new string[] { "1", "True", "true", "TRUE", " TRue " } } } });
                 }
             }
-            public class XElement_Op_Eplicit_Null : XLinqTestCase
+            public partial class XElement_Op_Eplicit_Null : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests+XElement_Op_Eplicit_Null
                 // Test Case
@@ -72,68 +71,66 @@ namespace CoreXml.Test.XLinq
                 {
                 }
             }
-            public class XElementName : XLinqTestCase
+            public partial class XElementName : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests+XElementName
                 // Test Case
                 public override void AddChildren()
                 {
-                    var xelementName = new XElementValueFunctionalTests.PropertiesTests.XElementName();
-                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - same name") { Params = new object[] { "<element>value</element>", "element" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - name with namespace") { Params = new object[] { "<element>value</element>", "{a}newElement" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - name with xml namespace") { Params = new object[] { "<element>value</element>", "{http://www.w3.org/XML/1998/namespace}newElement" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - element with namespace") { Params = new object[] { "<p:element xmlns:p='mynamespace'><p:child>value</p:child></p:element>", "{a}newElement" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.ValidVariation) { Attribute = new VariationAttribute("XElement - different name") { Params = new object[] { "<element>value</element>", "newElement" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.InValidVariation) { Attribute = new VariationAttribute("XElement - empty string name") { Params = new object[] { "<element>value</element>", "" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.InValidVariation) { Attribute = new VariationAttribute("XElement - null name") { Params = new object[] { "<element>value</element>", null }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.InValidVariation) { Attribute = new VariationAttribute("XElement - space character name") { Params = new object[] { "<element>value</element>", " " }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.ValidPIVariation) { Attribute = new VariationAttribute("XProcessingInstruction - Valid Name") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.InvalidPIVariation) { Attribute = new VariationAttribute("XProcessingInstruction - Invalid Name") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.ValidDocTypeVariation) { Attribute = new VariationAttribute("XDocumentType - Valid Name") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementName.InvalidDocTypeVariation) { Attribute = new VariationAttribute("XDocumentType - Invalid Name") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - same name") { Params = new object[] { "<element>value</element>", "element" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - name with namespace") { Params = new object[] { "<element>value</element>", "{a}newElement" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - name with xml namespace") { Params = new object[] { "<element>value</element>", "{http://www.w3.org/XML/1998/namespace}newElement" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - element with namespace") { Params = new object[] { "<p:element xmlns:p='mynamespace'><p:child>value</p:child></p:element>", "{a}newElement" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(ValidVariation) { Attribute = new VariationAttribute("XElement - different name") { Params = new object[] { "<element>value</element>", "newElement" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(InValidVariation) { Attribute = new VariationAttribute("XElement - empty string name") { Params = new object[] { "<element>value</element>", "" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(InValidVariation) { Attribute = new VariationAttribute("XElement - null name") { Params = new object[] { "<element>value</element>", null }, Priority = 0 } });
+                    this.AddChild(new TestVariation(InValidVariation) { Attribute = new VariationAttribute("XElement - space character name") { Params = new object[] { "<element>value</element>", " " }, Priority = 0 } });
+                    this.AddChild(new TestVariation(ValidPIVariation) { Attribute = new VariationAttribute("XProcessingInstruction - Valid Name") { Priority = 0 } });
+                    this.AddChild(new TestVariation(InvalidPIVariation) { Attribute = new VariationAttribute("XProcessingInstruction - Invalid Name") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ValidDocTypeVariation) { Attribute = new VariationAttribute("XDocumentType - Valid Name") { Priority = 0 } });
+                    this.AddChild(new TestVariation(InvalidDocTypeVariation) { Attribute = new VariationAttribute("XDocumentType - Invalid Name") { Priority = 0 } });
                 }
             }
-            public class XElementValue : XLinqTestCase
+            public partial class XElementValue : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+PropertiesTests+XElementValue
                 // Test Case
                 public override void AddChildren()
                 {
-                    var xelementValue = new XElementValueFunctionalTests.PropertiesTests.XElementValue();
-                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: String content") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Empty string node") { Params = new object[] { "<X>t0<A/>t00</X>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[t2]]></B><C>t3</C></A>t00</X>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - empty CDATA") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[]]></B><C>t3</C></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - empty XText") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[]]></B><C></C></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - whitespace") { Params = new object[] { "<X>t0<A>t1\n<B/><B xmlns='a'>\t<![CDATA[]]> </B>\n<C></C></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - no text nodes") { Params = new object[] { "<X>t0<A Id='a0'><B/><B xmlns='a'><?Pi c?></B><!--commm--><C></C></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.SmokeTest) { Attribute = new VariationAttribute("GET: Empty string node") { Params = new object[] { "<X>t0<A></A>t00</X>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementValue.APIModified1) { Attribute = new VariationAttribute("GET: Adjacent text nodes II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.APIModified1) { Attribute = new VariationAttribute("GET: Adjacent text nodes I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.APIModified2) { Attribute = new VariationAttribute("GET: Adjacent text nodes III.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.APIModified3) { Attribute = new VariationAttribute("GET: Concatenated text I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.APIModified3) { Attribute = new VariationAttribute("GET: Concatenated text II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.APIModified4) { Attribute = new VariationAttribute("GET: Removed node.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: String content, Empty string content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: Empty element, String content") { Params = new object[] { "<X>t0<A/>t00</X>", "\nt1 " }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: Empty element, Empty string content") { Params = new object[] { "<X>t0<A/>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: Empty string content, String content") { Params = new object[] { "<X>t0<A></A>t00</X>", "\nt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: Empty string content, Empty string content") { Params = new object[] { "<X>t0<A></A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set) { Attribute = new VariationAttribute("SET: String content, String content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "\nt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  XText content, string content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "\tt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content (PI only), string content") { Params = new object[] { "<X>t0<A is='is'><?PI aaa?></A>t00</X>", "\tt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  XText content, Empty string content") { Params = new object[] { "<X>t0<A xml:space='preserve'>orig</A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  CDATA content, Empty string content") { Params = new object[] { "<X>t0<A><![CDATA[cdata]]></A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  CDATA content, string content") { Params = new object[] { "<X>t0<A><![CDATA[cdata]]></A>t00</X>", "\tt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content, Empty string content") { Params = new object[] { "<X>t0<A xmlns:p='p'>t1<p:Y/></A>t00</X>", "" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content, string content") { Params = new object[] { "<X>t0<A is='is'><![CDATA[cdata]]>orig<C/><!--comment--></A>t00</X>", "\tt1 " }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xelementValue.Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content (comment only), string content") { Params = new object[] { "<X>t0<A is='is'><!--comment--></A>t00</X>", "\tt1 " }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xelementValue.set_APIModified1) { Attribute = new VariationAttribute("SET: Adjacent text nodes II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xelementValue.set_APIModified1) { Attribute = new VariationAttribute("SET: Adjacent text nodes I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xelementValue.set_APIModified2) { Attribute = new VariationAttribute("SET: Adjacent text nodes III.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xelementValue.set_APIModified3) { Attribute = new VariationAttribute("SET: Concatenated text I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xelementValue.set_APIModified3) { Attribute = new VariationAttribute("SET: Concatenated text II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>", "tn\n" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xelementValue.set_APIModified4) { Attribute = new VariationAttribute("SET: Removed node.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: String content") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Empty string node") { Params = new object[] { "<X>t0<A/>t00</X>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[t2]]></B><C>t3</C></A>t00</X>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - empty CDATA") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[]]></B><C>t3</C></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - empty XText") { Params = new object[] { "<X>t0<A>t1<B/><B xmlns='a'><![CDATA[]]></B><C></C></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - whitespace") { Params = new object[] { "<X>t0<A>t1\n<B/><B xmlns='a'>\t<![CDATA[]]> </B>\n<C></C></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Mixed content - no text nodes") { Params = new object[] { "<X>t0<A Id='a0'><B/><B xmlns='a'><?Pi c?></B><!--commm--><C></C></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(SmokeTest) { Attribute = new VariationAttribute("GET: Empty string node") { Params = new object[] { "<X>t0<A></A>t00</X>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(APIModified1) { Attribute = new VariationAttribute("GET: Adjacent text nodes II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(APIModified1) { Attribute = new VariationAttribute("GET: Adjacent text nodes I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(APIModified2) { Attribute = new VariationAttribute("GET: Adjacent text nodes III.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(APIModified3) { Attribute = new VariationAttribute("GET: Concatenated text I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(APIModified3) { Attribute = new VariationAttribute("GET: Concatenated text II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(APIModified4) { Attribute = new VariationAttribute("GET: Removed node.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: String content, Empty string content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: Empty element, String content") { Params = new object[] { "<X>t0<A/>t00</X>", "\nt1 " }, Priority = 0 } });
+                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: Empty element, Empty string content") { Params = new object[] { "<X>t0<A/>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: Empty string content, String content") { Params = new object[] { "<X>t0<A></A>t00</X>", "\nt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: Empty string content, Empty string content") { Params = new object[] { "<X>t0<A></A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set) { Attribute = new VariationAttribute("SET: String content, String content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "\nt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  XText content, string content") { Params = new object[] { "<X>t0<A>orig</A>t00</X>", "\tt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content (PI only), string content") { Params = new object[] { "<X>t0<A is='is'><?PI aaa?></A>t00</X>", "\tt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  XText content, Empty string content") { Params = new object[] { "<X>t0<A xml:space='preserve'>orig</A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  CDATA content, Empty string content") { Params = new object[] { "<X>t0<A><![CDATA[cdata]]></A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  CDATA content, string content") { Params = new object[] { "<X>t0<A><![CDATA[cdata]]></A>t00</X>", "\tt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content, Empty string content") { Params = new object[] { "<X>t0<A xmlns:p='p'>t1<p:Y/></A>t00</X>", "" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content, string content") { Params = new object[] { "<X>t0<A is='is'><![CDATA[cdata]]>orig<C/><!--comment--></A>t00</X>", "\tt1 " }, Priority = 0 } });
+                    this.AddChild(new TestVariation(Value_Set_WithNodes) { Attribute = new VariationAttribute("SET:  Mixed content (comment only), string content") { Params = new object[] { "<X>t0<A is='is'><!--comment--></A>t00</X>", "\tt1 " }, Priority = 1 } });
+                    this.AddChild(new TestVariation(set_APIModified1) { Attribute = new VariationAttribute("SET: Adjacent text nodes II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(set_APIModified1) { Attribute = new VariationAttribute("SET: Adjacent text nodes I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(set_APIModified2) { Attribute = new VariationAttribute("SET: Adjacent text nodes III.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(set_APIModified3) { Attribute = new VariationAttribute("SET: Concatenated text I.") { Params = new object[] { "<X>t0<A>truck</A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(set_APIModified3) { Attribute = new VariationAttribute("SET: Concatenated text II.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck<p:Y/></A>t00</X>", "tn\n" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(set_APIModified4) { Attribute = new VariationAttribute("SET: Removed node.") { Params = new object[] { "<X>t0<A xmlns:p='p'>truck\n<p:Y/>\nhello</A>t00</X>", "tn\n" }, Priority = 2 } });
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/tests/Properties/ImplicitConversionsRoundTrip.cs
+++ b/src/System.Private.Xml.Linq/tests/Properties/ImplicitConversionsRoundTrip.cs
@@ -15,9 +15,9 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ImplicitConversionsRoundTripFunctionalTests : TestModule
+    public partial class PropertiesFunctionalTests : TestModule
     {
-        public class PropertiesTests : XLinqTestCase
+        public partial class PropertiesTests : XLinqTestCase
         {
             public static object Explicit(Type ret, XAttribute data)
             {
@@ -169,7 +169,7 @@ namespace CoreXml.Test.XLinq
             //[TestCase(Name = "XAttribute - value conversion round trip (SetValue)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.RoundTrip, NodeCreateType.SetValue })]
             //[TestCase(Name = "XElement - XmlConvert conformance        (SetValue)", Params = new object[] { typeof(XElement), ExplicitCastTestType.XmlConvert, NodeCreateType.SetValue })]
             //[TestCase(Name = "XAttribute - XmlConvert conformance      (SetValue)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.XmlConvert, NodeCreateType.SetValue })]
-            public class XElement_Op_Eplicit : XLinqTestCase
+            public partial class XElement_Op_Eplicit : XLinqTestCase
             {
                 private object[] _data = new object[] {
                     // bool
@@ -395,7 +395,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class ExplicitCastVariation : TestVariation
+            public partial class ExplicitCastVariation : TestVariation
             {
                 private object _data;
                 private Type _nodeType;
@@ -521,7 +521,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class XElement_Op_Eplicit_Null : XLinqTestCase
+            public partial class XElement_Op_Eplicit_Null : XLinqTestCase
             {
                 protected override void DetermineChildren()
                 {
@@ -538,7 +538,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class ExplicitCastNullVariation : TestVariation
+            public partial class ExplicitCastNullVariation : TestVariation
             {
                 private Type _nodeType, _retType;
                 private bool _shouldThrow;

--- a/src/System.Private.Xml.Linq/tests/Properties/ImplicitConversionsRoundTrip.cs
+++ b/src/System.Private.Xml.Linq/tests/Properties/ImplicitConversionsRoundTrip.cs
@@ -15,9 +15,9 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ImplicitConversionsRoundTripFunctionalTests : TestModule
     {
-        public partial class PropertiesTests : XLinqTestCase
+        public class PropertiesTests : XLinqTestCase
         {
             public static object Explicit(Type ret, XAttribute data)
             {
@@ -169,7 +169,7 @@ namespace CoreXml.Test.XLinq
             //[TestCase(Name = "XAttribute - value conversion round trip (SetValue)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.RoundTrip, NodeCreateType.SetValue })]
             //[TestCase(Name = "XElement - XmlConvert conformance        (SetValue)", Params = new object[] { typeof(XElement), ExplicitCastTestType.XmlConvert, NodeCreateType.SetValue })]
             //[TestCase(Name = "XAttribute - XmlConvert conformance      (SetValue)", Params = new object[] { typeof(XAttribute), ExplicitCastTestType.XmlConvert, NodeCreateType.SetValue })]
-            public partial class XElement_Op_Eplicit : XLinqTestCase
+            public class XElement_Op_Eplicit : XLinqTestCase
             {
                 private object[] _data = new object[] {
                     // bool
@@ -395,7 +395,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class ExplicitCastVariation : TestVariation
+            public class ExplicitCastVariation : TestVariation
             {
                 private object _data;
                 private Type _nodeType;
@@ -521,7 +521,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class XElement_Op_Eplicit_Null : XLinqTestCase
+            public class XElement_Op_Eplicit_Null : XLinqTestCase
             {
                 protected override void DetermineChildren()
                 {
@@ -538,7 +538,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class ExplicitCastNullVariation : TestVariation
+            public class ExplicitCastNullVariation : TestVariation
             {
                 private Type _nodeType, _retType;
                 private bool _shouldThrow;

--- a/src/System.Private.Xml.Linq/tests/Properties/XElement_Value.cs
+++ b/src/System.Private.Xml.Linq/tests/Properties/XElement_Value.cs
@@ -14,13 +14,13 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class XElementValueFunctionalTests : TestModule
+    public partial class PropertiesFunctionalTests : TestModule
     {
-        public class PropertiesTests : XLinqTestCase
+        public partial class PropertiesTests : XLinqTestCase
         {
             //[TestCase(Name = "XElement.Name", Params = new object[] { false })]
             //[TestCase(Name = "XElement.Name with Events", Params = new object[] { true })]
-            public class XElementName : XLinqTestCase
+            public partial class XElementName : XLinqTestCase
             {
                 private EventsHelper _eHelper;
                 private bool _runWithEvents;
@@ -168,7 +168,7 @@ namespace CoreXml.Test.XLinq
 
             //[TestCase(Name = "XElement.Value", Params = new object[] { false })]
             //[TestCase(Name = "XElement.Value with Events", Params = new object[] { true })]
-            public class XElementValue : XLinqTestCase
+            public partial class XElementValue : XLinqTestCase
             {
                 private EventsHelper _eHelper;
                 private bool _runWithEvents;

--- a/src/System.Private.Xml.Linq/tests/Properties/XElement_Value.cs
+++ b/src/System.Private.Xml.Linq/tests/Properties/XElement_Value.cs
@@ -14,13 +14,13 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class XElementValueFunctionalTests : TestModule
     {
-        public partial class PropertiesTests : XLinqTestCase
+        public class PropertiesTests : XLinqTestCase
         {
             //[TestCase(Name = "XElement.Name", Params = new object[] { false })]
             //[TestCase(Name = "XElement.Name with Events", Params = new object[] { true })]
-            public partial class XElementName : XLinqTestCase
+            public class XElementName : XLinqTestCase
             {
                 private EventsHelper _eHelper;
                 private bool _runWithEvents;
@@ -168,7 +168,7 @@ namespace CoreXml.Test.XLinq
 
             //[TestCase(Name = "XElement.Value", Params = new object[] { false })]
             //[TestCase(Name = "XElement.Value with Events", Params = new object[] { true })]
-            public partial class XElementValue : XLinqTestCase
+            public class XElementValue : XLinqTestCase
             {
                 private EventsHelper _eHelper;
                 private bool _runWithEvents;

--- a/src/System.Private.Xml.Linq/tests/misc/FunctionalTests.cs
+++ b/src/System.Private.Xml.Linq/tests/misc/FunctionalTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public class MiscFunctionalTests : TestModule
+    public partial class MiscFunctionalTests : TestModule
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
@@ -27,55 +27,53 @@ namespace CoreXml.Test.XLinq
 
             Assert.Equal(0, module.FailCount);
         }
-        public class MiscTests : XLinqTestCase
+        public partial class MiscTests : XLinqTestCase
         {
             // Type is CoreXml.Test.XLinq.FunctionalTests+MiscTests
             // Test Case
             public override void AddChildren()
             {
                 this.AddChild(new PrefixImprovements() { Attribute = new TestCaseAttribute() { Name = "Prefix improvements :: Find correct namespace prefix. in case of redefinition conflict." } });
-                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - expanded name", Param = XNameAPIFunctionalTests.MiscTests.GetNameType.ExpandedName } });
-                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - expanded name (From string)", Param = XNameAPIFunctionalTests.MiscTests.GetNameType.FromString } });
-                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - two param Get", Param = XNameAPIFunctionalTests.MiscTests.GetNameType.TwoParamGet } });
-                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - XNamespace + string", Param = XNameAPIFunctionalTests.MiscTests.GetNameType.XNamespacePlusOperator } });
+                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - expanded name", Param = GetNameType.ExpandedName } });
+                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - expanded name (From string)", Param = GetNameType.FromString } });
+                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - two param Get", Param = GetNameType.TwoParamGet } });
+                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - XNamespace + string", Param = GetNameType.XNamespacePlusOperator } });
             }
-            public class PrefixImprovements : XLinqTestCase
+            public partial class PrefixImprovements : XLinqTestCase
             {
-                // Type is CoreXml.Test.XLinq.FunctionalTests+MiscTests+PrefixImprovements`
+                // Type is CoreXml.Test.XLinq.FunctionalTests+MiscTests+PrefixImprovements
                 // Test Case
                 public override void AddChildren()
                 {
-                    var prefixImprovements = new PrefixNamespaceFixesFunctionalTests.MiscTests.PrefixImprovements();
-                    this.AddChild(new TestVariation(prefixImprovements.var_1) { Attribute = new VariationAttribute("Smoke test") { Priority = 0 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_1a) { Attribute = new VariationAttribute("Smoke test with attributes.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_2) { Attribute = new VariationAttribute("Default namespace I.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_2a) { Attribute = new VariationAttribute("Default namespace I. (attributes)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_3) { Attribute = new VariationAttribute("Default namespace II.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_3a) { Attribute = new VariationAttribute("Default namespace II. (attributes)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_4) { Attribute = new VariationAttribute("Extended tree") { Priority = 2 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_5) { Attribute = new VariationAttribute("Attribute and element in default NS.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_5a) { Attribute = new VariationAttribute("Attribute and element in default NS II.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_5b) { Attribute = new VariationAttribute("Attribute and element in default NS (mix of all)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_6) { Attribute = new VariationAttribute("In depth ++") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_6b) { Attribute = new VariationAttribute("In depth --") { Priority = 1 } });
-                    this.AddChild(new TestVariation(prefixImprovements.var_7) { Attribute = new VariationAttribute("XmlWriter interference") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("Smoke test") { Priority = 0 } });
+                    this.AddChild(new TestVariation(var_1a) { Attribute = new VariationAttribute("Smoke test with attributes.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("Default namespace I.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_2a) { Attribute = new VariationAttribute("Default namespace I. (attributes)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("Default namespace II.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_3a) { Attribute = new VariationAttribute("Default namespace II. (attributes)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("Extended tree") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("Attribute and element in default NS.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_5a) { Attribute = new VariationAttribute("Attribute and element in default NS II.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_5b) { Attribute = new VariationAttribute("Attribute and element in default NS (mix of all)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_6) { Attribute = new VariationAttribute("In depth ++") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_6b) { Attribute = new VariationAttribute("In depth --") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_7) { Attribute = new VariationAttribute("XmlWriter interference") { Priority = 1 } });
                 }
             }
-            public class XNameAPI : XLinqTestCase
+            public partial class XNameAPI : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+MiscTests+XNameAPI
                 // Test Case
                 public override void AddChildren()
                 {
-                    var xnameapi = new XNameAPIFunctionalTests.MiscTests.XNameAPI();
-                    this.AddChild(new TestVariation(xnameapi.Variation1) { Attribute = new VariationAttribute("XName.Get: No Namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xnameapi.Variation2) { Attribute = new VariationAttribute("XName.Get: Valid Namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xnameapi.Variation3) { Attribute = new VariationAttribute("XName.Get: Xmlns Namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xnameapi.Variation4) { Attribute = new VariationAttribute("XName.Get: Xml Namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xnameapi.Variation5) { Attribute = new VariationAttribute("XName.Get: Invalid name (empty string)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(xnameapi.Variation6) { Attribute = new VariationAttribute("XName.Get: Invalid name (null)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(xnameapi.Variation12) { Attribute = new VariationAttribute("IEquatable: same names") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xnameapi.Variation13) { Attribute = new VariationAttribute("IEquatable: different names (NS)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(Variation1) { Attribute = new VariationAttribute("XName.Get: No Namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(Variation2) { Attribute = new VariationAttribute("XName.Get: Valid Namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(Variation3) { Attribute = new VariationAttribute("XName.Get: Xmlns Namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(Variation4) { Attribute = new VariationAttribute("XName.Get: Xml Namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(Variation5) { Attribute = new VariationAttribute("XName.Get: Invalid name (empty string)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(Variation6) { Attribute = new VariationAttribute("XName.Get: Invalid name (null)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(Variation12) { Attribute = new VariationAttribute("IEquatable: same names") { Priority = 0 } });
+                    this.AddChild(new TestVariation(Variation13) { Attribute = new VariationAttribute("IEquatable: different names (NS)") { Priority = 0 } });
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/tests/misc/FunctionalTests.cs
+++ b/src/System.Private.Xml.Linq/tests/misc/FunctionalTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class MiscFunctionalTests : TestModule
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
@@ -19,7 +19,7 @@ namespace CoreXml.Test.XLinq
         public static void RunTests()
         {
             TestInput.CommandLine = "";
-            FunctionalTests module = new FunctionalTests();
+            MiscFunctionalTests module = new MiscFunctionalTests();
             module.Init();
 
             module.AddChild(new MiscTests() { Attribute = new TestCaseAttribute() { Name = "Misc", Desc = "XLinq Misc. Tests" } });
@@ -27,53 +27,55 @@ namespace CoreXml.Test.XLinq
 
             Assert.Equal(0, module.FailCount);
         }
-        public partial class MiscTests : XLinqTestCase
+        public class MiscTests : XLinqTestCase
         {
             // Type is CoreXml.Test.XLinq.FunctionalTests+MiscTests
             // Test Case
             public override void AddChildren()
             {
                 this.AddChild(new PrefixImprovements() { Attribute = new TestCaseAttribute() { Name = "Prefix improvements :: Find correct namespace prefix. in case of redefinition conflict." } });
-                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - expanded name", Param = GetNameType.ExpandedName } });
-                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - expanded name (From string)", Param = GetNameType.FromString } });
-                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - two param Get", Param = GetNameType.TwoParamGet } });
-                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - XNamespace + string", Param = GetNameType.XNamespacePlusOperator } });
+                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - expanded name", Param = XNameAPIFunctionalTests.MiscTests.GetNameType.ExpandedName } });
+                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - expanded name (From string)", Param = XNameAPIFunctionalTests.MiscTests.GetNameType.FromString } });
+                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - two param Get", Param = XNameAPIFunctionalTests.MiscTests.GetNameType.TwoParamGet } });
+                this.AddChild(new XNameAPI() { Attribute = new TestCaseAttribute() { Name = "XName API - XNamespace + string", Param = XNameAPIFunctionalTests.MiscTests.GetNameType.XNamespacePlusOperator } });
             }
-            public partial class PrefixImprovements : XLinqTestCase
+            public class PrefixImprovements : XLinqTestCase
             {
-                // Type is CoreXml.Test.XLinq.FunctionalTests+MiscTests+PrefixImprovements
+                // Type is CoreXml.Test.XLinq.FunctionalTests+MiscTests+PrefixImprovements`
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("Smoke test") { Priority = 0 } });
-                    this.AddChild(new TestVariation(var_1a) { Attribute = new VariationAttribute("Smoke test with attributes.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("Default namespace I.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_2a) { Attribute = new VariationAttribute("Default namespace I. (attributes)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("Default namespace II.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_3a) { Attribute = new VariationAttribute("Default namespace II. (attributes)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("Extended tree") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("Attribute and element in default NS.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_5a) { Attribute = new VariationAttribute("Attribute and element in default NS II.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_5b) { Attribute = new VariationAttribute("Attribute and element in default NS (mix of all)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_6) { Attribute = new VariationAttribute("In depth ++") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_6b) { Attribute = new VariationAttribute("In depth --") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_7) { Attribute = new VariationAttribute("XmlWriter interference") { Priority = 1 } });
+                    var prefixImprovements = new PrefixNamespaceFixesFunctionalTests.MiscTests.PrefixImprovements();
+                    this.AddChild(new TestVariation(prefixImprovements.var_1) { Attribute = new VariationAttribute("Smoke test") { Priority = 0 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_1a) { Attribute = new VariationAttribute("Smoke test with attributes.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_2) { Attribute = new VariationAttribute("Default namespace I.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_2a) { Attribute = new VariationAttribute("Default namespace I. (attributes)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_3) { Attribute = new VariationAttribute("Default namespace II.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_3a) { Attribute = new VariationAttribute("Default namespace II. (attributes)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_4) { Attribute = new VariationAttribute("Extended tree") { Priority = 2 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_5) { Attribute = new VariationAttribute("Attribute and element in default NS.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_5a) { Attribute = new VariationAttribute("Attribute and element in default NS II.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_5b) { Attribute = new VariationAttribute("Attribute and element in default NS (mix of all)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_6) { Attribute = new VariationAttribute("In depth ++") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_6b) { Attribute = new VariationAttribute("In depth --") { Priority = 1 } });
+                    this.AddChild(new TestVariation(prefixImprovements.var_7) { Attribute = new VariationAttribute("XmlWriter interference") { Priority = 1 } });
                 }
             }
-            public partial class XNameAPI : XLinqTestCase
+            public class XNameAPI : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+MiscTests+XNameAPI
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(Variation1) { Attribute = new VariationAttribute("XName.Get: No Namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(Variation2) { Attribute = new VariationAttribute("XName.Get: Valid Namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(Variation3) { Attribute = new VariationAttribute("XName.Get: Xmlns Namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(Variation4) { Attribute = new VariationAttribute("XName.Get: Xml Namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(Variation5) { Attribute = new VariationAttribute("XName.Get: Invalid name (empty string)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(Variation6) { Attribute = new VariationAttribute("XName.Get: Invalid name (null)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(Variation12) { Attribute = new VariationAttribute("IEquatable: same names") { Priority = 0 } });
-                    this.AddChild(new TestVariation(Variation13) { Attribute = new VariationAttribute("IEquatable: different names (NS)") { Priority = 0 } });
+                    var xnameapi = new XNameAPIFunctionalTests.MiscTests.XNameAPI();
+                    this.AddChild(new TestVariation(xnameapi.Variation1) { Attribute = new VariationAttribute("XName.Get: No Namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xnameapi.Variation2) { Attribute = new VariationAttribute("XName.Get: Valid Namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xnameapi.Variation3) { Attribute = new VariationAttribute("XName.Get: Xmlns Namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xnameapi.Variation4) { Attribute = new VariationAttribute("XName.Get: Xml Namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xnameapi.Variation5) { Attribute = new VariationAttribute("XName.Get: Invalid name (empty string)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(xnameapi.Variation6) { Attribute = new VariationAttribute("XName.Get: Invalid name (null)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(xnameapi.Variation12) { Attribute = new VariationAttribute("IEquatable: same names") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xnameapi.Variation13) { Attribute = new VariationAttribute("IEquatable: different names (NS)") { Priority = 0 } });
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/tests/misc/PrefixNamespaceFixes.cs
+++ b/src/System.Private.Xml.Linq/tests/misc/PrefixNamespaceFixes.cs
@@ -10,11 +10,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class PrefixNamespaceFixesFunctionalTests : TestModule
+    public partial class MiscFunctionalTests : TestModule
     {
-        public class MiscTests : XLinqTestCase
+        public partial class MiscTests : XLinqTestCase
         {
-            public class PrefixImprovements : XLinqTestCase
+            public partial class PrefixImprovements : XLinqTestCase
             {
                 void CompareStringThroughXmlReader(string xml1, string xml2)
                 {

--- a/src/System.Private.Xml.Linq/tests/misc/PrefixNamespaceFixes.cs
+++ b/src/System.Private.Xml.Linq/tests/misc/PrefixNamespaceFixes.cs
@@ -10,11 +10,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class PrefixNamespaceFixesFunctionalTests : TestModule
     {
-        public partial class MiscTests : XLinqTestCase
+        public class MiscTests : XLinqTestCase
         {
-            public partial class PrefixImprovements : XLinqTestCase
+            public class PrefixImprovements : XLinqTestCase
             {
                 void CompareStringThroughXmlReader(string xml1, string xml2)
                 {

--- a/src/System.Private.Xml.Linq/tests/misc/XNameAPI.cs
+++ b/src/System.Private.Xml.Linq/tests/misc/XNameAPI.cs
@@ -10,9 +10,9 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class XNameAPIFunctionalTests : TestModule
+    public partial class MiscFunctionalTests : TestModule
     {
-        public class MiscTests : XLinqTestCase
+        public partial class MiscTests : XLinqTestCase
         {
             public enum GetNameType
             {
@@ -26,7 +26,7 @@ namespace CoreXml.Test.XLinq
             //[TestCase(Name = "XName API - expanded name (From string)", Param = GetNameType.FromString)]
             //[TestCase(Name = "XName API - two param Get", Param = GetNameType.TwoParamGet)]
             //[TestCase(Name = "XName API - XNamespace + string", Param = GetNameType.XNamespacePlusOperator)]
-            public class XNameAPI : XLinqTestCase
+            public partial class XNameAPI : XLinqTestCase
             {
                 //[Variation(Priority = 0, Desc = "XName.Get: No Namespace")]
                 public void Variation1()

--- a/src/System.Private.Xml.Linq/tests/misc/XNameAPI.cs
+++ b/src/System.Private.Xml.Linq/tests/misc/XNameAPI.cs
@@ -10,9 +10,9 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class XNameAPIFunctionalTests : TestModule
     {
-        public partial class MiscTests : XLinqTestCase
+        public class MiscTests : XLinqTestCase
         {
             public enum GetNameType
             {
@@ -26,7 +26,7 @@ namespace CoreXml.Test.XLinq
             //[TestCase(Name = "XName API - expanded name (From string)", Param = GetNameType.FromString)]
             //[TestCase(Name = "XName API - two param Get", Param = GetNameType.TwoParamGet)]
             //[TestCase(Name = "XName API - XNamespace + string", Param = GetNameType.XNamespacePlusOperator)]
-            public partial class XNameAPI : XLinqTestCase
+            public class XNameAPI : XLinqTestCase
             {
                 //[Variation(Priority = 0, Desc = "XName.Get: No Namespace")]
                 public void Variation1()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -19,12 +19,12 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public class CommonTestsFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
             //[TestCase(Name = "Auto-completion of tokens", Param = "XNodeBuilder")]
-            public class TCAutoComplete : BridgeHelpers
+            public partial class TCAutoComplete : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Missing EndAttr, followed by element", Priority = 1)]
                 public void var_1()
@@ -144,7 +144,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "WriteStart/EndDocument", Param = "XNodeBuilder")]
-            public class TCDocument : BridgeHelpers
+            public partial class TCDocument : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "StartDocument-EndDocument Sanity Test", Priority = 0)]
                 public void document_1()
@@ -421,7 +421,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCDocType : BridgeHelpers
+            public partial class TCDocType : BridgeHelpers
             {
                 //[Variation(Id = 4, Desc = "WriteDocType with name value = String.Empty", Param = "String.Empty", Priority = 1)]
                 //[Variation(Id = 5, Desc = "WriteDocType with name value = null", Param = "null", Priority = 1)]
@@ -496,7 +496,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "WriteStart/EndElement", Param = "XNodeBuilder")]
-            public class TCElement : BridgeHelpers
+            public partial class TCElement : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "StartElement-EndElement Sanity Test", Priority = 0)]
                 public void element_1()
@@ -614,7 +614,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCAttribute : BridgeHelpers
+            public partial class TCAttribute : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Sanity test for WriteAttribute", Priority = 0)]
                 public void attribute_1()
@@ -1064,7 +1064,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteAttributes : BridgeHelpers
+            public partial class TCWriteAttributes : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Call WriteAttributes with default DTD attributes = true", Priority = 1)]
                 public void writeAttributes_1()
@@ -1416,7 +1416,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteNode_XmlReader : BridgeHelpers
+            public partial class TCWriteNode_XmlReader : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteNode with null reader", Priority = 1)]
                 public void writeNode_XmlReader1()
@@ -2053,7 +2053,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "WriteFullEndElement", Param = "XNodeBuilder")]
-            public class TCFullEndElement : BridgeHelpers
+            public partial class TCFullEndElement : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Sanity test for WriteFullEndElement()", Priority = 0)]
                 public void fullEndElement_1()
@@ -2154,7 +2154,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCElemNamespace : BridgeHelpers
+            public partial class TCElemNamespace : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Multiple NS decl for same prefix on an element", Priority = 1)]
                 public void elemNamespace_1()
@@ -2675,7 +2675,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "Attribute Namespace", Param = "XNodeBuilder")]
-            public class TCAttrNamespace : BridgeHelpers
+            public partial class TCAttrNamespace : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Define prefix 'xml' with invalid namespace URI 'foo'", Priority = 1)]
                 public void attrNamespace_1()
@@ -3348,7 +3348,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCCData : BridgeHelpers
+            public partial class TCCData : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteCData with null", Priority = 1)]
                 public void CData_1()
@@ -3525,7 +3525,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCComment : BridgeHelpers
+            public partial class TCComment : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Sanity test for WriteComment", Priority = 0)]
                 public void comment_1()
@@ -3629,7 +3629,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCEntityRef : BridgeHelpers
+            public partial class TCEntityRef : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteEntityRef with value = null", Param = "null", Priority = 1)]
                 //[Variation(Id = 2, Desc = "WriteEntityRef with value = String.Empty", Param = "String.Empty", Priority = 1)]
@@ -3749,7 +3749,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCCharEntity : BridgeHelpers
+            public partial class TCCharEntity : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteCharEntity with valid Unicode character", Priority = 0)]
                 public void charEntity_1()
@@ -3876,7 +3876,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCSurrogateCharEntity : BridgeHelpers
+            public partial class TCSurrogateCharEntity : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "SurrogateCharEntity after WriteStartElement/WriteEndElement", Priority = 1)]
                 public void surrogateEntity_1()
@@ -4025,7 +4025,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCPI : BridgeHelpers
+            public partial class TCPI : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Sanity test for WritePI", Priority = 0)]
                 public void pi_1()
@@ -4270,7 +4270,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteNmToken : BridgeHelpers
+            public partial class TCWriteNmToken : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Name = null", Param = "null", Priority = 1)]
                 //[Variation(Id = 2, Desc = "Name = String.Empty", Param = "String.Empty", Priority = 1)]
@@ -4352,7 +4352,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteName : BridgeHelpers
+            public partial class TCWriteName : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Name = null", Param = "null", Priority = 1)]
                 //[Variation(Id = 2, Desc = "Name = String.Empty", Param = "String.Empty", Priority = 1)]
@@ -4432,7 +4432,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteQName : BridgeHelpers
+            public partial class TCWriteQName : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Name = null", Param = "null", Priority = 1)]
                 //[Variation(Id = 2, Desc = "Name = String.Empty", Param = "String.Empty", Priority = 1)]
@@ -4537,7 +4537,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteChars : BridgeHelpers
+            public partial class TCWriteChars : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteChars with valid buffer, number, count", Priority = 0)]
                 public void writeChars_1()
@@ -4672,7 +4672,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteString : BridgeHelpers
+            public partial class TCWriteString : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteString(null)", Priority = 0)]
                 public void writeString_1()
@@ -4900,7 +4900,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWhiteSpace : BridgeHelpers
+            public partial class TCWhiteSpace : BridgeHelpers
             {
                 //[Variation(Id = 3, Desc = "WriteWhitespace before and after root element", Priority = 1)]
                 public void whitespace_3()
@@ -4965,7 +4965,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteValue : BridgeHelpers
+            public partial class TCWriteValue : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteValue(boolean)", Priority = 1)]
                 public void writeValue_1()
@@ -5215,7 +5215,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCLookUpPrefix : BridgeHelpers
+            public partial class TCLookUpPrefix : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "LookupPrefix with null", Priority = 2)]
                 public void lookupPrefix_1()
@@ -5369,7 +5369,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCXmlSpaceWriter : BridgeHelpers
+            public partial class TCXmlSpaceWriter : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Verify XmlSpace as Preserve", Priority = 0)]
                 public void xmlSpace_1()
@@ -5524,7 +5524,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCXmlLangWriter : BridgeHelpers
+            public partial class TCXmlLangWriter : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Verify XmlLang sanity test", Priority = 0)]
                 public void XmlLang_1()
@@ -5680,7 +5680,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteRaw : BridgeHelpers
+            public partial class TCWriteRaw : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Call both WriteRaw Methods", Priority = 1)]
                 public void writeRaw_1()
@@ -5845,7 +5845,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteBase64 : BridgeHelpers
+            public partial class TCWriteBase64 : BridgeHelpers
             {
                 //[Variation(Id = 20, Desc = "WriteBase64 with count > buffer size", Priority = 1)]
                 public void Base64_2()
@@ -5973,7 +5973,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCWriteState : BridgeHelpers
+            public partial class TCWriteState : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Verify WriteState.Start when nothing has been written yet", Priority = 0)]
                 public void writeState_1()
@@ -6377,7 +6377,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TC_NDP20_NewMethods : BridgeHelpers
+            public partial class TC_NDP20_NewMethods : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteElementString(prefix, name, ns, value) sanity test", Priority = 0)]
                 public void var_1()
@@ -6460,7 +6460,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCGlobalization : BridgeHelpers
+            public partial class TCGlobalization : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Characters between 0xdfff and 0xfffe are valid Unicode characters", Priority = 1)]
                 public void var_1()
@@ -6504,7 +6504,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCClose : BridgeHelpers
+            public partial class TCClose : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Closing an XmlWriter should close all opened elements", Priority = 1)]
                 public void var_1()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -19,12 +19,12 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class CommonTestsFunctionalTests : TestModule
     {
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
             //[TestCase(Name = "Auto-completion of tokens", Param = "XNodeBuilder")]
-            public partial class TCAutoComplete : BridgeHelpers
+            public class TCAutoComplete : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Missing EndAttr, followed by element", Priority = 1)]
                 public void var_1()
@@ -144,7 +144,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "WriteStart/EndDocument", Param = "XNodeBuilder")]
-            public partial class TCDocument : BridgeHelpers
+            public class TCDocument : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "StartDocument-EndDocument Sanity Test", Priority = 0)]
                 public void document_1()
@@ -421,7 +421,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCDocType : BridgeHelpers
+            public class TCDocType : BridgeHelpers
             {
                 //[Variation(Id = 4, Desc = "WriteDocType with name value = String.Empty", Param = "String.Empty", Priority = 1)]
                 //[Variation(Id = 5, Desc = "WriteDocType with name value = null", Param = "null", Priority = 1)]
@@ -496,7 +496,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "WriteStart/EndElement", Param = "XNodeBuilder")]
-            public partial class TCElement : BridgeHelpers
+            public class TCElement : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "StartElement-EndElement Sanity Test", Priority = 0)]
                 public void element_1()
@@ -614,7 +614,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCAttribute : BridgeHelpers
+            public class TCAttribute : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Sanity test for WriteAttribute", Priority = 0)]
                 public void attribute_1()
@@ -1064,7 +1064,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteAttributes : BridgeHelpers
+            public class TCWriteAttributes : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Call WriteAttributes with default DTD attributes = true", Priority = 1)]
                 public void writeAttributes_1()
@@ -1416,7 +1416,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteNode_XmlReader : BridgeHelpers
+            public class TCWriteNode_XmlReader : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteNode with null reader", Priority = 1)]
                 public void writeNode_XmlReader1()
@@ -2053,7 +2053,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "WriteFullEndElement", Param = "XNodeBuilder")]
-            public partial class TCFullEndElement : BridgeHelpers
+            public class TCFullEndElement : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Sanity test for WriteFullEndElement()", Priority = 0)]
                 public void fullEndElement_1()
@@ -2154,7 +2154,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCElemNamespace : BridgeHelpers
+            public class TCElemNamespace : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Multiple NS decl for same prefix on an element", Priority = 1)]
                 public void elemNamespace_1()
@@ -2675,7 +2675,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "Attribute Namespace", Param = "XNodeBuilder")]
-            public partial class TCAttrNamespace : BridgeHelpers
+            public class TCAttrNamespace : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Define prefix 'xml' with invalid namespace URI 'foo'", Priority = 1)]
                 public void attrNamespace_1()
@@ -3348,7 +3348,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCCData : BridgeHelpers
+            public class TCCData : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteCData with null", Priority = 1)]
                 public void CData_1()
@@ -3525,7 +3525,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCComment : BridgeHelpers
+            public class TCComment : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Sanity test for WriteComment", Priority = 0)]
                 public void comment_1()
@@ -3629,7 +3629,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCEntityRef : BridgeHelpers
+            public class TCEntityRef : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteEntityRef with value = null", Param = "null", Priority = 1)]
                 //[Variation(Id = 2, Desc = "WriteEntityRef with value = String.Empty", Param = "String.Empty", Priority = 1)]
@@ -3749,7 +3749,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCCharEntity : BridgeHelpers
+            public class TCCharEntity : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteCharEntity with valid Unicode character", Priority = 0)]
                 public void charEntity_1()
@@ -3876,7 +3876,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCSurrogateCharEntity : BridgeHelpers
+            public class TCSurrogateCharEntity : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "SurrogateCharEntity after WriteStartElement/WriteEndElement", Priority = 1)]
                 public void surrogateEntity_1()
@@ -4025,7 +4025,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCPI : BridgeHelpers
+            public class TCPI : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Sanity test for WritePI", Priority = 0)]
                 public void pi_1()
@@ -4270,7 +4270,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteNmToken : BridgeHelpers
+            public class TCWriteNmToken : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Name = null", Param = "null", Priority = 1)]
                 //[Variation(Id = 2, Desc = "Name = String.Empty", Param = "String.Empty", Priority = 1)]
@@ -4352,7 +4352,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteName : BridgeHelpers
+            public class TCWriteName : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Name = null", Param = "null", Priority = 1)]
                 //[Variation(Id = 2, Desc = "Name = String.Empty", Param = "String.Empty", Priority = 1)]
@@ -4432,7 +4432,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteQName : BridgeHelpers
+            public class TCWriteQName : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Name = null", Param = "null", Priority = 1)]
                 //[Variation(Id = 2, Desc = "Name = String.Empty", Param = "String.Empty", Priority = 1)]
@@ -4537,7 +4537,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteChars : BridgeHelpers
+            public class TCWriteChars : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteChars with valid buffer, number, count", Priority = 0)]
                 public void writeChars_1()
@@ -4672,7 +4672,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteString : BridgeHelpers
+            public class TCWriteString : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteString(null)", Priority = 0)]
                 public void writeString_1()
@@ -4900,7 +4900,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWhiteSpace : BridgeHelpers
+            public class TCWhiteSpace : BridgeHelpers
             {
                 //[Variation(Id = 3, Desc = "WriteWhitespace before and after root element", Priority = 1)]
                 public void whitespace_3()
@@ -4965,7 +4965,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteValue : BridgeHelpers
+            public class TCWriteValue : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteValue(boolean)", Priority = 1)]
                 public void writeValue_1()
@@ -5215,7 +5215,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCLookUpPrefix : BridgeHelpers
+            public class TCLookUpPrefix : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "LookupPrefix with null", Priority = 2)]
                 public void lookupPrefix_1()
@@ -5369,7 +5369,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCXmlSpaceWriter : BridgeHelpers
+            public class TCXmlSpaceWriter : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Verify XmlSpace as Preserve", Priority = 0)]
                 public void xmlSpace_1()
@@ -5524,7 +5524,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCXmlLangWriter : BridgeHelpers
+            public class TCXmlLangWriter : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Verify XmlLang sanity test", Priority = 0)]
                 public void XmlLang_1()
@@ -5680,7 +5680,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteRaw : BridgeHelpers
+            public class TCWriteRaw : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Call both WriteRaw Methods", Priority = 1)]
                 public void writeRaw_1()
@@ -5845,7 +5845,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteBase64 : BridgeHelpers
+            public class TCWriteBase64 : BridgeHelpers
             {
                 //[Variation(Id = 20, Desc = "WriteBase64 with count > buffer size", Priority = 1)]
                 public void Base64_2()
@@ -5973,7 +5973,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCWriteState : BridgeHelpers
+            public class TCWriteState : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Verify WriteState.Start when nothing has been written yet", Priority = 0)]
                 public void writeState_1()
@@ -6377,7 +6377,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TC_NDP20_NewMethods : BridgeHelpers
+            public class TC_NDP20_NewMethods : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteElementString(prefix, name, ns, value) sanity test", Priority = 0)]
                 public void var_1()
@@ -6460,7 +6460,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCGlobalization : BridgeHelpers
+            public class TCGlobalization : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Characters between 0xdfff and 0xfffe are valid Unicode characters", Priority = 1)]
                 public void var_1()
@@ -6504,7 +6504,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCClose : BridgeHelpers
+            public class TCClose : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Closing an XmlWriter should close all opened elements", Priority = 1)]
                 public void var_1()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/EndOfLineHandlingTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/EndOfLineHandlingTests.cs
@@ -13,12 +13,12 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class EndOfLineHandlingTestsFunctionalTests : TestModule
     {
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
             //[TestCase(Name = "NewLineHandling", Param = "XNodeBuilder")]
-            public partial class TCEOFHandling : BridgeHelpers
+            public class TCEOFHandling : BridgeHelpers
             {
                 private XmlDiff _diff = null;
                 public TCEOFHandling()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/EndOfLineHandlingTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/EndOfLineHandlingTests.cs
@@ -13,12 +13,12 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class EndOfLineHandlingTestsFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
             //[TestCase(Name = "NewLineHandling", Param = "XNodeBuilder")]
-            public class TCEOFHandling : BridgeHelpers
+            public partial class TCEOFHandling : BridgeHelpers
             {
                 private XmlDiff _diff = null;
                 public TCEOFHandling()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/ErrorConditions.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/ErrorConditions.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ErrorConditionsFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
-            public class XObjectBuilderTest : BridgeHelpers
+            public partial class XObjectBuilderTest : BridgeHelpers
             {
                 //[Variation(Priority = 2, Desc = "LookupPrefix(null)")]
                 public void var_1()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/ErrorConditions.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/ErrorConditions.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ErrorConditionsFunctionalTests : TestModule
     {
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
-            public partial class XObjectBuilderTest : BridgeHelpers
+            public class XObjectBuilderTest : BridgeHelpers
             {
                 //[Variation(Priority = 2, Desc = "LookupPrefix(null)")]
                 public void var_1()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/FunctionalTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/FunctionalTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public class XNodeBuilderFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
@@ -34,7 +34,7 @@ namespace CoreXml.Test.XLinq
         }
 
         #region Code
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
             // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests
             // Test Case
@@ -89,1065 +89,1020 @@ namespace CoreXml.Test.XLinq
                 this.AddChild(new TCFragmentCL() { Attribute = new TestCaseAttribute() { Name = "CL = Fragment Tests" } });
                 this.AddChild(new TCAutoCL() { Attribute = new TestCaseAttribute() { Name = "CL = Auto Tests" } });
             }
-            public class TCAutoComplete : BridgeHelpers
+            public partial class TCAutoComplete : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCAutoComplete
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcAutoComplete = new CommonTestsFunctionalTests.XNodeBuilderTests.TCAutoComplete();
-                    this.AddChild(new TestVariation(tcAutoComplete.var_1) { Attribute = new VariationAttribute("Missing EndAttr, followed by element") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoComplete.var_2) { Attribute = new VariationAttribute("Missing EndAttr, followed by comment") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoComplete.var_3) { Attribute = new VariationAttribute("Write EndDocument with unclosed element tag") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoComplete.var_4) { Attribute = new VariationAttribute("WriteStartDocument - WriteEndDocument") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoComplete.var_5) { Attribute = new VariationAttribute("WriteEndElement without WriteStartElement") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoComplete.var_6) { Attribute = new VariationAttribute("WriteFullEndElement without WriteStartElement") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("Missing EndAttr, followed by element") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("Missing EndAttr, followed by comment") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("Write EndDocument with unclosed element tag") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("WriteStartDocument - WriteEndDocument") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("WriteEndElement without WriteStartElement") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_6) { Attribute = new VariationAttribute("WriteFullEndElement without WriteStartElement") { Id = 6, Priority = 1 } });
                 }
             }
-            public class TCDocument : BridgeHelpers
+            public partial class TCDocument : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCDocument
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcDocument = new CommonTestsFunctionalTests.XNodeBuilderTests.TCDocument();
-                    this.AddChild(new TestVariation(tcDocument.document_1) { Attribute = new VariationAttribute("StartDocument-EndDocument Sanity Test") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcDocument.document_2) { Attribute = new VariationAttribute("Multiple StartDocument should error") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocument.document_3) { Attribute = new VariationAttribute("Missing StartDocument should be fixed") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocument.document_4) { Attribute = new VariationAttribute("Multiple EndDocument should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocument.document_5) { Attribute = new VariationAttribute("Missing EndDocument should be fixed") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocument.document_6) { Attribute = new VariationAttribute("Call Start-EndDocument multiple times, should error") { Id = 6, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcDocument.document_7) { Attribute = new VariationAttribute("Multiple root elements should error") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocument.document_8) { Attribute = new VariationAttribute("Start-EndDocument without any element should error") { Id = 8, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcDocument.document_9) { Attribute = new VariationAttribute("Top level text should error - PROLOG") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocument.document_10) { Attribute = new VariationAttribute("Top level text should error - EPILOG") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocument.document_11) { Attribute = new VariationAttribute("Top level atomic value should error - PROLOG") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocument.document_12) { Attribute = new VariationAttribute("Top level atomic value should error - EPILOG") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_1) { Attribute = new VariationAttribute("StartDocument-EndDocument Sanity Test") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(document_2) { Attribute = new VariationAttribute("Multiple StartDocument should error") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_3) { Attribute = new VariationAttribute("Missing StartDocument should be fixed") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_4) { Attribute = new VariationAttribute("Multiple EndDocument should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_5) { Attribute = new VariationAttribute("Missing EndDocument should be fixed") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_6) { Attribute = new VariationAttribute("Call Start-EndDocument multiple times, should error") { Id = 6, Priority = 2 } });
+                    this.AddChild(new TestVariation(document_7) { Attribute = new VariationAttribute("Multiple root elements should error") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_8) { Attribute = new VariationAttribute("Start-EndDocument without any element should error") { Id = 8, Priority = 2 } });
+                    this.AddChild(new TestVariation(document_9) { Attribute = new VariationAttribute("Top level text should error - PROLOG") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_10) { Attribute = new VariationAttribute("Top level text should error - EPILOG") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_11) { Attribute = new VariationAttribute("Top level atomic value should error - PROLOG") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(document_12) { Attribute = new VariationAttribute("Top level atomic value should error - EPILOG") { Id = 12, Priority = 1 } });
                 }
             }
-            public class TCDocType : BridgeHelpers
+            public partial class TCDocType : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCDocType
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcDocType = new CommonTestsFunctionalTests.XNodeBuilderTests.TCDocType();
-                    this.AddChild(new TestVariation(tcDocType.docType_4) { Attribute = new VariationAttribute("WriteDocType with name value = null") { Param = "null", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocType.docType_4) { Attribute = new VariationAttribute("WriteDocType with name value = String.Empty") { Param = "String.Empty", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocType.docType_6) { Attribute = new VariationAttribute("Call WriteDocType in the root element") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcDocType.docType_7) { Attribute = new VariationAttribute("Call WriteDocType following root element") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(docType_4) { Attribute = new VariationAttribute("WriteDocType with name value = null") { Param = "null", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(docType_4) { Attribute = new VariationAttribute("WriteDocType with name value = String.Empty") { Param = "String.Empty", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(docType_6) { Attribute = new VariationAttribute("Call WriteDocType in the root element") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(docType_7) { Attribute = new VariationAttribute("Call WriteDocType following root element") { Id = 8, Priority = 1 } });
                 }
             }
-            public class TCElement : BridgeHelpers
+            public partial class TCElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcElement = new CommonTestsFunctionalTests.XNodeBuilderTests.TCElement();
-                    this.AddChild(new TestVariation(tcElement.element_1) { Attribute = new VariationAttribute("StartElement-EndElement Sanity Test") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcElement.element_2) { Attribute = new VariationAttribute("Sanity test for overload WriteStartElement(string prefix, string name, string ns)") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcElement.element_3) { Attribute = new VariationAttribute("Sanity test for overload WriteStartElement(string name, string ns)") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcElement.element_4) { Attribute = new VariationAttribute("Element name = String.Empty should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElement.element_5) { Attribute = new VariationAttribute("Element name = null should error") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElement.element_6) { Attribute = new VariationAttribute("Element NS = String.Empty") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElement.element_7) { Attribute = new VariationAttribute("Element NS = null") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElement.element_8) { Attribute = new VariationAttribute("Write 100 nested elements") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(element_1) { Attribute = new VariationAttribute("StartElement-EndElement Sanity Test") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(element_2) { Attribute = new VariationAttribute("Sanity test for overload WriteStartElement(string prefix, string name, string ns)") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(element_3) { Attribute = new VariationAttribute("Sanity test for overload WriteStartElement(string name, string ns)") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(element_4) { Attribute = new VariationAttribute("Element name = String.Empty should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(element_5) { Attribute = new VariationAttribute("Element name = null should error") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(element_6) { Attribute = new VariationAttribute("Element NS = String.Empty") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(element_7) { Attribute = new VariationAttribute("Element NS = null") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(element_8) { Attribute = new VariationAttribute("Write 100 nested elements") { Id = 8, Priority = 1 } });
                 }
             }
-            public class TCAttribute : BridgeHelpers
+            public partial class TCAttribute : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCAttribute
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcAttribute = new CommonTestsFunctionalTests.XNodeBuilderTests.TCAttribute();
-                    this.AddChild(new TestVariation(tcAttribute.attribute_1) { Attribute = new VariationAttribute("Sanity test for WriteAttribute") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_2) { Attribute = new VariationAttribute("Missing EndAttribute should be fixed") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_3) { Attribute = new VariationAttribute("WriteStartAttribute followed by WriteStartAttribute") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_4) { Attribute = new VariationAttribute("Multiple WritetAttributeString") { Id = 4, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_5) { Attribute = new VariationAttribute("WriteStartAttribute followed by WriteString") { Id = 5, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_6) { Attribute = new VariationAttribute("Sanity test for overload WriteStartAttribute(name, ns)") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_7) { Attribute = new VariationAttribute("Sanity test for overload WriteStartAttribute(prefix, name, ns)") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_8) { Attribute = new VariationAttribute("Duplicate attribute 'attr1'") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_9) { Attribute = new VariationAttribute("Duplicate attribute 'ns1:attr1'") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_10) { Attribute = new VariationAttribute("Attribute name = String.Empty should error") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_11) { Attribute = new VariationAttribute("Attribute name = null") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_12) { Attribute = new VariationAttribute("WriteAttribute with names Foo, fOo, foO, FOO") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_13) { Attribute = new VariationAttribute("Invalid value of xml:space") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_14) { Attribute = new VariationAttribute("SingleQuote in attribute value should be allowed") { Id = 14 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_15) { Attribute = new VariationAttribute("DoubleQuote in attribute value should be escaped") { Id = 15 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_16) { Attribute = new VariationAttribute("WriteAttribute with value = &, #65, #x20") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_17) { Attribute = new VariationAttribute("WriteAttributeString followed by WriteString") { Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_18) { Attribute = new VariationAttribute("WriteAttribute followed by WriteString") { Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_19) { Attribute = new VariationAttribute("WriteAttribute with all whitespace characters") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_20) { Attribute = new VariationAttribute("< > & chars should be escaped in attribute value") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_21) { Attribute = new VariationAttribute("testcase: Redefine auto generated prefix n1") { Id = 21 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_22) { Attribute = new VariationAttribute("testcase: Reuse and redefine existing prefix") { Id = 22 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_23) { Attribute = new VariationAttribute("WriteStartAttribute(attr) sanity test") { Id = 23 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_24) { Attribute = new VariationAttribute("WriteStartAttribute(attr) inside an element with changed default namespace") { Id = 24 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_25) { Attribute = new VariationAttribute("WriteStartAttribute(attr) and duplicate attrs") { Id = 25 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_26) { Attribute = new VariationAttribute("WriteStartAttribute(attr) when element has ns:attr") { Id = 26 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_27) { Attribute = new VariationAttribute("XmlCharCheckingWriter should not normalize newLines in attribute values when NewLinesHandling = Replace") { Id = 27 } });
-                    this.AddChild(new TestVariation(tcAttribute.attribute_29) { Attribute = new VariationAttribute("WriteAttributeString doesn't fail on invalid surrogate pair sequences") { Id = 29 } });
+                    this.AddChild(new TestVariation(attribute_1) { Attribute = new VariationAttribute("Sanity test for WriteAttribute") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(attribute_2) { Attribute = new VariationAttribute("Missing EndAttribute should be fixed") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(attribute_3) { Attribute = new VariationAttribute("WriteStartAttribute followed by WriteStartAttribute") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(attribute_4) { Attribute = new VariationAttribute("Multiple WritetAttributeString") { Id = 4, Priority = 0 } });
+                    this.AddChild(new TestVariation(attribute_5) { Attribute = new VariationAttribute("WriteStartAttribute followed by WriteString") { Id = 5, Priority = 0 } });
+                    this.AddChild(new TestVariation(attribute_6) { Attribute = new VariationAttribute("Sanity test for overload WriteStartAttribute(name, ns)") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_7) { Attribute = new VariationAttribute("Sanity test for overload WriteStartAttribute(prefix, name, ns)") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(attribute_8) { Attribute = new VariationAttribute("Duplicate attribute 'attr1'") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_9) { Attribute = new VariationAttribute("Duplicate attribute 'ns1:attr1'") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_10) { Attribute = new VariationAttribute("Attribute name = String.Empty should error") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_11) { Attribute = new VariationAttribute("Attribute name = null") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_12) { Attribute = new VariationAttribute("WriteAttribute with names Foo, fOo, foO, FOO") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_13) { Attribute = new VariationAttribute("Invalid value of xml:space") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_14) { Attribute = new VariationAttribute("SingleQuote in attribute value should be allowed") { Id = 14 } });
+                    this.AddChild(new TestVariation(attribute_15) { Attribute = new VariationAttribute("DoubleQuote in attribute value should be escaped") { Id = 15 } });
+                    this.AddChild(new TestVariation(attribute_16) { Attribute = new VariationAttribute("WriteAttribute with value = &, #65, #x20") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_17) { Attribute = new VariationAttribute("WriteAttributeString followed by WriteString") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_18) { Attribute = new VariationAttribute("WriteAttribute followed by WriteString") { Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_19) { Attribute = new VariationAttribute("WriteAttribute with all whitespace characters") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_20) { Attribute = new VariationAttribute("< > & chars should be escaped in attribute value") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(attribute_21) { Attribute = new VariationAttribute("testcase: Redefine auto generated prefix n1") { Id = 21 } });
+                    this.AddChild(new TestVariation(attribute_22) { Attribute = new VariationAttribute("testcase: Reuse and redefine existing prefix") { Id = 22 } });
+                    this.AddChild(new TestVariation(attribute_23) { Attribute = new VariationAttribute("WriteStartAttribute(attr) sanity test") { Id = 23 } });
+                    this.AddChild(new TestVariation(attribute_24) { Attribute = new VariationAttribute("WriteStartAttribute(attr) inside an element with changed default namespace") { Id = 24 } });
+                    this.AddChild(new TestVariation(attribute_25) { Attribute = new VariationAttribute("WriteStartAttribute(attr) and duplicate attrs") { Id = 25 } });
+                    this.AddChild(new TestVariation(attribute_26) { Attribute = new VariationAttribute("WriteStartAttribute(attr) when element has ns:attr") { Id = 26 } });
+                    this.AddChild(new TestVariation(attribute_27) { Attribute = new VariationAttribute("XmlCharCheckingWriter should not normalize newLines in attribute values when NewLinesHandling = Replace") { Id = 27 } });
+                    this.AddChild(new TestVariation(attribute_29) { Attribute = new VariationAttribute("WriteAttributeString doesn't fail on invalid surrogate pair sequences") { Id = 29 } });
                 }
             }
-            public class TCWriteAttributes : BridgeHelpers
+            public partial class TCWriteAttributes : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteAttributes
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteAttributes = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteAttributes();
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_1) { Attribute = new VariationAttribute("Call WriteAttributes with default DTD attributes = true") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_2) { Attribute = new VariationAttribute("Call WriteAttributes with default DTD attributes = false") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_3) { Attribute = new VariationAttribute("Call WriteAttributes with XmlReader = null") { Id = 3 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_4) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located on element") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_5) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located in the mIddle attribute") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_6) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located in the last attribute") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_8) { Attribute = new VariationAttribute("Call WriteAttributes with reader on XmlDeclaration") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on Text") { Param = "Text", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on PI") { Param = "ProcessingInstruction", Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on Comment") { Param = "Comment", Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on CDATA") { Param = "CDATA", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_12) { Attribute = new VariationAttribute("Call WriteAttributes with 100 attributes") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_13) { Attribute = new VariationAttribute("WriteAttributes with different builtin entities in attribute value") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_14) { Attribute = new VariationAttribute("WriteAttributes tries to duplicate attribute") { Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_1) { Attribute = new VariationAttribute("Call WriteAttributes with default DTD attributes = true") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_2) { Attribute = new VariationAttribute("Call WriteAttributes with default DTD attributes = false") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_3) { Attribute = new VariationAttribute("Call WriteAttributes with XmlReader = null") { Id = 3 } });
+                    this.AddChild(new TestVariation(writeAttributes_4) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located on element") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_5) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located in the mIddle attribute") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_6) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located in the last attribute") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_8) { Attribute = new VariationAttribute("Call WriteAttributes with reader on XmlDeclaration") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on Text") { Param = "Text", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on PI") { Param = "ProcessingInstruction", Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on Comment") { Param = "Comment", Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on CDATA") { Param = "CDATA", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_12) { Attribute = new VariationAttribute("Call WriteAttributes with 100 attributes") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_13) { Attribute = new VariationAttribute("WriteAttributes with different builtin entities in attribute value") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeAttributes_14) { Attribute = new VariationAttribute("WriteAttributes tries to duplicate attribute") { Id = 21, Priority = 1 } });
                 }
             }
-            public class TCWriteNode_XmlReader : BridgeHelpers
+            public partial class TCWriteNode_XmlReader : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteNode_XmlReader
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteNodeXmlReader = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteNode_XmlReader();
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader1) { Attribute = new VariationAttribute("WriteNode with null reader") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader2) { Attribute = new VariationAttribute("WriteNode with reader positioned on attribute, no operation") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader3) { Attribute = new VariationAttribute("WriteNode before reader.Read()") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader4) { Attribute = new VariationAttribute("WriteNode after first reader.Read()") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader5) { Attribute = new VariationAttribute("WriteNode when reader is positioned on mIddle of an element node") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader6) { Attribute = new VariationAttribute("WriteNode when reader state is EOF") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader7) { Attribute = new VariationAttribute("WriteNode when reader state is Closed") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader8) { Attribute = new VariationAttribute("WriteNode with reader on empty element node") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader9) { Attribute = new VariationAttribute("WriteNode with reader on 100 Nodes") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader10) { Attribute = new VariationAttribute("WriteNode with reader on node with mixed content") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader11) { Attribute = new VariationAttribute("WriteNode with reader on node with declared namespace in parent") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader14) { Attribute = new VariationAttribute("WriteNode with element that has different prefix") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader15) { Attribute = new VariationAttribute("Call WriteNode with default attributes = true and DTD") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader16) { Attribute = new VariationAttribute("Call WriteNode with default attributes = false and DTD") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader17) { Attribute = new VariationAttribute("WriteNode with reader on empty element with attributes") { Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader18) { Attribute = new VariationAttribute("WriteNode with document containing just empty element with attributes") { Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader19) { Attribute = new VariationAttribute("Call WriteNode with special entity references as attribute value") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader21) { Attribute = new VariationAttribute("Call WriteNode with full end element") { Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader22) { Attribute = new VariationAttribute("Call WriteNode with reader on element with 100 attributes") { Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader23) { Attribute = new VariationAttribute("Call WriteNode with reader on text node") { Id = 23, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader24) { Attribute = new VariationAttribute("Call WriteNode with reader on CDATA node") { Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader25) { Attribute = new VariationAttribute("Call WriteNode with reader on PI node") { Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader26) { Attribute = new VariationAttribute("Call WriteNode with reader on Comment node") { Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader27) { Attribute = new VariationAttribute("WriteNode should only write required namespaces") { Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader28) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, include xmlns:xml") { Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader29) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, exclude xmlns:xml") { Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader30) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at top level") { Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader31) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at same level") { Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader32) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at both levels") { Id = 32, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader33) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change ns uri for same prefix") { Id = 33, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader34) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, reuse prefix from top level") { Id = 34, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader1) { Attribute = new VariationAttribute("WriteNode with null reader") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader2) { Attribute = new VariationAttribute("WriteNode with reader positioned on attribute, no operation") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader3) { Attribute = new VariationAttribute("WriteNode before reader.Read()") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader4) { Attribute = new VariationAttribute("WriteNode after first reader.Read()") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader5) { Attribute = new VariationAttribute("WriteNode when reader is positioned on mIddle of an element node") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader6) { Attribute = new VariationAttribute("WriteNode when reader state is EOF") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader7) { Attribute = new VariationAttribute("WriteNode when reader state is Closed") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader8) { Attribute = new VariationAttribute("WriteNode with reader on empty element node") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader9) { Attribute = new VariationAttribute("WriteNode with reader on 100 Nodes") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader10) { Attribute = new VariationAttribute("WriteNode with reader on node with mixed content") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader11) { Attribute = new VariationAttribute("WriteNode with reader on node with declared namespace in parent") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader14) { Attribute = new VariationAttribute("WriteNode with element that has different prefix") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader15) { Attribute = new VariationAttribute("Call WriteNode with default attributes = true and DTD") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader16) { Attribute = new VariationAttribute("Call WriteNode with default attributes = false and DTD") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader17) { Attribute = new VariationAttribute("WriteNode with reader on empty element with attributes") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader18) { Attribute = new VariationAttribute("WriteNode with document containing just empty element with attributes") { Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader19) { Attribute = new VariationAttribute("Call WriteNode with special entity references as attribute value") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader21) { Attribute = new VariationAttribute("Call WriteNode with full end element") { Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader22) { Attribute = new VariationAttribute("Call WriteNode with reader on element with 100 attributes") { Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader23) { Attribute = new VariationAttribute("Call WriteNode with reader on text node") { Id = 23, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader24) { Attribute = new VariationAttribute("Call WriteNode with reader on CDATA node") { Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader25) { Attribute = new VariationAttribute("Call WriteNode with reader on PI node") { Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader26) { Attribute = new VariationAttribute("Call WriteNode with reader on Comment node") { Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader27) { Attribute = new VariationAttribute("WriteNode should only write required namespaces") { Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader28) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, include xmlns:xml") { Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader29) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, exclude xmlns:xml") { Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader30) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at top level") { Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader31) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at same level") { Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader32) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at both levels") { Id = 32, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader33) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change ns uri for same prefix") { Id = 33, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNode_XmlReader34) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, reuse prefix from top level") { Id = 34, Priority = 1 } });
                 }
             }
 
-            public class TCFullEndElement : BridgeHelpers
+            public partial class TCFullEndElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCFullEndElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcFullEndElement = new CommonTestsFunctionalTests.XNodeBuilderTests.TCFullEndElement();
-                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_1) { Attribute = new VariationAttribute("Sanity test for WriteFullEndElement()") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_2) { Attribute = new VariationAttribute("Call WriteFullEndElement before calling WriteStartElement") { Id = 2, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_3) { Attribute = new VariationAttribute("Call WriteFullEndElement after WriteEndElement") { Id = 3, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_4) { Attribute = new VariationAttribute("Call WriteFullEndElement without closing attributes") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_5) { Attribute = new VariationAttribute("Call WriteFullEndElement after WriteStartAttribute") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_6) { Attribute = new VariationAttribute("WriteFullEndElement for 100 nested elements") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(fullEndElement_1) { Attribute = new VariationAttribute("Sanity test for WriteFullEndElement()") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(fullEndElement_2) { Attribute = new VariationAttribute("Call WriteFullEndElement before calling WriteStartElement") { Id = 2, Priority = 2 } });
+                    this.AddChild(new TestVariation(fullEndElement_3) { Attribute = new VariationAttribute("Call WriteFullEndElement after WriteEndElement") { Id = 3, Priority = 2 } });
+                    this.AddChild(new TestVariation(fullEndElement_4) { Attribute = new VariationAttribute("Call WriteFullEndElement without closing attributes") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(fullEndElement_5) { Attribute = new VariationAttribute("Call WriteFullEndElement after WriteStartAttribute") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(fullEndElement_6) { Attribute = new VariationAttribute("WriteFullEndElement for 100 nested elements") { Id = 6, Priority = 1 } });
                 }
             }
-            public class TCElemNamespace : BridgeHelpers
+            public partial class TCElemNamespace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCElemNamespace
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcElemNamespace = new CommonTestsFunctionalTests.XNodeBuilderTests.TCElemNamespace();
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_1) { Attribute = new VariationAttribute("Multiple NS decl for same prefix on an element") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_2) { Attribute = new VariationAttribute("Multiple NS decl for same prefix (same NS value) on an element") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_3) { Attribute = new VariationAttribute("Element and attribute have same prefix, but different namespace value") { Id = 3, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_4) { Attribute = new VariationAttribute("Nested elements have same prefix, but different namespace") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_5) { Attribute = new VariationAttribute("Mapping reserved prefix xml to invalid namespace") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_6) { Attribute = new VariationAttribute("Mapping reserved prefix xml to correct namespace") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_7) { Attribute = new VariationAttribute("Write element with prefix beginning with xml") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_8) { Attribute = new VariationAttribute("Reuse prefix that refers the same as default namespace") { Id = 8, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_9) { Attribute = new VariationAttribute("Should throw error for prefix=xmlns") { Id = 9, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_10) { Attribute = new VariationAttribute("Create nested element without prefix but with namespace of parent element with a defined prefix") { Id = 10, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_11) { Attribute = new VariationAttribute("Create different prefix for element and attribute that have same namespace") { Id = 11, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_12) { Attribute = new VariationAttribute("Create same prefix for element and attribute that have same namespace") { Id = 12, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_13) { Attribute = new VariationAttribute("Try to re-define NS prefix on attribute which is already defined on an element") { Id = 13, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_14) { Attribute = new VariationAttribute("Namespace string contains surrogates, reuse at different levels") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_15) { Attribute = new VariationAttribute("Namespace containing entities, use at multiple levels") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_16) { Attribute = new VariationAttribute("Verify it resets default namespace when redefined earlier in the stack") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_17) { Attribute = new VariationAttribute("The default namespace for an element can not be changed once it is written out") { Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_18) { Attribute = new VariationAttribute("Map XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_19) { Attribute = new VariationAttribute("Pass NULL as NS to WriteStartElement") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_20) { Attribute = new VariationAttribute("Write element in reserved XML namespace, should error") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_21) { Attribute = new VariationAttribute("Write element in reserved XMLNS namespace, should error") { Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_22) { Attribute = new VariationAttribute("Mapping a prefix to empty ns should error") { Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_23) { Attribute = new VariationAttribute("Pass null prefix to WriteStartElement()") { Id = 23, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_24) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteStartElement()") { Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_25) { Attribute = new VariationAttribute("Pass null ns to WriteStartElement()") { Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_26) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement()") { Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_27) { Attribute = new VariationAttribute("Pass null prefix to WriteStartElement() when namespace is in scope") { Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_28) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteStartElement() when namespace is in scope") { Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_29) { Attribute = new VariationAttribute("Pass null ns to WriteStartElement() when prefix is in scope") { Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_30) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement() when prefix is in scope") { Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_31) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement() when prefix is in scope") { Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_32) { Attribute = new VariationAttribute("Mapping empty ns uri to a prefix should error") { Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_1) { Attribute = new VariationAttribute("Multiple NS decl for same prefix on an element") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_2) { Attribute = new VariationAttribute("Multiple NS decl for same prefix (same NS value) on an element") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_3) { Attribute = new VariationAttribute("Element and attribute have same prefix, but different namespace value") { Id = 3, Priority = 2 } });
+                    this.AddChild(new TestVariation(elemNamespace_4) { Attribute = new VariationAttribute("Nested elements have same prefix, but different namespace") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_5) { Attribute = new VariationAttribute("Mapping reserved prefix xml to invalid namespace") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_6) { Attribute = new VariationAttribute("Mapping reserved prefix xml to correct namespace") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_7) { Attribute = new VariationAttribute("Write element with prefix beginning with xml") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_8) { Attribute = new VariationAttribute("Reuse prefix that refers the same as default namespace") { Id = 8, Priority = 2 } });
+                    this.AddChild(new TestVariation(elemNamespace_9) { Attribute = new VariationAttribute("Should throw error for prefix=xmlns") { Id = 9, Priority = 2 } });
+                    this.AddChild(new TestVariation(elemNamespace_10) { Attribute = new VariationAttribute("Create nested element without prefix but with namespace of parent element with a defined prefix") { Id = 10, Priority = 2 } });
+                    this.AddChild(new TestVariation(elemNamespace_11) { Attribute = new VariationAttribute("Create different prefix for element and attribute that have same namespace") { Id = 11, Priority = 2 } });
+                    this.AddChild(new TestVariation(elemNamespace_12) { Attribute = new VariationAttribute("Create same prefix for element and attribute that have same namespace") { Id = 12, Priority = 2 } });
+                    this.AddChild(new TestVariation(elemNamespace_13) { Attribute = new VariationAttribute("Try to re-define NS prefix on attribute which is already defined on an element") { Id = 13, Priority = 2 } });
+                    this.AddChild(new TestVariation(elemNamespace_14) { Attribute = new VariationAttribute("Namespace string contains surrogates, reuse at different levels") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_15) { Attribute = new VariationAttribute("Namespace containing entities, use at multiple levels") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_16) { Attribute = new VariationAttribute("Verify it resets default namespace when redefined earlier in the stack") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_17) { Attribute = new VariationAttribute("The default namespace for an element can not be changed once it is written out") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_18) { Attribute = new VariationAttribute("Map XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_19) { Attribute = new VariationAttribute("Pass NULL as NS to WriteStartElement") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_20) { Attribute = new VariationAttribute("Write element in reserved XML namespace, should error") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_21) { Attribute = new VariationAttribute("Write element in reserved XMLNS namespace, should error") { Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_22) { Attribute = new VariationAttribute("Mapping a prefix to empty ns should error") { Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_23) { Attribute = new VariationAttribute("Pass null prefix to WriteStartElement()") { Id = 23, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_24) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteStartElement()") { Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_25) { Attribute = new VariationAttribute("Pass null ns to WriteStartElement()") { Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_26) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement()") { Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_27) { Attribute = new VariationAttribute("Pass null prefix to WriteStartElement() when namespace is in scope") { Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_28) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteStartElement() when namespace is in scope") { Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_29) { Attribute = new VariationAttribute("Pass null ns to WriteStartElement() when prefix is in scope") { Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_30) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement() when prefix is in scope") { Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_31) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement() when prefix is in scope") { Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(elemNamespace_32) { Attribute = new VariationAttribute("Mapping empty ns uri to a prefix should error") { Id = 31, Priority = 1 } });
                 }
             }
-            public class TCAttrNamespace : BridgeHelpers
+            public partial class TCAttrNamespace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCAttrNamespace
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcAttrNamespace = new CommonTestsFunctionalTests.XNodeBuilderTests.TCAttrNamespace();
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_1) { Attribute = new VariationAttribute("Define prefix 'xml' with invalid namespace URI 'foo'") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_2) { Attribute = new VariationAttribute("Bind NS prefix 'xml' with valid namespace URI") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_3) { Attribute = new VariationAttribute("Bind NS prefix 'xmlA' with namespace URI 'foo'") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_4) { Attribute = new VariationAttribute("Write attribute xml:space with correct namespace") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_5) { Attribute = new VariationAttribute("Write attribute xml:space with incorrect namespace") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_6) { Attribute = new VariationAttribute("Write attribute xml:lang with incorrect namespace") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_7) { Attribute = new VariationAttribute("WriteAttribute, define namespace attribute before value attribute") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_8) { Attribute = new VariationAttribute("WriteAttribute, define namespace attribute after value attribute") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_9) { Attribute = new VariationAttribute("WriteAttribute, redefine prefix at different scope and use both of them") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_10) { Attribute = new VariationAttribute("WriteAttribute, redefine namespace at different scope and use both of them") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_11) { Attribute = new VariationAttribute("WriteAttribute with collIding prefix with element") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_12) { Attribute = new VariationAttribute("WriteAttribute with collIding namespace with element") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_13) { Attribute = new VariationAttribute("WriteAttribute with namespace but no prefix") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_14) { Attribute = new VariationAttribute("WriteAttribute for 2 attributes with same prefix but different namespace") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_15) { Attribute = new VariationAttribute("WriteAttribute with String.Empty and null as namespace and prefix values") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_16) { Attribute = new VariationAttribute("WriteAttribute to manually create attribute of xmlns:x") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_17) { Attribute = new VariationAttribute("WriteAttribute with namespace value = null while a prefix exists") { Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_18) { Attribute = new VariationAttribute("WriteAttribute with namespace value = String.Empty while a prefix exists") { Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_19) { Attribute = new VariationAttribute("WriteAttribe in nested elements with same namespace but different prefix") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_20) { Attribute = new VariationAttribute("WriteAttribute for x:a and xmlns:a diff namespace") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_21) { Attribute = new VariationAttribute("WriteAttribute for x:a and xmlns:a same namespace") { Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_22) { Attribute = new VariationAttribute("WriteAttribute with collIding NS and prefix for 2 attributes") { Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_23) { Attribute = new VariationAttribute("WriteAttribute with DQ in namespace") { Id = 23, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_24) { Attribute = new VariationAttribute("Attach prefix with empty namespace") { Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_25) { Attribute = new VariationAttribute("Explicitly write namespace attribute that maps XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_26) { Attribute = new VariationAttribute("Map XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_27) { Attribute = new VariationAttribute("Pass empty namespace to WriteAttributeString(prefix, name, ns, value)") { Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_28) { Attribute = new VariationAttribute("Write attribute with prefix = xmlns") { Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_29) { Attribute = new VariationAttribute("Write attribute in reserved XML namespace, should error") { Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_30) { Attribute = new VariationAttribute("Write attribute in reserved XMLNS namespace, should error") { Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_31) { Attribute = new VariationAttribute("WriteAttributeString with no namespace under element with empty prefix") { Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_32) { Attribute = new VariationAttribute("Pass null prefix to WriteAttributeString()") { Id = 32, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_33) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteAttributeString()") { Id = 33, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_34) { Attribute = new VariationAttribute("Pass null ns to WriteAttributeString()") { Id = 34, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_35) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteAttributeString()") { Id = 35, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_36) { Attribute = new VariationAttribute("Pass null prefix to WriteAttributeString() when namespace is in scope") { Id = 36, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_37) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteAttributeString() when namespace is in scope") { Id = 37, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_38) { Attribute = new VariationAttribute("Pass null ns to WriteAttributeString() when prefix is in scope") { Id = 38, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_39) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteAttributeString() when prefix is in scope") { Id = 39, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_40) { Attribute = new VariationAttribute("Mapping empty ns uri to a prefix should error") { Id = 40, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_41) { Attribute = new VariationAttribute("WriteStartAttribute with prefix = null, localName = xmlns - case 1") { Id = 41, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_42) { Attribute = new VariationAttribute("WriteStartAttribute with prefix = null, localName = xmlns - case 2") { Id = 42, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_1) { Attribute = new VariationAttribute("Define prefix 'xml' with invalid namespace URI 'foo'") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_2) { Attribute = new VariationAttribute("Bind NS prefix 'xml' with valid namespace URI") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_3) { Attribute = new VariationAttribute("Bind NS prefix 'xmlA' with namespace URI 'foo'") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_4) { Attribute = new VariationAttribute("Write attribute xml:space with correct namespace") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_5) { Attribute = new VariationAttribute("Write attribute xml:space with incorrect namespace") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_6) { Attribute = new VariationAttribute("Write attribute xml:lang with incorrect namespace") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_7) { Attribute = new VariationAttribute("WriteAttribute, define namespace attribute before value attribute") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_8) { Attribute = new VariationAttribute("WriteAttribute, define namespace attribute after value attribute") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_9) { Attribute = new VariationAttribute("WriteAttribute, redefine prefix at different scope and use both of them") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_10) { Attribute = new VariationAttribute("WriteAttribute, redefine namespace at different scope and use both of them") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_11) { Attribute = new VariationAttribute("WriteAttribute with collIding prefix with element") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_12) { Attribute = new VariationAttribute("WriteAttribute with collIding namespace with element") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_13) { Attribute = new VariationAttribute("WriteAttribute with namespace but no prefix") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_14) { Attribute = new VariationAttribute("WriteAttribute for 2 attributes with same prefix but different namespace") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_15) { Attribute = new VariationAttribute("WriteAttribute with String.Empty and null as namespace and prefix values") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_16) { Attribute = new VariationAttribute("WriteAttribute to manually create attribute of xmlns:x") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_17) { Attribute = new VariationAttribute("WriteAttribute with namespace value = null while a prefix exists") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_18) { Attribute = new VariationAttribute("WriteAttribute with namespace value = String.Empty while a prefix exists") { Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_19) { Attribute = new VariationAttribute("WriteAttribe in nested elements with same namespace but different prefix") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_20) { Attribute = new VariationAttribute("WriteAttribute for x:a and xmlns:a diff namespace") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_21) { Attribute = new VariationAttribute("WriteAttribute for x:a and xmlns:a same namespace") { Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_22) { Attribute = new VariationAttribute("WriteAttribute with collIding NS and prefix for 2 attributes") { Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_23) { Attribute = new VariationAttribute("WriteAttribute with DQ in namespace") { Id = 23, Priority = 2 } });
+                    this.AddChild(new TestVariation(attrNamespace_24) { Attribute = new VariationAttribute("Attach prefix with empty namespace") { Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_25) { Attribute = new VariationAttribute("Explicitly write namespace attribute that maps XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_26) { Attribute = new VariationAttribute("Map XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_27) { Attribute = new VariationAttribute("Pass empty namespace to WriteAttributeString(prefix, name, ns, value)") { Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_28) { Attribute = new VariationAttribute("Write attribute with prefix = xmlns") { Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_29) { Attribute = new VariationAttribute("Write attribute in reserved XML namespace, should error") { Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_30) { Attribute = new VariationAttribute("Write attribute in reserved XMLNS namespace, should error") { Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_31) { Attribute = new VariationAttribute("WriteAttributeString with no namespace under element with empty prefix") { Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_32) { Attribute = new VariationAttribute("Pass null prefix to WriteAttributeString()") { Id = 32, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_33) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteAttributeString()") { Id = 33, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_34) { Attribute = new VariationAttribute("Pass null ns to WriteAttributeString()") { Id = 34, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_35) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteAttributeString()") { Id = 35, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_36) { Attribute = new VariationAttribute("Pass null prefix to WriteAttributeString() when namespace is in scope") { Id = 36, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_37) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteAttributeString() when namespace is in scope") { Id = 37, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_38) { Attribute = new VariationAttribute("Pass null ns to WriteAttributeString() when prefix is in scope") { Id = 38, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_39) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteAttributeString() when prefix is in scope") { Id = 39, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_40) { Attribute = new VariationAttribute("Mapping empty ns uri to a prefix should error") { Id = 40, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_41) { Attribute = new VariationAttribute("WriteStartAttribute with prefix = null, localName = xmlns - case 1") { Id = 41, Priority = 1 } });
+                    this.AddChild(new TestVariation(attrNamespace_42) { Attribute = new VariationAttribute("WriteStartAttribute with prefix = null, localName = xmlns - case 2") { Id = 42, Priority = 1 } });
                 }
             }
-            public class TCCData : BridgeHelpers
+            public partial class TCCData : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCCData
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcCData = new CommonTestsFunctionalTests.XNodeBuilderTests.TCCData();
-                    this.AddChild(new TestVariation(tcCData.CData_1) { Attribute = new VariationAttribute("WriteCData with null") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCData.CData_2) { Attribute = new VariationAttribute("WriteCData with String.Empty") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCData.CData_3) { Attribute = new VariationAttribute("WriteCData Sanity test") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcCData.CData_4) { Attribute = new VariationAttribute("WriteCData with valid surrogate pair") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCData.CData_6) { Attribute = new VariationAttribute("WriteCData with & < > chars, they should not be escaped") { Id = 6, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcCData.CData_7) { Attribute = new VariationAttribute("WriteCData with <![CDATA[") { Id = 7, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcCData.CData_8) { Attribute = new VariationAttribute("CData state machine") { Id = 8, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcCData.CData_9) { Attribute = new VariationAttribute("WriteCData with invalid surrogate pair") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCData.CData_10) { Attribute = new VariationAttribute("WriteCData after root element") { Id = 10 } });
-                    this.AddChild(new TestVariation(tcCData.CData_11) { Attribute = new VariationAttribute("Call WriteCData twice - that should write two CData blocks") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(CData_1) { Attribute = new VariationAttribute("WriteCData with null") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(CData_2) { Attribute = new VariationAttribute("WriteCData with String.Empty") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(CData_3) { Attribute = new VariationAttribute("WriteCData Sanity test") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(CData_4) { Attribute = new VariationAttribute("WriteCData with valid surrogate pair") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(CData_6) { Attribute = new VariationAttribute("WriteCData with & < > chars, they should not be escaped") { Id = 6, Priority = 2 } });
+                    this.AddChild(new TestVariation(CData_7) { Attribute = new VariationAttribute("WriteCData with <![CDATA[") { Id = 7, Priority = 2 } });
+                    this.AddChild(new TestVariation(CData_8) { Attribute = new VariationAttribute("CData state machine") { Id = 8, Priority = 2 } });
+                    this.AddChild(new TestVariation(CData_9) { Attribute = new VariationAttribute("WriteCData with invalid surrogate pair") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(CData_10) { Attribute = new VariationAttribute("WriteCData after root element") { Id = 10 } });
+                    this.AddChild(new TestVariation(CData_11) { Attribute = new VariationAttribute("Call WriteCData twice - that should write two CData blocks") { Id = 11, Priority = 1 } });
                 }
             }
-            public class TCComment : BridgeHelpers
+            public partial class TCComment : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCComment
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcComment = new CommonTestsFunctionalTests.XNodeBuilderTests.TCComment();
-                    this.AddChild(new TestVariation(tcComment.comment_1) { Attribute = new VariationAttribute("Sanity test for WriteComment") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcComment.comment_2) { Attribute = new VariationAttribute("Comment value = String.Empty") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcComment.comment_3) { Attribute = new VariationAttribute("Comment value = null") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcComment.comment_4) { Attribute = new VariationAttribute("WriteComment with valid surrogate pair") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcComment.comment_5) { Attribute = new VariationAttribute("WriteComment with invalid surrogate pair") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(comment_1) { Attribute = new VariationAttribute("Sanity test for WriteComment") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(comment_2) { Attribute = new VariationAttribute("Comment value = String.Empty") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(comment_3) { Attribute = new VariationAttribute("Comment value = null") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(comment_4) { Attribute = new VariationAttribute("WriteComment with valid surrogate pair") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(comment_5) { Attribute = new VariationAttribute("WriteComment with invalid surrogate pair") { Id = 5, Priority = 1 } });
                 }
             }
-            public class TCEntityRef : BridgeHelpers
+            public partial class TCEntityRef : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCEntityRef
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcEntityRef = new CommonTestsFunctionalTests.XNodeBuilderTests.TCEntityRef();
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value SQ") { Param = "test'test", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value <;") { Param = "test<test", Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value & and ;") { Param = "&test;", Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with value = null") { Param = "null", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value DQ") { Param = "test\"test", Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xD") { Param = "\xD", Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value &") { Param = "test&test", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with value = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xD#xA") { Param = "\xD\xA", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xA") { Param = "\r", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value >") { Param = "test>test", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_2) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: amp") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_3) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: apos") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.var_4) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: lt") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.var_5) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: quot") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEntityRef.entityRef_6) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: gt") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value SQ") { Param = "test'test", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value <;") { Param = "test<test", Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value & and ;") { Param = "&test;", Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with value = null") { Param = "null", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value DQ") { Param = "test\"test", Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xD") { Param = "\xD", Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value &") { Param = "test&test", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with value = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xD#xA") { Param = "\xD\xA", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xA") { Param = "\r", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value >") { Param = "test>test", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_2) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: amp") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_3) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: apos") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: lt") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: quot") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(entityRef_6) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: gt") { Id = 16, Priority = 1 } });
                 }
             }
-            public class TCCharEntity : BridgeHelpers
+            public partial class TCCharEntity : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCCharEntity
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcCharEntity = new CommonTestsFunctionalTests.XNodeBuilderTests.TCCharEntity();
-                    this.AddChild(new TestVariation(tcCharEntity.charEntity_1) { Attribute = new VariationAttribute("WriteCharEntity with valid Unicode character") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcCharEntity.charEntity_2) { Attribute = new VariationAttribute("Call WriteCharEntity after WriteStartElement/WriteEndElement") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcCharEntity.charEntity_3) { Attribute = new VariationAttribute("Call WriteCharEntity after WriteStartAttribute/WriteEndAttribute") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcCharEntity.charEntity_4) { Attribute = new VariationAttribute("Character from low surrogate range") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCharEntity.charEntity_5) { Attribute = new VariationAttribute("Character from high surrogate range") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCharEntity.charEntity_7) { Attribute = new VariationAttribute("Sanity test, pass 'a'") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcCharEntity.charEntity_8) { Attribute = new VariationAttribute("WriteCharEntity for special attributes") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(charEntity_1) { Attribute = new VariationAttribute("WriteCharEntity with valid Unicode character") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(charEntity_2) { Attribute = new VariationAttribute("Call WriteCharEntity after WriteStartElement/WriteEndElement") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(charEntity_3) { Attribute = new VariationAttribute("Call WriteCharEntity after WriteStartAttribute/WriteEndAttribute") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(charEntity_4) { Attribute = new VariationAttribute("Character from low surrogate range") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(charEntity_5) { Attribute = new VariationAttribute("Character from high surrogate range") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(charEntity_7) { Attribute = new VariationAttribute("Sanity test, pass 'a'") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(charEntity_8) { Attribute = new VariationAttribute("WriteCharEntity for special attributes") { Id = 8, Priority = 1 } });
                 }
             }
-            public class TCSurrogateCharEntity : BridgeHelpers
+            public partial class TCSurrogateCharEntity : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCSurrogateCharEntity
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcSurrogateCharEntity = new CommonTestsFunctionalTests.XNodeBuilderTests.TCSurrogateCharEntity();
-                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_1) { Attribute = new VariationAttribute("SurrogateCharEntity after WriteStartElement/WriteEndElement") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_2) { Attribute = new VariationAttribute("SurrogateCharEntity after WriteStartAttribute/WriteEndAttribute") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_3) { Attribute = new VariationAttribute("Test with limits of surrogate range") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_4) { Attribute = new VariationAttribute("MIddle surrogate character") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_5) { Attribute = new VariationAttribute("Invalid high surrogate character") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_6) { Attribute = new VariationAttribute("Invalid low surrogate character") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_7) { Attribute = new VariationAttribute("Swap high-low surrogate characters") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_8) { Attribute = new VariationAttribute("WriteSurrogateCharEntity for special attributes") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(surrogateEntity_1) { Attribute = new VariationAttribute("SurrogateCharEntity after WriteStartElement/WriteEndElement") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(surrogateEntity_2) { Attribute = new VariationAttribute("SurrogateCharEntity after WriteStartAttribute/WriteEndAttribute") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(surrogateEntity_3) { Attribute = new VariationAttribute("Test with limits of surrogate range") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(surrogateEntity_4) { Attribute = new VariationAttribute("MIddle surrogate character") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(surrogateEntity_5) { Attribute = new VariationAttribute("Invalid high surrogate character") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(surrogateEntity_6) { Attribute = new VariationAttribute("Invalid low surrogate character") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(surrogateEntity_7) { Attribute = new VariationAttribute("Swap high-low surrogate characters") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(surrogateEntity_8) { Attribute = new VariationAttribute("WriteSurrogateCharEntity for special attributes") { Id = 8, Priority = 1 } });
                 }
             }
-            public class TCPI : BridgeHelpers
+            public partial class TCPI : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCPI
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcPI = new CommonTestsFunctionalTests.XNodeBuilderTests.TCPI();
-                    this.AddChild(new TestVariation(tcPI.pi_1) { Attribute = new VariationAttribute("Sanity test for WritePI") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcPI.pi_2) { Attribute = new VariationAttribute("PI text value = null") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcPI.pi_3) { Attribute = new VariationAttribute("PI text value = String.Empty") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcPI.pi_4) { Attribute = new VariationAttribute("PI name = null should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcPI.pi_5) { Attribute = new VariationAttribute("PI name = String.Empty should error") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcPI.pi_6) { Attribute = new VariationAttribute("WritePI with xmlns as the name value") { Id = 6 } });
-                    this.AddChild(new TestVariation(tcPI.pi_7) { Attribute = new VariationAttribute("WritePI with XmL as the name value") { Id = 7 } });
-                    this.AddChild(new TestVariation(tcPI.pi_8) { Attribute = new VariationAttribute("WritePI before XmlDecl") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcPI.pi_9) { Attribute = new VariationAttribute("WritePI (after StartDocument) with name = 'xml' text = 'version = 1.0' should error") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcPI.pi_10) { Attribute = new VariationAttribute("WritePI (before StartDocument) with name = 'xml' text = 'version = 1.0' should error") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcPI.pi_12) { Attribute = new VariationAttribute("WriteProcessingInstruction with valid surrogate pair") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcPI.pi_13) { Attribute = new VariationAttribute("WritePI with invalid surrogate pair") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_1) { Attribute = new VariationAttribute("Sanity test for WritePI") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(pi_2) { Attribute = new VariationAttribute("PI text value = null") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_3) { Attribute = new VariationAttribute("PI text value = String.Empty") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_4) { Attribute = new VariationAttribute("PI name = null should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_5) { Attribute = new VariationAttribute("PI name = String.Empty should error") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_6) { Attribute = new VariationAttribute("WritePI with xmlns as the name value") { Id = 6 } });
+                    this.AddChild(new TestVariation(pi_7) { Attribute = new VariationAttribute("WritePI with XmL as the name value") { Id = 7 } });
+                    this.AddChild(new TestVariation(pi_8) { Attribute = new VariationAttribute("WritePI before XmlDecl") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_9) { Attribute = new VariationAttribute("WritePI (after StartDocument) with name = 'xml' text = 'version = 1.0' should error") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_10) { Attribute = new VariationAttribute("WritePI (before StartDocument) with name = 'xml' text = 'version = 1.0' should error") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_12) { Attribute = new VariationAttribute("WriteProcessingInstruction with valid surrogate pair") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(pi_13) { Attribute = new VariationAttribute("WritePI with invalid surrogate pair") { Id = 13, Priority = 1 } });
                 }
             }
-            public class TCWriteNmToken : BridgeHelpers
+            public partial class TCWriteNmToken : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteNmToken
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteNmToken = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteNmToken();
-                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_2) { Attribute = new VariationAttribute("Sanity test, Name = foo") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_3) { Attribute = new VariationAttribute("Name contains letters, digits, . _ - : chars") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_4) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "test test", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_4) { Attribute = new VariationAttribute("Name contains ? char") { Param = "test?", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_4) { Attribute = new VariationAttribute("Name contains DQ") { Param = "\"test", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_4) { Attribute = new VariationAttribute("Name contains SQ") { Param = "test'", Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNmToken_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNmToken_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNmToken_2) { Attribute = new VariationAttribute("Sanity test, Name = foo") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNmToken_3) { Attribute = new VariationAttribute("Name contains letters, digits, . _ - : chars") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNmToken_4) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "test test", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNmToken_4) { Attribute = new VariationAttribute("Name contains ? char") { Param = "test?", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNmToken_4) { Attribute = new VariationAttribute("Name contains DQ") { Param = "\"test", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeNmToken_4) { Attribute = new VariationAttribute("Name contains SQ") { Param = "test'", Id = 6, Priority = 1 } });
                 }
             }
-            public class TCWriteName : BridgeHelpers
+            public partial class TCWriteName : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteName
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteName = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteName();
-                    this.AddChild(new TestVariation(tcWriteName.writeName_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteName.writeName_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteName.writeName_2) { Attribute = new VariationAttribute("Sanity test, Name = foo") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteName.writeName_3) { Attribute = new VariationAttribute("Sanity test, Name = foo:bar") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteName.writeName_4) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "foo bar", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteName.writeName_4) { Attribute = new VariationAttribute("Name starts with :") { Param = ":bar", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeName_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeName_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeName_2) { Attribute = new VariationAttribute("Sanity test, Name = foo") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeName_3) { Attribute = new VariationAttribute("Sanity test, Name = foo:bar") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeName_4) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "foo bar", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeName_4) { Attribute = new VariationAttribute("Name starts with :") { Param = ":bar", Id = 4, Priority = 1 } });
                 }
             }
-            public class TCWriteQName : BridgeHelpers
+            public partial class TCWriteQName : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteQName
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteQName = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteQName();
-                    this.AddChild(new TestVariation(tcWriteQName.writeQName_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteQName.writeQName_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteQName.writeQName_2) { Attribute = new VariationAttribute("WriteQName with correct NS") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteQName.writeQName_3) { Attribute = new VariationAttribute("WriteQName when NS is auto-generated") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteQName.writeQName_4) { Attribute = new VariationAttribute("QName = foo:bar when foo is not in scope") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteQName.writeQName_5) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "foo bar", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteQName.writeQName_5) { Attribute = new VariationAttribute("Name starts with :") { Param = ":bar", Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeQName_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeQName_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeQName_2) { Attribute = new VariationAttribute("WriteQName with correct NS") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeQName_3) { Attribute = new VariationAttribute("WriteQName when NS is auto-generated") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeQName_4) { Attribute = new VariationAttribute("QName = foo:bar when foo is not in scope") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeQName_5) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "foo bar", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeQName_5) { Attribute = new VariationAttribute("Name starts with :") { Param = ":bar", Id = 6, Priority = 1 } });
                 }
             }
-            public class TCWriteChars : BridgeHelpers
+            public partial class TCWriteChars : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteChars
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteChars = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteChars();
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_1) { Attribute = new VariationAttribute("WriteChars with valid buffer, number, count") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_2) { Attribute = new VariationAttribute("WriteChars with & < >") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_3) { Attribute = new VariationAttribute("WriteChars following WriteStartAttribute") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_4) { Attribute = new VariationAttribute("WriteChars with entity ref included") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_5) { Attribute = new VariationAttribute("WriteChars with buffer = null") { Id = 5, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_6) { Attribute = new VariationAttribute("WriteChars with count > buffer size") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_7) { Attribute = new VariationAttribute("WriteChars with count < 0") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_8) { Attribute = new VariationAttribute("WriteChars with index > buffer size") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_9) { Attribute = new VariationAttribute("WriteChars with index < 0") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_10) { Attribute = new VariationAttribute("WriteChars with index + count exceeds buffer") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteChars.writeChars_11) { Attribute = new VariationAttribute("WriteChars for xml:lang attribute, index = count = 0") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_1) { Attribute = new VariationAttribute("WriteChars with valid buffer, number, count") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(writeChars_2) { Attribute = new VariationAttribute("WriteChars with & < >") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_3) { Attribute = new VariationAttribute("WriteChars following WriteStartAttribute") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_4) { Attribute = new VariationAttribute("WriteChars with entity ref included") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_5) { Attribute = new VariationAttribute("WriteChars with buffer = null") { Id = 5, Priority = 2 } });
+                    this.AddChild(new TestVariation(writeChars_6) { Attribute = new VariationAttribute("WriteChars with count > buffer size") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_7) { Attribute = new VariationAttribute("WriteChars with count < 0") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_8) { Attribute = new VariationAttribute("WriteChars with index > buffer size") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_9) { Attribute = new VariationAttribute("WriteChars with index < 0") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_10) { Attribute = new VariationAttribute("WriteChars with index + count exceeds buffer") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeChars_11) { Attribute = new VariationAttribute("WriteChars for xml:lang attribute, index = count = 0") { Id = 11, Priority = 1 } });
                 }
             }
-            public class TCWriteString : BridgeHelpers
+            public partial class TCWriteString : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteString
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteString = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteString();
-                    this.AddChild(new TestVariation(tcWriteString.writeString_1) { Attribute = new VariationAttribute("WriteString(null)") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_2) { Attribute = new VariationAttribute("WriteString(String.Empty)") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_3) { Attribute = new VariationAttribute("WriteString with valid surrogate pair") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_4) { Attribute = new VariationAttribute("WriteString with invalid surrogate pair") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_5) { Attribute = new VariationAttribute("WriteString with entity reference") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_6) { Attribute = new VariationAttribute("WriteString with single/double quote, &, <, >") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_9) { Attribute = new VariationAttribute("WriteString for value greater than x1F") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_11) { Attribute = new VariationAttribute("WriteString with CR, LF, CR LF inside attribute value") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_12) { Attribute = new VariationAttribute("Call WriteString for LF inside attribute") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_13) { Attribute = new VariationAttribute("Surrogate characters in text nodes, range limits") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_14) { Attribute = new VariationAttribute("High surrogate on last position") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_15) { Attribute = new VariationAttribute("Low surrogate on first position") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteString.writeString_16) { Attribute = new VariationAttribute("Swap low-high surrogates") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_1) { Attribute = new VariationAttribute("WriteString(null)") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(writeString_2) { Attribute = new VariationAttribute("WriteString(String.Empty)") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_3) { Attribute = new VariationAttribute("WriteString with valid surrogate pair") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_4) { Attribute = new VariationAttribute("WriteString with invalid surrogate pair") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_5) { Attribute = new VariationAttribute("WriteString with entity reference") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_6) { Attribute = new VariationAttribute("WriteString with single/double quote, &, <, >") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_9) { Attribute = new VariationAttribute("WriteString for value greater than x1F") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_11) { Attribute = new VariationAttribute("WriteString with CR, LF, CR LF inside attribute value") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_12) { Attribute = new VariationAttribute("Call WriteString for LF inside attribute") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_13) { Attribute = new VariationAttribute("Surrogate characters in text nodes, range limits") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_14) { Attribute = new VariationAttribute("High surrogate on last position") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_15) { Attribute = new VariationAttribute("Low surrogate on first position") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeString_16) { Attribute = new VariationAttribute("Swap low-high surrogates") { Id = 16, Priority = 1 } });
                 }
             }
-            public class TCWhiteSpace : BridgeHelpers
+            public partial class TCWhiteSpace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWhiteSpace
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWhiteSpace = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWhiteSpace();
-                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_3) { Attribute = new VariationAttribute("WriteWhitespace before and after root element") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_4) { Attribute = new VariationAttribute("WriteWhitespace with String.Empty ") { Param = "String.Empty", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_4) { Attribute = new VariationAttribute("WriteWhitespace with null ") { Param = "null", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 0, Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 16, Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 97, Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 31, Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 14, Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(whitespace_3) { Attribute = new VariationAttribute("WriteWhitespace before and after root element") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(whitespace_4) { Attribute = new VariationAttribute("WriteWhitespace with String.Empty ") { Param = "String.Empty", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(whitespace_4) { Attribute = new VariationAttribute("WriteWhitespace with null ") { Param = "null", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 0, Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 16, Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 97, Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 31, Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 14, Id = 7, Priority = 1 } });
                 }
             }
-            public class TCWriteValue : BridgeHelpers
+            public partial class TCWriteValue : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteValue
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteValue = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteValue();
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_1) { Attribute = new VariationAttribute("WriteValue(boolean)") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_2) { Attribute = new VariationAttribute("WriteValue(DateTime)") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_3) { Attribute = new VariationAttribute("WriteValue(decimal)") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_4) { Attribute = new VariationAttribute("WriteValue(double)") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_5) { Attribute = new VariationAttribute("WriteValue(int32)") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_6) { Attribute = new VariationAttribute("WriteValue(int64)") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_7) { Attribute = new VariationAttribute("WriteValue(single)") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_8) { Attribute = new VariationAttribute("WriteValue(string)") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_9) { Attribute = new VariationAttribute("WriteValue(DateTimeOffset)") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_11) { Attribute = new VariationAttribute("Write multiple atomic values inside element") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_12) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_13) { Attribute = new VariationAttribute("Write multiple atomic values inside element, separate by WriteWhitespace(' ')") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_14) { Attribute = new VariationAttribute("Write multiple atomic values inside element, separate by WriteString(' ')") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_15) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute, separate by WriteWhitespace(' ')") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_16) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute, seperate by WriteString(' ')") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteValue.writeValue_17) { Attribute = new VariationAttribute("WriteValue(long)") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_1) { Attribute = new VariationAttribute("WriteValue(boolean)") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_2) { Attribute = new VariationAttribute("WriteValue(DateTime)") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_3) { Attribute = new VariationAttribute("WriteValue(decimal)") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_4) { Attribute = new VariationAttribute("WriteValue(double)") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_5) { Attribute = new VariationAttribute("WriteValue(int32)") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_6) { Attribute = new VariationAttribute("WriteValue(int64)") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_7) { Attribute = new VariationAttribute("WriteValue(single)") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_8) { Attribute = new VariationAttribute("WriteValue(string)") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_9) { Attribute = new VariationAttribute("WriteValue(DateTimeOffset)") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_11) { Attribute = new VariationAttribute("Write multiple atomic values inside element") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_12) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_13) { Attribute = new VariationAttribute("Write multiple atomic values inside element, separate by WriteWhitespace(' ')") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_14) { Attribute = new VariationAttribute("Write multiple atomic values inside element, separate by WriteString(' ')") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_15) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute, separate by WriteWhitespace(' ')") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_16) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute, seperate by WriteString(' ')") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_17) { Attribute = new VariationAttribute("WriteValue(long)") { Id = 17, Priority = 1 } });
                 }
             }
-            public class TCLookUpPrefix : BridgeHelpers
+            public partial class TCLookUpPrefix : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCLookUpPrefix
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcLookUpPrefix = new CommonTestsFunctionalTests.XNodeBuilderTests.TCLookUpPrefix();
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_1) { Attribute = new VariationAttribute("LookupPrefix with null") { Id = 1, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_2) { Attribute = new VariationAttribute("LookupPrefix with String.Empty should if(!String.Empty") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_3) { Attribute = new VariationAttribute("LookupPrefix with generated namespace used for attributes") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_4) { Attribute = new VariationAttribute("LookupPrefix for namespace used with element") { Id = 4, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_5) { Attribute = new VariationAttribute("LookupPrefix for namespace used with attribute") { Id = 5, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_6) { Attribute = new VariationAttribute("Lookup prefix for a default namespace") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_7) { Attribute = new VariationAttribute("Lookup prefix for nested element with same namespace but different prefix") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_8) { Attribute = new VariationAttribute("Lookup prefix for multiple prefix associated with the same namespace") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_9) { Attribute = new VariationAttribute("Lookup prefix for namespace defined outside the scope of an empty element and also defined in its parent") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_10) { Attribute = new VariationAttribute("Lookup prefix for namespace declared as default and also with a prefix") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(lookupPrefix_1) { Attribute = new VariationAttribute("LookupPrefix with null") { Id = 1, Priority = 2 } });
+                    this.AddChild(new TestVariation(lookupPrefix_2) { Attribute = new VariationAttribute("LookupPrefix with String.Empty should if(!String.Empty") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(lookupPrefix_3) { Attribute = new VariationAttribute("LookupPrefix with generated namespace used for attributes") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(lookupPrefix_4) { Attribute = new VariationAttribute("LookupPrefix for namespace used with element") { Id = 4, Priority = 0 } });
+                    this.AddChild(new TestVariation(lookupPrefix_5) { Attribute = new VariationAttribute("LookupPrefix for namespace used with attribute") { Id = 5, Priority = 0 } });
+                    this.AddChild(new TestVariation(lookupPrefix_6) { Attribute = new VariationAttribute("Lookup prefix for a default namespace") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(lookupPrefix_7) { Attribute = new VariationAttribute("Lookup prefix for nested element with same namespace but different prefix") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(lookupPrefix_8) { Attribute = new VariationAttribute("Lookup prefix for multiple prefix associated with the same namespace") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(lookupPrefix_9) { Attribute = new VariationAttribute("Lookup prefix for namespace defined outside the scope of an empty element and also defined in its parent") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(lookupPrefix_10) { Attribute = new VariationAttribute("Lookup prefix for namespace declared as default and also with a prefix") { Id = 10, Priority = 1 } });
                 }
             }
-            public class TCXmlSpaceWriter : BridgeHelpers
+            public partial class TCXmlSpaceWriter : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCXmlSpaceWriter
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcXmlSpaceWriter = new CommonTestsFunctionalTests.XNodeBuilderTests.TCXmlSpaceWriter();
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_1) { Attribute = new VariationAttribute("Verify XmlSpace as Preserve") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_2) { Attribute = new VariationAttribute("Verify XmlSpace as Default") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_3) { Attribute = new VariationAttribute("Verify XmlSpace as None") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_4) { Attribute = new VariationAttribute("Verify XmlSpace within an empty element") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_5) { Attribute = new VariationAttribute("Verify XmlSpace - scope with nested elements (both PROLOG and EPILOG)") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_6) { Attribute = new VariationAttribute("Verify XmlSpace - outside defined scope") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_7) { Attribute = new VariationAttribute("Verify XmlSpace with invalid space value") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_8) { Attribute = new VariationAttribute("Duplicate xml:space attr should error") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_9) { Attribute = new VariationAttribute("Verify XmlSpace value when received through WriteString") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(xmlSpace_1) { Attribute = new VariationAttribute("Verify XmlSpace as Preserve") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(xmlSpace_2) { Attribute = new VariationAttribute("Verify XmlSpace as Default") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(xmlSpace_3) { Attribute = new VariationAttribute("Verify XmlSpace as None") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(xmlSpace_4) { Attribute = new VariationAttribute("Verify XmlSpace within an empty element") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(xmlSpace_5) { Attribute = new VariationAttribute("Verify XmlSpace - scope with nested elements (both PROLOG and EPILOG)") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(xmlSpace_6) { Attribute = new VariationAttribute("Verify XmlSpace - outside defined scope") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(xmlSpace_7) { Attribute = new VariationAttribute("Verify XmlSpace with invalid space value") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(xmlSpace_8) { Attribute = new VariationAttribute("Duplicate xml:space attr should error") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(xmlSpace_9) { Attribute = new VariationAttribute("Verify XmlSpace value when received through WriteString") { Id = 9, Priority = 1 } });
                 }
             }
-            public class TCXmlLangWriter : BridgeHelpers
+            public partial class TCXmlLangWriter : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCXmlLangWriter
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcXmlLangWriter = new CommonTestsFunctionalTests.XNodeBuilderTests.TCXmlLangWriter();
-                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_1) { Attribute = new VariationAttribute("Verify XmlLang sanity test") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_2) { Attribute = new VariationAttribute("Verify that default value of XmlLang is NULL") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_3) { Attribute = new VariationAttribute("Verify XmlLang scope inside nested elements (both PROLOG and EPILOG)") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_4) { Attribute = new VariationAttribute("Duplicate xml:lang attr should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_5) { Attribute = new VariationAttribute("Verify XmlLang value when received through WriteAttributes") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_6) { Attribute = new VariationAttribute("Verify XmlLang value when received through WriteString") { Id = 6 } });
-                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_7) { Attribute = new VariationAttribute("Should not check XmlLang value") { Id = 7, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_8) { Attribute = new VariationAttribute("More XmlLang with valid sequence") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(XmlLang_1) { Attribute = new VariationAttribute("Verify XmlLang sanity test") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(XmlLang_2) { Attribute = new VariationAttribute("Verify that default value of XmlLang is NULL") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(XmlLang_3) { Attribute = new VariationAttribute("Verify XmlLang scope inside nested elements (both PROLOG and EPILOG)") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(XmlLang_4) { Attribute = new VariationAttribute("Duplicate xml:lang attr should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(XmlLang_5) { Attribute = new VariationAttribute("Verify XmlLang value when received through WriteAttributes") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(XmlLang_6) { Attribute = new VariationAttribute("Verify XmlLang value when received through WriteString") { Id = 6 } });
+                    this.AddChild(new TestVariation(XmlLang_7) { Attribute = new VariationAttribute("Should not check XmlLang value") { Id = 7, Priority = 2 } });
+                    this.AddChild(new TestVariation(XmlLang_8) { Attribute = new VariationAttribute("More XmlLang with valid sequence") { Id = 8, Priority = 1 } });
                 }
             }
-            public class TCWriteRaw : BridgeHelpers
+            public partial class TCWriteRaw : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteRaw
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteRaw = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteRaw();
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_1) { Attribute = new VariationAttribute("Call both WriteRaw Methods") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_4) { Attribute = new VariationAttribute("Call WriteRaw to write the value of xml:space") { Id = 4 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writerRaw_5) { Attribute = new VariationAttribute("Call WriteRaw to write the value of xml:lang") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_6) { Attribute = new VariationAttribute("WriteRaw with count > buffer size") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_7) { Attribute = new VariationAttribute("WriteRaw with count < 0") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_8) { Attribute = new VariationAttribute("WriteRaw with index > buffer size") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_9) { Attribute = new VariationAttribute("WriteRaw with index < 0") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_10) { Attribute = new VariationAttribute("WriteRaw with index + count exceeds buffer") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_11) { Attribute = new VariationAttribute("WriteRaw with buffer = null") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_12) { Attribute = new VariationAttribute("WriteRaw with valid surrogate pair") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_13) { Attribute = new VariationAttribute("WriteRaw with invalid surrogate pair") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_14) { Attribute = new VariationAttribute("Index = Count = 0") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_1) { Attribute = new VariationAttribute("Call both WriteRaw Methods") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_4) { Attribute = new VariationAttribute("Call WriteRaw to write the value of xml:space") { Id = 4 } });
+                    this.AddChild(new TestVariation(writerRaw_5) { Attribute = new VariationAttribute("Call WriteRaw to write the value of xml:lang") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_6) { Attribute = new VariationAttribute("WriteRaw with count > buffer size") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_7) { Attribute = new VariationAttribute("WriteRaw with count < 0") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_8) { Attribute = new VariationAttribute("WriteRaw with index > buffer size") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_9) { Attribute = new VariationAttribute("WriteRaw with index < 0") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_10) { Attribute = new VariationAttribute("WriteRaw with index + count exceeds buffer") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_11) { Attribute = new VariationAttribute("WriteRaw with buffer = null") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_12) { Attribute = new VariationAttribute("WriteRaw with valid surrogate pair") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_13) { Attribute = new VariationAttribute("WriteRaw with invalid surrogate pair") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeRaw_14) { Attribute = new VariationAttribute("Index = Count = 0") { Id = 14, Priority = 1 } });
                 }
             }
-            public class TCWriteBase64 : BridgeHelpers
+            public partial class TCWriteBase64 : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteBase64
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteBase64 = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteBase64();
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_2) { Attribute = new VariationAttribute("WriteBase64 with count > buffer size") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_3) { Attribute = new VariationAttribute("WriteBase64 with count < 0") { Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_4) { Attribute = new VariationAttribute("WriteBase64 with index > buffer size") { Id = 40, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_5) { Attribute = new VariationAttribute("WriteBase64 with index < 0") { Id = 50, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_6) { Attribute = new VariationAttribute("WriteBase64 with index + count exceeds buffer") { Id = 60, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_7) { Attribute = new VariationAttribute("WriteBase64 with buffer = null") { Id = 70, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside namespace decl") { Param = "ns", Id = 92, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside xml:lang value") { Param = "lang", Id = 90, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteBase64.Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside xml:space value") { Param = "space", Id = 91, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_2) { Attribute = new VariationAttribute("WriteBase64 with count > buffer size") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_3) { Attribute = new VariationAttribute("WriteBase64 with count < 0") { Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_4) { Attribute = new VariationAttribute("WriteBase64 with index > buffer size") { Id = 40, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_5) { Attribute = new VariationAttribute("WriteBase64 with index < 0") { Id = 50, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_6) { Attribute = new VariationAttribute("WriteBase64 with index + count exceeds buffer") { Id = 60, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_7) { Attribute = new VariationAttribute("WriteBase64 with buffer = null") { Id = 70, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside namespace decl") { Param = "ns", Id = 92, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside xml:lang value") { Param = "lang", Id = 90, Priority = 1 } });
+                    this.AddChild(new TestVariation(Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside xml:space value") { Param = "space", Id = 91, Priority = 1 } });
                 }
             }
-            public class TCWriteState : BridgeHelpers
+            public partial class TCWriteState : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteState
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcWriteState = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteState();
-                    this.AddChild(new TestVariation(tcWriteState.writeState_1) { Attribute = new VariationAttribute("Verify WriteState.Start when nothing has been written yet") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_2) { Attribute = new VariationAttribute("Verify correct state when writing in Prolog") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_3) { Attribute = new VariationAttribute("Verify correct state when writing an attribute") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_4) { Attribute = new VariationAttribute("Verify correct state when writing element content") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_5) { Attribute = new VariationAttribute("Verify correct state after Close has been called") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_6) { Attribute = new VariationAttribute("Verify WriteState = Error after an exception") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteNmToken after WriteState = Error") { Param = "WriteNmToken", Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteBinHex after WriteState = Error") { Param = "WriteBinHex", Id = 23, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call LookupPrefix after WriteState = Error") { Param = "LookupPrefix", Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteComment after WriteState = Error") { Param = "WriteComment", Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteWhitespace after WriteState = Error") { Param = "WriteWhitespace", Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WritePI after WriteState = Error") { Param = "WritePI", Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteName after WriteState = Error") { Param = "WriteName", Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteString after WriteState = Error") { Param = "WriteString", Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteQualifiedName after WriteState = Error") { Param = "WriteQualifiedName", Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteValue after WriteState = Error") { Param = "WriteValue", Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteAttributes after WriteState = Error") { Param = "WriteAttributes", Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteNode(reader) after WriteState = Error") { Param = "WriteNodeReader", Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call Flush after WriteState = Error") { Param = "Flush", Id = 32, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteRaw after WriteState = Error") { Param = "WriteRaw", Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteSurrogateCharEntity after WriteState = Error") { Param = "WriteSurrogateCharEntity", Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteEntityRef after WriteState = Error") { Param = "WriteEntityRef", Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteCharEntiry after WriteState = Error") { Param = "WriteCharEntity", Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteBase64 after WriteState = Error") { Param = "WriteBase64", Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteChars after WriteState = Error") { Param = "WriteChars", Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteStartDocument after WriteState = Error") { Param = "WriteStartDocument", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteStartElement after WriteState = Error") { Param = "WriteStartElement", Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteEndElement after WriteState = Error") { Param = "WriteEndElement", Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteStartAttribute after WriteState = Error") { Param = "WriteStartAttribute", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteEndAttribute after WriteState = Error") { Param = "WriteEndAttribute", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteCData after WriteState = Error") { Param = "WriteCData", Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_8) { Attribute = new VariationAttribute("XmlSpace property after WriteState = Error") { Param = "XmlSpace", Id = 33, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_8) { Attribute = new VariationAttribute("XmlLang property after WriteState = Error") { Param = "XmlSpace", Id = 34, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteValue after Close()") { Param = "WriteValue", Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WritePI after Close()") { Param = "WritePI", Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteEntityRef after Close()") { Param = "WriteEntityRef", Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteCharEntiry after Close()") { Param = "WriteCharEntity", Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteSurrogateCharEntity after Close()") { Param = "WriteSurrogateCharEntity", Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteWhitespace after Close()") { Param = "WriteWhitespace", Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteString after Close()") { Param = "WriteString", Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteChars after Close()") { Param = "WriteChars", Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteRaw after Close()") { Param = "WriteRaw", Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteBase64 after Close()") { Param = "WriteBase64", Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteBinHex after Close()") { Param = "WriteBinHex", Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call LookupPrefix after Close()") { Param = "LookupPrefix", Id = 23, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteNmToken after Close()") { Param = "WriteNmToken", Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteName after Close()") { Param = "WriteName", Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteQualifiedName after Close()") { Param = "WriteQualifiedName", Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteStartDocument after Close()") { Param = "WriteStartDocument", Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteAttributes after Close()") { Param = "WriteAttributes", Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteNode(reader) after Close()") { Param = "WriteNodeReader", Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call Flush after Close()") { Param = "Flush", Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteStartElement after Close()") { Param = "WriteStartElement", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteEndElement after Close()") { Param = "WriteEndElement", Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteStartAttribute after Close()") { Param = "WriteStartAttribute", Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteEndAttribute after Close()") { Param = "WriteEndAttribute", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteCData after Close()") { Param = "WriteCData", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteComment after Close()") { Param = "WriteComment", Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_1) { Attribute = new VariationAttribute("Verify WriteState.Start when nothing has been written yet") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(writeState_2) { Attribute = new VariationAttribute("Verify correct state when writing in Prolog") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_3) { Attribute = new VariationAttribute("Verify correct state when writing an attribute") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_4) { Attribute = new VariationAttribute("Verify correct state when writing element content") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_5) { Attribute = new VariationAttribute("Verify correct state after Close has been called") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_6) { Attribute = new VariationAttribute("Verify WriteState = Error after an exception") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteNmToken after WriteState = Error") { Param = "WriteNmToken", Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteBinHex after WriteState = Error") { Param = "WriteBinHex", Id = 23, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call LookupPrefix after WriteState = Error") { Param = "LookupPrefix", Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteComment after WriteState = Error") { Param = "WriteComment", Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteWhitespace after WriteState = Error") { Param = "WriteWhitespace", Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WritePI after WriteState = Error") { Param = "WritePI", Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteName after WriteState = Error") { Param = "WriteName", Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteString after WriteState = Error") { Param = "WriteString", Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteQualifiedName after WriteState = Error") { Param = "WriteQualifiedName", Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteValue after WriteState = Error") { Param = "WriteValue", Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteAttributes after WriteState = Error") { Param = "WriteAttributes", Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteNode(reader) after WriteState = Error") { Param = "WriteNodeReader", Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call Flush after WriteState = Error") { Param = "Flush", Id = 32, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteRaw after WriteState = Error") { Param = "WriteRaw", Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteSurrogateCharEntity after WriteState = Error") { Param = "WriteSurrogateCharEntity", Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteEntityRef after WriteState = Error") { Param = "WriteEntityRef", Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteCharEntiry after WriteState = Error") { Param = "WriteCharEntity", Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteBase64 after WriteState = Error") { Param = "WriteBase64", Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteChars after WriteState = Error") { Param = "WriteChars", Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteStartDocument after WriteState = Error") { Param = "WriteStartDocument", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteStartElement after WriteState = Error") { Param = "WriteStartElement", Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteEndElement after WriteState = Error") { Param = "WriteEndElement", Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteStartAttribute after WriteState = Error") { Param = "WriteStartAttribute", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteEndAttribute after WriteState = Error") { Param = "WriteEndAttribute", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteCData after WriteState = Error") { Param = "WriteCData", Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_8) { Attribute = new VariationAttribute("XmlSpace property after WriteState = Error") { Param = "XmlSpace", Id = 33, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_8) { Attribute = new VariationAttribute("XmlLang property after WriteState = Error") { Param = "XmlSpace", Id = 34, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteValue after Close()") { Param = "WriteValue", Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WritePI after Close()") { Param = "WritePI", Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteEntityRef after Close()") { Param = "WriteEntityRef", Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteCharEntiry after Close()") { Param = "WriteCharEntity", Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteSurrogateCharEntity after Close()") { Param = "WriteSurrogateCharEntity", Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteWhitespace after Close()") { Param = "WriteWhitespace", Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteString after Close()") { Param = "WriteString", Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteChars after Close()") { Param = "WriteChars", Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteRaw after Close()") { Param = "WriteRaw", Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteBase64 after Close()") { Param = "WriteBase64", Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteBinHex after Close()") { Param = "WriteBinHex", Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call LookupPrefix after Close()") { Param = "LookupPrefix", Id = 23, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteNmToken after Close()") { Param = "WriteNmToken", Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteName after Close()") { Param = "WriteName", Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteQualifiedName after Close()") { Param = "WriteQualifiedName", Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteStartDocument after Close()") { Param = "WriteStartDocument", Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteAttributes after Close()") { Param = "WriteAttributes", Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteNode(reader) after Close()") { Param = "WriteNodeReader", Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call Flush after Close()") { Param = "Flush", Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteStartElement after Close()") { Param = "WriteStartElement", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteEndElement after Close()") { Param = "WriteEndElement", Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteStartAttribute after Close()") { Param = "WriteStartAttribute", Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteEndAttribute after Close()") { Param = "WriteEndAttribute", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteCData after Close()") { Param = "WriteCData", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteComment after Close()") { Param = "WriteComment", Id = 12, Priority = 1 } });
                 }
             }
-            public class TC_NDP20_NewMethods : BridgeHelpers
+            public partial class TC_NDP20_NewMethods : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TC_NDP20_NewMethods
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcNDP20_NewMethods = new CommonTestsFunctionalTests.XNodeBuilderTests.TC_NDP20_NewMethods();
-                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_1) { Attribute = new VariationAttribute("WriteElementString(prefix, name, ns, value) sanity test") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_2) { Attribute = new VariationAttribute("WriteElementString(prefix = xml, ns = XML namespace)") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_3) { Attribute = new VariationAttribute("WriteStartAttribute(string name) sanity test") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_4) { Attribute = new VariationAttribute("WriteElementString followed by attribute should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_5) { Attribute = new VariationAttribute("429445: XmlWellformedWriter wrapping another XmlWriter should check the duplicate attributes first") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("WriteElementString(prefix, name, ns, value) sanity test") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("WriteElementString(prefix = xml, ns = XML namespace)") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("WriteStartAttribute(string name) sanity test") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("WriteElementString followed by attribute should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("429445: XmlWellformedWriter wrapping another XmlWriter should check the duplicate attributes first") { Id = 5, Priority = 1 } });
                 }
             }
-            public class TCGlobalization : BridgeHelpers
+            public partial class TCGlobalization : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCGlobalization
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcGlobalization = new CommonTestsFunctionalTests.XNodeBuilderTests.TCGlobalization();
-                    this.AddChild(new TestVariation(tcGlobalization.var_1) { Attribute = new VariationAttribute("Characters between 0xdfff and 0xfffe are valid Unicode characters") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcGlobalization.var_2) { Attribute = new VariationAttribute("XmlWriter using UTF-16BE encoding writes out wrong encoding name value in the xml decl") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("Characters between 0xdfff and 0xfffe are valid Unicode characters") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("XmlWriter using UTF-16BE encoding writes out wrong encoding name value in the xml decl") { Id = 2, Priority = 1 } });
                 }
             }
-            public class TCClose : BridgeHelpers
+            public partial class TCClose : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCClose
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcClose = new CommonTestsFunctionalTests.XNodeBuilderTests.TCClose();
-                    this.AddChild(new TestVariation(tcClose.var_1) { Attribute = new VariationAttribute("Closing an XmlWriter should close all opened elements") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcClose.var_2) { Attribute = new VariationAttribute("Disposing an XmlWriter should close all opened elements") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcClose.var_3) { Attribute = new VariationAttribute("Dispose() shouldn't throw when a tag is not closed and inner stream is closed") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcClose.var_4) { Attribute = new VariationAttribute("Close() should be allowed when XML doesn't have content") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("Closing an XmlWriter should close all opened elements") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("Disposing an XmlWriter should close all opened elements") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("Dispose() shouldn't throw when a tag is not closed and inner stream is closed") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("Close() should be allowed when XML doesn't have content") { Id = 4, Priority = 1 } });
                 }
             }
-            public class TCEOFHandling : BridgeHelpers
+            public partial class TCEOFHandling : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCEOFHandling
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcEOFHandling = new EndOfLineHandlingTestsFunctionalTests.XNodeBuilderTests.TCEOFHandling();
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_01) { Attribute = new VariationAttribute("NewLineHandling Default value - NewLineHandling.Replace") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.Entitize") { Param = 1, Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.None") { Param = 2, Id = 4, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.Replace") { Param = 0, Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'Replace'") { Param = 0, Id = 15, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'Entitize'") { Param = 1, Id = 14, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'None'") { Param = 2, Id = 16, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_07) { Attribute = new VariationAttribute("Check for combinations of NewLine characters in attribute with 'Entitize'") { Param = 1, Id = 17, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_07) { Attribute = new VariationAttribute("Check for combinations of NewLine characters in attribute with 'Replace'") { Param = 0, Id = 18, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'None'") { Param = 2, Id = 22, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'Entitize'") { Param = 1, Id = 20, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'Replace'") { Param = 0, Id = 21, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_09) { Attribute = new VariationAttribute("Check for combinations of NewLine characters and entities in element with 'Entitize'") { Param = 1, Id = 23, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_09) { Attribute = new VariationAttribute("Check for combinations of NewLine characters and entities in element with 'Replace'") { Param = 0, Id = 24, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_10) { Attribute = new VariationAttribute("Check for tab character in attribute with 'Replace'") { Param = 0, Id = 27, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_10) { Attribute = new VariationAttribute("Check for tab character in attribute with 'Entitize'") { Param = 1, Id = 26, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, None") { Param = 2, Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, Replace") { Param = 0, Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, Entitize") { Param = 1, Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '\\r', '  '") { Params = new object[] { NewLineHandling.Replace, "\r", "  " }, Id = 33, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '\\r', '  '") { Params = new object[] { NewLineHandling.None, "\r", "  " }, Id = 34, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '&#xA;', '  '") { Params = new object[] { NewLineHandling.Entitize, "&#xA;", "  " }, Id = 35, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '\\r', '\\n'") { Params = new object[] { NewLineHandling.None, "\r", "\n" }, Id = 40, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '\\r', '  '") { Params = new object[] { NewLineHandling.Entitize, "\r", "  " }, Id = 32, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '&#xA;', '  '") { Params = new object[] { NewLineHandling.Replace, "&#xA;", "  " }, Id = 36, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '&#xA;', '  '") { Params = new object[] { NewLineHandling.None, "&#xA;", "  " }, Id = 37, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '\\r', '\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r", "\n" }, Id = 38, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '\\r', '\\n'") { Params = new object[] { NewLineHandling.Replace, "\r", "\n" }, Id = 39, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '\\r'") { Params = new object[] { NewLineHandling.Entitize, "\r" }, Id = 53, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '\\r\\n'") { Params = new object[] { NewLineHandling.Replace, "\r\n" }, Id = 51, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '\\r'") { Params = new object[] { NewLineHandling.Replace, "\r" }, Id = 54, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '---'") { Params = new object[] { NewLineHandling.Replace, "---" }, Id = 55, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '---'") { Params = new object[] { NewLineHandling.Entitize, "---" }, Id = 54, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '\\r\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r\n" }, Id = 50, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; None, '\\r\\n'") { Params = new object[] { NewLineHandling.None, "\r\n" }, Id = 58, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; None, '\\r'") { Params = new object[] { NewLineHandling.None, "\r" }, Id = 61, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Replace, '\\r'") { Params = new object[] { NewLineHandling.Replace, "\r" }, Id = 60, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Entitize, '\\r'") { Params = new object[] { NewLineHandling.Entitize, "\r" }, Id = 59, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Entitize, '\\r\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r\n" }, Id = 56, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Replace, '\\r\\n'") { Params = new object[] { NewLineHandling.Replace, "\r\n" }, Id = 57, Priority = 1 } });
+                    this.AddChild(new TestVariation(EOF_Handling_01) { Attribute = new VariationAttribute("NewLineHandling Default value - NewLineHandling.Replace") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.Entitize") { Param = 1, Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.None") { Param = 2, Id = 4, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.Replace") { Param = 0, Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'Replace'") { Param = 0, Id = 15, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'Entitize'") { Param = 1, Id = 14, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'None'") { Param = 2, Id = 16, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_07) { Attribute = new VariationAttribute("Check for combinations of NewLine characters in attribute with 'Entitize'") { Param = 1, Id = 17, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_07) { Attribute = new VariationAttribute("Check for combinations of NewLine characters in attribute with 'Replace'") { Param = 0, Id = 18, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'None'") { Param = 2, Id = 22, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'Entitize'") { Param = 1, Id = 20, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'Replace'") { Param = 0, Id = 21, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_09) { Attribute = new VariationAttribute("Check for combinations of NewLine characters and entities in element with 'Entitize'") { Param = 1, Id = 23, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_09) { Attribute = new VariationAttribute("Check for combinations of NewLine characters and entities in element with 'Replace'") { Param = 0, Id = 24, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_10) { Attribute = new VariationAttribute("Check for tab character in attribute with 'Replace'") { Param = 0, Id = 27, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_10) { Attribute = new VariationAttribute("Check for tab character in attribute with 'Entitize'") { Param = 1, Id = 26, Priority = 0 } });
+                    this.AddChild(new TestVariation(EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, None") { Param = 2, Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, Replace") { Param = 0, Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, Entitize") { Param = 1, Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '\\r', '  '") { Params = new object[] { NewLineHandling.Replace, "\r", "  " }, Id = 33, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '\\r', '  '") { Params = new object[] { NewLineHandling.None, "\r", "  " }, Id = 34, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '&#xA;', '  '") { Params = new object[] { NewLineHandling.Entitize, "&#xA;", "  " }, Id = 35, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '\\r', '\\n'") { Params = new object[] { NewLineHandling.None, "\r", "\n" }, Id = 40, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '\\r', '  '") { Params = new object[] { NewLineHandling.Entitize, "\r", "  " }, Id = 32, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '&#xA;', '  '") { Params = new object[] { NewLineHandling.Replace, "&#xA;", "  " }, Id = 36, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '&#xA;', '  '") { Params = new object[] { NewLineHandling.None, "&#xA;", "  " }, Id = 37, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '\\r', '\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r", "\n" }, Id = 38, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '\\r', '\\n'") { Params = new object[] { NewLineHandling.Replace, "\r", "\n" }, Id = 39, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '\\r'") { Params = new object[] { NewLineHandling.Entitize, "\r" }, Id = 53, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '\\r\\n'") { Params = new object[] { NewLineHandling.Replace, "\r\n" }, Id = 51, Priority = 1 } });
+                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '\\r'") { Params = new object[] { NewLineHandling.Replace, "\r" }, Id = 54, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '---'") { Params = new object[] { NewLineHandling.Replace, "---" }, Id = 55, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '---'") { Params = new object[] { NewLineHandling.Entitize, "---" }, Id = 54, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '\\r\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r\n" }, Id = 50, Priority = 1 } });
+                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; None, '\\r\\n'") { Params = new object[] { NewLineHandling.None, "\r\n" }, Id = 58, Priority = 1 } });
+                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; None, '\\r'") { Params = new object[] { NewLineHandling.None, "\r" }, Id = 61, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Replace, '\\r'") { Params = new object[] { NewLineHandling.Replace, "\r" }, Id = 60, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Entitize, '\\r'") { Params = new object[] { NewLineHandling.Entitize, "\r" }, Id = 59, Priority = 2 } });
+                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Entitize, '\\r\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r\n" }, Id = 56, Priority = 1 } });
+                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Replace, '\\r\\n'") { Params = new object[] { NewLineHandling.Replace, "\r\n" }, Id = 57, Priority = 1 } });
                 }
             }
-            public class XObjectBuilderTest : BridgeHelpers
+            public partial class XObjectBuilderTest : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+XObjectBuilderTest
                 // Test Case
                 public override void AddChildren()
                 {
-                    var xObjectBuilderTest = new ErrorConditionsFunctionalTests.XNodeBuilderTests.XObjectBuilderTest();
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_1) { Attribute = new VariationAttribute("LookupPrefix(null)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_2) { Attribute = new VariationAttribute("WriteAttributes(null, false)") { Param = false, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_2) { Attribute = new VariationAttribute("WriteAttributes(null, true)") { Param = true, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_3) { Attribute = new VariationAttribute("WriteAttributeString(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_3) { Attribute = new VariationAttribute("WriteAttributeString(String.Empty)") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_4) { Attribute = new VariationAttribute("WriteBase64(null)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_5) { Attribute = new VariationAttribute("WriteBinHex(null)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_6) { Attribute = new VariationAttribute("WriteCData('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_6) { Attribute = new VariationAttribute("WriteCData(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_7) { Attribute = new VariationAttribute("WriteChars(null)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_8) { Attribute = new VariationAttribute("Other APIs") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_9) { Attribute = new VariationAttribute("WriteDocType(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_9) { Attribute = new VariationAttribute("WriteDocType('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_10) { Attribute = new VariationAttribute("WriteElementString(String.Empty)") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_10) { Attribute = new VariationAttribute("WriteElementString(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_11) { Attribute = new VariationAttribute("WriteEndAttribute()") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_12) { Attribute = new VariationAttribute("WriteEndDocument()") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_13) { Attribute = new VariationAttribute("WriteEndElement()") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_14) { Attribute = new VariationAttribute("WriteEntityRef(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_14) { Attribute = new VariationAttribute("WriteEntityRef('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_15) { Attribute = new VariationAttribute("WriteFullEndElement()") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_16) { Attribute = new VariationAttribute("WriteName('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_16) { Attribute = new VariationAttribute("WriteName(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_17) { Attribute = new VariationAttribute("WriteNmToken('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_17) { Attribute = new VariationAttribute("WriteNmToken(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_18) { Attribute = new VariationAttribute("WriteNode(null)") { Params = new object[] { "reader", true }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_18) { Attribute = new VariationAttribute("WriteNode(null)") { Params = new object[] { "reader", false }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_19) { Attribute = new VariationAttribute("WriteProcessingInstruction('', '')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_19) { Attribute = new VariationAttribute("WriteProcessingInstruction(null, null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_20) { Attribute = new VariationAttribute("WriteQualifiedName('', '')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_20) { Attribute = new VariationAttribute("WriteQualifiedName(null, null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_21) { Attribute = new VariationAttribute("WriteRaw(null, 0, 0)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_22) { Attribute = new VariationAttribute("WriteStartAttribute(null, null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_22) { Attribute = new VariationAttribute("WriteStartAttribute('', '')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_23) { Attribute = new VariationAttribute("WriteStartElement(null, null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_23) { Attribute = new VariationAttribute("WriteStartElement('', '')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_24) { Attribute = new VariationAttribute("WriteStartDocument(true)") { Param = 2, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_24) { Attribute = new VariationAttribute("WriteStartDocument()") { Param = 1, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_24) { Attribute = new VariationAttribute("WriteStartDocument(false)") { Param = 3, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_25) { Attribute = new VariationAttribute("WriteString(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_25) { Attribute = new VariationAttribute("WriteString('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_26) { Attribute = new VariationAttribute("WriteValue(false)") { Param = false, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_26) { Attribute = new VariationAttribute("WriteValue(true)") { Param = true, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_27) { Attribute = new VariationAttribute("WriteWhitespace('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_27) { Attribute = new VariationAttribute("WriteWhitespace(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_28) { Attribute = new VariationAttribute("EntityRef after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_29) { Attribute = new VariationAttribute("EntityRef after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_30) { Attribute = new VariationAttribute("CharEntity after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_31) { Attribute = new VariationAttribute("CharEntity after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_32) { Attribute = new VariationAttribute("SurrogateCharEntity after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_33) { Attribute = new VariationAttribute("SurrogateCharEntity after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_34) { Attribute = new VariationAttribute("Attribute after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_35) { Attribute = new VariationAttribute("Attribute after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_36) { Attribute = new VariationAttribute("CDATA after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_37) { Attribute = new VariationAttribute("CDATA after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_38) { Attribute = new VariationAttribute("Element followed by Document should error") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.var_39) { Attribute = new VariationAttribute("Element followed by DocType should error") { Priority = 2 } });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.Variation41) { Attribute = new VariationAttribute("WriteBase64") });
-                    this.AddChild(new TestVariation(xObjectBuilderTest.Variation42) { Attribute = new VariationAttribute("WriteEntityRef") });
+                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("LookupPrefix(null)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("WriteAttributes(null, false)") { Param = false, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("WriteAttributes(null, true)") { Param = true, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("WriteAttributeString(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("WriteAttributeString(String.Empty)") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("WriteBase64(null)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("WriteBinHex(null)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_6) { Attribute = new VariationAttribute("WriteCData('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_6) { Attribute = new VariationAttribute("WriteCData(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_7) { Attribute = new VariationAttribute("WriteChars(null)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_8) { Attribute = new VariationAttribute("Other APIs") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_9) { Attribute = new VariationAttribute("WriteDocType(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_9) { Attribute = new VariationAttribute("WriteDocType('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_10) { Attribute = new VariationAttribute("WriteElementString(String.Empty)") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_10) { Attribute = new VariationAttribute("WriteElementString(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_11) { Attribute = new VariationAttribute("WriteEndAttribute()") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_12) { Attribute = new VariationAttribute("WriteEndDocument()") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_13) { Attribute = new VariationAttribute("WriteEndElement()") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_14) { Attribute = new VariationAttribute("WriteEntityRef(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_14) { Attribute = new VariationAttribute("WriteEntityRef('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_15) { Attribute = new VariationAttribute("WriteFullEndElement()") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_16) { Attribute = new VariationAttribute("WriteName('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_16) { Attribute = new VariationAttribute("WriteName(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_17) { Attribute = new VariationAttribute("WriteNmToken('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_17) { Attribute = new VariationAttribute("WriteNmToken(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_18) { Attribute = new VariationAttribute("WriteNode(null)") { Params = new object[] { "reader", true }, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_18) { Attribute = new VariationAttribute("WriteNode(null)") { Params = new object[] { "reader", false }, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_19) { Attribute = new VariationAttribute("WriteProcessingInstruction('', '')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_19) { Attribute = new VariationAttribute("WriteProcessingInstruction(null, null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_20) { Attribute = new VariationAttribute("WriteQualifiedName('', '')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_20) { Attribute = new VariationAttribute("WriteQualifiedName(null, null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_21) { Attribute = new VariationAttribute("WriteRaw(null, 0, 0)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_22) { Attribute = new VariationAttribute("WriteStartAttribute(null, null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_22) { Attribute = new VariationAttribute("WriteStartAttribute('', '')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_23) { Attribute = new VariationAttribute("WriteStartElement(null, null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_23) { Attribute = new VariationAttribute("WriteStartElement('', '')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_24) { Attribute = new VariationAttribute("WriteStartDocument(true)") { Param = 2, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_24) { Attribute = new VariationAttribute("WriteStartDocument()") { Param = 1, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_24) { Attribute = new VariationAttribute("WriteStartDocument(false)") { Param = 3, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_25) { Attribute = new VariationAttribute("WriteString(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_25) { Attribute = new VariationAttribute("WriteString('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_26) { Attribute = new VariationAttribute("WriteValue(false)") { Param = false, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_26) { Attribute = new VariationAttribute("WriteValue(true)") { Param = true, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_27) { Attribute = new VariationAttribute("WriteWhitespace('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(var_27) { Attribute = new VariationAttribute("WriteWhitespace(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(var_28) { Attribute = new VariationAttribute("EntityRef after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_29) { Attribute = new VariationAttribute("EntityRef after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_30) { Attribute = new VariationAttribute("CharEntity after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_31) { Attribute = new VariationAttribute("CharEntity after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_32) { Attribute = new VariationAttribute("SurrogateCharEntity after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_33) { Attribute = new VariationAttribute("SurrogateCharEntity after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_34) { Attribute = new VariationAttribute("Attribute after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_35) { Attribute = new VariationAttribute("Attribute after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_36) { Attribute = new VariationAttribute("CDATA after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_37) { Attribute = new VariationAttribute("CDATA after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_38) { Attribute = new VariationAttribute("Element followed by Document should error") { Priority = 2 } });
+                    this.AddChild(new TestVariation(var_39) { Attribute = new VariationAttribute("Element followed by DocType should error") { Priority = 2 } });
+                    this.AddChild(new TestVariation(Variation41) { Attribute = new VariationAttribute("WriteBase64") });
+                    this.AddChild(new TestVariation(Variation42) { Attribute = new VariationAttribute("WriteEntityRef") });
                 }
             }
-            public class NamespacehandlingWriterSanity : XLinqTestCase
+            public partial class NamespacehandlingWriterSanity : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+NamespacehandlingWriterSanity
                 // Test Case
                 public override void AddChildren()
                 {
-                    var namespacehandlingWriterSanity = new OmitDuplicateNamespaceDeclFunctionalTests.XNodeBuilderTests.NamespacehandlingWriterSanity();
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace II.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace III.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down") { Params = new object[] { "<p:A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down II.") { Params = new object[] { "<p:A xmlns:p='nsp'><B><C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down III.") { Params = new object[] { "<A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Siblings") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'/><C xmlns:p='nsp'/><p:C xmlns:p='nsp'/></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Children") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'><C xmlns:p='nsp'><p:C xmlns:p='nsp'/></C></p:B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace I.") { Params = new object[] { "<A xmlns:xml='http://www.w3.org/XML/1998/namespace'/>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></p:A>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down II.") { Params = new object[] { "<A><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></A>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Not used NS declarations") { Params = new object[] { "<A xmlns='nsp' xmlns:u='not-used'><p:B xmlns:p='nsp'><C xmlns:u='not-used' xmlns='nsp' /></p:B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("SameNS, different prefix") { Params = new object[] { "<p:A xmlns:p='nsp'><B xmlns:q='nsp'><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Default namespaces") { Params = new object[] { "<A xmlns='nsp'><p:B xmlns:p='nsp'><C xmlns='nsp' /></p:B></A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeTricky) { Attribute = new VariationAttribute("Default ns parent autogenerated") { Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testConflicts) { Attribute = new VariationAttribute("Conflicts: NS undeclaration, default NS") { Params = new object[] { "<A xmlns='nsp'><B xmlns=''><C xmlns='nsp'><D xmlns='nsp'/></C></B></A>", "<A xmlns='nsp'><B xmlns=''><C xmlns='nsp'><D/></C></B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='ns-other'><p:C xmlns:p='nsp'><D xmlns:p='nsp'/></p:C></p:B></p:A>", "<p:A xmlns:p='nsp'><p:B xmlns:p='ns-other'><p:C xmlns:p='nsp'><D/></p:C></p:B></p:A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition, default NS") { Params = new object[] { "<A xmlns='nsp'><B xmlns='ns-other'><C xmlns='nsp'><D xmlns='nsp'/></C></B></A>", "<A xmlns='nsp'><B xmlns='ns-other'><C xmlns='nsp'><D/></C></B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition, default NS II.") { Params = new object[] { "<A xmlns=''><B xmlns='ns-other'><C xmlns=''><D xmlns=''/></C></B></A>", "<A><B xmlns='ns-other'><C xmlns=''><D/></C></B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromChildNode1) { Attribute = new VariationAttribute("Not from root") { Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromChildNode2) { Attribute = new VariationAttribute("Not from root II.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromChildNode3) { Attribute = new VariationAttribute("Not from root III.") { Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromChildNode4) { Attribute = new VariationAttribute("Not from root IV.") { Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader III.") { Params = new object[] { "<p1:A xmlns:p1='nsp'><B xmlns:p1='nsp'/></p1:A>", "<p1:root xmlns:p1='nsp'><p1:A><B/></p1:A></p1:root>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader I.") { Params = new object[] { "<A xmlns:p1='nsp'/>", "<p1:root xmlns:p1='nsp'><A/></p1:root>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader II.") { Params = new object[] { "<p1:A xmlns:p1='nsp'/>", "<p1:root xmlns:p1='nsp'><p1:A/></p1:root>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriterDefaultNS) { Attribute = new VariationAttribute("Write into used reader I. (def. ns.)") { Params = new object[] { "<A xmlns='nsp'/>", "<root xmlns='nsp'><A/></root>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriterDefaultNS) { Attribute = new VariationAttribute("Write into used reader II. (def. ns.)") { Params = new object[] { "<A xmlns='ns-other'><B xmlns='nsp'><C xmlns='nsp'/></B></A>", "<root xmlns='nsp'><A xmlns='ns-other'><B xmlns='nsp'><C/></B></A></root>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriterXlinqLookup1) { Attribute = new VariationAttribute("Write into used reader (Xlinq lookup + existing hint in the Writer; different prefix)") { Params = new object[] { "<p1:root xmlns:p1='nsp'><p2:B xmlns:p2='nsp'/></p1:root>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriterXlinqLookup2) { Attribute = new VariationAttribute("Write into used reader (Xlinq lookup + existing hint in the Writer; same prefix)") { Params = new object[] { "<p1:root xmlns:p1='nsp'><p1:B /></p1:root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace II.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace III.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down") { Params = new object[] { "<p:A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down II.") { Params = new object[] { "<p:A xmlns:p='nsp'><B><C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down III.") { Params = new object[] { "<A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Siblings") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'/><C xmlns:p='nsp'/><p:C xmlns:p='nsp'/></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Children") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'><C xmlns:p='nsp'><p:C xmlns:p='nsp'/></C></p:B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace I.") { Params = new object[] { "<A xmlns:xml='http://www.w3.org/XML/1998/namespace'/>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></p:A>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down II.") { Params = new object[] { "<A><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></A>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Not used NS declarations") { Params = new object[] { "<A xmlns='nsp' xmlns:u='not-used'><p:B xmlns:p='nsp'><C xmlns:u='not-used' xmlns='nsp' /></p:B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("SameNS, different prefix") { Params = new object[] { "<p:A xmlns:p='nsp'><B xmlns:q='nsp'><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Default namespaces") { Params = new object[] { "<A xmlns='nsp'><p:B xmlns:p='nsp'><C xmlns='nsp' /></p:B></A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeTricky) { Attribute = new VariationAttribute("Default ns parent autogenerated") { Priority = 1 } });
+                    this.AddChild(new TestVariation(testConflicts) { Attribute = new VariationAttribute("Conflicts: NS undeclaration, default NS") { Params = new object[] { "<A xmlns='nsp'><B xmlns=''><C xmlns='nsp'><D xmlns='nsp'/></C></B></A>", "<A xmlns='nsp'><B xmlns=''><C xmlns='nsp'><D/></C></B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='ns-other'><p:C xmlns:p='nsp'><D xmlns:p='nsp'/></p:C></p:B></p:A>", "<p:A xmlns:p='nsp'><p:B xmlns:p='ns-other'><p:C xmlns:p='nsp'><D/></p:C></p:B></p:A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition, default NS") { Params = new object[] { "<A xmlns='nsp'><B xmlns='ns-other'><C xmlns='nsp'><D xmlns='nsp'/></C></B></A>", "<A xmlns='nsp'><B xmlns='ns-other'><C xmlns='nsp'><D/></C></B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition, default NS II.") { Params = new object[] { "<A xmlns=''><B xmlns='ns-other'><C xmlns=''><D xmlns=''/></C></B></A>", "<A><B xmlns='ns-other'><C xmlns=''><D/></C></B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromChildNode1) { Attribute = new VariationAttribute("Not from root") { Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromChildNode2) { Attribute = new VariationAttribute("Not from root II.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromChildNode3) { Attribute = new VariationAttribute("Not from root III.") { Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromChildNode4) { Attribute = new VariationAttribute("Not from root IV.") { Priority = 2 } });
+                    this.AddChild(new TestVariation(testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader III.") { Params = new object[] { "<p1:A xmlns:p1='nsp'><B xmlns:p1='nsp'/></p1:A>", "<p1:root xmlns:p1='nsp'><p1:A><B/></p1:A></p1:root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader I.") { Params = new object[] { "<A xmlns:p1='nsp'/>", "<p1:root xmlns:p1='nsp'><A/></p1:root>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader II.") { Params = new object[] { "<p1:A xmlns:p1='nsp'/>", "<p1:root xmlns:p1='nsp'><p1:A/></p1:root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testIntoOpenedWriterDefaultNS) { Attribute = new VariationAttribute("Write into used reader I. (def. ns.)") { Params = new object[] { "<A xmlns='nsp'/>", "<root xmlns='nsp'><A/></root>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(testIntoOpenedWriterDefaultNS) { Attribute = new VariationAttribute("Write into used reader II. (def. ns.)") { Params = new object[] { "<A xmlns='ns-other'><B xmlns='nsp'><C xmlns='nsp'/></B></A>", "<root xmlns='nsp'><A xmlns='ns-other'><B xmlns='nsp'><C/></B></A></root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testIntoOpenedWriterXlinqLookup1) { Attribute = new VariationAttribute("Write into used reader (Xlinq lookup + existing hint in the Writer; different prefix)") { Params = new object[] { "<p1:root xmlns:p1='nsp'><p2:B xmlns:p2='nsp'/></p1:root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testIntoOpenedWriterXlinqLookup2) { Attribute = new VariationAttribute("Write into used reader (Xlinq lookup + existing hint in the Writer; same prefix)") { Params = new object[] { "<p1:root xmlns:p1='nsp'><p1:B /></p1:root>" }, Priority = 2 } });
                 }
             }
-            public class OmitAnotation : XLinqTestCase
+            public partial class OmitAnotation : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+OmitAnotation
                 // Test Case
                 public override void AddChildren()
                 {
-                    var omitAnotation = new OmitDuplicatesAnnotationFunctionalTests.XNodeBuilderTests.OmitAnotation();
-                    this.AddChild(new TestVariation(omitAnotation.NoAnnotation) { Attribute = new VariationAttribute("No annotation - element") { Params = new object[] { typeof(XElement), "Simple.xml" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.NoAnnotation) { Attribute = new VariationAttribute("No annotation - document") { Params = new object[] { typeof(XDocument), "Simple.xml" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on document without omit - DisableFormating") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.DisableFormatting }, Priority = 2 } });
-                    this.AddChild(new TestVariation(omitAnotation.AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on element without omit - None") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.None }, Priority = 2 } });
-                    this.AddChild(new TestVariation(omitAnotation.AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on element without omit - DisableFormating") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.DisableFormatting }, Priority = 2 } });
-                    this.AddChild(new TestVariation(omitAnotation.AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on document without omit - None") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.None }, Priority = 2 } });
-                    this.AddChild(new TestVariation(omitAnotation.XDocAnnotation) { Attribute = new VariationAttribute("Annotation on document - Omit + Disable") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.OmitDuplicateNamespaces | SaveOptions.DisableFormatting }, Priority = 1 } });
-                    this.AddChild(new TestVariation(omitAnotation.XDocAnnotation) { Attribute = new VariationAttribute("Annotation on element - Omit + Disable") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.OmitDuplicateNamespaces | SaveOptions.DisableFormatting }, Priority = 1 } });
-                    this.AddChild(new TestVariation(omitAnotation.XDocAnnotation) { Attribute = new VariationAttribute("Annotation on element - Omit") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.OmitDuplicateNamespaces }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.XDocAnnotation) { Attribute = new VariationAttribute("Annotation on document - Omit") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.OmitDuplicateNamespaces }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.AnnotationOnParent1) { Attribute = new VariationAttribute("Annotation on the parent nodes, XDocument") { Params = new object[] { typeof(XDocument), "simple.xml" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.AnnotationOnParent1) { Attribute = new VariationAttribute("Annotation on the parent nodes, XElement") { Params = new object[] { typeof(XElement), "simple.xml" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsInTree) { Attribute = new VariationAttribute("Multiple annotations in the tree - both up - XDocument") { Param = typeof(XDocument), Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsInTree) { Attribute = new VariationAttribute("Multiple annotations in the tree - both up - XElement") { Param = typeof(XElement), Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsInTree2) { Attribute = new VariationAttribute("Multiple annotations in the tree - up/down - XDocument") { Param = typeof(XDocument), Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsInTree2) { Attribute = new VariationAttribute("Multiple annotations in the tree - up/down - XElement") { Param = typeof(XElement), Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsOnElement) { Attribute = new VariationAttribute("Multiple annotations on node - XElement") { Param = typeof(XElement), Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsOnElement) { Attribute = new VariationAttribute("Multiple annotations on node - XDocument") { Param = typeof(XDocument), Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.OnOtherNodesAttrs) { Attribute = new VariationAttribute("On other node types - attributes") { Param = typeof(XElement), Priority = 2 } });
-                    this.AddChild(new TestVariation(omitAnotation.SimulateVb1) { Attribute = new VariationAttribute("Simulate the VB behavior - Save") { Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.SimulateVb2) { Attribute = new VariationAttribute("Simulate the VB behavior - Reader") { Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.LocalOverride) { Attribute = new VariationAttribute("Local settings override annotation") { Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.ReaderOptionsSmoke) { Attribute = new VariationAttribute("XElement - ReaderOptions.None") { Params = new object[] { typeof(XElement), "simple.xml", ReaderOptions.None }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.ReaderOptionsSmoke) { Attribute = new VariationAttribute("XElement - ReaderOptions.OmitDuplicateNamespaces") { Params = new object[] { typeof(XElement), "simple.xml", ReaderOptions.OmitDuplicateNamespaces }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.ReaderOptionsSmoke) { Attribute = new VariationAttribute("XDocument - ReaderOptions.None") { Params = new object[] { typeof(XDocument), "simple.xml", ReaderOptions.None }, Priority = 0 } });
-                    this.AddChild(new TestVariation(omitAnotation.ReaderOptionsSmoke) { Attribute = new VariationAttribute("XDocument - ReaderOptions.OmitDuplicateNamespaces") { Params = new object[] { typeof(XDocument), "simple.xml", ReaderOptions.OmitDuplicateNamespaces }, Priority = 0 } });
+                    this.AddChild(new TestVariation(NoAnnotation) { Attribute = new VariationAttribute("No annotation - element") { Params = new object[] { typeof(XElement), "Simple.xml" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(NoAnnotation) { Attribute = new VariationAttribute("No annotation - document") { Params = new object[] { typeof(XDocument), "Simple.xml" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on document without omit - DisableFormating") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.DisableFormatting }, Priority = 2 } });
+                    this.AddChild(new TestVariation(AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on element without omit - None") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.None }, Priority = 2 } });
+                    this.AddChild(new TestVariation(AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on element without omit - DisableFormating") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.DisableFormatting }, Priority = 2 } });
+                    this.AddChild(new TestVariation(AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on document without omit - None") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.None }, Priority = 2 } });
+                    this.AddChild(new TestVariation(XDocAnnotation) { Attribute = new VariationAttribute("Annotation on document - Omit + Disable") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.OmitDuplicateNamespaces | SaveOptions.DisableFormatting }, Priority = 1 } });
+                    this.AddChild(new TestVariation(XDocAnnotation) { Attribute = new VariationAttribute("Annotation on element - Omit + Disable") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.OmitDuplicateNamespaces | SaveOptions.DisableFormatting }, Priority = 1 } });
+                    this.AddChild(new TestVariation(XDocAnnotation) { Attribute = new VariationAttribute("Annotation on element - Omit") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.OmitDuplicateNamespaces }, Priority = 0 } });
+                    this.AddChild(new TestVariation(XDocAnnotation) { Attribute = new VariationAttribute("Annotation on document - Omit") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.OmitDuplicateNamespaces }, Priority = 0 } });
+                    this.AddChild(new TestVariation(AnnotationOnParent1) { Attribute = new VariationAttribute("Annotation on the parent nodes, XDocument") { Params = new object[] { typeof(XDocument), "simple.xml" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(AnnotationOnParent1) { Attribute = new VariationAttribute("Annotation on the parent nodes, XElement") { Params = new object[] { typeof(XElement), "simple.xml" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(MultipleAnnotationsInTree) { Attribute = new VariationAttribute("Multiple annotations in the tree - both up - XDocument") { Param = typeof(XDocument), Priority = 0 } });
+                    this.AddChild(new TestVariation(MultipleAnnotationsInTree) { Attribute = new VariationAttribute("Multiple annotations in the tree - both up - XElement") { Param = typeof(XElement), Priority = 0 } });
+                    this.AddChild(new TestVariation(MultipleAnnotationsInTree2) { Attribute = new VariationAttribute("Multiple annotations in the tree - up/down - XDocument") { Param = typeof(XDocument), Priority = 0 } });
+                    this.AddChild(new TestVariation(MultipleAnnotationsInTree2) { Attribute = new VariationAttribute("Multiple annotations in the tree - up/down - XElement") { Param = typeof(XElement), Priority = 0 } });
+                    this.AddChild(new TestVariation(MultipleAnnotationsOnElement) { Attribute = new VariationAttribute("Multiple annotations on node - XElement") { Param = typeof(XElement), Priority = 0 } });
+                    this.AddChild(new TestVariation(MultipleAnnotationsOnElement) { Attribute = new VariationAttribute("Multiple annotations on node - XDocument") { Param = typeof(XDocument), Priority = 0 } });
+                    this.AddChild(new TestVariation(OnOtherNodesAttrs) { Attribute = new VariationAttribute("On other node types - attributes") { Param = typeof(XElement), Priority = 2 } });
+                    this.AddChild(new TestVariation(SimulateVb1) { Attribute = new VariationAttribute("Simulate the VB behavior - Save") { Priority = 0 } });
+                    this.AddChild(new TestVariation(SimulateVb2) { Attribute = new VariationAttribute("Simulate the VB behavior - Reader") { Priority = 0 } });
+                    this.AddChild(new TestVariation(LocalOverride) { Attribute = new VariationAttribute("Local settings override annotation") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReaderOptionsSmoke) { Attribute = new VariationAttribute("XElement - ReaderOptions.None") { Params = new object[] { typeof(XElement), "simple.xml", ReaderOptions.None }, Priority = 0 } });
+                    this.AddChild(new TestVariation(ReaderOptionsSmoke) { Attribute = new VariationAttribute("XElement - ReaderOptions.OmitDuplicateNamespaces") { Params = new object[] { typeof(XElement), "simple.xml", ReaderOptions.OmitDuplicateNamespaces }, Priority = 0 } });
+                    this.AddChild(new TestVariation(ReaderOptionsSmoke) { Attribute = new VariationAttribute("XDocument - ReaderOptions.None") { Params = new object[] { typeof(XDocument), "simple.xml", ReaderOptions.None }, Priority = 0 } });
+                    this.AddChild(new TestVariation(ReaderOptionsSmoke) { Attribute = new VariationAttribute("XDocument - ReaderOptions.OmitDuplicateNamespaces") { Params = new object[] { typeof(XDocument), "simple.xml", ReaderOptions.OmitDuplicateNamespaces }, Priority = 0 } });
                 }
             }
-            public class NamespacehandlingSaveOptions : XLinqTestCase
+            public partial class NamespacehandlingSaveOptions : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+NamespacehandlingSaveOptions
                 // Test Case
                 public override void AddChildren()
                 {
-                    var namespacehandlingSaveOptions = new SaveOptions_OmitDuplicateNamespaceFunctionalTests.XNodeBuilderTests.NamespacehandlingSaveOptions();
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down") { Params = new object[] { "<p:A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down III.") { Params = new object[] { "<A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Siblings") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'/><C xmlns:p='nsp'/><p:C xmlns:p='nsp'/></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace II.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down II.") { Params = new object[] { "<A><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></A>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down II.") { Params = new object[] { "<p:A xmlns:p='nsp'><B><C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Children") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'><C xmlns:p='nsp'><p:C xmlns:p='nsp'/></C></p:B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace I.") { Params = new object[] { "<A xmlns:xml='http://www.w3.org/XML/1998/namespace'/>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></p:A>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace III.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Default namespaces") { Params = new object[] { "<A xmlns='nsp'><p:B xmlns:p='nsp'><C xmlns='nsp' /></p:B></A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Not used NS declarations") { Params = new object[] { "<A xmlns='nsp' xmlns:u='not-used'><p:B xmlns:p='nsp'><C xmlns:u='not-used' xmlns='nsp' /></p:B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("SameNS, different prefix") { Params = new object[] { "<p:A xmlns:p='nsp'><B xmlns:q='nsp'><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeTricky) { Attribute = new VariationAttribute("Default ns parent autogenerated") { Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromChildNode1) { Attribute = new VariationAttribute("Not from root") { Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromChildNode2) { Attribute = new VariationAttribute("Not from root II.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromChildNode3) { Attribute = new VariationAttribute("Not from root III.") { Priority = 2 } });
-                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromChildNode4) { Attribute = new VariationAttribute("Not from root IV.") { Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down") { Params = new object[] { "<p:A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down III.") { Params = new object[] { "<A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Siblings") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'/><C xmlns:p='nsp'/><p:C xmlns:p='nsp'/></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace II.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down II.") { Params = new object[] { "<A><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></A>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down II.") { Params = new object[] { "<p:A xmlns:p='nsp'><B><C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Children") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'><C xmlns:p='nsp'><p:C xmlns:p='nsp'/></C></p:B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace I.") { Params = new object[] { "<A xmlns:xml='http://www.w3.org/XML/1998/namespace'/>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></p:A>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace III.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Default namespaces") { Params = new object[] { "<A xmlns='nsp'><p:B xmlns:p='nsp'><C xmlns='nsp' /></p:B></A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Not used NS declarations") { Params = new object[] { "<A xmlns='nsp' xmlns:u='not-used'><p:B xmlns:p='nsp'><C xmlns:u='not-used' xmlns='nsp' /></p:B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("SameNS, different prefix") { Params = new object[] { "<p:A xmlns:p='nsp'><B xmlns:q='nsp'><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromTheRootNodeTricky) { Attribute = new VariationAttribute("Default ns parent autogenerated") { Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromChildNode1) { Attribute = new VariationAttribute("Not from root") { Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromChildNode2) { Attribute = new VariationAttribute("Not from root II.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(testFromChildNode3) { Attribute = new VariationAttribute("Not from root III.") { Priority = 2 } });
+                    this.AddChild(new TestVariation(testFromChildNode4) { Attribute = new VariationAttribute("Not from root IV.") { Priority = 2 } });
                 }
             }
-            public class Writer_Settings : BridgeHelpers
+            public partial class Writer_Settings : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+Writer_Settings
                 // Test Case
                 public override void AddChildren()
                 {
-                    var writerSettings = new WriterSettingsFunctionalTests.XNodeBuilderTests.Writer_Settings();
-                    this.AddChild(new TestVariation(writerSettings.var_1) { Attribute = new VariationAttribute("XDocument: Settings before Close()") { Priority = 1 } });
-                    this.AddChild(new TestVariation(writerSettings.var_2) { Attribute = new VariationAttribute("XElement: Settings before Close()") { Priority = 1 } });
-                    this.AddChild(new TestVariation(writerSettings.var_3) { Attribute = new VariationAttribute("XDocument: Settings after Close()") { Priority = 1 } });
-                    this.AddChild(new TestVariation(writerSettings.var_4) { Attribute = new VariationAttribute("XElement: Settings after Close()") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("XDocument: Settings before Close()") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("XElement: Settings before Close()") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("XDocument: Settings after Close()") { Priority = 1 } });
+                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("XElement: Settings after Close()") { Priority = 1 } });
                 }
             }
-            public class TCCheckChars : BridgeHelpers
+            public partial class TCCheckChars : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCCheckChars
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcCheckChars = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCCheckChars();
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteEntityRef") { Param = "EntityRef", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteWhitespace") { Param = "Whitespace", Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid name chars WriteDocType(name)") { Param = "WriteDocTypeName", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteSurrogateCharEntity") { Param = "SurrogateCharEntity", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteEntityRef should error") { Params = new object[] { "EntityRef", true }, Id = 46, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteSurrogateCharEntity should error") { Params = new object[] { "Surrogate", false }, Id = 41, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteQualifiedName should error") { Params = new object[] { "QName", true }, Id = 47, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteSurrogateCharEntity should error") { Params = new object[] { "Surrogate", true }, Id = 45, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteWhitespace should error") { Params = new object[] { "Whitespace", false }, Id = 40, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteEntityRef should error") { Params = new object[] { "EntityRef", false }, Id = 42, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteQualifiedName should error") { Params = new object[] { "QName", false }, Id = 43, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteWhitespace should error") { Params = new object[] { "Whitespace", true }, Id = 44, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteEntityRef") { Param = "EntityRef", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteWhitespace") { Param = "Whitespace", Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid name chars WriteDocType(name)") { Param = "WriteDocTypeName", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteSurrogateCharEntity") { Param = "SurrogateCharEntity", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteEntityRef should error") { Params = new object[] { "EntityRef", true }, Id = 46, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteSurrogateCharEntity should error") { Params = new object[] { "Surrogate", false }, Id = 41, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteQualifiedName should error") { Params = new object[] { "QName", true }, Id = 47, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteSurrogateCharEntity should error") { Params = new object[] { "Surrogate", true }, Id = 45, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteWhitespace should error") { Params = new object[] { "Whitespace", false }, Id = 40, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteEntityRef should error") { Params = new object[] { "EntityRef", false }, Id = 42, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteQualifiedName should error") { Params = new object[] { "QName", false }, Id = 43, Priority = 1 } });
+                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteWhitespace should error") { Params = new object[] { "Whitespace", true }, Id = 44, Priority = 1 } });
                 }
             }
-            public class TCNewLineHandling : BridgeHelpers
+            public partial class TCNewLineHandling : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCNewLineHandling
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcNewLineHandling = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCNewLineHandling();
-                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_7) { Attribute = new VariationAttribute("Test for CR (xD) inside attr when NewLineHandling = Replace") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_8) { Attribute = new VariationAttribute("Test for LF (xA) inside attr when NewLineHandling = Replace") { Id = 8, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_9) { Attribute = new VariationAttribute("Test for CR LF (xD xA) inside attr when NewLineHandling = Replace") { Id = 9, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_10) { Attribute = new VariationAttribute("Test for CR (xD) inside attr when NewLineHandling = Entitize") { Id = 10, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_11) { Attribute = new VariationAttribute("Test for LF (xA) inside attr when NewLineHandling = Entitize") { Id = 11, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_12) { Attribute = new VariationAttribute("Test for CR LF (xD xA) inside attr when NewLineHandling = Entitize") { Id = 12, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_13) { Attribute = new VariationAttribute("Factory-created writers do not entitize 0xD character in text content when NewLineHandling=Entitize") { Id = 13 } });
+                    this.AddChild(new TestVariation(NewLineHandling_7) { Attribute = new VariationAttribute("Test for CR (xD) inside attr when NewLineHandling = Replace") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(NewLineHandling_8) { Attribute = new VariationAttribute("Test for LF (xA) inside attr when NewLineHandling = Replace") { Id = 8, Priority = 0 } });
+                    this.AddChild(new TestVariation(NewLineHandling_9) { Attribute = new VariationAttribute("Test for CR LF (xD xA) inside attr when NewLineHandling = Replace") { Id = 9, Priority = 0 } });
+                    this.AddChild(new TestVariation(NewLineHandling_10) { Attribute = new VariationAttribute("Test for CR (xD) inside attr when NewLineHandling = Entitize") { Id = 10, Priority = 0 } });
+                    this.AddChild(new TestVariation(NewLineHandling_11) { Attribute = new VariationAttribute("Test for LF (xA) inside attr when NewLineHandling = Entitize") { Id = 11, Priority = 0 } });
+                    this.AddChild(new TestVariation(NewLineHandling_12) { Attribute = new VariationAttribute("Test for CR LF (xD xA) inside attr when NewLineHandling = Entitize") { Id = 12, Priority = 0 } });
+                    this.AddChild(new TestVariation(NewLineHandling_13) { Attribute = new VariationAttribute("Factory-created writers do not entitize 0xD character in text content when NewLineHandling=Entitize") { Id = 13 } });
                 }
             }
-            public class TCIndent : BridgeHelpers
+            public partial class TCIndent : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCIndent
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcIndent = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCIndent();
-                    this.AddChild(new TestVariation(tcIndent.indent_1) { Attribute = new VariationAttribute("Simple test when false") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIndent.indent_2) { Attribute = new VariationAttribute("Simple test when true") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIndent.indent_3) { Attribute = new VariationAttribute("Indent = false, element content is empty") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIndent.indent_5) { Attribute = new VariationAttribute("Indent = false, element content is empty, FullEndElement") { Id = 5, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIndent.indent_6) { Attribute = new VariationAttribute("Indent = true, element content is empty, FullEndElement") { Id = 6, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIndent.indent_7) { Attribute = new VariationAttribute("Indent = true, mixed content") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIndent.indent_8) { Attribute = new VariationAttribute("Indent = true, mixed content, FullEndElement") { Id = 8, Priority = 0 } });
+                    this.AddChild(new TestVariation(indent_1) { Attribute = new VariationAttribute("Simple test when false") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(indent_2) { Attribute = new VariationAttribute("Simple test when true") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(indent_3) { Attribute = new VariationAttribute("Indent = false, element content is empty") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(indent_5) { Attribute = new VariationAttribute("Indent = false, element content is empty, FullEndElement") { Id = 5, Priority = 0 } });
+                    this.AddChild(new TestVariation(indent_6) { Attribute = new VariationAttribute("Indent = true, element content is empty, FullEndElement") { Id = 6, Priority = 0 } });
+                    this.AddChild(new TestVariation(indent_7) { Attribute = new VariationAttribute("Indent = true, mixed content") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(indent_8) { Attribute = new VariationAttribute("Indent = true, mixed content, FullEndElement") { Id = 8, Priority = 0 } });
                 }
             }
-            public class TCNewLineOnAttributes : BridgeHelpers
+            public partial class TCNewLineOnAttributes : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCNewLineOnAttributes
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcNewLineOnAttributes = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCNewLineOnAttributes();
-                    this.AddChild(new TestVariation(tcNewLineOnAttributes.NewLineOnAttributes_1) { Attribute = new VariationAttribute("Make sure the setting has no effect when Indent is false") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNewLineOnAttributes.NewLineOnAttributes_3) { Attribute = new VariationAttribute("Attributes of nested elements") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(NewLineOnAttributes_1) { Attribute = new VariationAttribute("Make sure the setting has no effect when Indent is false") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(NewLineOnAttributes_3) { Attribute = new VariationAttribute("Attributes of nested elements") { Id = 3, Priority = 1 } });
                 }
             }
-            public class TCStandAlone : BridgeHelpers
+            public partial class TCStandAlone : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCStandAlone
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcStandAlone = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCStandAlone();
-                    this.AddChild(new TestVariation(tcStandAlone.standalone_1) { Attribute = new VariationAttribute("StartDocument(bool standalone = true)") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcStandAlone.standalone_2) { Attribute = new VariationAttribute("StartDocument(bool standalone = false)") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(standalone_1) { Attribute = new VariationAttribute("StartDocument(bool standalone = true)") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(standalone_2) { Attribute = new VariationAttribute("StartDocument(bool standalone = false)") { Id = 2, Priority = 0 } });
                 }
             }
-            public class TCFragmentCL : BridgeHelpers
+            public partial class TCFragmentCL : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCFragmentCL
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcFragmentCL = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCFragmentCL();
-                    this.AddChild(new TestVariation(tcFragmentCL.frag_1) { Attribute = new VariationAttribute("WriteDocType should error when CL=fragment") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcFragmentCL.frag_2) { Attribute = new VariationAttribute("WriteStartDocument() should error when CL=fragment") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(frag_1) { Attribute = new VariationAttribute("WriteDocType should error when CL=fragment") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(frag_2) { Attribute = new VariationAttribute("WriteStartDocument() should error when CL=fragment") { Id = 2, Priority = 1 } });
                 }
             }
-            public class TCAutoCL : BridgeHelpers
+            public partial class TCAutoCL : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCAutoCL
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcAutoCL = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCAutoCL();
-                    this.AddChild(new TestVariation(tcAutoCL.auto_1) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument()") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_2) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument(standalone = true)") { Param = "true", Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_2) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument(standalone = false)") { Param = "false", Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_3) { Attribute = new VariationAttribute("Change to CL Document when you write DocType decl") { Id = 4, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_4) { Attribute = new VariationAttribute("Change to CL Fragment when you write a root element") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteCData at top level") { Param = "CData", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteCharEntity at top level") { Param = "CharEntity", Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteSurrogateCharEntity at top level") { Param = "SurrogateCharEntity", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteString at top level") { Param = "String", Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteRaw at top level") { Param = "Raw", Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteBinHex at top level") { Param = "BinHex", Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteChars at top level") { Param = "Chars", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_6) { Attribute = new VariationAttribute("WritePI at top level, followed by DTD, expected CL = Document") { Param = "PI", Id = 15, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_6) { Attribute = new VariationAttribute("WriteWhitespace at top level, followed by DTD, expected CL = Document") { Param = "WS", Id = 17, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_6) { Attribute = new VariationAttribute("WriteComment at top level, followed by DTD, expected CL = Document") { Param = "Comment", Id = 16, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_7) { Attribute = new VariationAttribute("WriteComment at top level, followed by text, expected CL = Fragment") { Param = "Comment", Id = 19, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_7) { Attribute = new VariationAttribute("WriteWhitespace at top level, followed by text, expected CL = Fragment") { Param = "WS", Id = 20, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_7) { Attribute = new VariationAttribute("WritePI at top level, followed by text, expected CL = Fragment") { Param = "PI", Id = 18, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_8) { Attribute = new VariationAttribute("WriteNode(XmlReader) when reader positioned on DocType node, expected CL = Document") { Id = 21, Priority = 2 } });
-                    this.AddChild(new TestVariation(tcAutoCL.auto_10) { Attribute = new VariationAttribute("WriteNode(XmlReader) when reader positioned on text node, expected CL = Fragment") { Id = 22, Priority = 2 } });
+                    this.AddChild(new TestVariation(auto_1) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument()") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(auto_2) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument(standalone = true)") { Param = "true", Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(auto_2) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument(standalone = false)") { Param = "false", Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(auto_3) { Attribute = new VariationAttribute("Change to CL Document when you write DocType decl") { Id = 4, Priority = 0 } });
+                    this.AddChild(new TestVariation(auto_4) { Attribute = new VariationAttribute("Change to CL Fragment when you write a root element") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteCData at top level") { Param = "CData", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteCharEntity at top level") { Param = "CharEntity", Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteSurrogateCharEntity at top level") { Param = "SurrogateCharEntity", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteString at top level") { Param = "String", Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteRaw at top level") { Param = "Raw", Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteBinHex at top level") { Param = "BinHex", Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteChars at top level") { Param = "Chars", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(auto_6) { Attribute = new VariationAttribute("WritePI at top level, followed by DTD, expected CL = Document") { Param = "PI", Id = 15, Priority = 2 } });
+                    this.AddChild(new TestVariation(auto_6) { Attribute = new VariationAttribute("WriteWhitespace at top level, followed by DTD, expected CL = Document") { Param = "WS", Id = 17, Priority = 2 } });
+                    this.AddChild(new TestVariation(auto_6) { Attribute = new VariationAttribute("WriteComment at top level, followed by DTD, expected CL = Document") { Param = "Comment", Id = 16, Priority = 2 } });
+                    this.AddChild(new TestVariation(auto_7) { Attribute = new VariationAttribute("WriteComment at top level, followed by text, expected CL = Fragment") { Param = "Comment", Id = 19, Priority = 2 } });
+                    this.AddChild(new TestVariation(auto_7) { Attribute = new VariationAttribute("WriteWhitespace at top level, followed by text, expected CL = Fragment") { Param = "WS", Id = 20, Priority = 2 } });
+                    this.AddChild(new TestVariation(auto_7) { Attribute = new VariationAttribute("WritePI at top level, followed by text, expected CL = Fragment") { Param = "PI", Id = 18, Priority = 2 } });
+                    this.AddChild(new TestVariation(auto_8) { Attribute = new VariationAttribute("WriteNode(XmlReader) when reader positioned on DocType node, expected CL = Document") { Id = 21, Priority = 2 } });
+                    this.AddChild(new TestVariation(auto_10) { Attribute = new VariationAttribute("WriteNode(XmlReader) when reader positioned on text node, expected CL = Fragment") { Id = 22, Priority = 2 } });
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/FunctionalTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/FunctionalTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class XNodeBuilderFunctionalTests : TestModule
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
@@ -22,7 +22,7 @@ namespace CoreXml.Test.XLinq
         public static void RunTests()
         {
             TestInput.CommandLine = "";
-            FunctionalTests module = new FunctionalTests();
+            XNodeBuilderFunctionalTests module = new XNodeBuilderFunctionalTests();
             module.Init();
 
             {
@@ -34,7 +34,7 @@ namespace CoreXml.Test.XLinq
         }
 
         #region Code
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
             // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests
             // Test Case
@@ -89,1020 +89,1065 @@ namespace CoreXml.Test.XLinq
                 this.AddChild(new TCFragmentCL() { Attribute = new TestCaseAttribute() { Name = "CL = Fragment Tests" } });
                 this.AddChild(new TCAutoCL() { Attribute = new TestCaseAttribute() { Name = "CL = Auto Tests" } });
             }
-            public partial class TCAutoComplete : BridgeHelpers
+            public class TCAutoComplete : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCAutoComplete
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("Missing EndAttr, followed by element") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("Missing EndAttr, followed by comment") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("Write EndDocument with unclosed element tag") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("WriteStartDocument - WriteEndDocument") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("WriteEndElement without WriteStartElement") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_6) { Attribute = new VariationAttribute("WriteFullEndElement without WriteStartElement") { Id = 6, Priority = 1 } });
+                    var tcAutoComplete = new CommonTestsFunctionalTests.XNodeBuilderTests.TCAutoComplete();
+                    this.AddChild(new TestVariation(tcAutoComplete.var_1) { Attribute = new VariationAttribute("Missing EndAttr, followed by element") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoComplete.var_2) { Attribute = new VariationAttribute("Missing EndAttr, followed by comment") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoComplete.var_3) { Attribute = new VariationAttribute("Write EndDocument with unclosed element tag") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoComplete.var_4) { Attribute = new VariationAttribute("WriteStartDocument - WriteEndDocument") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoComplete.var_5) { Attribute = new VariationAttribute("WriteEndElement without WriteStartElement") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoComplete.var_6) { Attribute = new VariationAttribute("WriteFullEndElement without WriteStartElement") { Id = 6, Priority = 1 } });
                 }
             }
-            public partial class TCDocument : BridgeHelpers
+            public class TCDocument : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCDocument
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(document_1) { Attribute = new VariationAttribute("StartDocument-EndDocument Sanity Test") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(document_2) { Attribute = new VariationAttribute("Multiple StartDocument should error") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(document_3) { Attribute = new VariationAttribute("Missing StartDocument should be fixed") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(document_4) { Attribute = new VariationAttribute("Multiple EndDocument should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(document_5) { Attribute = new VariationAttribute("Missing EndDocument should be fixed") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(document_6) { Attribute = new VariationAttribute("Call Start-EndDocument multiple times, should error") { Id = 6, Priority = 2 } });
-                    this.AddChild(new TestVariation(document_7) { Attribute = new VariationAttribute("Multiple root elements should error") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(document_8) { Attribute = new VariationAttribute("Start-EndDocument without any element should error") { Id = 8, Priority = 2 } });
-                    this.AddChild(new TestVariation(document_9) { Attribute = new VariationAttribute("Top level text should error - PROLOG") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(document_10) { Attribute = new VariationAttribute("Top level text should error - EPILOG") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(document_11) { Attribute = new VariationAttribute("Top level atomic value should error - PROLOG") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(document_12) { Attribute = new VariationAttribute("Top level atomic value should error - EPILOG") { Id = 12, Priority = 1 } });
+                    var tcDocument = new CommonTestsFunctionalTests.XNodeBuilderTests.TCDocument();
+                    this.AddChild(new TestVariation(tcDocument.document_1) { Attribute = new VariationAttribute("StartDocument-EndDocument Sanity Test") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcDocument.document_2) { Attribute = new VariationAttribute("Multiple StartDocument should error") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocument.document_3) { Attribute = new VariationAttribute("Missing StartDocument should be fixed") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocument.document_4) { Attribute = new VariationAttribute("Multiple EndDocument should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocument.document_5) { Attribute = new VariationAttribute("Missing EndDocument should be fixed") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocument.document_6) { Attribute = new VariationAttribute("Call Start-EndDocument multiple times, should error") { Id = 6, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcDocument.document_7) { Attribute = new VariationAttribute("Multiple root elements should error") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocument.document_8) { Attribute = new VariationAttribute("Start-EndDocument without any element should error") { Id = 8, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcDocument.document_9) { Attribute = new VariationAttribute("Top level text should error - PROLOG") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocument.document_10) { Attribute = new VariationAttribute("Top level text should error - EPILOG") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocument.document_11) { Attribute = new VariationAttribute("Top level atomic value should error - PROLOG") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocument.document_12) { Attribute = new VariationAttribute("Top level atomic value should error - EPILOG") { Id = 12, Priority = 1 } });
                 }
             }
-            public partial class TCDocType : BridgeHelpers
+            public class TCDocType : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCDocType
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(docType_4) { Attribute = new VariationAttribute("WriteDocType with name value = null") { Param = "null", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(docType_4) { Attribute = new VariationAttribute("WriteDocType with name value = String.Empty") { Param = "String.Empty", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(docType_6) { Attribute = new VariationAttribute("Call WriteDocType in the root element") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(docType_7) { Attribute = new VariationAttribute("Call WriteDocType following root element") { Id = 8, Priority = 1 } });
+                    var tcDocType = new CommonTestsFunctionalTests.XNodeBuilderTests.TCDocType();
+                    this.AddChild(new TestVariation(tcDocType.docType_4) { Attribute = new VariationAttribute("WriteDocType with name value = null") { Param = "null", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocType.docType_4) { Attribute = new VariationAttribute("WriteDocType with name value = String.Empty") { Param = "String.Empty", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocType.docType_6) { Attribute = new VariationAttribute("Call WriteDocType in the root element") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcDocType.docType_7) { Attribute = new VariationAttribute("Call WriteDocType following root element") { Id = 8, Priority = 1 } });
                 }
             }
-            public partial class TCElement : BridgeHelpers
+            public class TCElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(element_1) { Attribute = new VariationAttribute("StartElement-EndElement Sanity Test") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(element_2) { Attribute = new VariationAttribute("Sanity test for overload WriteStartElement(string prefix, string name, string ns)") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(element_3) { Attribute = new VariationAttribute("Sanity test for overload WriteStartElement(string name, string ns)") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(element_4) { Attribute = new VariationAttribute("Element name = String.Empty should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(element_5) { Attribute = new VariationAttribute("Element name = null should error") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(element_6) { Attribute = new VariationAttribute("Element NS = String.Empty") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(element_7) { Attribute = new VariationAttribute("Element NS = null") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(element_8) { Attribute = new VariationAttribute("Write 100 nested elements") { Id = 8, Priority = 1 } });
+                    var tcElement = new CommonTestsFunctionalTests.XNodeBuilderTests.TCElement();
+                    this.AddChild(new TestVariation(tcElement.element_1) { Attribute = new VariationAttribute("StartElement-EndElement Sanity Test") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcElement.element_2) { Attribute = new VariationAttribute("Sanity test for overload WriteStartElement(string prefix, string name, string ns)") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcElement.element_3) { Attribute = new VariationAttribute("Sanity test for overload WriteStartElement(string name, string ns)") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcElement.element_4) { Attribute = new VariationAttribute("Element name = String.Empty should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElement.element_5) { Attribute = new VariationAttribute("Element name = null should error") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElement.element_6) { Attribute = new VariationAttribute("Element NS = String.Empty") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElement.element_7) { Attribute = new VariationAttribute("Element NS = null") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElement.element_8) { Attribute = new VariationAttribute("Write 100 nested elements") { Id = 8, Priority = 1 } });
                 }
             }
-            public partial class TCAttribute : BridgeHelpers
+            public class TCAttribute : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCAttribute
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(attribute_1) { Attribute = new VariationAttribute("Sanity test for WriteAttribute") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(attribute_2) { Attribute = new VariationAttribute("Missing EndAttribute should be fixed") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(attribute_3) { Attribute = new VariationAttribute("WriteStartAttribute followed by WriteStartAttribute") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(attribute_4) { Attribute = new VariationAttribute("Multiple WritetAttributeString") { Id = 4, Priority = 0 } });
-                    this.AddChild(new TestVariation(attribute_5) { Attribute = new VariationAttribute("WriteStartAttribute followed by WriteString") { Id = 5, Priority = 0 } });
-                    this.AddChild(new TestVariation(attribute_6) { Attribute = new VariationAttribute("Sanity test for overload WriteStartAttribute(name, ns)") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_7) { Attribute = new VariationAttribute("Sanity test for overload WriteStartAttribute(prefix, name, ns)") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(attribute_8) { Attribute = new VariationAttribute("Duplicate attribute 'attr1'") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_9) { Attribute = new VariationAttribute("Duplicate attribute 'ns1:attr1'") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_10) { Attribute = new VariationAttribute("Attribute name = String.Empty should error") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_11) { Attribute = new VariationAttribute("Attribute name = null") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_12) { Attribute = new VariationAttribute("WriteAttribute with names Foo, fOo, foO, FOO") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_13) { Attribute = new VariationAttribute("Invalid value of xml:space") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_14) { Attribute = new VariationAttribute("SingleQuote in attribute value should be allowed") { Id = 14 } });
-                    this.AddChild(new TestVariation(attribute_15) { Attribute = new VariationAttribute("DoubleQuote in attribute value should be escaped") { Id = 15 } });
-                    this.AddChild(new TestVariation(attribute_16) { Attribute = new VariationAttribute("WriteAttribute with value = &, #65, #x20") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_17) { Attribute = new VariationAttribute("WriteAttributeString followed by WriteString") { Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_18) { Attribute = new VariationAttribute("WriteAttribute followed by WriteString") { Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_19) { Attribute = new VariationAttribute("WriteAttribute with all whitespace characters") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_20) { Attribute = new VariationAttribute("< > & chars should be escaped in attribute value") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(attribute_21) { Attribute = new VariationAttribute("testcase: Redefine auto generated prefix n1") { Id = 21 } });
-                    this.AddChild(new TestVariation(attribute_22) { Attribute = new VariationAttribute("testcase: Reuse and redefine existing prefix") { Id = 22 } });
-                    this.AddChild(new TestVariation(attribute_23) { Attribute = new VariationAttribute("WriteStartAttribute(attr) sanity test") { Id = 23 } });
-                    this.AddChild(new TestVariation(attribute_24) { Attribute = new VariationAttribute("WriteStartAttribute(attr) inside an element with changed default namespace") { Id = 24 } });
-                    this.AddChild(new TestVariation(attribute_25) { Attribute = new VariationAttribute("WriteStartAttribute(attr) and duplicate attrs") { Id = 25 } });
-                    this.AddChild(new TestVariation(attribute_26) { Attribute = new VariationAttribute("WriteStartAttribute(attr) when element has ns:attr") { Id = 26 } });
-                    this.AddChild(new TestVariation(attribute_27) { Attribute = new VariationAttribute("XmlCharCheckingWriter should not normalize newLines in attribute values when NewLinesHandling = Replace") { Id = 27 } });
-                    this.AddChild(new TestVariation(attribute_29) { Attribute = new VariationAttribute("WriteAttributeString doesn't fail on invalid surrogate pair sequences") { Id = 29 } });
+                    var tcAttribute = new CommonTestsFunctionalTests.XNodeBuilderTests.TCAttribute();
+                    this.AddChild(new TestVariation(tcAttribute.attribute_1) { Attribute = new VariationAttribute("Sanity test for WriteAttribute") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_2) { Attribute = new VariationAttribute("Missing EndAttribute should be fixed") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_3) { Attribute = new VariationAttribute("WriteStartAttribute followed by WriteStartAttribute") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_4) { Attribute = new VariationAttribute("Multiple WritetAttributeString") { Id = 4, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_5) { Attribute = new VariationAttribute("WriteStartAttribute followed by WriteString") { Id = 5, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_6) { Attribute = new VariationAttribute("Sanity test for overload WriteStartAttribute(name, ns)") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_7) { Attribute = new VariationAttribute("Sanity test for overload WriteStartAttribute(prefix, name, ns)") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_8) { Attribute = new VariationAttribute("Duplicate attribute 'attr1'") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_9) { Attribute = new VariationAttribute("Duplicate attribute 'ns1:attr1'") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_10) { Attribute = new VariationAttribute("Attribute name = String.Empty should error") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_11) { Attribute = new VariationAttribute("Attribute name = null") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_12) { Attribute = new VariationAttribute("WriteAttribute with names Foo, fOo, foO, FOO") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_13) { Attribute = new VariationAttribute("Invalid value of xml:space") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_14) { Attribute = new VariationAttribute("SingleQuote in attribute value should be allowed") { Id = 14 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_15) { Attribute = new VariationAttribute("DoubleQuote in attribute value should be escaped") { Id = 15 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_16) { Attribute = new VariationAttribute("WriteAttribute with value = &, #65, #x20") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_17) { Attribute = new VariationAttribute("WriteAttributeString followed by WriteString") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_18) { Attribute = new VariationAttribute("WriteAttribute followed by WriteString") { Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_19) { Attribute = new VariationAttribute("WriteAttribute with all whitespace characters") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_20) { Attribute = new VariationAttribute("< > & chars should be escaped in attribute value") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_21) { Attribute = new VariationAttribute("testcase: Redefine auto generated prefix n1") { Id = 21 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_22) { Attribute = new VariationAttribute("testcase: Reuse and redefine existing prefix") { Id = 22 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_23) { Attribute = new VariationAttribute("WriteStartAttribute(attr) sanity test") { Id = 23 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_24) { Attribute = new VariationAttribute("WriteStartAttribute(attr) inside an element with changed default namespace") { Id = 24 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_25) { Attribute = new VariationAttribute("WriteStartAttribute(attr) and duplicate attrs") { Id = 25 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_26) { Attribute = new VariationAttribute("WriteStartAttribute(attr) when element has ns:attr") { Id = 26 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_27) { Attribute = new VariationAttribute("XmlCharCheckingWriter should not normalize newLines in attribute values when NewLinesHandling = Replace") { Id = 27 } });
+                    this.AddChild(new TestVariation(tcAttribute.attribute_29) { Attribute = new VariationAttribute("WriteAttributeString doesn't fail on invalid surrogate pair sequences") { Id = 29 } });
                 }
             }
-            public partial class TCWriteAttributes : BridgeHelpers
+            public class TCWriteAttributes : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteAttributes
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeAttributes_1) { Attribute = new VariationAttribute("Call WriteAttributes with default DTD attributes = true") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_2) { Attribute = new VariationAttribute("Call WriteAttributes with default DTD attributes = false") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_3) { Attribute = new VariationAttribute("Call WriteAttributes with XmlReader = null") { Id = 3 } });
-                    this.AddChild(new TestVariation(writeAttributes_4) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located on element") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_5) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located in the mIddle attribute") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_6) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located in the last attribute") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_8) { Attribute = new VariationAttribute("Call WriteAttributes with reader on XmlDeclaration") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on Text") { Param = "Text", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on PI") { Param = "ProcessingInstruction", Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on Comment") { Param = "Comment", Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on CDATA") { Param = "CDATA", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_12) { Attribute = new VariationAttribute("Call WriteAttributes with 100 attributes") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_13) { Attribute = new VariationAttribute("WriteAttributes with different builtin entities in attribute value") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeAttributes_14) { Attribute = new VariationAttribute("WriteAttributes tries to duplicate attribute") { Id = 21, Priority = 1 } });
+                    var tcWriteAttributes = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteAttributes();
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_1) { Attribute = new VariationAttribute("Call WriteAttributes with default DTD attributes = true") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_2) { Attribute = new VariationAttribute("Call WriteAttributes with default DTD attributes = false") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_3) { Attribute = new VariationAttribute("Call WriteAttributes with XmlReader = null") { Id = 3 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_4) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located on element") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_5) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located in the mIddle attribute") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_6) { Attribute = new VariationAttribute("Call WriteAttributes when reader is located in the last attribute") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_8) { Attribute = new VariationAttribute("Call WriteAttributes with reader on XmlDeclaration") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on Text") { Param = "Text", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on PI") { Param = "ProcessingInstruction", Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on Comment") { Param = "Comment", Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_9) { Attribute = new VariationAttribute("Call WriteAttributes with reader on CDATA") { Param = "CDATA", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_12) { Attribute = new VariationAttribute("Call WriteAttributes with 100 attributes") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_13) { Attribute = new VariationAttribute("WriteAttributes with different builtin entities in attribute value") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteAttributes.writeAttributes_14) { Attribute = new VariationAttribute("WriteAttributes tries to duplicate attribute") { Id = 21, Priority = 1 } });
                 }
             }
-            public partial class TCWriteNode_XmlReader : BridgeHelpers
+            public class TCWriteNode_XmlReader : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteNode_XmlReader
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeNode_XmlReader1) { Attribute = new VariationAttribute("WriteNode with null reader") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader2) { Attribute = new VariationAttribute("WriteNode with reader positioned on attribute, no operation") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader3) { Attribute = new VariationAttribute("WriteNode before reader.Read()") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader4) { Attribute = new VariationAttribute("WriteNode after first reader.Read()") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader5) { Attribute = new VariationAttribute("WriteNode when reader is positioned on mIddle of an element node") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader6) { Attribute = new VariationAttribute("WriteNode when reader state is EOF") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader7) { Attribute = new VariationAttribute("WriteNode when reader state is Closed") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader8) { Attribute = new VariationAttribute("WriteNode with reader on empty element node") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader9) { Attribute = new VariationAttribute("WriteNode with reader on 100 Nodes") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader10) { Attribute = new VariationAttribute("WriteNode with reader on node with mixed content") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader11) { Attribute = new VariationAttribute("WriteNode with reader on node with declared namespace in parent") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader14) { Attribute = new VariationAttribute("WriteNode with element that has different prefix") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader15) { Attribute = new VariationAttribute("Call WriteNode with default attributes = true and DTD") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader16) { Attribute = new VariationAttribute("Call WriteNode with default attributes = false and DTD") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader17) { Attribute = new VariationAttribute("WriteNode with reader on empty element with attributes") { Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader18) { Attribute = new VariationAttribute("WriteNode with document containing just empty element with attributes") { Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader19) { Attribute = new VariationAttribute("Call WriteNode with special entity references as attribute value") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader21) { Attribute = new VariationAttribute("Call WriteNode with full end element") { Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader22) { Attribute = new VariationAttribute("Call WriteNode with reader on element with 100 attributes") { Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader23) { Attribute = new VariationAttribute("Call WriteNode with reader on text node") { Id = 23, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader24) { Attribute = new VariationAttribute("Call WriteNode with reader on CDATA node") { Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader25) { Attribute = new VariationAttribute("Call WriteNode with reader on PI node") { Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader26) { Attribute = new VariationAttribute("Call WriteNode with reader on Comment node") { Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader27) { Attribute = new VariationAttribute("WriteNode should only write required namespaces") { Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader28) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, include xmlns:xml") { Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader29) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, exclude xmlns:xml") { Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader30) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at top level") { Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader31) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at same level") { Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader32) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at both levels") { Id = 32, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader33) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change ns uri for same prefix") { Id = 33, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNode_XmlReader34) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, reuse prefix from top level") { Id = 34, Priority = 1 } });
+                    var tcWriteNodeXmlReader = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteNode_XmlReader();
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader1) { Attribute = new VariationAttribute("WriteNode with null reader") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader2) { Attribute = new VariationAttribute("WriteNode with reader positioned on attribute, no operation") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader3) { Attribute = new VariationAttribute("WriteNode before reader.Read()") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader4) { Attribute = new VariationAttribute("WriteNode after first reader.Read()") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader5) { Attribute = new VariationAttribute("WriteNode when reader is positioned on mIddle of an element node") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader6) { Attribute = new VariationAttribute("WriteNode when reader state is EOF") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader7) { Attribute = new VariationAttribute("WriteNode when reader state is Closed") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader8) { Attribute = new VariationAttribute("WriteNode with reader on empty element node") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader9) { Attribute = new VariationAttribute("WriteNode with reader on 100 Nodes") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader10) { Attribute = new VariationAttribute("WriteNode with reader on node with mixed content") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader11) { Attribute = new VariationAttribute("WriteNode with reader on node with declared namespace in parent") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader14) { Attribute = new VariationAttribute("WriteNode with element that has different prefix") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader15) { Attribute = new VariationAttribute("Call WriteNode with default attributes = true and DTD") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader16) { Attribute = new VariationAttribute("Call WriteNode with default attributes = false and DTD") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader17) { Attribute = new VariationAttribute("WriteNode with reader on empty element with attributes") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader18) { Attribute = new VariationAttribute("WriteNode with document containing just empty element with attributes") { Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader19) { Attribute = new VariationAttribute("Call WriteNode with special entity references as attribute value") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader21) { Attribute = new VariationAttribute("Call WriteNode with full end element") { Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader22) { Attribute = new VariationAttribute("Call WriteNode with reader on element with 100 attributes") { Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader23) { Attribute = new VariationAttribute("Call WriteNode with reader on text node") { Id = 23, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader24) { Attribute = new VariationAttribute("Call WriteNode with reader on CDATA node") { Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader25) { Attribute = new VariationAttribute("Call WriteNode with reader on PI node") { Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader26) { Attribute = new VariationAttribute("Call WriteNode with reader on Comment node") { Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader27) { Attribute = new VariationAttribute("WriteNode should only write required namespaces") { Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader28) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, include xmlns:xml") { Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader29) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, exclude xmlns:xml") { Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader30) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at top level") { Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader31) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at same level") { Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader32) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change default ns at both levels") { Id = 32, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader33) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, change ns uri for same prefix") { Id = 33, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNodeXmlReader.writeNode_XmlReader34) { Attribute = new VariationAttribute("WriteNode should only write required namespaces, reuse prefix from top level") { Id = 34, Priority = 1 } });
                 }
             }
 
-            public partial class TCFullEndElement : BridgeHelpers
+            public class TCFullEndElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCFullEndElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(fullEndElement_1) { Attribute = new VariationAttribute("Sanity test for WriteFullEndElement()") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(fullEndElement_2) { Attribute = new VariationAttribute("Call WriteFullEndElement before calling WriteStartElement") { Id = 2, Priority = 2 } });
-                    this.AddChild(new TestVariation(fullEndElement_3) { Attribute = new VariationAttribute("Call WriteFullEndElement after WriteEndElement") { Id = 3, Priority = 2 } });
-                    this.AddChild(new TestVariation(fullEndElement_4) { Attribute = new VariationAttribute("Call WriteFullEndElement without closing attributes") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(fullEndElement_5) { Attribute = new VariationAttribute("Call WriteFullEndElement after WriteStartAttribute") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(fullEndElement_6) { Attribute = new VariationAttribute("WriteFullEndElement for 100 nested elements") { Id = 6, Priority = 1 } });
+                    var tcFullEndElement = new CommonTestsFunctionalTests.XNodeBuilderTests.TCFullEndElement();
+                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_1) { Attribute = new VariationAttribute("Sanity test for WriteFullEndElement()") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_2) { Attribute = new VariationAttribute("Call WriteFullEndElement before calling WriteStartElement") { Id = 2, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_3) { Attribute = new VariationAttribute("Call WriteFullEndElement after WriteEndElement") { Id = 3, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_4) { Attribute = new VariationAttribute("Call WriteFullEndElement without closing attributes") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_5) { Attribute = new VariationAttribute("Call WriteFullEndElement after WriteStartAttribute") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcFullEndElement.fullEndElement_6) { Attribute = new VariationAttribute("WriteFullEndElement for 100 nested elements") { Id = 6, Priority = 1 } });
                 }
             }
-            public partial class TCElemNamespace : BridgeHelpers
+            public class TCElemNamespace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCElemNamespace
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(elemNamespace_1) { Attribute = new VariationAttribute("Multiple NS decl for same prefix on an element") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_2) { Attribute = new VariationAttribute("Multiple NS decl for same prefix (same NS value) on an element") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_3) { Attribute = new VariationAttribute("Element and attribute have same prefix, but different namespace value") { Id = 3, Priority = 2 } });
-                    this.AddChild(new TestVariation(elemNamespace_4) { Attribute = new VariationAttribute("Nested elements have same prefix, but different namespace") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_5) { Attribute = new VariationAttribute("Mapping reserved prefix xml to invalid namespace") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_6) { Attribute = new VariationAttribute("Mapping reserved prefix xml to correct namespace") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_7) { Attribute = new VariationAttribute("Write element with prefix beginning with xml") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_8) { Attribute = new VariationAttribute("Reuse prefix that refers the same as default namespace") { Id = 8, Priority = 2 } });
-                    this.AddChild(new TestVariation(elemNamespace_9) { Attribute = new VariationAttribute("Should throw error for prefix=xmlns") { Id = 9, Priority = 2 } });
-                    this.AddChild(new TestVariation(elemNamespace_10) { Attribute = new VariationAttribute("Create nested element without prefix but with namespace of parent element with a defined prefix") { Id = 10, Priority = 2 } });
-                    this.AddChild(new TestVariation(elemNamespace_11) { Attribute = new VariationAttribute("Create different prefix for element and attribute that have same namespace") { Id = 11, Priority = 2 } });
-                    this.AddChild(new TestVariation(elemNamespace_12) { Attribute = new VariationAttribute("Create same prefix for element and attribute that have same namespace") { Id = 12, Priority = 2 } });
-                    this.AddChild(new TestVariation(elemNamespace_13) { Attribute = new VariationAttribute("Try to re-define NS prefix on attribute which is already defined on an element") { Id = 13, Priority = 2 } });
-                    this.AddChild(new TestVariation(elemNamespace_14) { Attribute = new VariationAttribute("Namespace string contains surrogates, reuse at different levels") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_15) { Attribute = new VariationAttribute("Namespace containing entities, use at multiple levels") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_16) { Attribute = new VariationAttribute("Verify it resets default namespace when redefined earlier in the stack") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_17) { Attribute = new VariationAttribute("The default namespace for an element can not be changed once it is written out") { Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_18) { Attribute = new VariationAttribute("Map XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_19) { Attribute = new VariationAttribute("Pass NULL as NS to WriteStartElement") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_20) { Attribute = new VariationAttribute("Write element in reserved XML namespace, should error") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_21) { Attribute = new VariationAttribute("Write element in reserved XMLNS namespace, should error") { Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_22) { Attribute = new VariationAttribute("Mapping a prefix to empty ns should error") { Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_23) { Attribute = new VariationAttribute("Pass null prefix to WriteStartElement()") { Id = 23, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_24) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteStartElement()") { Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_25) { Attribute = new VariationAttribute("Pass null ns to WriteStartElement()") { Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_26) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement()") { Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_27) { Attribute = new VariationAttribute("Pass null prefix to WriteStartElement() when namespace is in scope") { Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_28) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteStartElement() when namespace is in scope") { Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_29) { Attribute = new VariationAttribute("Pass null ns to WriteStartElement() when prefix is in scope") { Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_30) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement() when prefix is in scope") { Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_31) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement() when prefix is in scope") { Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(elemNamespace_32) { Attribute = new VariationAttribute("Mapping empty ns uri to a prefix should error") { Id = 31, Priority = 1 } });
+                    var tcElemNamespace = new CommonTestsFunctionalTests.XNodeBuilderTests.TCElemNamespace();
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_1) { Attribute = new VariationAttribute("Multiple NS decl for same prefix on an element") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_2) { Attribute = new VariationAttribute("Multiple NS decl for same prefix (same NS value) on an element") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_3) { Attribute = new VariationAttribute("Element and attribute have same prefix, but different namespace value") { Id = 3, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_4) { Attribute = new VariationAttribute("Nested elements have same prefix, but different namespace") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_5) { Attribute = new VariationAttribute("Mapping reserved prefix xml to invalid namespace") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_6) { Attribute = new VariationAttribute("Mapping reserved prefix xml to correct namespace") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_7) { Attribute = new VariationAttribute("Write element with prefix beginning with xml") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_8) { Attribute = new VariationAttribute("Reuse prefix that refers the same as default namespace") { Id = 8, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_9) { Attribute = new VariationAttribute("Should throw error for prefix=xmlns") { Id = 9, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_10) { Attribute = new VariationAttribute("Create nested element without prefix but with namespace of parent element with a defined prefix") { Id = 10, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_11) { Attribute = new VariationAttribute("Create different prefix for element and attribute that have same namespace") { Id = 11, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_12) { Attribute = new VariationAttribute("Create same prefix for element and attribute that have same namespace") { Id = 12, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_13) { Attribute = new VariationAttribute("Try to re-define NS prefix on attribute which is already defined on an element") { Id = 13, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_14) { Attribute = new VariationAttribute("Namespace string contains surrogates, reuse at different levels") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_15) { Attribute = new VariationAttribute("Namespace containing entities, use at multiple levels") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_16) { Attribute = new VariationAttribute("Verify it resets default namespace when redefined earlier in the stack") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_17) { Attribute = new VariationAttribute("The default namespace for an element can not be changed once it is written out") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_18) { Attribute = new VariationAttribute("Map XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_19) { Attribute = new VariationAttribute("Pass NULL as NS to WriteStartElement") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_20) { Attribute = new VariationAttribute("Write element in reserved XML namespace, should error") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_21) { Attribute = new VariationAttribute("Write element in reserved XMLNS namespace, should error") { Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_22) { Attribute = new VariationAttribute("Mapping a prefix to empty ns should error") { Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_23) { Attribute = new VariationAttribute("Pass null prefix to WriteStartElement()") { Id = 23, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_24) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteStartElement()") { Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_25) { Attribute = new VariationAttribute("Pass null ns to WriteStartElement()") { Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_26) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement()") { Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_27) { Attribute = new VariationAttribute("Pass null prefix to WriteStartElement() when namespace is in scope") { Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_28) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteStartElement() when namespace is in scope") { Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_29) { Attribute = new VariationAttribute("Pass null ns to WriteStartElement() when prefix is in scope") { Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_30) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement() when prefix is in scope") { Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_31) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteStartElement() when prefix is in scope") { Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcElemNamespace.elemNamespace_32) { Attribute = new VariationAttribute("Mapping empty ns uri to a prefix should error") { Id = 31, Priority = 1 } });
                 }
             }
-            public partial class TCAttrNamespace : BridgeHelpers
+            public class TCAttrNamespace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCAttrNamespace
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(attrNamespace_1) { Attribute = new VariationAttribute("Define prefix 'xml' with invalid namespace URI 'foo'") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_2) { Attribute = new VariationAttribute("Bind NS prefix 'xml' with valid namespace URI") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_3) { Attribute = new VariationAttribute("Bind NS prefix 'xmlA' with namespace URI 'foo'") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_4) { Attribute = new VariationAttribute("Write attribute xml:space with correct namespace") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_5) { Attribute = new VariationAttribute("Write attribute xml:space with incorrect namespace") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_6) { Attribute = new VariationAttribute("Write attribute xml:lang with incorrect namespace") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_7) { Attribute = new VariationAttribute("WriteAttribute, define namespace attribute before value attribute") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_8) { Attribute = new VariationAttribute("WriteAttribute, define namespace attribute after value attribute") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_9) { Attribute = new VariationAttribute("WriteAttribute, redefine prefix at different scope and use both of them") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_10) { Attribute = new VariationAttribute("WriteAttribute, redefine namespace at different scope and use both of them") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_11) { Attribute = new VariationAttribute("WriteAttribute with collIding prefix with element") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_12) { Attribute = new VariationAttribute("WriteAttribute with collIding namespace with element") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_13) { Attribute = new VariationAttribute("WriteAttribute with namespace but no prefix") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_14) { Attribute = new VariationAttribute("WriteAttribute for 2 attributes with same prefix but different namespace") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_15) { Attribute = new VariationAttribute("WriteAttribute with String.Empty and null as namespace and prefix values") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_16) { Attribute = new VariationAttribute("WriteAttribute to manually create attribute of xmlns:x") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_17) { Attribute = new VariationAttribute("WriteAttribute with namespace value = null while a prefix exists") { Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_18) { Attribute = new VariationAttribute("WriteAttribute with namespace value = String.Empty while a prefix exists") { Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_19) { Attribute = new VariationAttribute("WriteAttribe in nested elements with same namespace but different prefix") { Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_20) { Attribute = new VariationAttribute("WriteAttribute for x:a and xmlns:a diff namespace") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_21) { Attribute = new VariationAttribute("WriteAttribute for x:a and xmlns:a same namespace") { Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_22) { Attribute = new VariationAttribute("WriteAttribute with collIding NS and prefix for 2 attributes") { Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_23) { Attribute = new VariationAttribute("WriteAttribute with DQ in namespace") { Id = 23, Priority = 2 } });
-                    this.AddChild(new TestVariation(attrNamespace_24) { Attribute = new VariationAttribute("Attach prefix with empty namespace") { Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_25) { Attribute = new VariationAttribute("Explicitly write namespace attribute that maps XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_26) { Attribute = new VariationAttribute("Map XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_27) { Attribute = new VariationAttribute("Pass empty namespace to WriteAttributeString(prefix, name, ns, value)") { Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_28) { Attribute = new VariationAttribute("Write attribute with prefix = xmlns") { Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_29) { Attribute = new VariationAttribute("Write attribute in reserved XML namespace, should error") { Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_30) { Attribute = new VariationAttribute("Write attribute in reserved XMLNS namespace, should error") { Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_31) { Attribute = new VariationAttribute("WriteAttributeString with no namespace under element with empty prefix") { Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_32) { Attribute = new VariationAttribute("Pass null prefix to WriteAttributeString()") { Id = 32, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_33) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteAttributeString()") { Id = 33, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_34) { Attribute = new VariationAttribute("Pass null ns to WriteAttributeString()") { Id = 34, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_35) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteAttributeString()") { Id = 35, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_36) { Attribute = new VariationAttribute("Pass null prefix to WriteAttributeString() when namespace is in scope") { Id = 36, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_37) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteAttributeString() when namespace is in scope") { Id = 37, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_38) { Attribute = new VariationAttribute("Pass null ns to WriteAttributeString() when prefix is in scope") { Id = 38, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_39) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteAttributeString() when prefix is in scope") { Id = 39, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_40) { Attribute = new VariationAttribute("Mapping empty ns uri to a prefix should error") { Id = 40, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_41) { Attribute = new VariationAttribute("WriteStartAttribute with prefix = null, localName = xmlns - case 1") { Id = 41, Priority = 1 } });
-                    this.AddChild(new TestVariation(attrNamespace_42) { Attribute = new VariationAttribute("WriteStartAttribute with prefix = null, localName = xmlns - case 2") { Id = 42, Priority = 1 } });
+                    var tcAttrNamespace = new CommonTestsFunctionalTests.XNodeBuilderTests.TCAttrNamespace();
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_1) { Attribute = new VariationAttribute("Define prefix 'xml' with invalid namespace URI 'foo'") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_2) { Attribute = new VariationAttribute("Bind NS prefix 'xml' with valid namespace URI") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_3) { Attribute = new VariationAttribute("Bind NS prefix 'xmlA' with namespace URI 'foo'") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_4) { Attribute = new VariationAttribute("Write attribute xml:space with correct namespace") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_5) { Attribute = new VariationAttribute("Write attribute xml:space with incorrect namespace") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_6) { Attribute = new VariationAttribute("Write attribute xml:lang with incorrect namespace") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_7) { Attribute = new VariationAttribute("WriteAttribute, define namespace attribute before value attribute") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_8) { Attribute = new VariationAttribute("WriteAttribute, define namespace attribute after value attribute") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_9) { Attribute = new VariationAttribute("WriteAttribute, redefine prefix at different scope and use both of them") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_10) { Attribute = new VariationAttribute("WriteAttribute, redefine namespace at different scope and use both of them") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_11) { Attribute = new VariationAttribute("WriteAttribute with collIding prefix with element") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_12) { Attribute = new VariationAttribute("WriteAttribute with collIding namespace with element") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_13) { Attribute = new VariationAttribute("WriteAttribute with namespace but no prefix") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_14) { Attribute = new VariationAttribute("WriteAttribute for 2 attributes with same prefix but different namespace") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_15) { Attribute = new VariationAttribute("WriteAttribute with String.Empty and null as namespace and prefix values") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_16) { Attribute = new VariationAttribute("WriteAttribute to manually create attribute of xmlns:x") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_17) { Attribute = new VariationAttribute("WriteAttribute with namespace value = null while a prefix exists") { Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_18) { Attribute = new VariationAttribute("WriteAttribute with namespace value = String.Empty while a prefix exists") { Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_19) { Attribute = new VariationAttribute("WriteAttribe in nested elements with same namespace but different prefix") { Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_20) { Attribute = new VariationAttribute("WriteAttribute for x:a and xmlns:a diff namespace") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_21) { Attribute = new VariationAttribute("WriteAttribute for x:a and xmlns:a same namespace") { Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_22) { Attribute = new VariationAttribute("WriteAttribute with collIding NS and prefix for 2 attributes") { Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_23) { Attribute = new VariationAttribute("WriteAttribute with DQ in namespace") { Id = 23, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_24) { Attribute = new VariationAttribute("Attach prefix with empty namespace") { Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_25) { Attribute = new VariationAttribute("Explicitly write namespace attribute that maps XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_26) { Attribute = new VariationAttribute("Map XML NS 'http://www.w3.org/XML/1998/namaespace' to another prefix") { Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_27) { Attribute = new VariationAttribute("Pass empty namespace to WriteAttributeString(prefix, name, ns, value)") { Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_28) { Attribute = new VariationAttribute("Write attribute with prefix = xmlns") { Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_29) { Attribute = new VariationAttribute("Write attribute in reserved XML namespace, should error") { Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_30) { Attribute = new VariationAttribute("Write attribute in reserved XMLNS namespace, should error") { Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_31) { Attribute = new VariationAttribute("WriteAttributeString with no namespace under element with empty prefix") { Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_32) { Attribute = new VariationAttribute("Pass null prefix to WriteAttributeString()") { Id = 32, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_33) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteAttributeString()") { Id = 33, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_34) { Attribute = new VariationAttribute("Pass null ns to WriteAttributeString()") { Id = 34, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_35) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteAttributeString()") { Id = 35, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_36) { Attribute = new VariationAttribute("Pass null prefix to WriteAttributeString() when namespace is in scope") { Id = 36, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_37) { Attribute = new VariationAttribute("Pass String.Empty prefix to WriteAttributeString() when namespace is in scope") { Id = 37, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_38) { Attribute = new VariationAttribute("Pass null ns to WriteAttributeString() when prefix is in scope") { Id = 38, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_39) { Attribute = new VariationAttribute("Pass String.Empty ns to WriteAttributeString() when prefix is in scope") { Id = 39, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_40) { Attribute = new VariationAttribute("Mapping empty ns uri to a prefix should error") { Id = 40, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_41) { Attribute = new VariationAttribute("WriteStartAttribute with prefix = null, localName = xmlns - case 1") { Id = 41, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAttrNamespace.attrNamespace_42) { Attribute = new VariationAttribute("WriteStartAttribute with prefix = null, localName = xmlns - case 2") { Id = 42, Priority = 1 } });
                 }
             }
-            public partial class TCCData : BridgeHelpers
+            public class TCCData : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCCData
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(CData_1) { Attribute = new VariationAttribute("WriteCData with null") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(CData_2) { Attribute = new VariationAttribute("WriteCData with String.Empty") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(CData_3) { Attribute = new VariationAttribute("WriteCData Sanity test") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(CData_4) { Attribute = new VariationAttribute("WriteCData with valid surrogate pair") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(CData_6) { Attribute = new VariationAttribute("WriteCData with & < > chars, they should not be escaped") { Id = 6, Priority = 2 } });
-                    this.AddChild(new TestVariation(CData_7) { Attribute = new VariationAttribute("WriteCData with <![CDATA[") { Id = 7, Priority = 2 } });
-                    this.AddChild(new TestVariation(CData_8) { Attribute = new VariationAttribute("CData state machine") { Id = 8, Priority = 2 } });
-                    this.AddChild(new TestVariation(CData_9) { Attribute = new VariationAttribute("WriteCData with invalid surrogate pair") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(CData_10) { Attribute = new VariationAttribute("WriteCData after root element") { Id = 10 } });
-                    this.AddChild(new TestVariation(CData_11) { Attribute = new VariationAttribute("Call WriteCData twice - that should write two CData blocks") { Id = 11, Priority = 1 } });
+                    var tcCData = new CommonTestsFunctionalTests.XNodeBuilderTests.TCCData();
+                    this.AddChild(new TestVariation(tcCData.CData_1) { Attribute = new VariationAttribute("WriteCData with null") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCData.CData_2) { Attribute = new VariationAttribute("WriteCData with String.Empty") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCData.CData_3) { Attribute = new VariationAttribute("WriteCData Sanity test") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcCData.CData_4) { Attribute = new VariationAttribute("WriteCData with valid surrogate pair") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCData.CData_6) { Attribute = new VariationAttribute("WriteCData with & < > chars, they should not be escaped") { Id = 6, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcCData.CData_7) { Attribute = new VariationAttribute("WriteCData with <![CDATA[") { Id = 7, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcCData.CData_8) { Attribute = new VariationAttribute("CData state machine") { Id = 8, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcCData.CData_9) { Attribute = new VariationAttribute("WriteCData with invalid surrogate pair") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCData.CData_10) { Attribute = new VariationAttribute("WriteCData after root element") { Id = 10 } });
+                    this.AddChild(new TestVariation(tcCData.CData_11) { Attribute = new VariationAttribute("Call WriteCData twice - that should write two CData blocks") { Id = 11, Priority = 1 } });
                 }
             }
-            public partial class TCComment : BridgeHelpers
+            public class TCComment : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCComment
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(comment_1) { Attribute = new VariationAttribute("Sanity test for WriteComment") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(comment_2) { Attribute = new VariationAttribute("Comment value = String.Empty") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(comment_3) { Attribute = new VariationAttribute("Comment value = null") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(comment_4) { Attribute = new VariationAttribute("WriteComment with valid surrogate pair") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(comment_5) { Attribute = new VariationAttribute("WriteComment with invalid surrogate pair") { Id = 5, Priority = 1 } });
+                    var tcComment = new CommonTestsFunctionalTests.XNodeBuilderTests.TCComment();
+                    this.AddChild(new TestVariation(tcComment.comment_1) { Attribute = new VariationAttribute("Sanity test for WriteComment") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcComment.comment_2) { Attribute = new VariationAttribute("Comment value = String.Empty") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcComment.comment_3) { Attribute = new VariationAttribute("Comment value = null") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcComment.comment_4) { Attribute = new VariationAttribute("WriteComment with valid surrogate pair") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcComment.comment_5) { Attribute = new VariationAttribute("WriteComment with invalid surrogate pair") { Id = 5, Priority = 1 } });
                 }
             }
-            public partial class TCEntityRef : BridgeHelpers
+            public class TCEntityRef : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCEntityRef
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value SQ") { Param = "test'test", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value <;") { Param = "test<test", Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value & and ;") { Param = "&test;", Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with value = null") { Param = "null", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value DQ") { Param = "test\"test", Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xD") { Param = "\xD", Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value &") { Param = "test&test", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with value = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xD#xA") { Param = "\xD\xA", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xA") { Param = "\r", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value >") { Param = "test>test", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_2) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: amp") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_3) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: apos") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: lt") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: quot") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(entityRef_6) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: gt") { Id = 16, Priority = 1 } });
+                    var tcEntityRef = new CommonTestsFunctionalTests.XNodeBuilderTests.TCEntityRef();
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value SQ") { Param = "test'test", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value <;") { Param = "test<test", Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value & and ;") { Param = "&test;", Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with value = null") { Param = "null", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value DQ") { Param = "test\"test", Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xD") { Param = "\xD", Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value &") { Param = "test&test", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with value = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xD#xA") { Param = "\xD\xA", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with #xA") { Param = "\r", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_1) { Attribute = new VariationAttribute("WriteEntityRef with invalid value >") { Param = "test>test", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_2) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: amp") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_3) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: apos") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.var_4) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: lt") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.var_5) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: quot") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEntityRef.entityRef_6) { Attribute = new VariationAttribute("XmlWriter: Entity Refs: gt") { Id = 16, Priority = 1 } });
                 }
             }
-            public partial class TCCharEntity : BridgeHelpers
+            public class TCCharEntity : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCCharEntity
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(charEntity_1) { Attribute = new VariationAttribute("WriteCharEntity with valid Unicode character") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(charEntity_2) { Attribute = new VariationAttribute("Call WriteCharEntity after WriteStartElement/WriteEndElement") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(charEntity_3) { Attribute = new VariationAttribute("Call WriteCharEntity after WriteStartAttribute/WriteEndAttribute") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(charEntity_4) { Attribute = new VariationAttribute("Character from low surrogate range") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(charEntity_5) { Attribute = new VariationAttribute("Character from high surrogate range") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(charEntity_7) { Attribute = new VariationAttribute("Sanity test, pass 'a'") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(charEntity_8) { Attribute = new VariationAttribute("WriteCharEntity for special attributes") { Id = 8, Priority = 1 } });
+                    var tcCharEntity = new CommonTestsFunctionalTests.XNodeBuilderTests.TCCharEntity();
+                    this.AddChild(new TestVariation(tcCharEntity.charEntity_1) { Attribute = new VariationAttribute("WriteCharEntity with valid Unicode character") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcCharEntity.charEntity_2) { Attribute = new VariationAttribute("Call WriteCharEntity after WriteStartElement/WriteEndElement") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcCharEntity.charEntity_3) { Attribute = new VariationAttribute("Call WriteCharEntity after WriteStartAttribute/WriteEndAttribute") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcCharEntity.charEntity_4) { Attribute = new VariationAttribute("Character from low surrogate range") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCharEntity.charEntity_5) { Attribute = new VariationAttribute("Character from high surrogate range") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCharEntity.charEntity_7) { Attribute = new VariationAttribute("Sanity test, pass 'a'") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcCharEntity.charEntity_8) { Attribute = new VariationAttribute("WriteCharEntity for special attributes") { Id = 8, Priority = 1 } });
                 }
             }
-            public partial class TCSurrogateCharEntity : BridgeHelpers
+            public class TCSurrogateCharEntity : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCSurrogateCharEntity
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(surrogateEntity_1) { Attribute = new VariationAttribute("SurrogateCharEntity after WriteStartElement/WriteEndElement") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(surrogateEntity_2) { Attribute = new VariationAttribute("SurrogateCharEntity after WriteStartAttribute/WriteEndAttribute") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(surrogateEntity_3) { Attribute = new VariationAttribute("Test with limits of surrogate range") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(surrogateEntity_4) { Attribute = new VariationAttribute("MIddle surrogate character") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(surrogateEntity_5) { Attribute = new VariationAttribute("Invalid high surrogate character") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(surrogateEntity_6) { Attribute = new VariationAttribute("Invalid low surrogate character") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(surrogateEntity_7) { Attribute = new VariationAttribute("Swap high-low surrogate characters") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(surrogateEntity_8) { Attribute = new VariationAttribute("WriteSurrogateCharEntity for special attributes") { Id = 8, Priority = 1 } });
+                    var tcSurrogateCharEntity = new CommonTestsFunctionalTests.XNodeBuilderTests.TCSurrogateCharEntity();
+                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_1) { Attribute = new VariationAttribute("SurrogateCharEntity after WriteStartElement/WriteEndElement") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_2) { Attribute = new VariationAttribute("SurrogateCharEntity after WriteStartAttribute/WriteEndAttribute") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_3) { Attribute = new VariationAttribute("Test with limits of surrogate range") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_4) { Attribute = new VariationAttribute("MIddle surrogate character") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_5) { Attribute = new VariationAttribute("Invalid high surrogate character") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_6) { Attribute = new VariationAttribute("Invalid low surrogate character") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_7) { Attribute = new VariationAttribute("Swap high-low surrogate characters") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcSurrogateCharEntity.surrogateEntity_8) { Attribute = new VariationAttribute("WriteSurrogateCharEntity for special attributes") { Id = 8, Priority = 1 } });
                 }
             }
-            public partial class TCPI : BridgeHelpers
+            public class TCPI : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCPI
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(pi_1) { Attribute = new VariationAttribute("Sanity test for WritePI") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(pi_2) { Attribute = new VariationAttribute("PI text value = null") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(pi_3) { Attribute = new VariationAttribute("PI text value = String.Empty") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(pi_4) { Attribute = new VariationAttribute("PI name = null should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(pi_5) { Attribute = new VariationAttribute("PI name = String.Empty should error") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(pi_6) { Attribute = new VariationAttribute("WritePI with xmlns as the name value") { Id = 6 } });
-                    this.AddChild(new TestVariation(pi_7) { Attribute = new VariationAttribute("WritePI with XmL as the name value") { Id = 7 } });
-                    this.AddChild(new TestVariation(pi_8) { Attribute = new VariationAttribute("WritePI before XmlDecl") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(pi_9) { Attribute = new VariationAttribute("WritePI (after StartDocument) with name = 'xml' text = 'version = 1.0' should error") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(pi_10) { Attribute = new VariationAttribute("WritePI (before StartDocument) with name = 'xml' text = 'version = 1.0' should error") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(pi_12) { Attribute = new VariationAttribute("WriteProcessingInstruction with valid surrogate pair") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(pi_13) { Attribute = new VariationAttribute("WritePI with invalid surrogate pair") { Id = 13, Priority = 1 } });
+                    var tcPI = new CommonTestsFunctionalTests.XNodeBuilderTests.TCPI();
+                    this.AddChild(new TestVariation(tcPI.pi_1) { Attribute = new VariationAttribute("Sanity test for WritePI") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcPI.pi_2) { Attribute = new VariationAttribute("PI text value = null") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcPI.pi_3) { Attribute = new VariationAttribute("PI text value = String.Empty") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcPI.pi_4) { Attribute = new VariationAttribute("PI name = null should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcPI.pi_5) { Attribute = new VariationAttribute("PI name = String.Empty should error") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcPI.pi_6) { Attribute = new VariationAttribute("WritePI with xmlns as the name value") { Id = 6 } });
+                    this.AddChild(new TestVariation(tcPI.pi_7) { Attribute = new VariationAttribute("WritePI with XmL as the name value") { Id = 7 } });
+                    this.AddChild(new TestVariation(tcPI.pi_8) { Attribute = new VariationAttribute("WritePI before XmlDecl") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcPI.pi_9) { Attribute = new VariationAttribute("WritePI (after StartDocument) with name = 'xml' text = 'version = 1.0' should error") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcPI.pi_10) { Attribute = new VariationAttribute("WritePI (before StartDocument) with name = 'xml' text = 'version = 1.0' should error") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcPI.pi_12) { Attribute = new VariationAttribute("WriteProcessingInstruction with valid surrogate pair") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcPI.pi_13) { Attribute = new VariationAttribute("WritePI with invalid surrogate pair") { Id = 13, Priority = 1 } });
                 }
             }
-            public partial class TCWriteNmToken : BridgeHelpers
+            public class TCWriteNmToken : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteNmToken
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeNmToken_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNmToken_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNmToken_2) { Attribute = new VariationAttribute("Sanity test, Name = foo") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNmToken_3) { Attribute = new VariationAttribute("Name contains letters, digits, . _ - : chars") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNmToken_4) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "test test", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNmToken_4) { Attribute = new VariationAttribute("Name contains ? char") { Param = "test?", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNmToken_4) { Attribute = new VariationAttribute("Name contains DQ") { Param = "\"test", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeNmToken_4) { Attribute = new VariationAttribute("Name contains SQ") { Param = "test'", Id = 6, Priority = 1 } });
+                    var tcWriteNmToken = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteNmToken();
+                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_2) { Attribute = new VariationAttribute("Sanity test, Name = foo") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_3) { Attribute = new VariationAttribute("Name contains letters, digits, . _ - : chars") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_4) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "test test", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_4) { Attribute = new VariationAttribute("Name contains ? char") { Param = "test?", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_4) { Attribute = new VariationAttribute("Name contains DQ") { Param = "\"test", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteNmToken.writeNmToken_4) { Attribute = new VariationAttribute("Name contains SQ") { Param = "test'", Id = 6, Priority = 1 } });
                 }
             }
-            public partial class TCWriteName : BridgeHelpers
+            public class TCWriteName : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteName
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeName_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeName_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeName_2) { Attribute = new VariationAttribute("Sanity test, Name = foo") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeName_3) { Attribute = new VariationAttribute("Sanity test, Name = foo:bar") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeName_4) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "foo bar", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeName_4) { Attribute = new VariationAttribute("Name starts with :") { Param = ":bar", Id = 4, Priority = 1 } });
+                    var tcWriteName = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteName();
+                    this.AddChild(new TestVariation(tcWriteName.writeName_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteName.writeName_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteName.writeName_2) { Attribute = new VariationAttribute("Sanity test, Name = foo") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteName.writeName_3) { Attribute = new VariationAttribute("Sanity test, Name = foo:bar") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteName.writeName_4) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "foo bar", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteName.writeName_4) { Attribute = new VariationAttribute("Name starts with :") { Param = ":bar", Id = 4, Priority = 1 } });
                 }
             }
-            public partial class TCWriteQName : BridgeHelpers
+            public class TCWriteQName : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteQName
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeQName_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeQName_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeQName_2) { Attribute = new VariationAttribute("WriteQName with correct NS") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeQName_3) { Attribute = new VariationAttribute("WriteQName when NS is auto-generated") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeQName_4) { Attribute = new VariationAttribute("QName = foo:bar when foo is not in scope") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeQName_5) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "foo bar", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeQName_5) { Attribute = new VariationAttribute("Name starts with :") { Param = ":bar", Id = 6, Priority = 1 } });
+                    var tcWriteQName = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteQName();
+                    this.AddChild(new TestVariation(tcWriteQName.writeQName_1) { Attribute = new VariationAttribute("Name = null") { Param = "null", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteQName.writeQName_1) { Attribute = new VariationAttribute("Name = String.Empty") { Param = "String.Empty", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteQName.writeQName_2) { Attribute = new VariationAttribute("WriteQName with correct NS") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteQName.writeQName_3) { Attribute = new VariationAttribute("WriteQName when NS is auto-generated") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteQName.writeQName_4) { Attribute = new VariationAttribute("QName = foo:bar when foo is not in scope") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteQName.writeQName_5) { Attribute = new VariationAttribute("Name contains whitespace char") { Param = "foo bar", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteQName.writeQName_5) { Attribute = new VariationAttribute("Name starts with :") { Param = ":bar", Id = 6, Priority = 1 } });
                 }
             }
-            public partial class TCWriteChars : BridgeHelpers
+            public class TCWriteChars : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteChars
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeChars_1) { Attribute = new VariationAttribute("WriteChars with valid buffer, number, count") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(writeChars_2) { Attribute = new VariationAttribute("WriteChars with & < >") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeChars_3) { Attribute = new VariationAttribute("WriteChars following WriteStartAttribute") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeChars_4) { Attribute = new VariationAttribute("WriteChars with entity ref included") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeChars_5) { Attribute = new VariationAttribute("WriteChars with buffer = null") { Id = 5, Priority = 2 } });
-                    this.AddChild(new TestVariation(writeChars_6) { Attribute = new VariationAttribute("WriteChars with count > buffer size") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeChars_7) { Attribute = new VariationAttribute("WriteChars with count < 0") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeChars_8) { Attribute = new VariationAttribute("WriteChars with index > buffer size") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeChars_9) { Attribute = new VariationAttribute("WriteChars with index < 0") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeChars_10) { Attribute = new VariationAttribute("WriteChars with index + count exceeds buffer") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeChars_11) { Attribute = new VariationAttribute("WriteChars for xml:lang attribute, index = count = 0") { Id = 11, Priority = 1 } });
+                    var tcWriteChars = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteChars();
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_1) { Attribute = new VariationAttribute("WriteChars with valid buffer, number, count") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_2) { Attribute = new VariationAttribute("WriteChars with & < >") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_3) { Attribute = new VariationAttribute("WriteChars following WriteStartAttribute") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_4) { Attribute = new VariationAttribute("WriteChars with entity ref included") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_5) { Attribute = new VariationAttribute("WriteChars with buffer = null") { Id = 5, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_6) { Attribute = new VariationAttribute("WriteChars with count > buffer size") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_7) { Attribute = new VariationAttribute("WriteChars with count < 0") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_8) { Attribute = new VariationAttribute("WriteChars with index > buffer size") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_9) { Attribute = new VariationAttribute("WriteChars with index < 0") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_10) { Attribute = new VariationAttribute("WriteChars with index + count exceeds buffer") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteChars.writeChars_11) { Attribute = new VariationAttribute("WriteChars for xml:lang attribute, index = count = 0") { Id = 11, Priority = 1 } });
                 }
             }
-            public partial class TCWriteString : BridgeHelpers
+            public class TCWriteString : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteString
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeString_1) { Attribute = new VariationAttribute("WriteString(null)") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(writeString_2) { Attribute = new VariationAttribute("WriteString(String.Empty)") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_3) { Attribute = new VariationAttribute("WriteString with valid surrogate pair") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_4) { Attribute = new VariationAttribute("WriteString with invalid surrogate pair") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_5) { Attribute = new VariationAttribute("WriteString with entity reference") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_6) { Attribute = new VariationAttribute("WriteString with single/double quote, &, <, >") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_9) { Attribute = new VariationAttribute("WriteString for value greater than x1F") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_11) { Attribute = new VariationAttribute("WriteString with CR, LF, CR LF inside attribute value") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_12) { Attribute = new VariationAttribute("Call WriteString for LF inside attribute") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_13) { Attribute = new VariationAttribute("Surrogate characters in text nodes, range limits") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_14) { Attribute = new VariationAttribute("High surrogate on last position") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_15) { Attribute = new VariationAttribute("Low surrogate on first position") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeString_16) { Attribute = new VariationAttribute("Swap low-high surrogates") { Id = 16, Priority = 1 } });
+                    var tcWriteString = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteString();
+                    this.AddChild(new TestVariation(tcWriteString.writeString_1) { Attribute = new VariationAttribute("WriteString(null)") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_2) { Attribute = new VariationAttribute("WriteString(String.Empty)") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_3) { Attribute = new VariationAttribute("WriteString with valid surrogate pair") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_4) { Attribute = new VariationAttribute("WriteString with invalid surrogate pair") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_5) { Attribute = new VariationAttribute("WriteString with entity reference") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_6) { Attribute = new VariationAttribute("WriteString with single/double quote, &, <, >") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_9) { Attribute = new VariationAttribute("WriteString for value greater than x1F") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_11) { Attribute = new VariationAttribute("WriteString with CR, LF, CR LF inside attribute value") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_12) { Attribute = new VariationAttribute("Call WriteString for LF inside attribute") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_13) { Attribute = new VariationAttribute("Surrogate characters in text nodes, range limits") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_14) { Attribute = new VariationAttribute("High surrogate on last position") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_15) { Attribute = new VariationAttribute("Low surrogate on first position") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteString.writeString_16) { Attribute = new VariationAttribute("Swap low-high surrogates") { Id = 16, Priority = 1 } });
                 }
             }
-            public partial class TCWhiteSpace : BridgeHelpers
+            public class TCWhiteSpace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWhiteSpace
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(whitespace_3) { Attribute = new VariationAttribute("WriteWhitespace before and after root element") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(whitespace_4) { Attribute = new VariationAttribute("WriteWhitespace with String.Empty ") { Param = "String.Empty", Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(whitespace_4) { Attribute = new VariationAttribute("WriteWhitespace with null ") { Param = "null", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 0, Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 16, Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 97, Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 31, Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 14, Id = 7, Priority = 1 } });
+                    var tcWhiteSpace = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWhiteSpace();
+                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_3) { Attribute = new VariationAttribute("WriteWhitespace before and after root element") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_4) { Attribute = new VariationAttribute("WriteWhitespace with String.Empty ") { Param = "String.Empty", Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_4) { Attribute = new VariationAttribute("WriteWhitespace with null ") { Param = "null", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 0, Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 16, Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 97, Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 31, Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWhiteSpace.whitespace_5) { Attribute = new VariationAttribute("WriteWhitespace with invalid char") { Param = 14, Id = 7, Priority = 1 } });
                 }
             }
-            public partial class TCWriteValue : BridgeHelpers
+            public class TCWriteValue : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteValue
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeValue_1) { Attribute = new VariationAttribute("WriteValue(boolean)") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_2) { Attribute = new VariationAttribute("WriteValue(DateTime)") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_3) { Attribute = new VariationAttribute("WriteValue(decimal)") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_4) { Attribute = new VariationAttribute("WriteValue(double)") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_5) { Attribute = new VariationAttribute("WriteValue(int32)") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_6) { Attribute = new VariationAttribute("WriteValue(int64)") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_7) { Attribute = new VariationAttribute("WriteValue(single)") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_8) { Attribute = new VariationAttribute("WriteValue(string)") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_9) { Attribute = new VariationAttribute("WriteValue(DateTimeOffset)") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_11) { Attribute = new VariationAttribute("Write multiple atomic values inside element") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_12) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_13) { Attribute = new VariationAttribute("Write multiple atomic values inside element, separate by WriteWhitespace(' ')") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_14) { Attribute = new VariationAttribute("Write multiple atomic values inside element, separate by WriteString(' ')") { Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_15) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute, separate by WriteWhitespace(' ')") { Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_16) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute, seperate by WriteString(' ')") { Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeValue_17) { Attribute = new VariationAttribute("WriteValue(long)") { Id = 17, Priority = 1 } });
+                    var tcWriteValue = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteValue();
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_1) { Attribute = new VariationAttribute("WriteValue(boolean)") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_2) { Attribute = new VariationAttribute("WriteValue(DateTime)") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_3) { Attribute = new VariationAttribute("WriteValue(decimal)") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_4) { Attribute = new VariationAttribute("WriteValue(double)") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_5) { Attribute = new VariationAttribute("WriteValue(int32)") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_6) { Attribute = new VariationAttribute("WriteValue(int64)") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_7) { Attribute = new VariationAttribute("WriteValue(single)") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_8) { Attribute = new VariationAttribute("WriteValue(string)") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_9) { Attribute = new VariationAttribute("WriteValue(DateTimeOffset)") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_11) { Attribute = new VariationAttribute("Write multiple atomic values inside element") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_12) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_13) { Attribute = new VariationAttribute("Write multiple atomic values inside element, separate by WriteWhitespace(' ')") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_14) { Attribute = new VariationAttribute("Write multiple atomic values inside element, separate by WriteString(' ')") { Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_15) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute, separate by WriteWhitespace(' ')") { Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_16) { Attribute = new VariationAttribute("Write multiple atomic values inside attribute, seperate by WriteString(' ')") { Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteValue.writeValue_17) { Attribute = new VariationAttribute("WriteValue(long)") { Id = 17, Priority = 1 } });
                 }
             }
-            public partial class TCLookUpPrefix : BridgeHelpers
+            public class TCLookUpPrefix : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCLookUpPrefix
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(lookupPrefix_1) { Attribute = new VariationAttribute("LookupPrefix with null") { Id = 1, Priority = 2 } });
-                    this.AddChild(new TestVariation(lookupPrefix_2) { Attribute = new VariationAttribute("LookupPrefix with String.Empty should if(!String.Empty") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(lookupPrefix_3) { Attribute = new VariationAttribute("LookupPrefix with generated namespace used for attributes") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(lookupPrefix_4) { Attribute = new VariationAttribute("LookupPrefix for namespace used with element") { Id = 4, Priority = 0 } });
-                    this.AddChild(new TestVariation(lookupPrefix_5) { Attribute = new VariationAttribute("LookupPrefix for namespace used with attribute") { Id = 5, Priority = 0 } });
-                    this.AddChild(new TestVariation(lookupPrefix_6) { Attribute = new VariationAttribute("Lookup prefix for a default namespace") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(lookupPrefix_7) { Attribute = new VariationAttribute("Lookup prefix for nested element with same namespace but different prefix") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(lookupPrefix_8) { Attribute = new VariationAttribute("Lookup prefix for multiple prefix associated with the same namespace") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(lookupPrefix_9) { Attribute = new VariationAttribute("Lookup prefix for namespace defined outside the scope of an empty element and also defined in its parent") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(lookupPrefix_10) { Attribute = new VariationAttribute("Lookup prefix for namespace declared as default and also with a prefix") { Id = 10, Priority = 1 } });
+                    var tcLookUpPrefix = new CommonTestsFunctionalTests.XNodeBuilderTests.TCLookUpPrefix();
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_1) { Attribute = new VariationAttribute("LookupPrefix with null") { Id = 1, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_2) { Attribute = new VariationAttribute("LookupPrefix with String.Empty should if(!String.Empty") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_3) { Attribute = new VariationAttribute("LookupPrefix with generated namespace used for attributes") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_4) { Attribute = new VariationAttribute("LookupPrefix for namespace used with element") { Id = 4, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_5) { Attribute = new VariationAttribute("LookupPrefix for namespace used with attribute") { Id = 5, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_6) { Attribute = new VariationAttribute("Lookup prefix for a default namespace") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_7) { Attribute = new VariationAttribute("Lookup prefix for nested element with same namespace but different prefix") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_8) { Attribute = new VariationAttribute("Lookup prefix for multiple prefix associated with the same namespace") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_9) { Attribute = new VariationAttribute("Lookup prefix for namespace defined outside the scope of an empty element and also defined in its parent") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcLookUpPrefix.lookupPrefix_10) { Attribute = new VariationAttribute("Lookup prefix for namespace declared as default and also with a prefix") { Id = 10, Priority = 1 } });
                 }
             }
-            public partial class TCXmlSpaceWriter : BridgeHelpers
+            public class TCXmlSpaceWriter : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCXmlSpaceWriter
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(xmlSpace_1) { Attribute = new VariationAttribute("Verify XmlSpace as Preserve") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(xmlSpace_2) { Attribute = new VariationAttribute("Verify XmlSpace as Default") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(xmlSpace_3) { Attribute = new VariationAttribute("Verify XmlSpace as None") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(xmlSpace_4) { Attribute = new VariationAttribute("Verify XmlSpace within an empty element") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(xmlSpace_5) { Attribute = new VariationAttribute("Verify XmlSpace - scope with nested elements (both PROLOG and EPILOG)") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(xmlSpace_6) { Attribute = new VariationAttribute("Verify XmlSpace - outside defined scope") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(xmlSpace_7) { Attribute = new VariationAttribute("Verify XmlSpace with invalid space value") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(xmlSpace_8) { Attribute = new VariationAttribute("Duplicate xml:space attr should error") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(xmlSpace_9) { Attribute = new VariationAttribute("Verify XmlSpace value when received through WriteString") { Id = 9, Priority = 1 } });
+                    var tcXmlSpaceWriter = new CommonTestsFunctionalTests.XNodeBuilderTests.TCXmlSpaceWriter();
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_1) { Attribute = new VariationAttribute("Verify XmlSpace as Preserve") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_2) { Attribute = new VariationAttribute("Verify XmlSpace as Default") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_3) { Attribute = new VariationAttribute("Verify XmlSpace as None") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_4) { Attribute = new VariationAttribute("Verify XmlSpace within an empty element") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_5) { Attribute = new VariationAttribute("Verify XmlSpace - scope with nested elements (both PROLOG and EPILOG)") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_6) { Attribute = new VariationAttribute("Verify XmlSpace - outside defined scope") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_7) { Attribute = new VariationAttribute("Verify XmlSpace with invalid space value") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_8) { Attribute = new VariationAttribute("Duplicate xml:space attr should error") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcXmlSpaceWriter.xmlSpace_9) { Attribute = new VariationAttribute("Verify XmlSpace value when received through WriteString") { Id = 9, Priority = 1 } });
                 }
             }
-            public partial class TCXmlLangWriter : BridgeHelpers
+            public class TCXmlLangWriter : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCXmlLangWriter
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(XmlLang_1) { Attribute = new VariationAttribute("Verify XmlLang sanity test") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(XmlLang_2) { Attribute = new VariationAttribute("Verify that default value of XmlLang is NULL") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(XmlLang_3) { Attribute = new VariationAttribute("Verify XmlLang scope inside nested elements (both PROLOG and EPILOG)") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(XmlLang_4) { Attribute = new VariationAttribute("Duplicate xml:lang attr should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(XmlLang_5) { Attribute = new VariationAttribute("Verify XmlLang value when received through WriteAttributes") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(XmlLang_6) { Attribute = new VariationAttribute("Verify XmlLang value when received through WriteString") { Id = 6 } });
-                    this.AddChild(new TestVariation(XmlLang_7) { Attribute = new VariationAttribute("Should not check XmlLang value") { Id = 7, Priority = 2 } });
-                    this.AddChild(new TestVariation(XmlLang_8) { Attribute = new VariationAttribute("More XmlLang with valid sequence") { Id = 8, Priority = 1 } });
+                    var tcXmlLangWriter = new CommonTestsFunctionalTests.XNodeBuilderTests.TCXmlLangWriter();
+                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_1) { Attribute = new VariationAttribute("Verify XmlLang sanity test") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_2) { Attribute = new VariationAttribute("Verify that default value of XmlLang is NULL") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_3) { Attribute = new VariationAttribute("Verify XmlLang scope inside nested elements (both PROLOG and EPILOG)") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_4) { Attribute = new VariationAttribute("Duplicate xml:lang attr should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_5) { Attribute = new VariationAttribute("Verify XmlLang value when received through WriteAttributes") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_6) { Attribute = new VariationAttribute("Verify XmlLang value when received through WriteString") { Id = 6 } });
+                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_7) { Attribute = new VariationAttribute("Should not check XmlLang value") { Id = 7, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcXmlLangWriter.XmlLang_8) { Attribute = new VariationAttribute("More XmlLang with valid sequence") { Id = 8, Priority = 1 } });
                 }
             }
-            public partial class TCWriteRaw : BridgeHelpers
+            public class TCWriteRaw : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteRaw
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeRaw_1) { Attribute = new VariationAttribute("Call both WriteRaw Methods") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_4) { Attribute = new VariationAttribute("Call WriteRaw to write the value of xml:space") { Id = 4 } });
-                    this.AddChild(new TestVariation(writerRaw_5) { Attribute = new VariationAttribute("Call WriteRaw to write the value of xml:lang") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_6) { Attribute = new VariationAttribute("WriteRaw with count > buffer size") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_7) { Attribute = new VariationAttribute("WriteRaw with count < 0") { Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_8) { Attribute = new VariationAttribute("WriteRaw with index > buffer size") { Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_9) { Attribute = new VariationAttribute("WriteRaw with index < 0") { Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_10) { Attribute = new VariationAttribute("WriteRaw with index + count exceeds buffer") { Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_11) { Attribute = new VariationAttribute("WriteRaw with buffer = null") { Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_12) { Attribute = new VariationAttribute("WriteRaw with valid surrogate pair") { Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_13) { Attribute = new VariationAttribute("WriteRaw with invalid surrogate pair") { Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeRaw_14) { Attribute = new VariationAttribute("Index = Count = 0") { Id = 14, Priority = 1 } });
+                    var tcWriteRaw = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteRaw();
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_1) { Attribute = new VariationAttribute("Call both WriteRaw Methods") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_4) { Attribute = new VariationAttribute("Call WriteRaw to write the value of xml:space") { Id = 4 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writerRaw_5) { Attribute = new VariationAttribute("Call WriteRaw to write the value of xml:lang") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_6) { Attribute = new VariationAttribute("WriteRaw with count > buffer size") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_7) { Attribute = new VariationAttribute("WriteRaw with count < 0") { Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_8) { Attribute = new VariationAttribute("WriteRaw with index > buffer size") { Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_9) { Attribute = new VariationAttribute("WriteRaw with index < 0") { Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_10) { Attribute = new VariationAttribute("WriteRaw with index + count exceeds buffer") { Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_11) { Attribute = new VariationAttribute("WriteRaw with buffer = null") { Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_12) { Attribute = new VariationAttribute("WriteRaw with valid surrogate pair") { Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_13) { Attribute = new VariationAttribute("WriteRaw with invalid surrogate pair") { Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteRaw.writeRaw_14) { Attribute = new VariationAttribute("Index = Count = 0") { Id = 14, Priority = 1 } });
                 }
             }
-            public partial class TCWriteBase64 : BridgeHelpers
+            public class TCWriteBase64 : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteBase64
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(Base64_2) { Attribute = new VariationAttribute("WriteBase64 with count > buffer size") { Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(Base64_3) { Attribute = new VariationAttribute("WriteBase64 with count < 0") { Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(Base64_4) { Attribute = new VariationAttribute("WriteBase64 with index > buffer size") { Id = 40, Priority = 1 } });
-                    this.AddChild(new TestVariation(Base64_5) { Attribute = new VariationAttribute("WriteBase64 with index < 0") { Id = 50, Priority = 1 } });
-                    this.AddChild(new TestVariation(Base64_6) { Attribute = new VariationAttribute("WriteBase64 with index + count exceeds buffer") { Id = 60, Priority = 1 } });
-                    this.AddChild(new TestVariation(Base64_7) { Attribute = new VariationAttribute("WriteBase64 with buffer = null") { Id = 70, Priority = 1 } });
-                    this.AddChild(new TestVariation(Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside namespace decl") { Param = "ns", Id = 92, Priority = 1 } });
-                    this.AddChild(new TestVariation(Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside xml:lang value") { Param = "lang", Id = 90, Priority = 1 } });
-                    this.AddChild(new TestVariation(Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside xml:space value") { Param = "space", Id = 91, Priority = 1 } });
+                    var tcWriteBase64 = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteBase64();
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_2) { Attribute = new VariationAttribute("WriteBase64 with count > buffer size") { Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_3) { Attribute = new VariationAttribute("WriteBase64 with count < 0") { Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_4) { Attribute = new VariationAttribute("WriteBase64 with index > buffer size") { Id = 40, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_5) { Attribute = new VariationAttribute("WriteBase64 with index < 0") { Id = 50, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_6) { Attribute = new VariationAttribute("WriteBase64 with index + count exceeds buffer") { Id = 60, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_7) { Attribute = new VariationAttribute("WriteBase64 with buffer = null") { Id = 70, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside namespace decl") { Param = "ns", Id = 92, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside xml:lang value") { Param = "lang", Id = 90, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteBase64.Base64_9) { Attribute = new VariationAttribute("Base64 should not be allowed inside xml:space value") { Param = "space", Id = 91, Priority = 1 } });
                 }
             }
-            public partial class TCWriteState : BridgeHelpers
+            public class TCWriteState : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCWriteState
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(writeState_1) { Attribute = new VariationAttribute("Verify WriteState.Start when nothing has been written yet") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(writeState_2) { Attribute = new VariationAttribute("Verify correct state when writing in Prolog") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_3) { Attribute = new VariationAttribute("Verify correct state when writing an attribute") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_4) { Attribute = new VariationAttribute("Verify correct state when writing element content") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_5) { Attribute = new VariationAttribute("Verify correct state after Close has been called") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_6) { Attribute = new VariationAttribute("Verify WriteState = Error after an exception") { Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteNmToken after WriteState = Error") { Param = "WriteNmToken", Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteBinHex after WriteState = Error") { Param = "WriteBinHex", Id = 23, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call LookupPrefix after WriteState = Error") { Param = "LookupPrefix", Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteComment after WriteState = Error") { Param = "WriteComment", Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteWhitespace after WriteState = Error") { Param = "WriteWhitespace", Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WritePI after WriteState = Error") { Param = "WritePI", Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteName after WriteState = Error") { Param = "WriteName", Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteString after WriteState = Error") { Param = "WriteString", Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteQualifiedName after WriteState = Error") { Param = "WriteQualifiedName", Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteValue after WriteState = Error") { Param = "WriteValue", Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteAttributes after WriteState = Error") { Param = "WriteAttributes", Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteNode(reader) after WriteState = Error") { Param = "WriteNodeReader", Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call Flush after WriteState = Error") { Param = "Flush", Id = 32, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteRaw after WriteState = Error") { Param = "WriteRaw", Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteSurrogateCharEntity after WriteState = Error") { Param = "WriteSurrogateCharEntity", Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteEntityRef after WriteState = Error") { Param = "WriteEntityRef", Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteCharEntiry after WriteState = Error") { Param = "WriteCharEntity", Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteBase64 after WriteState = Error") { Param = "WriteBase64", Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteChars after WriteState = Error") { Param = "WriteChars", Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteStartDocument after WriteState = Error") { Param = "WriteStartDocument", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteStartElement after WriteState = Error") { Param = "WriteStartElement", Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteEndElement after WriteState = Error") { Param = "WriteEndElement", Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteStartAttribute after WriteState = Error") { Param = "WriteStartAttribute", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteEndAttribute after WriteState = Error") { Param = "WriteEndAttribute", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_7) { Attribute = new VariationAttribute("Call WriteCData after WriteState = Error") { Param = "WriteCData", Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_8) { Attribute = new VariationAttribute("XmlSpace property after WriteState = Error") { Param = "XmlSpace", Id = 33, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_8) { Attribute = new VariationAttribute("XmlLang property after WriteState = Error") { Param = "XmlSpace", Id = 34, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteValue after Close()") { Param = "WriteValue", Id = 27, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WritePI after Close()") { Param = "WritePI", Id = 13, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteEntityRef after Close()") { Param = "WriteEntityRef", Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteCharEntiry after Close()") { Param = "WriteCharEntity", Id = 15, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteSurrogateCharEntity after Close()") { Param = "WriteSurrogateCharEntity", Id = 16, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteWhitespace after Close()") { Param = "WriteWhitespace", Id = 17, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteString after Close()") { Param = "WriteString", Id = 18, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteChars after Close()") { Param = "WriteChars", Id = 19, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteRaw after Close()") { Param = "WriteRaw", Id = 20, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteBase64 after Close()") { Param = "WriteBase64", Id = 21, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteBinHex after Close()") { Param = "WriteBinHex", Id = 22, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call LookupPrefix after Close()") { Param = "LookupPrefix", Id = 23, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteNmToken after Close()") { Param = "WriteNmToken", Id = 24, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteName after Close()") { Param = "WriteName", Id = 25, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteQualifiedName after Close()") { Param = "WriteQualifiedName", Id = 26, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteStartDocument after Close()") { Param = "WriteStartDocument", Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteAttributes after Close()") { Param = "WriteAttributes", Id = 28, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteNode(reader) after Close()") { Param = "WriteNodeReader", Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call Flush after Close()") { Param = "Flush", Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteStartElement after Close()") { Param = "WriteStartElement", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteEndElement after Close()") { Param = "WriteEndElement", Id = 8, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteStartAttribute after Close()") { Param = "WriteStartAttribute", Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteEndAttribute after Close()") { Param = "WriteEndAttribute", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteCData after Close()") { Param = "WriteCData", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(writeState_9) { Attribute = new VariationAttribute("Call WriteComment after Close()") { Param = "WriteComment", Id = 12, Priority = 1 } });
+                    var tcWriteState = new CommonTestsFunctionalTests.XNodeBuilderTests.TCWriteState();
+                    this.AddChild(new TestVariation(tcWriteState.writeState_1) { Attribute = new VariationAttribute("Verify WriteState.Start when nothing has been written yet") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_2) { Attribute = new VariationAttribute("Verify correct state when writing in Prolog") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_3) { Attribute = new VariationAttribute("Verify correct state when writing an attribute") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_4) { Attribute = new VariationAttribute("Verify correct state when writing element content") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_5) { Attribute = new VariationAttribute("Verify correct state after Close has been called") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_6) { Attribute = new VariationAttribute("Verify WriteState = Error after an exception") { Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteNmToken after WriteState = Error") { Param = "WriteNmToken", Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteBinHex after WriteState = Error") { Param = "WriteBinHex", Id = 23, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call LookupPrefix after WriteState = Error") { Param = "LookupPrefix", Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteComment after WriteState = Error") { Param = "WriteComment", Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteWhitespace after WriteState = Error") { Param = "WriteWhitespace", Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WritePI after WriteState = Error") { Param = "WritePI", Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteName after WriteState = Error") { Param = "WriteName", Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteString after WriteState = Error") { Param = "WriteString", Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteQualifiedName after WriteState = Error") { Param = "WriteQualifiedName", Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteValue after WriteState = Error") { Param = "WriteValue", Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteAttributes after WriteState = Error") { Param = "WriteAttributes", Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteNode(reader) after WriteState = Error") { Param = "WriteNodeReader", Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call Flush after WriteState = Error") { Param = "Flush", Id = 32, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteRaw after WriteState = Error") { Param = "WriteRaw", Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteSurrogateCharEntity after WriteState = Error") { Param = "WriteSurrogateCharEntity", Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteEntityRef after WriteState = Error") { Param = "WriteEntityRef", Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteCharEntiry after WriteState = Error") { Param = "WriteCharEntity", Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteBase64 after WriteState = Error") { Param = "WriteBase64", Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteChars after WriteState = Error") { Param = "WriteChars", Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteStartDocument after WriteState = Error") { Param = "WriteStartDocument", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteStartElement after WriteState = Error") { Param = "WriteStartElement", Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteEndElement after WriteState = Error") { Param = "WriteEndElement", Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteStartAttribute after WriteState = Error") { Param = "WriteStartAttribute", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteEndAttribute after WriteState = Error") { Param = "WriteEndAttribute", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_7) { Attribute = new VariationAttribute("Call WriteCData after WriteState = Error") { Param = "WriteCData", Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_8) { Attribute = new VariationAttribute("XmlSpace property after WriteState = Error") { Param = "XmlSpace", Id = 33, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_8) { Attribute = new VariationAttribute("XmlLang property after WriteState = Error") { Param = "XmlSpace", Id = 34, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteValue after Close()") { Param = "WriteValue", Id = 27, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WritePI after Close()") { Param = "WritePI", Id = 13, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteEntityRef after Close()") { Param = "WriteEntityRef", Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteCharEntiry after Close()") { Param = "WriteCharEntity", Id = 15, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteSurrogateCharEntity after Close()") { Param = "WriteSurrogateCharEntity", Id = 16, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteWhitespace after Close()") { Param = "WriteWhitespace", Id = 17, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteString after Close()") { Param = "WriteString", Id = 18, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteChars after Close()") { Param = "WriteChars", Id = 19, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteRaw after Close()") { Param = "WriteRaw", Id = 20, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteBase64 after Close()") { Param = "WriteBase64", Id = 21, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteBinHex after Close()") { Param = "WriteBinHex", Id = 22, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call LookupPrefix after Close()") { Param = "LookupPrefix", Id = 23, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteNmToken after Close()") { Param = "WriteNmToken", Id = 24, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteName after Close()") { Param = "WriteName", Id = 25, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteQualifiedName after Close()") { Param = "WriteQualifiedName", Id = 26, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteStartDocument after Close()") { Param = "WriteStartDocument", Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteAttributes after Close()") { Param = "WriteAttributes", Id = 28, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteNode(reader) after Close()") { Param = "WriteNodeReader", Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call Flush after Close()") { Param = "Flush", Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteStartElement after Close()") { Param = "WriteStartElement", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteEndElement after Close()") { Param = "WriteEndElement", Id = 8, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteStartAttribute after Close()") { Param = "WriteStartAttribute", Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteEndAttribute after Close()") { Param = "WriteEndAttribute", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteCData after Close()") { Param = "WriteCData", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcWriteState.writeState_9) { Attribute = new VariationAttribute("Call WriteComment after Close()") { Param = "WriteComment", Id = 12, Priority = 1 } });
                 }
             }
-            public partial class TC_NDP20_NewMethods : BridgeHelpers
+            public class TC_NDP20_NewMethods : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TC_NDP20_NewMethods
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("WriteElementString(prefix, name, ns, value) sanity test") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("WriteElementString(prefix = xml, ns = XML namespace)") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("WriteStartAttribute(string name) sanity test") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("WriteElementString followed by attribute should error") { Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("429445: XmlWellformedWriter wrapping another XmlWriter should check the duplicate attributes first") { Id = 5, Priority = 1 } });
+                    var tcNDP20_NewMethods = new CommonTestsFunctionalTests.XNodeBuilderTests.TC_NDP20_NewMethods();
+                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_1) { Attribute = new VariationAttribute("WriteElementString(prefix, name, ns, value) sanity test") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_2) { Attribute = new VariationAttribute("WriteElementString(prefix = xml, ns = XML namespace)") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_3) { Attribute = new VariationAttribute("WriteStartAttribute(string name) sanity test") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_4) { Attribute = new VariationAttribute("WriteElementString followed by attribute should error") { Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcNDP20_NewMethods.var_5) { Attribute = new VariationAttribute("429445: XmlWellformedWriter wrapping another XmlWriter should check the duplicate attributes first") { Id = 5, Priority = 1 } });
                 }
             }
-            public partial class TCGlobalization : BridgeHelpers
+            public class TCGlobalization : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCGlobalization
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("Characters between 0xdfff and 0xfffe are valid Unicode characters") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("XmlWriter using UTF-16BE encoding writes out wrong encoding name value in the xml decl") { Id = 2, Priority = 1 } });
+                    var tcGlobalization = new CommonTestsFunctionalTests.XNodeBuilderTests.TCGlobalization();
+                    this.AddChild(new TestVariation(tcGlobalization.var_1) { Attribute = new VariationAttribute("Characters between 0xdfff and 0xfffe are valid Unicode characters") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcGlobalization.var_2) { Attribute = new VariationAttribute("XmlWriter using UTF-16BE encoding writes out wrong encoding name value in the xml decl") { Id = 2, Priority = 1 } });
                 }
             }
-            public partial class TCClose : BridgeHelpers
+            public class TCClose : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCClose
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("Closing an XmlWriter should close all opened elements") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("Disposing an XmlWriter should close all opened elements") { Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("Dispose() shouldn't throw when a tag is not closed and inner stream is closed") { Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("Close() should be allowed when XML doesn't have content") { Id = 4, Priority = 1 } });
+                    var tcClose = new CommonTestsFunctionalTests.XNodeBuilderTests.TCClose();
+                    this.AddChild(new TestVariation(tcClose.var_1) { Attribute = new VariationAttribute("Closing an XmlWriter should close all opened elements") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcClose.var_2) { Attribute = new VariationAttribute("Disposing an XmlWriter should close all opened elements") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcClose.var_3) { Attribute = new VariationAttribute("Dispose() shouldn't throw when a tag is not closed and inner stream is closed") { Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcClose.var_4) { Attribute = new VariationAttribute("Close() should be allowed when XML doesn't have content") { Id = 4, Priority = 1 } });
                 }
             }
-            public partial class TCEOFHandling : BridgeHelpers
+            public class TCEOFHandling : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCEOFHandling
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(EOF_Handling_01) { Attribute = new VariationAttribute("NewLineHandling Default value - NewLineHandling.Replace") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.Entitize") { Param = 1, Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.None") { Param = 2, Id = 4, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.Replace") { Param = 0, Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'Replace'") { Param = 0, Id = 15, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'Entitize'") { Param = 1, Id = 14, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'None'") { Param = 2, Id = 16, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_07) { Attribute = new VariationAttribute("Check for combinations of NewLine characters in attribute with 'Entitize'") { Param = 1, Id = 17, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_07) { Attribute = new VariationAttribute("Check for combinations of NewLine characters in attribute with 'Replace'") { Param = 0, Id = 18, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'None'") { Param = 2, Id = 22, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'Entitize'") { Param = 1, Id = 20, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'Replace'") { Param = 0, Id = 21, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_09) { Attribute = new VariationAttribute("Check for combinations of NewLine characters and entities in element with 'Entitize'") { Param = 1, Id = 23, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_09) { Attribute = new VariationAttribute("Check for combinations of NewLine characters and entities in element with 'Replace'") { Param = 0, Id = 24, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_10) { Attribute = new VariationAttribute("Check for tab character in attribute with 'Replace'") { Param = 0, Id = 27, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_10) { Attribute = new VariationAttribute("Check for tab character in attribute with 'Entitize'") { Param = 1, Id = 26, Priority = 0 } });
-                    this.AddChild(new TestVariation(EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, None") { Param = 2, Id = 31, Priority = 1 } });
-                    this.AddChild(new TestVariation(EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, Replace") { Param = 0, Id = 30, Priority = 1 } });
-                    this.AddChild(new TestVariation(EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, Entitize") { Param = 1, Id = 29, Priority = 1 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '\\r', '  '") { Params = new object[] { NewLineHandling.Replace, "\r", "  " }, Id = 33, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '\\r', '  '") { Params = new object[] { NewLineHandling.None, "\r", "  " }, Id = 34, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '&#xA;', '  '") { Params = new object[] { NewLineHandling.Entitize, "&#xA;", "  " }, Id = 35, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '\\r', '\\n'") { Params = new object[] { NewLineHandling.None, "\r", "\n" }, Id = 40, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '\\r', '  '") { Params = new object[] { NewLineHandling.Entitize, "\r", "  " }, Id = 32, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '&#xA;', '  '") { Params = new object[] { NewLineHandling.Replace, "&#xA;", "  " }, Id = 36, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '&#xA;', '  '") { Params = new object[] { NewLineHandling.None, "&#xA;", "  " }, Id = 37, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '\\r', '\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r", "\n" }, Id = 38, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '\\r', '\\n'") { Params = new object[] { NewLineHandling.Replace, "\r", "\n" }, Id = 39, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '\\r'") { Params = new object[] { NewLineHandling.Entitize, "\r" }, Id = 53, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '\\r\\n'") { Params = new object[] { NewLineHandling.Replace, "\r\n" }, Id = 51, Priority = 1 } });
-                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '\\r'") { Params = new object[] { NewLineHandling.Replace, "\r" }, Id = 54, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '---'") { Params = new object[] { NewLineHandling.Replace, "---" }, Id = 55, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '---'") { Params = new object[] { NewLineHandling.Entitize, "---" }, Id = 54, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '\\r\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r\n" }, Id = 50, Priority = 1 } });
-                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; None, '\\r\\n'") { Params = new object[] { NewLineHandling.None, "\r\n" }, Id = 58, Priority = 1 } });
-                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; None, '\\r'") { Params = new object[] { NewLineHandling.None, "\r" }, Id = 61, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Replace, '\\r'") { Params = new object[] { NewLineHandling.Replace, "\r" }, Id = 60, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Entitize, '\\r'") { Params = new object[] { NewLineHandling.Entitize, "\r" }, Id = 59, Priority = 2 } });
-                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Entitize, '\\r\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r\n" }, Id = 56, Priority = 1 } });
-                    this.AddChild(new TestVariation(EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Replace, '\\r\\n'") { Params = new object[] { NewLineHandling.Replace, "\r\n" }, Id = 57, Priority = 1 } });
+                    var tcEOFHandling = new EndOfLineHandlingTestsFunctionalTests.XNodeBuilderTests.TCEOFHandling();
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_01) { Attribute = new VariationAttribute("NewLineHandling Default value - NewLineHandling.Replace") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.Entitize") { Param = 1, Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.None") { Param = 2, Id = 4, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_02) { Attribute = new VariationAttribute("XmlWriter creation with NewLineHandling.Replace") { Param = 0, Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'Replace'") { Param = 0, Id = 15, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'Entitize'") { Param = 1, Id = 14, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_06) { Attribute = new VariationAttribute("Check for tab character in element with 'None'") { Param = 2, Id = 16, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_07) { Attribute = new VariationAttribute("Check for combinations of NewLine characters in attribute with 'Entitize'") { Param = 1, Id = 17, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_07) { Attribute = new VariationAttribute("Check for combinations of NewLine characters in attribute with 'Replace'") { Param = 0, Id = 18, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'None'") { Param = 2, Id = 22, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'Entitize'") { Param = 1, Id = 20, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_08) { Attribute = new VariationAttribute("Check for combinations of entities in attribute with 'Replace'") { Param = 0, Id = 21, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_09) { Attribute = new VariationAttribute("Check for combinations of NewLine characters and entities in element with 'Entitize'") { Param = 1, Id = 23, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_09) { Attribute = new VariationAttribute("Check for combinations of NewLine characters and entities in element with 'Replace'") { Param = 0, Id = 24, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_10) { Attribute = new VariationAttribute("Check for tab character in attribute with 'Replace'") { Param = 0, Id = 27, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_10) { Attribute = new VariationAttribute("Check for tab character in attribute with 'Entitize'") { Param = 1, Id = 26, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, None") { Param = 2, Id = 31, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, Replace") { Param = 0, Id = 30, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_11) { Attribute = new VariationAttribute("NewLineChars and IndentChars Default values and test for proper indentation, Entitize") { Param = 1, Id = 29, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '\\r', '  '") { Params = new object[] { NewLineHandling.Replace, "\r", "  " }, Id = 33, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '\\r', '  '") { Params = new object[] { NewLineHandling.None, "\r", "  " }, Id = 34, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '&#xA;', '  '") { Params = new object[] { NewLineHandling.Entitize, "&#xA;", "  " }, Id = 35, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '\\r', '\\n'") { Params = new object[] { NewLineHandling.None, "\r", "\n" }, Id = 40, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '\\r', '  '") { Params = new object[] { NewLineHandling.Entitize, "\r", "  " }, Id = 32, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '&#xA;', '  '") { Params = new object[] { NewLineHandling.Replace, "&#xA;", "  " }, Id = 36, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; None, '&#xA;', '  '") { Params = new object[] { NewLineHandling.None, "&#xA;", "  " }, Id = 37, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Entitize, '\\r', '\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r", "\n" }, Id = 38, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_13) { Attribute = new VariationAttribute("Test fo proper indentation and newline handling when Indent = true, with custom NewLineChars and IndentChars; Replace, '\\r', '\\n'") { Params = new object[] { NewLineHandling.Replace, "\r", "\n" }, Id = 39, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '\\r'") { Params = new object[] { NewLineHandling.Entitize, "\r" }, Id = 53, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '\\r\\n'") { Params = new object[] { NewLineHandling.Replace, "\r\n" }, Id = 51, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '\\r'") { Params = new object[] { NewLineHandling.Replace, "\r" }, Id = 54, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Replace, '---'") { Params = new object[] { NewLineHandling.Replace, "---" }, Id = 55, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '---'") { Params = new object[] { NewLineHandling.Entitize, "---" }, Id = 54, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_15) { Attribute = new VariationAttribute("NewLine handling in attribute when Indent=true; Entitize, '\\r\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r\n" }, Id = 50, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; None, '\\r\\n'") { Params = new object[] { NewLineHandling.None, "\r\n" }, Id = 58, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; None, '\\r'") { Params = new object[] { NewLineHandling.None, "\r" }, Id = 61, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Replace, '\\r'") { Params = new object[] { NewLineHandling.Replace, "\r" }, Id = 60, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Entitize, '\\r'") { Params = new object[] { NewLineHandling.Entitize, "\r" }, Id = 59, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Entitize, '\\r\\n'") { Params = new object[] { NewLineHandling.Entitize, "\r\n" }, Id = 56, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcEOFHandling.EOF_Handling_16) { Attribute = new VariationAttribute("NewLine handling between attributes when NewLineOnAttributes=true; Replace, '\\r\\n'") { Params = new object[] { NewLineHandling.Replace, "\r\n" }, Id = 57, Priority = 1 } });
                 }
             }
-            public partial class XObjectBuilderTest : BridgeHelpers
+            public class XObjectBuilderTest : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+XObjectBuilderTest
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("LookupPrefix(null)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("WriteAttributes(null, false)") { Param = false, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("WriteAttributes(null, true)") { Param = true, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("WriteAttributeString(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("WriteAttributeString(String.Empty)") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("WriteBase64(null)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_5) { Attribute = new VariationAttribute("WriteBinHex(null)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_6) { Attribute = new VariationAttribute("WriteCData('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_6) { Attribute = new VariationAttribute("WriteCData(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_7) { Attribute = new VariationAttribute("WriteChars(null)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_8) { Attribute = new VariationAttribute("Other APIs") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_9) { Attribute = new VariationAttribute("WriteDocType(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_9) { Attribute = new VariationAttribute("WriteDocType('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_10) { Attribute = new VariationAttribute("WriteElementString(String.Empty)") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_10) { Attribute = new VariationAttribute("WriteElementString(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_11) { Attribute = new VariationAttribute("WriteEndAttribute()") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_12) { Attribute = new VariationAttribute("WriteEndDocument()") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_13) { Attribute = new VariationAttribute("WriteEndElement()") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_14) { Attribute = new VariationAttribute("WriteEntityRef(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_14) { Attribute = new VariationAttribute("WriteEntityRef('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_15) { Attribute = new VariationAttribute("WriteFullEndElement()") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_16) { Attribute = new VariationAttribute("WriteName('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_16) { Attribute = new VariationAttribute("WriteName(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_17) { Attribute = new VariationAttribute("WriteNmToken('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_17) { Attribute = new VariationAttribute("WriteNmToken(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_18) { Attribute = new VariationAttribute("WriteNode(null)") { Params = new object[] { "reader", true }, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_18) { Attribute = new VariationAttribute("WriteNode(null)") { Params = new object[] { "reader", false }, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_19) { Attribute = new VariationAttribute("WriteProcessingInstruction('', '')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_19) { Attribute = new VariationAttribute("WriteProcessingInstruction(null, null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_20) { Attribute = new VariationAttribute("WriteQualifiedName('', '')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_20) { Attribute = new VariationAttribute("WriteQualifiedName(null, null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_21) { Attribute = new VariationAttribute("WriteRaw(null, 0, 0)") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_22) { Attribute = new VariationAttribute("WriteStartAttribute(null, null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_22) { Attribute = new VariationAttribute("WriteStartAttribute('', '')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_23) { Attribute = new VariationAttribute("WriteStartElement(null, null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_23) { Attribute = new VariationAttribute("WriteStartElement('', '')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_24) { Attribute = new VariationAttribute("WriteStartDocument(true)") { Param = 2, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_24) { Attribute = new VariationAttribute("WriteStartDocument()") { Param = 1, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_24) { Attribute = new VariationAttribute("WriteStartDocument(false)") { Param = 3, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_25) { Attribute = new VariationAttribute("WriteString(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_25) { Attribute = new VariationAttribute("WriteString('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_26) { Attribute = new VariationAttribute("WriteValue(false)") { Param = false, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_26) { Attribute = new VariationAttribute("WriteValue(true)") { Param = true, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_27) { Attribute = new VariationAttribute("WriteWhitespace('')") { Param = "", Priority = 2 } });
-                    this.AddChild(new TestVariation(var_27) { Attribute = new VariationAttribute("WriteWhitespace(null)") { Param = null, Priority = 2 } });
-                    this.AddChild(new TestVariation(var_28) { Attribute = new VariationAttribute("EntityRef after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_29) { Attribute = new VariationAttribute("EntityRef after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_30) { Attribute = new VariationAttribute("CharEntity after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_31) { Attribute = new VariationAttribute("CharEntity after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_32) { Attribute = new VariationAttribute("SurrogateCharEntity after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_33) { Attribute = new VariationAttribute("SurrogateCharEntity after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_34) { Attribute = new VariationAttribute("Attribute after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_35) { Attribute = new VariationAttribute("Attribute after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_36) { Attribute = new VariationAttribute("CDATA after Document should error - PROLOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_37) { Attribute = new VariationAttribute("CDATA after Document should error - EPILOG") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_38) { Attribute = new VariationAttribute("Element followed by Document should error") { Priority = 2 } });
-                    this.AddChild(new TestVariation(var_39) { Attribute = new VariationAttribute("Element followed by DocType should error") { Priority = 2 } });
-                    this.AddChild(new TestVariation(Variation41) { Attribute = new VariationAttribute("WriteBase64") });
-                    this.AddChild(new TestVariation(Variation42) { Attribute = new VariationAttribute("WriteEntityRef") });
+                    var xObjectBuilderTest = new ErrorConditionsFunctionalTests.XNodeBuilderTests.XObjectBuilderTest();
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_1) { Attribute = new VariationAttribute("LookupPrefix(null)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_2) { Attribute = new VariationAttribute("WriteAttributes(null, false)") { Param = false, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_2) { Attribute = new VariationAttribute("WriteAttributes(null, true)") { Param = true, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_3) { Attribute = new VariationAttribute("WriteAttributeString(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_3) { Attribute = new VariationAttribute("WriteAttributeString(String.Empty)") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_4) { Attribute = new VariationAttribute("WriteBase64(null)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_5) { Attribute = new VariationAttribute("WriteBinHex(null)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_6) { Attribute = new VariationAttribute("WriteCData('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_6) { Attribute = new VariationAttribute("WriteCData(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_7) { Attribute = new VariationAttribute("WriteChars(null)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_8) { Attribute = new VariationAttribute("Other APIs") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_9) { Attribute = new VariationAttribute("WriteDocType(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_9) { Attribute = new VariationAttribute("WriteDocType('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_10) { Attribute = new VariationAttribute("WriteElementString(String.Empty)") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_10) { Attribute = new VariationAttribute("WriteElementString(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_11) { Attribute = new VariationAttribute("WriteEndAttribute()") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_12) { Attribute = new VariationAttribute("WriteEndDocument()") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_13) { Attribute = new VariationAttribute("WriteEndElement()") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_14) { Attribute = new VariationAttribute("WriteEntityRef(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_14) { Attribute = new VariationAttribute("WriteEntityRef('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_15) { Attribute = new VariationAttribute("WriteFullEndElement()") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_16) { Attribute = new VariationAttribute("WriteName('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_16) { Attribute = new VariationAttribute("WriteName(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_17) { Attribute = new VariationAttribute("WriteNmToken('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_17) { Attribute = new VariationAttribute("WriteNmToken(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_18) { Attribute = new VariationAttribute("WriteNode(null)") { Params = new object[] { "reader", true }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_18) { Attribute = new VariationAttribute("WriteNode(null)") { Params = new object[] { "reader", false }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_19) { Attribute = new VariationAttribute("WriteProcessingInstruction('', '')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_19) { Attribute = new VariationAttribute("WriteProcessingInstruction(null, null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_20) { Attribute = new VariationAttribute("WriteQualifiedName('', '')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_20) { Attribute = new VariationAttribute("WriteQualifiedName(null, null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_21) { Attribute = new VariationAttribute("WriteRaw(null, 0, 0)") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_22) { Attribute = new VariationAttribute("WriteStartAttribute(null, null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_22) { Attribute = new VariationAttribute("WriteStartAttribute('', '')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_23) { Attribute = new VariationAttribute("WriteStartElement(null, null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_23) { Attribute = new VariationAttribute("WriteStartElement('', '')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_24) { Attribute = new VariationAttribute("WriteStartDocument(true)") { Param = 2, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_24) { Attribute = new VariationAttribute("WriteStartDocument()") { Param = 1, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_24) { Attribute = new VariationAttribute("WriteStartDocument(false)") { Param = 3, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_25) { Attribute = new VariationAttribute("WriteString(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_25) { Attribute = new VariationAttribute("WriteString('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_26) { Attribute = new VariationAttribute("WriteValue(false)") { Param = false, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_26) { Attribute = new VariationAttribute("WriteValue(true)") { Param = true, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_27) { Attribute = new VariationAttribute("WriteWhitespace('')") { Param = "", Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_27) { Attribute = new VariationAttribute("WriteWhitespace(null)") { Param = null, Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_28) { Attribute = new VariationAttribute("EntityRef after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_29) { Attribute = new VariationAttribute("EntityRef after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_30) { Attribute = new VariationAttribute("CharEntity after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_31) { Attribute = new VariationAttribute("CharEntity after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_32) { Attribute = new VariationAttribute("SurrogateCharEntity after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_33) { Attribute = new VariationAttribute("SurrogateCharEntity after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_34) { Attribute = new VariationAttribute("Attribute after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_35) { Attribute = new VariationAttribute("Attribute after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_36) { Attribute = new VariationAttribute("CDATA after Document should error - PROLOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_37) { Attribute = new VariationAttribute("CDATA after Document should error - EPILOG") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_38) { Attribute = new VariationAttribute("Element followed by Document should error") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.var_39) { Attribute = new VariationAttribute("Element followed by DocType should error") { Priority = 2 } });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.Variation41) { Attribute = new VariationAttribute("WriteBase64") });
+                    this.AddChild(new TestVariation(xObjectBuilderTest.Variation42) { Attribute = new VariationAttribute("WriteEntityRef") });
                 }
             }
-            public partial class NamespacehandlingWriterSanity : XLinqTestCase
+            public class NamespacehandlingWriterSanity : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+NamespacehandlingWriterSanity
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace II.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace III.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down") { Params = new object[] { "<p:A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down II.") { Params = new object[] { "<p:A xmlns:p='nsp'><B><C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down III.") { Params = new object[] { "<A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Siblings") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'/><C xmlns:p='nsp'/><p:C xmlns:p='nsp'/></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Children") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'><C xmlns:p='nsp'><p:C xmlns:p='nsp'/></C></p:B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace I.") { Params = new object[] { "<A xmlns:xml='http://www.w3.org/XML/1998/namespace'/>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></p:A>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down II.") { Params = new object[] { "<A><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></A>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Not used NS declarations") { Params = new object[] { "<A xmlns='nsp' xmlns:u='not-used'><p:B xmlns:p='nsp'><C xmlns:u='not-used' xmlns='nsp' /></p:B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("SameNS, different prefix") { Params = new object[] { "<p:A xmlns:p='nsp'><B xmlns:q='nsp'><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Default namespaces") { Params = new object[] { "<A xmlns='nsp'><p:B xmlns:p='nsp'><C xmlns='nsp' /></p:B></A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeTricky) { Attribute = new VariationAttribute("Default ns parent autogenerated") { Priority = 1 } });
-                    this.AddChild(new TestVariation(testConflicts) { Attribute = new VariationAttribute("Conflicts: NS undeclaration, default NS") { Params = new object[] { "<A xmlns='nsp'><B xmlns=''><C xmlns='nsp'><D xmlns='nsp'/></C></B></A>", "<A xmlns='nsp'><B xmlns=''><C xmlns='nsp'><D/></C></B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='ns-other'><p:C xmlns:p='nsp'><D xmlns:p='nsp'/></p:C></p:B></p:A>", "<p:A xmlns:p='nsp'><p:B xmlns:p='ns-other'><p:C xmlns:p='nsp'><D/></p:C></p:B></p:A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition, default NS") { Params = new object[] { "<A xmlns='nsp'><B xmlns='ns-other'><C xmlns='nsp'><D xmlns='nsp'/></C></B></A>", "<A xmlns='nsp'><B xmlns='ns-other'><C xmlns='nsp'><D/></C></B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition, default NS II.") { Params = new object[] { "<A xmlns=''><B xmlns='ns-other'><C xmlns=''><D xmlns=''/></C></B></A>", "<A><B xmlns='ns-other'><C xmlns=''><D/></C></B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromChildNode1) { Attribute = new VariationAttribute("Not from root") { Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromChildNode2) { Attribute = new VariationAttribute("Not from root II.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromChildNode3) { Attribute = new VariationAttribute("Not from root III.") { Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromChildNode4) { Attribute = new VariationAttribute("Not from root IV.") { Priority = 2 } });
-                    this.AddChild(new TestVariation(testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader III.") { Params = new object[] { "<p1:A xmlns:p1='nsp'><B xmlns:p1='nsp'/></p1:A>", "<p1:root xmlns:p1='nsp'><p1:A><B/></p1:A></p1:root>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader I.") { Params = new object[] { "<A xmlns:p1='nsp'/>", "<p1:root xmlns:p1='nsp'><A/></p1:root>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader II.") { Params = new object[] { "<p1:A xmlns:p1='nsp'/>", "<p1:root xmlns:p1='nsp'><p1:A/></p1:root>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testIntoOpenedWriterDefaultNS) { Attribute = new VariationAttribute("Write into used reader I. (def. ns.)") { Params = new object[] { "<A xmlns='nsp'/>", "<root xmlns='nsp'><A/></root>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(testIntoOpenedWriterDefaultNS) { Attribute = new VariationAttribute("Write into used reader II. (def. ns.)") { Params = new object[] { "<A xmlns='ns-other'><B xmlns='nsp'><C xmlns='nsp'/></B></A>", "<root xmlns='nsp'><A xmlns='ns-other'><B xmlns='nsp'><C/></B></A></root>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testIntoOpenedWriterXlinqLookup1) { Attribute = new VariationAttribute("Write into used reader (Xlinq lookup + existing hint in the Writer; different prefix)") { Params = new object[] { "<p1:root xmlns:p1='nsp'><p2:B xmlns:p2='nsp'/></p1:root>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testIntoOpenedWriterXlinqLookup2) { Attribute = new VariationAttribute("Write into used reader (Xlinq lookup + existing hint in the Writer; same prefix)") { Params = new object[] { "<p1:root xmlns:p1='nsp'><p1:B /></p1:root>" }, Priority = 2 } });
+                    var namespacehandlingWriterSanity = new OmitDuplicateNamespaceDeclFunctionalTests.XNodeBuilderTests.NamespacehandlingWriterSanity();
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace II.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace III.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down") { Params = new object[] { "<p:A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down II.") { Params = new object[] { "<p:A xmlns:p='nsp'><B><C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down III.") { Params = new object[] { "<A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Siblings") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'/><C xmlns:p='nsp'/><p:C xmlns:p='nsp'/></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Children") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'><C xmlns:p='nsp'><p:C xmlns:p='nsp'/></C></p:B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace I.") { Params = new object[] { "<A xmlns:xml='http://www.w3.org/XML/1998/namespace'/>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></p:A>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down II.") { Params = new object[] { "<A><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></A>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Not used NS declarations") { Params = new object[] { "<A xmlns='nsp' xmlns:u='not-used'><p:B xmlns:p='nsp'><C xmlns:u='not-used' xmlns='nsp' /></p:B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("SameNS, different prefix") { Params = new object[] { "<p:A xmlns:p='nsp'><B xmlns:q='nsp'><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Default namespaces") { Params = new object[] { "<A xmlns='nsp'><p:B xmlns:p='nsp'><C xmlns='nsp' /></p:B></A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromTheRootNodeTricky) { Attribute = new VariationAttribute("Default ns parent autogenerated") { Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testConflicts) { Attribute = new VariationAttribute("Conflicts: NS undeclaration, default NS") { Params = new object[] { "<A xmlns='nsp'><B xmlns=''><C xmlns='nsp'><D xmlns='nsp'/></C></B></A>", "<A xmlns='nsp'><B xmlns=''><C xmlns='nsp'><D/></C></B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='ns-other'><p:C xmlns:p='nsp'><D xmlns:p='nsp'/></p:C></p:B></p:A>", "<p:A xmlns:p='nsp'><p:B xmlns:p='ns-other'><p:C xmlns:p='nsp'><D/></p:C></p:B></p:A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition, default NS") { Params = new object[] { "<A xmlns='nsp'><B xmlns='ns-other'><C xmlns='nsp'><D xmlns='nsp'/></C></B></A>", "<A xmlns='nsp'><B xmlns='ns-other'><C xmlns='nsp'><D/></C></B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testConflicts) { Attribute = new VariationAttribute("Conflicts: NS redefinition, default NS II.") { Params = new object[] { "<A xmlns=''><B xmlns='ns-other'><C xmlns=''><D xmlns=''/></C></B></A>", "<A><B xmlns='ns-other'><C xmlns=''><D/></C></B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromChildNode1) { Attribute = new VariationAttribute("Not from root") { Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromChildNode2) { Attribute = new VariationAttribute("Not from root II.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromChildNode3) { Attribute = new VariationAttribute("Not from root III.") { Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testFromChildNode4) { Attribute = new VariationAttribute("Not from root IV.") { Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader III.") { Params = new object[] { "<p1:A xmlns:p1='nsp'><B xmlns:p1='nsp'/></p1:A>", "<p1:root xmlns:p1='nsp'><p1:A><B/></p1:A></p1:root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader I.") { Params = new object[] { "<A xmlns:p1='nsp'/>", "<p1:root xmlns:p1='nsp'><A/></p1:root>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriter) { Attribute = new VariationAttribute("Write into used reader II.") { Params = new object[] { "<p1:A xmlns:p1='nsp'/>", "<p1:root xmlns:p1='nsp'><p1:A/></p1:root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriterDefaultNS) { Attribute = new VariationAttribute("Write into used reader I. (def. ns.)") { Params = new object[] { "<A xmlns='nsp'/>", "<root xmlns='nsp'><A/></root>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriterDefaultNS) { Attribute = new VariationAttribute("Write into used reader II. (def. ns.)") { Params = new object[] { "<A xmlns='ns-other'><B xmlns='nsp'><C xmlns='nsp'/></B></A>", "<root xmlns='nsp'><A xmlns='ns-other'><B xmlns='nsp'><C/></B></A></root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriterXlinqLookup1) { Attribute = new VariationAttribute("Write into used reader (Xlinq lookup + existing hint in the Writer; different prefix)") { Params = new object[] { "<p1:root xmlns:p1='nsp'><p2:B xmlns:p2='nsp'/></p1:root>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingWriterSanity.testIntoOpenedWriterXlinqLookup2) { Attribute = new VariationAttribute("Write into used reader (Xlinq lookup + existing hint in the Writer; same prefix)") { Params = new object[] { "<p1:root xmlns:p1='nsp'><p1:B /></p1:root>" }, Priority = 2 } });
                 }
             }
-            public partial class OmitAnotation : XLinqTestCase
+            public class OmitAnotation : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+OmitAnotation
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(NoAnnotation) { Attribute = new VariationAttribute("No annotation - element") { Params = new object[] { typeof(XElement), "Simple.xml" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(NoAnnotation) { Attribute = new VariationAttribute("No annotation - document") { Params = new object[] { typeof(XDocument), "Simple.xml" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on document without omit - DisableFormating") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.DisableFormatting }, Priority = 2 } });
-                    this.AddChild(new TestVariation(AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on element without omit - None") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.None }, Priority = 2 } });
-                    this.AddChild(new TestVariation(AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on element without omit - DisableFormating") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.DisableFormatting }, Priority = 2 } });
-                    this.AddChild(new TestVariation(AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on document without omit - None") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.None }, Priority = 2 } });
-                    this.AddChild(new TestVariation(XDocAnnotation) { Attribute = new VariationAttribute("Annotation on document - Omit + Disable") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.OmitDuplicateNamespaces | SaveOptions.DisableFormatting }, Priority = 1 } });
-                    this.AddChild(new TestVariation(XDocAnnotation) { Attribute = new VariationAttribute("Annotation on element - Omit + Disable") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.OmitDuplicateNamespaces | SaveOptions.DisableFormatting }, Priority = 1 } });
-                    this.AddChild(new TestVariation(XDocAnnotation) { Attribute = new VariationAttribute("Annotation on element - Omit") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.OmitDuplicateNamespaces }, Priority = 0 } });
-                    this.AddChild(new TestVariation(XDocAnnotation) { Attribute = new VariationAttribute("Annotation on document - Omit") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.OmitDuplicateNamespaces }, Priority = 0 } });
-                    this.AddChild(new TestVariation(AnnotationOnParent1) { Attribute = new VariationAttribute("Annotation on the parent nodes, XDocument") { Params = new object[] { typeof(XDocument), "simple.xml" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(AnnotationOnParent1) { Attribute = new VariationAttribute("Annotation on the parent nodes, XElement") { Params = new object[] { typeof(XElement), "simple.xml" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(MultipleAnnotationsInTree) { Attribute = new VariationAttribute("Multiple annotations in the tree - both up - XDocument") { Param = typeof(XDocument), Priority = 0 } });
-                    this.AddChild(new TestVariation(MultipleAnnotationsInTree) { Attribute = new VariationAttribute("Multiple annotations in the tree - both up - XElement") { Param = typeof(XElement), Priority = 0 } });
-                    this.AddChild(new TestVariation(MultipleAnnotationsInTree2) { Attribute = new VariationAttribute("Multiple annotations in the tree - up/down - XDocument") { Param = typeof(XDocument), Priority = 0 } });
-                    this.AddChild(new TestVariation(MultipleAnnotationsInTree2) { Attribute = new VariationAttribute("Multiple annotations in the tree - up/down - XElement") { Param = typeof(XElement), Priority = 0 } });
-                    this.AddChild(new TestVariation(MultipleAnnotationsOnElement) { Attribute = new VariationAttribute("Multiple annotations on node - XElement") { Param = typeof(XElement), Priority = 0 } });
-                    this.AddChild(new TestVariation(MultipleAnnotationsOnElement) { Attribute = new VariationAttribute("Multiple annotations on node - XDocument") { Param = typeof(XDocument), Priority = 0 } });
-                    this.AddChild(new TestVariation(OnOtherNodesAttrs) { Attribute = new VariationAttribute("On other node types - attributes") { Param = typeof(XElement), Priority = 2 } });
-                    this.AddChild(new TestVariation(SimulateVb1) { Attribute = new VariationAttribute("Simulate the VB behavior - Save") { Priority = 0 } });
-                    this.AddChild(new TestVariation(SimulateVb2) { Attribute = new VariationAttribute("Simulate the VB behavior - Reader") { Priority = 0 } });
-                    this.AddChild(new TestVariation(LocalOverride) { Attribute = new VariationAttribute("Local settings override annotation") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReaderOptionsSmoke) { Attribute = new VariationAttribute("XElement - ReaderOptions.None") { Params = new object[] { typeof(XElement), "simple.xml", ReaderOptions.None }, Priority = 0 } });
-                    this.AddChild(new TestVariation(ReaderOptionsSmoke) { Attribute = new VariationAttribute("XElement - ReaderOptions.OmitDuplicateNamespaces") { Params = new object[] { typeof(XElement), "simple.xml", ReaderOptions.OmitDuplicateNamespaces }, Priority = 0 } });
-                    this.AddChild(new TestVariation(ReaderOptionsSmoke) { Attribute = new VariationAttribute("XDocument - ReaderOptions.None") { Params = new object[] { typeof(XDocument), "simple.xml", ReaderOptions.None }, Priority = 0 } });
-                    this.AddChild(new TestVariation(ReaderOptionsSmoke) { Attribute = new VariationAttribute("XDocument - ReaderOptions.OmitDuplicateNamespaces") { Params = new object[] { typeof(XDocument), "simple.xml", ReaderOptions.OmitDuplicateNamespaces }, Priority = 0 } });
+                    var omitAnotation = new OmitDuplicatesAnnotationFunctionalTests.XNodeBuilderTests.OmitAnotation();
+                    this.AddChild(new TestVariation(omitAnotation.NoAnnotation) { Attribute = new VariationAttribute("No annotation - element") { Params = new object[] { typeof(XElement), "Simple.xml" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.NoAnnotation) { Attribute = new VariationAttribute("No annotation - document") { Params = new object[] { typeof(XDocument), "Simple.xml" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on document without omit - DisableFormating") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.DisableFormatting }, Priority = 2 } });
+                    this.AddChild(new TestVariation(omitAnotation.AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on element without omit - None") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.None }, Priority = 2 } });
+                    this.AddChild(new TestVariation(omitAnotation.AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on element without omit - DisableFormating") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.DisableFormatting }, Priority = 2 } });
+                    this.AddChild(new TestVariation(omitAnotation.AnnotationWithoutTheOmitDuplicates) { Attribute = new VariationAttribute("Annotation on document without omit - None") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.None }, Priority = 2 } });
+                    this.AddChild(new TestVariation(omitAnotation.XDocAnnotation) { Attribute = new VariationAttribute("Annotation on document - Omit + Disable") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.OmitDuplicateNamespaces | SaveOptions.DisableFormatting }, Priority = 1 } });
+                    this.AddChild(new TestVariation(omitAnotation.XDocAnnotation) { Attribute = new VariationAttribute("Annotation on element - Omit + Disable") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.OmitDuplicateNamespaces | SaveOptions.DisableFormatting }, Priority = 1 } });
+                    this.AddChild(new TestVariation(omitAnotation.XDocAnnotation) { Attribute = new VariationAttribute("Annotation on element - Omit") { Params = new object[] { typeof(XElement), "Simple.xml", SaveOptions.OmitDuplicateNamespaces }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.XDocAnnotation) { Attribute = new VariationAttribute("Annotation on document - Omit") { Params = new object[] { typeof(XDocument), "Simple.xml", SaveOptions.OmitDuplicateNamespaces }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.AnnotationOnParent1) { Attribute = new VariationAttribute("Annotation on the parent nodes, XDocument") { Params = new object[] { typeof(XDocument), "simple.xml" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.AnnotationOnParent1) { Attribute = new VariationAttribute("Annotation on the parent nodes, XElement") { Params = new object[] { typeof(XElement), "simple.xml" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsInTree) { Attribute = new VariationAttribute("Multiple annotations in the tree - both up - XDocument") { Param = typeof(XDocument), Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsInTree) { Attribute = new VariationAttribute("Multiple annotations in the tree - both up - XElement") { Param = typeof(XElement), Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsInTree2) { Attribute = new VariationAttribute("Multiple annotations in the tree - up/down - XDocument") { Param = typeof(XDocument), Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsInTree2) { Attribute = new VariationAttribute("Multiple annotations in the tree - up/down - XElement") { Param = typeof(XElement), Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsOnElement) { Attribute = new VariationAttribute("Multiple annotations on node - XElement") { Param = typeof(XElement), Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.MultipleAnnotationsOnElement) { Attribute = new VariationAttribute("Multiple annotations on node - XDocument") { Param = typeof(XDocument), Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.OnOtherNodesAttrs) { Attribute = new VariationAttribute("On other node types - attributes") { Param = typeof(XElement), Priority = 2 } });
+                    this.AddChild(new TestVariation(omitAnotation.SimulateVb1) { Attribute = new VariationAttribute("Simulate the VB behavior - Save") { Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.SimulateVb2) { Attribute = new VariationAttribute("Simulate the VB behavior - Reader") { Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.LocalOverride) { Attribute = new VariationAttribute("Local settings override annotation") { Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.ReaderOptionsSmoke) { Attribute = new VariationAttribute("XElement - ReaderOptions.None") { Params = new object[] { typeof(XElement), "simple.xml", ReaderOptions.None }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.ReaderOptionsSmoke) { Attribute = new VariationAttribute("XElement - ReaderOptions.OmitDuplicateNamespaces") { Params = new object[] { typeof(XElement), "simple.xml", ReaderOptions.OmitDuplicateNamespaces }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.ReaderOptionsSmoke) { Attribute = new VariationAttribute("XDocument - ReaderOptions.None") { Params = new object[] { typeof(XDocument), "simple.xml", ReaderOptions.None }, Priority = 0 } });
+                    this.AddChild(new TestVariation(omitAnotation.ReaderOptionsSmoke) { Attribute = new VariationAttribute("XDocument - ReaderOptions.OmitDuplicateNamespaces") { Params = new object[] { typeof(XDocument), "simple.xml", ReaderOptions.OmitDuplicateNamespaces }, Priority = 0 } });
                 }
             }
-            public partial class NamespacehandlingSaveOptions : XLinqTestCase
+            public class NamespacehandlingSaveOptions : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+NamespacehandlingSaveOptions
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down") { Params = new object[] { "<p:A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down III.") { Params = new object[] { "<A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Siblings") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'/><C xmlns:p='nsp'/><p:C xmlns:p='nsp'/></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace II.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down II.") { Params = new object[] { "<A><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></A>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down II.") { Params = new object[] { "<p:A xmlns:p='nsp'><B><C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Children") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'><C xmlns:p='nsp'><p:C xmlns:p='nsp'/></C></p:B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace I.") { Params = new object[] { "<A xmlns:xml='http://www.w3.org/XML/1998/namespace'/>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></p:A>" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace III.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Default namespaces") { Params = new object[] { "<A xmlns='nsp'><p:B xmlns:p='nsp'><C xmlns='nsp' /></p:B></A>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Not used NS declarations") { Params = new object[] { "<A xmlns='nsp' xmlns:u='not-used'><p:B xmlns:p='nsp'><C xmlns:u='not-used' xmlns='nsp' /></p:B></A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeSimple) { Attribute = new VariationAttribute("SameNS, different prefix") { Params = new object[] { "<p:A xmlns:p='nsp'><B xmlns:q='nsp'><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromTheRootNodeTricky) { Attribute = new VariationAttribute("Default ns parent autogenerated") { Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromChildNode1) { Attribute = new VariationAttribute("Not from root") { Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromChildNode2) { Attribute = new VariationAttribute("Not from root II.") { Priority = 1 } });
-                    this.AddChild(new TestVariation(testFromChildNode3) { Attribute = new VariationAttribute("Not from root III.") { Priority = 2 } });
-                    this.AddChild(new TestVariation(testFromChildNode4) { Attribute = new VariationAttribute("Not from root IV.") { Priority = 2 } });
+                    var namespacehandlingSaveOptions = new SaveOptions_OmitDuplicateNamespaceFunctionalTests.XNodeBuilderTests.NamespacehandlingSaveOptions();
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down") { Params = new object[] { "<p:A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down III.") { Params = new object[] { "<A xmlns:p='nsp'><B><p:C xmlns:p='nsp'/></B></A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Siblings") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'/><C xmlns:p='nsp'/><p:C xmlns:p='nsp'/></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace II.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down II.") { Params = new object[] { "<A><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></A>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("2 levels down II.") { Params = new object[] { "<p:A xmlns:p='nsp'><B><C xmlns:p='nsp'/></B></p:A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Children") { Params = new object[] { "<A xmlns:p='nsp'><p:B xmlns:p='nsp'><C xmlns:p='nsp'><p:C xmlns:p='nsp'/></C></p:B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace I.") { Params = new object[] { "<A xmlns:xml='http://www.w3.org/XML/1998/namespace'/>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("1 level down") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:p='nsp'><p:C xmlns:p='nsp'/></p:B></p:A>" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Xml namespace III.") { Params = new object[] { "<p:A xmlns:p='nsp'><p:B xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:p='nsp'><p:C xmlns:p='nsp' xmlns:xml='http://www.w3.org/XML/1998/namespace'/></p:B></p:A>" }, Priority = 3 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Default namespaces") { Params = new object[] { "<A xmlns='nsp'><p:B xmlns:p='nsp'><C xmlns='nsp' /></p:B></A>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("Not used NS declarations") { Params = new object[] { "<A xmlns='nsp' xmlns:u='not-used'><p:B xmlns:p='nsp'><C xmlns:u='not-used' xmlns='nsp' /></p:B></A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeSimple) { Attribute = new VariationAttribute("SameNS, different prefix") { Params = new object[] { "<p:A xmlns:p='nsp'><B xmlns:q='nsp'><p:C xmlns:p='nsp'/></B></p:A>" }, Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromTheRootNodeTricky) { Attribute = new VariationAttribute("Default ns parent autogenerated") { Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromChildNode1) { Attribute = new VariationAttribute("Not from root") { Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromChildNode2) { Attribute = new VariationAttribute("Not from root II.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromChildNode3) { Attribute = new VariationAttribute("Not from root III.") { Priority = 2 } });
+                    this.AddChild(new TestVariation(namespacehandlingSaveOptions.testFromChildNode4) { Attribute = new VariationAttribute("Not from root IV.") { Priority = 2 } });
                 }
             }
-            public partial class Writer_Settings : BridgeHelpers
+            public class Writer_Settings : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+Writer_Settings
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(var_1) { Attribute = new VariationAttribute("XDocument: Settings before Close()") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_2) { Attribute = new VariationAttribute("XElement: Settings before Close()") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_3) { Attribute = new VariationAttribute("XDocument: Settings after Close()") { Priority = 1 } });
-                    this.AddChild(new TestVariation(var_4) { Attribute = new VariationAttribute("XElement: Settings after Close()") { Priority = 1 } });
+                    var writerSettings = new WriterSettingsFunctionalTests.XNodeBuilderTests.Writer_Settings();
+                    this.AddChild(new TestVariation(writerSettings.var_1) { Attribute = new VariationAttribute("XDocument: Settings before Close()") { Priority = 1 } });
+                    this.AddChild(new TestVariation(writerSettings.var_2) { Attribute = new VariationAttribute("XElement: Settings before Close()") { Priority = 1 } });
+                    this.AddChild(new TestVariation(writerSettings.var_3) { Attribute = new VariationAttribute("XDocument: Settings after Close()") { Priority = 1 } });
+                    this.AddChild(new TestVariation(writerSettings.var_4) { Attribute = new VariationAttribute("XElement: Settings after Close()") { Priority = 1 } });
                 }
             }
-            public partial class TCCheckChars : BridgeHelpers
+            public class TCCheckChars : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCCheckChars
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteEntityRef") { Param = "EntityRef", Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteWhitespace") { Param = "Whitespace", Id = 3, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid name chars WriteDocType(name)") { Param = "WriteDocTypeName", Id = 4, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteSurrogateCharEntity") { Param = "SurrogateCharEntity", Id = 2, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteEntityRef should error") { Params = new object[] { "EntityRef", true }, Id = 46, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteSurrogateCharEntity should error") { Params = new object[] { "Surrogate", false }, Id = 41, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteQualifiedName should error") { Params = new object[] { "QName", true }, Id = 47, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteSurrogateCharEntity should error") { Params = new object[] { "Surrogate", true }, Id = 45, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteWhitespace should error") { Params = new object[] { "Whitespace", false }, Id = 40, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteEntityRef should error") { Params = new object[] { "EntityRef", false }, Id = 42, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteQualifiedName should error") { Params = new object[] { "QName", false }, Id = 43, Priority = 1 } });
-                    this.AddChild(new TestVariation(checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteWhitespace should error") { Params = new object[] { "Whitespace", true }, Id = 44, Priority = 1 } });
+                    var tcCheckChars = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCCheckChars();
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteEntityRef") { Param = "EntityRef", Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteWhitespace") { Param = "Whitespace", Id = 3, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid name chars WriteDocType(name)") { Param = "WriteDocTypeName", Id = 4, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_1) { Attribute = new VariationAttribute("CheckChars=true, invalid XML test WriteSurrogateCharEntity") { Param = "SurrogateCharEntity", Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteEntityRef should error") { Params = new object[] { "EntityRef", true }, Id = 46, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteSurrogateCharEntity should error") { Params = new object[] { "Surrogate", false }, Id = 41, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteQualifiedName should error") { Params = new object[] { "QName", true }, Id = 47, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteSurrogateCharEntity should error") { Params = new object[] { "Surrogate", true }, Id = 45, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteWhitespace should error") { Params = new object[] { "Whitespace", false }, Id = 40, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteEntityRef should error") { Params = new object[] { "EntityRef", false }, Id = 42, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=false, invalid XML characters in WriteQualifiedName should error") { Params = new object[] { "QName", false }, Id = 43, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcCheckChars.checkChars_4) { Attribute = new VariationAttribute("CheckChars=true, invalid XML characters in WriteWhitespace should error") { Params = new object[] { "Whitespace", true }, Id = 44, Priority = 1 } });
                 }
             }
-            public partial class TCNewLineHandling : BridgeHelpers
+            public class TCNewLineHandling : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCNewLineHandling
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(NewLineHandling_7) { Attribute = new VariationAttribute("Test for CR (xD) inside attr when NewLineHandling = Replace") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(NewLineHandling_8) { Attribute = new VariationAttribute("Test for LF (xA) inside attr when NewLineHandling = Replace") { Id = 8, Priority = 0 } });
-                    this.AddChild(new TestVariation(NewLineHandling_9) { Attribute = new VariationAttribute("Test for CR LF (xD xA) inside attr when NewLineHandling = Replace") { Id = 9, Priority = 0 } });
-                    this.AddChild(new TestVariation(NewLineHandling_10) { Attribute = new VariationAttribute("Test for CR (xD) inside attr when NewLineHandling = Entitize") { Id = 10, Priority = 0 } });
-                    this.AddChild(new TestVariation(NewLineHandling_11) { Attribute = new VariationAttribute("Test for LF (xA) inside attr when NewLineHandling = Entitize") { Id = 11, Priority = 0 } });
-                    this.AddChild(new TestVariation(NewLineHandling_12) { Attribute = new VariationAttribute("Test for CR LF (xD xA) inside attr when NewLineHandling = Entitize") { Id = 12, Priority = 0 } });
-                    this.AddChild(new TestVariation(NewLineHandling_13) { Attribute = new VariationAttribute("Factory-created writers do not entitize 0xD character in text content when NewLineHandling=Entitize") { Id = 13 } });
+                    var tcNewLineHandling = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCNewLineHandling();
+                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_7) { Attribute = new VariationAttribute("Test for CR (xD) inside attr when NewLineHandling = Replace") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_8) { Attribute = new VariationAttribute("Test for LF (xA) inside attr when NewLineHandling = Replace") { Id = 8, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_9) { Attribute = new VariationAttribute("Test for CR LF (xD xA) inside attr when NewLineHandling = Replace") { Id = 9, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_10) { Attribute = new VariationAttribute("Test for CR (xD) inside attr when NewLineHandling = Entitize") { Id = 10, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_11) { Attribute = new VariationAttribute("Test for LF (xA) inside attr when NewLineHandling = Entitize") { Id = 11, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_12) { Attribute = new VariationAttribute("Test for CR LF (xD xA) inside attr when NewLineHandling = Entitize") { Id = 12, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNewLineHandling.NewLineHandling_13) { Attribute = new VariationAttribute("Factory-created writers do not entitize 0xD character in text content when NewLineHandling=Entitize") { Id = 13 } });
                 }
             }
-            public partial class TCIndent : BridgeHelpers
+            public class TCIndent : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCIndent
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(indent_1) { Attribute = new VariationAttribute("Simple test when false") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(indent_2) { Attribute = new VariationAttribute("Simple test when true") { Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(indent_3) { Attribute = new VariationAttribute("Indent = false, element content is empty") { Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(indent_5) { Attribute = new VariationAttribute("Indent = false, element content is empty, FullEndElement") { Id = 5, Priority = 0 } });
-                    this.AddChild(new TestVariation(indent_6) { Attribute = new VariationAttribute("Indent = true, element content is empty, FullEndElement") { Id = 6, Priority = 0 } });
-                    this.AddChild(new TestVariation(indent_7) { Attribute = new VariationAttribute("Indent = true, mixed content") { Id = 7, Priority = 0 } });
-                    this.AddChild(new TestVariation(indent_8) { Attribute = new VariationAttribute("Indent = true, mixed content, FullEndElement") { Id = 8, Priority = 0 } });
+                    var tcIndent = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCIndent();
+                    this.AddChild(new TestVariation(tcIndent.indent_1) { Attribute = new VariationAttribute("Simple test when false") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIndent.indent_2) { Attribute = new VariationAttribute("Simple test when true") { Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIndent.indent_3) { Attribute = new VariationAttribute("Indent = false, element content is empty") { Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIndent.indent_5) { Attribute = new VariationAttribute("Indent = false, element content is empty, FullEndElement") { Id = 5, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIndent.indent_6) { Attribute = new VariationAttribute("Indent = true, element content is empty, FullEndElement") { Id = 6, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIndent.indent_7) { Attribute = new VariationAttribute("Indent = true, mixed content") { Id = 7, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIndent.indent_8) { Attribute = new VariationAttribute("Indent = true, mixed content, FullEndElement") { Id = 8, Priority = 0 } });
                 }
             }
-            public partial class TCNewLineOnAttributes : BridgeHelpers
+            public class TCNewLineOnAttributes : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCNewLineOnAttributes
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(NewLineOnAttributes_1) { Attribute = new VariationAttribute("Make sure the setting has no effect when Indent is false") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(NewLineOnAttributes_3) { Attribute = new VariationAttribute("Attributes of nested elements") { Id = 3, Priority = 1 } });
+                    var tcNewLineOnAttributes = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCNewLineOnAttributes();
+                    this.AddChild(new TestVariation(tcNewLineOnAttributes.NewLineOnAttributes_1) { Attribute = new VariationAttribute("Make sure the setting has no effect when Indent is false") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNewLineOnAttributes.NewLineOnAttributes_3) { Attribute = new VariationAttribute("Attributes of nested elements") { Id = 3, Priority = 1 } });
                 }
             }
-            public partial class TCStandAlone : BridgeHelpers
+            public class TCStandAlone : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCStandAlone
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(standalone_1) { Attribute = new VariationAttribute("StartDocument(bool standalone = true)") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(standalone_2) { Attribute = new VariationAttribute("StartDocument(bool standalone = false)") { Id = 2, Priority = 0 } });
+                    var tcStandAlone = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCStandAlone();
+                    this.AddChild(new TestVariation(tcStandAlone.standalone_1) { Attribute = new VariationAttribute("StartDocument(bool standalone = true)") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcStandAlone.standalone_2) { Attribute = new VariationAttribute("StartDocument(bool standalone = false)") { Id = 2, Priority = 0 } });
                 }
             }
-            public partial class TCFragmentCL : BridgeHelpers
+            public class TCFragmentCL : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCFragmentCL
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(frag_1) { Attribute = new VariationAttribute("WriteDocType should error when CL=fragment") { Id = 1, Priority = 1 } });
-                    this.AddChild(new TestVariation(frag_2) { Attribute = new VariationAttribute("WriteStartDocument() should error when CL=fragment") { Id = 2, Priority = 1 } });
+                    var tcFragmentCL = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCFragmentCL();
+                    this.AddChild(new TestVariation(tcFragmentCL.frag_1) { Attribute = new VariationAttribute("WriteDocType should error when CL=fragment") { Id = 1, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcFragmentCL.frag_2) { Attribute = new VariationAttribute("WriteStartDocument() should error when CL=fragment") { Id = 2, Priority = 1 } });
                 }
             }
-            public partial class TCAutoCL : BridgeHelpers
+            public class TCAutoCL : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeBuilderTests+TCAutoCL
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(auto_1) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument()") { Id = 1, Priority = 0 } });
-                    this.AddChild(new TestVariation(auto_2) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument(standalone = true)") { Param = "true", Id = 2, Priority = 0 } });
-                    this.AddChild(new TestVariation(auto_2) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument(standalone = false)") { Param = "false", Id = 3, Priority = 0 } });
-                    this.AddChild(new TestVariation(auto_3) { Attribute = new VariationAttribute("Change to CL Document when you write DocType decl") { Id = 4, Priority = 0 } });
-                    this.AddChild(new TestVariation(auto_4) { Attribute = new VariationAttribute("Change to CL Fragment when you write a root element") { Id = 5, Priority = 1 } });
-                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteCData at top level") { Param = "CData", Id = 7, Priority = 1 } });
-                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteCharEntity at top level") { Param = "CharEntity", Id = 9, Priority = 1 } });
-                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteSurrogateCharEntity at top level") { Param = "SurrogateCharEntity", Id = 10, Priority = 1 } });
-                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteString at top level") { Param = "String", Id = 6, Priority = 1 } });
-                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteRaw at top level") { Param = "Raw", Id = 12, Priority = 1 } });
-                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteBinHex at top level") { Param = "BinHex", Id = 14, Priority = 1 } });
-                    this.AddChild(new TestVariation(auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteChars at top level") { Param = "Chars", Id = 11, Priority = 1 } });
-                    this.AddChild(new TestVariation(auto_6) { Attribute = new VariationAttribute("WritePI at top level, followed by DTD, expected CL = Document") { Param = "PI", Id = 15, Priority = 2 } });
-                    this.AddChild(new TestVariation(auto_6) { Attribute = new VariationAttribute("WriteWhitespace at top level, followed by DTD, expected CL = Document") { Param = "WS", Id = 17, Priority = 2 } });
-                    this.AddChild(new TestVariation(auto_6) { Attribute = new VariationAttribute("WriteComment at top level, followed by DTD, expected CL = Document") { Param = "Comment", Id = 16, Priority = 2 } });
-                    this.AddChild(new TestVariation(auto_7) { Attribute = new VariationAttribute("WriteComment at top level, followed by text, expected CL = Fragment") { Param = "Comment", Id = 19, Priority = 2 } });
-                    this.AddChild(new TestVariation(auto_7) { Attribute = new VariationAttribute("WriteWhitespace at top level, followed by text, expected CL = Fragment") { Param = "WS", Id = 20, Priority = 2 } });
-                    this.AddChild(new TestVariation(auto_7) { Attribute = new VariationAttribute("WritePI at top level, followed by text, expected CL = Fragment") { Param = "PI", Id = 18, Priority = 2 } });
-                    this.AddChild(new TestVariation(auto_8) { Attribute = new VariationAttribute("WriteNode(XmlReader) when reader positioned on DocType node, expected CL = Document") { Id = 21, Priority = 2 } });
-                    this.AddChild(new TestVariation(auto_10) { Attribute = new VariationAttribute("WriteNode(XmlReader) when reader positioned on text node, expected CL = Fragment") { Id = 22, Priority = 2 } });
+                    var tcAutoCL = new XmlFactoryWriterTestsFunctionalTests.XNodeBuilderTests.TCAutoCL();
+                    this.AddChild(new TestVariation(tcAutoCL.auto_1) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument()") { Id = 1, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_2) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument(standalone = true)") { Param = "true", Id = 2, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_2) { Attribute = new VariationAttribute("Change to CL Document after WriteStartDocument(standalone = false)") { Param = "false", Id = 3, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_3) { Attribute = new VariationAttribute("Change to CL Document when you write DocType decl") { Id = 4, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_4) { Attribute = new VariationAttribute("Change to CL Fragment when you write a root element") { Id = 5, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteCData at top level") { Param = "CData", Id = 7, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteCharEntity at top level") { Param = "CharEntity", Id = 9, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteSurrogateCharEntity at top level") { Param = "SurrogateCharEntity", Id = 10, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteString at top level") { Param = "String", Id = 6, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteRaw at top level") { Param = "Raw", Id = 12, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteBinHex at top level") { Param = "BinHex", Id = 14, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_5) { Attribute = new VariationAttribute("Change to CL Fragment for WriteChars at top level") { Param = "Chars", Id = 11, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_6) { Attribute = new VariationAttribute("WritePI at top level, followed by DTD, expected CL = Document") { Param = "PI", Id = 15, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_6) { Attribute = new VariationAttribute("WriteWhitespace at top level, followed by DTD, expected CL = Document") { Param = "WS", Id = 17, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_6) { Attribute = new VariationAttribute("WriteComment at top level, followed by DTD, expected CL = Document") { Param = "Comment", Id = 16, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_7) { Attribute = new VariationAttribute("WriteComment at top level, followed by text, expected CL = Fragment") { Param = "Comment", Id = 19, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_7) { Attribute = new VariationAttribute("WriteWhitespace at top level, followed by text, expected CL = Fragment") { Param = "WS", Id = 20, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_7) { Attribute = new VariationAttribute("WritePI at top level, followed by text, expected CL = Fragment") { Param = "PI", Id = 18, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_8) { Attribute = new VariationAttribute("WriteNode(XmlReader) when reader positioned on DocType node, expected CL = Document") { Id = 21, Priority = 2 } });
+                    this.AddChild(new TestVariation(tcAutoCL.auto_10) { Attribute = new VariationAttribute("WriteNode(XmlReader) when reader positioned on text node, expected CL = Fragment") { Id = 22, Priority = 2 } });
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/OmitDuplicateNamespaceDecl.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/OmitDuplicateNamespaceDecl.cs
@@ -12,11 +12,11 @@ using System.IO;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class OmitDuplicateNamespaceDeclFunctionalTests : TestModule
     {
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
-            public partial class NamespacehandlingWriterSanity : XLinqTestCase
+            public class NamespacehandlingWriterSanity : XLinqTestCase
             {
                 #region helpers
                 private string SaveXElementUsingXmlWriter(XElement elem, NamespaceHandling nsHandling)

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/OmitDuplicateNamespaceDecl.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/OmitDuplicateNamespaceDecl.cs
@@ -12,11 +12,11 @@ using System.IO;
 
 namespace CoreXml.Test.XLinq
 {
-    public class OmitDuplicateNamespaceDeclFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
-            public class NamespacehandlingWriterSanity : XLinqTestCase
+            public partial class NamespacehandlingWriterSanity : XLinqTestCase
             {
                 #region helpers
                 private string SaveXElementUsingXmlWriter(XElement elem, NamespaceHandling nsHandling)

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/OmitDuplicatesAnnotation.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/OmitDuplicatesAnnotation.cs
@@ -15,11 +15,11 @@ using XmlCoreTest.Common;
 
 namespace CoreXml.Test.XLinq
 {
-    public class OmitDuplicatesAnnotationFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
-            public class OmitAnotation : XLinqTestCase
+            public partial class OmitAnotation : XLinqTestCase
             {
                 private static string s_MyPath = Path.Combine(FilePathUtil.GetTestDataPath(), @"Xlinq\DuplicateNamespaces");
 

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/OmitDuplicatesAnnotation.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/OmitDuplicatesAnnotation.cs
@@ -15,11 +15,11 @@ using XmlCoreTest.Common;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class OmitDuplicatesAnnotationFunctionalTests : TestModule
     {
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
-            public partial class OmitAnotation : XLinqTestCase
+            public class OmitAnotation : XLinqTestCase
             {
                 private static string s_MyPath = Path.Combine(FilePathUtil.GetTestDataPath(), @"Xlinq\DuplicateNamespaces");
 

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/SaveOptions_OmitDuplicateNamespace.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/SaveOptions_OmitDuplicateNamespace.cs
@@ -14,11 +14,11 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class SaveOptions_OmitDuplicateNamespaceFunctionalTests : TestModule
     {
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
-            public partial class NamespacehandlingSaveOptions : XLinqTestCase
+            public class NamespacehandlingSaveOptions : XLinqTestCase
             {
                 private string _mode;
                 private Type _type;

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/SaveOptions_OmitDuplicateNamespace.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/SaveOptions_OmitDuplicateNamespace.cs
@@ -14,11 +14,11 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public class SaveOptions_OmitDuplicateNamespaceFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
-            public class NamespacehandlingSaveOptions : XLinqTestCase
+            public partial class NamespacehandlingSaveOptions : XLinqTestCase
             {
                 private string _mode;
                 private Type _type;

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/WriterSettings.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/WriterSettings.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class WriterSettingsFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
-            public class Writer_Settings : BridgeHelpers
+            public partial class Writer_Settings : BridgeHelpers
             {
                 //[Variation(Desc = "XDocument: Settings before Close()", Priority = 1)]
                 public void var_1()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/WriterSettings.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/WriterSettings.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class WriterSettingsFunctionalTests : TestModule
     {
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
-            public partial class Writer_Settings : BridgeHelpers
+            public class Writer_Settings : BridgeHelpers
             {
                 //[Variation(Desc = "XDocument: Settings before Close()", Priority = 1)]
                 public void var_1()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/XmlFactoryWriterTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/XmlFactoryWriterTests.cs
@@ -13,11 +13,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class XmlFactoryWriterTestsFunctionalTests : TestModule
+    public partial class XNodeBuilderFunctionalTests : TestModule
     {
-        public class XNodeBuilderTests : XLinqTestCase
+        public partial class XNodeBuilderTests : XLinqTestCase
         {
-            public class TCCheckChars : BridgeHelpers
+            public partial class TCCheckChars : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "CheckChars=true, invalid XML test WriteEntityRef", Priority = 1, Param = "EntityRef")]
                 //[Variation(Id = 2, Desc = "CheckChars=true, invalid XML test WriteSurrogateCharEntity", Priority = 1, Param = "SurrogateCharEntity")]
@@ -170,7 +170,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCNewLineHandling : BridgeHelpers
+            public partial class TCNewLineHandling : BridgeHelpers
             {
                 //[Variation(Id = 7, Desc = "Test for CR (xD) inside attr when NewLineHandling = Replace", Priority = 0)]
                 public void NewLineHandling_7()
@@ -264,7 +264,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCIndent : BridgeHelpers
+            public partial class TCIndent : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Simple test when false", Priority = 0)]
                 public void indent_1()
@@ -365,7 +365,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCNewLineOnAttributes : BridgeHelpers
+            public partial class TCNewLineOnAttributes : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Make sure the setting has no effect when Indent is false", Priority = 0)]
                 public void NewLineOnAttributes_1()
@@ -404,7 +404,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCStandAlone : BridgeHelpers
+            public partial class TCStandAlone : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "StartDocument(bool standalone = true)", Priority = 0)]
                 public void standalone_1()
@@ -435,7 +435,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCFragmentCL : BridgeHelpers
+            public partial class TCFragmentCL : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteDocType should error when CL=fragment", Priority = 1)]
                 public void frag_1()
@@ -478,7 +478,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCAutoCL : BridgeHelpers
+            public partial class TCAutoCL : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Change to CL Document after WriteStartDocument()", Priority = 0)]
                 public void auto_1()

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/XmlFactoryWriterTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/XmlFactoryWriterTests.cs
@@ -13,11 +13,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class XmlFactoryWriterTestsFunctionalTests : TestModule
     {
-        public partial class XNodeBuilderTests : XLinqTestCase
+        public class XNodeBuilderTests : XLinqTestCase
         {
-            public partial class TCCheckChars : BridgeHelpers
+            public class TCCheckChars : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "CheckChars=true, invalid XML test WriteEntityRef", Priority = 1, Param = "EntityRef")]
                 //[Variation(Id = 2, Desc = "CheckChars=true, invalid XML test WriteSurrogateCharEntity", Priority = 1, Param = "SurrogateCharEntity")]
@@ -170,7 +170,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCNewLineHandling : BridgeHelpers
+            public class TCNewLineHandling : BridgeHelpers
             {
                 //[Variation(Id = 7, Desc = "Test for CR (xD) inside attr when NewLineHandling = Replace", Priority = 0)]
                 public void NewLineHandling_7()
@@ -264,7 +264,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCIndent : BridgeHelpers
+            public class TCIndent : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Simple test when false", Priority = 0)]
                 public void indent_1()
@@ -365,7 +365,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCNewLineOnAttributes : BridgeHelpers
+            public class TCNewLineOnAttributes : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Make sure the setting has no effect when Indent is false", Priority = 0)]
                 public void NewLineOnAttributes_1()
@@ -404,7 +404,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCStandAlone : BridgeHelpers
+            public class TCStandAlone : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "StartDocument(bool standalone = true)", Priority = 0)]
                 public void standalone_1()
@@ -435,7 +435,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCFragmentCL : BridgeHelpers
+            public class TCFragmentCL : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "WriteDocType should error when CL=fragment", Priority = 1)]
                 public void frag_1()
@@ -478,7 +478,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCAutoCL : BridgeHelpers
+            public class TCAutoCL : BridgeHelpers
             {
                 //[Variation(Id = 1, Desc = "Change to CL Document after WriteStartDocument()", Priority = 0)]
                 public void auto_1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/CXMLGeneralTest.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/CXMLGeneralTest.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class CXMLGeneralTestFunctionalTests : TestModule
     {
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class TCDepth : BridgeHelpers
+            public class TCDepth : BridgeHelpers
             {
                 //[Variation("XmlReader Depth at the Root", Priority = 0)]
                 public void TestDepth1()
@@ -65,7 +65,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCNamespace : BridgeHelpers
+            public class TCNamespace : BridgeHelpers
             {
                 public static string pNONAMESPACE = "NONAMESPACE";
 
@@ -234,7 +234,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCLookupNamespace : BridgeHelpers
+            public class TCLookupNamespace : BridgeHelpers
             {
                 //[Variation("LookupNamespace test within EmptyTag")]
                 public void LookupNamespace1()
@@ -490,7 +490,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCHasValue : BridgeHelpers
+            public class TCHasValue : BridgeHelpers
             {
                 //[Variation("HasValue On None")]
                 public void TestHasValueNodeType_None()
@@ -691,7 +691,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCIsEmptyElement2 : BridgeHelpers
+            public class TCIsEmptyElement2 : BridgeHelpers
             {
                 //[Variation("Set and Get an element that ends with />", Priority = 0)]
                 public void TestEmpty1()
@@ -883,7 +883,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCXmlSpace : BridgeHelpers
+            public class TCXmlSpace : BridgeHelpers
             {
                 //[Variation("XmlSpace test within EmptyTag")]
                 public void TestXmlSpace1()
@@ -985,7 +985,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCXmlLang : BridgeHelpers
+            public class TCXmlLang : BridgeHelpers
             {
                 //[Variation("XmlLang test within EmptyTag")]
                 public void TestXmlLang1()
@@ -1137,7 +1137,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCSkip : BridgeHelpers
+            public class TCSkip : BridgeHelpers
             {
                 public bool VerifySkipOnNodeType(XmlNodeType testNodeType)
                 {
@@ -1371,11 +1371,11 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCIsDefault : BridgeHelpers
+            public class TCIsDefault : BridgeHelpers
             {
             }
 
-            public partial class TCBaseURI : BridgeHelpers
+            public class TCBaseURI : BridgeHelpers
             {
                 //[Variation("BaseURI for element node", Priority = 0)]
                 public void TestBaseURI1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/CXMLGeneralTest.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/CXMLGeneralTest.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class CXMLGeneralTestFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class TCDepth : BridgeHelpers
+            public partial class TCDepth : BridgeHelpers
             {
                 //[Variation("XmlReader Depth at the Root", Priority = 0)]
                 public void TestDepth1()
@@ -65,7 +65,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCNamespace : BridgeHelpers
+            public partial class TCNamespace : BridgeHelpers
             {
                 public static string pNONAMESPACE = "NONAMESPACE";
 
@@ -234,7 +234,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCLookupNamespace : BridgeHelpers
+            public partial class TCLookupNamespace : BridgeHelpers
             {
                 //[Variation("LookupNamespace test within EmptyTag")]
                 public void LookupNamespace1()
@@ -490,7 +490,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCHasValue : BridgeHelpers
+            public partial class TCHasValue : BridgeHelpers
             {
                 //[Variation("HasValue On None")]
                 public void TestHasValueNodeType_None()
@@ -691,7 +691,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCIsEmptyElement2 : BridgeHelpers
+            public partial class TCIsEmptyElement2 : BridgeHelpers
             {
                 //[Variation("Set and Get an element that ends with />", Priority = 0)]
                 public void TestEmpty1()
@@ -883,7 +883,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCXmlSpace : BridgeHelpers
+            public partial class TCXmlSpace : BridgeHelpers
             {
                 //[Variation("XmlSpace test within EmptyTag")]
                 public void TestXmlSpace1()
@@ -985,7 +985,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCXmlLang : BridgeHelpers
+            public partial class TCXmlLang : BridgeHelpers
             {
                 //[Variation("XmlLang test within EmptyTag")]
                 public void TestXmlLang1()
@@ -1137,7 +1137,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCSkip : BridgeHelpers
+            public partial class TCSkip : BridgeHelpers
             {
                 public bool VerifySkipOnNodeType(XmlNodeType testNodeType)
                 {
@@ -1371,11 +1371,11 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCIsDefault : BridgeHelpers
+            public partial class TCIsDefault : BridgeHelpers
             {
             }
 
-            public class TCBaseURI : BridgeHelpers
+            public partial class TCBaseURI : BridgeHelpers
             {
                 //[Variation("BaseURI for element node", Priority = 0)]
                 public void TestBaseURI1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/CXMLReaderAttrTest.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/CXMLReaderAttrTest.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class CXMLReaderAttrTestFunctionalTests : TestModule
     {
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class TCAttributeAccess : BridgeHelpers
+            public class TCAttributeAccess : BridgeHelpers
             {
                 //[Variation("Attribute Access test using ordinal (Ascending Order)", Priority = 0)]
                 public void TestAttributeAccess1()
@@ -236,7 +236,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCThisName : BridgeHelpers
+            public class TCThisName : BridgeHelpers
             {
                 //[Variation("This[Name] Verify with GetAttribute(Name)", Priority = 0)]
                 public void ThisWithName1()
@@ -452,7 +452,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCMoveToAttributeReader : BridgeHelpers
+            public class TCMoveToAttributeReader : BridgeHelpers
             {
                 //[Variation("MoveToAttribute(String.Empty)")]
                 public void MoveToAttributeWithName1()
@@ -474,7 +474,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "GetAttributeOrdinal", Desc = "GetAttributeOrdinal")]
-            public partial class TCGetAttributeOrdinal : BridgeHelpers
+            public class TCGetAttributeOrdinal : BridgeHelpers
             {
                 //[Variation("GetAttribute(i) Verify with This[i] - Double Quote", Priority = 0)]
                 public void GetAttributeWithGetAttrDoubleQ()
@@ -562,7 +562,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "GetAttributeName", Desc = "GetAttributeName")]
-            public partial class TCGetAttributeName : BridgeHelpers
+            public class TCGetAttributeName : BridgeHelpers
             {
                 //[Variation("GetAttribute(Name) Verify with This[Name]", Priority = 0)]
                 public void GetAttributeWithName1()
@@ -758,7 +758,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ThisOrdinal", Desc = "ThisOrdinal")]
-            public partial class TCThisOrdinal : BridgeHelpers
+            public class TCThisOrdinal : BridgeHelpers
             {
                 //[Variation("This[i] Verify with GetAttribute[i] - Double Quote", Priority = 0)]
                 public void OrdinalWithGetAttrDoubleQ()
@@ -846,7 +846,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "MoveToAttributeOrdinal", Desc = "MoveToAttributeOrdinal")]
-            public partial class TCMoveToAttributeOrdinal : BridgeHelpers
+            public class TCMoveToAttributeOrdinal : BridgeHelpers
             {
                 //[Variation("MoveToAttribute(i) Verify with This[i] - Double Quote", Priority = 0)]
                 public void MoveToAttributeWithGetAttrDoubleQ()
@@ -968,7 +968,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "MoveToFirstAttribute", Desc = "MoveToFirstAttribute")]
-            public partial class TCMoveToFirstAttribute : BridgeHelpers
+            public class TCMoveToFirstAttribute : BridgeHelpers
             {
                 //[Variation("MoveToFirstAttribute() When AttributeCount=0, <EMPTY1/> ", Priority = 0)]
                 public void MoveToFirstAttribute1()
@@ -1075,7 +1075,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCMoveToNextAttribute : BridgeHelpers
+            public class TCMoveToNextAttribute : BridgeHelpers
             {
                 //[Variation("MoveToNextAttribute() When AttributeCount=0, <EMPTY1/> ", Priority = 0)]
                 public void MoveToNextAttribute1()
@@ -1205,7 +1205,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCAttributeTest : BridgeHelpers
+            public class TCAttributeTest : BridgeHelpers
             {
                 //[Variation("Attribute Test On None")]
                 public void TestAttributeTestNodeType_None()
@@ -1355,7 +1355,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadURI", Desc = "Read URI")]
-            public partial class TATextReaderDocType : BridgeHelpers
+            public class TATextReaderDocType : BridgeHelpers
             {
                 //[Variation("Valid URI reference as SystemLiteral")]
                 public void TATextReaderDocType_1()
@@ -1387,7 +1387,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCXmlns : BridgeHelpers
+            public class TCXmlns : BridgeHelpers
             {
                 private string _ST_ENS1 = "EMPTY_NAMESPACE1";
                 private string _ST_NS2 = "NAMESPACE2";
@@ -1483,7 +1483,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCXmlnsPrefix : BridgeHelpers
+            public class TCXmlnsPrefix : BridgeHelpers
             {
                 private string _ST_ENS1 = "EMPTY_NAMESPACE1";
                 private string _ST_NS2 = "NAMESPACE2";

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/CXMLReaderAttrTest.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/CXMLReaderAttrTest.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class CXMLReaderAttrTestFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class TCAttributeAccess : BridgeHelpers
+            public partial class TCAttributeAccess : BridgeHelpers
             {
                 //[Variation("Attribute Access test using ordinal (Ascending Order)", Priority = 0)]
                 public void TestAttributeAccess1()
@@ -236,7 +236,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCThisName : BridgeHelpers
+            public partial class TCThisName : BridgeHelpers
             {
                 //[Variation("This[Name] Verify with GetAttribute(Name)", Priority = 0)]
                 public void ThisWithName1()
@@ -452,7 +452,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCMoveToAttributeReader : BridgeHelpers
+            public partial class TCMoveToAttributeReader : BridgeHelpers
             {
                 //[Variation("MoveToAttribute(String.Empty)")]
                 public void MoveToAttributeWithName1()
@@ -474,7 +474,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "GetAttributeOrdinal", Desc = "GetAttributeOrdinal")]
-            public class TCGetAttributeOrdinal : BridgeHelpers
+            public partial class TCGetAttributeOrdinal : BridgeHelpers
             {
                 //[Variation("GetAttribute(i) Verify with This[i] - Double Quote", Priority = 0)]
                 public void GetAttributeWithGetAttrDoubleQ()
@@ -562,7 +562,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "GetAttributeName", Desc = "GetAttributeName")]
-            public class TCGetAttributeName : BridgeHelpers
+            public partial class TCGetAttributeName : BridgeHelpers
             {
                 //[Variation("GetAttribute(Name) Verify with This[Name]", Priority = 0)]
                 public void GetAttributeWithName1()
@@ -758,7 +758,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ThisOrdinal", Desc = "ThisOrdinal")]
-            public class TCThisOrdinal : BridgeHelpers
+            public partial class TCThisOrdinal : BridgeHelpers
             {
                 //[Variation("This[i] Verify with GetAttribute[i] - Double Quote", Priority = 0)]
                 public void OrdinalWithGetAttrDoubleQ()
@@ -846,7 +846,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "MoveToAttributeOrdinal", Desc = "MoveToAttributeOrdinal")]
-            public class TCMoveToAttributeOrdinal : BridgeHelpers
+            public partial class TCMoveToAttributeOrdinal : BridgeHelpers
             {
                 //[Variation("MoveToAttribute(i) Verify with This[i] - Double Quote", Priority = 0)]
                 public void MoveToAttributeWithGetAttrDoubleQ()
@@ -968,7 +968,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "MoveToFirstAttribute", Desc = "MoveToFirstAttribute")]
-            public class TCMoveToFirstAttribute : BridgeHelpers
+            public partial class TCMoveToFirstAttribute : BridgeHelpers
             {
                 //[Variation("MoveToFirstAttribute() When AttributeCount=0, <EMPTY1/> ", Priority = 0)]
                 public void MoveToFirstAttribute1()
@@ -1075,7 +1075,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCMoveToNextAttribute : BridgeHelpers
+            public partial class TCMoveToNextAttribute : BridgeHelpers
             {
                 //[Variation("MoveToNextAttribute() When AttributeCount=0, <EMPTY1/> ", Priority = 0)]
                 public void MoveToNextAttribute1()
@@ -1205,7 +1205,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCAttributeTest : BridgeHelpers
+            public partial class TCAttributeTest : BridgeHelpers
             {
                 //[Variation("Attribute Test On None")]
                 public void TestAttributeTestNodeType_None()
@@ -1355,7 +1355,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadURI", Desc = "Read URI")]
-            public class TATextReaderDocType : BridgeHelpers
+            public partial class TATextReaderDocType : BridgeHelpers
             {
                 //[Variation("Valid URI reference as SystemLiteral")]
                 public void TATextReaderDocType_1()
@@ -1387,7 +1387,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCXmlns : BridgeHelpers
+            public partial class TCXmlns : BridgeHelpers
             {
                 private string _ST_ENS1 = "EMPTY_NAMESPACE1";
                 private string _ST_NS2 = "NAMESPACE2";
@@ -1483,7 +1483,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCXmlnsPrefix : BridgeHelpers
+            public partial class TCXmlnsPrefix : BridgeHelpers
             {
                 private string _ST_ENS1 = "EMPTY_NAMESPACE1";
                 private string _ST_NS2 = "NAMESPACE2";

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/CXmlReaderReadEtc.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/CXmlReaderReadEtc.cs
@@ -10,12 +10,12 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class CXmlReaderReadEtcFunctionalTests : TestModule
     {
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadState", Desc = "ReadState")]
-            public partial class TCReadState : BridgeHelpers
+            public class TCReadState : BridgeHelpers
             {
                 //[Variation("XmlReader ReadState Initial", Priority = 0)]
                 public void ReadState1()
@@ -83,7 +83,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadInnerXml", Desc = "ReadInnerXml")]
-            public partial class TCReadInnerXml : BridgeHelpers
+            public class TCReadInnerXml : BridgeHelpers
             {
                 void VerifyNextNode(XmlReader DataReader, XmlNodeType nt, string name, string value)
                 {
@@ -338,7 +338,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "MoveToContent", Desc = "MoveToContent")]
-            public partial class TCMoveToContent : BridgeHelpers
+            public class TCMoveToContent : BridgeHelpers
             {
                 public const String ST_TEST_NAME1 = "GOTOCONTENT";
                 public const String ST_TEST_NAME2 = "SKIPCONTENT";
@@ -424,7 +424,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "IsStartElement", Desc = "IsStartElement")]
-            public partial class TCIsStartElement : BridgeHelpers
+            public class TCIsStartElement : BridgeHelpers
             {
                 private const String ST_TEST_ELEM = "DOCNAMESPACE";
                 private const String ST_TEST_EMPTY_ELEM = "NOSPACE";
@@ -565,7 +565,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadStartElement", Desc = "ReadStartElement")]
-            public partial class TCReadStartElement : BridgeHelpers
+            public class TCReadStartElement : BridgeHelpers
             {
                 private const String ST_TEST_ELEM = "DOCNAMESPACE";
                 private const String ST_TEST_EMPTY_ELEM = "NOSPACE";
@@ -836,7 +836,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadEndElement", Desc = "ReadEndElement")]
-            public partial class TCReadEndElement : BridgeHelpers
+            public class TCReadEndElement : BridgeHelpers
             {
                 private const String ST_TEST_ELEM = "DOCNAMESPACE";
                 private const String ST_TEST_EMPTY_ELEM = "NOSPACE";
@@ -1041,7 +1041,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCMoveToElement : BridgeHelpers
+            public class TCMoveToElement : BridgeHelpers
             {
                 //[Variation("Attribute node")]
                 public void v1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/CXmlReaderReadEtc.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/CXmlReaderReadEtc.cs
@@ -10,12 +10,12 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public class CXmlReaderReadEtcFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadState", Desc = "ReadState")]
-            public class TCReadState : BridgeHelpers
+            public partial class TCReadState : BridgeHelpers
             {
                 //[Variation("XmlReader ReadState Initial", Priority = 0)]
                 public void ReadState1()
@@ -83,7 +83,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadInnerXml", Desc = "ReadInnerXml")]
-            public class TCReadInnerXml : BridgeHelpers
+            public partial class TCReadInnerXml : BridgeHelpers
             {
                 void VerifyNextNode(XmlReader DataReader, XmlNodeType nt, string name, string value)
                 {
@@ -338,7 +338,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "MoveToContent", Desc = "MoveToContent")]
-            public class TCMoveToContent : BridgeHelpers
+            public partial class TCMoveToContent : BridgeHelpers
             {
                 public const String ST_TEST_NAME1 = "GOTOCONTENT";
                 public const String ST_TEST_NAME2 = "SKIPCONTENT";
@@ -424,7 +424,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "IsStartElement", Desc = "IsStartElement")]
-            public class TCIsStartElement : BridgeHelpers
+            public partial class TCIsStartElement : BridgeHelpers
             {
                 private const String ST_TEST_ELEM = "DOCNAMESPACE";
                 private const String ST_TEST_EMPTY_ELEM = "NOSPACE";
@@ -565,7 +565,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadStartElement", Desc = "ReadStartElement")]
-            public class TCReadStartElement : BridgeHelpers
+            public partial class TCReadStartElement : BridgeHelpers
             {
                 private const String ST_TEST_ELEM = "DOCNAMESPACE";
                 private const String ST_TEST_EMPTY_ELEM = "NOSPACE";
@@ -836,7 +836,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadEndElement", Desc = "ReadEndElement")]
-            public class TCReadEndElement : BridgeHelpers
+            public partial class TCReadEndElement : BridgeHelpers
             {
                 private const String ST_TEST_ELEM = "DOCNAMESPACE";
                 private const String ST_TEST_EMPTY_ELEM = "NOSPACE";
@@ -1041,7 +1041,7 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public class TCMoveToElement : BridgeHelpers
+            public partial class TCMoveToElement : BridgeHelpers
             {
                 //[Variation("Attribute node")]
                 public void v1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/CommonTest.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/CommonTest.cs
@@ -10,12 +10,12 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class CommonTestFunctionalTests : TestModule
     {
 
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class TCDispose : BridgeHelpers
+            public class TCDispose : BridgeHelpers
             {
                 //[Variation("Test Integrity of all values after Dispose")]
                 public void Variation1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/CommonTest.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/CommonTest.cs
@@ -10,12 +10,12 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class CommonTestFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
 
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class TCDispose : BridgeHelpers
+            public partial class TCDispose : BridgeHelpers
             {
                 //[Variation("Test Integrity of all values after Dispose")]
                 public void Variation1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ErrorConditions.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ErrorConditions.cs
@@ -10,11 +10,11 @@ using System.Xml.Linq;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class XNodeReaderErrorConditionsFunctionalTests : TestModule
     {
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class ErrorConditions : BridgeHelpers
+            public class ErrorConditions : BridgeHelpers
             {
                 //[Variation(Desc = "Move to Attribute using []")]
                 public void Variation1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ErrorConditions.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ErrorConditions.cs
@@ -10,11 +10,11 @@ using System.Xml.Linq;
 
 namespace CoreXml.Test.XLinq
 {
-    public class XNodeReaderErrorConditionsFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class ErrorConditions : BridgeHelpers
+            public partial class ErrorConditions : BridgeHelpers
             {
                 //[Variation(Desc = "Move to Attribute using []")]
                 public void Variation1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/FunctionalTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/FunctionalTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public class XNodeReaderFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
@@ -31,7 +31,7 @@ namespace CoreXml.Test.XLinq
         }
 
         #region Class
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
             // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests
             public override void AddChildren()
@@ -45,7 +45,7 @@ namespace CoreXml.Test.XLinq
                 this.AddChild(new TCXmlSpace() { Attribute = new TestCaseAttribute() { Name = "XmlSpace", Desc = "XmlSpace" } });
                 this.AddChild(new TCXmlLang() { Attribute = new TestCaseAttribute() { Name = "XmlLang", Desc = "XmlLang" } });
                 this.AddChild(new TCSkip() { Attribute = new TestCaseAttribute() { Name = "Skip", Desc = "Skip" } });
-                this.AddChild(new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCIsDefault() { Attribute = new TestCaseAttribute() { Name = "IsDefault", Desc = "IsDefault" } });
+                this.AddChild(new TCIsDefault() { Attribute = new TestCaseAttribute() { Name = "IsDefault", Desc = "IsDefault" } });
                 this.AddChild(new TCBaseURI() { Attribute = new TestCaseAttribute() { Name = "BaseUri", Desc = "BaseUri" } });
                 this.AddChild(new TCAttributeAccess() { Attribute = new TestCaseAttribute() { Name = "AttributeAccess", Desc = "AttributeAccess" } });
                 this.AddChild(new TCThisName() { Attribute = new TestCaseAttribute() { Name = "ThisName", Desc = "ThisName" } });
@@ -81,982 +81,939 @@ namespace CoreXml.Test.XLinq
                 this.AddChild(new TCReadValue() { Attribute = new TestCaseAttribute() { Name = "ReadValue", Desc = "ReadValue" } });
                 this.AddChild(new XNodeReaderAPI() { Attribute = new TestCaseAttribute() { Name = "API Tests" } });
             }
-            public class TCDispose : BridgeHelpers
+            public partial class TCDispose : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCDispose
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcDispose = new CommonTestFunctionalTests.XNodeReaderTests.TCDispose();
-                    this.AddChild(new TestVariation(tcDispose.Variation1) { Attribute = new VariationAttribute("Test Integrity of all values after Dispose") });
-                    this.AddChild(new TestVariation(tcDispose.Variation2) { Attribute = new VariationAttribute("Call Dispose Multiple(3) Times") });
+                    this.AddChild(new TestVariation(Variation1) { Attribute = new VariationAttribute("Test Integrity of all values after Dispose") });
+                    this.AddChild(new TestVariation(Variation2) { Attribute = new VariationAttribute("Call Dispose Multiple(3) Times") });
                 }
             }
-            public class TCDepth : BridgeHelpers
+            public partial class TCDepth : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCDepth
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcDepth = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCDepth();
-                    this.AddChild(new TestVariation(tcDepth.TestDepth1) { Attribute = new VariationAttribute("XmlReader Depth at the Root") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcDepth.TestDepth2) { Attribute = new VariationAttribute("XmlReader Depth at Empty Tag") });
-                    this.AddChild(new TestVariation(tcDepth.TestDepth3) { Attribute = new VariationAttribute("XmlReader Depth at Empty Tag with Attributes") });
-                    this.AddChild(new TestVariation(tcDepth.TestDepth4) { Attribute = new VariationAttribute("XmlReader Depth at Non Empty Tag with Text") });
+                    this.AddChild(new TestVariation(TestDepth1) { Attribute = new VariationAttribute("XmlReader Depth at the Root") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestDepth2) { Attribute = new VariationAttribute("XmlReader Depth at Empty Tag") });
+                    this.AddChild(new TestVariation(TestDepth3) { Attribute = new VariationAttribute("XmlReader Depth at Empty Tag with Attributes") });
+                    this.AddChild(new TestVariation(TestDepth4) { Attribute = new VariationAttribute("XmlReader Depth at Non Empty Tag with Text") });
                 }
             }
-            public class TCNamespace : BridgeHelpers
+            public partial class TCNamespace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCNamespace
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcNamespace = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCNamespace();
-                    this.AddChild(new TestVariation(tcNamespace.TestNamespace1) { Attribute = new VariationAttribute("Namespace test within a scope (no nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNamespace.TestNamespace2) { Attribute = new VariationAttribute("Namespace test within a scope (with nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNamespace.TestNamespace3) { Attribute = new VariationAttribute("Namespace test immediately outside the Namespace scope") });
-                    this.AddChild(new TestVariation(tcNamespace.TestNamespace4) { Attribute = new VariationAttribute("Namespace test Attribute should has no default namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNamespace.TestNamespace5) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcNamespace.TestNamespace6) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration, including default namespace") });
-                    this.AddChild(new TestVariation(tcNamespace.TestNamespace7) { Attribute = new VariationAttribute("Namespace URI for xml prefix") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestNamespace1) { Attribute = new VariationAttribute("Namespace test within a scope (no nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestNamespace2) { Attribute = new VariationAttribute("Namespace test within a scope (with nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestNamespace3) { Attribute = new VariationAttribute("Namespace test immediately outside the Namespace scope") });
+                    this.AddChild(new TestVariation(TestNamespace4) { Attribute = new VariationAttribute("Namespace test Attribute should has no default namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestNamespace5) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestNamespace6) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration, including default namespace") });
+                    this.AddChild(new TestVariation(TestNamespace7) { Attribute = new VariationAttribute("Namespace URI for xml prefix") { Priority = 0 } });
                 }
             }
-            public class TCLookupNamespace : BridgeHelpers
+            public partial class TCLookupNamespace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCLookupNamespace
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcLookupNamespace = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCLookupNamespace();
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace1) { Attribute = new VariationAttribute("LookupNamespace test within EmptyTag") });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace2) { Attribute = new VariationAttribute("LookupNamespace test with Default namespace within EmptyTag") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace3) { Attribute = new VariationAttribute("LookupNamespace test within a scope (no nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace4) { Attribute = new VariationAttribute("LookupNamespace test within a scope (with nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace5) { Attribute = new VariationAttribute("LookupNamespace test immediately outside the Namespace scope") });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace6) { Attribute = new VariationAttribute("LookupNamespace test with multiple Namespace declaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace7) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration, including default namespace") });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace8) { Attribute = new VariationAttribute("LookupNamespace on whitespace node PreserveWhitespaces = true") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace9) { Attribute = new VariationAttribute("Different prefix on inner element for the same namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace10) { Attribute = new VariationAttribute("LookupNamespace when Namespaces = false") { Priority = 0 } });
+                    this.AddChild(new TestVariation(LookupNamespace1) { Attribute = new VariationAttribute("LookupNamespace test within EmptyTag") });
+                    this.AddChild(new TestVariation(LookupNamespace2) { Attribute = new VariationAttribute("LookupNamespace test with Default namespace within EmptyTag") { Priority = 0 } });
+                    this.AddChild(new TestVariation(LookupNamespace3) { Attribute = new VariationAttribute("LookupNamespace test within a scope (no nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(LookupNamespace4) { Attribute = new VariationAttribute("LookupNamespace test within a scope (with nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(LookupNamespace5) { Attribute = new VariationAttribute("LookupNamespace test immediately outside the Namespace scope") });
+                    this.AddChild(new TestVariation(LookupNamespace6) { Attribute = new VariationAttribute("LookupNamespace test with multiple Namespace declaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(LookupNamespace7) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration, including default namespace") });
+                    this.AddChild(new TestVariation(LookupNamespace8) { Attribute = new VariationAttribute("LookupNamespace on whitespace node PreserveWhitespaces = true") { Priority = 0 } });
+                    this.AddChild(new TestVariation(LookupNamespace9) { Attribute = new VariationAttribute("Different prefix on inner element for the same namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(LookupNamespace10) { Attribute = new VariationAttribute("LookupNamespace when Namespaces = false") { Priority = 0 } });
                 }
             }
-            public class TCHasValue : BridgeHelpers
+            public partial class TCHasValue : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCHasValue
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcHasValue = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCHasValue();
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_None) { Attribute = new VariationAttribute("HasValue On None") });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Element) { Attribute = new VariationAttribute("HasValue On Element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValue1) { Attribute = new VariationAttribute("Get node with a scalar value, verify the value with valid ReadString") });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Attribute) { Attribute = new VariationAttribute("HasValue On Attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Text) { Attribute = new VariationAttribute("HasValue On Text") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_CDATA) { Attribute = new VariationAttribute("HasValue On CDATA") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("HasValue On ProcessingInstruction") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Comment) { Attribute = new VariationAttribute("HasValue On Comment") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_DocumentType) { Attribute = new VariationAttribute("HasValue On DocumentType") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Whitespace) { Attribute = new VariationAttribute("HasValue On Whitespace PreserveWhitespaces = true") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_EndElement) { Attribute = new VariationAttribute("HasValue On EndElement") });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_XmlDeclaration) { Attribute = new VariationAttribute("HasValue On XmlDeclaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_EntityReference) { Attribute = new VariationAttribute("HasValue On EntityReference") });
-                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_EndEntity) { Attribute = new VariationAttribute("HasValue On EndEntity") });
-                    this.AddChild(new TestVariation(tcHasValue.v13) { Attribute = new VariationAttribute("PI Value containing surrogates") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_None) { Attribute = new VariationAttribute("HasValue On None") });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_Element) { Attribute = new VariationAttribute("HasValue On Element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValue1) { Attribute = new VariationAttribute("Get node with a scalar value, verify the value with valid ReadString") });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_Attribute) { Attribute = new VariationAttribute("HasValue On Attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_Text) { Attribute = new VariationAttribute("HasValue On Text") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_CDATA) { Attribute = new VariationAttribute("HasValue On CDATA") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("HasValue On ProcessingInstruction") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_Comment) { Attribute = new VariationAttribute("HasValue On Comment") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_DocumentType) { Attribute = new VariationAttribute("HasValue On DocumentType") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_Whitespace) { Attribute = new VariationAttribute("HasValue On Whitespace PreserveWhitespaces = true") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_EndElement) { Attribute = new VariationAttribute("HasValue On EndElement") });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_XmlDeclaration) { Attribute = new VariationAttribute("HasValue On XmlDeclaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_EntityReference) { Attribute = new VariationAttribute("HasValue On EntityReference") });
+                    this.AddChild(new TestVariation(TestHasValueNodeType_EndEntity) { Attribute = new VariationAttribute("HasValue On EndEntity") });
+                    this.AddChild(new TestVariation(v13) { Attribute = new VariationAttribute("PI Value containing surrogates") { Priority = 0 } });
                 }
             }
-            public class TCIsEmptyElement2 : BridgeHelpers
+            public partial class TCIsEmptyElement2 : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCIsEmptyElement2
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcIsEmptyElement2 = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCIsEmptyElement2();
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmpty1) { Attribute = new VariationAttribute("Set and Get an element that ends with />") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmpty2) { Attribute = new VariationAttribute("Set and Get an element with an attribute that ends with />") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmpty3) { Attribute = new VariationAttribute("Set and Get an element that ends without />") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmpty4) { Attribute = new VariationAttribute("Set and Get an element with an attribute that ends with />") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_Element) { Attribute = new VariationAttribute("IsEmptyElement On Element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_None) { Attribute = new VariationAttribute("IsEmptyElement On None") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_Text) { Attribute = new VariationAttribute("IsEmptyElement On Text") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_CDATA) { Attribute = new VariationAttribute("IsEmptyElement On CDATA") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("IsEmptyElement On ProcessingInstruction") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_Comment) { Attribute = new VariationAttribute("IsEmptyElement On Comment") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_DocumentType) { Attribute = new VariationAttribute("IsEmptyElement On DocumentType") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_Whitespace) { Attribute = new VariationAttribute("IsEmptyElement On Whitespace PreserveWhitespaces = true") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_EndElement) { Attribute = new VariationAttribute("IsEmptyElement On EndElement") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_EntityReference) { Attribute = new VariationAttribute("IsEmptyElement On EntityReference") });
-                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_EndEntity) { Attribute = new VariationAttribute("IsEmptyElement On EndEntity") });
+                    this.AddChild(new TestVariation(TestEmpty1) { Attribute = new VariationAttribute("Set and Get an element that ends with />") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestEmpty2) { Attribute = new VariationAttribute("Set and Get an element with an attribute that ends with />") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestEmpty3) { Attribute = new VariationAttribute("Set and Get an element that ends without />") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestEmpty4) { Attribute = new VariationAttribute("Set and Get an element with an attribute that ends with />") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_Element) { Attribute = new VariationAttribute("IsEmptyElement On Element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_None) { Attribute = new VariationAttribute("IsEmptyElement On None") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_Text) { Attribute = new VariationAttribute("IsEmptyElement On Text") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_CDATA) { Attribute = new VariationAttribute("IsEmptyElement On CDATA") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("IsEmptyElement On ProcessingInstruction") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_Comment) { Attribute = new VariationAttribute("IsEmptyElement On Comment") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_DocumentType) { Attribute = new VariationAttribute("IsEmptyElement On DocumentType") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_Whitespace) { Attribute = new VariationAttribute("IsEmptyElement On Whitespace PreserveWhitespaces = true") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_EndElement) { Attribute = new VariationAttribute("IsEmptyElement On EndElement") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_EntityReference) { Attribute = new VariationAttribute("IsEmptyElement On EntityReference") });
+                    this.AddChild(new TestVariation(TestEmptyNodeType_EndEntity) { Attribute = new VariationAttribute("IsEmptyElement On EndEntity") });
                 }
             }
-            public class TCXmlSpace : BridgeHelpers
+            public partial class TCXmlSpace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlSpace
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcXmlSpace = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCXmlSpace();
-                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace1) { Attribute = new VariationAttribute("XmlSpace test within EmptyTag") });
-                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace2) { Attribute = new VariationAttribute("Xmlspace test within a scope (no nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace3) { Attribute = new VariationAttribute("Xmlspace test within a scope (with nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace4) { Attribute = new VariationAttribute("Xmlspace test immediately outside the XmlSpace scope") });
-                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace5) { Attribute = new VariationAttribute("XmlSpace test with multiple XmlSpace declaration") });
+                    this.AddChild(new TestVariation(TestXmlSpace1) { Attribute = new VariationAttribute("XmlSpace test within EmptyTag") });
+                    this.AddChild(new TestVariation(TestXmlSpace2) { Attribute = new VariationAttribute("Xmlspace test within a scope (no nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestXmlSpace3) { Attribute = new VariationAttribute("Xmlspace test within a scope (with nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestXmlSpace4) { Attribute = new VariationAttribute("Xmlspace test immediately outside the XmlSpace scope") });
+                    this.AddChild(new TestVariation(TestXmlSpace5) { Attribute = new VariationAttribute("XmlSpace test with multiple XmlSpace declaration") });
                 }
             }
-            public class TCXmlLang : BridgeHelpers
+            public partial class TCXmlLang : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlLang
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcXmlLang = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCXmlLang();
-                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang1) { Attribute = new VariationAttribute("XmlLang test within EmptyTag") });
-                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang2) { Attribute = new VariationAttribute("XmlLang test within a scope (no nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang3) { Attribute = new VariationAttribute("XmlLang test within a scope (with nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang4) { Attribute = new VariationAttribute("XmlLang test immediately outside the XmlLang scope") });
-                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang5) { Attribute = new VariationAttribute("XmlLang test with multiple XmlLang declaration") });
-                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang6) { Attribute = new VariationAttribute("XmlLang valid values") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlLang.TestXmlTextReaderLang1) { Attribute = new VariationAttribute("More XmlLang valid values") });
+                    this.AddChild(new TestVariation(TestXmlLang1) { Attribute = new VariationAttribute("XmlLang test within EmptyTag") });
+                    this.AddChild(new TestVariation(TestXmlLang2) { Attribute = new VariationAttribute("XmlLang test within a scope (no nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestXmlLang3) { Attribute = new VariationAttribute("XmlLang test within a scope (with nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestXmlLang4) { Attribute = new VariationAttribute("XmlLang test immediately outside the XmlLang scope") });
+                    this.AddChild(new TestVariation(TestXmlLang5) { Attribute = new VariationAttribute("XmlLang test with multiple XmlLang declaration") });
+                    this.AddChild(new TestVariation(TestXmlLang6) { Attribute = new VariationAttribute("XmlLang valid values") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestXmlTextReaderLang1) { Attribute = new VariationAttribute("More XmlLang valid values") });
                 }
             }
-            public class TCSkip : BridgeHelpers
+            public partial class TCSkip : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCSkip
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcSkip = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCSkip();
-                    this.AddChild(new TestVariation(tcSkip.TestSkip1) { Attribute = new VariationAttribute("Call Skip on empty element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip2) { Attribute = new VariationAttribute("Call Skip on element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip3) { Attribute = new VariationAttribute("Call Skip on element with content") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip4) { Attribute = new VariationAttribute("Call Skip on text node (leave node)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.skip307543) { Attribute = new VariationAttribute("Call Skip in while read loop") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip5) { Attribute = new VariationAttribute("Call Skip on text node with another element: <elem2>text<elem3></elem3></elem2>") });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip6) { Attribute = new VariationAttribute("Call Skip on attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip7) { Attribute = new VariationAttribute("Call Skip on text node of attribute") });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip8) { Attribute = new VariationAttribute("Call Skip on CDATA") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip9) { Attribute = new VariationAttribute("Call Skip on Processing Instruction") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip10) { Attribute = new VariationAttribute("Call Skip on Comment") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip12) { Attribute = new VariationAttribute("Call Skip on Whitespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip13) { Attribute = new VariationAttribute("Call Skip on EndElement") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcSkip.TestSkip14) { Attribute = new VariationAttribute("Call Skip on root Element") });
-                    this.AddChild(new TestVariation(tcSkip.XmlTextReaderDoesNotThrowWhenHandlingAmpersands) { Attribute = new VariationAttribute("XmlTextReader ArgumentOutOfRangeException when handling ampersands") });
+                    this.AddChild(new TestVariation(TestSkip1) { Attribute = new VariationAttribute("Call Skip on empty element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip2) { Attribute = new VariationAttribute("Call Skip on element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip3) { Attribute = new VariationAttribute("Call Skip on element with content") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip4) { Attribute = new VariationAttribute("Call Skip on text node (leave node)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(skip307543) { Attribute = new VariationAttribute("Call Skip in while read loop") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip5) { Attribute = new VariationAttribute("Call Skip on text node with another element: <elem2>text<elem3></elem3></elem2>") });
+                    this.AddChild(new TestVariation(TestSkip6) { Attribute = new VariationAttribute("Call Skip on attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip7) { Attribute = new VariationAttribute("Call Skip on text node of attribute") });
+                    this.AddChild(new TestVariation(TestSkip8) { Attribute = new VariationAttribute("Call Skip on CDATA") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip9) { Attribute = new VariationAttribute("Call Skip on Processing Instruction") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip10) { Attribute = new VariationAttribute("Call Skip on Comment") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip12) { Attribute = new VariationAttribute("Call Skip on Whitespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip13) { Attribute = new VariationAttribute("Call Skip on EndElement") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestSkip14) { Attribute = new VariationAttribute("Call Skip on root Element") });
+                    this.AddChild(new TestVariation(XmlTextReaderDoesNotThrowWhenHandlingAmpersands) { Attribute = new VariationAttribute("XmlTextReader ArgumentOutOfRangeException when handling ampersands") });
                 }
             }
-            public class TCBaseURI : BridgeHelpers
+            public partial class TCBaseURI : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCBaseURI
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcBaseURI = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCBaseURI();
-                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI1) { Attribute = new VariationAttribute("BaseURI for element node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI2) { Attribute = new VariationAttribute("BaseURI for attribute node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI3) { Attribute = new VariationAttribute("BaseURI for text node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI4) { Attribute = new VariationAttribute("BaseURI for CDATA node") });
-                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI6) { Attribute = new VariationAttribute("BaseURI for PI node") });
-                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI7) { Attribute = new VariationAttribute("BaseURI for Comment node") });
-                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI9) { Attribute = new VariationAttribute("BaseURI for Whitespace node PreserveWhitespaces = true") });
-                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI10) { Attribute = new VariationAttribute("BaseURI for EndElement node") });
-                    this.AddChild(new TestVariation(tcBaseURI.TestTextReaderBaseURI4) { Attribute = new VariationAttribute("BaseURI for external General Entity") });
+                    this.AddChild(new TestVariation(TestBaseURI1) { Attribute = new VariationAttribute("BaseURI for element node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestBaseURI2) { Attribute = new VariationAttribute("BaseURI for attribute node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestBaseURI3) { Attribute = new VariationAttribute("BaseURI for text node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestBaseURI4) { Attribute = new VariationAttribute("BaseURI for CDATA node") });
+                    this.AddChild(new TestVariation(TestBaseURI6) { Attribute = new VariationAttribute("BaseURI for PI node") });
+                    this.AddChild(new TestVariation(TestBaseURI7) { Attribute = new VariationAttribute("BaseURI for Comment node") });
+                    this.AddChild(new TestVariation(TestBaseURI9) { Attribute = new VariationAttribute("BaseURI for Whitespace node PreserveWhitespaces = true") });
+                    this.AddChild(new TestVariation(TestBaseURI10) { Attribute = new VariationAttribute("BaseURI for EndElement node") });
+                    this.AddChild(new TestVariation(TestTextReaderBaseURI4) { Attribute = new VariationAttribute("BaseURI for external General Entity") });
                 }
             }
-            public class TCAttributeAccess : BridgeHelpers
+            public partial class TCAttributeAccess : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCAttributeAccess
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcAttributeAccess = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCAttributeAccess();
-                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess1) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Ascending Order)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess2) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Descending Order)") });
-                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess3) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Odd number)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess4) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Even number)") });
-                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess5) { Attribute = new VariationAttribute("Attribute Access with namespace=null") });
+                    this.AddChild(new TestVariation(TestAttributeAccess1) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Ascending Order)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestAttributeAccess2) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Descending Order)") });
+                    this.AddChild(new TestVariation(TestAttributeAccess3) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Odd number)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestAttributeAccess4) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Even number)") });
+                    this.AddChild(new TestVariation(TestAttributeAccess5) { Attribute = new VariationAttribute("Attribute Access with namespace=null") });
                 }
             }
-            public class TCThisName : BridgeHelpers
+            public partial class TCThisName : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCThisName
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcThisName = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCThisName();
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName1) { Attribute = new VariationAttribute("This[Name] Verify with GetAttribute(Name)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName2) { Attribute = new VariationAttribute("This[Name, null] Verify with GetAttribute(Name)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName3) { Attribute = new VariationAttribute("This[Name] Verify with GetAttribute(Name,null)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName4) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify with GetAttribute(Name, NamespaceURI)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName5) { Attribute = new VariationAttribute("This[Name, null] Verify not the same as GetAttribute(Name, NamespaceURI)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName6) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify not the same as GetAttribute(Name, null)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName7) { Attribute = new VariationAttribute("This[Name] Verify with MoveToAttribute(Name)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName8) { Attribute = new VariationAttribute("This[Name, null] Verify with MoveToAttribute(Name)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName9) { Attribute = new VariationAttribute("This[Name] Verify with MoveToAttribute(Name,null)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName10) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify not the same as MoveToAttribute(Name, null)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName11) { Attribute = new VariationAttribute("This[Name, null] Verify not the same as MoveToAttribute(Name, NamespaceURI)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName12) { Attribute = new VariationAttribute("This[Name, namespace] Verify not the same as MoveToAttribute(Name, namespace)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName13) { Attribute = new VariationAttribute("This(String.Empty)") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName14) { Attribute = new VariationAttribute("This[String.Empty,String.Empty]") });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName15) { Attribute = new VariationAttribute("This[QName] Verify with GetAttribute(Name, NamespaceURI)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisName.ThisWithName16) { Attribute = new VariationAttribute("This[QName] invalid Qname") });
+                    this.AddChild(new TestVariation(ThisWithName1) { Attribute = new VariationAttribute("This[Name] Verify with GetAttribute(Name)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ThisWithName2) { Attribute = new VariationAttribute("This[Name, null] Verify with GetAttribute(Name)") });
+                    this.AddChild(new TestVariation(ThisWithName3) { Attribute = new VariationAttribute("This[Name] Verify with GetAttribute(Name,null)") });
+                    this.AddChild(new TestVariation(ThisWithName4) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify with GetAttribute(Name, NamespaceURI)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ThisWithName5) { Attribute = new VariationAttribute("This[Name, null] Verify not the same as GetAttribute(Name, NamespaceURI)") });
+                    this.AddChild(new TestVariation(ThisWithName6) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify not the same as GetAttribute(Name, null)") });
+                    this.AddChild(new TestVariation(ThisWithName7) { Attribute = new VariationAttribute("This[Name] Verify with MoveToAttribute(Name)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ThisWithName8) { Attribute = new VariationAttribute("This[Name, null] Verify with MoveToAttribute(Name)") });
+                    this.AddChild(new TestVariation(ThisWithName9) { Attribute = new VariationAttribute("This[Name] Verify with MoveToAttribute(Name,null)") });
+                    this.AddChild(new TestVariation(ThisWithName10) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify not the same as MoveToAttribute(Name, null)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ThisWithName11) { Attribute = new VariationAttribute("This[Name, null] Verify not the same as MoveToAttribute(Name, NamespaceURI)") });
+                    this.AddChild(new TestVariation(ThisWithName12) { Attribute = new VariationAttribute("This[Name, namespace] Verify not the same as MoveToAttribute(Name, namespace)") });
+                    this.AddChild(new TestVariation(ThisWithName13) { Attribute = new VariationAttribute("This(String.Empty)") });
+                    this.AddChild(new TestVariation(ThisWithName14) { Attribute = new VariationAttribute("This[String.Empty,String.Empty]") });
+                    this.AddChild(new TestVariation(ThisWithName15) { Attribute = new VariationAttribute("This[QName] Verify with GetAttribute(Name, NamespaceURI)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ThisWithName16) { Attribute = new VariationAttribute("This[QName] invalid Qname") });
                 }
             }
-            public class TCMoveToAttributeReader : BridgeHelpers
+            public partial class TCMoveToAttributeReader : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToAttributeReader
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcMoveToAttributeReader = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCMoveToAttributeReader();
-                    this.AddChild(new TestVariation(tcMoveToAttributeReader.MoveToAttributeWithName1) { Attribute = new VariationAttribute("MoveToAttribute(String.Empty)") });
-                    this.AddChild(new TestVariation(tcMoveToAttributeReader.MoveToAttributeWithName2) { Attribute = new VariationAttribute("MoveToAttribute(String.Empty,String.Empty)") });
+                    this.AddChild(new TestVariation(MoveToAttributeWithName1) { Attribute = new VariationAttribute("MoveToAttribute(String.Empty)") });
+                    this.AddChild(new TestVariation(MoveToAttributeWithName2) { Attribute = new VariationAttribute("MoveToAttribute(String.Empty,String.Empty)") });
                 }
             }
-            public class TCGetAttributeOrdinal : BridgeHelpers
+            public partial class TCGetAttributeOrdinal : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCGetAttributeOrdinal
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcGetAttributeOrdinal = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCGetAttributeOrdinal();
-                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.GetAttributeWithGetAttrDoubleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with This[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.OrdinalWithGetAttrSingleQ) { Attribute = new VariationAttribute("GetAttribute[i] Verify with This[i] - Single Quote") });
-                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.GetAttributeWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with MoveToAttribute[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.GetAttributeWithMoveAttrSingleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with MoveToAttribute[i] - Single Quote") });
-                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.NegativeOneOrdinal) { Attribute = new VariationAttribute("GetAttribute(i) NegativeOneOrdinal") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.FieldCountOrdinal) { Attribute = new VariationAttribute("GetAttribute(i) FieldCountOrdinal") });
-                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.OrdinalPlusOne) { Attribute = new VariationAttribute("GetAttribute(i) OrdinalPlusOne") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.OrdinalMinusOne) { Attribute = new VariationAttribute("GetAttribute(i) OrdinalMinusOne") });
+                    this.AddChild(new TestVariation(GetAttributeWithGetAttrDoubleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with This[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(OrdinalWithGetAttrSingleQ) { Attribute = new VariationAttribute("GetAttribute[i] Verify with This[i] - Single Quote") });
+                    this.AddChild(new TestVariation(GetAttributeWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with MoveToAttribute[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(GetAttributeWithMoveAttrSingleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with MoveToAttribute[i] - Single Quote") });
+                    this.AddChild(new TestVariation(NegativeOneOrdinal) { Attribute = new VariationAttribute("GetAttribute(i) NegativeOneOrdinal") { Priority = 0 } });
+                    this.AddChild(new TestVariation(FieldCountOrdinal) { Attribute = new VariationAttribute("GetAttribute(i) FieldCountOrdinal") });
+                    this.AddChild(new TestVariation(OrdinalPlusOne) { Attribute = new VariationAttribute("GetAttribute(i) OrdinalPlusOne") { Priority = 0 } });
+                    this.AddChild(new TestVariation(OrdinalMinusOne) { Attribute = new VariationAttribute("GetAttribute(i) OrdinalMinusOne") });
                 }
             }
-            public class TCGetAttributeName : BridgeHelpers
+            public partial class TCGetAttributeName : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCGetAttributeName
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcGetAttributeName = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCGetAttributeName();
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName1) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with This[Name]") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName2) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify with This[Name]") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName3) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with This[Name,null]") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName4) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify with This[Name, NamespaceURI]") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName5) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify not the same as This[Name, NamespaceURI]") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName6) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify not the same as This[Name, null]") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName7) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with MoveToAttribute(Name)") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName8) { Attribute = new VariationAttribute("GetAttribute(Name,null) Verify with MoveToAttribute(Name)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName9) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with MoveToAttribute(Name,null)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName10) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify not the same as MoveToAttribute(Name, null)") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName11) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify not the same as MoveToAttribute(Name, NamespaceURI)") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName12) { Attribute = new VariationAttribute("GetAttribute(Name, namespace) Verify not the same as MoveToAttribute(Name, namespace)") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName13) { Attribute = new VariationAttribute("GetAttribute(String.Empty)") });
-                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName14) { Attribute = new VariationAttribute("GetAttribute(String.Empty,String.Empty)") });
+                    this.AddChild(new TestVariation(GetAttributeWithName1) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with This[Name]") { Priority = 0 } });
+                    this.AddChild(new TestVariation(GetAttributeWithName2) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify with This[Name]") });
+                    this.AddChild(new TestVariation(GetAttributeWithName3) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with This[Name,null]") });
+                    this.AddChild(new TestVariation(GetAttributeWithName4) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify with This[Name, NamespaceURI]") { Priority = 0 } });
+                    this.AddChild(new TestVariation(GetAttributeWithName5) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify not the same as This[Name, NamespaceURI]") });
+                    this.AddChild(new TestVariation(GetAttributeWithName6) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify not the same as This[Name, null]") });
+                    this.AddChild(new TestVariation(GetAttributeWithName7) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with MoveToAttribute(Name)") });
+                    this.AddChild(new TestVariation(GetAttributeWithName8) { Attribute = new VariationAttribute("GetAttribute(Name,null) Verify with MoveToAttribute(Name)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(GetAttributeWithName9) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with MoveToAttribute(Name,null)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(GetAttributeWithName10) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify not the same as MoveToAttribute(Name, null)") });
+                    this.AddChild(new TestVariation(GetAttributeWithName11) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify not the same as MoveToAttribute(Name, NamespaceURI)") });
+                    this.AddChild(new TestVariation(GetAttributeWithName12) { Attribute = new VariationAttribute("GetAttribute(Name, namespace) Verify not the same as MoveToAttribute(Name, namespace)") });
+                    this.AddChild(new TestVariation(GetAttributeWithName13) { Attribute = new VariationAttribute("GetAttribute(String.Empty)") });
+                    this.AddChild(new TestVariation(GetAttributeWithName14) { Attribute = new VariationAttribute("GetAttribute(String.Empty,String.Empty)") });
                 }
             }
-            public class TCThisOrdinal : BridgeHelpers
+            public partial class TCThisOrdinal : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCThisOrdinal
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcThisOrdinal = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCThisOrdinal();
-                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalWithGetAttrDoubleQ) { Attribute = new VariationAttribute("This[i] Verify with GetAttribute[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalWithGetAttrSingleQ) { Attribute = new VariationAttribute("This[i] Verify with GetAttribute[i] - Single Quote") });
-                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalWithMoveAttrSingleQ) { Attribute = new VariationAttribute("This[i] Verify with MoveToAttribute[i] - Single Quote") });
-                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("This[i] Verify with MoveToAttribute[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisOrdinal.NegativeOneOrdinal) { Attribute = new VariationAttribute("ThisOrdinal NegativeOneOrdinal") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisOrdinal.FieldCountOrdinal) { Attribute = new VariationAttribute("ThisOrdinal FieldCountOrdinal") });
-                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalPlusOne) { Attribute = new VariationAttribute("ThisOrdinal OrdinalPlusOne") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalMinusOne) { Attribute = new VariationAttribute("ThisOrdinal OrdinalMinusOne") });
+                    this.AddChild(new TestVariation(OrdinalWithGetAttrDoubleQ) { Attribute = new VariationAttribute("This[i] Verify with GetAttribute[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(OrdinalWithGetAttrSingleQ) { Attribute = new VariationAttribute("This[i] Verify with GetAttribute[i] - Single Quote") });
+                    this.AddChild(new TestVariation(OrdinalWithMoveAttrSingleQ) { Attribute = new VariationAttribute("This[i] Verify with MoveToAttribute[i] - Single Quote") });
+                    this.AddChild(new TestVariation(OrdinalWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("This[i] Verify with MoveToAttribute[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(NegativeOneOrdinal) { Attribute = new VariationAttribute("ThisOrdinal NegativeOneOrdinal") { Priority = 0 } });
+                    this.AddChild(new TestVariation(FieldCountOrdinal) { Attribute = new VariationAttribute("ThisOrdinal FieldCountOrdinal") });
+                    this.AddChild(new TestVariation(OrdinalPlusOne) { Attribute = new VariationAttribute("ThisOrdinal OrdinalPlusOne") { Priority = 0 } });
+                    this.AddChild(new TestVariation(OrdinalMinusOne) { Attribute = new VariationAttribute("ThisOrdinal OrdinalMinusOne") });
                 }
             }
-            public class TCMoveToAttributeOrdinal : BridgeHelpers
+            public partial class TCMoveToAttributeOrdinal : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToAttributeOrdinal
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcMoveToAttributeOrdinal = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCMoveToAttributeOrdinal();
-                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.MoveToAttributeWithGetAttrDoubleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with This[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.MoveToAttributeWithGetAttrSingleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with This[i] - Single Quote") });
-                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.MoveToAttributeWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with GetAttribute(i) - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.MoveToAttributeWithMoveAttrSingleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with GetAttribute[i] - Single Quote") });
-                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.NegativeOneOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i) NegativeOneOrdinal") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.FieldCountOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i) FieldCountOrdinal") });
-                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.OrdinalPlusOne) { Attribute = new VariationAttribute("MoveToAttribute(i) OrdinalPlusOne") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.OrdinalMinusOne) { Attribute = new VariationAttribute("MoveToAttribute(i) OrdinalMinusOne") });
+                    this.AddChild(new TestVariation(MoveToAttributeWithGetAttrDoubleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with This[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(MoveToAttributeWithGetAttrSingleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with This[i] - Single Quote") });
+                    this.AddChild(new TestVariation(MoveToAttributeWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with GetAttribute(i) - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(MoveToAttributeWithMoveAttrSingleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with GetAttribute[i] - Single Quote") });
+                    this.AddChild(new TestVariation(NegativeOneOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i) NegativeOneOrdinal") { Priority = 0 } });
+                    this.AddChild(new TestVariation(FieldCountOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i) FieldCountOrdinal") });
+                    this.AddChild(new TestVariation(OrdinalPlusOne) { Attribute = new VariationAttribute("MoveToAttribute(i) OrdinalPlusOne") { Priority = 0 } });
+                    this.AddChild(new TestVariation(OrdinalMinusOne) { Attribute = new VariationAttribute("MoveToAttribute(i) OrdinalMinusOne") });
                 }
             }
-            public class TCMoveToFirstAttribute : BridgeHelpers
+            public partial class TCMoveToFirstAttribute : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToFirstAttribute
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcMoveToFirstAttribute = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCMoveToFirstAttribute();
-                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute1) { Attribute = new VariationAttribute("MoveToFirstAttribute() When AttributeCount=0, <EMPTY1/> ") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute2) { Attribute = new VariationAttribute("MoveToFirstAttribute() When AttributeCount=0, <NONEMPTY1>ABCDE</NONEMPTY1> ") });
-                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute3) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=0, with namespace") });
-                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute4) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=0, without namespace") });
-                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute5) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, with namespace") });
-                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute6) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, without namespace") });
-                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute7) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, with namespace") });
-                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute8) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, without namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute1) { Attribute = new VariationAttribute("MoveToFirstAttribute() When AttributeCount=0, <EMPTY1/> ") { Priority = 0 } });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute2) { Attribute = new VariationAttribute("MoveToFirstAttribute() When AttributeCount=0, <NONEMPTY1>ABCDE</NONEMPTY1> ") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute3) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=0, with namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute4) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=0, without namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute5) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, with namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute6) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, without namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute7) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, with namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute8) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, without namespace") });
                 }
             }
-            public class TCMoveToNextAttribute : BridgeHelpers
+            public partial class TCMoveToNextAttribute : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToNextAttribute
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcMoveToNextAttribute = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCMoveToNextAttribute();
-                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToNextAttribute1) { Attribute = new VariationAttribute("MoveToNextAttribute() When AttributeCount=0, <EMPTY1/> ") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToNextAttribute2) { Attribute = new VariationAttribute("MoveToNextAttribute() When AttributeCount=0, <NONEMPTY1>ABCDE</NONEMPTY1> ") });
-                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToNextAttribute3) { Attribute = new VariationAttribute("MoveToNextAttribute() When iOrdinal=0, with namespace") });
-                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToNextAttribute4) { Attribute = new VariationAttribute("MoveToNextAttribute() When iOrdinal=0, without namespace") });
-                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToFirstAttribute5) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, with namespace") });
-                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToFirstAttribute6) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, without namespace") });
-                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToFirstAttribute7) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, with namespace") });
-                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToFirstAttribute8) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, without namespace") });
+                    this.AddChild(new TestVariation(MoveToNextAttribute1) { Attribute = new VariationAttribute("MoveToNextAttribute() When AttributeCount=0, <EMPTY1/> ") { Priority = 0 } });
+                    this.AddChild(new TestVariation(MoveToNextAttribute2) { Attribute = new VariationAttribute("MoveToNextAttribute() When AttributeCount=0, <NONEMPTY1>ABCDE</NONEMPTY1> ") });
+                    this.AddChild(new TestVariation(MoveToNextAttribute3) { Attribute = new VariationAttribute("MoveToNextAttribute() When iOrdinal=0, with namespace") });
+                    this.AddChild(new TestVariation(MoveToNextAttribute4) { Attribute = new VariationAttribute("MoveToNextAttribute() When iOrdinal=0, without namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute5) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, with namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute6) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, without namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute7) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, with namespace") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute8) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, without namespace") });
                 }
             }
-            public class TCAttributeTest : BridgeHelpers
+            public partial class TCAttributeTest : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCAttributeTest
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcAttributeTest = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCAttributeTest();
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_None) { Attribute = new VariationAttribute("Attribute Test On None") });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_Element) { Attribute = new VariationAttribute("Attribute Test  On Element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_Text) { Attribute = new VariationAttribute("Attribute Test On Text") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_CDATA) { Attribute = new VariationAttribute("Attribute Test On CDATA") });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("Attribute Test On ProcessingInstruction") });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_Comment) { Attribute = new VariationAttribute("AttributeTest On Comment") });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_DocumentType) { Attribute = new VariationAttribute("AttributeTest On DocumentType") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_Whitespace) { Attribute = new VariationAttribute("AttributeTest On Whitespace") });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_EndElement) { Attribute = new VariationAttribute("AttributeTest On EndElement") });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_XmlDeclaration) { Attribute = new VariationAttribute("AttributeTest On XmlDeclaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_EndEntity) { Attribute = new VariationAttribute("AttributeTest On EndEntity") });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_None) { Attribute = new VariationAttribute("Attribute Test On None") });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_Element) { Attribute = new VariationAttribute("Attribute Test  On Element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_Text) { Attribute = new VariationAttribute("Attribute Test On Text") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_CDATA) { Attribute = new VariationAttribute("Attribute Test On CDATA") });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("Attribute Test On ProcessingInstruction") });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_Comment) { Attribute = new VariationAttribute("AttributeTest On Comment") });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_DocumentType) { Attribute = new VariationAttribute("AttributeTest On DocumentType") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_Whitespace) { Attribute = new VariationAttribute("AttributeTest On Whitespace") });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_EndElement) { Attribute = new VariationAttribute("AttributeTest On EndElement") });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_XmlDeclaration) { Attribute = new VariationAttribute("AttributeTest On XmlDeclaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestAttributeTestNodeType_EndEntity) { Attribute = new VariationAttribute("AttributeTest On EndEntity") });
                 }
             }
-            public class TCXmlns : BridgeHelpers
+            public partial class TCXmlns : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlns
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcXmlns = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCXmlns();
-                    this.AddChild(new TestVariation(tcXmlns.TXmlns1) { Attribute = new VariationAttribute("Name, LocalName, Prefix and Value with xmlns=ns attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlns.TXmlns2) { Attribute = new VariationAttribute("Name, LocalName, Prefix and Value with xmlns:p=ns attribute") });
-                    this.AddChild(new TestVariation(tcXmlns.TXmlns3) { Attribute = new VariationAttribute("LookupNamespace with xmlns=ns attribute") });
-                    this.AddChild(new TestVariation(tcXmlns.TXmlns4) { Attribute = new VariationAttribute("MoveToAttribute access on xmlns attribute") });
-                    this.AddChild(new TestVariation(tcXmlns.TXmlns5) { Attribute = new VariationAttribute("GetAttribute access on xmlns attribute") });
-                    this.AddChild(new TestVariation(tcXmlns.TXmlns6) { Attribute = new VariationAttribute("this[xmlns] attribute access") });
+                    this.AddChild(new TestVariation(TXmlns1) { Attribute = new VariationAttribute("Name, LocalName, Prefix and Value with xmlns=ns attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TXmlns2) { Attribute = new VariationAttribute("Name, LocalName, Prefix and Value with xmlns:p=ns attribute") });
+                    this.AddChild(new TestVariation(TXmlns3) { Attribute = new VariationAttribute("LookupNamespace with xmlns=ns attribute") });
+                    this.AddChild(new TestVariation(TXmlns4) { Attribute = new VariationAttribute("MoveToAttribute access on xmlns attribute") });
+                    this.AddChild(new TestVariation(TXmlns5) { Attribute = new VariationAttribute("GetAttribute access on xmlns attribute") });
+                    this.AddChild(new TestVariation(TXmlns6) { Attribute = new VariationAttribute("this[xmlns] attribute access") });
                 }
             }
-            public class TCXmlnsPrefix : BridgeHelpers
+            public partial class TCXmlnsPrefix : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlnsPrefix
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcXmlnsPrefix = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCXmlnsPrefix();
-                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix1) { Attribute = new VariationAttribute("NamespaceURI of xmlns:a attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix2) { Attribute = new VariationAttribute("NamespaceURI of element/attribute with xmlns attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix3) { Attribute = new VariationAttribute("LookupNamespace with xmlns prefix") });
-                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix4) { Attribute = new VariationAttribute("Define prefix for 'www.w3.org/2000/xmlns'") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix5) { Attribute = new VariationAttribute("Redefine namespace attached to xmlns prefix") });
+                    this.AddChild(new TestVariation(TXmlnsPrefix1) { Attribute = new VariationAttribute("NamespaceURI of xmlns:a attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TXmlnsPrefix2) { Attribute = new VariationAttribute("NamespaceURI of element/attribute with xmlns attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TXmlnsPrefix3) { Attribute = new VariationAttribute("LookupNamespace with xmlns prefix") });
+                    this.AddChild(new TestVariation(TXmlnsPrefix4) { Attribute = new VariationAttribute("Define prefix for 'www.w3.org/2000/xmlns'") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TXmlnsPrefix5) { Attribute = new VariationAttribute("Redefine namespace attached to xmlns prefix") });
                 }
             }
-            public class TCReadState : BridgeHelpers
+            public partial class TCReadState : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadState
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadState = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCReadState();
-                    this.AddChild(new TestVariation(tcReadState.ReadState1) { Attribute = new VariationAttribute("XmlReader ReadState Initial") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadState.ReadState2) { Attribute = new VariationAttribute("XmlReader ReadState Interactive") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadState.ReadState3) { Attribute = new VariationAttribute("XmlReader ReadState EndOfFile") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadState.ReadState4) { Attribute = new VariationAttribute("XmlReader ReadState Initial") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadState.ReadState5) { Attribute = new VariationAttribute("XmlReader ReadState EndOfFile") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadState1) { Attribute = new VariationAttribute("XmlReader ReadState Initial") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadState2) { Attribute = new VariationAttribute("XmlReader ReadState Interactive") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadState3) { Attribute = new VariationAttribute("XmlReader ReadState EndOfFile") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadState4) { Attribute = new VariationAttribute("XmlReader ReadState Initial") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadState5) { Attribute = new VariationAttribute("XmlReader ReadState EndOfFile") { Priority = 0 } });
                 }
             }
-            public class TCReadInnerXml : BridgeHelpers
+            public partial class TCReadInnerXml : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadInnerXml
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadInnerXml = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCReadInnerXml();
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml1) { Attribute = new VariationAttribute("ReadInnerXml on Empty Tag") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml on non Empty Tag") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml3) { Attribute = new VariationAttribute("ReadInnerXml on non Empty Tag with text content") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml6) { Attribute = new VariationAttribute("ReadInnerXml with multiple Level of elements") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml7) { Attribute = new VariationAttribute("ReadInnerXml with multiple Level of elements, text and attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml8) { Attribute = new VariationAttribute("ReadInnerXml with entity references, EntityHandling = ExpandEntities") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml9) { Attribute = new VariationAttribute("ReadInnerXml on attribute node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml10) { Attribute = new VariationAttribute("ReadInnerXml on attribute node with entity reference in value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml11) { Attribute = new VariationAttribute("ReadInnerXml on Text") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml12) { Attribute = new VariationAttribute("ReadInnerXml on CDATA") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml13) { Attribute = new VariationAttribute("ReadInnerXml on ProcessingInstruction") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml14) { Attribute = new VariationAttribute("ReadInnerXml on Comment") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml16) { Attribute = new VariationAttribute("ReadInnerXml on EndElement") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml17) { Attribute = new VariationAttribute("ReadInnerXml on XmlDeclaration") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml18) { Attribute = new VariationAttribute("Current node after ReadInnerXml on element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml19) { Attribute = new VariationAttribute("Current node after ReadInnerXml on element") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestTextReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml with entity references, EntityHandling = ExpandCharEntites") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestTextReadInnerXml4) { Attribute = new VariationAttribute("ReadInnerXml on EntityReference") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestTextReadInnerXml5) { Attribute = new VariationAttribute("ReadInnerXml on EndEntity") });
-                    this.AddChild(new TestVariation(tcReadInnerXml.TestTextReadInnerXml18) { Attribute = new VariationAttribute("One large element") });
+                    this.AddChild(new TestVariation(TestReadInnerXml1) { Attribute = new VariationAttribute("ReadInnerXml on Empty Tag") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml on non Empty Tag") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadInnerXml3) { Attribute = new VariationAttribute("ReadInnerXml on non Empty Tag with text content") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadInnerXml6) { Attribute = new VariationAttribute("ReadInnerXml with multiple Level of elements") });
+                    this.AddChild(new TestVariation(TestReadInnerXml7) { Attribute = new VariationAttribute("ReadInnerXml with multiple Level of elements, text and attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadInnerXml8) { Attribute = new VariationAttribute("ReadInnerXml with entity references, EntityHandling = ExpandEntities") });
+                    this.AddChild(new TestVariation(TestReadInnerXml9) { Attribute = new VariationAttribute("ReadInnerXml on attribute node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadInnerXml10) { Attribute = new VariationAttribute("ReadInnerXml on attribute node with entity reference in value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadInnerXml11) { Attribute = new VariationAttribute("ReadInnerXml on Text") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadInnerXml12) { Attribute = new VariationAttribute("ReadInnerXml on CDATA") });
+                    this.AddChild(new TestVariation(TestReadInnerXml13) { Attribute = new VariationAttribute("ReadInnerXml on ProcessingInstruction") });
+                    this.AddChild(new TestVariation(TestReadInnerXml14) { Attribute = new VariationAttribute("ReadInnerXml on Comment") });
+                    this.AddChild(new TestVariation(TestReadInnerXml16) { Attribute = new VariationAttribute("ReadInnerXml on EndElement") });
+                    this.AddChild(new TestVariation(TestReadInnerXml17) { Attribute = new VariationAttribute("ReadInnerXml on XmlDeclaration") });
+                    this.AddChild(new TestVariation(TestReadInnerXml18) { Attribute = new VariationAttribute("Current node after ReadInnerXml on element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadInnerXml19) { Attribute = new VariationAttribute("Current node after ReadInnerXml on element") });
+                    this.AddChild(new TestVariation(TestTextReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml with entity references, EntityHandling = ExpandCharEntites") });
+                    this.AddChild(new TestVariation(TestTextReadInnerXml4) { Attribute = new VariationAttribute("ReadInnerXml on EntityReference") });
+                    this.AddChild(new TestVariation(TestTextReadInnerXml5) { Attribute = new VariationAttribute("ReadInnerXml on EndEntity") });
+                    this.AddChild(new TestVariation(TestTextReadInnerXml18) { Attribute = new VariationAttribute("One large element") });
                 }
             }
-            public class TCMoveToContent : BridgeHelpers
+            public partial class TCMoveToContent : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToContent
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcMoveToContent = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCMoveToContent();
-                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent1) { Attribute = new VariationAttribute("MoveToContent on Skip XmlDeclaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent2) { Attribute = new VariationAttribute("MoveToContent on Read through All valid Content Node(Element, Text, CDATA, and EndElement)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent3) { Attribute = new VariationAttribute("MoveToContent on Read through All invalid Content Node(PI, Comment and whitespace)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent4) { Attribute = new VariationAttribute("MoveToContent on Read through Mix valid and Invalid Content Node") });
-                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent5) { Attribute = new VariationAttribute("MoveToContent on Attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestMoveToContent1) { Attribute = new VariationAttribute("MoveToContent on Skip XmlDeclaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestMoveToContent2) { Attribute = new VariationAttribute("MoveToContent on Read through All valid Content Node(Element, Text, CDATA, and EndElement)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestMoveToContent3) { Attribute = new VariationAttribute("MoveToContent on Read through All invalid Content Node(PI, Comment and whitespace)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestMoveToContent4) { Attribute = new VariationAttribute("MoveToContent on Read through Mix valid and Invalid Content Node") });
+                    this.AddChild(new TestVariation(TestMoveToContent5) { Attribute = new VariationAttribute("MoveToContent on Attribute") { Priority = 0 } });
                 }
             }
-            public class TCIsStartElement : BridgeHelpers
+            public partial class TCIsStartElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCIsStartElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcIsStartElement = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCIsStartElement();
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement1) { Attribute = new VariationAttribute("IsStartElement on Regular Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement2) { Attribute = new VariationAttribute("IsStartElement on Empty Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement3) { Attribute = new VariationAttribute("IsStartElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement4) { Attribute = new VariationAttribute("IsStartElement on Empty Tag, with default namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement5) { Attribute = new VariationAttribute("IsStartElement with Name=String.Empty") });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement6) { Attribute = new VariationAttribute("IsStartElement on Empty Element with Name and Namespace=String.Empty") });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement7) { Attribute = new VariationAttribute("IsStartElement on CDATA") });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement8) { Attribute = new VariationAttribute("IsStartElement on EndElement, no namespace") });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement9) { Attribute = new VariationAttribute("IsStartElement on EndElement, with namespace") });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement10) { Attribute = new VariationAttribute("IsStartElement on Attribute") });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement11) { Attribute = new VariationAttribute("IsStartElement on Text") });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement12) { Attribute = new VariationAttribute("IsStartElement on ProcessingInstruction") });
-                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement13) { Attribute = new VariationAttribute("IsStartElement on Comment") });
+                    this.AddChild(new TestVariation(TestIsStartElement1) { Attribute = new VariationAttribute("IsStartElement on Regular Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestIsStartElement2) { Attribute = new VariationAttribute("IsStartElement on Empty Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestIsStartElement3) { Attribute = new VariationAttribute("IsStartElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestIsStartElement4) { Attribute = new VariationAttribute("IsStartElement on Empty Tag, with default namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestIsStartElement5) { Attribute = new VariationAttribute("IsStartElement with Name=String.Empty") });
+                    this.AddChild(new TestVariation(TestIsStartElement6) { Attribute = new VariationAttribute("IsStartElement on Empty Element with Name and Namespace=String.Empty") });
+                    this.AddChild(new TestVariation(TestIsStartElement7) { Attribute = new VariationAttribute("IsStartElement on CDATA") });
+                    this.AddChild(new TestVariation(TestIsStartElement8) { Attribute = new VariationAttribute("IsStartElement on EndElement, no namespace") });
+                    this.AddChild(new TestVariation(TestIsStartElement9) { Attribute = new VariationAttribute("IsStartElement on EndElement, with namespace") });
+                    this.AddChild(new TestVariation(TestIsStartElement10) { Attribute = new VariationAttribute("IsStartElement on Attribute") });
+                    this.AddChild(new TestVariation(TestIsStartElement11) { Attribute = new VariationAttribute("IsStartElement on Text") });
+                    this.AddChild(new TestVariation(TestIsStartElement12) { Attribute = new VariationAttribute("IsStartElement on ProcessingInstruction") });
+                    this.AddChild(new TestVariation(TestIsStartElement13) { Attribute = new VariationAttribute("IsStartElement on Comment") });
                 }
             }
-            public class TCReadStartElement : BridgeHelpers
+            public partial class TCReadStartElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadStartElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadStartElement = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCReadStartElement();
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement1) { Attribute = new VariationAttribute("ReadStartElement on Regular Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement2) { Attribute = new VariationAttribute("ReadStartElement on Empty Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement3) { Attribute = new VariationAttribute("ReadStartElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement4) { Attribute = new VariationAttribute("Passing ns=String.EmptyErrorCase: ReadStartElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement5) { Attribute = new VariationAttribute("Passing no ns: ReadStartElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement6) { Attribute = new VariationAttribute("ReadStartElement on Empty Tag, with namespace") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement7) { Attribute = new VariationAttribute("ErrorCase: ReadStartElement on Empty Tag, with namespace, passing ns=String.Empty") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement8) { Attribute = new VariationAttribute("ReadStartElement on Empty Tag, with namespace, passing no ns") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement9) { Attribute = new VariationAttribute("ReadStartElement with Name=String.Empty") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement10) { Attribute = new VariationAttribute("ReadStartElement on Empty Element with Name and Namespace=String.Empty") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement11) { Attribute = new VariationAttribute("ReadStartElement on CDATA") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement12) { Attribute = new VariationAttribute("ReadStartElement() on EndElement, no namespace") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement13) { Attribute = new VariationAttribute("ReadStartElement(n) on EndElement, no namespace") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement14) { Attribute = new VariationAttribute("ReadStartElement(n, String.Empty) on EndElement, no namespace") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement15) { Attribute = new VariationAttribute("ReadStartElement() on EndElement, with namespace") });
-                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement16) { Attribute = new VariationAttribute("ReadStartElement(n,ns) on EndElement, with namespace") });
+                    this.AddChild(new TestVariation(TestReadStartElement1) { Attribute = new VariationAttribute("ReadStartElement on Regular Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadStartElement2) { Attribute = new VariationAttribute("ReadStartElement on Empty Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadStartElement3) { Attribute = new VariationAttribute("ReadStartElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadStartElement4) { Attribute = new VariationAttribute("Passing ns=String.EmptyErrorCase: ReadStartElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadStartElement5) { Attribute = new VariationAttribute("Passing no ns: ReadStartElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadStartElement6) { Attribute = new VariationAttribute("ReadStartElement on Empty Tag, with namespace") });
+                    this.AddChild(new TestVariation(TestReadStartElement7) { Attribute = new VariationAttribute("ErrorCase: ReadStartElement on Empty Tag, with namespace, passing ns=String.Empty") });
+                    this.AddChild(new TestVariation(TestReadStartElement8) { Attribute = new VariationAttribute("ReadStartElement on Empty Tag, with namespace, passing no ns") });
+                    this.AddChild(new TestVariation(TestReadStartElement9) { Attribute = new VariationAttribute("ReadStartElement with Name=String.Empty") });
+                    this.AddChild(new TestVariation(TestReadStartElement10) { Attribute = new VariationAttribute("ReadStartElement on Empty Element with Name and Namespace=String.Empty") });
+                    this.AddChild(new TestVariation(TestReadStartElement11) { Attribute = new VariationAttribute("ReadStartElement on CDATA") });
+                    this.AddChild(new TestVariation(TestReadStartElement12) { Attribute = new VariationAttribute("ReadStartElement() on EndElement, no namespace") });
+                    this.AddChild(new TestVariation(TestReadStartElement13) { Attribute = new VariationAttribute("ReadStartElement(n) on EndElement, no namespace") });
+                    this.AddChild(new TestVariation(TestReadStartElement14) { Attribute = new VariationAttribute("ReadStartElement(n, String.Empty) on EndElement, no namespace") });
+                    this.AddChild(new TestVariation(TestReadStartElement15) { Attribute = new VariationAttribute("ReadStartElement() on EndElement, with namespace") });
+                    this.AddChild(new TestVariation(TestReadStartElement16) { Attribute = new VariationAttribute("ReadStartElement(n,ns) on EndElement, with namespace") });
                 }
             }
-            public class TCReadEndElement : BridgeHelpers
+            public partial class TCReadEndElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadEndElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadEndElement = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCReadEndElement();
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement3) { Attribute = new VariationAttribute("ReadEndElement on Start Element, no namespace") });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement4) { Attribute = new VariationAttribute("ReadEndElement on Empty Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement5) { Attribute = new VariationAttribute("ReadEndElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement6) { Attribute = new VariationAttribute("ReadEndElement on Empty Tag, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement7) { Attribute = new VariationAttribute("ReadEndElement on CDATA") });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement9) { Attribute = new VariationAttribute("ReadEndElement on Text") });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement10) { Attribute = new VariationAttribute("ReadEndElement on ProcessingInstruction") });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement11) { Attribute = new VariationAttribute("ReadEndElement on Comment") });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement13) { Attribute = new VariationAttribute("ReadEndElement on XmlDeclaration") });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestTextReadEndElement1) { Attribute = new VariationAttribute("ReadEndElement on EntityReference") });
-                    this.AddChild(new TestVariation(tcReadEndElement.TestTextReadEndElement2) { Attribute = new VariationAttribute("ReadEndElement on EndEntity") });
+                    this.AddChild(new TestVariation(TestReadEndElement3) { Attribute = new VariationAttribute("ReadEndElement on Start Element, no namespace") });
+                    this.AddChild(new TestVariation(TestReadEndElement4) { Attribute = new VariationAttribute("ReadEndElement on Empty Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadEndElement5) { Attribute = new VariationAttribute("ReadEndElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadEndElement6) { Attribute = new VariationAttribute("ReadEndElement on Empty Tag, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadEndElement7) { Attribute = new VariationAttribute("ReadEndElement on CDATA") });
+                    this.AddChild(new TestVariation(TestReadEndElement9) { Attribute = new VariationAttribute("ReadEndElement on Text") });
+                    this.AddChild(new TestVariation(TestReadEndElement10) { Attribute = new VariationAttribute("ReadEndElement on ProcessingInstruction") });
+                    this.AddChild(new TestVariation(TestReadEndElement11) { Attribute = new VariationAttribute("ReadEndElement on Comment") });
+                    this.AddChild(new TestVariation(TestReadEndElement13) { Attribute = new VariationAttribute("ReadEndElement on XmlDeclaration") });
+                    this.AddChild(new TestVariation(TestTextReadEndElement1) { Attribute = new VariationAttribute("ReadEndElement on EntityReference") });
+                    this.AddChild(new TestVariation(TestTextReadEndElement2) { Attribute = new VariationAttribute("ReadEndElement on EndEntity") });
                 }
             }
 
-            public class TCMoveToElement : BridgeHelpers
+            public partial class TCMoveToElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcMoveToElement = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCMoveToElement();
-                    this.AddChild(new TestVariation(tcMoveToElement.v1) { Attribute = new VariationAttribute("Attribute node") });
-                    this.AddChild(new TestVariation(tcMoveToElement.v2) { Attribute = new VariationAttribute("Element node") });
-                    this.AddChild(new TestVariation(tcMoveToElement.v5) { Attribute = new VariationAttribute("Comment node") });
+                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Attribute node") });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Element node") });
+                    this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Comment node") });
                 }
             }
-            public class ErrorConditions : BridgeHelpers
+            public partial class ErrorConditions : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+ErrorConditions
                 // Test Case
                 public override void AddChildren()
                 {
-                    var errorConditions = new XNodeReaderErrorConditionsFunctionalTests.XNodeReaderTests.ErrorConditions();
-                    this.AddChild(new TestVariation(errorConditions.Variation1) { Attribute = new VariationAttribute("Move to Attribute using []") });
-                    this.AddChild(new TestVariation(errorConditions.Variation2) { Attribute = new VariationAttribute("GetAttribute") });
-                    this.AddChild(new TestVariation(errorConditions.Variation3) { Attribute = new VariationAttribute("IsStartElement") });
-                    this.AddChild(new TestVariation(errorConditions.Variation4) { Attribute = new VariationAttribute("LookupNamespace") });
-                    this.AddChild(new TestVariation(errorConditions.Variation5) { Attribute = new VariationAttribute("MoveToAttribute") });
-                    this.AddChild(new TestVariation(errorConditions.Variation6) { Attribute = new VariationAttribute("Other APIs") });
-                    this.AddChild(new TestVariation(errorConditions.Variation7) { Attribute = new VariationAttribute("ReadContentAs(null, null)") });
-                    this.AddChild(new TestVariation(errorConditions.Variation8) { Attribute = new VariationAttribute("ReadContentAsBase64") });
-                    this.AddChild(new TestVariation(errorConditions.Variation9) { Attribute = new VariationAttribute("ReadContentAsBinHex") });
-                    this.AddChild(new TestVariation(errorConditions.Variation10) { Attribute = new VariationAttribute("ReadContentAsBoolean") });
-                    this.AddChild(new TestVariation(errorConditions.Variation11b) { Attribute = new VariationAttribute("ReadContentAsDateTimeOffset") });
-                    this.AddChild(new TestVariation(errorConditions.Variation12) { Attribute = new VariationAttribute("ReadContentAsDecimal") });
-                    this.AddChild(new TestVariation(errorConditions.Variation13) { Attribute = new VariationAttribute("ReadContentAsDouble") });
-                    this.AddChild(new TestVariation(errorConditions.Variation14) { Attribute = new VariationAttribute("ReadContentAsFloat") });
-                    this.AddChild(new TestVariation(errorConditions.Variation15) { Attribute = new VariationAttribute("ReadContentAsInt") });
-                    this.AddChild(new TestVariation(errorConditions.Variation16) { Attribute = new VariationAttribute("ReadContentAsLong") });
-                    this.AddChild(new TestVariation(errorConditions.Variation17) { Attribute = new VariationAttribute("ReadElementContentAs(null, null)") });
-                    this.AddChild(new TestVariation(errorConditions.Variation18) { Attribute = new VariationAttribute("ReadElementContentAsBase64") });
-                    this.AddChild(new TestVariation(errorConditions.Variation19) { Attribute = new VariationAttribute("ReadElementContentAsBinHex") });
-                    this.AddChild(new TestVariation(errorConditions.Variation20) { Attribute = new VariationAttribute("ReadElementContentAsBoolean") });
-                    this.AddChild(new TestVariation(errorConditions.Variation22) { Attribute = new VariationAttribute("ReadElementContentAsDecimal") });
-                    this.AddChild(new TestVariation(errorConditions.Variation23) { Attribute = new VariationAttribute("ReadElementContentAsDouble") });
-                    this.AddChild(new TestVariation(errorConditions.Variation24) { Attribute = new VariationAttribute("ReadElementContentAsFloat") });
-                    this.AddChild(new TestVariation(errorConditions.Variation25) { Attribute = new VariationAttribute("ReadElementContentAsInt") });
-                    this.AddChild(new TestVariation(errorConditions.Variation26) { Attribute = new VariationAttribute("ReadElementContentAsLong") });
-                    this.AddChild(new TestVariation(errorConditions.Variation27) { Attribute = new VariationAttribute("ReadElementContentAsObject") });
-                    this.AddChild(new TestVariation(errorConditions.Variation28) { Attribute = new VariationAttribute("ReadElementContentAsString") });
-                    this.AddChild(new TestVariation(errorConditions.Variation30) { Attribute = new VariationAttribute("ReadStartElement") });
-                    this.AddChild(new TestVariation(errorConditions.Variation31) { Attribute = new VariationAttribute("ReadToDescendant(null)") });
-                    this.AddChild(new TestVariation(errorConditions.Variation32) { Attribute = new VariationAttribute("ReadToDescendant(String.Empty)") });
-                    this.AddChild(new TestVariation(errorConditions.Variation33) { Attribute = new VariationAttribute("ReadToFollowing(null)") });
-                    this.AddChild(new TestVariation(errorConditions.Variation34) { Attribute = new VariationAttribute("ReadToFollowing(String.Empty)") });
-                    this.AddChild(new TestVariation(errorConditions.Variation35) { Attribute = new VariationAttribute("ReadToNextSibling(null)") });
-                    this.AddChild(new TestVariation(errorConditions.Variation36) { Attribute = new VariationAttribute("ReadToNextSibling(String.Empty)") });
-                    this.AddChild(new TestVariation(errorConditions.Variation37) { Attribute = new VariationAttribute("ReadValueChunk") });
-                    this.AddChild(new TestVariation(errorConditions.Variation38) { Attribute = new VariationAttribute("ReadElementContentAsObject") });
-                    this.AddChild(new TestVariation(errorConditions.Variation39) { Attribute = new VariationAttribute("ReadElementContentAsString") });
+                    this.AddChild(new TestVariation(Variation1) { Attribute = new VariationAttribute("Move to Attribute using []") });
+                    this.AddChild(new TestVariation(Variation2) { Attribute = new VariationAttribute("GetAttribute") });
+                    this.AddChild(new TestVariation(Variation3) { Attribute = new VariationAttribute("IsStartElement") });
+                    this.AddChild(new TestVariation(Variation4) { Attribute = new VariationAttribute("LookupNamespace") });
+                    this.AddChild(new TestVariation(Variation5) { Attribute = new VariationAttribute("MoveToAttribute") });
+                    this.AddChild(new TestVariation(Variation6) { Attribute = new VariationAttribute("Other APIs") });
+                    this.AddChild(new TestVariation(Variation7) { Attribute = new VariationAttribute("ReadContentAs(null, null)") });
+                    this.AddChild(new TestVariation(Variation8) { Attribute = new VariationAttribute("ReadContentAsBase64") });
+                    this.AddChild(new TestVariation(Variation9) { Attribute = new VariationAttribute("ReadContentAsBinHex") });
+                    this.AddChild(new TestVariation(Variation10) { Attribute = new VariationAttribute("ReadContentAsBoolean") });
+                    this.AddChild(new TestVariation(Variation11b) { Attribute = new VariationAttribute("ReadContentAsDateTimeOffset") });
+                    this.AddChild(new TestVariation(Variation12) { Attribute = new VariationAttribute("ReadContentAsDecimal") });
+                    this.AddChild(new TestVariation(Variation13) { Attribute = new VariationAttribute("ReadContentAsDouble") });
+                    this.AddChild(new TestVariation(Variation14) { Attribute = new VariationAttribute("ReadContentAsFloat") });
+                    this.AddChild(new TestVariation(Variation15) { Attribute = new VariationAttribute("ReadContentAsInt") });
+                    this.AddChild(new TestVariation(Variation16) { Attribute = new VariationAttribute("ReadContentAsLong") });
+                    this.AddChild(new TestVariation(Variation17) { Attribute = new VariationAttribute("ReadElementContentAs(null, null)") });
+                    this.AddChild(new TestVariation(Variation18) { Attribute = new VariationAttribute("ReadElementContentAsBase64") });
+                    this.AddChild(new TestVariation(Variation19) { Attribute = new VariationAttribute("ReadElementContentAsBinHex") });
+                    this.AddChild(new TestVariation(Variation20) { Attribute = new VariationAttribute("ReadElementContentAsBoolean") });
+                    this.AddChild(new TestVariation(Variation22) { Attribute = new VariationAttribute("ReadElementContentAsDecimal") });
+                    this.AddChild(new TestVariation(Variation23) { Attribute = new VariationAttribute("ReadElementContentAsDouble") });
+                    this.AddChild(new TestVariation(Variation24) { Attribute = new VariationAttribute("ReadElementContentAsFloat") });
+                    this.AddChild(new TestVariation(Variation25) { Attribute = new VariationAttribute("ReadElementContentAsInt") });
+                    this.AddChild(new TestVariation(Variation26) { Attribute = new VariationAttribute("ReadElementContentAsLong") });
+                    this.AddChild(new TestVariation(Variation27) { Attribute = new VariationAttribute("ReadElementContentAsObject") });
+                    this.AddChild(new TestVariation(Variation28) { Attribute = new VariationAttribute("ReadElementContentAsString") });
+                    this.AddChild(new TestVariation(Variation30) { Attribute = new VariationAttribute("ReadStartElement") });
+                    this.AddChild(new TestVariation(Variation31) { Attribute = new VariationAttribute("ReadToDescendant(null)") });
+                    this.AddChild(new TestVariation(Variation32) { Attribute = new VariationAttribute("ReadToDescendant(String.Empty)") });
+                    this.AddChild(new TestVariation(Variation33) { Attribute = new VariationAttribute("ReadToFollowing(null)") });
+                    this.AddChild(new TestVariation(Variation34) { Attribute = new VariationAttribute("ReadToFollowing(String.Empty)") });
+                    this.AddChild(new TestVariation(Variation35) { Attribute = new VariationAttribute("ReadToNextSibling(null)") });
+                    this.AddChild(new TestVariation(Variation36) { Attribute = new VariationAttribute("ReadToNextSibling(String.Empty)") });
+                    this.AddChild(new TestVariation(Variation37) { Attribute = new VariationAttribute("ReadValueChunk") });
+                    this.AddChild(new TestVariation(Variation38) { Attribute = new VariationAttribute("ReadElementContentAsObject") });
+                    this.AddChild(new TestVariation(Variation39) { Attribute = new VariationAttribute("ReadElementContentAsString") });
                 }
             }
-            public class TCXMLIntegrityBase : BridgeHelpers
+            public partial class TCXMLIntegrityBase : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXMLIntegrityBase
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcXMLIntegrityBase = new IntegrityTestFunctionalTests.XNodeReaderTests.TCXMLIntegrityBase();
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlReaderNodeType) { Attribute = new VariationAttribute("NodeType") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlReaderName) { Attribute = new VariationAttribute("Name") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlReaderLocalName) { Attribute = new VariationAttribute("LocalName") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.Namespace) { Attribute = new VariationAttribute("NamespaceURI") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.Prefix) { Attribute = new VariationAttribute("Prefix") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HasValue) { Attribute = new VariationAttribute("HasValue") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlReaderValue) { Attribute = new VariationAttribute("Value") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetDepth) { Attribute = new VariationAttribute("Depth") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetBaseURI) { Attribute = new VariationAttribute("BaseURI") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.IsEmptyElement) { Attribute = new VariationAttribute("IsEmptyElement") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.IsDefault) { Attribute = new VariationAttribute("IsDefault") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlSpace) { Attribute = new VariationAttribute("XmlSpace") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlLang) { Attribute = new VariationAttribute("XmlLang") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.AttributeCount) { Attribute = new VariationAttribute("AttributeCount") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HasAttribute) { Attribute = new VariationAttribute("HasAttributes") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeName) { Attribute = new VariationAttribute("GetAttributes(name)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeEmptyName) { Attribute = new VariationAttribute("GetAttribute(String.Empty)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeNameNamespace) { Attribute = new VariationAttribute("GetAttribute(name,ns)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeEmptyNameNamespace) { Attribute = new VariationAttribute("GetAttribute(String.Empty, String.Empty)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeOrdinal) { Attribute = new VariationAttribute("GetAttribute(i)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HelperThisOrdinal) { Attribute = new VariationAttribute("this[i]") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HelperThisName) { Attribute = new VariationAttribute("this[name]") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HelperThisNameNamespace) { Attribute = new VariationAttribute("this[name,namespace]") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToAttributeName) { Attribute = new VariationAttribute("MoveToAttribute(name)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToAttributeNameNamespace) { Attribute = new VariationAttribute("MoveToAttributeNameNamespace(name,ns)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToAttributeOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToFirstAttribute) { Attribute = new VariationAttribute("MoveToFirstAttribute()") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToNextAttribute) { Attribute = new VariationAttribute("MoveToNextAttribute()") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToElement) { Attribute = new VariationAttribute("MoveToElement()") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.ReadTestAfterClose) { Attribute = new VariationAttribute("Read") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetEOF) { Attribute = new VariationAttribute("GetEOF") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetReadState) { Attribute = new VariationAttribute("GetReadState") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.XMLSkip) { Attribute = new VariationAttribute("Skip") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestNameTable) { Attribute = new VariationAttribute("NameTable") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.ReadInnerXmlTestAfterClose) { Attribute = new VariationAttribute("ReadInnerXml") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadOuterXml) { Attribute = new VariationAttribute("ReadOuterXml") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestMoveToContent) { Attribute = new VariationAttribute("MoveToContent") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElement) { Attribute = new VariationAttribute("IsStartElement") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElementName) { Attribute = new VariationAttribute("IsStartElement(name)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElementName2) { Attribute = new VariationAttribute("IsStartElement(String.Empty)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElementNameNs) { Attribute = new VariationAttribute("IsStartElement(name, ns)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElementNameNs2) { Attribute = new VariationAttribute("IsStartElement(String.Empty,String.Empty)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElement) { Attribute = new VariationAttribute("ReadStartElement") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElementName) { Attribute = new VariationAttribute("ReadStartElement(name)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElementName2) { Attribute = new VariationAttribute("ReadStartElement(String.Empty)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElementNameNs) { Attribute = new VariationAttribute("ReadStartElement(name, ns)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElementNameNs2) { Attribute = new VariationAttribute("ReadStartElement(String.Empty,String.Empty)") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadEndElement) { Attribute = new VariationAttribute("ReadEndElement") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.LookupNamespace) { Attribute = new VariationAttribute("LookupNamespace") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.ReadAttributeValue) { Attribute = new VariationAttribute("ReadAttributeValue") });
-                    this.AddChild(new TestVariation(tcXMLIntegrityBase.CloseTest) { Attribute = new VariationAttribute("Close") });
+                    this.AddChild(new TestVariation(GetXmlReaderNodeType) { Attribute = new VariationAttribute("NodeType") });
+                    this.AddChild(new TestVariation(GetXmlReaderName) { Attribute = new VariationAttribute("Name") });
+                    this.AddChild(new TestVariation(GetXmlReaderLocalName) { Attribute = new VariationAttribute("LocalName") });
+                    this.AddChild(new TestVariation(Namespace) { Attribute = new VariationAttribute("NamespaceURI") });
+                    this.AddChild(new TestVariation(Prefix) { Attribute = new VariationAttribute("Prefix") });
+                    this.AddChild(new TestVariation(HasValue) { Attribute = new VariationAttribute("HasValue") });
+                    this.AddChild(new TestVariation(GetXmlReaderValue) { Attribute = new VariationAttribute("Value") });
+                    this.AddChild(new TestVariation(GetDepth) { Attribute = new VariationAttribute("Depth") });
+                    this.AddChild(new TestVariation(GetBaseURI) { Attribute = new VariationAttribute("BaseURI") });
+                    this.AddChild(new TestVariation(IsEmptyElement) { Attribute = new VariationAttribute("IsEmptyElement") });
+                    this.AddChild(new TestVariation(IsDefault) { Attribute = new VariationAttribute("IsDefault") });
+                    this.AddChild(new TestVariation(GetXmlSpace) { Attribute = new VariationAttribute("XmlSpace") });
+                    this.AddChild(new TestVariation(GetXmlLang) { Attribute = new VariationAttribute("XmlLang") });
+                    this.AddChild(new TestVariation(AttributeCount) { Attribute = new VariationAttribute("AttributeCount") });
+                    this.AddChild(new TestVariation(HasAttribute) { Attribute = new VariationAttribute("HasAttributes") });
+                    this.AddChild(new TestVariation(GetAttributeName) { Attribute = new VariationAttribute("GetAttributes(name)") });
+                    this.AddChild(new TestVariation(GetAttributeEmptyName) { Attribute = new VariationAttribute("GetAttribute(String.Empty)") });
+                    this.AddChild(new TestVariation(GetAttributeNameNamespace) { Attribute = new VariationAttribute("GetAttribute(name,ns)") });
+                    this.AddChild(new TestVariation(GetAttributeEmptyNameNamespace) { Attribute = new VariationAttribute("GetAttribute(String.Empty, String.Empty)") });
+                    this.AddChild(new TestVariation(GetAttributeOrdinal) { Attribute = new VariationAttribute("GetAttribute(i)") });
+                    this.AddChild(new TestVariation(HelperThisOrdinal) { Attribute = new VariationAttribute("this[i]") });
+                    this.AddChild(new TestVariation(HelperThisName) { Attribute = new VariationAttribute("this[name]") });
+                    this.AddChild(new TestVariation(HelperThisNameNamespace) { Attribute = new VariationAttribute("this[name,namespace]") });
+                    this.AddChild(new TestVariation(MoveToAttributeName) { Attribute = new VariationAttribute("MoveToAttribute(name)") });
+                    this.AddChild(new TestVariation(MoveToAttributeNameNamespace) { Attribute = new VariationAttribute("MoveToAttributeNameNamespace(name,ns)") });
+                    this.AddChild(new TestVariation(MoveToAttributeOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i)") });
+                    this.AddChild(new TestVariation(MoveToFirstAttribute) { Attribute = new VariationAttribute("MoveToFirstAttribute()") });
+                    this.AddChild(new TestVariation(MoveToNextAttribute) { Attribute = new VariationAttribute("MoveToNextAttribute()") });
+                    this.AddChild(new TestVariation(MoveToElement) { Attribute = new VariationAttribute("MoveToElement()") });
+                    this.AddChild(new TestVariation(ReadTestAfterClose) { Attribute = new VariationAttribute("Read") });
+                    this.AddChild(new TestVariation(GetEOF) { Attribute = new VariationAttribute("GetEOF") });
+                    this.AddChild(new TestVariation(GetReadState) { Attribute = new VariationAttribute("GetReadState") });
+                    this.AddChild(new TestVariation(XMLSkip) { Attribute = new VariationAttribute("Skip") });
+                    this.AddChild(new TestVariation(TestNameTable) { Attribute = new VariationAttribute("NameTable") });
+                    this.AddChild(new TestVariation(ReadInnerXmlTestAfterClose) { Attribute = new VariationAttribute("ReadInnerXml") });
+                    this.AddChild(new TestVariation(TestReadOuterXml) { Attribute = new VariationAttribute("ReadOuterXml") });
+                    this.AddChild(new TestVariation(TestMoveToContent) { Attribute = new VariationAttribute("MoveToContent") });
+                    this.AddChild(new TestVariation(TestIsStartElement) { Attribute = new VariationAttribute("IsStartElement") });
+                    this.AddChild(new TestVariation(TestIsStartElementName) { Attribute = new VariationAttribute("IsStartElement(name)") });
+                    this.AddChild(new TestVariation(TestIsStartElementName2) { Attribute = new VariationAttribute("IsStartElement(String.Empty)") });
+                    this.AddChild(new TestVariation(TestIsStartElementNameNs) { Attribute = new VariationAttribute("IsStartElement(name, ns)") });
+                    this.AddChild(new TestVariation(TestIsStartElementNameNs2) { Attribute = new VariationAttribute("IsStartElement(String.Empty,String.Empty)") });
+                    this.AddChild(new TestVariation(TestReadStartElement) { Attribute = new VariationAttribute("ReadStartElement") });
+                    this.AddChild(new TestVariation(TestReadStartElementName) { Attribute = new VariationAttribute("ReadStartElement(name)") });
+                    this.AddChild(new TestVariation(TestReadStartElementName2) { Attribute = new VariationAttribute("ReadStartElement(String.Empty)") });
+                    this.AddChild(new TestVariation(TestReadStartElementNameNs) { Attribute = new VariationAttribute("ReadStartElement(name, ns)") });
+                    this.AddChild(new TestVariation(TestReadStartElementNameNs2) { Attribute = new VariationAttribute("ReadStartElement(String.Empty,String.Empty)") });
+                    this.AddChild(new TestVariation(TestReadEndElement) { Attribute = new VariationAttribute("ReadEndElement") });
+                    this.AddChild(new TestVariation(LookupNamespace) { Attribute = new VariationAttribute("LookupNamespace") });
+                    this.AddChild(new TestVariation(ReadAttributeValue) { Attribute = new VariationAttribute("ReadAttributeValue") });
+                    this.AddChild(new TestVariation(CloseTest) { Attribute = new VariationAttribute("Close") });
                 }
             }
-            public class TCReadContentAsBase64 : BridgeHelpers
+            public partial class TCReadContentAsBase64 : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadContentAsBase64
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadContentAsBase64 = new ReadBase64FunctionalTests.XNodeReaderTests.TCReadContentAsBase64();
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_1) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_2) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Num value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_3) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Text value") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_5) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_6) { Attribute = new VariationAttribute("ReadBase64 Element with Long valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_7) { Attribute = new VariationAttribute("ReadBase64 with count > buffer size") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_8) { Attribute = new VariationAttribute("ReadBase64 with count < 0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_9) { Attribute = new VariationAttribute("ReadBase64 with index > buffer size") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_10) { Attribute = new VariationAttribute("ReadBase64 with index < 0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_11) { Attribute = new VariationAttribute("ReadBase64 with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_12) { Attribute = new VariationAttribute("ReadBase64 index & count =0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_13) { Attribute = new VariationAttribute("ReadBase64 Element multiple into same buffer (using offset), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_14) { Attribute = new VariationAttribute("ReadBase64 with buffer == null") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_16) { Attribute = new VariationAttribute("Read after ReadBase64") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_18) { Attribute = new VariationAttribute("No op node types") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespace in the mIddle") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestTextReadBase64_27) { Attribute = new VariationAttribute("ReadBase64 with = in the mIddle") });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "10000000" } } });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "1000000" } } });
-                    this.AddChild(new TestVariation(tcReadContentAsBase64.RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "10000" } } });
+                    this.AddChild(new TestVariation(TestReadBase64_1) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value") });
+                    this.AddChild(new TestVariation(TestReadBase64_2) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Num value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadBase64_3) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Text value") });
+                    this.AddChild(new TestVariation(TestReadBase64_5) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(TestReadBase64_6) { Attribute = new VariationAttribute("ReadBase64 Element with Long valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(ReadBase64_7) { Attribute = new VariationAttribute("ReadBase64 with count > buffer size") });
+                    this.AddChild(new TestVariation(ReadBase64_8) { Attribute = new VariationAttribute("ReadBase64 with count < 0") });
+                    this.AddChild(new TestVariation(ReadBase64_9) { Attribute = new VariationAttribute("ReadBase64 with index > buffer size") });
+                    this.AddChild(new TestVariation(ReadBase64_10) { Attribute = new VariationAttribute("ReadBase64 with index < 0") });
+                    this.AddChild(new TestVariation(ReadBase64_11) { Attribute = new VariationAttribute("ReadBase64 with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(ReadBase64_12) { Attribute = new VariationAttribute("ReadBase64 index & count =0") });
+                    this.AddChild(new TestVariation(TestReadBase64_13) { Attribute = new VariationAttribute("ReadBase64 Element multiple into same buffer (using offset), Priority=0") });
+                    this.AddChild(new TestVariation(TestReadBase64_14) { Attribute = new VariationAttribute("ReadBase64 with buffer == null") });
+                    this.AddChild(new TestVariation(TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
+                    this.AddChild(new TestVariation(TestReadBase64_16) { Attribute = new VariationAttribute("Read after partial ReadBase64") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
+                    this.AddChild(new TestVariation(TestReadBase64_18) { Attribute = new VariationAttribute("No op node types") });
+                    this.AddChild(new TestVariation(TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
+                    this.AddChild(new TestVariation(TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespace in the mIddle") });
+                    this.AddChild(new TestVariation(TestTextReadBase64_27) { Attribute = new VariationAttribute("ReadBase64 with = in the mIddle") });
+                    this.AddChild(new TestVariation(RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "10000000" } } });
+                    this.AddChild(new TestVariation(RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "1000000" } } });
+                    this.AddChild(new TestVariation(RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "10000" } } });
                 }
             }
-            public class TCReadElementContentAsBase64 : BridgeHelpers
+            public partial class TCReadElementContentAsBase64 : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadElementContentAsBase64
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadElementContentAsBase64 = new ReadBase64FunctionalTests.XNodeReaderTests.TCReadElementContentAsBase64();
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_1) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_2) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Num value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_3) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Text value") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_5) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_6) { Attribute = new VariationAttribute("ReadBase64 Element with Long valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_7) { Attribute = new VariationAttribute("ReadBase64 with count > buffer size") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_8) { Attribute = new VariationAttribute("ReadBase64 with count < 0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_9) { Attribute = new VariationAttribute("ReadBase64 with index > buffer size") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_10) { Attribute = new VariationAttribute("ReadBase64 with index < 0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_11) { Attribute = new VariationAttribute("ReadBase64 with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_12) { Attribute = new VariationAttribute("ReadBase64 index & count =0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_13) { Attribute = new VariationAttribute("ReadBase64 Element multiple into same buffer (using offset), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_14) { Attribute = new VariationAttribute("ReadBase64 with buffer == null") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_16) { Attribute = new VariationAttribute("Read after ReadBase64") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespace in the mIddle") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestTextReadBase64_27) { Attribute = new VariationAttribute("ReadBase64 with = in the mIddle") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "10000000" } } });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "1000000" } } });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "10000" } } });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.SubtreeReaderInsertedAttributesWontWorkWithReadContentAsBase64) { Attribute = new VariationAttribute("430329: SubtreeReader inserted attributes don't work with ReadContentAsBase64") });
+                    this.AddChild(new TestVariation(TestReadBase64_1) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value") });
+                    this.AddChild(new TestVariation(TestReadBase64_2) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Num value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadBase64_3) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Text value") });
+                    this.AddChild(new TestVariation(TestReadBase64_5) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(TestReadBase64_6) { Attribute = new VariationAttribute("ReadBase64 Element with Long valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(ReadBase64_7) { Attribute = new VariationAttribute("ReadBase64 with count > buffer size") });
+                    this.AddChild(new TestVariation(ReadBase64_8) { Attribute = new VariationAttribute("ReadBase64 with count < 0") });
+                    this.AddChild(new TestVariation(ReadBase64_9) { Attribute = new VariationAttribute("ReadBase64 with index > buffer size") });
+                    this.AddChild(new TestVariation(ReadBase64_10) { Attribute = new VariationAttribute("ReadBase64 with index < 0") });
+                    this.AddChild(new TestVariation(ReadBase64_11) { Attribute = new VariationAttribute("ReadBase64 with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(ReadBase64_12) { Attribute = new VariationAttribute("ReadBase64 index & count =0") });
+                    this.AddChild(new TestVariation(TestReadBase64_13) { Attribute = new VariationAttribute("ReadBase64 Element multiple into same buffer (using offset), Priority=0") });
+                    this.AddChild(new TestVariation(TestReadBase64_14) { Attribute = new VariationAttribute("ReadBase64 with buffer == null") });
+                    this.AddChild(new TestVariation(TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
+                    this.AddChild(new TestVariation(TestReadBase64_16) { Attribute = new VariationAttribute("Read after partial ReadBase64") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
+                    this.AddChild(new TestVariation(TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
+                    this.AddChild(new TestVariation(TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespace in the mIddle") });
+                    this.AddChild(new TestVariation(TestTextReadBase64_27) { Attribute = new VariationAttribute("ReadBase64 with = in the mIddle") });
+                    this.AddChild(new TestVariation(ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "10000000" } } });
+                    this.AddChild(new TestVariation(ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "1000000" } } });
+                    this.AddChild(new TestVariation(ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "10000" } } });
+                    this.AddChild(new TestVariation(SubtreeReaderInsertedAttributesWontWorkWithReadContentAsBase64) { Attribute = new VariationAttribute("430329: SubtreeReader inserted attributes don't work with ReadContentAsBase64") });
                 }
             }
-            public class TCReadContentAsBinHex : BridgeHelpers
+            public partial class TCReadContentAsBinHex : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadContentAsBinHex
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadContentAsBinHex = new ReadBinHexFunctionalTests.XNodeReaderTests.TCReadContentAsBinHex();
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_1) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_2) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Num value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_3) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Text value") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_4) { Attribute = new VariationAttribute("ReadBinHex Element on CDATA") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_5) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_6) { Attribute = new VariationAttribute("ReadBinHex Element with all long valid value (from concatenation)") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_7) { Attribute = new VariationAttribute("ReadBinHex with count > buffer size") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_8) { Attribute = new VariationAttribute("ReadBinHex with count < 0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.vReadBinHex_9) { Attribute = new VariationAttribute("ReadBinHex with index > buffer size") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_10) { Attribute = new VariationAttribute("ReadBinHex with index < 0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_11) { Attribute = new VariationAttribute("ReadBinHex with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_12) { Attribute = new VariationAttribute("ReadBinHex index & count =0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_13) { Attribute = new VariationAttribute("ReadBinHex Element multiple into same buffer (using offset), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_14) { Attribute = new VariationAttribute("ReadBinHex with buffer == null") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_15) { Attribute = new VariationAttribute("ReadBinHex after failed ReadBinHex") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_16) { Attribute = new VariationAttribute("Read after ReadBinHex") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestTextReadBinHex_21) { Attribute = new VariationAttribute("ReadBinHex with whitespace") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestTextReadBinHex_22) { Attribute = new VariationAttribute("ReadBinHex with odd number of chars") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestTextReadBinHex_23) { Attribute = new VariationAttribute("ReadBinHex when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestTextReadBinHex_24) { Attribute = new VariationAttribute("WS:WireCompat:hex binary fails to send/return data after 1787 bytes going Whidbey to Everett") });
-                    this.AddChild(new TestVariation(tcReadContentAsBinHex.DebugAssertInReadContentAsBinHex) { Attribute = new VariationAttribute("DebugAssert in ReadContentAsBinHex") });
+                    this.AddChild(new TestVariation(TestReadBinHex_1) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value") });
+                    this.AddChild(new TestVariation(TestReadBinHex_2) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Num value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadBinHex_3) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Text value") });
+                    this.AddChild(new TestVariation(TestReadBinHex_4) { Attribute = new VariationAttribute("ReadBinHex Element on CDATA") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadBinHex_5) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(TestReadBinHex_6) { Attribute = new VariationAttribute("ReadBinHex Element with all long valid value (from concatenation)") });
+                    this.AddChild(new TestVariation(TestReadBinHex_7) { Attribute = new VariationAttribute("ReadBinHex with count > buffer size") });
+                    this.AddChild(new TestVariation(TestReadBinHex_8) { Attribute = new VariationAttribute("ReadBinHex with count < 0") });
+                    this.AddChild(new TestVariation(vReadBinHex_9) { Attribute = new VariationAttribute("ReadBinHex with index > buffer size") });
+                    this.AddChild(new TestVariation(TestReadBinHex_10) { Attribute = new VariationAttribute("ReadBinHex with index < 0") });
+                    this.AddChild(new TestVariation(TestReadBinHex_11) { Attribute = new VariationAttribute("ReadBinHex with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(TestReadBinHex_12) { Attribute = new VariationAttribute("ReadBinHex index & count =0") });
+                    this.AddChild(new TestVariation(TestReadBinHex_13) { Attribute = new VariationAttribute("ReadBinHex Element multiple into same buffer (using offset), Priority=0") });
+                    this.AddChild(new TestVariation(TestReadBinHex_14) { Attribute = new VariationAttribute("ReadBinHex with buffer == null") });
+                    this.AddChild(new TestVariation(TestReadBinHex_15) { Attribute = new VariationAttribute("ReadBinHex after failed ReadBinHex") });
+                    this.AddChild(new TestVariation(TestReadBinHex_16) { Attribute = new VariationAttribute("Read after partial ReadBinHex") });
+                    this.AddChild(new TestVariation(TestReadBinHex_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_21) { Attribute = new VariationAttribute("ReadBinHex with whitespace") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_22) { Attribute = new VariationAttribute("ReadBinHex with odd number of chars") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_23) { Attribute = new VariationAttribute("ReadBinHex when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_24) { Attribute = new VariationAttribute("WS:WireCompat:hex binary fails to send/return data after 1787 bytes going Whidbey to Everett") });
+                    this.AddChild(new TestVariation(DebugAssertInReadContentAsBinHex) { Attribute = new VariationAttribute("DebugAssert in ReadContentAsBinHex") });
                 }
             }
-            public class TCReadElementContentAsBinHex : BridgeHelpers
+            public partial class TCReadElementContentAsBinHex : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadElementContentAsBinHex
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadElementContentAsBinHex = new ReadBinHexFunctionalTests.XNodeReaderTests.TCReadElementContentAsBinHex();
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_1) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_2) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Num value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_3) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Text value") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_4) { Attribute = new VariationAttribute("ReadBinHex Element with Comments and PIs") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_5) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_6) { Attribute = new VariationAttribute("ReadBinHex Element with all long valid value (from concatenation)") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_7) { Attribute = new VariationAttribute("ReadBinHex with count > buffer size") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_8) { Attribute = new VariationAttribute("ReadBinHex with count < 0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.vReadBinHex_9) { Attribute = new VariationAttribute("ReadBinHex with index > buffer size") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_10) { Attribute = new VariationAttribute("ReadBinHex with index < 0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_11) { Attribute = new VariationAttribute("ReadBinHex with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_12) { Attribute = new VariationAttribute("ReadBinHex index & count =0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_13) { Attribute = new VariationAttribute("ReadBinHex Element multiple into same buffer (using offset), Priority=0") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_14) { Attribute = new VariationAttribute("ReadBinHex with buffer == null") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_15) { Attribute = new VariationAttribute("ReadBinHex after failed ReadBinHex") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_16) { Attribute = new VariationAttribute("Read after ReadBinHex") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_21) { Attribute = new VariationAttribute("ReadBinHex with whitespace") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_22) { Attribute = new VariationAttribute("ReadBinHex with odd number of chars") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_23) { Attribute = new VariationAttribute("ReadBinHex when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_24) { Attribute = new VariationAttribute("WS:WireCompat:hex binary fails to send/return data after 1787 bytes going Whidbey to Everett") });
-                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_25) { Attribute = new VariationAttribute("SubtreeReader inserted attributes don't work with ReadContentAsBinHex") });
+                    this.AddChild(new TestVariation(TestReadBinHex_1) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value") });
+                    this.AddChild(new TestVariation(TestReadBinHex_2) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Num value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadBinHex_3) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Text value") });
+                    this.AddChild(new TestVariation(TestReadBinHex_4) { Attribute = new VariationAttribute("ReadBinHex Element with Comments and PIs") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadBinHex_5) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(TestReadBinHex_6) { Attribute = new VariationAttribute("ReadBinHex Element with all long valid value (from concatenation)") });
+                    this.AddChild(new TestVariation(TestReadBinHex_7) { Attribute = new VariationAttribute("ReadBinHex with count > buffer size") });
+                    this.AddChild(new TestVariation(TestReadBinHex_8) { Attribute = new VariationAttribute("ReadBinHex with count < 0") });
+                    this.AddChild(new TestVariation(vReadBinHex_9) { Attribute = new VariationAttribute("ReadBinHex with index > buffer size") });
+                    this.AddChild(new TestVariation(TestReadBinHex_10) { Attribute = new VariationAttribute("ReadBinHex with index < 0") });
+                    this.AddChild(new TestVariation(TestReadBinHex_11) { Attribute = new VariationAttribute("ReadBinHex with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(TestReadBinHex_12) { Attribute = new VariationAttribute("ReadBinHex index & count =0") });
+                    this.AddChild(new TestVariation(TestReadBinHex_13) { Attribute = new VariationAttribute("ReadBinHex Element multiple into same buffer (using offset), Priority=0") });
+                    this.AddChild(new TestVariation(TestReadBinHex_14) { Attribute = new VariationAttribute("ReadBinHex with buffer == null") });
+                    this.AddChild(new TestVariation(TestReadBinHex_15) { Attribute = new VariationAttribute("ReadBinHex after failed ReadBinHex") });
+                    this.AddChild(new TestVariation(TestReadBinHex_16) { Attribute = new VariationAttribute("Read after partial ReadBinHex") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_21) { Attribute = new VariationAttribute("ReadBinHex with whitespace") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_22) { Attribute = new VariationAttribute("ReadBinHex with odd number of chars") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_23) { Attribute = new VariationAttribute("ReadBinHex when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_24) { Attribute = new VariationAttribute("WS:WireCompat:hex binary fails to send/return data after 1787 bytes going Whidbey to Everett") });
+                    this.AddChild(new TestVariation(TestTextReadBinHex_25) { Attribute = new VariationAttribute("SubtreeReader inserted attributes don't work with ReadContentAsBinHex") });
                 }
             }
-            public class CReaderTestModule : BridgeHelpers
+            public partial class CReaderTestModule : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+CReaderTestModule
                 // Test Case
                 public override void AddChildren()
                 {
-                    var cReaderTestModule = new ReaderPropertyFunctionalTests.XNodeReaderTests.CReaderTestModule();
-                    this.AddChild(new TestVariation(cReaderTestModule.v1) { Attribute = new VariationAttribute("Reader Property empty doc") { Priority = 0 } });
-                    this.AddChild(new TestVariation(cReaderTestModule.v2) { Attribute = new VariationAttribute("Reader Property after Read") { Priority = 0 } });
-                    this.AddChild(new TestVariation(cReaderTestModule.v3) { Attribute = new VariationAttribute("Reader Property after EOF") { Priority = 0 } });
-                    this.AddChild(new TestVariation(cReaderTestModule.v4) { Attribute = new VariationAttribute("Default Reader Settings") { Priority = 0 } });
+                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Reader Property empty doc") { Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Reader Property after Read") { Priority = 0 } });
+                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Reader Property after EOF") { Priority = 0 } });
+                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("Default Reader Settings") { Priority = 0 } });
                 }
             }
-            public class TCReadOuterXml : BridgeHelpers
+            public partial class TCReadOuterXml : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadOuterXml
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadOuterXml = new ReadOuterXmlFunctionalTests.XNodeReaderTests.TCReadOuterXml();
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml1) { Attribute = new VariationAttribute("ReadOuterXml on empty element w/o attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml2) { Attribute = new VariationAttribute("ReadOuterXml on empty element w/ attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml3) { Attribute = new VariationAttribute("ReadOuterXml on full empty element w/o attributes") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml4) { Attribute = new VariationAttribute("ReadOuterXml on full empty element w/ attributes") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml5) { Attribute = new VariationAttribute("ReadOuterXml on element with text content") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml6) { Attribute = new VariationAttribute("ReadOuterXml on element with attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml7) { Attribute = new VariationAttribute("ReadOuterXml on element with text and markup content") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml8) { Attribute = new VariationAttribute("ReadOuterXml with multiple level of elements") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml9) { Attribute = new VariationAttribute("ReadOuterXml with multiple level of elements, text and attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml10) { Attribute = new VariationAttribute("ReadOuterXml on element with complex content (CDATA, PIs, Comments)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml12) { Attribute = new VariationAttribute("ReadOuterXml on attribute node of empty element") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml13) { Attribute = new VariationAttribute("ReadOuterXml on attribute node of full empty element") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml14) { Attribute = new VariationAttribute("ReadOuterXml on attribute node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml15) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandEntities") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml17) { Attribute = new VariationAttribute("ReadOuterXml on ProcessingInstruction") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml24) { Attribute = new VariationAttribute("ReadOuterXml on CDATA") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.TRReadOuterXml27) { Attribute = new VariationAttribute("ReadOuterXml on element with entities, EntityHandling = ExpandCharEntities") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.TRReadOuterXml28) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandCharEntites") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.TestTextReadOuterXml29) { Attribute = new VariationAttribute("One large element") });
-                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXmlWhenNamespacesEqualsToFalseAndHasAnAttributeXmlns) { Attribute = new VariationAttribute("Read OuterXml when Namespaces=false and has an attribute xmlns") });
+                    this.AddChild(new TestVariation(ReadOuterXml1) { Attribute = new VariationAttribute("ReadOuterXml on empty element w/o attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadOuterXml2) { Attribute = new VariationAttribute("ReadOuterXml on empty element w/ attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadOuterXml3) { Attribute = new VariationAttribute("ReadOuterXml on full empty element w/o attributes") });
+                    this.AddChild(new TestVariation(ReadOuterXml4) { Attribute = new VariationAttribute("ReadOuterXml on full empty element w/ attributes") });
+                    this.AddChild(new TestVariation(ReadOuterXml5) { Attribute = new VariationAttribute("ReadOuterXml on element with text content") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadOuterXml6) { Attribute = new VariationAttribute("ReadOuterXml on element with attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadOuterXml7) { Attribute = new VariationAttribute("ReadOuterXml on element with text and markup content") });
+                    this.AddChild(new TestVariation(ReadOuterXml8) { Attribute = new VariationAttribute("ReadOuterXml with multiple level of elements") });
+                    this.AddChild(new TestVariation(ReadOuterXml9) { Attribute = new VariationAttribute("ReadOuterXml with multiple level of elements, text and attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadOuterXml10) { Attribute = new VariationAttribute("ReadOuterXml on element with complex content (CDATA, PIs, Comments)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadOuterXml12) { Attribute = new VariationAttribute("ReadOuterXml on attribute node of empty element") });
+                    this.AddChild(new TestVariation(ReadOuterXml13) { Attribute = new VariationAttribute("ReadOuterXml on attribute node of full empty element") });
+                    this.AddChild(new TestVariation(ReadOuterXml14) { Attribute = new VariationAttribute("ReadOuterXml on attribute node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadOuterXml15) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandEntities") { Priority = 0 } });
+                    this.AddChild(new TestVariation(ReadOuterXml17) { Attribute = new VariationAttribute("ReadOuterXml on ProcessingInstruction") });
+                    this.AddChild(new TestVariation(ReadOuterXml24) { Attribute = new VariationAttribute("ReadOuterXml on CDATA") });
+                    this.AddChild(new TestVariation(TRReadOuterXml27) { Attribute = new VariationAttribute("ReadOuterXml on element with entities, EntityHandling = ExpandCharEntities") });
+                    this.AddChild(new TestVariation(TRReadOuterXml28) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandCharEntites") });
+                    this.AddChild(new TestVariation(TestTextReadOuterXml29) { Attribute = new VariationAttribute("One large element") });
+                    this.AddChild(new TestVariation(ReadOuterXmlWhenNamespacesEqualsToFalseAndHasAnAttributeXmlns) { Attribute = new VariationAttribute("Read OuterXml when Namespaces=false and has an attribute xmlns") });
                 }
             }
-            public class TCReadSubtree : BridgeHelpers
+            public partial class TCReadSubtree : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadSubtree
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadSubtree = new ReadSubTreeFunctionalTests.XNodeReaderTests.TCReadSubtree();
-                    this.AddChild(new TestVariation(tcReadSubtree.ReadSubtreeOnlyWorksOnElementNode) { Attribute = new VariationAttribute("ReadSubtree only works on Element Node") });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=1") { Params = new object[] { "elem1", "", "ELEMENT", "elem5", "", "ELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=2") { Params = new object[] { "elem2", "", "ELEMENT", "elem1", "", "ENDELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test empty element") { Params = new object[] { "elem5", "", "ELEMENT", "elem6", "", "ELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test on Root") { Params = new object[] { "root", "", "ELEMENT", "", "", "NONE" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test Comment after element") { Params = new object[] { "elem", "", "ELEMENT", "", "Comment", "COMMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=4") { Params = new object[] { "elem4", "", "ELEMENT", "x:elem3", "", "ENDELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=3") { Params = new object[] { "x:elem3", "", "ELEMENT", "elem2", "", "ENDELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test empty element before root") { Params = new object[] { "elem6", "", "ELEMENT", "root", "", "ENDELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test PI after element") { Params = new object[] { "elempi", "", "ELEMENT", "pi", "target", "PROCESSINGINSTRUCTION" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v3) { Attribute = new VariationAttribute("Read with entities") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v4) { Attribute = new VariationAttribute("Inner XML on Subtree reader") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v5) { Attribute = new VariationAttribute("Outer XML on Subtree reader") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v6) { Attribute = new VariationAttribute("ReadString on Subtree reader") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v7) { Attribute = new VariationAttribute("Close on inner reader with CloseInput should not close the outer reader") { Params = new object[] { "true" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v7) { Attribute = new VariationAttribute("Close on inner reader with CloseInput should not close the outer reader") { Params = new object[] { "false" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v8) { Attribute = new VariationAttribute("Nested Subtree reader calls") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.v100) { Attribute = new VariationAttribute("ReadSubtree for element depth more than 4K chars") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.MultipleNamespacesOnSubtreeReader) { Attribute = new VariationAttribute("Multiple Namespaces on Subtree reader") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadSubtree.SubtreeReaderCachesNodeTypeAndReportsNodeTypeOfAttributeOnSubsequentReads) { Attribute = new VariationAttribute("Subtree Reader caches the NodeType and reports node type of Attribute on subsequent reads.") { Priority = 1 } });
+                    this.AddChild(new TestVariation(ReadSubtreeOnlyWorksOnElementNode) { Attribute = new VariationAttribute("ReadSubtree only works on Element Node") });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=1") { Params = new object[] { "elem1", "", "ELEMENT", "elem5", "", "ELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=2") { Params = new object[] { "elem2", "", "ELEMENT", "elem1", "", "ENDELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test empty element") { Params = new object[] { "elem5", "", "ELEMENT", "elem6", "", "ELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test on Root") { Params = new object[] { "root", "", "ELEMENT", "", "", "NONE" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test Comment after element") { Params = new object[] { "elem", "", "ELEMENT", "", "Comment", "COMMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=4") { Params = new object[] { "elem4", "", "ELEMENT", "x:elem3", "", "ENDELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=3") { Params = new object[] { "x:elem3", "", "ELEMENT", "elem2", "", "ENDELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test empty element before root") { Params = new object[] { "elem6", "", "ELEMENT", "root", "", "ENDELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test PI after element") { Params = new object[] { "elempi", "", "ELEMENT", "pi", "target", "PROCESSINGINSTRUCTION" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read with entities") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("Inner XML on Subtree reader") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Outer XML on Subtree reader") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v6) { Attribute = new VariationAttribute("ReadString on Subtree reader") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v7) { Attribute = new VariationAttribute("Close on inner reader with CloseInput should not close the outer reader") { Params = new object[] { "true" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v7) { Attribute = new VariationAttribute("Close on inner reader with CloseInput should not close the outer reader") { Params = new object[] { "false" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v8) { Attribute = new VariationAttribute("Nested Subtree reader calls") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v100) { Attribute = new VariationAttribute("ReadSubtree for element depth more than 4K chars") { Priority = 2 } });
+                    this.AddChild(new TestVariation(MultipleNamespacesOnSubtreeReader) { Attribute = new VariationAttribute("Multiple Namespaces on Subtree reader") { Priority = 1 } });
+                    this.AddChild(new TestVariation(SubtreeReaderCachesNodeTypeAndReportsNodeTypeOfAttributeOnSubsequentReads) { Attribute = new VariationAttribute("Subtree Reader caches the NodeType and reports node type of Attribute on subsequent reads.") { Priority = 1 } });
                 }
             }
-            public class TCReadToDescendant : BridgeHelpers
+            public partial class TCReadToDescendant : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadToDescendant
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadToDescendant = new ReadToDescendantFunctionalTests.XNodeReaderTests.TCReadToDescendant();                    
-                    this.AddChild(new TestVariation(tcReadToDescendant.v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "DNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v2) { Attribute = new VariationAttribute("Read on a deep tree at least more than 4K boundary") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "DNS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "NNS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "NS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v4) { Attribute = new VariationAttribute("If name not found, stop at end element of the subtree") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v5) { Attribute = new VariationAttribute("Positioning on a level and try to find the name which is on a level higher") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v6) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v7) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it, with namespace") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v8) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it, with prefix") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v9) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NNS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v10) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, DNS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v11) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v12) { Attribute = new VariationAttribute("Call from different nodetypes") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v14) { Attribute = new VariationAttribute("Only child has namespaces and read to it") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v15) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "DNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "NNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "NS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToDescendant.v19) { Attribute = new VariationAttribute("427176	Assertion failed when call XmlReader.ReadToDescendant() for non-existing node") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "DNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on a deep tree at least more than 4K boundary") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "DNS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "NNS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "NS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("If name not found, stop at end element of the subtree") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Positioning on a level and try to find the name which is on a level higher") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v6) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v7) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it, with namespace") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v8) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it, with prefix") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v9) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NNS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v10) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, DNS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v11) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v12) { Attribute = new VariationAttribute("Call from different nodetypes") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v14) { Attribute = new VariationAttribute("Only child has namespaces and read to it") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v15) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "DNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "NNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "NS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v19) { Attribute = new VariationAttribute("427176	Assertion failed when call XmlReader.ReadToDescendant() for non-existing node") { Priority = 1 } });
                 }
             }
-            public class TCReadToFollowing : BridgeHelpers
+            public partial class TCReadToFollowing : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadToFollowing
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadToFollowing = new ReadToFollowingFunctionalTests.XNodeReaderTests.TCReadToFollowing();
-                    this.AddChild(new TestVariation(tcReadToFollowing.v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "DNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "NNS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "NS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "DNS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v4) { Attribute = new VariationAttribute("If name not found, go to eof") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v5_1) { Attribute = new VariationAttribute("If localname not found go to eof") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v5_2) { Attribute = new VariationAttribute("If uri not found, go to eof") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v6) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v7) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it, with namespace") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v8) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it, with prefix") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v9) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NNS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v10) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, DNS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v11) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v14) { Attribute = new VariationAttribute("Only child has namespaces and read to it") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v15) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToFollowing.v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "DNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "NNS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "NS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "DNS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("If name not found, go to eof") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v5_1) { Attribute = new VariationAttribute("If localname not found go to eof") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v5_2) { Attribute = new VariationAttribute("If uri not found, go to eof") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v6) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v7) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it, with namespace") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v8) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it, with prefix") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v9) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NNS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v10) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, DNS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v11) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v14) { Attribute = new VariationAttribute("Only child has namespaces and read to it") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v15) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
                 }
             }
-            public class TCReadToNextSibling : BridgeHelpers
+            public partial class TCReadToNextSibling : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadToNextSibling
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadToNextSibling = new ReadToNextSiblingFunctionalTests.XNodeReaderTests.TCReadToNextSibling();
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v) { Attribute = new VariationAttribute("Simple positive test 2") { Params = new object[] { "DNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v) { Attribute = new VariationAttribute("Simple positive test 3") { Params = new object[] { "NS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v) { Attribute = new VariationAttribute("Simple positive test 1") { Params = new object[] { "NNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v2) { Attribute = new VariationAttribute("Read on a deep tree at least more than 4K boundary") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v3) { Attribute = new VariationAttribute("Read to next sibling with same names 1") { Params = new object[] { "NNS", "<root><a att='1'/><a att='2'/><a att='3'/></root>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v3) { Attribute = new VariationAttribute("Read on next sibling with same names 2") { Params = new object[] { "DNS", "<root xmlns='a'><a att='1'/><a att='2'/><a att='3'/></root>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v3) { Attribute = new VariationAttribute("Read on next sibling with same names 3") { Params = new object[] { "NS", "<root xmlns:a='a'><a:a att='1'/><a:a att='2'/><a:a att='3'/></root>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v4) { Attribute = new VariationAttribute("If name not found, stop at end element of the subtree") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v5) { Attribute = new VariationAttribute("Positioning on a level and try to find the name which is on a level higher") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v6) { Attribute = new VariationAttribute("Read to next sibling on one level and again to level below it") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v12) { Attribute = new VariationAttribute("Call from different nodetypes") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v16) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadToNextSibling.v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test 2") { Params = new object[] { "DNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test 3") { Params = new object[] { "NS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test 1") { Params = new object[] { "NNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on a deep tree at least more than 4K boundary") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read to next sibling with same names 1") { Params = new object[] { "NNS", "<root><a att='1'/><a att='2'/><a att='3'/></root>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on next sibling with same names 2") { Params = new object[] { "DNS", "<root xmlns='a'><a att='1'/><a att='2'/><a att='3'/></root>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on next sibling with same names 3") { Params = new object[] { "NS", "<root xmlns:a='a'><a:a att='1'/><a:a att='2'/><a:a att='3'/></root>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("If name not found, stop at end element of the subtree") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Positioning on a level and try to find the name which is on a level higher") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v6) { Attribute = new VariationAttribute("Read to next sibling on one level and again to level below it") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v12) { Attribute = new VariationAttribute("Call from different nodetypes") { Priority = 1 } });
+                    this.AddChild(new TestVariation(v16) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
+                    this.AddChild(new TestVariation(v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
                 }
             }
-            public class TCReadValue : BridgeHelpers
+            public partial class TCReadValue : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadValue
                 // Test Case
                 public override void AddChildren()
                 {
-                    var tcReadValue = new ReadValueFunctionalTests.XNodeReaderTests.TCReadValue();                    
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValuePri0) { Attribute = new VariationAttribute("ReadValue") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValuePri0onElement) { Attribute = new VariationAttribute("ReadValue on Element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnAttribute0) { Attribute = new VariationAttribute("ReadValue on Attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnAttribute1) { Attribute = new VariationAttribute("ReadValue on Attribute after ReadAttributeValue") { Priority = 2 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue2Pri0) { Attribute = new VariationAttribute("ReadValue on empty buffer") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue3Pri0) { Attribute = new VariationAttribute("ReadValue on negative count") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue4Pri0) { Attribute = new VariationAttribute("ReadValue on negative offset") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue1) { Attribute = new VariationAttribute("ReadValue with buffer = element content / 2") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue2) { Attribute = new VariationAttribute("ReadValue entire value in one call") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue3) { Attribute = new VariationAttribute("ReadValue bit by bit") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue4) { Attribute = new VariationAttribute("ReadValue for value more than 4K") { Priority = 0 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue5) { Attribute = new VariationAttribute("ReadValue for value more than 4K and invalid element") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue6) { Attribute = new VariationAttribute("ReadValue with Entity Reference, EntityHandling = ExpandEntities") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue7) { Attribute = new VariationAttribute("ReadValue with count > buffer size") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue8) { Attribute = new VariationAttribute("ReadValue with index > buffer size") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValue10) { Attribute = new VariationAttribute("ReadValue with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadChar11) { Attribute = new VariationAttribute("ReadValue with combination Text, CDATA and Whitespace") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadChar12) { Attribute = new VariationAttribute("ReadValue with combination Text, CDATA and SignificantWhitespace") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadChar13) { Attribute = new VariationAttribute("ReadValue with buffer == null") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadChar14) { Attribute = new VariationAttribute("ReadValue with multiple different inner nodes") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadChar15) { Attribute = new VariationAttribute("ReadValue after failed ReadValue") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadChar16) { Attribute = new VariationAttribute("Read after ReadValue") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadChar19) { Attribute = new VariationAttribute("Test error after successful ReadValue") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadChar21) { Attribute = new VariationAttribute("Call on invalid element content after 4k boundary") { Priority = 1 } });
-                    this.AddChild(new TestVariation(tcReadValue.TestTextReadValue25) { Attribute = new VariationAttribute("ReadValue with whitespace") });
-                    this.AddChild(new TestVariation(tcReadValue.TestTextReadValue26) { Attribute = new VariationAttribute("ReadValue when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(tcReadValue.TestCharEntities0) { Attribute = new VariationAttribute("Testing with character entities") });
-                    this.AddChild(new TestVariation(tcReadValue.TestCharEntities1) { Attribute = new VariationAttribute("Testing with character entities when value more than 4k") });
-                    this.AddChild(new TestVariation(tcReadValue.TestCharEntities2) { Attribute = new VariationAttribute("Testing with character entities with another pattern") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnBig) { Attribute = new VariationAttribute("Testing a use case pattern with large file") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnComments0) { Attribute = new VariationAttribute("ReadValue on Comments with IgnoreComments") });
-                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnPIs0) { Attribute = new VariationAttribute("ReadValue on PI with IgnorePI") });
-                    this.AddChild(new TestVariation(tcReadValue.bug340158) { Attribute = new VariationAttribute("Skip after ReadAttributeValue/ReadValueChunk") });
+                    this.AddChild(new TestVariation(TestReadValuePri0) { Attribute = new VariationAttribute("ReadValue") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValuePri0onElement) { Attribute = new VariationAttribute("ReadValue on Element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValueOnAttribute0) { Attribute = new VariationAttribute("ReadValue on Attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValueOnAttribute1) { Attribute = new VariationAttribute("ReadValue on Attribute after ReadAttributeValue") { Priority = 2 } });
+                    this.AddChild(new TestVariation(TestReadValue2Pri0) { Attribute = new VariationAttribute("ReadValue on empty buffer") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValue3Pri0) { Attribute = new VariationAttribute("ReadValue on negative count") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValue4Pri0) { Attribute = new VariationAttribute("ReadValue on negative offset") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValue1) { Attribute = new VariationAttribute("ReadValue with buffer = element content / 2") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValue2) { Attribute = new VariationAttribute("ReadValue entire value in one call") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValue3) { Attribute = new VariationAttribute("ReadValue bit by bit") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValue4) { Attribute = new VariationAttribute("ReadValue for value more than 4K") { Priority = 0 } });
+                    this.AddChild(new TestVariation(TestReadValue5) { Attribute = new VariationAttribute("ReadValue for value more than 4K and invalid element") { Priority = 1 } });
+                    this.AddChild(new TestVariation(TestReadValue6) { Attribute = new VariationAttribute("ReadValue with Entity Reference, EntityHandling = ExpandEntities") });
+                    this.AddChild(new TestVariation(TestReadValue7) { Attribute = new VariationAttribute("ReadValue with count > buffer size") });
+                    this.AddChild(new TestVariation(TestReadValue8) { Attribute = new VariationAttribute("ReadValue with index > buffer size") });
+                    this.AddChild(new TestVariation(TestReadValue10) { Attribute = new VariationAttribute("ReadValue with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(TestReadChar11) { Attribute = new VariationAttribute("ReadValue with combination Text, CDATA and Whitespace") });
+                    this.AddChild(new TestVariation(TestReadChar12) { Attribute = new VariationAttribute("ReadValue with combination Text, CDATA and SignificantWhitespace") });
+                    this.AddChild(new TestVariation(TestReadChar13) { Attribute = new VariationAttribute("ReadValue with buffer == null") });
+                    this.AddChild(new TestVariation(TestReadChar14) { Attribute = new VariationAttribute("ReadValue with multiple different inner nodes") });
+                    this.AddChild(new TestVariation(TestReadChar15) { Attribute = new VariationAttribute("ReadValue after failed ReadValue") });
+                    this.AddChild(new TestVariation(TestReadChar16) { Attribute = new VariationAttribute("Read after partial ReadValue") });
+                    this.AddChild(new TestVariation(TestReadChar19) { Attribute = new VariationAttribute("Test error after successful ReadValue") });
+                    this.AddChild(new TestVariation(TestReadChar21) { Attribute = new VariationAttribute("Call on invalid element content after 4k boundary") { Priority = 1 } });
+                    this.AddChild(new TestVariation(TestTextReadValue25) { Attribute = new VariationAttribute("ReadValue with whitespace") });
+                    this.AddChild(new TestVariation(TestTextReadValue26) { Attribute = new VariationAttribute("ReadValue when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(TestCharEntities0) { Attribute = new VariationAttribute("Testing with character entities") });
+                    this.AddChild(new TestVariation(TestCharEntities1) { Attribute = new VariationAttribute("Testing with character entities when value more than 4k") });
+                    this.AddChild(new TestVariation(TestCharEntities2) { Attribute = new VariationAttribute("Testing with character entities with another pattern") });
+                    this.AddChild(new TestVariation(TestReadValueOnBig) { Attribute = new VariationAttribute("Testing a use case pattern with large file") });
+                    this.AddChild(new TestVariation(TestReadValueOnComments0) { Attribute = new VariationAttribute("ReadValue on Comments with IgnoreComments") });
+                    this.AddChild(new TestVariation(TestReadValueOnPIs0) { Attribute = new VariationAttribute("ReadValue on PI with IgnorePI") });
+                    this.AddChild(new TestVariation(bug340158) { Attribute = new VariationAttribute("Skip after ReadAttributeValue/ReadValueChunk") });
                 }
             }
-            public class XNodeReaderAPI : XLinqTestCase
+            public partial class XNodeReaderAPI : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+XNodeReaderAPI
                 // Test Case
                 public override void AddChildren()
                 {
-                    var xNodeReaderAPI = new XNodeReaderAPIFunctionalTests.XNodeReaderTests.XNodeReaderAPI();
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Text") { Params = new object[] { XmlNodeType.Text, 1, new string[] { "some_text" }, 1 }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: PI (root level)") { Params = new object[] { XmlNodeType.ProcessingInstruction, 0, new string[] { "PI", "" }, 1 }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Comment") { Params = new object[] { XmlNodeType.Comment, 1, new string[] { "comm2" }, 1 }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Text (root level)") { Params = new object[] { XmlNodeType.Text, 0, new string[] { "\t" }, 1 }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (root)") { Params = new object[] { XmlNodeType.Element, 0, new string[] { "A", "", "" }, 15 }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: PI") { Params = new object[] { XmlNodeType.ProcessingInstruction, 1, new string[] { "PIX", "click" }, 1 }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Comment (root level)") { Params = new object[] { XmlNodeType.Comment, 0, new string[] { "comment1" }, 1 }, Priority = 2 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (in the mIddle)") { Params = new object[] { XmlNodeType.Element, 1, new string[] { "B", "", "x" }, 11 }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (leaf I.)") { Params = new object[] { XmlNodeType.Element, 3, new string[] { "D", "", "y" }, 2 }, Priority = 0 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (leaf II.)") { Params = new object[] { XmlNodeType.Element, 4, new string[] { "E", "p", "nsp" }, 1 }, Priority = 1 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.Namespaces) { Attribute = new VariationAttribute("Namespaces - Comment") { Params = new object[] { XmlNodeType.Comment, 1, new string[] { "", "x" }, new string[] { "p", "nsp" } } } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.Namespaces) { Attribute = new VariationAttribute("Namespaces - root element") { Params = new object[] { XmlNodeType.Element, 0, new string[] { "", "" } } } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.Namespaces) { Attribute = new VariationAttribute("Namespaces - element") { Params = new object[] { XmlNodeType.Element, 1, new string[] { "", "x" }, new string[] { "p", "nsp" } } } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.Namespaces) { Attribute = new VariationAttribute("Namespaces - element, def. ns redef") { Params = new object[] { XmlNodeType.Element, 3, new string[] { "", "y" }, new string[] { "p", "nsp" } } } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.ReadSubtreeSanity) { Attribute = new VariationAttribute("ReadSubtree (sanity)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.AdjacentTextNodes1) { Attribute = new VariationAttribute("Adjacent text nodes (sanity I.)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.AdjacentTextNodes2) { Attribute = new VariationAttribute("Adjacent text nodes (sanity II.) : ReadElementContent") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.AdjacentTextNodesI) { Attribute = new VariationAttribute("Adjacent text nodes (sanity IV.) : ReadInnerXml") { Priority = 0 } });
-                    this.AddChild(new TestVariation(xNodeReaderAPI.AdjacentTextNodes3) { Attribute = new VariationAttribute("Adjacent text nodes (sanity III.) : ReadContent") { Priority = 0 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Text") { Params = new object[] { XmlNodeType.Text, 1, new string[] { "some_text" }, 1 }, Priority = 1 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: PI (root level)") { Params = new object[] { XmlNodeType.ProcessingInstruction, 0, new string[] { "PI", "" }, 1 }, Priority = 2 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Comment") { Params = new object[] { XmlNodeType.Comment, 1, new string[] { "comm2" }, 1 }, Priority = 2 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Text (root level)") { Params = new object[] { XmlNodeType.Text, 0, new string[] { "\t" }, 1 }, Priority = 0 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (root)") { Params = new object[] { XmlNodeType.Element, 0, new string[] { "A", "", "" }, 15 }, Priority = 1 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: PI") { Params = new object[] { XmlNodeType.ProcessingInstruction, 1, new string[] { "PIX", "click" }, 1 }, Priority = 2 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Comment (root level)") { Params = new object[] { XmlNodeType.Comment, 0, new string[] { "comment1" }, 1 }, Priority = 2 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (in the mIddle)") { Params = new object[] { XmlNodeType.Element, 1, new string[] { "B", "", "x" }, 11 }, Priority = 0 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (leaf I.)") { Params = new object[] { XmlNodeType.Element, 3, new string[] { "D", "", "y" }, 2 }, Priority = 0 } });
+                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (leaf II.)") { Params = new object[] { XmlNodeType.Element, 4, new string[] { "E", "p", "nsp" }, 1 }, Priority = 1 } });
+                    this.AddChild(new TestVariation(Namespaces) { Attribute = new VariationAttribute("Namespaces - Comment") { Params = new object[] { XmlNodeType.Comment, 1, new string[] { "", "x" }, new string[] { "p", "nsp" } } } });
+                    this.AddChild(new TestVariation(Namespaces) { Attribute = new VariationAttribute("Namespaces - root element") { Params = new object[] { XmlNodeType.Element, 0, new string[] { "", "" } } } });
+                    this.AddChild(new TestVariation(Namespaces) { Attribute = new VariationAttribute("Namespaces - element") { Params = new object[] { XmlNodeType.Element, 1, new string[] { "", "x" }, new string[] { "p", "nsp" } } } });
+                    this.AddChild(new TestVariation(Namespaces) { Attribute = new VariationAttribute("Namespaces - element, def. ns redef") { Params = new object[] { XmlNodeType.Element, 3, new string[] { "", "y" }, new string[] { "p", "nsp" } } } });
+                    this.AddChild(new TestVariation(ReadSubtreeSanity) { Attribute = new VariationAttribute("ReadSubtree (sanity)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(AdjacentTextNodes1) { Attribute = new VariationAttribute("Adjacent text nodes (sanity I.)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(AdjacentTextNodes2) { Attribute = new VariationAttribute("Adjacent text nodes (sanity II.) : ReadElementContent") { Priority = 0 } });
+                    this.AddChild(new TestVariation(AdjacentTextNodesI) { Attribute = new VariationAttribute("Adjacent text nodes (sanity IV.) : ReadInnerXml") { Priority = 0 } });
+                    this.AddChild(new TestVariation(AdjacentTextNodes3) { Attribute = new VariationAttribute("Adjacent text nodes (sanity III.) : ReadContent") { Priority = 0 } });
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/FunctionalTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/FunctionalTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class XNodeReaderFunctionalTests : TestModule
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
@@ -21,7 +21,7 @@ namespace CoreXml.Test.XLinq
         public static void RunTests()
         {
             TestInput.CommandLine = "";
-            FunctionalTests module = new FunctionalTests();
+            XNodeReaderFunctionalTests module = new XNodeReaderFunctionalTests();
             module.Init();
 
             module.AddChild(new XNodeReaderTests() { Attribute = new TestCaseAttribute() { Name = "XNodeReader", Desc = "XLinq XNodeReader Tests" } });
@@ -31,7 +31,7 @@ namespace CoreXml.Test.XLinq
         }
 
         #region Class
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
             // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests
             public override void AddChildren()
@@ -45,7 +45,7 @@ namespace CoreXml.Test.XLinq
                 this.AddChild(new TCXmlSpace() { Attribute = new TestCaseAttribute() { Name = "XmlSpace", Desc = "XmlSpace" } });
                 this.AddChild(new TCXmlLang() { Attribute = new TestCaseAttribute() { Name = "XmlLang", Desc = "XmlLang" } });
                 this.AddChild(new TCSkip() { Attribute = new TestCaseAttribute() { Name = "Skip", Desc = "Skip" } });
-                this.AddChild(new TCIsDefault() { Attribute = new TestCaseAttribute() { Name = "IsDefault", Desc = "IsDefault" } });
+                this.AddChild(new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCIsDefault() { Attribute = new TestCaseAttribute() { Name = "IsDefault", Desc = "IsDefault" } });
                 this.AddChild(new TCBaseURI() { Attribute = new TestCaseAttribute() { Name = "BaseUri", Desc = "BaseUri" } });
                 this.AddChild(new TCAttributeAccess() { Attribute = new TestCaseAttribute() { Name = "AttributeAccess", Desc = "AttributeAccess" } });
                 this.AddChild(new TCThisName() { Attribute = new TestCaseAttribute() { Name = "ThisName", Desc = "ThisName" } });
@@ -81,939 +81,982 @@ namespace CoreXml.Test.XLinq
                 this.AddChild(new TCReadValue() { Attribute = new TestCaseAttribute() { Name = "ReadValue", Desc = "ReadValue" } });
                 this.AddChild(new XNodeReaderAPI() { Attribute = new TestCaseAttribute() { Name = "API Tests" } });
             }
-            public partial class TCDispose : BridgeHelpers
+            public class TCDispose : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCDispose
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(Variation1) { Attribute = new VariationAttribute("Test Integrity of all values after Dispose") });
-                    this.AddChild(new TestVariation(Variation2) { Attribute = new VariationAttribute("Call Dispose Multiple(3) Times") });
+                    var tcDispose = new CommonTestFunctionalTests.XNodeReaderTests.TCDispose();
+                    this.AddChild(new TestVariation(tcDispose.Variation1) { Attribute = new VariationAttribute("Test Integrity of all values after Dispose") });
+                    this.AddChild(new TestVariation(tcDispose.Variation2) { Attribute = new VariationAttribute("Call Dispose Multiple(3) Times") });
                 }
             }
-            public partial class TCDepth : BridgeHelpers
+            public class TCDepth : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCDepth
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestDepth1) { Attribute = new VariationAttribute("XmlReader Depth at the Root") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestDepth2) { Attribute = new VariationAttribute("XmlReader Depth at Empty Tag") });
-                    this.AddChild(new TestVariation(TestDepth3) { Attribute = new VariationAttribute("XmlReader Depth at Empty Tag with Attributes") });
-                    this.AddChild(new TestVariation(TestDepth4) { Attribute = new VariationAttribute("XmlReader Depth at Non Empty Tag with Text") });
+                    var tcDepth = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCDepth();
+                    this.AddChild(new TestVariation(tcDepth.TestDepth1) { Attribute = new VariationAttribute("XmlReader Depth at the Root") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcDepth.TestDepth2) { Attribute = new VariationAttribute("XmlReader Depth at Empty Tag") });
+                    this.AddChild(new TestVariation(tcDepth.TestDepth3) { Attribute = new VariationAttribute("XmlReader Depth at Empty Tag with Attributes") });
+                    this.AddChild(new TestVariation(tcDepth.TestDepth4) { Attribute = new VariationAttribute("XmlReader Depth at Non Empty Tag with Text") });
                 }
             }
-            public partial class TCNamespace : BridgeHelpers
+            public class TCNamespace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCNamespace
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestNamespace1) { Attribute = new VariationAttribute("Namespace test within a scope (no nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestNamespace2) { Attribute = new VariationAttribute("Namespace test within a scope (with nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestNamespace3) { Attribute = new VariationAttribute("Namespace test immediately outside the Namespace scope") });
-                    this.AddChild(new TestVariation(TestNamespace4) { Attribute = new VariationAttribute("Namespace test Attribute should has no default namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestNamespace5) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestNamespace6) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration, including default namespace") });
-                    this.AddChild(new TestVariation(TestNamespace7) { Attribute = new VariationAttribute("Namespace URI for xml prefix") { Priority = 0 } });
+                    var tcNamespace = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCNamespace();
+                    this.AddChild(new TestVariation(tcNamespace.TestNamespace1) { Attribute = new VariationAttribute("Namespace test within a scope (no nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNamespace.TestNamespace2) { Attribute = new VariationAttribute("Namespace test within a scope (with nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNamespace.TestNamespace3) { Attribute = new VariationAttribute("Namespace test immediately outside the Namespace scope") });
+                    this.AddChild(new TestVariation(tcNamespace.TestNamespace4) { Attribute = new VariationAttribute("Namespace test Attribute should has no default namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNamespace.TestNamespace5) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcNamespace.TestNamespace6) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration, including default namespace") });
+                    this.AddChild(new TestVariation(tcNamespace.TestNamespace7) { Attribute = new VariationAttribute("Namespace URI for xml prefix") { Priority = 0 } });
                 }
             }
-            public partial class TCLookupNamespace : BridgeHelpers
+            public class TCLookupNamespace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCLookupNamespace
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(LookupNamespace1) { Attribute = new VariationAttribute("LookupNamespace test within EmptyTag") });
-                    this.AddChild(new TestVariation(LookupNamespace2) { Attribute = new VariationAttribute("LookupNamespace test with Default namespace within EmptyTag") { Priority = 0 } });
-                    this.AddChild(new TestVariation(LookupNamespace3) { Attribute = new VariationAttribute("LookupNamespace test within a scope (no nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(LookupNamespace4) { Attribute = new VariationAttribute("LookupNamespace test within a scope (with nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(LookupNamespace5) { Attribute = new VariationAttribute("LookupNamespace test immediately outside the Namespace scope") });
-                    this.AddChild(new TestVariation(LookupNamespace6) { Attribute = new VariationAttribute("LookupNamespace test with multiple Namespace declaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(LookupNamespace7) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration, including default namespace") });
-                    this.AddChild(new TestVariation(LookupNamespace8) { Attribute = new VariationAttribute("LookupNamespace on whitespace node PreserveWhitespaces = true") { Priority = 0 } });
-                    this.AddChild(new TestVariation(LookupNamespace9) { Attribute = new VariationAttribute("Different prefix on inner element for the same namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(LookupNamespace10) { Attribute = new VariationAttribute("LookupNamespace when Namespaces = false") { Priority = 0 } });
+                    var tcLookupNamespace = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCLookupNamespace();
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace1) { Attribute = new VariationAttribute("LookupNamespace test within EmptyTag") });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace2) { Attribute = new VariationAttribute("LookupNamespace test with Default namespace within EmptyTag") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace3) { Attribute = new VariationAttribute("LookupNamespace test within a scope (no nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace4) { Attribute = new VariationAttribute("LookupNamespace test within a scope (with nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace5) { Attribute = new VariationAttribute("LookupNamespace test immediately outside the Namespace scope") });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace6) { Attribute = new VariationAttribute("LookupNamespace test with multiple Namespace declaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace7) { Attribute = new VariationAttribute("Namespace test with multiple Namespace declaration, including default namespace") });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace8) { Attribute = new VariationAttribute("LookupNamespace on whitespace node PreserveWhitespaces = true") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace9) { Attribute = new VariationAttribute("Different prefix on inner element for the same namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcLookupNamespace.LookupNamespace10) { Attribute = new VariationAttribute("LookupNamespace when Namespaces = false") { Priority = 0 } });
                 }
             }
-            public partial class TCHasValue : BridgeHelpers
+            public class TCHasValue : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCHasValue
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestHasValueNodeType_None) { Attribute = new VariationAttribute("HasValue On None") });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_Element) { Attribute = new VariationAttribute("HasValue On Element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValue1) { Attribute = new VariationAttribute("Get node with a scalar value, verify the value with valid ReadString") });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_Attribute) { Attribute = new VariationAttribute("HasValue On Attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_Text) { Attribute = new VariationAttribute("HasValue On Text") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_CDATA) { Attribute = new VariationAttribute("HasValue On CDATA") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("HasValue On ProcessingInstruction") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_Comment) { Attribute = new VariationAttribute("HasValue On Comment") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_DocumentType) { Attribute = new VariationAttribute("HasValue On DocumentType") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_Whitespace) { Attribute = new VariationAttribute("HasValue On Whitespace PreserveWhitespaces = true") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_EndElement) { Attribute = new VariationAttribute("HasValue On EndElement") });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_XmlDeclaration) { Attribute = new VariationAttribute("HasValue On XmlDeclaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_EntityReference) { Attribute = new VariationAttribute("HasValue On EntityReference") });
-                    this.AddChild(new TestVariation(TestHasValueNodeType_EndEntity) { Attribute = new VariationAttribute("HasValue On EndEntity") });
-                    this.AddChild(new TestVariation(v13) { Attribute = new VariationAttribute("PI Value containing surrogates") { Priority = 0 } });
+                    var tcHasValue = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCHasValue();
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_None) { Attribute = new VariationAttribute("HasValue On None") });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Element) { Attribute = new VariationAttribute("HasValue On Element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValue1) { Attribute = new VariationAttribute("Get node with a scalar value, verify the value with valid ReadString") });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Attribute) { Attribute = new VariationAttribute("HasValue On Attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Text) { Attribute = new VariationAttribute("HasValue On Text") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_CDATA) { Attribute = new VariationAttribute("HasValue On CDATA") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("HasValue On ProcessingInstruction") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Comment) { Attribute = new VariationAttribute("HasValue On Comment") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_DocumentType) { Attribute = new VariationAttribute("HasValue On DocumentType") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_Whitespace) { Attribute = new VariationAttribute("HasValue On Whitespace PreserveWhitespaces = true") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_EndElement) { Attribute = new VariationAttribute("HasValue On EndElement") });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_XmlDeclaration) { Attribute = new VariationAttribute("HasValue On XmlDeclaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_EntityReference) { Attribute = new VariationAttribute("HasValue On EntityReference") });
+                    this.AddChild(new TestVariation(tcHasValue.TestHasValueNodeType_EndEntity) { Attribute = new VariationAttribute("HasValue On EndEntity") });
+                    this.AddChild(new TestVariation(tcHasValue.v13) { Attribute = new VariationAttribute("PI Value containing surrogates") { Priority = 0 } });
                 }
             }
-            public partial class TCIsEmptyElement2 : BridgeHelpers
+            public class TCIsEmptyElement2 : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCIsEmptyElement2
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestEmpty1) { Attribute = new VariationAttribute("Set and Get an element that ends with />") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestEmpty2) { Attribute = new VariationAttribute("Set and Get an element with an attribute that ends with />") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestEmpty3) { Attribute = new VariationAttribute("Set and Get an element that ends without />") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestEmpty4) { Attribute = new VariationAttribute("Set and Get an element with an attribute that ends with />") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_Element) { Attribute = new VariationAttribute("IsEmptyElement On Element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_None) { Attribute = new VariationAttribute("IsEmptyElement On None") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_Text) { Attribute = new VariationAttribute("IsEmptyElement On Text") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_CDATA) { Attribute = new VariationAttribute("IsEmptyElement On CDATA") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("IsEmptyElement On ProcessingInstruction") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_Comment) { Attribute = new VariationAttribute("IsEmptyElement On Comment") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_DocumentType) { Attribute = new VariationAttribute("IsEmptyElement On DocumentType") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_Whitespace) { Attribute = new VariationAttribute("IsEmptyElement On Whitespace PreserveWhitespaces = true") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_EndElement) { Attribute = new VariationAttribute("IsEmptyElement On EndElement") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_EntityReference) { Attribute = new VariationAttribute("IsEmptyElement On EntityReference") });
-                    this.AddChild(new TestVariation(TestEmptyNodeType_EndEntity) { Attribute = new VariationAttribute("IsEmptyElement On EndEntity") });
+                    var tcIsEmptyElement2 = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCIsEmptyElement2();
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmpty1) { Attribute = new VariationAttribute("Set and Get an element that ends with />") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmpty2) { Attribute = new VariationAttribute("Set and Get an element with an attribute that ends with />") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmpty3) { Attribute = new VariationAttribute("Set and Get an element that ends without />") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmpty4) { Attribute = new VariationAttribute("Set and Get an element with an attribute that ends with />") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_Element) { Attribute = new VariationAttribute("IsEmptyElement On Element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_None) { Attribute = new VariationAttribute("IsEmptyElement On None") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_Text) { Attribute = new VariationAttribute("IsEmptyElement On Text") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_CDATA) { Attribute = new VariationAttribute("IsEmptyElement On CDATA") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("IsEmptyElement On ProcessingInstruction") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_Comment) { Attribute = new VariationAttribute("IsEmptyElement On Comment") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_DocumentType) { Attribute = new VariationAttribute("IsEmptyElement On DocumentType") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_Whitespace) { Attribute = new VariationAttribute("IsEmptyElement On Whitespace PreserveWhitespaces = true") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_EndElement) { Attribute = new VariationAttribute("IsEmptyElement On EndElement") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_EntityReference) { Attribute = new VariationAttribute("IsEmptyElement On EntityReference") });
+                    this.AddChild(new TestVariation(tcIsEmptyElement2.TestEmptyNodeType_EndEntity) { Attribute = new VariationAttribute("IsEmptyElement On EndEntity") });
                 }
             }
-            public partial class TCXmlSpace : BridgeHelpers
+            public class TCXmlSpace : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlSpace
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestXmlSpace1) { Attribute = new VariationAttribute("XmlSpace test within EmptyTag") });
-                    this.AddChild(new TestVariation(TestXmlSpace2) { Attribute = new VariationAttribute("Xmlspace test within a scope (no nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestXmlSpace3) { Attribute = new VariationAttribute("Xmlspace test within a scope (with nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestXmlSpace4) { Attribute = new VariationAttribute("Xmlspace test immediately outside the XmlSpace scope") });
-                    this.AddChild(new TestVariation(TestXmlSpace5) { Attribute = new VariationAttribute("XmlSpace test with multiple XmlSpace declaration") });
+                    var tcXmlSpace = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCXmlSpace();
+                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace1) { Attribute = new VariationAttribute("XmlSpace test within EmptyTag") });
+                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace2) { Attribute = new VariationAttribute("Xmlspace test within a scope (no nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace3) { Attribute = new VariationAttribute("Xmlspace test within a scope (with nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace4) { Attribute = new VariationAttribute("Xmlspace test immediately outside the XmlSpace scope") });
+                    this.AddChild(new TestVariation(tcXmlSpace.TestXmlSpace5) { Attribute = new VariationAttribute("XmlSpace test with multiple XmlSpace declaration") });
                 }
             }
-            public partial class TCXmlLang : BridgeHelpers
+            public class TCXmlLang : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlLang
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestXmlLang1) { Attribute = new VariationAttribute("XmlLang test within EmptyTag") });
-                    this.AddChild(new TestVariation(TestXmlLang2) { Attribute = new VariationAttribute("XmlLang test within a scope (no nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestXmlLang3) { Attribute = new VariationAttribute("XmlLang test within a scope (with nested element)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestXmlLang4) { Attribute = new VariationAttribute("XmlLang test immediately outside the XmlLang scope") });
-                    this.AddChild(new TestVariation(TestXmlLang5) { Attribute = new VariationAttribute("XmlLang test with multiple XmlLang declaration") });
-                    this.AddChild(new TestVariation(TestXmlLang6) { Attribute = new VariationAttribute("XmlLang valid values") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestXmlTextReaderLang1) { Attribute = new VariationAttribute("More XmlLang valid values") });
+                    var tcXmlLang = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCXmlLang();
+                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang1) { Attribute = new VariationAttribute("XmlLang test within EmptyTag") });
+                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang2) { Attribute = new VariationAttribute("XmlLang test within a scope (no nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang3) { Attribute = new VariationAttribute("XmlLang test within a scope (with nested element)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang4) { Attribute = new VariationAttribute("XmlLang test immediately outside the XmlLang scope") });
+                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang5) { Attribute = new VariationAttribute("XmlLang test with multiple XmlLang declaration") });
+                    this.AddChild(new TestVariation(tcXmlLang.TestXmlLang6) { Attribute = new VariationAttribute("XmlLang valid values") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlLang.TestXmlTextReaderLang1) { Attribute = new VariationAttribute("More XmlLang valid values") });
                 }
             }
-            public partial class TCSkip : BridgeHelpers
+            public class TCSkip : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCSkip
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestSkip1) { Attribute = new VariationAttribute("Call Skip on empty element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip2) { Attribute = new VariationAttribute("Call Skip on element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip3) { Attribute = new VariationAttribute("Call Skip on element with content") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip4) { Attribute = new VariationAttribute("Call Skip on text node (leave node)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(skip307543) { Attribute = new VariationAttribute("Call Skip in while read loop") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip5) { Attribute = new VariationAttribute("Call Skip on text node with another element: <elem2>text<elem3></elem3></elem2>") });
-                    this.AddChild(new TestVariation(TestSkip6) { Attribute = new VariationAttribute("Call Skip on attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip7) { Attribute = new VariationAttribute("Call Skip on text node of attribute") });
-                    this.AddChild(new TestVariation(TestSkip8) { Attribute = new VariationAttribute("Call Skip on CDATA") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip9) { Attribute = new VariationAttribute("Call Skip on Processing Instruction") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip10) { Attribute = new VariationAttribute("Call Skip on Comment") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip12) { Attribute = new VariationAttribute("Call Skip on Whitespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip13) { Attribute = new VariationAttribute("Call Skip on EndElement") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip14) { Attribute = new VariationAttribute("Call Skip on root Element") });
-                    this.AddChild(new TestVariation(XmlTextReaderDoesNotThrowWhenHandlingAmpersands) { Attribute = new VariationAttribute("XmlTextReader ArgumentOutOfRangeException when handling ampersands") });
+                    var tcSkip = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCSkip();
+                    this.AddChild(new TestVariation(tcSkip.TestSkip1) { Attribute = new VariationAttribute("Call Skip on empty element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip2) { Attribute = new VariationAttribute("Call Skip on element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip3) { Attribute = new VariationAttribute("Call Skip on element with content") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip4) { Attribute = new VariationAttribute("Call Skip on text node (leave node)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.skip307543) { Attribute = new VariationAttribute("Call Skip in while read loop") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip5) { Attribute = new VariationAttribute("Call Skip on text node with another element: <elem2>text<elem3></elem3></elem2>") });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip6) { Attribute = new VariationAttribute("Call Skip on attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip7) { Attribute = new VariationAttribute("Call Skip on text node of attribute") });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip8) { Attribute = new VariationAttribute("Call Skip on CDATA") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip9) { Attribute = new VariationAttribute("Call Skip on Processing Instruction") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip10) { Attribute = new VariationAttribute("Call Skip on Comment") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip12) { Attribute = new VariationAttribute("Call Skip on Whitespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip13) { Attribute = new VariationAttribute("Call Skip on EndElement") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcSkip.TestSkip14) { Attribute = new VariationAttribute("Call Skip on root Element") });
+                    this.AddChild(new TestVariation(tcSkip.XmlTextReaderDoesNotThrowWhenHandlingAmpersands) { Attribute = new VariationAttribute("XmlTextReader ArgumentOutOfRangeException when handling ampersands") });
                 }
             }
-            public partial class TCBaseURI : BridgeHelpers
+            public class TCBaseURI : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCBaseURI
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestBaseURI1) { Attribute = new VariationAttribute("BaseURI for element node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestBaseURI2) { Attribute = new VariationAttribute("BaseURI for attribute node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestBaseURI3) { Attribute = new VariationAttribute("BaseURI for text node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestBaseURI4) { Attribute = new VariationAttribute("BaseURI for CDATA node") });
-                    this.AddChild(new TestVariation(TestBaseURI6) { Attribute = new VariationAttribute("BaseURI for PI node") });
-                    this.AddChild(new TestVariation(TestBaseURI7) { Attribute = new VariationAttribute("BaseURI for Comment node") });
-                    this.AddChild(new TestVariation(TestBaseURI9) { Attribute = new VariationAttribute("BaseURI for Whitespace node PreserveWhitespaces = true") });
-                    this.AddChild(new TestVariation(TestBaseURI10) { Attribute = new VariationAttribute("BaseURI for EndElement node") });
-                    this.AddChild(new TestVariation(TestTextReaderBaseURI4) { Attribute = new VariationAttribute("BaseURI for external General Entity") });
+                    var tcBaseURI = new CXMLGeneralTestFunctionalTests.XNodeReaderTests.TCBaseURI();
+                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI1) { Attribute = new VariationAttribute("BaseURI for element node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI2) { Attribute = new VariationAttribute("BaseURI for attribute node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI3) { Attribute = new VariationAttribute("BaseURI for text node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI4) { Attribute = new VariationAttribute("BaseURI for CDATA node") });
+                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI6) { Attribute = new VariationAttribute("BaseURI for PI node") });
+                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI7) { Attribute = new VariationAttribute("BaseURI for Comment node") });
+                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI9) { Attribute = new VariationAttribute("BaseURI for Whitespace node PreserveWhitespaces = true") });
+                    this.AddChild(new TestVariation(tcBaseURI.TestBaseURI10) { Attribute = new VariationAttribute("BaseURI for EndElement node") });
+                    this.AddChild(new TestVariation(tcBaseURI.TestTextReaderBaseURI4) { Attribute = new VariationAttribute("BaseURI for external General Entity") });
                 }
             }
-            public partial class TCAttributeAccess : BridgeHelpers
+            public class TCAttributeAccess : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCAttributeAccess
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestAttributeAccess1) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Ascending Order)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestAttributeAccess2) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Descending Order)") });
-                    this.AddChild(new TestVariation(TestAttributeAccess3) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Odd number)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestAttributeAccess4) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Even number)") });
-                    this.AddChild(new TestVariation(TestAttributeAccess5) { Attribute = new VariationAttribute("Attribute Access with namespace=null") });
+                    var tcAttributeAccess = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCAttributeAccess();
+                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess1) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Ascending Order)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess2) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Descending Order)") });
+                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess3) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Odd number)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess4) { Attribute = new VariationAttribute("Attribute Access test using ordinal (Even number)") });
+                    this.AddChild(new TestVariation(tcAttributeAccess.TestAttributeAccess5) { Attribute = new VariationAttribute("Attribute Access with namespace=null") });
                 }
             }
-            public partial class TCThisName : BridgeHelpers
+            public class TCThisName : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCThisName
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(ThisWithName1) { Attribute = new VariationAttribute("This[Name] Verify with GetAttribute(Name)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ThisWithName2) { Attribute = new VariationAttribute("This[Name, null] Verify with GetAttribute(Name)") });
-                    this.AddChild(new TestVariation(ThisWithName3) { Attribute = new VariationAttribute("This[Name] Verify with GetAttribute(Name,null)") });
-                    this.AddChild(new TestVariation(ThisWithName4) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify with GetAttribute(Name, NamespaceURI)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ThisWithName5) { Attribute = new VariationAttribute("This[Name, null] Verify not the same as GetAttribute(Name, NamespaceURI)") });
-                    this.AddChild(new TestVariation(ThisWithName6) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify not the same as GetAttribute(Name, null)") });
-                    this.AddChild(new TestVariation(ThisWithName7) { Attribute = new VariationAttribute("This[Name] Verify with MoveToAttribute(Name)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ThisWithName8) { Attribute = new VariationAttribute("This[Name, null] Verify with MoveToAttribute(Name)") });
-                    this.AddChild(new TestVariation(ThisWithName9) { Attribute = new VariationAttribute("This[Name] Verify with MoveToAttribute(Name,null)") });
-                    this.AddChild(new TestVariation(ThisWithName10) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify not the same as MoveToAttribute(Name, null)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ThisWithName11) { Attribute = new VariationAttribute("This[Name, null] Verify not the same as MoveToAttribute(Name, NamespaceURI)") });
-                    this.AddChild(new TestVariation(ThisWithName12) { Attribute = new VariationAttribute("This[Name, namespace] Verify not the same as MoveToAttribute(Name, namespace)") });
-                    this.AddChild(new TestVariation(ThisWithName13) { Attribute = new VariationAttribute("This(String.Empty)") });
-                    this.AddChild(new TestVariation(ThisWithName14) { Attribute = new VariationAttribute("This[String.Empty,String.Empty]") });
-                    this.AddChild(new TestVariation(ThisWithName15) { Attribute = new VariationAttribute("This[QName] Verify with GetAttribute(Name, NamespaceURI)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ThisWithName16) { Attribute = new VariationAttribute("This[QName] invalid Qname") });
+                    var tcThisName = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCThisName();
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName1) { Attribute = new VariationAttribute("This[Name] Verify with GetAttribute(Name)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName2) { Attribute = new VariationAttribute("This[Name, null] Verify with GetAttribute(Name)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName3) { Attribute = new VariationAttribute("This[Name] Verify with GetAttribute(Name,null)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName4) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify with GetAttribute(Name, NamespaceURI)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName5) { Attribute = new VariationAttribute("This[Name, null] Verify not the same as GetAttribute(Name, NamespaceURI)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName6) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify not the same as GetAttribute(Name, null)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName7) { Attribute = new VariationAttribute("This[Name] Verify with MoveToAttribute(Name)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName8) { Attribute = new VariationAttribute("This[Name, null] Verify with MoveToAttribute(Name)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName9) { Attribute = new VariationAttribute("This[Name] Verify with MoveToAttribute(Name,null)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName10) { Attribute = new VariationAttribute("This[Name, NamespaceURI] Verify not the same as MoveToAttribute(Name, null)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName11) { Attribute = new VariationAttribute("This[Name, null] Verify not the same as MoveToAttribute(Name, NamespaceURI)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName12) { Attribute = new VariationAttribute("This[Name, namespace] Verify not the same as MoveToAttribute(Name, namespace)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName13) { Attribute = new VariationAttribute("This(String.Empty)") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName14) { Attribute = new VariationAttribute("This[String.Empty,String.Empty]") });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName15) { Attribute = new VariationAttribute("This[QName] Verify with GetAttribute(Name, NamespaceURI)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisName.ThisWithName16) { Attribute = new VariationAttribute("This[QName] invalid Qname") });
                 }
             }
-            public partial class TCMoveToAttributeReader : BridgeHelpers
+            public class TCMoveToAttributeReader : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToAttributeReader
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(MoveToAttributeWithName1) { Attribute = new VariationAttribute("MoveToAttribute(String.Empty)") });
-                    this.AddChild(new TestVariation(MoveToAttributeWithName2) { Attribute = new VariationAttribute("MoveToAttribute(String.Empty,String.Empty)") });
+                    var tcMoveToAttributeReader = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCMoveToAttributeReader();
+                    this.AddChild(new TestVariation(tcMoveToAttributeReader.MoveToAttributeWithName1) { Attribute = new VariationAttribute("MoveToAttribute(String.Empty)") });
+                    this.AddChild(new TestVariation(tcMoveToAttributeReader.MoveToAttributeWithName2) { Attribute = new VariationAttribute("MoveToAttribute(String.Empty,String.Empty)") });
                 }
             }
-            public partial class TCGetAttributeOrdinal : BridgeHelpers
+            public class TCGetAttributeOrdinal : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCGetAttributeOrdinal
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(GetAttributeWithGetAttrDoubleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with This[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(OrdinalWithGetAttrSingleQ) { Attribute = new VariationAttribute("GetAttribute[i] Verify with This[i] - Single Quote") });
-                    this.AddChild(new TestVariation(GetAttributeWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with MoveToAttribute[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(GetAttributeWithMoveAttrSingleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with MoveToAttribute[i] - Single Quote") });
-                    this.AddChild(new TestVariation(NegativeOneOrdinal) { Attribute = new VariationAttribute("GetAttribute(i) NegativeOneOrdinal") { Priority = 0 } });
-                    this.AddChild(new TestVariation(FieldCountOrdinal) { Attribute = new VariationAttribute("GetAttribute(i) FieldCountOrdinal") });
-                    this.AddChild(new TestVariation(OrdinalPlusOne) { Attribute = new VariationAttribute("GetAttribute(i) OrdinalPlusOne") { Priority = 0 } });
-                    this.AddChild(new TestVariation(OrdinalMinusOne) { Attribute = new VariationAttribute("GetAttribute(i) OrdinalMinusOne") });
+                    var tcGetAttributeOrdinal = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCGetAttributeOrdinal();
+                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.GetAttributeWithGetAttrDoubleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with This[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.OrdinalWithGetAttrSingleQ) { Attribute = new VariationAttribute("GetAttribute[i] Verify with This[i] - Single Quote") });
+                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.GetAttributeWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with MoveToAttribute[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.GetAttributeWithMoveAttrSingleQ) { Attribute = new VariationAttribute("GetAttribute(i) Verify with MoveToAttribute[i] - Single Quote") });
+                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.NegativeOneOrdinal) { Attribute = new VariationAttribute("GetAttribute(i) NegativeOneOrdinal") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.FieldCountOrdinal) { Attribute = new VariationAttribute("GetAttribute(i) FieldCountOrdinal") });
+                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.OrdinalPlusOne) { Attribute = new VariationAttribute("GetAttribute(i) OrdinalPlusOne") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcGetAttributeOrdinal.OrdinalMinusOne) { Attribute = new VariationAttribute("GetAttribute(i) OrdinalMinusOne") });
                 }
             }
-            public partial class TCGetAttributeName : BridgeHelpers
+            public class TCGetAttributeName : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCGetAttributeName
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(GetAttributeWithName1) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with This[Name]") { Priority = 0 } });
-                    this.AddChild(new TestVariation(GetAttributeWithName2) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify with This[Name]") });
-                    this.AddChild(new TestVariation(GetAttributeWithName3) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with This[Name,null]") });
-                    this.AddChild(new TestVariation(GetAttributeWithName4) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify with This[Name, NamespaceURI]") { Priority = 0 } });
-                    this.AddChild(new TestVariation(GetAttributeWithName5) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify not the same as This[Name, NamespaceURI]") });
-                    this.AddChild(new TestVariation(GetAttributeWithName6) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify not the same as This[Name, null]") });
-                    this.AddChild(new TestVariation(GetAttributeWithName7) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with MoveToAttribute(Name)") });
-                    this.AddChild(new TestVariation(GetAttributeWithName8) { Attribute = new VariationAttribute("GetAttribute(Name,null) Verify with MoveToAttribute(Name)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(GetAttributeWithName9) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with MoveToAttribute(Name,null)") { Priority = 1 } });
-                    this.AddChild(new TestVariation(GetAttributeWithName10) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify not the same as MoveToAttribute(Name, null)") });
-                    this.AddChild(new TestVariation(GetAttributeWithName11) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify not the same as MoveToAttribute(Name, NamespaceURI)") });
-                    this.AddChild(new TestVariation(GetAttributeWithName12) { Attribute = new VariationAttribute("GetAttribute(Name, namespace) Verify not the same as MoveToAttribute(Name, namespace)") });
-                    this.AddChild(new TestVariation(GetAttributeWithName13) { Attribute = new VariationAttribute("GetAttribute(String.Empty)") });
-                    this.AddChild(new TestVariation(GetAttributeWithName14) { Attribute = new VariationAttribute("GetAttribute(String.Empty,String.Empty)") });
+                    var tcGetAttributeName = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCGetAttributeName();
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName1) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with This[Name]") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName2) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify with This[Name]") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName3) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with This[Name,null]") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName4) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify with This[Name, NamespaceURI]") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName5) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify not the same as This[Name, NamespaceURI]") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName6) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify not the same as This[Name, null]") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName7) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with MoveToAttribute(Name)") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName8) { Attribute = new VariationAttribute("GetAttribute(Name,null) Verify with MoveToAttribute(Name)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName9) { Attribute = new VariationAttribute("GetAttribute(Name) Verify with MoveToAttribute(Name,null)") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName10) { Attribute = new VariationAttribute("GetAttribute(Name, NamespaceURI) Verify not the same as MoveToAttribute(Name, null)") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName11) { Attribute = new VariationAttribute("GetAttribute(Name, null) Verify not the same as MoveToAttribute(Name, NamespaceURI)") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName12) { Attribute = new VariationAttribute("GetAttribute(Name, namespace) Verify not the same as MoveToAttribute(Name, namespace)") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName13) { Attribute = new VariationAttribute("GetAttribute(String.Empty)") });
+                    this.AddChild(new TestVariation(tcGetAttributeName.GetAttributeWithName14) { Attribute = new VariationAttribute("GetAttribute(String.Empty,String.Empty)") });
                 }
             }
-            public partial class TCThisOrdinal : BridgeHelpers
+            public class TCThisOrdinal : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCThisOrdinal
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(OrdinalWithGetAttrDoubleQ) { Attribute = new VariationAttribute("This[i] Verify with GetAttribute[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(OrdinalWithGetAttrSingleQ) { Attribute = new VariationAttribute("This[i] Verify with GetAttribute[i] - Single Quote") });
-                    this.AddChild(new TestVariation(OrdinalWithMoveAttrSingleQ) { Attribute = new VariationAttribute("This[i] Verify with MoveToAttribute[i] - Single Quote") });
-                    this.AddChild(new TestVariation(OrdinalWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("This[i] Verify with MoveToAttribute[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(NegativeOneOrdinal) { Attribute = new VariationAttribute("ThisOrdinal NegativeOneOrdinal") { Priority = 0 } });
-                    this.AddChild(new TestVariation(FieldCountOrdinal) { Attribute = new VariationAttribute("ThisOrdinal FieldCountOrdinal") });
-                    this.AddChild(new TestVariation(OrdinalPlusOne) { Attribute = new VariationAttribute("ThisOrdinal OrdinalPlusOne") { Priority = 0 } });
-                    this.AddChild(new TestVariation(OrdinalMinusOne) { Attribute = new VariationAttribute("ThisOrdinal OrdinalMinusOne") });
+                    var tcThisOrdinal = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCThisOrdinal();
+                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalWithGetAttrDoubleQ) { Attribute = new VariationAttribute("This[i] Verify with GetAttribute[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalWithGetAttrSingleQ) { Attribute = new VariationAttribute("This[i] Verify with GetAttribute[i] - Single Quote") });
+                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalWithMoveAttrSingleQ) { Attribute = new VariationAttribute("This[i] Verify with MoveToAttribute[i] - Single Quote") });
+                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("This[i] Verify with MoveToAttribute[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisOrdinal.NegativeOneOrdinal) { Attribute = new VariationAttribute("ThisOrdinal NegativeOneOrdinal") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisOrdinal.FieldCountOrdinal) { Attribute = new VariationAttribute("ThisOrdinal FieldCountOrdinal") });
+                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalPlusOne) { Attribute = new VariationAttribute("ThisOrdinal OrdinalPlusOne") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcThisOrdinal.OrdinalMinusOne) { Attribute = new VariationAttribute("ThisOrdinal OrdinalMinusOne") });
                 }
             }
-            public partial class TCMoveToAttributeOrdinal : BridgeHelpers
+            public class TCMoveToAttributeOrdinal : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToAttributeOrdinal
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(MoveToAttributeWithGetAttrDoubleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with This[i] - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(MoveToAttributeWithGetAttrSingleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with This[i] - Single Quote") });
-                    this.AddChild(new TestVariation(MoveToAttributeWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with GetAttribute(i) - Double Quote") { Priority = 0 } });
-                    this.AddChild(new TestVariation(MoveToAttributeWithMoveAttrSingleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with GetAttribute[i] - Single Quote") });
-                    this.AddChild(new TestVariation(NegativeOneOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i) NegativeOneOrdinal") { Priority = 0 } });
-                    this.AddChild(new TestVariation(FieldCountOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i) FieldCountOrdinal") });
-                    this.AddChild(new TestVariation(OrdinalPlusOne) { Attribute = new VariationAttribute("MoveToAttribute(i) OrdinalPlusOne") { Priority = 0 } });
-                    this.AddChild(new TestVariation(OrdinalMinusOne) { Attribute = new VariationAttribute("MoveToAttribute(i) OrdinalMinusOne") });
+                    var tcMoveToAttributeOrdinal = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCMoveToAttributeOrdinal();
+                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.MoveToAttributeWithGetAttrDoubleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with This[i] - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.MoveToAttributeWithGetAttrSingleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with This[i] - Single Quote") });
+                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.MoveToAttributeWithMoveAttrDoubleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with GetAttribute(i) - Double Quote") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.MoveToAttributeWithMoveAttrSingleQ) { Attribute = new VariationAttribute("MoveToAttribute(i) Verify with GetAttribute[i] - Single Quote") });
+                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.NegativeOneOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i) NegativeOneOrdinal") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.FieldCountOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i) FieldCountOrdinal") });
+                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.OrdinalPlusOne) { Attribute = new VariationAttribute("MoveToAttribute(i) OrdinalPlusOne") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToAttributeOrdinal.OrdinalMinusOne) { Attribute = new VariationAttribute("MoveToAttribute(i) OrdinalMinusOne") });
                 }
             }
-            public partial class TCMoveToFirstAttribute : BridgeHelpers
+            public class TCMoveToFirstAttribute : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToFirstAttribute
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(MoveToFirstAttribute1) { Attribute = new VariationAttribute("MoveToFirstAttribute() When AttributeCount=0, <EMPTY1/> ") { Priority = 0 } });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute2) { Attribute = new VariationAttribute("MoveToFirstAttribute() When AttributeCount=0, <NONEMPTY1>ABCDE</NONEMPTY1> ") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute3) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=0, with namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute4) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=0, without namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute5) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, with namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute6) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, without namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute7) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, with namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute8) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, without namespace") });
+                    var tcMoveToFirstAttribute = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCMoveToFirstAttribute();
+                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute1) { Attribute = new VariationAttribute("MoveToFirstAttribute() When AttributeCount=0, <EMPTY1/> ") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute2) { Attribute = new VariationAttribute("MoveToFirstAttribute() When AttributeCount=0, <NONEMPTY1>ABCDE</NONEMPTY1> ") });
+                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute3) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=0, with namespace") });
+                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute4) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=0, without namespace") });
+                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute5) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, with namespace") });
+                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute6) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, without namespace") });
+                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute7) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, with namespace") });
+                    this.AddChild(new TestVariation(tcMoveToFirstAttribute.MoveToFirstAttribute8) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, without namespace") });
                 }
             }
-            public partial class TCMoveToNextAttribute : BridgeHelpers
+            public class TCMoveToNextAttribute : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToNextAttribute
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(MoveToNextAttribute1) { Attribute = new VariationAttribute("MoveToNextAttribute() When AttributeCount=0, <EMPTY1/> ") { Priority = 0 } });
-                    this.AddChild(new TestVariation(MoveToNextAttribute2) { Attribute = new VariationAttribute("MoveToNextAttribute() When AttributeCount=0, <NONEMPTY1>ABCDE</NONEMPTY1> ") });
-                    this.AddChild(new TestVariation(MoveToNextAttribute3) { Attribute = new VariationAttribute("MoveToNextAttribute() When iOrdinal=0, with namespace") });
-                    this.AddChild(new TestVariation(MoveToNextAttribute4) { Attribute = new VariationAttribute("MoveToNextAttribute() When iOrdinal=0, without namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute5) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, with namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute6) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, without namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute7) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, with namespace") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute8) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, without namespace") });
+                    var tcMoveToNextAttribute = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCMoveToNextAttribute();
+                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToNextAttribute1) { Attribute = new VariationAttribute("MoveToNextAttribute() When AttributeCount=0, <EMPTY1/> ") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToNextAttribute2) { Attribute = new VariationAttribute("MoveToNextAttribute() When AttributeCount=0, <NONEMPTY1>ABCDE</NONEMPTY1> ") });
+                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToNextAttribute3) { Attribute = new VariationAttribute("MoveToNextAttribute() When iOrdinal=0, with namespace") });
+                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToNextAttribute4) { Attribute = new VariationAttribute("MoveToNextAttribute() When iOrdinal=0, without namespace") });
+                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToFirstAttribute5) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, with namespace") });
+                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToFirstAttribute6) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=mIddle, without namespace") });
+                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToFirstAttribute7) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, with namespace") });
+                    this.AddChild(new TestVariation(tcMoveToNextAttribute.MoveToFirstAttribute8) { Attribute = new VariationAttribute("MoveToFirstAttribute() When iOrdinal=end, without namespace") });
                 }
             }
-            public partial class TCAttributeTest : BridgeHelpers
+            public class TCAttributeTest : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCAttributeTest
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_None) { Attribute = new VariationAttribute("Attribute Test On None") });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_Element) { Attribute = new VariationAttribute("Attribute Test  On Element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_Text) { Attribute = new VariationAttribute("Attribute Test On Text") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_CDATA) { Attribute = new VariationAttribute("Attribute Test On CDATA") });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("Attribute Test On ProcessingInstruction") });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_Comment) { Attribute = new VariationAttribute("AttributeTest On Comment") });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_DocumentType) { Attribute = new VariationAttribute("AttributeTest On DocumentType") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_Whitespace) { Attribute = new VariationAttribute("AttributeTest On Whitespace") });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_EndElement) { Attribute = new VariationAttribute("AttributeTest On EndElement") });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_XmlDeclaration) { Attribute = new VariationAttribute("AttributeTest On XmlDeclaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestAttributeTestNodeType_EndEntity) { Attribute = new VariationAttribute("AttributeTest On EndEntity") });
+                    var tcAttributeTest = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCAttributeTest();
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_None) { Attribute = new VariationAttribute("Attribute Test On None") });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_Element) { Attribute = new VariationAttribute("Attribute Test  On Element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_Text) { Attribute = new VariationAttribute("Attribute Test On Text") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_CDATA) { Attribute = new VariationAttribute("Attribute Test On CDATA") });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_ProcessingInstruction) { Attribute = new VariationAttribute("Attribute Test On ProcessingInstruction") });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_Comment) { Attribute = new VariationAttribute("AttributeTest On Comment") });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_DocumentType) { Attribute = new VariationAttribute("AttributeTest On DocumentType") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_Whitespace) { Attribute = new VariationAttribute("AttributeTest On Whitespace") });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_EndElement) { Attribute = new VariationAttribute("AttributeTest On EndElement") });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_XmlDeclaration) { Attribute = new VariationAttribute("AttributeTest On XmlDeclaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcAttributeTest.TestAttributeTestNodeType_EndEntity) { Attribute = new VariationAttribute("AttributeTest On EndEntity") });
                 }
             }
-            public partial class TCXmlns : BridgeHelpers
+            public class TCXmlns : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlns
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TXmlns1) { Attribute = new VariationAttribute("Name, LocalName, Prefix and Value with xmlns=ns attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TXmlns2) { Attribute = new VariationAttribute("Name, LocalName, Prefix and Value with xmlns:p=ns attribute") });
-                    this.AddChild(new TestVariation(TXmlns3) { Attribute = new VariationAttribute("LookupNamespace with xmlns=ns attribute") });
-                    this.AddChild(new TestVariation(TXmlns4) { Attribute = new VariationAttribute("MoveToAttribute access on xmlns attribute") });
-                    this.AddChild(new TestVariation(TXmlns5) { Attribute = new VariationAttribute("GetAttribute access on xmlns attribute") });
-                    this.AddChild(new TestVariation(TXmlns6) { Attribute = new VariationAttribute("this[xmlns] attribute access") });
+                    var tcXmlns = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCXmlns();
+                    this.AddChild(new TestVariation(tcXmlns.TXmlns1) { Attribute = new VariationAttribute("Name, LocalName, Prefix and Value with xmlns=ns attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlns.TXmlns2) { Attribute = new VariationAttribute("Name, LocalName, Prefix and Value with xmlns:p=ns attribute") });
+                    this.AddChild(new TestVariation(tcXmlns.TXmlns3) { Attribute = new VariationAttribute("LookupNamespace with xmlns=ns attribute") });
+                    this.AddChild(new TestVariation(tcXmlns.TXmlns4) { Attribute = new VariationAttribute("MoveToAttribute access on xmlns attribute") });
+                    this.AddChild(new TestVariation(tcXmlns.TXmlns5) { Attribute = new VariationAttribute("GetAttribute access on xmlns attribute") });
+                    this.AddChild(new TestVariation(tcXmlns.TXmlns6) { Attribute = new VariationAttribute("this[xmlns] attribute access") });
                 }
             }
-            public partial class TCXmlnsPrefix : BridgeHelpers
+            public class TCXmlnsPrefix : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlnsPrefix
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TXmlnsPrefix1) { Attribute = new VariationAttribute("NamespaceURI of xmlns:a attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TXmlnsPrefix2) { Attribute = new VariationAttribute("NamespaceURI of element/attribute with xmlns attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TXmlnsPrefix3) { Attribute = new VariationAttribute("LookupNamespace with xmlns prefix") });
-                    this.AddChild(new TestVariation(TXmlnsPrefix4) { Attribute = new VariationAttribute("Define prefix for 'www.w3.org/2000/xmlns'") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TXmlnsPrefix5) { Attribute = new VariationAttribute("Redefine namespace attached to xmlns prefix") });
+                    var tcXmlnsPrefix = new CXMLReaderAttrTestFunctionalTests.XNodeReaderTests.TCXmlnsPrefix();
+                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix1) { Attribute = new VariationAttribute("NamespaceURI of xmlns:a attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix2) { Attribute = new VariationAttribute("NamespaceURI of element/attribute with xmlns attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix3) { Attribute = new VariationAttribute("LookupNamespace with xmlns prefix") });
+                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix4) { Attribute = new VariationAttribute("Define prefix for 'www.w3.org/2000/xmlns'") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcXmlnsPrefix.TXmlnsPrefix5) { Attribute = new VariationAttribute("Redefine namespace attached to xmlns prefix") });
                 }
             }
-            public partial class TCReadState : BridgeHelpers
+            public class TCReadState : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadState
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(ReadState1) { Attribute = new VariationAttribute("XmlReader ReadState Initial") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadState2) { Attribute = new VariationAttribute("XmlReader ReadState Interactive") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadState3) { Attribute = new VariationAttribute("XmlReader ReadState EndOfFile") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadState4) { Attribute = new VariationAttribute("XmlReader ReadState Initial") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadState5) { Attribute = new VariationAttribute("XmlReader ReadState EndOfFile") { Priority = 0 } });
+                    var tcReadState = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCReadState();
+                    this.AddChild(new TestVariation(tcReadState.ReadState1) { Attribute = new VariationAttribute("XmlReader ReadState Initial") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadState.ReadState2) { Attribute = new VariationAttribute("XmlReader ReadState Interactive") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadState.ReadState3) { Attribute = new VariationAttribute("XmlReader ReadState EndOfFile") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadState.ReadState4) { Attribute = new VariationAttribute("XmlReader ReadState Initial") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadState.ReadState5) { Attribute = new VariationAttribute("XmlReader ReadState EndOfFile") { Priority = 0 } });
                 }
             }
-            public partial class TCReadInnerXml : BridgeHelpers
+            public class TCReadInnerXml : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadInnerXml
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadInnerXml1) { Attribute = new VariationAttribute("ReadInnerXml on Empty Tag") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml on non Empty Tag") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadInnerXml3) { Attribute = new VariationAttribute("ReadInnerXml on non Empty Tag with text content") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadInnerXml6) { Attribute = new VariationAttribute("ReadInnerXml with multiple Level of elements") });
-                    this.AddChild(new TestVariation(TestReadInnerXml7) { Attribute = new VariationAttribute("ReadInnerXml with multiple Level of elements, text and attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadInnerXml8) { Attribute = new VariationAttribute("ReadInnerXml with entity references, EntityHandling = ExpandEntities") });
-                    this.AddChild(new TestVariation(TestReadInnerXml9) { Attribute = new VariationAttribute("ReadInnerXml on attribute node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadInnerXml10) { Attribute = new VariationAttribute("ReadInnerXml on attribute node with entity reference in value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadInnerXml11) { Attribute = new VariationAttribute("ReadInnerXml on Text") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadInnerXml12) { Attribute = new VariationAttribute("ReadInnerXml on CDATA") });
-                    this.AddChild(new TestVariation(TestReadInnerXml13) { Attribute = new VariationAttribute("ReadInnerXml on ProcessingInstruction") });
-                    this.AddChild(new TestVariation(TestReadInnerXml14) { Attribute = new VariationAttribute("ReadInnerXml on Comment") });
-                    this.AddChild(new TestVariation(TestReadInnerXml16) { Attribute = new VariationAttribute("ReadInnerXml on EndElement") });
-                    this.AddChild(new TestVariation(TestReadInnerXml17) { Attribute = new VariationAttribute("ReadInnerXml on XmlDeclaration") });
-                    this.AddChild(new TestVariation(TestReadInnerXml18) { Attribute = new VariationAttribute("Current node after ReadInnerXml on element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadInnerXml19) { Attribute = new VariationAttribute("Current node after ReadInnerXml on element") });
-                    this.AddChild(new TestVariation(TestTextReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml with entity references, EntityHandling = ExpandCharEntites") });
-                    this.AddChild(new TestVariation(TestTextReadInnerXml4) { Attribute = new VariationAttribute("ReadInnerXml on EntityReference") });
-                    this.AddChild(new TestVariation(TestTextReadInnerXml5) { Attribute = new VariationAttribute("ReadInnerXml on EndEntity") });
-                    this.AddChild(new TestVariation(TestTextReadInnerXml18) { Attribute = new VariationAttribute("One large element") });
+                    var tcReadInnerXml = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCReadInnerXml();
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml1) { Attribute = new VariationAttribute("ReadInnerXml on Empty Tag") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml on non Empty Tag") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml3) { Attribute = new VariationAttribute("ReadInnerXml on non Empty Tag with text content") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml6) { Attribute = new VariationAttribute("ReadInnerXml with multiple Level of elements") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml7) { Attribute = new VariationAttribute("ReadInnerXml with multiple Level of elements, text and attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml8) { Attribute = new VariationAttribute("ReadInnerXml with entity references, EntityHandling = ExpandEntities") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml9) { Attribute = new VariationAttribute("ReadInnerXml on attribute node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml10) { Attribute = new VariationAttribute("ReadInnerXml on attribute node with entity reference in value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml11) { Attribute = new VariationAttribute("ReadInnerXml on Text") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml12) { Attribute = new VariationAttribute("ReadInnerXml on CDATA") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml13) { Attribute = new VariationAttribute("ReadInnerXml on ProcessingInstruction") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml14) { Attribute = new VariationAttribute("ReadInnerXml on Comment") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml16) { Attribute = new VariationAttribute("ReadInnerXml on EndElement") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml17) { Attribute = new VariationAttribute("ReadInnerXml on XmlDeclaration") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml18) { Attribute = new VariationAttribute("Current node after ReadInnerXml on element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestReadInnerXml19) { Attribute = new VariationAttribute("Current node after ReadInnerXml on element") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestTextReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml with entity references, EntityHandling = ExpandCharEntites") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestTextReadInnerXml4) { Attribute = new VariationAttribute("ReadInnerXml on EntityReference") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestTextReadInnerXml5) { Attribute = new VariationAttribute("ReadInnerXml on EndEntity") });
+                    this.AddChild(new TestVariation(tcReadInnerXml.TestTextReadInnerXml18) { Attribute = new VariationAttribute("One large element") });
                 }
             }
-            public partial class TCMoveToContent : BridgeHelpers
+            public class TCMoveToContent : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToContent
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestMoveToContent1) { Attribute = new VariationAttribute("MoveToContent on Skip XmlDeclaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestMoveToContent2) { Attribute = new VariationAttribute("MoveToContent on Read through All valid Content Node(Element, Text, CDATA, and EndElement)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestMoveToContent3) { Attribute = new VariationAttribute("MoveToContent on Read through All invalid Content Node(PI, Comment and whitespace)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestMoveToContent4) { Attribute = new VariationAttribute("MoveToContent on Read through Mix valid and Invalid Content Node") });
-                    this.AddChild(new TestVariation(TestMoveToContent5) { Attribute = new VariationAttribute("MoveToContent on Attribute") { Priority = 0 } });
+                    var tcMoveToContent = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCMoveToContent();
+                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent1) { Attribute = new VariationAttribute("MoveToContent on Skip XmlDeclaration") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent2) { Attribute = new VariationAttribute("MoveToContent on Read through All valid Content Node(Element, Text, CDATA, and EndElement)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent3) { Attribute = new VariationAttribute("MoveToContent on Read through All invalid Content Node(PI, Comment and whitespace)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent4) { Attribute = new VariationAttribute("MoveToContent on Read through Mix valid and Invalid Content Node") });
+                    this.AddChild(new TestVariation(tcMoveToContent.TestMoveToContent5) { Attribute = new VariationAttribute("MoveToContent on Attribute") { Priority = 0 } });
                 }
             }
-            public partial class TCIsStartElement : BridgeHelpers
+            public class TCIsStartElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCIsStartElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestIsStartElement1) { Attribute = new VariationAttribute("IsStartElement on Regular Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestIsStartElement2) { Attribute = new VariationAttribute("IsStartElement on Empty Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestIsStartElement3) { Attribute = new VariationAttribute("IsStartElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestIsStartElement4) { Attribute = new VariationAttribute("IsStartElement on Empty Tag, with default namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestIsStartElement5) { Attribute = new VariationAttribute("IsStartElement with Name=String.Empty") });
-                    this.AddChild(new TestVariation(TestIsStartElement6) { Attribute = new VariationAttribute("IsStartElement on Empty Element with Name and Namespace=String.Empty") });
-                    this.AddChild(new TestVariation(TestIsStartElement7) { Attribute = new VariationAttribute("IsStartElement on CDATA") });
-                    this.AddChild(new TestVariation(TestIsStartElement8) { Attribute = new VariationAttribute("IsStartElement on EndElement, no namespace") });
-                    this.AddChild(new TestVariation(TestIsStartElement9) { Attribute = new VariationAttribute("IsStartElement on EndElement, with namespace") });
-                    this.AddChild(new TestVariation(TestIsStartElement10) { Attribute = new VariationAttribute("IsStartElement on Attribute") });
-                    this.AddChild(new TestVariation(TestIsStartElement11) { Attribute = new VariationAttribute("IsStartElement on Text") });
-                    this.AddChild(new TestVariation(TestIsStartElement12) { Attribute = new VariationAttribute("IsStartElement on ProcessingInstruction") });
-                    this.AddChild(new TestVariation(TestIsStartElement13) { Attribute = new VariationAttribute("IsStartElement on Comment") });
+                    var tcIsStartElement = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCIsStartElement();
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement1) { Attribute = new VariationAttribute("IsStartElement on Regular Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement2) { Attribute = new VariationAttribute("IsStartElement on Empty Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement3) { Attribute = new VariationAttribute("IsStartElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement4) { Attribute = new VariationAttribute("IsStartElement on Empty Tag, with default namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement5) { Attribute = new VariationAttribute("IsStartElement with Name=String.Empty") });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement6) { Attribute = new VariationAttribute("IsStartElement on Empty Element with Name and Namespace=String.Empty") });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement7) { Attribute = new VariationAttribute("IsStartElement on CDATA") });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement8) { Attribute = new VariationAttribute("IsStartElement on EndElement, no namespace") });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement9) { Attribute = new VariationAttribute("IsStartElement on EndElement, with namespace") });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement10) { Attribute = new VariationAttribute("IsStartElement on Attribute") });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement11) { Attribute = new VariationAttribute("IsStartElement on Text") });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement12) { Attribute = new VariationAttribute("IsStartElement on ProcessingInstruction") });
+                    this.AddChild(new TestVariation(tcIsStartElement.TestIsStartElement13) { Attribute = new VariationAttribute("IsStartElement on Comment") });
                 }
             }
-            public partial class TCReadStartElement : BridgeHelpers
+            public class TCReadStartElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadStartElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadStartElement1) { Attribute = new VariationAttribute("ReadStartElement on Regular Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadStartElement2) { Attribute = new VariationAttribute("ReadStartElement on Empty Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadStartElement3) { Attribute = new VariationAttribute("ReadStartElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadStartElement4) { Attribute = new VariationAttribute("Passing ns=String.EmptyErrorCase: ReadStartElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadStartElement5) { Attribute = new VariationAttribute("Passing no ns: ReadStartElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadStartElement6) { Attribute = new VariationAttribute("ReadStartElement on Empty Tag, with namespace") });
-                    this.AddChild(new TestVariation(TestReadStartElement7) { Attribute = new VariationAttribute("ErrorCase: ReadStartElement on Empty Tag, with namespace, passing ns=String.Empty") });
-                    this.AddChild(new TestVariation(TestReadStartElement8) { Attribute = new VariationAttribute("ReadStartElement on Empty Tag, with namespace, passing no ns") });
-                    this.AddChild(new TestVariation(TestReadStartElement9) { Attribute = new VariationAttribute("ReadStartElement with Name=String.Empty") });
-                    this.AddChild(new TestVariation(TestReadStartElement10) { Attribute = new VariationAttribute("ReadStartElement on Empty Element with Name and Namespace=String.Empty") });
-                    this.AddChild(new TestVariation(TestReadStartElement11) { Attribute = new VariationAttribute("ReadStartElement on CDATA") });
-                    this.AddChild(new TestVariation(TestReadStartElement12) { Attribute = new VariationAttribute("ReadStartElement() on EndElement, no namespace") });
-                    this.AddChild(new TestVariation(TestReadStartElement13) { Attribute = new VariationAttribute("ReadStartElement(n) on EndElement, no namespace") });
-                    this.AddChild(new TestVariation(TestReadStartElement14) { Attribute = new VariationAttribute("ReadStartElement(n, String.Empty) on EndElement, no namespace") });
-                    this.AddChild(new TestVariation(TestReadStartElement15) { Attribute = new VariationAttribute("ReadStartElement() on EndElement, with namespace") });
-                    this.AddChild(new TestVariation(TestReadStartElement16) { Attribute = new VariationAttribute("ReadStartElement(n,ns) on EndElement, with namespace") });
+                    var tcReadStartElement = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCReadStartElement();
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement1) { Attribute = new VariationAttribute("ReadStartElement on Regular Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement2) { Attribute = new VariationAttribute("ReadStartElement on Empty Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement3) { Attribute = new VariationAttribute("ReadStartElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement4) { Attribute = new VariationAttribute("Passing ns=String.EmptyErrorCase: ReadStartElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement5) { Attribute = new VariationAttribute("Passing no ns: ReadStartElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement6) { Attribute = new VariationAttribute("ReadStartElement on Empty Tag, with namespace") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement7) { Attribute = new VariationAttribute("ErrorCase: ReadStartElement on Empty Tag, with namespace, passing ns=String.Empty") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement8) { Attribute = new VariationAttribute("ReadStartElement on Empty Tag, with namespace, passing no ns") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement9) { Attribute = new VariationAttribute("ReadStartElement with Name=String.Empty") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement10) { Attribute = new VariationAttribute("ReadStartElement on Empty Element with Name and Namespace=String.Empty") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement11) { Attribute = new VariationAttribute("ReadStartElement on CDATA") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement12) { Attribute = new VariationAttribute("ReadStartElement() on EndElement, no namespace") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement13) { Attribute = new VariationAttribute("ReadStartElement(n) on EndElement, no namespace") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement14) { Attribute = new VariationAttribute("ReadStartElement(n, String.Empty) on EndElement, no namespace") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement15) { Attribute = new VariationAttribute("ReadStartElement() on EndElement, with namespace") });
+                    this.AddChild(new TestVariation(tcReadStartElement.TestReadStartElement16) { Attribute = new VariationAttribute("ReadStartElement(n,ns) on EndElement, with namespace") });
                 }
             }
-            public partial class TCReadEndElement : BridgeHelpers
+            public class TCReadEndElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadEndElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadEndElement3) { Attribute = new VariationAttribute("ReadEndElement on Start Element, no namespace") });
-                    this.AddChild(new TestVariation(TestReadEndElement4) { Attribute = new VariationAttribute("ReadEndElement on Empty Element, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadEndElement5) { Attribute = new VariationAttribute("ReadEndElement on regular Element, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadEndElement6) { Attribute = new VariationAttribute("ReadEndElement on Empty Tag, with namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadEndElement7) { Attribute = new VariationAttribute("ReadEndElement on CDATA") });
-                    this.AddChild(new TestVariation(TestReadEndElement9) { Attribute = new VariationAttribute("ReadEndElement on Text") });
-                    this.AddChild(new TestVariation(TestReadEndElement10) { Attribute = new VariationAttribute("ReadEndElement on ProcessingInstruction") });
-                    this.AddChild(new TestVariation(TestReadEndElement11) { Attribute = new VariationAttribute("ReadEndElement on Comment") });
-                    this.AddChild(new TestVariation(TestReadEndElement13) { Attribute = new VariationAttribute("ReadEndElement on XmlDeclaration") });
-                    this.AddChild(new TestVariation(TestTextReadEndElement1) { Attribute = new VariationAttribute("ReadEndElement on EntityReference") });
-                    this.AddChild(new TestVariation(TestTextReadEndElement2) { Attribute = new VariationAttribute("ReadEndElement on EndEntity") });
+                    var tcReadEndElement = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCReadEndElement();
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement3) { Attribute = new VariationAttribute("ReadEndElement on Start Element, no namespace") });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement4) { Attribute = new VariationAttribute("ReadEndElement on Empty Element, no namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement5) { Attribute = new VariationAttribute("ReadEndElement on regular Element, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement6) { Attribute = new VariationAttribute("ReadEndElement on Empty Tag, with namespace") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement7) { Attribute = new VariationAttribute("ReadEndElement on CDATA") });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement9) { Attribute = new VariationAttribute("ReadEndElement on Text") });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement10) { Attribute = new VariationAttribute("ReadEndElement on ProcessingInstruction") });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement11) { Attribute = new VariationAttribute("ReadEndElement on Comment") });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestReadEndElement13) { Attribute = new VariationAttribute("ReadEndElement on XmlDeclaration") });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestTextReadEndElement1) { Attribute = new VariationAttribute("ReadEndElement on EntityReference") });
+                    this.AddChild(new TestVariation(tcReadEndElement.TestTextReadEndElement2) { Attribute = new VariationAttribute("ReadEndElement on EndEntity") });
                 }
             }
 
-            public partial class TCMoveToElement : BridgeHelpers
+            public class TCMoveToElement : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCMoveToElement
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Attribute node") });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Element node") });
-                    this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Comment node") });
+                    var tcMoveToElement = new CXmlReaderReadEtcFunctionalTests.XNodeReaderTests.TCMoveToElement();
+                    this.AddChild(new TestVariation(tcMoveToElement.v1) { Attribute = new VariationAttribute("Attribute node") });
+                    this.AddChild(new TestVariation(tcMoveToElement.v2) { Attribute = new VariationAttribute("Element node") });
+                    this.AddChild(new TestVariation(tcMoveToElement.v5) { Attribute = new VariationAttribute("Comment node") });
                 }
             }
-            public partial class ErrorConditions : BridgeHelpers
+            public class ErrorConditions : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+ErrorConditions
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(Variation1) { Attribute = new VariationAttribute("Move to Attribute using []") });
-                    this.AddChild(new TestVariation(Variation2) { Attribute = new VariationAttribute("GetAttribute") });
-                    this.AddChild(new TestVariation(Variation3) { Attribute = new VariationAttribute("IsStartElement") });
-                    this.AddChild(new TestVariation(Variation4) { Attribute = new VariationAttribute("LookupNamespace") });
-                    this.AddChild(new TestVariation(Variation5) { Attribute = new VariationAttribute("MoveToAttribute") });
-                    this.AddChild(new TestVariation(Variation6) { Attribute = new VariationAttribute("Other APIs") });
-                    this.AddChild(new TestVariation(Variation7) { Attribute = new VariationAttribute("ReadContentAs(null, null)") });
-                    this.AddChild(new TestVariation(Variation8) { Attribute = new VariationAttribute("ReadContentAsBase64") });
-                    this.AddChild(new TestVariation(Variation9) { Attribute = new VariationAttribute("ReadContentAsBinHex") });
-                    this.AddChild(new TestVariation(Variation10) { Attribute = new VariationAttribute("ReadContentAsBoolean") });
-                    this.AddChild(new TestVariation(Variation11b) { Attribute = new VariationAttribute("ReadContentAsDateTimeOffset") });
-                    this.AddChild(new TestVariation(Variation12) { Attribute = new VariationAttribute("ReadContentAsDecimal") });
-                    this.AddChild(new TestVariation(Variation13) { Attribute = new VariationAttribute("ReadContentAsDouble") });
-                    this.AddChild(new TestVariation(Variation14) { Attribute = new VariationAttribute("ReadContentAsFloat") });
-                    this.AddChild(new TestVariation(Variation15) { Attribute = new VariationAttribute("ReadContentAsInt") });
-                    this.AddChild(new TestVariation(Variation16) { Attribute = new VariationAttribute("ReadContentAsLong") });
-                    this.AddChild(new TestVariation(Variation17) { Attribute = new VariationAttribute("ReadElementContentAs(null, null)") });
-                    this.AddChild(new TestVariation(Variation18) { Attribute = new VariationAttribute("ReadElementContentAsBase64") });
-                    this.AddChild(new TestVariation(Variation19) { Attribute = new VariationAttribute("ReadElementContentAsBinHex") });
-                    this.AddChild(new TestVariation(Variation20) { Attribute = new VariationAttribute("ReadElementContentAsBoolean") });
-                    this.AddChild(new TestVariation(Variation22) { Attribute = new VariationAttribute("ReadElementContentAsDecimal") });
-                    this.AddChild(new TestVariation(Variation23) { Attribute = new VariationAttribute("ReadElementContentAsDouble") });
-                    this.AddChild(new TestVariation(Variation24) { Attribute = new VariationAttribute("ReadElementContentAsFloat") });
-                    this.AddChild(new TestVariation(Variation25) { Attribute = new VariationAttribute("ReadElementContentAsInt") });
-                    this.AddChild(new TestVariation(Variation26) { Attribute = new VariationAttribute("ReadElementContentAsLong") });
-                    this.AddChild(new TestVariation(Variation27) { Attribute = new VariationAttribute("ReadElementContentAsObject") });
-                    this.AddChild(new TestVariation(Variation28) { Attribute = new VariationAttribute("ReadElementContentAsString") });
-                    this.AddChild(new TestVariation(Variation30) { Attribute = new VariationAttribute("ReadStartElement") });
-                    this.AddChild(new TestVariation(Variation31) { Attribute = new VariationAttribute("ReadToDescendant(null)") });
-                    this.AddChild(new TestVariation(Variation32) { Attribute = new VariationAttribute("ReadToDescendant(String.Empty)") });
-                    this.AddChild(new TestVariation(Variation33) { Attribute = new VariationAttribute("ReadToFollowing(null)") });
-                    this.AddChild(new TestVariation(Variation34) { Attribute = new VariationAttribute("ReadToFollowing(String.Empty)") });
-                    this.AddChild(new TestVariation(Variation35) { Attribute = new VariationAttribute("ReadToNextSibling(null)") });
-                    this.AddChild(new TestVariation(Variation36) { Attribute = new VariationAttribute("ReadToNextSibling(String.Empty)") });
-                    this.AddChild(new TestVariation(Variation37) { Attribute = new VariationAttribute("ReadValueChunk") });
-                    this.AddChild(new TestVariation(Variation38) { Attribute = new VariationAttribute("ReadElementContentAsObject") });
-                    this.AddChild(new TestVariation(Variation39) { Attribute = new VariationAttribute("ReadElementContentAsString") });
+                    var errorConditions = new XNodeReaderErrorConditionsFunctionalTests.XNodeReaderTests.ErrorConditions();
+                    this.AddChild(new TestVariation(errorConditions.Variation1) { Attribute = new VariationAttribute("Move to Attribute using []") });
+                    this.AddChild(new TestVariation(errorConditions.Variation2) { Attribute = new VariationAttribute("GetAttribute") });
+                    this.AddChild(new TestVariation(errorConditions.Variation3) { Attribute = new VariationAttribute("IsStartElement") });
+                    this.AddChild(new TestVariation(errorConditions.Variation4) { Attribute = new VariationAttribute("LookupNamespace") });
+                    this.AddChild(new TestVariation(errorConditions.Variation5) { Attribute = new VariationAttribute("MoveToAttribute") });
+                    this.AddChild(new TestVariation(errorConditions.Variation6) { Attribute = new VariationAttribute("Other APIs") });
+                    this.AddChild(new TestVariation(errorConditions.Variation7) { Attribute = new VariationAttribute("ReadContentAs(null, null)") });
+                    this.AddChild(new TestVariation(errorConditions.Variation8) { Attribute = new VariationAttribute("ReadContentAsBase64") });
+                    this.AddChild(new TestVariation(errorConditions.Variation9) { Attribute = new VariationAttribute("ReadContentAsBinHex") });
+                    this.AddChild(new TestVariation(errorConditions.Variation10) { Attribute = new VariationAttribute("ReadContentAsBoolean") });
+                    this.AddChild(new TestVariation(errorConditions.Variation11b) { Attribute = new VariationAttribute("ReadContentAsDateTimeOffset") });
+                    this.AddChild(new TestVariation(errorConditions.Variation12) { Attribute = new VariationAttribute("ReadContentAsDecimal") });
+                    this.AddChild(new TestVariation(errorConditions.Variation13) { Attribute = new VariationAttribute("ReadContentAsDouble") });
+                    this.AddChild(new TestVariation(errorConditions.Variation14) { Attribute = new VariationAttribute("ReadContentAsFloat") });
+                    this.AddChild(new TestVariation(errorConditions.Variation15) { Attribute = new VariationAttribute("ReadContentAsInt") });
+                    this.AddChild(new TestVariation(errorConditions.Variation16) { Attribute = new VariationAttribute("ReadContentAsLong") });
+                    this.AddChild(new TestVariation(errorConditions.Variation17) { Attribute = new VariationAttribute("ReadElementContentAs(null, null)") });
+                    this.AddChild(new TestVariation(errorConditions.Variation18) { Attribute = new VariationAttribute("ReadElementContentAsBase64") });
+                    this.AddChild(new TestVariation(errorConditions.Variation19) { Attribute = new VariationAttribute("ReadElementContentAsBinHex") });
+                    this.AddChild(new TestVariation(errorConditions.Variation20) { Attribute = new VariationAttribute("ReadElementContentAsBoolean") });
+                    this.AddChild(new TestVariation(errorConditions.Variation22) { Attribute = new VariationAttribute("ReadElementContentAsDecimal") });
+                    this.AddChild(new TestVariation(errorConditions.Variation23) { Attribute = new VariationAttribute("ReadElementContentAsDouble") });
+                    this.AddChild(new TestVariation(errorConditions.Variation24) { Attribute = new VariationAttribute("ReadElementContentAsFloat") });
+                    this.AddChild(new TestVariation(errorConditions.Variation25) { Attribute = new VariationAttribute("ReadElementContentAsInt") });
+                    this.AddChild(new TestVariation(errorConditions.Variation26) { Attribute = new VariationAttribute("ReadElementContentAsLong") });
+                    this.AddChild(new TestVariation(errorConditions.Variation27) { Attribute = new VariationAttribute("ReadElementContentAsObject") });
+                    this.AddChild(new TestVariation(errorConditions.Variation28) { Attribute = new VariationAttribute("ReadElementContentAsString") });
+                    this.AddChild(new TestVariation(errorConditions.Variation30) { Attribute = new VariationAttribute("ReadStartElement") });
+                    this.AddChild(new TestVariation(errorConditions.Variation31) { Attribute = new VariationAttribute("ReadToDescendant(null)") });
+                    this.AddChild(new TestVariation(errorConditions.Variation32) { Attribute = new VariationAttribute("ReadToDescendant(String.Empty)") });
+                    this.AddChild(new TestVariation(errorConditions.Variation33) { Attribute = new VariationAttribute("ReadToFollowing(null)") });
+                    this.AddChild(new TestVariation(errorConditions.Variation34) { Attribute = new VariationAttribute("ReadToFollowing(String.Empty)") });
+                    this.AddChild(new TestVariation(errorConditions.Variation35) { Attribute = new VariationAttribute("ReadToNextSibling(null)") });
+                    this.AddChild(new TestVariation(errorConditions.Variation36) { Attribute = new VariationAttribute("ReadToNextSibling(String.Empty)") });
+                    this.AddChild(new TestVariation(errorConditions.Variation37) { Attribute = new VariationAttribute("ReadValueChunk") });
+                    this.AddChild(new TestVariation(errorConditions.Variation38) { Attribute = new VariationAttribute("ReadElementContentAsObject") });
+                    this.AddChild(new TestVariation(errorConditions.Variation39) { Attribute = new VariationAttribute("ReadElementContentAsString") });
                 }
             }
-            public partial class TCXMLIntegrityBase : BridgeHelpers
+            public class TCXMLIntegrityBase : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXMLIntegrityBase
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(GetXmlReaderNodeType) { Attribute = new VariationAttribute("NodeType") });
-                    this.AddChild(new TestVariation(GetXmlReaderName) { Attribute = new VariationAttribute("Name") });
-                    this.AddChild(new TestVariation(GetXmlReaderLocalName) { Attribute = new VariationAttribute("LocalName") });
-                    this.AddChild(new TestVariation(Namespace) { Attribute = new VariationAttribute("NamespaceURI") });
-                    this.AddChild(new TestVariation(Prefix) { Attribute = new VariationAttribute("Prefix") });
-                    this.AddChild(new TestVariation(HasValue) { Attribute = new VariationAttribute("HasValue") });
-                    this.AddChild(new TestVariation(GetXmlReaderValue) { Attribute = new VariationAttribute("Value") });
-                    this.AddChild(new TestVariation(GetDepth) { Attribute = new VariationAttribute("Depth") });
-                    this.AddChild(new TestVariation(GetBaseURI) { Attribute = new VariationAttribute("BaseURI") });
-                    this.AddChild(new TestVariation(IsEmptyElement) { Attribute = new VariationAttribute("IsEmptyElement") });
-                    this.AddChild(new TestVariation(IsDefault) { Attribute = new VariationAttribute("IsDefault") });
-                    this.AddChild(new TestVariation(GetXmlSpace) { Attribute = new VariationAttribute("XmlSpace") });
-                    this.AddChild(new TestVariation(GetXmlLang) { Attribute = new VariationAttribute("XmlLang") });
-                    this.AddChild(new TestVariation(AttributeCount) { Attribute = new VariationAttribute("AttributeCount") });
-                    this.AddChild(new TestVariation(HasAttribute) { Attribute = new VariationAttribute("HasAttributes") });
-                    this.AddChild(new TestVariation(GetAttributeName) { Attribute = new VariationAttribute("GetAttributes(name)") });
-                    this.AddChild(new TestVariation(GetAttributeEmptyName) { Attribute = new VariationAttribute("GetAttribute(String.Empty)") });
-                    this.AddChild(new TestVariation(GetAttributeNameNamespace) { Attribute = new VariationAttribute("GetAttribute(name,ns)") });
-                    this.AddChild(new TestVariation(GetAttributeEmptyNameNamespace) { Attribute = new VariationAttribute("GetAttribute(String.Empty, String.Empty)") });
-                    this.AddChild(new TestVariation(GetAttributeOrdinal) { Attribute = new VariationAttribute("GetAttribute(i)") });
-                    this.AddChild(new TestVariation(HelperThisOrdinal) { Attribute = new VariationAttribute("this[i]") });
-                    this.AddChild(new TestVariation(HelperThisName) { Attribute = new VariationAttribute("this[name]") });
-                    this.AddChild(new TestVariation(HelperThisNameNamespace) { Attribute = new VariationAttribute("this[name,namespace]") });
-                    this.AddChild(new TestVariation(MoveToAttributeName) { Attribute = new VariationAttribute("MoveToAttribute(name)") });
-                    this.AddChild(new TestVariation(MoveToAttributeNameNamespace) { Attribute = new VariationAttribute("MoveToAttributeNameNamespace(name,ns)") });
-                    this.AddChild(new TestVariation(MoveToAttributeOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i)") });
-                    this.AddChild(new TestVariation(MoveToFirstAttribute) { Attribute = new VariationAttribute("MoveToFirstAttribute()") });
-                    this.AddChild(new TestVariation(MoveToNextAttribute) { Attribute = new VariationAttribute("MoveToNextAttribute()") });
-                    this.AddChild(new TestVariation(MoveToElement) { Attribute = new VariationAttribute("MoveToElement()") });
-                    this.AddChild(new TestVariation(ReadTestAfterClose) { Attribute = new VariationAttribute("Read") });
-                    this.AddChild(new TestVariation(GetEOF) { Attribute = new VariationAttribute("GetEOF") });
-                    this.AddChild(new TestVariation(GetReadState) { Attribute = new VariationAttribute("GetReadState") });
-                    this.AddChild(new TestVariation(XMLSkip) { Attribute = new VariationAttribute("Skip") });
-                    this.AddChild(new TestVariation(TestNameTable) { Attribute = new VariationAttribute("NameTable") });
-                    this.AddChild(new TestVariation(ReadInnerXmlTestAfterClose) { Attribute = new VariationAttribute("ReadInnerXml") });
-                    this.AddChild(new TestVariation(TestReadOuterXml) { Attribute = new VariationAttribute("ReadOuterXml") });
-                    this.AddChild(new TestVariation(TestMoveToContent) { Attribute = new VariationAttribute("MoveToContent") });
-                    this.AddChild(new TestVariation(TestIsStartElement) { Attribute = new VariationAttribute("IsStartElement") });
-                    this.AddChild(new TestVariation(TestIsStartElementName) { Attribute = new VariationAttribute("IsStartElement(name)") });
-                    this.AddChild(new TestVariation(TestIsStartElementName2) { Attribute = new VariationAttribute("IsStartElement(String.Empty)") });
-                    this.AddChild(new TestVariation(TestIsStartElementNameNs) { Attribute = new VariationAttribute("IsStartElement(name, ns)") });
-                    this.AddChild(new TestVariation(TestIsStartElementNameNs2) { Attribute = new VariationAttribute("IsStartElement(String.Empty,String.Empty)") });
-                    this.AddChild(new TestVariation(TestReadStartElement) { Attribute = new VariationAttribute("ReadStartElement") });
-                    this.AddChild(new TestVariation(TestReadStartElementName) { Attribute = new VariationAttribute("ReadStartElement(name)") });
-                    this.AddChild(new TestVariation(TestReadStartElementName2) { Attribute = new VariationAttribute("ReadStartElement(String.Empty)") });
-                    this.AddChild(new TestVariation(TestReadStartElementNameNs) { Attribute = new VariationAttribute("ReadStartElement(name, ns)") });
-                    this.AddChild(new TestVariation(TestReadStartElementNameNs2) { Attribute = new VariationAttribute("ReadStartElement(String.Empty,String.Empty)") });
-                    this.AddChild(new TestVariation(TestReadEndElement) { Attribute = new VariationAttribute("ReadEndElement") });
-                    this.AddChild(new TestVariation(LookupNamespace) { Attribute = new VariationAttribute("LookupNamespace") });
-                    this.AddChild(new TestVariation(ReadAttributeValue) { Attribute = new VariationAttribute("ReadAttributeValue") });
-                    this.AddChild(new TestVariation(CloseTest) { Attribute = new VariationAttribute("Close") });
+                    var tcXMLIntegrityBase = new IntegrityTestFunctionalTests.XNodeReaderTests.TCXMLIntegrityBase();
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlReaderNodeType) { Attribute = new VariationAttribute("NodeType") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlReaderName) { Attribute = new VariationAttribute("Name") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlReaderLocalName) { Attribute = new VariationAttribute("LocalName") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.Namespace) { Attribute = new VariationAttribute("NamespaceURI") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.Prefix) { Attribute = new VariationAttribute("Prefix") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HasValue) { Attribute = new VariationAttribute("HasValue") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlReaderValue) { Attribute = new VariationAttribute("Value") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetDepth) { Attribute = new VariationAttribute("Depth") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetBaseURI) { Attribute = new VariationAttribute("BaseURI") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.IsEmptyElement) { Attribute = new VariationAttribute("IsEmptyElement") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.IsDefault) { Attribute = new VariationAttribute("IsDefault") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlSpace) { Attribute = new VariationAttribute("XmlSpace") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetXmlLang) { Attribute = new VariationAttribute("XmlLang") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.AttributeCount) { Attribute = new VariationAttribute("AttributeCount") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HasAttribute) { Attribute = new VariationAttribute("HasAttributes") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeName) { Attribute = new VariationAttribute("GetAttributes(name)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeEmptyName) { Attribute = new VariationAttribute("GetAttribute(String.Empty)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeNameNamespace) { Attribute = new VariationAttribute("GetAttribute(name,ns)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeEmptyNameNamespace) { Attribute = new VariationAttribute("GetAttribute(String.Empty, String.Empty)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetAttributeOrdinal) { Attribute = new VariationAttribute("GetAttribute(i)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HelperThisOrdinal) { Attribute = new VariationAttribute("this[i]") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HelperThisName) { Attribute = new VariationAttribute("this[name]") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.HelperThisNameNamespace) { Attribute = new VariationAttribute("this[name,namespace]") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToAttributeName) { Attribute = new VariationAttribute("MoveToAttribute(name)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToAttributeNameNamespace) { Attribute = new VariationAttribute("MoveToAttributeNameNamespace(name,ns)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToAttributeOrdinal) { Attribute = new VariationAttribute("MoveToAttribute(i)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToFirstAttribute) { Attribute = new VariationAttribute("MoveToFirstAttribute()") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToNextAttribute) { Attribute = new VariationAttribute("MoveToNextAttribute()") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.MoveToElement) { Attribute = new VariationAttribute("MoveToElement()") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.ReadTestAfterClose) { Attribute = new VariationAttribute("Read") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetEOF) { Attribute = new VariationAttribute("GetEOF") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.GetReadState) { Attribute = new VariationAttribute("GetReadState") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.XMLSkip) { Attribute = new VariationAttribute("Skip") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestNameTable) { Attribute = new VariationAttribute("NameTable") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.ReadInnerXmlTestAfterClose) { Attribute = new VariationAttribute("ReadInnerXml") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadOuterXml) { Attribute = new VariationAttribute("ReadOuterXml") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestMoveToContent) { Attribute = new VariationAttribute("MoveToContent") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElement) { Attribute = new VariationAttribute("IsStartElement") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElementName) { Attribute = new VariationAttribute("IsStartElement(name)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElementName2) { Attribute = new VariationAttribute("IsStartElement(String.Empty)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElementNameNs) { Attribute = new VariationAttribute("IsStartElement(name, ns)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestIsStartElementNameNs2) { Attribute = new VariationAttribute("IsStartElement(String.Empty,String.Empty)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElement) { Attribute = new VariationAttribute("ReadStartElement") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElementName) { Attribute = new VariationAttribute("ReadStartElement(name)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElementName2) { Attribute = new VariationAttribute("ReadStartElement(String.Empty)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElementNameNs) { Attribute = new VariationAttribute("ReadStartElement(name, ns)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadStartElementNameNs2) { Attribute = new VariationAttribute("ReadStartElement(String.Empty,String.Empty)") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.TestReadEndElement) { Attribute = new VariationAttribute("ReadEndElement") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.LookupNamespace) { Attribute = new VariationAttribute("LookupNamespace") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.ReadAttributeValue) { Attribute = new VariationAttribute("ReadAttributeValue") });
+                    this.AddChild(new TestVariation(tcXMLIntegrityBase.CloseTest) { Attribute = new VariationAttribute("Close") });
                 }
             }
-            public partial class TCReadContentAsBase64 : BridgeHelpers
+            public class TCReadContentAsBase64 : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadContentAsBase64
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadBase64_1) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value") });
-                    this.AddChild(new TestVariation(TestReadBase64_2) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Num value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadBase64_3) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Text value") });
-                    this.AddChild(new TestVariation(TestReadBase64_5) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(TestReadBase64_6) { Attribute = new VariationAttribute("ReadBase64 Element with Long valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(ReadBase64_7) { Attribute = new VariationAttribute("ReadBase64 with count > buffer size") });
-                    this.AddChild(new TestVariation(ReadBase64_8) { Attribute = new VariationAttribute("ReadBase64 with count < 0") });
-                    this.AddChild(new TestVariation(ReadBase64_9) { Attribute = new VariationAttribute("ReadBase64 with index > buffer size") });
-                    this.AddChild(new TestVariation(ReadBase64_10) { Attribute = new VariationAttribute("ReadBase64 with index < 0") });
-                    this.AddChild(new TestVariation(ReadBase64_11) { Attribute = new VariationAttribute("ReadBase64 with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(ReadBase64_12) { Attribute = new VariationAttribute("ReadBase64 index & count =0") });
-                    this.AddChild(new TestVariation(TestReadBase64_13) { Attribute = new VariationAttribute("ReadBase64 Element multiple into same buffer (using offset), Priority=0") });
-                    this.AddChild(new TestVariation(TestReadBase64_14) { Attribute = new VariationAttribute("ReadBase64 with buffer == null") });
-                    this.AddChild(new TestVariation(TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
-                    this.AddChild(new TestVariation(TestReadBase64_16) { Attribute = new VariationAttribute("Read after partial ReadBase64") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
-                    this.AddChild(new TestVariation(TestReadBase64_18) { Attribute = new VariationAttribute("No op node types") });
-                    this.AddChild(new TestVariation(TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
-                    this.AddChild(new TestVariation(TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespace in the mIddle") });
-                    this.AddChild(new TestVariation(TestTextReadBase64_27) { Attribute = new VariationAttribute("ReadBase64 with = in the mIddle") });
-                    this.AddChild(new TestVariation(RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "10000000" } } });
-                    this.AddChild(new TestVariation(RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "1000000" } } });
-                    this.AddChild(new TestVariation(RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "10000" } } });
+                    var tcReadContentAsBase64 = new ReadBase64FunctionalTests.XNodeReaderTests.TCReadContentAsBase64();
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_1) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_2) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Num value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_3) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Text value") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_5) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_6) { Attribute = new VariationAttribute("ReadBase64 Element with Long valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_7) { Attribute = new VariationAttribute("ReadBase64 with count > buffer size") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_8) { Attribute = new VariationAttribute("ReadBase64 with count < 0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_9) { Attribute = new VariationAttribute("ReadBase64 with index > buffer size") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_10) { Attribute = new VariationAttribute("ReadBase64 with index < 0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_11) { Attribute = new VariationAttribute("ReadBase64 with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.ReadBase64_12) { Attribute = new VariationAttribute("ReadBase64 index & count =0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_13) { Attribute = new VariationAttribute("ReadBase64 Element multiple into same buffer (using offset), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_14) { Attribute = new VariationAttribute("ReadBase64 with buffer == null") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_16) { Attribute = new VariationAttribute("Read after ReadBase64") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestReadBase64_18) { Attribute = new VariationAttribute("No op node types") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespace in the mIddle") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.TestTextReadBase64_27) { Attribute = new VariationAttribute("ReadBase64 with = in the mIddle") });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "10000000" } } });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "1000000" } } });
+                    this.AddChild(new TestVariation(tcReadContentAsBase64.RunBase64DoesnNotRunIntoOverflow) { Attribute = new VariationAttribute("ReadBase64 runs into an Overflow") { Params = new object[] { "10000" } } });
                 }
             }
-            public partial class TCReadElementContentAsBase64 : BridgeHelpers
+            public class TCReadElementContentAsBase64 : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadElementContentAsBase64
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadBase64_1) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value") });
-                    this.AddChild(new TestVariation(TestReadBase64_2) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Num value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadBase64_3) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Text value") });
-                    this.AddChild(new TestVariation(TestReadBase64_5) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(TestReadBase64_6) { Attribute = new VariationAttribute("ReadBase64 Element with Long valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(ReadBase64_7) { Attribute = new VariationAttribute("ReadBase64 with count > buffer size") });
-                    this.AddChild(new TestVariation(ReadBase64_8) { Attribute = new VariationAttribute("ReadBase64 with count < 0") });
-                    this.AddChild(new TestVariation(ReadBase64_9) { Attribute = new VariationAttribute("ReadBase64 with index > buffer size") });
-                    this.AddChild(new TestVariation(ReadBase64_10) { Attribute = new VariationAttribute("ReadBase64 with index < 0") });
-                    this.AddChild(new TestVariation(ReadBase64_11) { Attribute = new VariationAttribute("ReadBase64 with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(ReadBase64_12) { Attribute = new VariationAttribute("ReadBase64 index & count =0") });
-                    this.AddChild(new TestVariation(TestReadBase64_13) { Attribute = new VariationAttribute("ReadBase64 Element multiple into same buffer (using offset), Priority=0") });
-                    this.AddChild(new TestVariation(TestReadBase64_14) { Attribute = new VariationAttribute("ReadBase64 with buffer == null") });
-                    this.AddChild(new TestVariation(TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
-                    this.AddChild(new TestVariation(TestReadBase64_16) { Attribute = new VariationAttribute("Read after partial ReadBase64") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
-                    this.AddChild(new TestVariation(TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
-                    this.AddChild(new TestVariation(TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespace in the mIddle") });
-                    this.AddChild(new TestVariation(TestTextReadBase64_27) { Attribute = new VariationAttribute("ReadBase64 with = in the mIddle") });
-                    this.AddChild(new TestVariation(ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "10000000" } } });
-                    this.AddChild(new TestVariation(ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "1000000" } } });
-                    this.AddChild(new TestVariation(ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "10000" } } });
-                    this.AddChild(new TestVariation(SubtreeReaderInsertedAttributesWontWorkWithReadContentAsBase64) { Attribute = new VariationAttribute("430329: SubtreeReader inserted attributes don't work with ReadContentAsBase64") });
+                    var tcReadElementContentAsBase64 = new ReadBase64FunctionalTests.XNodeReaderTests.TCReadElementContentAsBase64();
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_1) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_2) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Num value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_3) { Attribute = new VariationAttribute("ReadBase64 Element with all valid Text value") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_5) { Attribute = new VariationAttribute("ReadBase64 Element with all valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_6) { Attribute = new VariationAttribute("ReadBase64 Element with Long valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_7) { Attribute = new VariationAttribute("ReadBase64 with count > buffer size") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_8) { Attribute = new VariationAttribute("ReadBase64 with count < 0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_9) { Attribute = new VariationAttribute("ReadBase64 with index > buffer size") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_10) { Attribute = new VariationAttribute("ReadBase64 with index < 0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_11) { Attribute = new VariationAttribute("ReadBase64 with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64_12) { Attribute = new VariationAttribute("ReadBase64 index & count =0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_13) { Attribute = new VariationAttribute("ReadBase64 Element multiple into same buffer (using offset), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_14) { Attribute = new VariationAttribute("ReadBase64 with buffer == null") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_16) { Attribute = new VariationAttribute("Read after ReadBase64") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespace in the mIddle") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.TestTextReadBase64_27) { Attribute = new VariationAttribute("ReadBase64 with = in the mIddle") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "10000000" } } });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "1000000" } } });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.ReadBase64DoesNotRunIntoOverflow2) { Attribute = new VariationAttribute("105376: ReadBase64 runs into an Overflow") { Params = new object[] { "10000" } } });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBase64.SubtreeReaderInsertedAttributesWontWorkWithReadContentAsBase64) { Attribute = new VariationAttribute("430329: SubtreeReader inserted attributes don't work with ReadContentAsBase64") });
                 }
             }
-            public partial class TCReadContentAsBinHex : BridgeHelpers
+            public class TCReadContentAsBinHex : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadContentAsBinHex
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadBinHex_1) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value") });
-                    this.AddChild(new TestVariation(TestReadBinHex_2) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Num value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadBinHex_3) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Text value") });
-                    this.AddChild(new TestVariation(TestReadBinHex_4) { Attribute = new VariationAttribute("ReadBinHex Element on CDATA") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadBinHex_5) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(TestReadBinHex_6) { Attribute = new VariationAttribute("ReadBinHex Element with all long valid value (from concatenation)") });
-                    this.AddChild(new TestVariation(TestReadBinHex_7) { Attribute = new VariationAttribute("ReadBinHex with count > buffer size") });
-                    this.AddChild(new TestVariation(TestReadBinHex_8) { Attribute = new VariationAttribute("ReadBinHex with count < 0") });
-                    this.AddChild(new TestVariation(vReadBinHex_9) { Attribute = new VariationAttribute("ReadBinHex with index > buffer size") });
-                    this.AddChild(new TestVariation(TestReadBinHex_10) { Attribute = new VariationAttribute("ReadBinHex with index < 0") });
-                    this.AddChild(new TestVariation(TestReadBinHex_11) { Attribute = new VariationAttribute("ReadBinHex with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(TestReadBinHex_12) { Attribute = new VariationAttribute("ReadBinHex index & count =0") });
-                    this.AddChild(new TestVariation(TestReadBinHex_13) { Attribute = new VariationAttribute("ReadBinHex Element multiple into same buffer (using offset), Priority=0") });
-                    this.AddChild(new TestVariation(TestReadBinHex_14) { Attribute = new VariationAttribute("ReadBinHex with buffer == null") });
-                    this.AddChild(new TestVariation(TestReadBinHex_15) { Attribute = new VariationAttribute("ReadBinHex after failed ReadBinHex") });
-                    this.AddChild(new TestVariation(TestReadBinHex_16) { Attribute = new VariationAttribute("Read after partial ReadBinHex") });
-                    this.AddChild(new TestVariation(TestReadBinHex_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_21) { Attribute = new VariationAttribute("ReadBinHex with whitespace") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_22) { Attribute = new VariationAttribute("ReadBinHex with odd number of chars") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_23) { Attribute = new VariationAttribute("ReadBinHex when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_24) { Attribute = new VariationAttribute("WS:WireCompat:hex binary fails to send/return data after 1787 bytes going Whidbey to Everett") });
-                    this.AddChild(new TestVariation(DebugAssertInReadContentAsBinHex) { Attribute = new VariationAttribute("DebugAssert in ReadContentAsBinHex") });
+                    var tcReadContentAsBinHex = new ReadBinHexFunctionalTests.XNodeReaderTests.TCReadContentAsBinHex();
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_1) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_2) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Num value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_3) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Text value") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_4) { Attribute = new VariationAttribute("ReadBinHex Element on CDATA") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_5) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_6) { Attribute = new VariationAttribute("ReadBinHex Element with all long valid value (from concatenation)") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_7) { Attribute = new VariationAttribute("ReadBinHex with count > buffer size") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_8) { Attribute = new VariationAttribute("ReadBinHex with count < 0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.vReadBinHex_9) { Attribute = new VariationAttribute("ReadBinHex with index > buffer size") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_10) { Attribute = new VariationAttribute("ReadBinHex with index < 0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_11) { Attribute = new VariationAttribute("ReadBinHex with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_12) { Attribute = new VariationAttribute("ReadBinHex index & count =0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_13) { Attribute = new VariationAttribute("ReadBinHex Element multiple into same buffer (using offset), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_14) { Attribute = new VariationAttribute("ReadBinHex with buffer == null") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_15) { Attribute = new VariationAttribute("ReadBinHex after failed ReadBinHex") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_16) { Attribute = new VariationAttribute("Read after ReadBinHex") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestReadBinHex_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestTextReadBinHex_21) { Attribute = new VariationAttribute("ReadBinHex with whitespace") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestTextReadBinHex_22) { Attribute = new VariationAttribute("ReadBinHex with odd number of chars") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestTextReadBinHex_23) { Attribute = new VariationAttribute("ReadBinHex when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.TestTextReadBinHex_24) { Attribute = new VariationAttribute("WS:WireCompat:hex binary fails to send/return data after 1787 bytes going Whidbey to Everett") });
+                    this.AddChild(new TestVariation(tcReadContentAsBinHex.DebugAssertInReadContentAsBinHex) { Attribute = new VariationAttribute("DebugAssert in ReadContentAsBinHex") });
                 }
             }
-            public partial class TCReadElementContentAsBinHex : BridgeHelpers
+            public class TCReadElementContentAsBinHex : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadElementContentAsBinHex
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadBinHex_1) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value") });
-                    this.AddChild(new TestVariation(TestReadBinHex_2) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Num value") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadBinHex_3) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Text value") });
-                    this.AddChild(new TestVariation(TestReadBinHex_4) { Attribute = new VariationAttribute("ReadBinHex Element with Comments and PIs") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadBinHex_5) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value (from concatenation), Priority=0") });
-                    this.AddChild(new TestVariation(TestReadBinHex_6) { Attribute = new VariationAttribute("ReadBinHex Element with all long valid value (from concatenation)") });
-                    this.AddChild(new TestVariation(TestReadBinHex_7) { Attribute = new VariationAttribute("ReadBinHex with count > buffer size") });
-                    this.AddChild(new TestVariation(TestReadBinHex_8) { Attribute = new VariationAttribute("ReadBinHex with count < 0") });
-                    this.AddChild(new TestVariation(vReadBinHex_9) { Attribute = new VariationAttribute("ReadBinHex with index > buffer size") });
-                    this.AddChild(new TestVariation(TestReadBinHex_10) { Attribute = new VariationAttribute("ReadBinHex with index < 0") });
-                    this.AddChild(new TestVariation(TestReadBinHex_11) { Attribute = new VariationAttribute("ReadBinHex with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(TestReadBinHex_12) { Attribute = new VariationAttribute("ReadBinHex index & count =0") });
-                    this.AddChild(new TestVariation(TestReadBinHex_13) { Attribute = new VariationAttribute("ReadBinHex Element multiple into same buffer (using offset), Priority=0") });
-                    this.AddChild(new TestVariation(TestReadBinHex_14) { Attribute = new VariationAttribute("ReadBinHex with buffer == null") });
-                    this.AddChild(new TestVariation(TestReadBinHex_15) { Attribute = new VariationAttribute("ReadBinHex after failed ReadBinHex") });
-                    this.AddChild(new TestVariation(TestReadBinHex_16) { Attribute = new VariationAttribute("Read after partial ReadBinHex") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_21) { Attribute = new VariationAttribute("ReadBinHex with whitespace") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_22) { Attribute = new VariationAttribute("ReadBinHex with odd number of chars") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_23) { Attribute = new VariationAttribute("ReadBinHex when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_24) { Attribute = new VariationAttribute("WS:WireCompat:hex binary fails to send/return data after 1787 bytes going Whidbey to Everett") });
-                    this.AddChild(new TestVariation(TestTextReadBinHex_25) { Attribute = new VariationAttribute("SubtreeReader inserted attributes don't work with ReadContentAsBinHex") });
+                    var tcReadElementContentAsBinHex = new ReadBinHexFunctionalTests.XNodeReaderTests.TCReadElementContentAsBinHex();
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_1) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_2) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Num value") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_3) { Attribute = new VariationAttribute("ReadBinHex Element with all valid Text value") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_4) { Attribute = new VariationAttribute("ReadBinHex Element with Comments and PIs") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_5) { Attribute = new VariationAttribute("ReadBinHex Element with all valid value (from concatenation), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_6) { Attribute = new VariationAttribute("ReadBinHex Element with all long valid value (from concatenation)") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_7) { Attribute = new VariationAttribute("ReadBinHex with count > buffer size") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_8) { Attribute = new VariationAttribute("ReadBinHex with count < 0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.vReadBinHex_9) { Attribute = new VariationAttribute("ReadBinHex with index > buffer size") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_10) { Attribute = new VariationAttribute("ReadBinHex with index < 0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_11) { Attribute = new VariationAttribute("ReadBinHex with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_12) { Attribute = new VariationAttribute("ReadBinHex index & count =0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_13) { Attribute = new VariationAttribute("ReadBinHex Element multiple into same buffer (using offset), Priority=0") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_14) { Attribute = new VariationAttribute("ReadBinHex with buffer == null") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_15) { Attribute = new VariationAttribute("ReadBinHex after failed ReadBinHex") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestReadBinHex_16) { Attribute = new VariationAttribute("Read after ReadBinHex") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_21) { Attribute = new VariationAttribute("ReadBinHex with whitespace") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_22) { Attribute = new VariationAttribute("ReadBinHex with odd number of chars") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_23) { Attribute = new VariationAttribute("ReadBinHex when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_24) { Attribute = new VariationAttribute("WS:WireCompat:hex binary fails to send/return data after 1787 bytes going Whidbey to Everett") });
+                    this.AddChild(new TestVariation(tcReadElementContentAsBinHex.TestTextReadBinHex_25) { Attribute = new VariationAttribute("SubtreeReader inserted attributes don't work with ReadContentAsBinHex") });
                 }
             }
-            public partial class CReaderTestModule : BridgeHelpers
+            public class CReaderTestModule : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+CReaderTestModule
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Reader Property empty doc") { Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Reader Property after Read") { Priority = 0 } });
-                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Reader Property after EOF") { Priority = 0 } });
-                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("Default Reader Settings") { Priority = 0 } });
+                    var cReaderTestModule = new ReaderPropertyFunctionalTests.XNodeReaderTests.CReaderTestModule();
+                    this.AddChild(new TestVariation(cReaderTestModule.v1) { Attribute = new VariationAttribute("Reader Property empty doc") { Priority = 0 } });
+                    this.AddChild(new TestVariation(cReaderTestModule.v2) { Attribute = new VariationAttribute("Reader Property after Read") { Priority = 0 } });
+                    this.AddChild(new TestVariation(cReaderTestModule.v3) { Attribute = new VariationAttribute("Reader Property after EOF") { Priority = 0 } });
+                    this.AddChild(new TestVariation(cReaderTestModule.v4) { Attribute = new VariationAttribute("Default Reader Settings") { Priority = 0 } });
                 }
             }
-            public partial class TCReadOuterXml : BridgeHelpers
+            public class TCReadOuterXml : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadOuterXml
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(ReadOuterXml1) { Attribute = new VariationAttribute("ReadOuterXml on empty element w/o attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadOuterXml2) { Attribute = new VariationAttribute("ReadOuterXml on empty element w/ attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadOuterXml3) { Attribute = new VariationAttribute("ReadOuterXml on full empty element w/o attributes") });
-                    this.AddChild(new TestVariation(ReadOuterXml4) { Attribute = new VariationAttribute("ReadOuterXml on full empty element w/ attributes") });
-                    this.AddChild(new TestVariation(ReadOuterXml5) { Attribute = new VariationAttribute("ReadOuterXml on element with text content") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadOuterXml6) { Attribute = new VariationAttribute("ReadOuterXml on element with attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadOuterXml7) { Attribute = new VariationAttribute("ReadOuterXml on element with text and markup content") });
-                    this.AddChild(new TestVariation(ReadOuterXml8) { Attribute = new VariationAttribute("ReadOuterXml with multiple level of elements") });
-                    this.AddChild(new TestVariation(ReadOuterXml9) { Attribute = new VariationAttribute("ReadOuterXml with multiple level of elements, text and attributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadOuterXml10) { Attribute = new VariationAttribute("ReadOuterXml on element with complex content (CDATA, PIs, Comments)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadOuterXml12) { Attribute = new VariationAttribute("ReadOuterXml on attribute node of empty element") });
-                    this.AddChild(new TestVariation(ReadOuterXml13) { Attribute = new VariationAttribute("ReadOuterXml on attribute node of full empty element") });
-                    this.AddChild(new TestVariation(ReadOuterXml14) { Attribute = new VariationAttribute("ReadOuterXml on attribute node") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadOuterXml15) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandEntities") { Priority = 0 } });
-                    this.AddChild(new TestVariation(ReadOuterXml17) { Attribute = new VariationAttribute("ReadOuterXml on ProcessingInstruction") });
-                    this.AddChild(new TestVariation(ReadOuterXml24) { Attribute = new VariationAttribute("ReadOuterXml on CDATA") });
-                    this.AddChild(new TestVariation(TRReadOuterXml27) { Attribute = new VariationAttribute("ReadOuterXml on element with entities, EntityHandling = ExpandCharEntities") });
-                    this.AddChild(new TestVariation(TRReadOuterXml28) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandCharEntites") });
-                    this.AddChild(new TestVariation(TestTextReadOuterXml29) { Attribute = new VariationAttribute("One large element") });
-                    this.AddChild(new TestVariation(ReadOuterXmlWhenNamespacesEqualsToFalseAndHasAnAttributeXmlns) { Attribute = new VariationAttribute("Read OuterXml when Namespaces=false and has an attribute xmlns") });
+                    var tcReadOuterXml = new ReadOuterXmlFunctionalTests.XNodeReaderTests.TCReadOuterXml();
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml1) { Attribute = new VariationAttribute("ReadOuterXml on empty element w/o attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml2) { Attribute = new VariationAttribute("ReadOuterXml on empty element w/ attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml3) { Attribute = new VariationAttribute("ReadOuterXml on full empty element w/o attributes") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml4) { Attribute = new VariationAttribute("ReadOuterXml on full empty element w/ attributes") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml5) { Attribute = new VariationAttribute("ReadOuterXml on element with text content") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml6) { Attribute = new VariationAttribute("ReadOuterXml on element with attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml7) { Attribute = new VariationAttribute("ReadOuterXml on element with text and markup content") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml8) { Attribute = new VariationAttribute("ReadOuterXml with multiple level of elements") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml9) { Attribute = new VariationAttribute("ReadOuterXml with multiple level of elements, text and attributes") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml10) { Attribute = new VariationAttribute("ReadOuterXml on element with complex content (CDATA, PIs, Comments)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml12) { Attribute = new VariationAttribute("ReadOuterXml on attribute node of empty element") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml13) { Attribute = new VariationAttribute("ReadOuterXml on attribute node of full empty element") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml14) { Attribute = new VariationAttribute("ReadOuterXml on attribute node") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml15) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandEntities") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml17) { Attribute = new VariationAttribute("ReadOuterXml on ProcessingInstruction") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXml24) { Attribute = new VariationAttribute("ReadOuterXml on CDATA") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.TRReadOuterXml27) { Attribute = new VariationAttribute("ReadOuterXml on element with entities, EntityHandling = ExpandCharEntities") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.TRReadOuterXml28) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandCharEntites") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.TestTextReadOuterXml29) { Attribute = new VariationAttribute("One large element") });
+                    this.AddChild(new TestVariation(tcReadOuterXml.ReadOuterXmlWhenNamespacesEqualsToFalseAndHasAnAttributeXmlns) { Attribute = new VariationAttribute("Read OuterXml when Namespaces=false and has an attribute xmlns") });
                 }
             }
-            public partial class TCReadSubtree : BridgeHelpers
+            public class TCReadSubtree : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadSubtree
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(ReadSubtreeOnlyWorksOnElementNode) { Attribute = new VariationAttribute("ReadSubtree only works on Element Node") });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=1") { Params = new object[] { "elem1", "", "ELEMENT", "elem5", "", "ELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=2") { Params = new object[] { "elem2", "", "ELEMENT", "elem1", "", "ENDELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test empty element") { Params = new object[] { "elem5", "", "ELEMENT", "elem6", "", "ELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test on Root") { Params = new object[] { "root", "", "ELEMENT", "", "", "NONE" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test Comment after element") { Params = new object[] { "elem", "", "ELEMENT", "", "Comment", "COMMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=4") { Params = new object[] { "elem4", "", "ELEMENT", "x:elem3", "", "ENDELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=3") { Params = new object[] { "x:elem3", "", "ELEMENT", "elem2", "", "ENDELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test empty element before root") { Params = new object[] { "elem6", "", "ELEMENT", "root", "", "ENDELEMENT" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("ReadSubtree Test PI after element") { Params = new object[] { "elempi", "", "ELEMENT", "pi", "target", "PROCESSINGINSTRUCTION" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read with entities") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("Inner XML on Subtree reader") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Outer XML on Subtree reader") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v6) { Attribute = new VariationAttribute("ReadString on Subtree reader") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v7) { Attribute = new VariationAttribute("Close on inner reader with CloseInput should not close the outer reader") { Params = new object[] { "true" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v7) { Attribute = new VariationAttribute("Close on inner reader with CloseInput should not close the outer reader") { Params = new object[] { "false" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v8) { Attribute = new VariationAttribute("Nested Subtree reader calls") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v100) { Attribute = new VariationAttribute("ReadSubtree for element depth more than 4K chars") { Priority = 2 } });
-                    this.AddChild(new TestVariation(MultipleNamespacesOnSubtreeReader) { Attribute = new VariationAttribute("Multiple Namespaces on Subtree reader") { Priority = 1 } });
-                    this.AddChild(new TestVariation(SubtreeReaderCachesNodeTypeAndReportsNodeTypeOfAttributeOnSubsequentReads) { Attribute = new VariationAttribute("Subtree Reader caches the NodeType and reports node type of Attribute on subsequent reads.") { Priority = 1 } });
+                    var tcReadSubtree = new ReadSubTreeFunctionalTests.XNodeReaderTests.TCReadSubtree();
+                    this.AddChild(new TestVariation(tcReadSubtree.ReadSubtreeOnlyWorksOnElementNode) { Attribute = new VariationAttribute("ReadSubtree only works on Element Node") });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=1") { Params = new object[] { "elem1", "", "ELEMENT", "elem5", "", "ELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=2") { Params = new object[] { "elem2", "", "ELEMENT", "elem1", "", "ENDELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test empty element") { Params = new object[] { "elem5", "", "ELEMENT", "elem6", "", "ELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test on Root") { Params = new object[] { "root", "", "ELEMENT", "", "", "NONE" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test Comment after element") { Params = new object[] { "elem", "", "ELEMENT", "", "Comment", "COMMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=4") { Params = new object[] { "elem4", "", "ELEMENT", "x:elem3", "", "ENDELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test depth=3") { Params = new object[] { "x:elem3", "", "ELEMENT", "elem2", "", "ENDELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test empty element before root") { Params = new object[] { "elem6", "", "ELEMENT", "root", "", "ENDELEMENT" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v2) { Attribute = new VariationAttribute("ReadSubtree Test PI after element") { Params = new object[] { "elempi", "", "ELEMENT", "pi", "target", "PROCESSINGINSTRUCTION" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v3) { Attribute = new VariationAttribute("Read with entities") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v4) { Attribute = new VariationAttribute("Inner XML on Subtree reader") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v5) { Attribute = new VariationAttribute("Outer XML on Subtree reader") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v6) { Attribute = new VariationAttribute("ReadString on Subtree reader") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v7) { Attribute = new VariationAttribute("Close on inner reader with CloseInput should not close the outer reader") { Params = new object[] { "true" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v7) { Attribute = new VariationAttribute("Close on inner reader with CloseInput should not close the outer reader") { Params = new object[] { "false" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v8) { Attribute = new VariationAttribute("Nested Subtree reader calls") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.v100) { Attribute = new VariationAttribute("ReadSubtree for element depth more than 4K chars") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.MultipleNamespacesOnSubtreeReader) { Attribute = new VariationAttribute("Multiple Namespaces on Subtree reader") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadSubtree.SubtreeReaderCachesNodeTypeAndReportsNodeTypeOfAttributeOnSubsequentReads) { Attribute = new VariationAttribute("Subtree Reader caches the NodeType and reports node type of Attribute on subsequent reads.") { Priority = 1 } });
                 }
             }
-            public partial class TCReadToDescendant : BridgeHelpers
+            public class TCReadToDescendant : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadToDescendant
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "DNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on a deep tree at least more than 4K boundary") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "DNS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "NNS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "NS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("If name not found, stop at end element of the subtree") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Positioning on a level and try to find the name which is on a level higher") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v6) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v7) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it, with namespace") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v8) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it, with prefix") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v9) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NNS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v10) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, DNS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v11) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v12) { Attribute = new VariationAttribute("Call from different nodetypes") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v14) { Attribute = new VariationAttribute("Only child has namespaces and read to it") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v15) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "DNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "NNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "NS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v19) { Attribute = new VariationAttribute("427176	Assertion failed when call XmlReader.ReadToDescendant() for non-existing node") { Priority = 1 } });
+                    var tcReadToDescendant = new ReadToDescendantFunctionalTests.XNodeReaderTests.TCReadToDescendant();                    
+                    this.AddChild(new TestVariation(tcReadToDescendant.v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "DNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v2) { Attribute = new VariationAttribute("Read on a deep tree at least more than 4K boundary") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "DNS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "NNS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v3) { Attribute = new VariationAttribute("Read on descendant with same names") { Params = new object[] { "NS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v4) { Attribute = new VariationAttribute("If name not found, stop at end element of the subtree") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v5) { Attribute = new VariationAttribute("Positioning on a level and try to find the name which is on a level higher") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v6) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v7) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it, with namespace") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v8) { Attribute = new VariationAttribute("Read to Descendant on one level and again to level below it, with prefix") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v9) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NNS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v10) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, DNS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v11) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v12) { Attribute = new VariationAttribute("Call from different nodetypes") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v14) { Attribute = new VariationAttribute("Only child has namespaces and read to it") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v15) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "DNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "NNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v18) { Attribute = new VariationAttribute("On Root Node") { Params = new object[] { "NS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToDescendant.v19) { Attribute = new VariationAttribute("427176	Assertion failed when call XmlReader.ReadToDescendant() for non-existing node") { Priority = 1 } });
                 }
             }
-            public partial class TCReadToFollowing : BridgeHelpers
+            public class TCReadToFollowing : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadToFollowing
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "DNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "NNS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "NS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "DNS" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("If name not found, go to eof") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v5_1) { Attribute = new VariationAttribute("If localname not found go to eof") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v5_2) { Attribute = new VariationAttribute("If uri not found, go to eof") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v6) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v7) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it, with namespace") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v8) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it, with prefix") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v9) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NNS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v10) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, DNS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v11) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NS") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v14) { Attribute = new VariationAttribute("Only child has namespaces and read to it") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v15) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
+                    var tcReadToFollowing = new ReadToFollowingFunctionalTests.XNodeReaderTests.TCReadToFollowing();
+                    this.AddChild(new TestVariation(tcReadToFollowing.v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "DNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v1) { Attribute = new VariationAttribute("Simple positive test") { Params = new object[] { "NNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "NNS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "NS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v2) { Attribute = new VariationAttribute("Read on following with same names") { Params = new object[] { "DNS" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v4) { Attribute = new VariationAttribute("If name not found, go to eof") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v5_1) { Attribute = new VariationAttribute("If localname not found go to eof") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v5_2) { Attribute = new VariationAttribute("If uri not found, go to eof") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v6) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v7) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it, with namespace") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v8) { Attribute = new VariationAttribute("Read to Following on one level and again to level below it, with prefix") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v9) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NNS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v10) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, DNS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v11) { Attribute = new VariationAttribute("Multiple Reads to children and then next siblings, NS") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v14) { Attribute = new VariationAttribute("Only child has namespaces and read to it") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v15) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToFollowing.v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
                 }
             }
-            public partial class TCReadToNextSibling : BridgeHelpers
+            public class TCReadToNextSibling : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadToNextSibling
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test 2") { Params = new object[] { "DNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test 3") { Params = new object[] { "NS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v) { Attribute = new VariationAttribute("Simple positive test 1") { Params = new object[] { "NNS" }, Priority = 0 } });
-                    this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Read on a deep tree at least more than 4K boundary") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read to next sibling with same names 1") { Params = new object[] { "NNS", "<root><a att='1'/><a att='2'/><a att='3'/></root>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on next sibling with same names 2") { Params = new object[] { "DNS", "<root xmlns='a'><a att='1'/><a att='2'/><a att='3'/></root>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v3) { Attribute = new VariationAttribute("Read on next sibling with same names 3") { Params = new object[] { "NS", "<root xmlns:a='a'><a:a att='1'/><a:a att='2'/><a:a att='3'/></root>" }, Priority = 1 } });
-                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("If name not found, stop at end element of the subtree") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Positioning on a level and try to find the name which is on a level higher") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v6) { Attribute = new VariationAttribute("Read to next sibling on one level and again to level below it") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v12) { Attribute = new VariationAttribute("Call from different nodetypes") { Priority = 1 } });
-                    this.AddChild(new TestVariation(v16) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
-                    this.AddChild(new TestVariation(v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
+                    var tcReadToNextSibling = new ReadToNextSiblingFunctionalTests.XNodeReaderTests.TCReadToNextSibling();
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v) { Attribute = new VariationAttribute("Simple positive test 2") { Params = new object[] { "DNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v) { Attribute = new VariationAttribute("Simple positive test 3") { Params = new object[] { "NS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v) { Attribute = new VariationAttribute("Simple positive test 1") { Params = new object[] { "NNS" }, Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v2) { Attribute = new VariationAttribute("Read on a deep tree at least more than 4K boundary") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v3) { Attribute = new VariationAttribute("Read to next sibling with same names 1") { Params = new object[] { "NNS", "<root><a att='1'/><a att='2'/><a att='3'/></root>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v3) { Attribute = new VariationAttribute("Read on next sibling with same names 2") { Params = new object[] { "DNS", "<root xmlns='a'><a att='1'/><a att='2'/><a att='3'/></root>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v3) { Attribute = new VariationAttribute("Read on next sibling with same names 3") { Params = new object[] { "NS", "<root xmlns:a='a'><a:a att='1'/><a:a att='2'/><a:a att='3'/></root>" }, Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v4) { Attribute = new VariationAttribute("If name not found, stop at end element of the subtree") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v5) { Attribute = new VariationAttribute("Positioning on a level and try to find the name which is on a level higher") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v6) { Attribute = new VariationAttribute("Read to next sibling on one level and again to level below it") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v12) { Attribute = new VariationAttribute("Call from different nodetypes") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v16) { Attribute = new VariationAttribute("Pass null to both arguments throws ArgumentException") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadToNextSibling.v17) { Attribute = new VariationAttribute("Different names, same uri works correctly") { Priority = 2 } });
                 }
             }
-            public partial class TCReadValue : BridgeHelpers
+            public class TCReadValue : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCReadValue
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadValuePri0) { Attribute = new VariationAttribute("ReadValue") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValuePri0onElement) { Attribute = new VariationAttribute("ReadValue on Element") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValueOnAttribute0) { Attribute = new VariationAttribute("ReadValue on Attribute") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValueOnAttribute1) { Attribute = new VariationAttribute("ReadValue on Attribute after ReadAttributeValue") { Priority = 2 } });
-                    this.AddChild(new TestVariation(TestReadValue2Pri0) { Attribute = new VariationAttribute("ReadValue on empty buffer") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValue3Pri0) { Attribute = new VariationAttribute("ReadValue on negative count") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValue4Pri0) { Attribute = new VariationAttribute("ReadValue on negative offset") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValue1) { Attribute = new VariationAttribute("ReadValue with buffer = element content / 2") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValue2) { Attribute = new VariationAttribute("ReadValue entire value in one call") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValue3) { Attribute = new VariationAttribute("ReadValue bit by bit") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValue4) { Attribute = new VariationAttribute("ReadValue for value more than 4K") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadValue5) { Attribute = new VariationAttribute("ReadValue for value more than 4K and invalid element") { Priority = 1 } });
-                    this.AddChild(new TestVariation(TestReadValue6) { Attribute = new VariationAttribute("ReadValue with Entity Reference, EntityHandling = ExpandEntities") });
-                    this.AddChild(new TestVariation(TestReadValue7) { Attribute = new VariationAttribute("ReadValue with count > buffer size") });
-                    this.AddChild(new TestVariation(TestReadValue8) { Attribute = new VariationAttribute("ReadValue with index > buffer size") });
-                    this.AddChild(new TestVariation(TestReadValue10) { Attribute = new VariationAttribute("ReadValue with index + count exceeds buffer") });
-                    this.AddChild(new TestVariation(TestReadChar11) { Attribute = new VariationAttribute("ReadValue with combination Text, CDATA and Whitespace") });
-                    this.AddChild(new TestVariation(TestReadChar12) { Attribute = new VariationAttribute("ReadValue with combination Text, CDATA and SignificantWhitespace") });
-                    this.AddChild(new TestVariation(TestReadChar13) { Attribute = new VariationAttribute("ReadValue with buffer == null") });
-                    this.AddChild(new TestVariation(TestReadChar14) { Attribute = new VariationAttribute("ReadValue with multiple different inner nodes") });
-                    this.AddChild(new TestVariation(TestReadChar15) { Attribute = new VariationAttribute("ReadValue after failed ReadValue") });
-                    this.AddChild(new TestVariation(TestReadChar16) { Attribute = new VariationAttribute("Read after partial ReadValue") });
-                    this.AddChild(new TestVariation(TestReadChar19) { Attribute = new VariationAttribute("Test error after successful ReadValue") });
-                    this.AddChild(new TestVariation(TestReadChar21) { Attribute = new VariationAttribute("Call on invalid element content after 4k boundary") { Priority = 1 } });
-                    this.AddChild(new TestVariation(TestTextReadValue25) { Attribute = new VariationAttribute("ReadValue with whitespace") });
-                    this.AddChild(new TestVariation(TestTextReadValue26) { Attribute = new VariationAttribute("ReadValue when end tag doesn't exist") });
-                    this.AddChild(new TestVariation(TestCharEntities0) { Attribute = new VariationAttribute("Testing with character entities") });
-                    this.AddChild(new TestVariation(TestCharEntities1) { Attribute = new VariationAttribute("Testing with character entities when value more than 4k") });
-                    this.AddChild(new TestVariation(TestCharEntities2) { Attribute = new VariationAttribute("Testing with character entities with another pattern") });
-                    this.AddChild(new TestVariation(TestReadValueOnBig) { Attribute = new VariationAttribute("Testing a use case pattern with large file") });
-                    this.AddChild(new TestVariation(TestReadValueOnComments0) { Attribute = new VariationAttribute("ReadValue on Comments with IgnoreComments") });
-                    this.AddChild(new TestVariation(TestReadValueOnPIs0) { Attribute = new VariationAttribute("ReadValue on PI with IgnorePI") });
-                    this.AddChild(new TestVariation(bug340158) { Attribute = new VariationAttribute("Skip after ReadAttributeValue/ReadValueChunk") });
+                    var tcReadValue = new ReadValueFunctionalTests.XNodeReaderTests.TCReadValue();                    
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValuePri0) { Attribute = new VariationAttribute("ReadValue") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValuePri0onElement) { Attribute = new VariationAttribute("ReadValue on Element") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnAttribute0) { Attribute = new VariationAttribute("ReadValue on Attribute") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnAttribute1) { Attribute = new VariationAttribute("ReadValue on Attribute after ReadAttributeValue") { Priority = 2 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue2Pri0) { Attribute = new VariationAttribute("ReadValue on empty buffer") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue3Pri0) { Attribute = new VariationAttribute("ReadValue on negative count") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue4Pri0) { Attribute = new VariationAttribute("ReadValue on negative offset") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue1) { Attribute = new VariationAttribute("ReadValue with buffer = element content / 2") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue2) { Attribute = new VariationAttribute("ReadValue entire value in one call") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue3) { Attribute = new VariationAttribute("ReadValue bit by bit") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue4) { Attribute = new VariationAttribute("ReadValue for value more than 4K") { Priority = 0 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue5) { Attribute = new VariationAttribute("ReadValue for value more than 4K and invalid element") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue6) { Attribute = new VariationAttribute("ReadValue with Entity Reference, EntityHandling = ExpandEntities") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue7) { Attribute = new VariationAttribute("ReadValue with count > buffer size") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue8) { Attribute = new VariationAttribute("ReadValue with index > buffer size") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValue10) { Attribute = new VariationAttribute("ReadValue with index + count exceeds buffer") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadChar11) { Attribute = new VariationAttribute("ReadValue with combination Text, CDATA and Whitespace") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadChar12) { Attribute = new VariationAttribute("ReadValue with combination Text, CDATA and SignificantWhitespace") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadChar13) { Attribute = new VariationAttribute("ReadValue with buffer == null") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadChar14) { Attribute = new VariationAttribute("ReadValue with multiple different inner nodes") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadChar15) { Attribute = new VariationAttribute("ReadValue after failed ReadValue") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadChar16) { Attribute = new VariationAttribute("Read after ReadValue") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadChar19) { Attribute = new VariationAttribute("Test error after successful ReadValue") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadChar21) { Attribute = new VariationAttribute("Call on invalid element content after 4k boundary") { Priority = 1 } });
+                    this.AddChild(new TestVariation(tcReadValue.TestTextReadValue25) { Attribute = new VariationAttribute("ReadValue with whitespace") });
+                    this.AddChild(new TestVariation(tcReadValue.TestTextReadValue26) { Attribute = new VariationAttribute("ReadValue when end tag doesn't exist") });
+                    this.AddChild(new TestVariation(tcReadValue.TestCharEntities0) { Attribute = new VariationAttribute("Testing with character entities") });
+                    this.AddChild(new TestVariation(tcReadValue.TestCharEntities1) { Attribute = new VariationAttribute("Testing with character entities when value more than 4k") });
+                    this.AddChild(new TestVariation(tcReadValue.TestCharEntities2) { Attribute = new VariationAttribute("Testing with character entities with another pattern") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnBig) { Attribute = new VariationAttribute("Testing a use case pattern with large file") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnComments0) { Attribute = new VariationAttribute("ReadValue on Comments with IgnoreComments") });
+                    this.AddChild(new TestVariation(tcReadValue.TestReadValueOnPIs0) { Attribute = new VariationAttribute("ReadValue on PI with IgnorePI") });
+                    this.AddChild(new TestVariation(tcReadValue.bug340158) { Attribute = new VariationAttribute("Skip after ReadAttributeValue/ReadValueChunk") });
                 }
             }
-            public partial class XNodeReaderAPI : XLinqTestCase
+            public class XNodeReaderAPI : XLinqTestCase
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+XNodeReaderAPI
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Text") { Params = new object[] { XmlNodeType.Text, 1, new string[] { "some_text" }, 1 }, Priority = 1 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: PI (root level)") { Params = new object[] { XmlNodeType.ProcessingInstruction, 0, new string[] { "PI", "" }, 1 }, Priority = 2 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Comment") { Params = new object[] { XmlNodeType.Comment, 1, new string[] { "comm2" }, 1 }, Priority = 2 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Text (root level)") { Params = new object[] { XmlNodeType.Text, 0, new string[] { "\t" }, 1 }, Priority = 0 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (root)") { Params = new object[] { XmlNodeType.Element, 0, new string[] { "A", "", "" }, 15 }, Priority = 1 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: PI") { Params = new object[] { XmlNodeType.ProcessingInstruction, 1, new string[] { "PIX", "click" }, 1 }, Priority = 2 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Comment (root level)") { Params = new object[] { XmlNodeType.Comment, 0, new string[] { "comment1" }, 1 }, Priority = 2 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (in the mIddle)") { Params = new object[] { XmlNodeType.Element, 1, new string[] { "B", "", "x" }, 11 }, Priority = 0 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (leaf I.)") { Params = new object[] { XmlNodeType.Element, 3, new string[] { "D", "", "y" }, 2 }, Priority = 0 } });
-                    this.AddChild(new TestVariation(OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (leaf II.)") { Params = new object[] { XmlNodeType.Element, 4, new string[] { "E", "p", "nsp" }, 1 }, Priority = 1 } });
-                    this.AddChild(new TestVariation(Namespaces) { Attribute = new VariationAttribute("Namespaces - Comment") { Params = new object[] { XmlNodeType.Comment, 1, new string[] { "", "x" }, new string[] { "p", "nsp" } } } });
-                    this.AddChild(new TestVariation(Namespaces) { Attribute = new VariationAttribute("Namespaces - root element") { Params = new object[] { XmlNodeType.Element, 0, new string[] { "", "" } } } });
-                    this.AddChild(new TestVariation(Namespaces) { Attribute = new VariationAttribute("Namespaces - element") { Params = new object[] { XmlNodeType.Element, 1, new string[] { "", "x" }, new string[] { "p", "nsp" } } } });
-                    this.AddChild(new TestVariation(Namespaces) { Attribute = new VariationAttribute("Namespaces - element, def. ns redef") { Params = new object[] { XmlNodeType.Element, 3, new string[] { "", "y" }, new string[] { "p", "nsp" } } } });
-                    this.AddChild(new TestVariation(ReadSubtreeSanity) { Attribute = new VariationAttribute("ReadSubtree (sanity)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(AdjacentTextNodes1) { Attribute = new VariationAttribute("Adjacent text nodes (sanity I.)") { Priority = 0 } });
-                    this.AddChild(new TestVariation(AdjacentTextNodes2) { Attribute = new VariationAttribute("Adjacent text nodes (sanity II.) : ReadElementContent") { Priority = 0 } });
-                    this.AddChild(new TestVariation(AdjacentTextNodesI) { Attribute = new VariationAttribute("Adjacent text nodes (sanity IV.) : ReadInnerXml") { Priority = 0 } });
-                    this.AddChild(new TestVariation(AdjacentTextNodes3) { Attribute = new VariationAttribute("Adjacent text nodes (sanity III.) : ReadContent") { Priority = 0 } });
+                    var xNodeReaderAPI = new XNodeReaderAPIFunctionalTests.XNodeReaderTests.XNodeReaderAPI();
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Text") { Params = new object[] { XmlNodeType.Text, 1, new string[] { "some_text" }, 1 }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: PI (root level)") { Params = new object[] { XmlNodeType.ProcessingInstruction, 0, new string[] { "PI", "" }, 1 }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Comment") { Params = new object[] { XmlNodeType.Comment, 1, new string[] { "comm2" }, 1 }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Text (root level)") { Params = new object[] { XmlNodeType.Text, 0, new string[] { "\t" }, 1 }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (root)") { Params = new object[] { XmlNodeType.Element, 0, new string[] { "A", "", "" }, 15 }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: PI") { Params = new object[] { XmlNodeType.ProcessingInstruction, 1, new string[] { "PIX", "click" }, 1 }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: Comment (root level)") { Params = new object[] { XmlNodeType.Comment, 0, new string[] { "comment1" }, 1 }, Priority = 2 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (in the mIddle)") { Params = new object[] { XmlNodeType.Element, 1, new string[] { "B", "", "x" }, 11 }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (leaf I.)") { Params = new object[] { XmlNodeType.Element, 3, new string[] { "D", "", "y" }, 2 }, Priority = 0 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.OpenOnNodeType) { Attribute = new VariationAttribute("Open on node type: XElement (leaf II.)") { Params = new object[] { XmlNodeType.Element, 4, new string[] { "E", "p", "nsp" }, 1 }, Priority = 1 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.Namespaces) { Attribute = new VariationAttribute("Namespaces - Comment") { Params = new object[] { XmlNodeType.Comment, 1, new string[] { "", "x" }, new string[] { "p", "nsp" } } } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.Namespaces) { Attribute = new VariationAttribute("Namespaces - root element") { Params = new object[] { XmlNodeType.Element, 0, new string[] { "", "" } } } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.Namespaces) { Attribute = new VariationAttribute("Namespaces - element") { Params = new object[] { XmlNodeType.Element, 1, new string[] { "", "x" }, new string[] { "p", "nsp" } } } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.Namespaces) { Attribute = new VariationAttribute("Namespaces - element, def. ns redef") { Params = new object[] { XmlNodeType.Element, 3, new string[] { "", "y" }, new string[] { "p", "nsp" } } } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.ReadSubtreeSanity) { Attribute = new VariationAttribute("ReadSubtree (sanity)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.AdjacentTextNodes1) { Attribute = new VariationAttribute("Adjacent text nodes (sanity I.)") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.AdjacentTextNodes2) { Attribute = new VariationAttribute("Adjacent text nodes (sanity II.) : ReadElementContent") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.AdjacentTextNodesI) { Attribute = new VariationAttribute("Adjacent text nodes (sanity IV.) : ReadInnerXml") { Priority = 0 } });
+                    this.AddChild(new TestVariation(xNodeReaderAPI.AdjacentTextNodes3) { Attribute = new VariationAttribute("Adjacent text nodes (sanity III.) : ReadContent") { Priority = 0 } });
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/IntegrityTest.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/IntegrityTest.cs
@@ -8,10 +8,10 @@ using System.Xml;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class IntegrityTestFunctionalTests : TestModule
     {
 
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
             public enum EINTEGRITY
             {
@@ -32,7 +32,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "XMLIntegrityBase", Desc = "XMLIntegrityBase")]
-            public partial class TCXMLIntegrityBase : BridgeHelpers
+            public class TCXMLIntegrityBase : BridgeHelpers
             {
                 private EINTEGRITY _eEIntegrity;
 

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/IntegrityTest.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/IntegrityTest.cs
@@ -8,10 +8,10 @@ using System.Xml;
 
 namespace CoreXml.Test.XLinq
 {
-    public class IntegrityTestFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
 
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
             public enum EINTEGRITY
             {
@@ -32,7 +32,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "XMLIntegrityBase", Desc = "XMLIntegrityBase")]
-            public class TCXMLIntegrityBase : BridgeHelpers
+            public partial class TCXMLIntegrityBase : BridgeHelpers
             {
                 private EINTEGRITY _eEIntegrity;
 

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadBase64.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadBase64.cs
@@ -11,13 +11,13 @@ using XmlCoreTest.Common;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReadBase64FunctionalTests : TestModule
     {
 
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadContentAsBase64", Desc = "ReadContentAsBase64")]
-            public partial class TCReadContentAsBase64 : BridgeHelpers
+            public class TCReadContentAsBase64 : BridgeHelpers
             {
                 public const string ST_ELEM_NAME1 = "ElemAll";
                 public const string ST_ELEM_NAME2 = "ElemEmpty";
@@ -521,7 +521,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadElementContentAsBase64", Desc = "ReadElementContentAsBase64")]
-            public partial class TCReadElementContentAsBase64 : BridgeHelpers
+            public class TCReadElementContentAsBase64 : BridgeHelpers
             {
                 public const string ST_ELEM_NAME1 = "ElemAll";
                 public const string ST_ELEM_NAME2 = "ElemEmpty";

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadBase64.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadBase64.cs
@@ -11,13 +11,13 @@ using XmlCoreTest.Common;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReadBase64FunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
 
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadContentAsBase64", Desc = "ReadContentAsBase64")]
-            public class TCReadContentAsBase64 : BridgeHelpers
+            public partial class TCReadContentAsBase64 : BridgeHelpers
             {
                 public const string ST_ELEM_NAME1 = "ElemAll";
                 public const string ST_ELEM_NAME2 = "ElemEmpty";
@@ -521,7 +521,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadElementContentAsBase64", Desc = "ReadElementContentAsBase64")]
-            public class TCReadElementContentAsBase64 : BridgeHelpers
+            public partial class TCReadElementContentAsBase64 : BridgeHelpers
             {
                 public const string ST_ELEM_NAME1 = "ElemAll";
                 public const string ST_ELEM_NAME2 = "ElemEmpty";

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadBinHex.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadBinHex.cs
@@ -10,11 +10,11 @@ using System.Xml;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReadBinHexFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class TCReadContentAsBinHex : BridgeHelpers
+            public partial class TCReadContentAsBinHex : BridgeHelpers
             {
                 public const string ST_ELEM_NAME1 = "ElemAll";
                 public const string ST_ELEM_NAME2 = "ElemEmpty";
@@ -479,7 +479,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadElementContentAsBinHex", Desc = "ReadElementContentAsBinHex")]
-            public class TCReadElementContentAsBinHex : BridgeHelpers
+            public partial class TCReadElementContentAsBinHex : BridgeHelpers
             {
                 public const string ST_ELEM_NAME1 = "ElemAll";
                 public const string ST_ELEM_NAME2 = "ElemEmpty";

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadBinHex.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadBinHex.cs
@@ -10,11 +10,11 @@ using System.Xml;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReadBinHexFunctionalTests : TestModule
     {
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class TCReadContentAsBinHex : BridgeHelpers
+            public class TCReadContentAsBinHex : BridgeHelpers
             {
                 public const string ST_ELEM_NAME1 = "ElemAll";
                 public const string ST_ELEM_NAME2 = "ElemEmpty";
@@ -479,7 +479,7 @@ namespace CoreXml.Test.XLinq
             }
 
             //[TestCase(Name = "ReadElementContentAsBinHex", Desc = "ReadElementContentAsBinHex")]
-            public partial class TCReadElementContentAsBinHex : BridgeHelpers
+            public class TCReadElementContentAsBinHex : BridgeHelpers
             {
                 public const string ST_ELEM_NAME1 = "ElemAll";
                 public const string ST_ELEM_NAME2 = "ElemEmpty";

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadOuterXml.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadOuterXml.cs
@@ -9,12 +9,12 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReadOuterXmlFunctionalTests : TestModule
     {
 
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class TCReadOuterXml : BridgeHelpers
+            public class TCReadOuterXml : BridgeHelpers
             {
                 // Element names to test ReadOuterXml on
                 private static string s_EMP1 = "EMPTY1";

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadOuterXml.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadOuterXml.cs
@@ -9,12 +9,12 @@ using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReadOuterXmlFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
 
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class TCReadOuterXml : BridgeHelpers
+            public partial class TCReadOuterXml : BridgeHelpers
             {
                 // Element names to test ReadOuterXml on
                 private static string s_EMP1 = "EMPTY1";

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadSubTree.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadSubTree.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReadSubTreeFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class TCReadSubtree : BridgeHelpers
+            public partial class TCReadSubtree : BridgeHelpers
             {
                 //[Variation("ReadSubtree only works on Element Node")]
                 public void ReadSubtreeOnlyWorksOnElementNode()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadSubTree.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadSubTree.cs
@@ -9,11 +9,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReadSubTreeFunctionalTests : TestModule
     {
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class TCReadSubtree : BridgeHelpers
+            public class TCReadSubtree : BridgeHelpers
             {
                 //[Variation("ReadSubtree only works on Element Node")]
                 public void ReadSubtreeOnlyWorksOnElementNode()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToDescendant.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToDescendant.cs
@@ -9,13 +9,13 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReadToDescendantFunctionalTests : TestModule
     {
 
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadToDescendant", Desc = "ReadToDescendant")]
-            public partial class TCReadToDescendant : BridgeHelpers
+            public class TCReadToDescendant : BridgeHelpers
             {
                 #region XMLSTR
                 private string _xmlStr = @"<?xml version='1.0'?>

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToDescendant.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToDescendant.cs
@@ -9,13 +9,13 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReadToDescendantFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
 
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadToDescendant", Desc = "ReadToDescendant")]
-            public class TCReadToDescendant : BridgeHelpers
+            public partial class TCReadToDescendant : BridgeHelpers
             {
                 #region XMLSTR
                 private string _xmlStr = @"<?xml version='1.0'?>

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToFollowing.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToFollowing.cs
@@ -9,13 +9,13 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReadToFollowingFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
 
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadToFollowing", Desc = "ReadToFollowing")]
-            public class TCReadToFollowing : BridgeHelpers
+            public partial class TCReadToFollowing : BridgeHelpers
             {
                 #region XMLSTR
                 private string _xmlStr = @"<?xml version='1.0'?>

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToFollowing.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToFollowing.cs
@@ -9,13 +9,13 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReadToFollowingFunctionalTests : TestModule
     {
 
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadToFollowing", Desc = "ReadToFollowing")]
-            public partial class TCReadToFollowing : BridgeHelpers
+            public class TCReadToFollowing : BridgeHelpers
             {
                 #region XMLSTR
                 private string _xmlStr = @"<?xml version='1.0'?>

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToNextSibling.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToNextSibling.cs
@@ -9,13 +9,13 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReadToNextSiblingFunctionalTests : TestModule
     {
 
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadToNextSibling", Desc = "ReadToNextSibling")]
-            public partial class TCReadToNextSibling : BridgeHelpers
+            public class TCReadToNextSibling : BridgeHelpers
             {
                 #region XMLSTR
                 private string _xmlStr = @"<?xml version='1.0'?>

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToNextSibling.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadToNextSibling.cs
@@ -9,13 +9,13 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReadToNextSiblingFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
 
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadToNextSibling", Desc = "ReadToNextSibling")]
-            public class TCReadToNextSibling : BridgeHelpers
+            public partial class TCReadToNextSibling : BridgeHelpers
             {
                 #region XMLSTR
                 private string _xmlStr = @"<?xml version='1.0'?>

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadValue.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadValue.cs
@@ -10,12 +10,12 @@ using XmlCoreTest.Common;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReadValueFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadValue", Desc = "ReadValue")]
-            public class TCReadValue : BridgeHelpers
+            public partial class TCReadValue : BridgeHelpers
             {
                 private bool VerifyInvalidReadValue(int iBufferSize, int iIndex, int iCount, Type exceptionType)
                 {

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReadValue.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReadValue.cs
@@ -10,12 +10,12 @@ using XmlCoreTest.Common;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReadValueFunctionalTests : TestModule
     {
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
             //[TestCase(Name = "ReadValue", Desc = "ReadValue")]
-            public partial class TCReadValue : BridgeHelpers
+            public class TCReadValue : BridgeHelpers
             {
                 private bool VerifyInvalidReadValue(int iBufferSize, int iIndex, int iCount, Type exceptionType)
                 {

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReaderProperty.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReaderProperty.cs
@@ -8,12 +8,12 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class ReaderPropertyFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
 
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class CReaderTestModule : BridgeHelpers
+            public partial class CReaderTestModule : BridgeHelpers
             {
                 //[Variation("Reader Property empty doc", Priority = 0)]
                 public void v1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/ReaderProperty.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/ReaderProperty.cs
@@ -8,12 +8,12 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class ReaderPropertyFunctionalTests : TestModule
     {
 
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class CReaderTestModule : BridgeHelpers
+            public class CReaderTestModule : BridgeHelpers
             {
                 //[Variation("Reader Property empty doc", Priority = 0)]
                 public void v1()

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/XNodeReaderAPI.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/XNodeReaderAPI.cs
@@ -10,11 +10,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public partial class FunctionalTests : TestModule
+    public class XNodeReaderAPIFunctionalTests : TestModule
     {
-        public partial class XNodeReaderTests : XLinqTestCase
+        public class XNodeReaderTests : XLinqTestCase
         {
-            public partial class XNodeReaderAPI : XLinqTestCase
+            public class XNodeReaderAPI : XLinqTestCase
             {
                 // open on different node types, scoping
                 // namespaces ...

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/XNodeReaderAPI.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/XNodeReaderAPI.cs
@@ -10,11 +10,11 @@ using Microsoft.Test.ModuleCore;
 
 namespace CoreXml.Test.XLinq
 {
-    public class XNodeReaderAPIFunctionalTests : TestModule
+    public partial class XNodeReaderFunctionalTests : TestModule
     {
-        public class XNodeReaderTests : XLinqTestCase
+        public partial class XNodeReaderTests : XLinqTestCase
         {
-            public class XNodeReaderAPI : XLinqTestCase
+            public partial class XNodeReaderAPI : XLinqTestCase
             {
                 // open on different node types, scoping
                 // namespaces ...


### PR DESCRIPTION
It allows to fix build issues and makes easier import System.Private.Xml.Linq tests to Mono (https://github.com/mono/mono/issues/8122).