### PR TITLE
Reducing chances of polluting SSL error queue

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Print.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Print.cs
@@ -26,6 +26,7 @@ internal static partial class Interop
 
             if (asn1String.IsInvalid)
             {
+                Interop.Crypto.ErrClearError();
                 return null;
             }
 
@@ -54,6 +55,8 @@ internal static partial class Interop
 
             using (SafeBioHandle bio = CreateMemoryBio())
             {
+                CheckValidOpenSslHandle(bio);
+                
                 int len = asn1StringPrintEx(bio, asn1String, Asn1StringPrintFlags.ASN1_STRFLGS_UTF8_CONVERT);
 
                 if (len < 0)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -20,7 +20,17 @@ internal static partial class Interop
         private static extern unsafe int ObjObj2Txt(byte* buf, int buf_len, IntPtr a);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetObjectDefinitionByName", CharSet = CharSet.Ansi)]
-        internal static extern IntPtr GetObjectDefinitionByName(string friendlyName);
+        private static extern IntPtr CryptoNative_GetObjectDefinitionByName(string friendlyName);
+        internal static IntPtr GetObjectDefinitionByName(string friendlyName)
+        {
+            IntPtr ret = CryptoNative_GetObjectDefinitionByName(friendlyName);
+            if (ret == IntPtr.Zero)
+            {
+                ErrClearError();
+            }
+
+            return ret;
+        }
 
         // Returns shared pointers, should not be tracked as a SafeHandle.
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjNid2Obj")]

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Bignum.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Bignum.cs
@@ -29,7 +29,14 @@ internal static partial class Interop
                 return IntPtr.Zero;
             }
 
-            return BigNumFromBinary(bigEndianValue, bigEndianValue.Length);
+            IntPtr ret = BigNumFromBinary(bigEndianValue, bigEndianValue.Length);
+
+            if (ret == IntPtr.Zero)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+
+            return ret;
         }
 
         internal static SafeBignumHandle CreateBignum(byte[] bigEndianValue)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -16,7 +16,18 @@ internal static partial class Interop
         private delegate int NegativeSizeReadMethod<in THandle>(THandle handle, byte[] buf, int cBuf);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioTell")]
-        internal static extern int BioTell(SafeBioHandle bio);
+        internal static extern int CryptoNative_BioTell(SafeBioHandle bio);
+
+        internal static int BioTell(SafeBioHandle bio)
+        {
+            int ret = CryptoNative_BioTell(bio);
+            if (ret < 0)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+
+            return ret;
+        }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioSeek")]
         internal static extern int BioSeek(SafeBioHandle bio, int pos);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
@@ -73,8 +73,24 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool DsaSign(SafeDsaHandle dsa, ref byte hash, int hashLength, ref byte refSignature, out int outSignatureLength);
 
-        internal static bool DsaVerify(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, int hashLength, ReadOnlySpan<byte> signature, int signatureLength) =>
-            DsaVerify(dsa, ref MemoryMarshal.GetReference(hash), hashLength, ref MemoryMarshal.GetReference(signature), signatureLength);
+        internal static bool DsaVerify(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature)
+        {
+            bool ret = DsaVerify(
+                dsa,
+                ref MemoryMarshal.GetReference(hash),
+                hash.Length,
+                ref MemoryMarshal.GetReference(signature),
+                signature.Length);
+
+            if (!ret)
+            {
+                // OpenSSL DSA signature processing requires a DER encode and decode, so
+                // the error queue may have been contaminated.
+                ErrClearError();
+            }
+
+            return ret;
+        }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaVerify")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -92,6 +92,10 @@ internal static partial class Interop
                 throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
+            // EcKeyCreateByExplicitParameters may have polluted the error queue, but key was good in the end.
+            // Clean up the error queue.
+            Interop.Crypto.ErrClearError();
+
             return key;
         }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -34,7 +34,12 @@ internal static partial class Interop
             if (rc == -1)
             {
                 if (key != null)
+                {
                     key.Dispose();
+                }
+
+                Interop.Crypto.ErrClearError();
+                
                 throw new PlatformNotSupportedException(string.Format(SR.Cryptography_CurveNotSupported, oid));
             }
             return key;

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.cs
@@ -17,8 +17,24 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool EcDsaSign(ref byte dgst, int dlen, ref byte sig, [In, Out] ref int siglen, SafeEcKeyHandle ecKey);
 
