### PR TITLE
Add more Span-based parsing tests for Int32 and friends

### DIFF
--- a/src/System.Runtime/tests/System/BooleanTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/BooleanTests.netcoreapp.cs
@@ -2,19 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Tests
 {
     public partial class BooleanTests
     {
-        [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, bool expected)
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
         {
-            Assert.Equal(expected, bool.Parse(value.AsSpan()));
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1] };
+            }
 
-            Assert.True(bool.TryParse(value.AsSpan(), out bool result));
+            yield return new object[] { " \0 \0  TrueFalse   \0 ", 6, 4, true };
+            yield return new object[] { " \0 \0  TrueFalse   \0 ", 10, 5, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, bool expected)
+        {
+            Assert.Equal(expected, bool.Parse(value.AsSpan(offset, count)));
+
+            Assert.True(bool.TryParse(value.AsSpan(offset, count), out bool result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/ByteTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ByteTests.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -9,13 +10,30 @@ namespace System.Tests
 {
     public partial class ByteTests
     {
-        [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, byte expected)
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
         {
-            Assert.Equal(expected, byte.Parse(value.AsSpan(), style, provider));
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1], inputs[2], inputs[3] };
+            }
 
-            Assert.True(byte.TryParse(value.AsSpan(), style, provider, out byte result));
+            yield return new object[] { "123", 0, 2, NumberStyles.Integer, null, (byte)12 };
+            yield return new object[] { "+123", 0, 2, NumberStyles.Integer, null, (byte)1 };
+            yield return new object[] { "+123", 1, 3, NumberStyles.Integer, null, (byte)123 };
+            yield return new object[] { "  123  ", 4, 1, NumberStyles.Integer, null, (byte)3 };
+            yield return new object[] { "12", 1, 1, NumberStyles.HexNumber, null, (byte)0x2 };
+            yield return new object[] { "10", 0, 1, NumberStyles.AllowThousands, null, (byte)1 };
+            yield return new object[] { "$100", 0, 2, NumberStyles.Currency, new NumberFormatInfo() { CurrencySymbol = "$" }, (byte)1 };
+        }
+
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, byte expected)
+        {
+            Assert.Equal(expected, byte.Parse(value.AsSpan(offset, count), style, provider));
+
+            Assert.True(byte.TryParse(value.AsSpan(offset, count), style, provider, out byte result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/DateTimeOffsetTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffsetTests.netcoreapp.cs
@@ -25,6 +25,24 @@ namespace System.Tests
             Assert.Equal(expectedString, actual.ToString());
         }
 
+        [Theory]
+        [InlineData("r")]
+        [InlineData("o")]
+        public static void ToString_Slice_ParseSpan_RoundtripsSuccessfully(string roundtripFormat)
+        {
+            string expectedString = DateTimeOffset.UtcNow.ToString(roundtripFormat);
+            ReadOnlySpan<char> expectedSpan = ("abcd" + expectedString + "1234").AsSpan("abcd".Length, expectedString.Length);
+
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedSpan).ToString(roundtripFormat));
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedSpan, null).ToString(roundtripFormat));
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedSpan, null, DateTimeStyles.None).ToString(roundtripFormat));
+
+            Assert.True(DateTimeOffset.TryParse(expectedSpan, out DateTimeOffset actual));
+            Assert.Equal(expectedString, actual.ToString(roundtripFormat));
+            Assert.True(DateTimeOffset.TryParse(expectedSpan, null, DateTimeStyles.None, out actual));
+            Assert.Equal(expectedString, actual.ToString(roundtripFormat));
+        }
+
         [Fact]
         public static void ToString_ParseExactSpan_RoundtripsSuccessfully()
         {

--- a/src/System.Runtime/tests/System/DoubleTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DoubleTests.netcoreapp.cs
@@ -87,9 +87,24 @@ namespace System.Tests
             Assert.Equal(expected, double.IsSubnormal(d));
         }
 
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
+        {
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1], inputs[2], inputs[3] };
+            }
+
+            const NumberStyles DefaultStyle = NumberStyles.Float | NumberStyles.AllowThousands;
+            yield return new object[] { "-123", 0, 3, DefaultStyle, null, (double)-12 };
+            yield return new object[] { "-123", 1, 3, DefaultStyle, null, (double)123 };
+            yield return new object[] { "1E23", 0, 3, DefaultStyle, null, 1E2 };
+            yield return new object[] { "(123)", 1, 3, NumberStyles.AllowParentheses, new NumberFormatInfo() { NumberDecimalSeparator = "." }, 123 };
+            yield return new object[] { "-Infinity", 1, 8, NumberStyles.Any, NumberFormatInfo.InvariantInfo, double.PositiveInfinity };
+        }
+
         [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, double expected)
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, double expected)
         {
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             double result;
@@ -98,18 +113,18 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(double.TryParse(value.AsSpan(), out result));
+                    Assert.True(double.TryParse(value.AsSpan(offset, count), out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, double.Parse(value.AsSpan()));
+                    Assert.Equal(expected, double.Parse(value.AsSpan(offset, count)));
                 }
 
-                Assert.Equal(expected, double.Parse(value.AsSpan(), provider: provider));
+                Assert.Equal(expected, double.Parse(value.AsSpan(offset, count), provider: provider));
             }
 
