### PR TITLE
[mono] Fix compilation with compilers missing `__has_extension`

### DIFF
--- a/src/Native/Unix/Common/pal_compiler.h
+++ b/src/Native/Unix/Common/pal_compiler.h
@@ -13,9 +13,13 @@
 #define END_EXTERN_C
 #endif
 
+#ifndef __has_extension
+#define __has_extension(...) 0
+#endif
+
 #ifdef static_assert
 #define c_static_assert(e) static_assert((e),"")
-#elif defined(__has_extension) && __has_extension(c_static_assert)
+#elif __has_extension(c_static_assert)
 #define c_static_assert(e) _Static_assert((e), "")
 #else
 #define c_static_assert(e) typedef char __c_static_assert__[(e)?1:-1]


### PR DESCRIPTION
For some obscure reasons, `if defined(__has_extension) && __has_extension(c_static_assert)` wouldn't be able to guard against the absence of `__has_entension` with some compilers. To fix that, we just make sure it is always defined, even if it will by default always return `0`.

See mono/mono#8051 for the System.Native integration PR to Mono.