### PR TITLE
Check URI scheme length only after verifying the scheme contains valid characters

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -3732,17 +3732,10 @@ namespace System
                 return 0;
             }
 
-            // Here could be a possibly valid, and not well-known scheme
-            // Finds the scheme delimiter
-            // we don;t work with the schemes names > c_MaxUriSchemeName (should be ~1k)
-            if ((end - idx) > c_MaxUriSchemeName)
-            {
-                err = ParsingError.SchemeLimit;
-                return 0;
-            }
-
-            //Check the syntax, canonicalize  and avoid a GC call
+            // This appears to be an unknown but potentially valid scheme.
+            // Check the syntax, canonicalize and avoid a GC call.
             err = CheckSchemeSyntax(new ReadOnlySpan<char>(uriString + idx, end - idx), ref syntax);
+
             if (err != ParsingError.None)
             {
                 return 0;
@@ -3927,6 +3920,11 @@ namespace System
             else if ((uint)(firstLower - 'a') > 'z' - 'a')
             {
                 return ParsingError.BadScheme;
+            }
+
+            if(length > c_MaxUriSchemeName)
+            {
+                return ParsingError.SchemeLimit;
             }
 
             // Special-case common and known schemes to avoid allocations and dictionary lookups in these cases.

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -3733,9 +3733,8 @@ namespace System
             }
 
             // This appears to be an unknown but potentially valid scheme.
-            // Check the syntax, canonicalize and avoid a GC call.
+            // Check for illegal characters, canonicalize, and check the length.
             err = CheckSchemeSyntax(new ReadOnlySpan<char>(uriString + idx, end - idx), ref syntax);
-
             if (err != ParsingError.None)
             {
                 return 0;
@@ -3922,7 +3921,7 @@ namespace System
                 return ParsingError.BadScheme;
             }
 
-            if(length > c_MaxUriSchemeName)
+            if (length > c_MaxUriSchemeName)
             {
                 return ParsingError.SchemeLimit;
             }

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -3921,11 +3921,6 @@ namespace System
                 return ParsingError.BadScheme;
             }
 
-            if (length > c_MaxUriSchemeName)
-            {
-                return ParsingError.SchemeLimit;
-            }
-
             // Special-case common and known schemes to avoid allocations and dictionary lookups in these cases.
             const int wsMask = 'w' << 8 | 's';
             const int ftpMask = 'f' << 16 | 't' << 8 | 'p';
@@ -3993,6 +3988,11 @@ namespace System
                 {
                     return ParsingError.BadScheme;
                 }
+            }
+
+            if (span.Length > c_MaxUriSchemeName)
+            {
+                return ParsingError.SchemeLimit;
             }
 
             // Then look up the syntax in a string-based table.

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -3732,7 +3732,7 @@ namespace System
                 return 0;
             }
 
