### PR TITLE
Increase unexpected thread wait timeout in tests

### DIFF
--- a/src/Common/tests/System/Threading/ThreadTestHelpers.cs
+++ b/src/Common/tests/System/Threading/ThreadTestHelpers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Threading.Tests
@@ -10,6 +12,11 @@ namespace System.Threading.Tests
     {
         public const int ExpectedTimeoutMilliseconds = 50;
         public const int UnexpectedTimeoutMilliseconds = 1000 * 30;
+
+        // Wait longer for a thread to time out, so that an unexpected timeout in the thread is more likely to expire first and
+        // provide a better stack trace for the failure
+        public const int UnexpectedThreadTimeoutMilliseconds =
+            UnexpectedTimeoutMilliseconds + RemoteExecutorTestBase.FailWaitTimeoutMilliseconds;
 
         public static Thread CreateGuardedThread(out Action waitForThread, Action start)
         {
@@ -45,7 +52,7 @@ namespace System.Threading.Tests
             waitForThread =
                 () =>
                 {
-                    Assert.True(t.Join(UnexpectedTimeoutMilliseconds));
+                    Assert.True(t.Join(UnexpectedThreadTimeoutMilliseconds));
                     localCheckForThreadErrors();
                 };
             return t;
@@ -85,7 +92,7 @@ namespace System.Threading.Tests
             waitForThread =
                 () =>
                 {
-                    Assert.True(t.Join(UnexpectedTimeoutMilliseconds));
+                    Assert.True(t.Join(UnexpectedThreadTimeoutMilliseconds));
                     localCheckForThreadErrors();
                 };
             return t;
@@ -128,6 +135,11 @@ namespace System.Threading.Tests
         public static void CheckedWait(this ManualResetEventSlim e)
         {
             Assert.True(e.Wait(UnexpectedTimeoutMilliseconds));
+        }
+
+        public static void CheckedWait(this Task t)
+        {
+            Assert.True(t.Wait(UnexpectedTimeoutMilliseconds));
         }
     }
 }


### PR DESCRIPTION
To make it more likely for a timeout in the thread to occur first and get better stack traces.

Closes https://github.com/dotnet/corefx/issues/24504 until another repro.