### PR TITLE
Switch source build property to DotNetBuildFromSource

### DIFF
--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <!-- Used to determine if we should build some packages only once across multiple official build legs.
          For offline builds we still set OfficialBuildId but we need to build all the packages for a single
-         leg only, so we also take DotNetBuildOffline into account. -->
-    <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' AND '$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
+         leg only, so we also take DotNetBuildFromSource  into account. -->
+    <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' AND '$(OfficialBuildId)' != '' AND '$(DotNetBuildFromSource )' != 'true'">true</BuildingAnOfficialBuildLeg>
   </PropertyGroup>
 
   <!-- Packages opt-in to automatic RID-specific builds by placing a *.RID.props next to their project


### PR DESCRIPTION
Detect source-build via DotNetBuildFromSource instead of
DotNetBuildOffline which is set for the tarball build.

Port https://github.com/dotnet/corefx/pull/29418 to master.
cc @dseefeld 