### PR TITLE
Disable read of arbitrary Console Title on NETFX

### DIFF
--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -132,7 +132,8 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // In appcontainer, the stream cannot be opened: there is no Console
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "In appcontainer, the stream cannot be opened: there is no Console")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "// NETFX does not have the fix https://github.com/dotnet/corefx/pull/28905")]
     public static void Title_Get_Windows()
     {
         Assert.NotNull(Console.Title);
@@ -140,7 +141,8 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // In appcontainer, the stream cannot be opened: there is no Console
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "In appcontainer, the stream cannot be opened: there is no Console")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "// NETFX does not have the fix https://github.com/dotnet/corefx/pull/28905")]
     public static void Title_Get_Windows_NoNulls()
     {
         string title = Console.Title;


### PR DESCRIPTION
It breaks for long titles, which apparently we sometimes have in runs:
https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fdesktop~2Fcli~2F/build/20180430.04/workItem/System.Console.Tests

.NET Core has the fix: https://github.com/dotnet/corefx/pull/28905