### PR TITLE
Port #29413 to release branch

### DIFF
--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -19,6 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="System\IO\Enumeration\FileSystemEntry.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEnumerable.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEnumerableFactory.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEnumerator.cs" />

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -9,7 +9,7 @@ namespace System.IO.Enumeration
     /// <summary>
     /// Lower level view of FileSystemInfo used for processing and filtering find results.
     /// </summary>
-    public unsafe ref struct FileSystemEntry
+    public unsafe ref partial struct FileSystemEntry
     {
         private const int FileNameBufferSize = 256;
         internal Interop.Sys.DirectoryEntry _directoryEntry;
@@ -136,12 +136,6 @@ namespace System.IO.Enumeration
             string fullPath = ToFullPath();
             return FileSystemInfo.Create(fullPath, new string(FileName), ref _status);
         }
-
-        /// <summary>
-        /// Returns the full path for find results, based on the initially provided path.
-        /// </summary>
-        public string ToSpecifiedFullPath() =>
-            Path.Join(OriginalRootDirectory, Directory.Slice(RootDirectory.Length), FileName);
 
         /// <summary>
         /// Returns the full path of the find result.

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Windows.cs
@@ -7,7 +7,7 @@ namespace System.IO.Enumeration
     /// <summary>
     /// Lower level view of FileSystemInfo used for processing and filtering find results.
     /// </summary>