-        internal static unsafe int EcDsaVerify(ReadOnlySpan<byte> dgst, int dgst_len, ReadOnlySpan<byte> sigbuf, int sig_len, SafeEcKeyHandle ecKey) =>
-            EcDsaVerify(ref MemoryMarshal.GetReference(dgst), dgst_len, ref MemoryMarshal.GetReference(sigbuf), sig_len, ecKey);
+        internal static int EcDsaVerify(ReadOnlySpan<byte> dgst, ReadOnlySpan<byte> sigbuf, SafeEcKeyHandle ecKey)
+        {
+            int ret = EcDsaVerify(
+                ref MemoryMarshal.GetReference(dgst),
+                dgst.Length,
+                ref MemoryMarshal.GetReference(sigbuf),
+                sigbuf.Length,
+                ecKey);
+
+            if (ret == 0)
+            {
+                // OpenSSL ECDSA signature processing requires a DER encode and decode, so
+                // the error queue may have been contaminated.
+                ErrClearError();
+            }
+
+            return ret;
+        }
 
         /*-
          * returns
@@ -31,6 +47,18 @@ internal static partial class Interop
 
         // returns the maximum length of a DER encoded ECDSA signature created with this key.
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSize")]
-        internal static extern int EcDsaSize(SafeEcKeyHandle ecKey);
+        private static extern int CryptoNative_EcDsaSize(SafeEcKeyHandle ecKey);
+
+        internal static int EcDsaSize(SafeEcKeyHandle ecKey)
+        {
+            int ret = CryptoNative_EcDsaSize(ecKey);
+
+            if (ret == 0)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+
+            return ret;
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcKey.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcKey.cs
@@ -12,7 +12,17 @@ internal static partial class Interop
     internal static partial class Crypto
     {
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByOid")]
-        internal static extern SafeEcKeyHandle EcKeyCreateByOid(string oid);
+        private static extern SafeEcKeyHandle CryptoNative_EcKeyCreateByOid(string oid);
+        internal static SafeEcKeyHandle EcKeyCreateByOid(string oid)
+        {
+            SafeEcKeyHandle handle = CryptoNative_EcKeyCreateByOid(oid);
+            if (handle == null || handle.IsInvalid)
+            {
+                ErrClearError();
+            }
+
+            return handle;
+        }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyDestroy")]
         internal static extern void EcKeyDestroy(IntPtr a);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Encode.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Encode.cs
@@ -28,8 +28,18 @@ internal static partial class Interop
             byte[] data = new byte[size];
 
             int size2 = encode(handle, data);
-            Debug.Assert(size == size2);
+            if (size2 < 1)
+            {
+                Debug.Fail(
+                    $"{nameof(OpenSslEncode)}: {nameof(getSize)} succeeded ({size}) and {nameof(encode)} failed ({size2})");
 
+                // If it ever happens, ensure the error queue gets cleared.
+                // And since it didn't write the data, reporting an exception is good too.
+                throw CreateOpenSslCryptographicException();
+            }
+
+            Debug.Assert(size == size2);
+            
             return data;
         }
     }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -246,6 +246,10 @@ internal static partial class Interop
 
         internal static int Encrypt(SafeSslHandle context, ReadOnlyMemory<byte> input, ref byte[] output, out Ssl.SslErrorCode errorCode)
         {
+#if DEBUG
+            ulong assertNoError = Crypto.ErrPeekError();
+            Debug.Assert(assertNoError == 0, "OpenSsl error queue is not empty, run: 'openssl errstr " + assertNoError.ToString("X") + "' for original error.");
+#endif
             errorCode = Ssl.SslErrorCode.SSL_ERROR_NONE;
 
             int retVal;
@@ -295,6 +299,10 @@ internal static partial class Interop
 
         internal static int Decrypt(SafeSslHandle context, byte[] outBuffer, int offset, int count, out Ssl.SslErrorCode errorCode)
         {
+#if DEBUG
+            ulong assertNoError = Crypto.ErrPeekError();
+            Debug.Assert(assertNoError == 0, "OpenSsl error queue is not empty, run: 'openssl errstr " + assertNoError.ToString("X") + "' for original error.");
+#endif
             errorCode = Ssl.SslErrorCode.SSL_ERROR_NONE;
 
             int retVal = BioWrite(context.InputBio, outBuffer, offset, count);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -94,6 +94,7 @@ internal static partial class Interop
 
                 if (!Ssl.SetEncryptionPolicy(innerContext, policy))
                 {
+                    Crypto.ErrClearError();
                     throw new PlatformNotSupportedException(SR.Format(SR.net_ssl_encryptionpolicy_notsupported, policy));
                 }
 
@@ -144,7 +145,10 @@ internal static partial class Interop
                         string punyCode = s_idnMapping.GetAscii(sslAuthenticationOptions.TargetHost);
 
                         // Similar to windows behavior, set SNI on openssl by default for client context, ignore errors.
-                        Ssl.SslSetTlsExtHostName(context, punyCode);
+                        if (!Ssl.SslSetTlsExtHostName(context, punyCode))
+                        {
+                            Crypto.ErrClearError();
+                        }
                     }
 
                     if (hasCertificateAndKey)
@@ -225,7 +229,7 @@ internal static partial class Interop
                     if (sendCount <= 0)
                     {
                         // Make sure we clear out the error that is stored in the queue
-                        Crypto.ErrGetError();
+                        Crypto.ErrClearError();
                         sendBuf = null;
                         sendCount = 0;
                     }
@@ -282,7 +286,7 @@ internal static partial class Interop
                 if (retVal <= 0)
                 {
                     // Make sure we clear out the error that is stored in the queue
-                    Crypto.ErrGetError();
+                    Crypto.ErrClearError();
                 }
             }
 
@@ -362,6 +366,12 @@ internal static partial class Interop
             if (0 == certHashLength)
             {
                 throw CreateSslException(SR.net_ssl_get_channel_binding_token_failed);
+            }
+
+            if (!sessionReused)
+            {
+                // The operation may have left errors on the queue
+                Crypto.ErrClearError();
             }
 
             bindingHandle.SetCertHashLength(certHashLength);
@@ -520,7 +530,9 @@ internal static partial class Interop
 
         internal static SslException CreateSslException(string message)
         {
-            ulong errorVal = Crypto.ErrGetError();
+            // Capture last error to be consistent with CreateOpenSslCryptographicException
+            ulong errorVal = Crypto.ErrPeekLastError();
+            Crypto.ErrClearError();
             string msg = SR.Format(message, Marshal.PtrToStringAnsi(Crypto.ErrReasonErrorString(errorVal)));
             return new SslException(msg, (int)errorVal);
         }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -49,7 +49,8 @@ internal static partial class Interop
         private static extern IntPtr SslGetVersion(SafeSslHandle ssl);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetTlsExtHostName")]
-        internal static extern int SslSetTlsExtHostName(SafeSslHandle ssl, string host);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool SslSetTlsExtHostName(SafeSslHandle ssl, string host);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGet0AlpnSelected")]
         internal static extern void SslGetAlpnSelected(SafeSslHandle ssl, out IntPtr protocol, out int len);
@@ -128,6 +129,7 @@ internal static partial class Interop
         internal static extern int SslGetFinished(SafeSslHandle ssl, IntPtr buf, int count);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSessionReused")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SslSessionReused(SafeSslHandle ssl);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddExtraChainCert")]
@@ -161,6 +163,7 @@ internal static partial class Interop
                 Crypto.CheckValidOpenSslHandle(dupCertHandle);
                 if (!SslAddExtraChainCert(sslContext, dupCertHandle))
                 {
+                    Crypto.ErrClearError();
                     dupCertHandle.Dispose(); // we still own the safe handle; clean it up
                     return false;
                 }

--- a/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -282,7 +282,7 @@ namespace System.Security.Cryptography
 
                 byte[] openSslFormat = AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(signature);
 
-                return Interop.Crypto.DsaVerify(key, hash, hash.Length, openSslFormat, openSslFormat.Length);
+                return Interop.Crypto.DsaVerify(key, hash, openSslFormat);
             }
 
             private void SetKey(SafeDsaHandle newKey)

--- a/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -149,7 +149,7 @@ namespace System.Security.Cryptography
                 byte[] openSslFormat = AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(signature);
 
                 SafeEcKeyHandle key = _key.Value;
-                int verifyResult = Interop.Crypto.EcDsaVerify(hash, hash.Length, openSslFormat, openSslFormat.Length, key);
+                int verifyResult = Interop.Crypto.EcDsaVerify(hash, openSslFormat, key);
                 return verifyResult == 1;
             }
 

--- a/src/Common/src/System/Security/Cryptography/ECOpenSsl.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/ECOpenSsl.ImportExport.cs
@@ -42,6 +42,10 @@ namespace System.Security.Cryptography
                 throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
 
+            // The Import* methods above may have polluted the error queue even if in the end they succeeded.
+            // Clean up the error queue.
+            Interop.Crypto.ErrClearError();
+
             FreeKey();
             _key = new Lazy<SafeEcKeyHandle>(key);
             return KeySize;

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -355,7 +355,7 @@ namespace System.Security.Cryptography
 
             try
             {
-                Interop.Crypto.SetRsaParameters(
+                if (!Interop.Crypto.SetRsaParameters(
                     key,
                     parameters.Modulus,
                     parameters.Modulus != null ? parameters.Modulus.Length : 0,
@@ -372,7 +372,10 @@ namespace System.Security.Cryptography
                     parameters.DQ, 
                     parameters.DQ != null ? parameters.DQ.Length : 0,
                     parameters.InverseQ,
-                    parameters.InverseQ != null ? parameters.InverseQ.Length : 0);
+                    parameters.InverseQ != null ? parameters.InverseQ.Length : 0))
+                {
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
+                }
 
                 imported = true;
             }
@@ -694,7 +697,7 @@ namespace System.Security.Cryptography
             {
                 int algorithmNid = GetAlgorithmNid(hashAlgorithm);
                 SafeRsaHandle rsa = _key.Value;
-                return Interop.Crypto.RsaVerify(algorithmNid, hash, hash.Length, signature, signature.Length, rsa);
+                return Interop.Crypto.RsaVerify(algorithmNid, hash, signature, rsa);
             }
             else if (padding == RSASignaturePadding.Pss)
             {
@@ -748,6 +751,7 @@ namespace System.Security.Cryptography
 
             if (nid == Interop.Crypto.NID_undef)
             {
+                Interop.Crypto.ErrClearError();
                 throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmName.Name);
             }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.cpp
@@ -141,7 +141,7 @@ extern "C" int32_t CryptoNative_GetDsaParameters(
     return 1;
 }
 
-static void SetDsaParameter(BIGNUM** dsaFieldAddress, uint8_t* buffer, int32_t bufferLength)
+static int32_t SetDsaParameter(BIGNUM** dsaFieldAddress, uint8_t* buffer, int32_t bufferLength)
 {
     assert(dsaFieldAddress != nullptr);
     if (dsaFieldAddress)
@@ -149,13 +149,18 @@ static void SetDsaParameter(BIGNUM** dsaFieldAddress, uint8_t* buffer, int32_t b
         if (!buffer || !bufferLength)
         {
             *dsaFieldAddress = nullptr;
+            return 1;
         }
         else
         {
             BIGNUM* bigNum = BN_bin2bn(buffer, bufferLength, nullptr);
             *dsaFieldAddress = bigNum;
+
+            return bigNum != nullptr;
         }
     }
+
+    return 0;
 }
 
 extern "C" int32_t CryptoNative_DsaKeyCreateByExplicitParameters(
@@ -185,11 +190,10 @@ extern "C" int32_t CryptoNative_DsaKeyCreateByExplicitParameters(
 
     DSA* dsa = *outDsa;
 
-    SetDsaParameter(&dsa->p, p, pLength);
-    SetDsaParameter(&dsa->q, q, qLength);
-    SetDsaParameter(&dsa->g, g, gLength);
-    SetDsaParameter(&dsa->pub_key, y, yLength);
-    SetDsaParameter(&dsa->priv_key, x, xLength);
-
-    return 1;
+    return
+        SetDsaParameter(&dsa->p, p, pLength) &&
+        SetDsaParameter(&dsa->q, q, qLength) &&
+        SetDsaParameter(&dsa->g, g, gLength) &&
+        SetDsaParameter(&dsa->pub_key, y, yLength) &&
+        SetDsaParameter(&dsa->priv_key, x, xLength);
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.cpp
@@ -215,7 +215,7 @@ extern "C" int32_t CryptoNative_GetRsaParameters(const RSA* rsa,
     return 1;
 }
 
-static void SetRsaParameter(BIGNUM** rsaFieldAddress, uint8_t* buffer, int32_t bufferLength)
+static int32_t SetRsaParameter(BIGNUM** rsaFieldAddress, uint8_t* buffer, int32_t bufferLength)
 {
     assert(rsaFieldAddress != nullptr);
     if (rsaFieldAddress)
@@ -223,16 +223,21 @@ static void SetRsaParameter(BIGNUM** rsaFieldAddress, uint8_t* buffer, int32_t b
         if (!buffer || !bufferLength)
         {
             *rsaFieldAddress = nullptr;
+            return 1;
         }
         else
         {
             BIGNUM* bigNum = BN_bin2bn(buffer, bufferLength, nullptr);
             *rsaFieldAddress = bigNum;
+
+            return bigNum != nullptr;
         }
     }
+
+    return 0;
 }
 
-extern "C" void CryptoNative_SetRsaParameters(RSA* rsa,
+extern "C" int32_t CryptoNative_SetRsaParameters(RSA* rsa,
                                               uint8_t* n,
                                               int32_t nLength,
                                               uint8_t* e,
@@ -253,15 +258,16 @@ extern "C" void CryptoNative_SetRsaParameters(RSA* rsa,
     if (!rsa)
     {
         assert(false);
-        return;
+        return 0;
     }
 
-    SetRsaParameter(&rsa->n, n, nLength);
-    SetRsaParameter(&rsa->e, e, eLength);
-    SetRsaParameter(&rsa->d, d, dLength);
-    SetRsaParameter(&rsa->p, p, pLength);
-    SetRsaParameter(&rsa->dmp1, dmp1, dmp1Length);
-    SetRsaParameter(&rsa->q, q, qLength);
-    SetRsaParameter(&rsa->dmq1, dmq1, dmq1Length);
-    SetRsaParameter(&rsa->iqmp, iqmp, iqmpLength);
+    return 
+        SetRsaParameter(&rsa->n, n, nLength) &&
+        SetRsaParameter(&rsa->e, e, eLength) &&
+        SetRsaParameter(&rsa->d, d, dLength) &&
+        SetRsaParameter(&rsa->p, p, pLength) &&
+        SetRsaParameter(&rsa->dmp1, dmp1, dmp1Length) &&
+        SetRsaParameter(&rsa->q, q, qLength) &&
+        SetRsaParameter(&rsa->dmq1, dmq1, dmq1Length) &&
+        SetRsaParameter(&rsa->iqmp, iqmp, iqmpLength);
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.h
@@ -126,7 +126,7 @@ extern "C" int32_t CryptoNative_GetRsaParameters(const RSA* rsa,
 /*
 Sets all the parameters on the RSA instance.
 */