-            Assert.Equal(expected, double.Parse(value.AsSpan(), style, provider));
+            Assert.Equal(expected, double.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(double.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.True(double.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/Int16Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Int16Tests.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -9,13 +10,30 @@ namespace System.Tests
 {
     public partial class Int16Tests
     {
-        [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, short expected)
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
         {
-            Assert.Equal(expected, short.Parse(value.AsSpan(), style, provider));
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1], inputs[2], inputs[3] };
+            }
 
-            Assert.True(short.TryParse(value.AsSpan(), style, provider, out short result));
+            yield return new object[] { "-32767", 1, 5, NumberStyles.Integer, null, (short)32767 };
+            yield return new object[] { "-32768", 0, 5, NumberStyles.Integer, null, (short)-3276 };
+            yield return new object[] { "abc", 0, 2, NumberStyles.HexNumber, null, (short)0xab };
+            yield return new object[] { "abc", 1, 2, NumberStyles.HexNumber, null, (short)0xbc };
+            yield return new object[] { "(123)", 1, 3, NumberStyles.AllowParentheses, null, (short)123 };
+            yield return new object[] { "123", 0, 1, NumberStyles.Integer, new NumberFormatInfo(), (short)1 };
+            yield return new object[] { "$1,000", 1, 5, NumberStyles.Currency, new NumberFormatInfo() { CurrencySymbol = "$" }, (short)1000 };
+            yield return new object[] { "$1,000", 0, 2, NumberStyles.Currency, new NumberFormatInfo() { CurrencySymbol = "$" }, (short)1 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, short expected)
+        {
+            Assert.Equal(expected, short.Parse(value.AsSpan(offset, count), style, provider));
+
+            Assert.True(short.TryParse(value.AsSpan(offset, count), style, provider, out short result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/Int32Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Int32Tests.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -9,13 +10,77 @@ namespace System.Tests
 {
     public partial class Int32Tests
     {
-        [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, int expected)
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
         {
-            Assert.Equal(expected, int.Parse(value.AsSpan(), style, provider));
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1], inputs[2], inputs[3] };
+            }
 
-            Assert.True(int.TryParse(value.AsSpan(), style, provider, out int result));
+            NumberFormatInfo samePositiveNegativeFormat = new NumberFormatInfo()
+            {
+                PositiveSign = "|",
+                NegativeSign = "|"
+            };
+
+            NumberFormatInfo emptyPositiveFormat = new NumberFormatInfo() { PositiveSign = "" };
+            NumberFormatInfo emptyNegativeFormat = new NumberFormatInfo() { NegativeSign = "" };
+
+            // None
+            yield return new object[] { "2147483647", 1, 9, NumberStyles.None, null, 147483647 };
+            yield return new object[] { "2147483647", 1, 1, NumberStyles.None, null, 1 };
+            yield return new object[] { "123\0\0", 2, 2, NumberStyles.None, null, 3 };
+
+            // Hex
+            yield return new object[] { "abc", 0, 1, NumberStyles.HexNumber, null, 0xa };
+            yield return new object[] { "ABC", 1, 1, NumberStyles.HexNumber, null, 0xB };
+            yield return new object[] { "FFFFFFFF", 6, 2, NumberStyles.HexNumber, null, 0xFF };
+            yield return new object[] { "FFFFFFFF", 0, 1, NumberStyles.HexNumber, null, 0xF };
+
+            // Currency
+            yield return new object[] { "-$1000", 1, 5, NumberStyles.Currency, new NumberFormatInfo()
+            {
+                CurrencySymbol = "$",
+                CurrencyGroupSeparator = "|",
+                NumberGroupSeparator = "/"
+            }, 1000 };
+
+            NumberFormatInfo emptyCurrencyFormat = new NumberFormatInfo() { CurrencySymbol = "" };
+            yield return new object[] { "100", 1, 2, NumberStyles.Currency, emptyCurrencyFormat, 0 };
+            yield return new object[] { "100", 0, 1, NumberStyles.Currency, emptyCurrencyFormat, 1 };
+
+            // If CurrencySymbol and Negative are the same, NegativeSign is preferred
+            NumberFormatInfo sameCurrencyNegativeSignFormat = new NumberFormatInfo()
+            {
+                NegativeSign = "|",
+                CurrencySymbol = "|"
+            };
+            yield return new object[] { "1000", 1, 3, NumberStyles.AllowCurrencySymbol | NumberStyles.AllowLeadingSign, sameCurrencyNegativeSignFormat, 0 };
+            yield return new object[] { "|1000", 0, 2, NumberStyles.AllowCurrencySymbol | NumberStyles.AllowLeadingSign, sameCurrencyNegativeSignFormat, -1 };
+
+            // Any
+            yield return new object[] { "123", 0, 2, NumberStyles.Any, null, 12 };
+
+            // AllowLeadingSign
+            yield return new object[] { "-2147483648", 0, 10, NumberStyles.AllowLeadingSign, null, -214748364 };
+
+            // AllowTrailingSign
+            yield return new object[] { "123-", 0, 3, NumberStyles.AllowTrailingSign, null, 123 };
+
+            // AllowExponent
+            yield return new object[] { "1E2", 0, 1, NumberStyles.AllowExponent, null, 1 };
+            yield return new object[] { "1E+2", 3, 1, NumberStyles.AllowExponent, null, 2 };
+            yield return new object[] { "(1E2)", 1, 3, NumberStyles.AllowExponent | NumberStyles.AllowParentheses, null, 1E2 };
+            yield return new object[] { "-1E2", 1, 3, NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign, null, 1E2 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, int expected)
+        {
+            Assert.Equal(expected, int.Parse(value.AsSpan(offset, count), style, provider));
+
+            Assert.True(int.TryParse(value.AsSpan(offset, count), style, provider, out int result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/SByteTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/SByteTests.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -9,13 +10,28 @@ namespace System.Tests
 {
     public partial class SByteTests
     {
-        [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, sbyte expected)
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
         {
-            Assert.Equal(expected, sbyte.Parse(value.AsSpan(), style, provider));
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1], inputs[2], inputs[3] };
+            }
 
-            Assert.True(sbyte.TryParse(value.AsSpan(), style, provider, out sbyte result));
+            yield return new object[] { "-123", 0, 2, NumberStyles.Integer, null, (sbyte)-1 };
+            yield return new object[] { "-123", 1, 3, NumberStyles.Integer, null, (sbyte)123 };
+            yield return new object[] { "12", 0, 1, NumberStyles.HexNumber, null, (sbyte)0x1 };
+            yield return new object[] { "12", 1, 1, NumberStyles.HexNumber, null, (sbyte)0x2 };
+            yield return new object[] { "(123)", 1, 3, NumberStyles.AllowParentheses, null, (sbyte)123 };
+            yield return new object[] { "$100", 1, 1, NumberStyles.Currency, new NumberFormatInfo() { CurrencySymbol = "$" }, (sbyte)1 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, sbyte expected)
+        {
+            Assert.Equal(expected, sbyte.Parse(value.AsSpan(offset, count), style, provider));
+
+            Assert.True(sbyte.TryParse(value.AsSpan(offset, count), style, provider, out sbyte result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/UInt16Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/UInt16Tests.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -9,13 +10,29 @@ namespace System.Tests
 {
     public partial class UInt16Tests
     {
-        [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, ushort expected)
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
         {
-            Assert.Equal(expected, ushort.Parse(value.AsSpan(), style, provider));
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1], inputs[2], inputs[3] };
+            }
 
-            Assert.True(ushort.TryParse(value.AsSpan(), style, provider, out ushort result));
+            yield return new object[] { "123", 0, 2, NumberStyles.Integer, null, (ushort)12 };
+            yield return new object[] { "123", 1, 2, NumberStyles.Integer, null, (ushort)23 };
+            yield return new object[] { "+123", 0, 2, NumberStyles.Integer, null, (ushort)1 };
+            yield return new object[] { "+123", 1, 3, NumberStyles.Integer, null, (ushort)123 };
+            yield return new object[] { "AJK", 0, 1, NumberStyles.HexNumber, new NumberFormatInfo(), (ushort)0XA };
+            yield return new object[] { "$1,000", 0, 2, NumberStyles.Currency, new NumberFormatInfo() { CurrencySymbol = "$" }, (ushort)1 };
+            yield return new object[] { "$1,000", 1, 3, NumberStyles.Currency, new NumberFormatInfo() { CurrencySymbol = "$" }, (ushort)10 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, ushort expected)
+        {
+            Assert.Equal(expected, ushort.Parse(value.AsSpan(offset, count), style, provider));
+
+            Assert.True(ushort.TryParse(value.AsSpan(offset, count), style, provider, out ushort result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/UInt32Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/UInt32Tests.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -9,13 +10,29 @@ namespace System.Tests
 {
     public partial class UInt32Tests
     {
-        [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, uint expected)
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
         {
-            Assert.Equal(expected, uint.Parse(value.AsSpan(), style, provider));
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1], inputs[2], inputs[3] };
+            }
 
-            Assert.True(uint.TryParse(value.AsSpan(), style, provider, out uint result));
+            yield return new object[] { "123", 0, 2, NumberStyles.Integer, null, (uint)12 };
+            yield return new object[] { "123", 1, 2, NumberStyles.Integer, null, (uint)23 };
+            yield return new object[] { "4294967295", 0, 1, NumberStyles.Integer, null, 4 };
+            yield return new object[] { "4294967295", 9, 1, NumberStyles.Integer, null, 5 };
+            yield return new object[] { "12", 0, 1, NumberStyles.HexNumber, null, (uint)0x1 };
+            yield return new object[] { "12", 1, 1, NumberStyles.HexNumber, null, (uint)0x2 };
+            yield return new object[] { "$1,000", 1, 3, NumberStyles.Currency, new NumberFormatInfo() { CurrencySymbol = "$" }, (uint)10 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, uint expected)
+        {
+            Assert.Equal(expected, uint.Parse(value.AsSpan(offset, count), style, provider));
+
+            Assert.True(uint.TryParse(value.AsSpan(offset, count), style, provider, out uint result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/UInt64Tests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/UInt64Tests.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -9,13 +10,28 @@ namespace System.Tests
 {
     public partial class UInt64Tests
     {
-        [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_Valid(string value, NumberStyles style, IFormatProvider provider, ulong expected)
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
         {
-            Assert.Equal(expected, ulong.Parse(value.AsSpan(), style, provider));
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1], inputs[2], inputs[3] };
+            }
 
-            Assert.True(ulong.TryParse(value.AsSpan(), style, provider, out ulong result));
+            yield return new object[] { "+123", 1, 3, NumberStyles.Integer, null, (ulong)123 };
+            yield return new object[] { "+123", 0, 3, NumberStyles.Integer, null, (ulong)12 };
+            yield return new object[] { "  123  ", 1, 2, NumberStyles.Integer, null, (ulong)1 };
+            yield return new object[] { "12", 0, 1, NumberStyles.HexNumber, null, (ulong)0x1 };
+            yield return new object[] { "ABC", 1, 1, NumberStyles.HexNumber, null, (ulong)0xb };
+            yield return new object[] { "$1,000", 1, 3, NumberStyles.Currency, new NumberFormatInfo() { CurrencySymbol = "$" }, (ulong)10 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, ulong expected)
+        {
+            Assert.Equal(expected, ulong.Parse(value.AsSpan(offset, count), style, provider));
+
+            Assert.True(ulong.TryParse(value.AsSpan(offset, count), style, provider, out ulong result));
             Assert.Equal(expected, result);
         }
 

--- a/src/System.Runtime/tests/System/VersionTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/VersionTests.netcoreapp.cs
@@ -2,24 +2,38 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Tests
 {
     public partial class VersionTests
     {
+        public static IEnumerable<object[]> Parse_ValidWithOffsetCount_TestData()
+        {
+            foreach (object[] inputs in Parse_Valid_TestData())
+            {
+                yield return new object[] { inputs[0], 0, ((string)inputs[0]).Length, inputs[1] };
+            }
+
+            yield return new object[] { "1.2.3", 0, 3, new Version(1, 2) };
+            yield return new object[] { "1.2.3", 2, 3, new Version(2, 3) };
+            yield return new object[] { "2  .3.    4.  \t\r\n15  ", 0, 11, new Version(2, 3, 4) };
+            yield return new object[] { "+1.+2.+3.+4", 3, 5, new Version(2, 3) };
+        }
+
         [Theory]
-        [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse_Span_ValidInput_ReturnsExpected(string input, Version expected)
+        [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        public static void Parse_Span_ValidInput_ReturnsExpected(string input, int offset, int count, Version expected)
         {
             if (input == null)
             {
                 return;
             }
 
-            Assert.Equal(expected, Version.Parse(input.AsSpan()));
+            Assert.Equal(expected, Version.Parse(input.AsSpan(offset, count)));
 
-            Assert.True(Version.TryParse(input.AsSpan(), out Version version));
+            Assert.True(Version.TryParse(input.AsSpan(offset, count), out Version version));
             Assert.Equal(expected, version);
         }
 


### PR DESCRIPTION
We currently only ever parse a full string as a span; this adds tests for parsing substrings as spans, which is important in case the parsing routine walks off the beginning or end of the input.

Contributes to https://github.com/dotnet/corefx/issues/29343
Depends on https://github.com/dotnet/coreclr/pull/17808; won't pass until that's merged and consumed into corefx.

cc: @jkotas, @danmosemsft