### PR TITLE
Correctly deserialize indefinite-length octet and bit strings

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1V2.Serializer.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1V2.Serializer.cs
@@ -879,7 +879,7 @@ namespace System.Security.Cryptography.Asn1
 
                         try
                         {
-                            if (reader.TryCopyBitStringBytes(rented, out _, out int bytesWritten))
+                            if (reader.TryCopyBitStringBytes(expectedTag, rented, out _, out int bytesWritten))
                             {
                                 return new ReadOnlyMemory<byte>(rented.AsSpan(0, bytesWritten).ToArray());
                             }
@@ -910,7 +910,7 @@ namespace System.Security.Cryptography.Asn1
 
                         try
                         {
-                            if (reader.TryCopyOctetStringBytes(rented, out int bytesWritten))
+                            if (reader.TryCopyOctetStringBytes(expectedTag, rented, out int bytesWritten))
                             {
                                 return new ReadOnlyMemory<byte>(rented.AsSpan(0, bytesWritten).ToArray());
                             }

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
@@ -113,6 +113,38 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal<string>(expectedIssuers, actualIssuers);
         }
 
+
+        [Fact]
+        public static void DecodeAllIndefinite()
+        {
+            byte[] encrypted = Convert.FromBase64String(
+                @"
+MIAGCSqGSIb3DQEHA6CAMIACAQAxggFXMIIBUwIBADA7MDMxGTAXBgNVBAoMEERh
+dGEgSW50ZXJjaGFuZ2UxFjAUBgNVBAMMDVVubyBUZXN0IFJvb3QCBFqG6RQwDQYJ
+KoZIhvcNAQEBBQAEggEAUPilAHUe67HG5vDCO/JBmof44G/XnDLtiDrbxD4QekGq
+mdPqazZiLDKEewlBy2uFJr/JijeYx6qNKTXs/EShw/lYnKisaK5ue6JZ7ssMunM9
+HpkiDfM+iyN7PxnC1riZ/Kg2JExY8pf5R1Zuvu29JSLhM9ajWk9C1pBzQRJ4vkY2
+OvFKR2th0Vgw7mTmc2X6HUK4tosB3LGKDVNd6BVoMQMvfkseCqeZOe1KIiBFmhyk
+E+B2UZcD6Z6kLnCk4LNGyoyxW6Thv5s/lwP9p7trVVbPXbuep1l8uMCGj6vjTD66
+AamEIRmTFvEVHzyO2MGG9V0bM+8UpqPAVFNCXOm6mjCABgkqhkiG9w0BBwEwFAYI
+KoZIhvcNAwcECJ01qtX2EKx6oIAEEM7op+R2U3GQbYwlEj5X+h0AAAAAAAAAAAAA
+");
+            EnvelopedCms cms = new EnvelopedCms();
+            cms.Decode(encrypted);
+
+            RecipientInfoCollection recipientInfos = cms.RecipientInfos;
+
+            Assert.Equal(1, recipientInfos.Count);
+            Assert.Equal(
+                SubjectIdentifierType.IssuerAndSerialNumber,
+                recipientInfos[0].RecipientIdentifier.Type);
+
+            // Still encrypted.
+            Assert.Equal(
+                "CEE8A7E4765371906D8C25123E57FA1D",
+                cms.ContentInfo.Content.ByteArrayToHex());
+        }
+
         [Fact]
         public static void TestGetContentTypeEnveloped()
         {


### PR DESCRIPTION
When a BIT STRING or OCTET STRING is implicitly tagged using a tag from the
context-specific, application, or private tag classes and has an indefinite length
representation, the outer tag is the specified tag and the inner tags are 03 or 04.

In the deserializer the correct tag was used for TryGetPrimitive[Type]Bytes, but
that returns false for indefinite length encodings (because the content bytes
are not contiguous).  During the fallback to TryCopy[Type]Bytes the expected
tag value was not passed along, so the read operation failed with a tag
mismatch.

Now we correctly pass the expected tag, so TryCopy[Type]Bytes matches the
expected outer tag and continues with the constructed encoding (definite or
indefinite length) rules for the BIT STRING or OCTET STRING value.

Character string types also have TryGetPrimitive overloads, but these aren't
used in the deserializer, currently only the string-allocating forms are
supported.

Addresses #29345 (in master).