### PR TITLE
Include fragment and query in Uri.LocalPath on Unix

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -1029,7 +1029,7 @@ namespace System
 
                 return new string(result, 0, count);
             }
-            else if (IsUnixPath)
+            else if (IsUnixPath && IsImplicitFile)
             {
                 return GetUnescapedParts(UriComponents.Path | UriComponents.Query | UriComponents.Fragment | UriComponents.KeepDelimiter, UriFormat.Unescaped);
             }

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -1029,6 +1029,10 @@ namespace System
 
                 return new string(result, 0, count);
             }
+            else if (IsUnixPath)
+            {
+                return GetUnescapedParts(UriComponents.Path | UriComponents.Query | UriComponents.Fragment | UriComponents.KeepDelimiter, UriFormat.Unescaped);
+            }
             else
             {
                 // Return unescaped canonical path

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -19,6 +19,10 @@ namespace System.PrivateUri.Tests
                     yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1/path2/path3", @"/path1/path2/path3", @"file:///path1/path2/path3", ""};
                     yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1/path2/path3/path4/", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1/path2/path3/path4/", "localhost"};
                     yield return new object[] { @"file://randomhost/path1%5Cpath2\path3", @"/path1/path2/path3", @"\\randomhost\path1\path2\path3", @"file://randomhost/path1/path2/path3", "randomhost"};
+                    yield return new object[] { @"c:\path1\path2\path3#path4", @"c:/path1/path2/path3%23path4", @"c:\path1\path2\path3#path4", @"file:///c:/path1/path2/path3%23path4", "" };
+                    yield return new object[] { @"c:\path1\path2\path3?path4", @"c:/path1/path2/path3%3Fpath4", @"c:\path1\path2\path3?path4", @"file:///c:/path1/path2/path3%3Fpath4", "" };
+                    yield return new object[] { @"c:\path1\path2?path3#path4", @"c:/path1/path2%3Fpath3%23path4", @"c:\path1\path2?path3#path4", @"file:///c:/path1/path2%3Fpath3%23path4", "" };
+                    yield return new object[] { @"c:\path1\path2#path3?path4", @"c:/path1/path2%23path3%3Fpath4", @"c:\path1\path2#path3?path4", @"file:///c:/path1/path2%23path3%3Fpath4", "" };
                 }
                 else
                 {
@@ -26,11 +30,15 @@ namespace System.PrivateUri.Tests
                     yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"/path1\path2\path3", @"file:///path1%5Cpath2%5Cpath3", ""};
                     yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1%5Cpath2/path3%5Cpath4%5C", "localhost"};
                     yield return new object[] { @"file://randomhost/path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"\\randomhost\path1\path2\path3", @"file://randomhost/path1%5Cpath2%5Cpath3", "randomhost"};
-                    yield return new object[] { @"file:///path1/path2/path3#path4", @"/path1/path2/path3", @"/path1/path2/path3#path4", @"file:///path1/path2/path3#path4", "" };
-                    yield return new object[] { @"file:///path1/path2/path3?path4", @"/path1/path2/path3", @"/path1/path2/path3?path4", @"file:///path1/path2/path3?path4", "" };
-                    yield return new object[] { @"file:///path1/path2?path3#path4", @"/path1/path2", @"/path1/path2?path3#path4", @"file:///path1/path2?path3#path4", "" };
-                    yield return new object[] { @"file:///path1/path2#path3?path4", @"/path1/path2", @"/path1/path2#path3?path4", @"file:///path1/path2#path3?path4", "" };
+                    yield return new object[] { @"/path1/path2/path3#path4", @"/path1/path2/path3%23path4", @"/path1/path2/path3#path4", @"file:///path1/path2/path3%23path4", "" };
+                    yield return new object[] { @"/path1/path2/path3?path4", @"/path1/path2/path3%3Fpath4", @"/path1/path2/path3?path4", @"file:///path1/path2/path3%3Fpath4", "" };
+                    yield return new object[] { @"/path1/path2?path3#path4", @"/path1/path2%3Fpath3%23path4", @"/path1/path2?path3#path4", @"file:///path1/path2%3Fpath3%23path4", "" };
+                    yield return new object[] { @"/path1/path2#path3?path4", @"/path1/path2%23path3%3Fpath4", @"/path1/path2#path3?path4", @"file:///path1/path2%23path3%3Fpath4", "" };
                 }
