### PR TITLE
Fix regression in SslStream eof handling

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -265,9 +265,10 @@ namespace System.Net.Security
                     }
 
                     readBytes = await FillBufferAsync(adapter, SecureChannel.ReadHeaderSize + payloadBytes).ConfigureAwait(false);
-                    if (readBytes < 0)
+                    Debug.Assert(readBytes >= 0);
+                    if (readBytes == 0)
                     {
-                        throw new IOException(SR.net_frame_read_size);
+                        throw new IOException(SR.net_io_eof);
                     }
 
                     // At this point, readBytes contains the size of the header plus body.

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -42,6 +42,9 @@
     <Compile Include="ServiceNameCollectionTest.cs" />
     <Compile Include="NegotiateStreamKerberosTest.cs" />
     <!-- Common test files -->
+    <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
+      <Link>Common\System\IO\DelegateStream.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>
     </Compile>


### PR DESCRIPTION
If SslStream reads 0 bytes from the underlying stream while reading the frame header and payload, it should throw an IOException for EOF, but on Windows it's passing empty data off to the native decryption routine and on Unix it's hanging in an infinite loop.  This is a regression from 2.0 due to refactorings done in 2.1.

cc: @geoffkizer, @davidsh, @halter73, @Drawaes, @karelz 