-    public unsafe ref struct FileSystemEntry
+    public unsafe ref partial struct FileSystemEntry
     {
         internal static void Initialize(
             ref FileSystemEntry entry,
@@ -74,12 +74,6 @@ namespace System.IO.Enumeration
 
         public FileSystemInfo ToFileSystemInfo()
             => FileSystemInfo.Create(Path.Join(Directory, FileName), ref this);
-
-        /// <summary>
-        /// Returns the full path for find results, based on the initially provided path.
-        /// </summary>
-        public string ToSpecifiedFullPath() =>
-            Path.Join(OriginalRootDirectory, Directory.Slice(RootDirectory.Length), FileName);
 
         /// <summary>
         /// Returns the full path of the find result.

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Enumeration
+{
+    public ref partial struct FileSystemEntry
+    {
+        /// <summary>
+        /// Returns the full path for find results, based on the initially provided path.
+        /// </summary>
+        public string ToSpecifiedFullPath()
+        {
+            // We want to provide the enumerated segment of the path appended to the originally specified path. This is
+            // the behavior of the various Directory APIs that return a list of strings.
+            //
+            // RootDirectory has the final separator trimmed, OriginalRootDirectory does not. Our legacy behavior would
+            // effectively account for this by appending subdirectory names as it recursed. As such we need to trim one
+            // separator when combining with the relative path (Directory.Slice(RootDirectory.Length)).
+            //
+            //   Original  =>  Root   => Directory    => FileName => relativePath => Specified
+            //   C:\foo        C:\foo    C:\foo          bar         ""              C:\foo\bar
+            //   C:\foo\       C:\foo    C:\foo          bar         ""              C:\foo\bar
+            //   C:\foo/       C:\foo    C:\foo          bar         ""              C:\foo/bar
+            //   C:\foo\\      C:\foo    C:\foo          bar         ""              C:\foo\\bar
+            //   C:\foo        C:\foo    C:\foo\bar      jar         "bar"           C:\foo\bar\jar
+            //   C:\foo\       C:\foo    C:\foo\bar      jar         "bar"           C:\foo\bar\jar
+            //   C:\foo/       C:\foo    C:\foo\bar      jar         "bar"           C:\foo/bar\jar
+
+
+            // If we're at the top level directory the Directory and RootDirectory will be identical. As there are no
+            // trailing slashes in play, once we're in a subdirectory, slicing off the root will leave us with an
+            // initial separator. We need to trim that off if it exists, but it isn't needed if the original root
+            // didn't have a separator. Join() would handle it if we did trim it, not doing so is an optimization.
+
+            ReadOnlySpan<char> relativePath = Directory.Slice(RootDirectory.Length);
+            if (PathInternal.EndsInDirectorySeparator(OriginalRootDirectory) && PathInternal.StartsWithDirectorySeparator(relativePath))
+                relativePath = relativePath.Slice(1);
+
+            return Path.Join(OriginalRootDirectory, relativePath, FileName);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles.cs
@@ -147,6 +147,8 @@ namespace System.IO.Tests
 
     public class Directory_GetFiles_str_str_so : Directory_GetFileSystemEntries_str_str_so
     {
+        public virtual bool IsDirectoryInfo => false;
+
         protected override bool TestFiles { get { return true; } }
         protected override bool TestDirectories { get { return false; } }
 
@@ -163,6 +165,33 @@ namespace System.IO.Tests
         public override string[] GetEntries(string path, string searchPattern, SearchOption option)
         {
             return Directory.GetFiles(path, searchPattern, option);
+        }
+
+        [Theory, MemberData(nameof(TrailingSeparators))]
+        public void DirectoryWithTrailingSeparators(string trailing)
+        {
+            // When getting strings back we should retain the root path as specified for Directory.
+            // DirectoryInfo returns the normalized full path in all cases.
+
+            // Add the trailing separator up front for Directory as we want to validate against
+            // the path _with_ the separator on it. Creation doesn't care about trailing, and
+            // Path.Combine doesn't change the existing separators, it just adds the canonical
+            // separator if needed.
+            string root = GetTestFilePath() + (IsDirectoryInfo ? "" : trailing);
+            string rootFile = Path.Combine(root, GetTestFileName());
+            string subDirectory = Path.Combine(root, GetTestFileName());
+            string nestedFile = Path.Combine(subDirectory, GetTestFileName());
+
+            Directory.CreateDirectory(subDirectory);
+            File.Create(rootFile).Dispose();
+            File.Create(nestedFile).Dispose();
+
+            // Add the trailing separator if we haven't (for DI) so we can validate that we
+            // either retain (D) or don't retain (DI) the separators as we specified them.
+            // Note that some of the cases actually match canonical (one standard separator)
+            // so they never change.
+            string[] files = GetEntries(root + (IsDirectoryInfo ? trailing : ""), "*", SearchOption.AllDirectories);
+            FSAssert.EqualWhenOrdered(new string[] { rootFile, nestedFile }, files);
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/EnumerableAPIs.cs
@@ -32,6 +32,8 @@ namespace System.IO.Tests
 
     public class DirectoryInfo_EnumerateFiles_str_str_so : Directory_GetFiles_str_str_so
     {
+        public override bool IsDirectoryInfo => true;
+
         public override string[] GetEntries(string path)
         {
             return ((new DirectoryInfo(path).EnumerateFiles("*", SearchOption.TopDirectoryOnly).Select(x => x.FullName)).ToArray());

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
@@ -30,6 +30,8 @@ namespace System.IO.Tests
 
     public class DirectoryInfo_GetFiles_str_so : Directory_GetFiles_str_str_so
     {
+        public override bool IsDirectoryInfo => true;
+
         public override string[] GetEntries(string path)
         {
             return ((new DirectoryInfo(path).GetFiles("*", SearchOption.TopDirectoryOnly).Select(x => x.FullName)).ToArray());

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -33,6 +33,26 @@ namespace System.IO.Tests
         public static TheoryData ControlWhiteSpace = IOInputs.GetControlWhiteSpace().ToTheoryData();
         public static TheoryData NonControlWhiteSpace = IOInputs.GetNonControlWhiteSpace().ToTheoryData();
 
+        public static TheoryData<string> TrailingSeparators
+        {
+            get
+            {
+                var data = new TheoryData<string>()
+                {
+                    "",
+                    "" + Path.DirectorySeparatorChar,
+                    "" + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar
+                };
+
+                if (PlatformDetection.IsWindows)
+                {
+                    data.Add("" + Path.AltDirectorySeparatorChar);
+                }
+
+                return data;
+            }
+        }
+
         /// <summary>
         /// In some cases (such as when running without elevated privileges),
         /// the symbolic link may fail to create. Only run this test if it creates


### PR DESCRIPTION
Enumerating strings should retain trailing separators
(#29413)

This is a regression introduced by the enumeration overhaul. We didn't have tests that covered trailing separators in the specified root directory when enumerating. They should be retained as is.