### PR TITLE
Add better portable PDB caching to System.Diagnostics.StackTrace. 

### DIFF
--- a/src/System.Diagnostics.StackTrace/src/System.Diagnostics.StackTrace.csproj
+++ b/src/System.Diagnostics.StackTrace/src/System.Diagnostics.StackTrace.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">
     <Compile Include="System\Diagnostics\StackTraceSymbols.CoreCLR.cs" />
-    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />
+    <ProjectReference Include="..\..\System.Collections.Concurrent\src\System.Collections.Concurrent.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
     <ProjectReference Include="..\..\System.IO\src\System.IO.csproj" />
     <ProjectReference Include="..\..\System.IO.FileSystem\src\System.IO.FileSystem.csproj" />

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.CoreCLR.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.CoreCLR.cs
@@ -29,10 +29,7 @@ namespace System.Diagnostics
         {
             foreach (MetadataReaderProvider provider in _metadataCache.Values)
             {
-                if (provider != null)
-                {
-                    provider.Dispose();
-                }
+                provider?.Dispose();
             }
 
             _metadataCache.Clear();
@@ -126,11 +123,7 @@ namespace System.Diagnostics
             MetadataReaderProvider provider;
             if (_metadataCache.TryGetValue(cacheKey, out provider))
             {
-                if (provider == null)
-                {
-                    return null;
-                }
-                return provider.GetMetadataReader();
+                return provider?.GetMetadataReader();
             }
 
             provider = (inMemoryPdbAddress != IntPtr.Zero) ?

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.CoreCLR.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.CoreCLR.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -12,14 +12,14 @@ namespace System.Diagnostics
 {
     internal class StackTraceSymbols : IDisposable
     {
-        private readonly Dictionary<IntPtr, MetadataReaderProvider> _metadataCache;
+        private readonly ConcurrentDictionary<IntPtr, MetadataReaderProvider> _metadataCache;
 
         /// <summary>
         /// Create an instance of this class.
         /// </summary>
         public StackTraceSymbols()
         {
-            _metadataCache = new Dictionary<IntPtr, MetadataReaderProvider>();
+            _metadataCache = new ConcurrentDictionary<IntPtr, MetadataReaderProvider>();
         }
 
         /// <summary>
@@ -29,7 +29,10 @@ namespace System.Diagnostics
         {
             foreach (MetadataReaderProvider provider in _metadataCache.Values)
             {
-                provider.Dispose();
+                if (provider != null)
+                {
+                    provider.Dispose();
+                }
             }
 
             _metadataCache.Clear();
@@ -123,6 +126,10 @@ namespace System.Diagnostics
             MetadataReaderProvider provider;
             if (_metadataCache.TryGetValue(cacheKey, out provider))
             {
+                if (provider == null)
+                {
+                    return null;
+                }
                 return provider.GetMetadataReader();
             }
 
@@ -130,12 +137,13 @@ namespace System.Diagnostics
                 TryOpenReaderForInMemoryPdb(inMemoryPdbAddress, inMemoryPdbSize) :
                 TryOpenReaderFromAssemblyFile(assemblyPath, loadedPeAddress, loadedPeSize);
 
+            // This may fail as another thread might have beaten us to it, but it doesn't matter
+            _metadataCache.TryAdd(cacheKey, provider);
+
             if (provider == null)
             {
                 return null;
             }
-
-            _metadataCache.Add(cacheKey, provider);
 
             // The reader has already been open, so this doesn't throw:
             return provider.GetMetadataReader();


### PR DESCRIPTION
Make the pdb reader caching for StackTrace thread safe.