### PR TITLE
Add two missing ConfigureAwait(false) calls in SocketsHttpHandler

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -3,15 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace System.Net.Test.Common
 {
@@ -276,6 +275,33 @@ namespace System.Net.Test.Common
                     return "Insufficient Storage";
             }
             return null;
+        }
+
+        public enum ContentMode
+        {
+            ContentLength,
+            SingleChunk,
+            BytePerChunk,
+            ConnectionClose
+        }
+
+        public static string GetContentModeResponse(ContentMode mode, string content, bool connectionClose = false)
+        {
+            switch (mode)
+            {
+                case ContentMode.ContentLength:
+                    return GetHttpResponse(content: content, connectionClose: connectionClose);
+                case ContentMode.SingleChunk:
+                    return GetSingleChunkHttpResponse(content: content, connectionClose: connectionClose);
+                case ContentMode.BytePerChunk:
+                    return GetBytePerChunkHttpResponse(content: content, connectionClose: connectionClose);
+                case ContentMode.ConnectionClose:
+                    Assert.True(connectionClose);
+                    return GetConnectionCloseResponse(content: content);
+                default:
+                    Assert.True(false, $"Unknown content mode: {mode}");
+                    return null;
+            }
         }
 
         public static string GetHttpResponse(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null, bool connectionClose = false) =>

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -311,6 +311,14 @@ namespace System.Net.Test.Common
             $"0\r\n" +
             $"\r\n";
 
+        public static string GetConnectionCloseResponse(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null) =>
+            $"HTTP/1.1 {(int)statusCode} {GetStatusDescription(statusCode)}\r\n" +
+            "Connection: close\r\n" +
+            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+            additionalHeaders +
+            "\r\n" +
+            content;
+
         public class Options
         {
             public IPAddress Address { get; set; } = IPAddress.Loopback;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -104,7 +104,7 @@ namespace System.Net.Http
                         }
 
                         // We're only here if we need more data to make forward progress.
-                        await _connection.FillAsync();
+                        await _connection.FillAsync().ConfigureAwait(false);
 
                         // Now that we have more, see if we can get any response data, and if
                         // we can we're done.

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -385,7 +385,7 @@ namespace System.Net.Http
             HttpRequestMessage tunnelRequest = new HttpRequestMessage(HttpMethod.Connect, _proxyUri);
             tunnelRequest.Headers.Host = $"{_host}:{_port}";    // This specifies destination host/port to connect to
 