-extern "C" void CryptoNative_SetRsaParameters(RSA* rsa,
+extern "C" int32_t CryptoNative_SetRsaParameters(RSA* rsa,
                                               uint8_t* n,
                                               int32_t nLength,
                                               uint8_t* e,

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -102,7 +102,10 @@ extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols proto
 #endif
 
     SSL_CTX_set_options(ctx, protocolOptions);
-    TrySetECDHNamedCurve(ctx);
+    if (TrySetECDHNamedCurve(ctx) == 0)
+    {
+        ERR_clear_error();
+    }
 }
 
 extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx)

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
@@ -382,7 +382,6 @@ namespace System.Net.Http
 
                         // X509_verify_cert can return < 0 in the case of programmer error
                         Debug.Assert(sslResult == 0, "Unexpected error from X509_verify_cert: " + sslResult);
-                        Interop.Crypto.ErrClearError();
                     }
 
                     // Either OpenSSL verification failed, or there was a server validation callback

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
@@ -382,6 +382,7 @@ namespace System.Net.Http
 
                         // X509_verify_cert can return < 0 in the case of programmer error
                         Debug.Assert(sslResult == 0, "Unexpected error from X509_verify_cert: " + sslResult);
+                        Interop.Crypto.ErrClearError();
                     }
 
                     // Either OpenSSL verification failed, or there was a server validation callback

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.Unix.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.Unix.cs
@@ -32,6 +32,9 @@ namespace Internal.Cryptography
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 default:
                     Debug.Assert(result == 0, "LookupFriendlyNameByOid returned unexpected result " + result);
