### PR TITLE
Unify setting null CookieContainer behavior on HttpClientHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -72,6 +72,11 @@ namespace System.Net.Http
             get => _curlHandler != null ? _curlHandler.CookieContainer : _socketsHttpHandler.CookieContainer;
             set
             {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
                 if (_curlHandler != null)
                 {
                     _curlHandler.CookieContainer = value;

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -74,7 +74,7 @@ namespace System.Net.Http
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 if (_curlHandler != null)

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -96,6 +96,11 @@ namespace System.Net.Http
             get => _winHttpHandler != null ? _winHttpHandler.CookieContainer : _socketsHttpHandler.CookieContainer;
             set
             {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
                 if (_winHttpHandler != null)
                 {
                     _winHttpHandler.CookieContainer = value;

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -98,7 +98,7 @@ namespace System.Net.Http
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 if (_winHttpHandler != null)

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -514,9 +514,7 @@ namespace System.Net.Http.Functional.Tests
                         {
                             // Forces a synchronous exception for WinHttpHandler
                             handler.UseCookies = true;
-                            handler.CookieContainer = null;
-
-                            Assert.ThrowsAsync<InvalidOperationException>(() => client.GetAsync($"http://{Guid.NewGuid()}.com")).Wait();
+                            Assert.Throws<ArgumentNullException>(() => handler.CookieContainer = null);
                         }
                     }
                     // Poll with a timeout since logging response is not synchronized with returning a response.

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -122,6 +122,15 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        public void CookieContainer_SetNull_ThrowsArgumentNullException()
+        {
+            using (HttpClientHandler handler = CreateHttpClientHandler())
+            {
+                Assert.Throws<ArgumentNullException>(() => handler.CookieContainer = null);
+            }
+        }
+
+        [Fact]
         public void Ctor_ExpectedDefaultPropertyValues_CommonPlatform()
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -36,6 +36,14 @@ namespace System.Net.Http.Functional.Tests
 
         private static string GetCookieHeaderValue(string cookieName, string cookieValue) => $"{cookieName}={cookieValue}";
 
+        [Fact]
+        public void HttpClientHandler_SetNullCookieContainer_ThrowsArgumentNullException()
+        {
+            using (HttpClientHandler handler = CreateHttpClientHandler())
+            {
+                Assert.Throws<ArgumentNullException>(() => handler.CookieContainer = null);
+            }
+        }
 
         [Fact]
         public async Task GetAsync_DefaultCoookieContainer_NoCookieSent()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -36,14 +36,6 @@ namespace System.Net.Http.Functional.Tests
 
         private static string GetCookieHeaderValue(string cookieName, string cookieValue) => $"{cookieName}={cookieValue}";
 
-        [Fact]
-        public void HttpClientHandler_SetNullCookieContainer_ThrowsArgumentNullException()
-        {
-            using (HttpClientHandler handler = CreateHttpClientHandler())
-            {
-                Assert.Throws<ArgumentNullException>(() => handler.CookieContainer = null);
-            }
-        }
 
         [Fact]
         public async Task GetAsync_DefaultCoookieContainer_NoCookieSent()


### PR DESCRIPTION
For HttpClientHandler layer (above the WinHttpHandler layer on Windows), we should be consistent and throw the exception in the CookieContainer setter when null value is provided, to match .NET Framework's behavior.
This would keep the same behavior across all platforms for the setter of the HttpClientHandler.CookieContainer property.

Close: #3205