-            HttpResponseMessage tunnelResponse = await _poolManager.SendProxyConnectAsync(tunnelRequest, _proxyUri, cancellationToken);
+            HttpResponseMessage tunnelResponse = await _poolManager.SendProxyConnectAsync(tunnelRequest, _proxyUri, cancellationToken).ConfigureAwait(false);
 
             if (tunnelResponse.StatusCode != HttpStatusCode.OK)
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Asynchrony.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Asynchrony.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Test.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public abstract class HttpClientHandler_Asynchrony_Test : HttpClientTestBase
+    {
+        [Theory]
+        [InlineData(false, null)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, null)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task ResponseHeadersRead_SynchronizationContextNotUsedByHandler(bool responseHeadersRead, bool? chunked)
+        {
+            await Task.Run(async delegate // escape xunit's sync ctx
+            {
+                await LoopbackServer.CreateClientAndServerAsync(uri =>
+                {
+                    return Task.Run(() => // allow client and server to run concurrently even though this is all synchronous/blocking
+                    {
+                        var sc = new TrackingSynchronizationContext();
+                        SynchronizationContext.SetSynchronizationContext(sc);
+
+                        using (HttpClient client = CreateHttpClient())
+                        {
+                            if (responseHeadersRead)
+                            {
+                                using (HttpResponseMessage resp = client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult())
+                                using (Stream respStream = resp.Content.ReadAsStreamAsync().GetAwaiter().GetResult())
+                                {
+                                    byte[] buffer = new byte[0x1000];
+                                    while (respStream.ReadAsync(buffer, 0, buffer.Length).GetAwaiter().GetResult() > 0);
+                                }
+                            }
+                            else
+                            {
+                                client.GetStringAsync(uri).GetAwaiter().GetResult();
+                            }
+                        }
+
+                        Assert.True(sc.CallStacks.Count == 0, "Sync Ctx used: " + string.Join(Environment.NewLine + Environment.NewLine, sc.CallStacks));
+                    });
+                }, async server =>
+                {
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        await connection.ReadRequestHeaderAsync();
+
+                        string responseData = string.Concat(Enumerable.Repeat('s', 10_000));
+                        string response;
+                        switch (chunked)
+                        {
+                            case false:
+                                response = LoopbackServer.GetBytePerChunkHttpResponse(content: responseData);
+                                break;
+
+                            case true:
+                                response = LoopbackServer.GetHttpResponse(content: responseData);
+                                break;
+
+                            default:
+                                response = LoopbackServer.GetConnectionCloseResponse(content: responseData);
+                                break;
+                        }
+                        await connection.Writer.WriteAsync(response);
+                    });
+                }, new LoopbackServer.Options { StreamWrapper = s => new DribbleStream(s) });
+            });
+        }
+
+        private sealed class TrackingSynchronizationContext : SynchronizationContext
+        {
+            public readonly List<string> CallStacks = new List<string>();
+
+            public override void OperationStarted() => CallStacks.Add(Environment.StackTrace);
+            public override void OperationCompleted() => CallStacks.Add(Environment.StackTrace);
+
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                CallStacks.Add(Environment.StackTrace);
+                ThreadPool.QueueUserWorkItem(delegate
+                {
+                    SetSynchronizationContext(this);
+                    d(state);
+                });
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                CallStacks.Add(Environment.StackTrace);
+                ThreadPool.QueueUserWorkItem(delegate
+                {
+                    SynchronizationContext orig = SynchronizationContext.Current;
+                    try
+                    {
+                        SetSynchronizationContext(this);
+                        d(state);
+                    }
+                    finally
+                    {
+                        SetSynchronizationContext(orig);
+                    }
+                });
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -2,26 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Security;
-using System.Net.Sockets;
-using System.Net.Test.Common;
-using System.Reflection;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
+    public sealed class PlatformHandler_HttpClientHandler_Asynchrony_Test : HttpClientHandler_Asynchrony_Test
+    {
+        protected override bool UseSocketsHttpHandler => false;
+    }
+
     public sealed class PlatformHandler_HttpProtocolTests : HttpProtocolTests
     {
         protected override bool UseSocketsHttpHandler => false;

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -183,10 +183,10 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop]
         [Theory]
-        [InlineData(1024 * 1024 * 2, 9_500, 1024 * 1024 * 3, ContentMode.ContentLength)]
-        [InlineData(1024 * 1024 * 2, 9_500, 1024 * 1024 * 3, ContentMode.SingleChunk)]
-        [InlineData(1024 * 1024 * 2, 9_500, 1024 * 1024 * 13, ContentMode.BytePerChunk)]
-        public async Task GetAsyncWithMaxConnections_DisposeBeforeReadingToEnd_DrainsRequestsUnderMaxDrainSizeAndReusesConnection(int totalSize, int readSize, int maxDrainSize, ContentMode mode)
+        [InlineData(1024 * 1024 * 2, 9_500, 1024 * 1024 * 3, LoopbackServer.ContentMode.ContentLength)]
+        [InlineData(1024 * 1024 * 2, 9_500, 1024 * 1024 * 3, LoopbackServer.ContentMode.SingleChunk)]
+        [InlineData(1024 * 1024 * 2, 9_500, 1024 * 1024 * 13, LoopbackServer.ContentMode.BytePerChunk)]
+        public async Task GetAsyncWithMaxConnections_DisposeBeforeReadingToEnd_DrainsRequestsUnderMaxDrainSizeAndReusesConnection(int totalSize, int readSize, int maxDrainSize, LoopbackServer.ContentMode mode)
         {
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
@@ -218,7 +218,7 @@ namespace System.Net.Http.Functional.Tests
                 async server =>
                 {
                     string content = new string('a', totalSize);
-                    string response = GetResponseForContentMode(content, mode);
+                    string response = LoopbackServer.GetContentModeResponse(mode, content);
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         server.ListenSocket.Close(); // Shut down the listen socket so attempts at additional connections would fail on the client
@@ -230,10 +230,10 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop]
         [Theory]
-        [InlineData(100_000, 0,  ContentMode.ContentLength)]
-        [InlineData(100_000, 0, ContentMode.SingleChunk)]
-        [InlineData(100_000, 0, ContentMode.BytePerChunk)]
-        public async Task GetAsyncWithMaxConnections_DisposeLargerThanMaxDrainSize_KillsConnection(int totalSize, int maxDrainSize, ContentMode mode)
+        [InlineData(100_000, 0, LoopbackServer.ContentMode.ContentLength)]
+        [InlineData(100_000, 0, LoopbackServer.ContentMode.SingleChunk)]
+        [InlineData(100_000, 0, LoopbackServer.ContentMode.BytePerChunk)]
+        public async Task GetAsyncWithMaxConnections_DisposeLargerThanMaxDrainSize_KillsConnection(int totalSize, int maxDrainSize, LoopbackServer.ContentMode mode)
         {
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
@@ -265,21 +265,21 @@ namespace System.Net.Http.Functional.Tests
                         await connection.ReadRequestHeaderAsync();
                         try
                         {
-                            await connection.Writer.WriteAsync(GetResponseForContentMode(content, mode, connectionClose: false));
+                            await connection.Writer.WriteAsync(LoopbackServer.GetContentModeResponse(mode, content, connectionClose: false));
                         }
                         catch (Exception) { }     // Eat errors from client disconnect.
 
-                        await server.AcceptConnectionSendCustomResponseAndCloseAsync(GetResponseForContentMode(content, mode, connectionClose: true));
+                        await server.AcceptConnectionSendCustomResponseAndCloseAsync(LoopbackServer.GetContentModeResponse(mode, content, connectionClose: true));
                     });
                 });
         }
 
         [OuterLoop]
         [Theory]
