### PR TITLE
Increase default value of TimeoutTime to 20m in run-test.sh

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -293,7 +293,7 @@ coreclr_code_coverage()
 
 RunTestSequential=0
 ((serverGC = 0))
-TimeoutTime=15m
+TimeoutTime=20m
 
 while [[ $# > 0 ]]
 do


### PR DESCRIPTION
Found more corefx tests that need even more time to pass on Ubuntu/arm (https://github.com/dotnet/coreclr/issues/17754#issuecomment-385574676)