### PR TITLE
Increase default value of TimeoutTime to 15m in run-test.sh

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -293,7 +293,7 @@ coreclr_code_coverage()
 
 RunTestSequential=0
 ((serverGC = 0))
-TimeoutTime=10m
+TimeoutTime=15m
 
 while [[ $# > 0 ]]
 do


### PR DESCRIPTION
Some corefx test assemblies need more than 10 minutes to finish (e.g. `System.Runtime.Tests` dotnet/coreclr#17755, `System.Collections.Tests` in dotnet/coreclr#17754)
Increasing default value of `TimeoutTime` in `run-test.sh` to 15 minutes.