-            // This appears to be an unknown but potentially valid scheme.
+            // This is a potentially valid scheme, but we have not identified it yet.
             // Check for illegal characters, canonicalize, and check the length.
             err = CheckSchemeSyntax(new ReadOnlySpan<char>(uriString + idx, end - idx), ref syntax);
             if (err != ParsingError.None)

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -901,7 +901,7 @@ namespace System.PrivateUri.Tests
         public static void Uri_ColonInLongRelativeUri_SchemeSuccessfullyParsed()
         {
             Uri absolutePart = new Uri("http://www.contoso.com");
-            string relativePart = "a/" + new String('a', 1024) + ":";
+            string relativePart = "a/" + new String('a', 1024) + ":";// 1024 is the maximum scheme length supported by System.Uri.
             Uri u = new Uri(absolutePart, relativePart);
             Assert.Equal("http", u.Scheme);
         }

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -898,6 +898,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This test depends on a fix that has not yet made it to .NET Framework.")]
         public static void Uri_ColonInLongRelativeUri_SchemeSuccessfullyParsed()
         {
             Uri absolutePart = new Uri("http://www.contoso.com");

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -902,9 +902,16 @@ namespace System.PrivateUri.Tests
         public static void Uri_ColonInLongRelativeUri_SchemeSuccessfullyParsed()
         {
             Uri absolutePart = new Uri("http://www.contoso.com");
-            string relativePart = "a/" + new String('a', 1024) + ":";// 1024 is the maximum scheme length supported by System.Uri.
-            Uri u = new Uri(absolutePart, relativePart);
+            string relativePart = "a/" + new String('a', 1024) + ":"; // 1024 is the maximum scheme length supported by System.Uri.
+            Uri u = new Uri(absolutePart, relativePart); // On .NET Framework this will throw System.UriFormatException: Invalid URI: The Uri scheme is too long.
             Assert.Equal("http", u.Scheme);
+        }
+
+        [Fact]
+        public static void Uri_ExtremelyLongScheme_ThrowsUriFormatException()
+        {
+            string largeString = new String('a', 1_000_000) + ":"; // 2MB is large enough to cause a stack overflow if we stackalloc the scheme buffer.
+            Assert.Throws<UriFormatException>(() => new Uri(largeString));
         }
     }
 }

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -896,5 +896,14 @@ namespace System.PrivateUri.Tests
             Uri u = new Uri(new Uri("http://example.com/", UriKind.Absolute), new Uri("C(B:G", UriKind.Relative));
             Assert.Equal("http://example.com/C(B:G", u.ToString());
         }
+
+        [Fact]
+        public static void Uri_ColonInLongRelativeUri_SchemeSuccessfullyParsed()
+        {
+            Uri absolutePart = new Uri("http://www.contoso.com");
+            string relativePart = "a/" + new String('a', 1024) + ":";
+            Uri u = new Uri(absolutePart, relativePart);
+            Assert.Equal("http", u.Scheme);
+        }
     }
 }


### PR DESCRIPTION
URI construction is failing on valid URIs under the following conditions:
- An absolute URI is constructed using the `Uri(Uri absolute, string relative)` constructor.
- The relative string begins with 1024+ characters, followed by a colon.
- The relative string contains but does not begin with a forward or back slash.

See the test added in this PR for an example URI.

The fix is to check the scheme length _after_ validating that the potential scheme contains only legal characters (ie, not a forward or back slash). This keeps us from running into the situation above, where the relative URI contains a colon that is unambiguously not a scheme separator because the "scheme" is actually just a path that contains a colon.

This fix improves the correctness of our relative path parsing at the cost of an additional stacalloc in the case where the relative part of the URI is really an absolute URI with a scheme length >= 1024.

Fixes: #29011 

Details below:
---------
When we construct an absolute URI from a relative URI, the first thing we try to do is parse the relative URI as an absolute URI. That parsing process returns an error code that we use to determine what happens next. The parsing errors are as follows:
https://github.com/dotnet/corefx/blob/bffef76f6af208e2042a2f27bc081ee908bb390b/src/System.Private.Uri/src/System/UriEnumTypes.cs#L67-L93

If we successfully parse an absolute URI (error = None), we return that URI and ignore the absolute URI we were passed.   That might seem a little odd, but it's a useful behavior in practice.

If we get an error that is less than `LastRelativeUriOkErrIndex`(see the code above), we attempt to create a relative URI from the string and then root it with the absolute URI provided.

If we return any other error, we believe that the string is neither a valid relative or absolute URI and throw an exception. In this case, PrivateParseMinimal is returning the error `SchemeLimit`, which indicates that we have too large of a scheme. As documented in the code above, this isn't considered a recoverable error.

The relative string provided has some characters that are clearly invalid in a scheme, so the real error we should be returning from TryParse is `InvalidScheme`. Since `InvalidScheme` is less than `LastRelativeUriOkErrIndex`, we will then be able to create a relative URI. Fixing the returned parsing error allows this URI to be constructed successfully.