+                yield return new object[] { @"file:///path1/path2/path3#path4", @"/path1/path2/path3", @"/path1/path2/path3", @"file:///path1/path2/path3#path4", "" };
+                yield return new object[] { @"file:///path1/path2/path3?path4", @"/path1/path2/path3", @"/path1/path2/path3", @"file:///path1/path2/path3?path4", "" };
+                yield return new object[] { @"file:///path1/path2?path3#path4", @"/path1/path2", @"/path1/path2", @"file:///path1/path2?path3#path4", "" };
+                yield return new object[] { @"file:///path1/path2#path3?path4", @"/path1/path2", @"/path1/path2", @"file:///path1/path2#path3?path4", "" };
             }
         }
 

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -26,6 +26,10 @@ namespace System.PrivateUri.Tests
                     yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"/path1\path2\path3", @"file:///path1%5Cpath2%5Cpath3", ""};
                     yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1%5Cpath2/path3%5Cpath4%5C", "localhost"};
                     yield return new object[] { @"file://randomhost/path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"\\randomhost\path1\path2\path3", @"file://randomhost/path1%5Cpath2%5Cpath3", "randomhost"};
+                    yield return new object[] { @"file:///path1/path2/path3#path4", @"/path1/path2/path3", @"/path1/path2/path3#path4", @"file:///path1/path2/path3#path4", "" };
+                    yield return new object[] { @"file:///path1/path2/path3?path4", @"/path1/path2/path3", @"/path1/path2/path3?path4", @"file:///path1/path2/path3?path4", "" };
+                    yield return new object[] { @"file:///path1/path2?path3#path4", @"/path1/path2", @"/path1/path2?path3#path4", @"file:///path1/path2?path3#path4", "" };
+                    yield return new object[] { @"file:///path1/path2#path3?path4", @"/path1/path2", @"/path1/path2#path3?path4", @"file:///path1/path2#path3?path4", "" };
                 }
             }
         }

--- a/src/System.Private.Xml/tests/Misc/XmlUrlResolverTests.cs
+++ b/src/System.Private.Xml/tests/Misc/XmlUrlResolverTests.cs
@@ -46,13 +46,9 @@ namespace System.Xml.Tests
             // Base URI as null is the default for internal Xml operation.
             var baseUris = new List<Uri> { null };
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // The case below does not work on Unix, the '#' ends up treated as a fragment and the path is cut there.
-                var currDirWithDirSeparator = Environment.CurrentDirectory + Path.DirectorySeparatorChar;
-                baseUris.Add(new Uri(currDirWithDirSeparator, UriKind.Absolute));
-                baseUris.Add(new Uri(string.Empty, UriKind.RelativeOrAbsolute));
-            }
+            var currDirWithDirSeparator = Environment.CurrentDirectory + Path.DirectorySeparatorChar;
+            baseUris.Add(new Uri(currDirWithDirSeparator, UriKind.Absolute));
+            baseUris.Add(new Uri(string.Empty, UriKind.RelativeOrAbsolute));
 
             foreach (Uri baseUri in baseUris)
             {


### PR DESCRIPTION
While testing XmlUriResolver, @pjanotti discovered that any segments of a file path following a '#' symbol will be cut out of Uri.LocalPath on Unix. Based on additional tests, this also occurs for the '?' symbol. This is happening because the Unix specific case for local path only uses the path component of the URI:
https://github.com/dotnet/corefx/blob/9e8d443ff78c4f0a9a6bedf7f95961cf96ceff0a/src/System.Private.Uri/src/System/Uri.cs#L1032-L1037

The fix here is to include the fragment and query in LocalPath in the Unix path specific case. This PR enables the test case in XmlUriResolver that uncovered this issues, and adds some additional cases to our URI tests.

Fixes: #28486 