-        [InlineData(ContentMode.ContentLength)]
-        [InlineData(ContentMode.SingleChunk)]
-        [InlineData(ContentMode.BytePerChunk)]
-        public async Task GetAsyncWithMaxConnections_DrainTakesLongerThanTimeout_KillsConnection(ContentMode mode)
+        [InlineData(LoopbackServer.ContentMode.ContentLength)]
+        [InlineData(LoopbackServer.ContentMode.SingleChunk)]
+        [InlineData(LoopbackServer.ContentMode.BytePerChunk)]
+        public async Task GetAsyncWithMaxConnections_DrainTakesLongerThanTimeout_KillsConnection(LoopbackServer.ContentMode mode)
         {
             const int ContentLength = 10_000;
 
@@ -312,7 +312,7 @@ namespace System.Net.Http.Functional.Tests
                     string content = new string('a', ContentLength);
                     await server.AcceptConnectionAsync(async connection =>
                     {
-                        string response = GetResponseForContentMode(content, mode, connectionClose: false);
+                        string response = LoopbackServer.GetContentModeResponse(mode, content, connectionClose: false);
                         await connection.ReadRequestHeaderAsync();
                         try
                         {
@@ -321,7 +321,7 @@ namespace System.Net.Http.Functional.Tests
                         }
                         catch (Exception) { }     // Eat errors from client disconnect.
 
-                        response = GetResponseForContentMode(content, mode, connectionClose: true);
+                        response = LoopbackServer.GetContentModeResponse(mode, content, connectionClose: true);
                         await server.AcceptConnectionSendCustomResponseAndCloseAsync(response);
                     });
                 });

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -19,6 +19,11 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
+    public sealed class SocketsHttpHandler_HttpClientHandler_Asynchrony_Test : HttpClientHandler_Asynchrony_Test
+    {
+        protected override bool UseSocketsHttpHandler => true;
+    }
+
     public sealed class SocketsHttpHandler_HttpProtocolTests : HttpProtocolTests
     {
         protected override bool UseSocketsHttpHandler => true;

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="HttpClientHandlerTest.cs" />
     <Compile Include="HttpClientHandlerTest.Cancellation.cs" />
     <Compile Include="HttpClientHandlerTest.ClientCertificates.cs" />
+    <Compile Include="HttpClientHandlerTest.Asynchrony.cs" />
     <Compile Include="HttpClientHandlerTest.DefaultProxyCredentials.cs" />
     <Compile Include="HttpClientHandlerTest.ResponseDrain.cs" />
     <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
@@ -158,7 +159,7 @@
   <ItemGroup Condition="'$(TargetsOSX)'=='true'">
     <TestCommandLines Include="ulimit -Sn 4096" />
   </ItemGroup>
-  <ItemGroup >
+  <ItemGroup>
     <EmbeddedResource Include="SelectedSitesTest.txt">
       <Link>SelectedSitesTest.txt</Link>
     </EmbeddedResource>


### PR DESCRIPTION
ChunkedTransferEncodingReadStream's ReadAsync had one await missing a ConfigureAwait(false).  If there's a synchronization context set on the calling thread, this results in a continuation being created that posts back to that context, which can cause problems (e.g. deadlocks) if that context is blocked, e.g. if the synchronous Read method is being used to block waiting for ReadAsync to complete.  The fix is simply to add `.ConfigureAwait(false)`.

As long as I was fixing that, I also reviewed all `await`s in SocketsHttpHandler and found one more that was missing `.ConfigureAwait(false)`, in HttpConnectionPool's EstablishProxyTunnel, and so fixed that, too.

And added some tests.

Fixes https://github.com/dotnet/corefx/issues/29453
cc: @geoffkizer, @davidsh, @ayende, @pjanotti