### PR TITLE
Remove manual typeforwards to S.P.CoreLib for now exposed types.

### DIFF
--- a/src/shims/manual/mscorlib.forwards.cs
+++ b/src/shims/manual/mscorlib.forwards.cs
@@ -2,25 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Add any internal types that we need to forward from mscorlib. 
-
-// These types are required for Desktop to Core serialization as they are not covered by GenAPI because they are marked as internal.
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.GenericComparer<>))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.NullableComparer<>))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.ObjectComparer<>))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.GenericEqualityComparer<>))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.NullableEqualityComparer<>))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.ObjectEqualityComparer<>))]
-// This is required for back-compatibility with .NET Core 2.0 as we exposed the NonRandomizedStringEqualityComparer inside the serialization blob
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.NonRandomizedStringEqualityComparer))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.ByteEqualityComparer))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.EnumEqualityComparer<>))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.ListDictionaryInternal))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.CultureAwareComparer))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.OrdinalComparer))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.UnitySerializationHolder))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Diagnostics.Contracts.ContractException))]
-
 // This is temporary as we are building the mscorlib shim against netfx461 which doesn't contain ValueTuples.
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.ValueTuple))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.ValueTuple<>))]


### PR DESCRIPTION
Relates to https://github.com/dotnet/coreclr/pull/17185

@safern I would like to get rid off the ValueTuple typeforwards and with that get rid of the whole manual shim for mscorlib. That requires that we compile against a newer netfx version where ValueTuples are inbox. 

cc @jkotas