### PR TITLE
Fix charset parsing in HttpListenerRequest

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -292,20 +292,20 @@ namespace System.Net
             //
             internal static string GetCharSetValueFromHeader(string headerValue)
             {
-                string attrName = "charset";
+                const string AttrName = "charset";
 
                 if (headerValue == null)
                     return null;
 
                 int l = headerValue.Length;
-                int k = attrName.Length;
+                int k = AttrName.Length;
 
                 // find properly separated attribute name
                 int i = 1; // start searching from 1
 
                 while (i < l)
                 {
-                    i = CultureInfo.InvariantCulture.CompareInfo.IndexOf(headerValue, attrName, i, CompareOptions.IgnoreCase);
+                    i = CultureInfo.InvariantCulture.CompareInfo.IndexOf(headerValue, AttrName, i, CompareOptions.IgnoreCase);
                     if (i < 0)
                         break;
                     if (i + k >= l)

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -92,7 +92,7 @@ namespace System.Net
                 {
                     if (ContentType != null)
                     {
-                        string charSet = Helpers.GetAttributeFromHeader(ContentType, "charset");
+                        string charSet = Helpers.GetCharSetValueFromHeader(ContentType);
                         if (charSet != null)
                         {
                             try
@@ -290,8 +290,10 @@ namespace System.Net
             //
             // Get attribute off header value
             //
-            internal static string GetAttributeFromHeader(string headerValue, string attrName)
+            internal static string GetCharSetValueFromHeader(string headerValue)
             {
+                string attrName = "charset";
+
                 if (headerValue == null)
                     return null;
 
@@ -351,7 +353,7 @@ namespace System.Net
                 {
                     for (j = i; j < l; j++)
                     {
-                        if (headerValue[j] == ' ' || headerValue[j] == ',')
+                        if (headerValue[j] == ';')
                             break;
                     }
 

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -83,14 +83,11 @@ namespace System.Net.Tests
             yield return new object[] { "Content-Type:application.json;charset=\"unicode", Encoding.Default };
             yield return new object[] { "Content-Type:application/json;charset=NoSuchEncoding", Encoding.Default };
 
-            yield return new object[] { "Content-Type:application/json;charset=unicode; boundary=something", Encoding.Unicode };
             yield return new object[] { "Content-Type:application/json;charset=unicode   ; boundary=something", Encoding.Unicode };
             yield return new object[] { "Content-Type:application/json;charset=unicode ; ; boundary=something", Encoding.Unicode };
             yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode", Encoding.Unicode };
             yield return new object[] { "Content-Type:application/json;boundary=something;charset=unicode   ", Encoding.Unicode };
-            yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode;", Encoding.Unicode };
             yield return new object[] { "Content-Type:application/json;boundary=something;charset=unicode   ;", Encoding.Unicode };
-            yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode;   ", Encoding.Unicode };
             yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode ;", Encoding.Unicode };
 
             yield return new object[] { "Content-Type:application.json;charset=\"unicode\";", Encoding.Unicode };
@@ -102,6 +99,17 @@ namespace System.Net.Tests
             yield return new object[] { "Content-Type:application/json;charset=\" unicode ;\"; boundary=something", Encoding.Default };
 
             yield return new object[] { "Unknown-Header: Test", Encoding.Default };
+
+            if (!PlatformDetection.IsFullFramework)
+            {
+                // .NET Framework wrongly uses ' ' and ',' as delimiter for parsing Content-Type header.
+                // "charset=unicode;" will be parsed as "unicode;" for charSet parameter. Then the following GetEncoding(charSet)
+                // will fail with ArgumentException. In this case, Encoding.Default will be chosen for ContentEncoding,
+                // even if client explicitly specifies the Unicode encoding in the header.
+                yield return new object[] { "Content-Type:application/json;charset=unicode; boundary=something", Encoding.Unicode };
+                yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode;", Encoding.Unicode };
+                yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode;   ", Encoding.Unicode };
+            }
         }
 
         [Theory]

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -82,7 +82,24 @@ namespace System.Net.Tests
             yield return new object[] { "Content-Type:application.json;charset=,", Encoding.Default };
             yield return new object[] { "Content-Type:application.json;charset=\"unicode", Encoding.Default };
             yield return new object[] { "Content-Type:application/json;charset=NoSuchEncoding", Encoding.Default };
-            yield return new object[] { "Content-Type:application/json;charset=unicode; boundary=something", Encoding.Default };
+
+            yield return new object[] { "Content-Type:application/json;charset=unicode; boundary=something", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json;charset=unicode   ; boundary=something", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json;charset=unicode ; ; boundary=something", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json;boundary=something;charset=unicode   ", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode;", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json;boundary=something;charset=unicode   ;", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode;   ", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json;boundary=something; charset=unicode ;", Encoding.Unicode };
+
+            yield return new object[] { "Content-Type:application.json;charset=\"unicode\";", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application.json; charset=\"unicode;\"", Encoding.Default };
+            yield return new object[] { "Content-Type:application/json;charset=\"unicode\" ; boundary=something", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json; charset=\"unicode;\";boundary=something", Encoding.Default };
+            yield return new object[] { "Content-Type:application/json;charset=\" unicode \"; boundary=something", Encoding.Unicode };
+            yield return new object[] { "Content-Type:application/json; charset=\"unicode ;\"; boundary=something", Encoding.Default };
+            yield return new object[] { "Content-Type:application/json;charset=\" unicode ;\"; boundary=something", Encoding.Default };
 
             yield return new object[] { "Unknown-Header: Test", Encoding.Default };
         }


### PR DESCRIPTION
The function `GetAttributeFromHeader` was ported from Framework. It's obsolete and serves as a single purpose to parse the `charset` attribute for `ContentType` header in HttpListener's request.

If the parameter value ends with a `;`, after parsing, the value will contain that undesired semicolon in it. 
For example, `"charset=unicode;"` will be parsed to `"unicode;"`, thus the following `Encoding.GetEncoding(charSet)` will fail with `ArgumentException`. In this case, `Encoding.Default` will be chose for `ContentEncoding`, even if client explicitly specifies the Unicode encoding in the header.

The fix is following rfc2045 section 5.1.:

```
5.1.  Syntax of the Content-Type Header Field

     content := "Content-Type" ":" type "/" subtype
                *(";" parameter)

parameter := attribute "=" value
```

Usually `charset` parameter is at the end, and we don't need to worry about the `;`. But it could be possible that `charset` parameter is in the middle, and followed by a `;`, thus fails parsing.

Per RFC, the last parameter should not followed by a `;`. In our code, the parsing is more robust, which I think it's acceptable. Please let me know if you have different thoughts.

Close: #23506