+
+                    // The lookup may have left errors in this case, clean up for precaution.
+                    Interop.Crypto.ErrClearError();
                     return null;
             }
         }

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OpenSslAsnFormatter.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OpenSslAsnFormatter.cs
@@ -23,44 +23,63 @@ namespace Internal.Cryptography
             // or to return null and let rawData get hex-encoded.  CryptographicException should not
             // be raised.
 
-            using (SafeAsn1ObjectHandle asnOid = Interop.Crypto.ObjTxt2Obj(oid.Value))
-            using (SafeAsn1OctetStringHandle octetString = Interop.Crypto.Asn1OctetStringNew())
+            bool clearErrors = true;
+            try
             {
-                if (asnOid.IsInvalid || octetString.IsInvalid)
+                using (SafeAsn1ObjectHandle asnOid = Interop.Crypto.ObjTxt2Obj(oid.Value))
+                using (SafeAsn1OctetStringHandle octetString = Interop.Crypto.Asn1OctetStringNew())
                 {
-                    return null;
-                }
-
-                if (!Interop.Crypto.Asn1OctetStringSet(octetString, rawData, rawData.Length))
-                {
-                    return null;
-                }
-
-                using (SafeBioHandle bio = Interop.Crypto.CreateMemoryBio())
-                using (SafeX509ExtensionHandle x509Ext = Interop.Crypto.X509ExtensionCreateByObj(asnOid, false, octetString))
-                {
-                    if (bio.IsInvalid || x509Ext.IsInvalid)
+                    if (asnOid.IsInvalid || octetString.IsInvalid)
                     {
                         return null;
                     }
 
-                    if (!Interop.Crypto.X509V3ExtPrint(bio, x509Ext))
+                    if (!Interop.Crypto.Asn1OctetStringSet(octetString, rawData, rawData.Length))
                     {
                         return null;
                     }
 
-                    int printLen = Interop.Crypto.GetMemoryBioSize(bio);
-
-                    // Account for the null terminator that it'll want to write.
-                    var buf = new byte[printLen + 1];
-                    int read = Interop.Crypto.BioGets(bio, buf, buf.Length);
-
-                    if (read < 0)
+                    using (SafeBioHandle bio = Interop.Crypto.CreateMemoryBio())
+                    using (SafeX509ExtensionHandle x509Ext = Interop.Crypto.X509ExtensionCreateByObj(asnOid, false, octetString))
                     {
-                        throw Interop.Crypto.CreateOpenSslCryptographicException();
-                    }
+                        if (bio.IsInvalid || x509Ext.IsInvalid)
+                        {
+                            return null;
+                        }
 
-                    return Encoding.UTF8.GetString(buf, 0, read);
+                        if (!Interop.Crypto.X509V3ExtPrint(bio, x509Ext))
+                        {
+                            return null;
+                        }
+
+                        // X509V3ExtPrint might contaminate the error queue on success, always clear now.
+                        Interop.Crypto.ErrClearError();
+
+                        // Errors past here are handled by throws, don't need to double-lock
+                        // the success path.
+                        clearErrors = false;
+
+                        int printLen = Interop.Crypto.GetMemoryBioSize(bio);
+
+                        // Account for the null terminator that it'll want to write.
+                        var buf = new byte[printLen + 1];
+                        int read = Interop.Crypto.BioGets(bio, buf, buf.Length);
+
+                        if (read < 0)
+                        {
+                            throw Interop.Crypto.CreateOpenSslCryptographicException();
+                        }
+
+                        return Encoding.UTF8.GetString(buf, 0, read);
+                    }
+                }
+            }
+            finally
+            {
+                // All of the return null paths might have errors that we are ignoring.
+                if (clearErrors)
+                {
+                    Interop.Crypto.ErrClearError();
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
@@ -54,9 +54,15 @@ namespace Internal.Cryptography.Pal
 
             using (SafeBioHandle bio = Interop.Crypto.CreateMemoryBio())
             {
+                Interop.Crypto.CheckValidOpenSslHandle(bio);
+                
                 Interop.Crypto.BioWrite(bio, data, data.Length);
 
                 handle = Interop.Crypto.PemReadBioX509Crl(bio);
+
+                // DecodeX509Crl failed, so we need to clear its error.
+                // If PemReadBioX509Crl failed, clear that too.
+                Interop.Crypto.ErrClearError();
 
                 if (!handle.IsInvalid)
                 {

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
@@ -118,7 +118,10 @@ namespace Internal.Cryptography.Pal
             // 
             // Use BioSeek directly for the last seek attempt, because any failure here should instead
             // report the already created (but not yet thrown) exception.
-            Interop.Crypto.BioSeek(bio, bioPosition);
+            if (Interop.Crypto.BioSeek(bio, bioPosition) < 0)
+            {
+                Interop.Crypto.ErrClearError();
+            }
 
             Debug.Assert(openSslException != null);
             throw openSslException;
@@ -172,7 +175,11 @@ namespace Internal.Cryptography.Pal
             {
                 Interop.Crypto.CheckValidOpenSslHandle(bio);
 
-                Interop.Crypto.BioWrite(bio, rawData, rawData.Length);
+                if (Interop.Crypto.BioWrite(bio, rawData, rawData.Length) != rawData.Length)
+                {
+                    Interop.Crypto.ErrClearError();
+                }
+
                 return TryReadX509Pem(bio, out certPal);
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -128,6 +128,7 @@ namespace Internal.Cryptography.Pal
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
+                
 
                 // Because our callback tells OpenSSL that every problem is ignorable, it should tell us that the
                 // chain is just fine (unless it returned a negative code for an exception)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -128,7 +128,6 @@ namespace Internal.Cryptography.Pal
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
-                
 
                 // Because our callback tells OpenSSL that every problem is ignorable, it should tell us that the
                 // chain is just fine (unless it returned a negative code for an exception)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
@@ -30,7 +30,10 @@ namespace Internal.Cryptography.Pal
             {
                 Interop.Crypto.CheckValidOpenSslHandle(bio);
 
-                Interop.Crypto.BioWrite(bio, rawData, rawData.Length);
+                if (Interop.Crypto.BioWrite(bio, rawData, rawData.Length) != rawData.Length)
+                {
+                    Interop.Crypto.ErrClearError();
+                }
 
                 using (SafePkcs7Handle pkcs7 = Interop.Crypto.PemReadBioPkcs7(bio))
                 {
@@ -179,7 +182,10 @@ namespace Internal.Cryptography.Pal
             {
                 Interop.Crypto.CheckValidOpenSslHandle(bio);
 
-                Interop.Crypto.BioWrite(bio, rawData, rawData.Length);
+                if (Interop.Crypto.BioWrite(bio, rawData, rawData.Length) != rawData.Length)
+                {
+                    Interop.Crypto.ErrClearError();
+                }
 
                 return TryReadPkcs7Pem(bio, single, out certPal, out certPals);
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -120,7 +120,10 @@ namespace Internal.Cryptography.Pal
             // 
             // Use BioSeek directly for the last seek attempt, because any failure here should instead
             // report the already created (but not yet thrown) exception.
-            Interop.Crypto.BioSeek(bio, bioPosition);
+            if (Interop.Crypto.BioSeek(bio, bioPosition) < 0)
+            {
+                Interop.Crypto.ErrClearError();
+            }
             
             Debug.Assert(openSslException != null);
             throw openSslException;
@@ -251,6 +254,8 @@ namespace Internal.Cryptography.Pal
             {
                 using (SafeBioHandle fileBio = Interop.Crypto.BioNewFile(file.FullName, "rb"))
                 {
+                    Interop.Crypto.CheckValidOpenSslHandle(fileBio);
+
                     ICertificatePal pal;
 
                     while (CertificatePal.TryReadX509Pem(fileBio, out pal) ||

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.OpenSslDecode.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.OpenSslDecode.cs
@@ -23,6 +23,7 @@ namespace Internal.Cryptography.Pal
             {
                 if (x509Name.IsInvalid)
                 {
+                    Interop.Crypto.ErrClearError();
                     return "";
                 }
 


### PR DESCRIPTION
This merges my sample change with some changes coded by @bartonjs.

If errors were being ignored the typical approach is for adding a managed wrapper that P/Invokes the native PAL and clear the error there, alternatively it could have been done on the native but per conversation, @bartonjs [asked for consistency and to make it in managed](https://github.com/dotnet/corefx/pull/29287/files#r183577442). 

In a few cases it is more economical (in terms of # of lines changed) to do everything on the code calling the PAL methods, e.g.: single call can clean up multiple methods. In other situations this is required to keep the current exceptions unchanged and still having something to report. Some errors related to OOM on the native PAL were being ignored and likely causing failures later, these now should throw with proper exception. A few changes to the native PAL were required either to return errors to managed or in a special case clean-up the errors that were ignored.

A wider refactoring regarding error handling for usage of OpenSsl is desirable in the future (perhaps when upgrading to newer version of OpenSsl). This change is tactical with the goal of being relatively low risk while reducing the risk of, self-inflicted, spurious SslStream errors during Write/Read.