### PR TITLE
Improve ManualResetValueTaskSource prototype

### DIFF
--- a/src/Common/tests/System/Threading/Tasks/Sources/ManualResetValueTaskSourceFactory.cs
+++ b/src/Common/tests/System/Threading/Tasks/Sources/ManualResetValueTaskSourceFactory.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks.Sources;
+
+namespace System.Threading.Tasks.Tests
+{
+    internal static class ManualResetValueTaskSourceFactory
+    {
+        public static ManualResetValueTaskSource<T> Completed<T>(T result, Exception error = null)
+        {
+            var vts = new ManualResetValueTaskSource<T>();
+            if (error != null)
+            {
+                vts.SetException(error);
+            }
+            else
+            {
+                vts.SetResult(result);
+            }
+            return vts;
+        }
+
+        public static ManualResetValueTaskSource<T> Delay<T>(int delayMs, T result, Exception error = null)
+        {
+            var vts = new ManualResetValueTaskSource<T>();
+            Task.Delay(delayMs).ContinueWith(_ =>
+            {
+                if (error != null)
+                {
+                    vts.SetException(error);
+                }
+                else
+                {
+                    vts.SetResult(result);
+                }
+            });
+            return vts;
+        }
+    }
+}

--- a/src/System.Threading.Tasks.Extensions/tests/AsyncValueTaskMethodBuilderTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/AsyncValueTaskMethodBuilderTests.cs
@@ -355,20 +355,20 @@ namespace System.Threading.Tasks.Tests
                     await Task.FromResult(42);
                     await new ValueTask();
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(Task.FromException<int>(new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSource.Completed(0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, new FormatException()), 0));
                     Assert.Equal(42, await new ValueTask<int>(42));
                     Assert.Equal(42, await new ValueTask<int>(Task.FromResult(42)));
-                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0));
+                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0));
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(Task.FromException<int>(new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSource.Completed(0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(0, new FormatException()), 0));
 
                     // Incomplete
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(Task.Delay(1).ContinueWith(_ => throw new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0));
                     Assert.Equal(42, await new ValueTask<int>(Task.Delay(1).ContinueWith(_ => 42)));
-                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSource.Delay(1, 42, null), 0));
+                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSourceFactory.Delay(1, 42, null), 0));
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(Task.Delay(1).ContinueWith<int>(_ => throw new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0));
                     await Task.Yield();
                 }
             }
@@ -382,20 +382,20 @@ namespace System.Threading.Tasks.Tests
                     await Task.FromResult(42);
                     await new ValueTask();
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(Task.FromException<int>(new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSource.Completed(0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, new FormatException()), 0));
                     Assert.Equal(42, await new ValueTask<int>(42));
                     Assert.Equal(42, await new ValueTask<int>(Task.FromResult(42)));
-                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0));
+                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0));
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(Task.FromException<int>(new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSource.Completed(0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(0, new FormatException()), 0));
 
                     // Incomplete
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(Task.Delay(1).ContinueWith(_ => throw new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0));
                     Assert.Equal(42, await new ValueTask<int>(Task.Delay(1).ContinueWith(_ => 42)));
-                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSource.Delay(1, 42, null), 0));
+                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSourceFactory.Delay(1, 42, null), 0));
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(Task.Delay(1).ContinueWith<int>(_ => throw new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0));
                     await Task.Yield();
                 }
                 return 17;
@@ -410,20 +410,20 @@ namespace System.Threading.Tasks.Tests
                     await Task.FromResult(42);
                     await new ValueTask();
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(Task.FromException<int>(new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSource.Completed(0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, new FormatException()), 0));
                     Assert.Equal(42, await new ValueTask<int>(42));
                     Assert.Equal(42, await new ValueTask<int>(Task.FromResult(42)));
-                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0));
+                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0));
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(Task.FromException<int>(new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSource.Completed(0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(0, new FormatException()), 0));
 
                     // Incomplete
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(Task.Delay(1).ContinueWith(_ => throw new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0));
                     Assert.Equal(42, await new ValueTask<int>(Task.Delay(1).ContinueWith(_ => 42)));
-                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSource.Delay(1, 42, null), 0));
+                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSourceFactory.Delay(1, 42, null), 0));
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(Task.Delay(1).ContinueWith<int>(_ => throw new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0));
                     await Task.Yield();
                 }
             }
@@ -437,20 +437,20 @@ namespace System.Threading.Tasks.Tests
                     await Task.FromResult(42);
                     await new ValueTask();
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(Task.FromException<int>(new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSource.Completed(0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, new FormatException()), 0));
                     Assert.Equal(42, await new ValueTask<int>(42));
                     Assert.Equal(42, await new ValueTask<int>(Task.FromResult(42)));
-                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0));
+                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0));
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(Task.FromException<int>(new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSource.Completed(0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(0, new FormatException()), 0));
 
                     // Incomplete
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(Task.Delay(1).ContinueWith(_ => throw new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask(ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0));
                     Assert.Equal(42, await new ValueTask<int>(Task.Delay(1).ContinueWith(_ => 42)));
-                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSource.Delay(1, 42, null), 0));
+                    Assert.Equal(42, await new ValueTask<int>(ManualResetValueTaskSourceFactory.Delay(1, 42, null), 0));
                     await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(Task.Delay(1).ContinueWith<int>(_ => throw new FormatException())));
-                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0));
+                    await Assert.ThrowsAsync<FormatException>(async () => await new ValueTask<int>(ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0));
                     await Task.Yield();
                 }
                 return 18;

--- a/src/System.Threading.Tasks.Extensions/tests/ManualResetValueTaskSourceTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ManualResetValueTaskSourceTests.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace System.Threading.Tasks.Sources.Tests
+{
+    public class ManualResetValueTaskSourceTests
+    {
+        [Fact]
+        public async Task ReuseInstanceWithResets_Success()
+        {
+            var mrvts = new ManualResetValueTaskSource<int>();
+
+            for (short i = 42; i < 48; i++)
+            {
+                var ignored = Task.Delay(1).ContinueWith(_ => mrvts.SetResult(i));
+                Assert.Equal(i, await new ValueTask<int>(mrvts, mrvts.Version));
+                Assert.Equal(i, await new ValueTask<int>(mrvts, mrvts.Version)); // can use multiple times until it's reset
+
+                mrvts.Reset();
+            }
+        }
+
+        [Fact]
+        public void AccessAfterReset_Fails()
+        {
+            var mrvts = new ManualResetValueTaskSource<int>();
+            mrvts.Reset();
+            Assert.Throws<InvalidOperationException>(() => mrvts.GetResult(0));
+            Assert.Throws<InvalidOperationException>(() => mrvts.GetStatus(0));
+            Assert.Throws<InvalidOperationException>(() => mrvts.OnCompleted(_ => { }, new object(), 0, ValueTaskSourceOnCompletedFlags.None));
+        }
+
+        [Fact]
+        public void SetTwice_Fails()
+        {
+            var mrvts = new ManualResetValueTaskSource<int>();
+
+            mrvts.SetResult(42);
+            Assert.Throws<InvalidOperationException>(() => mrvts.SetResult(42));
+            Assert.Throws<InvalidOperationException>(() => mrvts.SetException(new Exception()));
+
+            mrvts.Reset();
+            mrvts.SetException(new Exception());
+            Assert.Throws<InvalidOperationException>(() => mrvts.SetResult(42));
+            Assert.Throws<InvalidOperationException>(() => mrvts.SetException(new Exception()));
+        }
+
+        [Fact]
+        public async Task AsyncEnumerable_Success()
+        {
+            // Equivalent to:
+            //   int total = 0;
+            //   foreach async(int i in CountAsync(20))
+            //   {
+            //       total += i;
+            //   }
+            //   Assert.Equal(190, i);
+
+            IAsyncEnumerator<int> enumerator = CountAsync(20).GetAsyncEnumerator();
+            try
+            {
+                int total = 0;
+                while (await enumerator.MoveNextAsync())
+                {
+                    total += enumerator.Current;
+                }
+                Assert.Equal(190, total);
+            }
+            finally
+            {
+                await enumerator.DisposeAsync();
+            }
+        }
+
+        // The following is a sketch of an implementation to explore the IAsyncEnumerable feature.
+        // This should be replaced with the real implementation when available.
+        // https://github.com/dotnet/csharplang/issues/43
+
+        internal interface IAsyncEnumerable<out T>
+        {
+            IAsyncEnumerator<T> GetAsyncEnumerator();
+        }
+
+        internal interface IAsyncEnumerator<out T> : IAsyncDisposable
+        {
+            // One of two potential shapes for IAsyncEnumerator; another is
+            //     ValueTask<bool> WaitForNextAsync();
+            //     bool TryGetNext(out T current);
+            // which has several advantages, including that while the next
+            // result is available synchronously, it incurs only one interface
+            // call rather than two, and doesn't incur any boilerplate related
+            // to await.
+
+            ValueTask<bool> MoveNextAsync();
+            T Current { get; }
+        }
+
+        internal interface IAsyncDisposable
+        {
+            ValueTask DisposeAsync();
+        }
+
+        // Approximate compiler-generated code for:
+        //     internal static AsyncEnumerable<int> CountAsync(int items)
+        //     {
+        //         for (int i = 0; i < items; i++)
+        //         {
+        //             await Task.Delay(i).ConfigureAwait(false);
+        //             yield return i;
+        //         }
+        //     }
+        internal static IAsyncEnumerable<int> CountAsync(int items) =>
+            new CountAsyncEnumerable(items);
+
+        private sealed class CountAsyncEnumerable :
+            IAsyncEnumerable<int>,  // used as the enumerable itself
+            IAsyncEnumerator<int>,  // used as the enumerator returned from first call to enumerable's GetAsyncEnumerator
+            IValueTaskSource<bool>, // used as the backing store behind the ValueTask<bool> returned from each MoveNextAsync
+            IStrongBox<ManualResetValueTaskSourceLogic<bool>>, // exposes its ValueTaskSource logic implementation
+            IAsyncStateMachine // uses existing builder's support for ExecutionContext, optimized awaits, etc.
+        {
+            // This implementation will generally incur only two allocations of overhead
+            // for the entire enumeration:
+            // - The CountAsyncEnumerable object itself.
+            // - A throw-away task object inside of _builder.
+            // The task built by the builder isn't necessary, but using the _builder allows
+            // this implementation to a) avoid needing to be concerned with ExecutionContext
+            // flowing, and b) enables the implementation to take advantage of optimizations
+            // such as avoiding Action allocation when all awaited types are known to corelib.
+
+            private const int StateStart = -1;
+            private const int StateDisposed = -2;
+            private const int StateCtor = -3;
+
+            /// <summary>Current state of the state machine.</summary>
+            private int _state = StateCtor;
+            /// <summary>All of the logic for managing the IValueTaskSource implementation</summary>
+            private ManualResetValueTaskSourceLogic<bool> _vts; // mutable struct; do not make this readonly
+            /// <summary>Builder used for efficiently waiting and appropriately managing ExecutionContext.</summary>
+            private AsyncTaskMethodBuilder _builder = AsyncTaskMethodBuilder.Create(); // mutable struct; do not make this readonly
+
+            private readonly int _param_items;
+
+            private int _local_items;
+            private int _local_i;
+            private TaskAwaiter _awaiter0;
+
+            public CountAsyncEnumerable(int items)
+            {
+                _local_items = _param_items = items;
+                _vts = new ManualResetValueTaskSourceLogic<bool>(this);
+            }
+
+            ref ManualResetValueTaskSourceLogic<bool> IStrongBox<ManualResetValueTaskSourceLogic<bool>>.Value => ref _vts;
+
+            public IAsyncEnumerator<int> GetAsyncEnumerator() =>
+                Interlocked.CompareExchange(ref _state, StateStart, StateCtor) == StateCtor ?
+                    this :
+                    new CountAsyncEnumerable(_param_items) { _state = StateStart };
+
+            public ValueTask<bool> MoveNextAsync()
+            {
+                _vts.Reset();
+
+                CountAsyncEnumerable inst = this;
+                _builder.Start(ref inst); // invokes MoveNext, protected by ExecutionContext guards
+
+                switch (_vts.GetStatus(_vts.Version))
+                {
+                    case ValueTaskSourceStatus.Succeeded:
+                        return new ValueTask<bool>(_vts.GetResult(_vts.Version));
+                    default:
+                        return new ValueTask<bool>(this, _vts.Version);
+                }
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                _vts.Reset();
+                _state = StateDisposed;
+                return default;
+            }
+
+            public int Current { get; private set; }
+
+            public void MoveNext()
+            {
+                try
+                {
+                    switch (_state)
+                    {
+                        case StateStart:
+                            _local_i = 0;
+                            goto case 0;
+
+                        case 0:
+                            if (_local_i < _local_items)
+                            {
+                                _awaiter0 = Task.Delay(_local_i).GetAwaiter();
+                                if (!_awaiter0.IsCompleted)
+                                {
+                                    _state = 1;
+                                    CountAsyncEnumerable inst = this;
+                                    _builder.AwaitUnsafeOnCompleted(ref _awaiter0, ref inst);
+                                    return;
+                                }
+                                goto case 1;
+                            }
+                            _state = int.MaxValue;
+                            _vts.SetResult(false);
+                            return;
+
+                        case 1:
+                            _awaiter0.GetResult();
+                            _awaiter0 = default;
+
+                            Current = _local_i;
+                            _state = 2;
+                            _vts.SetResult(true);
+                            return;
+
+                        case 2:
+                            _local_i++;
+                            _state = 0;
+                            goto case 0;
+
+                        default:
+                            throw new InvalidOperationException();
+                    }
+                }
+                catch (Exception e)
+                {
+                    _state = int.MaxValue;
+                    _vts.SetException(e); // see https://github.com/dotnet/roslyn/issues/26567; we may want to move this out of the catch
+                    return;
+                }
+            }
+            void IAsyncStateMachine.SetStateMachine(IAsyncStateMachine stateMachine) { }
+
+            bool IValueTaskSource<bool>.GetResult(short token) => _vts.GetResult(token);
+            ValueTaskSourceStatus IValueTaskSource<bool>.GetStatus(short token) => _vts.GetStatus(token);
+            void IValueTaskSource<bool>.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                _vts.OnCompleted(continuation, state, token, flags);
+        }
+    }
+}

--- a/src/System.Threading.Tasks.Extensions/tests/Performance/Perf.ValueTask.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/Performance/Perf.ValueTask.cs
@@ -49,7 +49,7 @@ namespace System.Threading.Tasks
         [Benchmark(InnerIterationCount = 10_000_000), MeasureGCAllocations]
         public async Task Await_FromCompletedValueTaskSource()
         {
-            ValueTask<int> vt = new ValueTask<int>(ManualResetValueTaskSource.Completed<int>(42), 0);
+            ValueTask<int> vt = new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed<int>(42), 0);
             foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 long iters = Benchmark.InnerIterationCount;
@@ -132,7 +132,7 @@ namespace System.Threading.Tasks
         [Benchmark(InnerIterationCount = 10_000_000), MeasureGCAllocations]
         public async Task CreateAndAwait_FromCompletedValueTaskSource()
         {
-            IValueTaskSource<int> vts = ManualResetValueTaskSource.Completed(42);
+            IValueTaskSource<int> vts = ManualResetValueTaskSourceFactory.Completed(42);
             foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 long iters = Benchmark.InnerIterationCount;
@@ -149,7 +149,7 @@ namespace System.Threading.Tasks
         [Benchmark(InnerIterationCount = 10_000_000), MeasureGCAllocations]
         public async Task CreateAndAwait_FromCompletedValueTaskSource_ConfigureAwait()
         {
-            IValueTaskSource<int> vts = ManualResetValueTaskSource.Completed(42);
+            IValueTaskSource<int> vts = ManualResetValueTaskSourceFactory.Completed(42);
             foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 long iters = Benchmark.InnerIterationCount;
@@ -235,7 +235,7 @@ namespace System.Threading.Tasks
         [Benchmark(InnerIterationCount = 10_000_000), MeasureGCAllocations]
         public void Copy_PassAsArgumentAndReturn_FromValueTaskSource()
         {
-            ValueTask<int> vt = new ValueTask<int>(ManualResetValueTaskSource.Completed(42), 0);
+            ValueTask<int> vt = new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42), 0);
             foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 long iters = Benchmark.InnerIterationCount;

--- a/src/System.Threading.Tasks.Extensions/tests/Performance/System.Threading.Tasks.Extensions.Performance.Tests.csproj
+++ b/src/System.Threading.Tasks.Extensions/tests/Performance/System.Threading.Tasks.Extensions.Performance.Tests.csproj
@@ -16,6 +16,9 @@
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\Sources\ManualResetValueTaskSource.cs">
       <Link>Common\System\Threading\Tasks\Sources\ManualResetValueTaskSource.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\Sources\ManualResetValueTaskSourceFactory.cs">
+      <Link>Common\System\Threading\Tasks\Sources\ManualResetValueTaskSourceFactory.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonPath)\..\perf\PerfRunner\PerfRunner.csproj">

--- a/src/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
+++ b/src/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
@@ -13,9 +13,13 @@
   <ItemGroup>
     <Compile Include="AsyncMethodBuilderAttributeTests.cs" />
     <Compile Include="AsyncValueTaskMethodBuilderTests.cs" />
+    <Compile Include="ManualResetValueTaskSourceTests.cs" />
     <Compile Include="ValueTaskTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\Sources\ManualResetValueTaskSource.cs">
       <Link>Common\System\Threading\Tasks\Sources\ManualResetValueTaskSource.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\Sources\ManualResetValueTaskSourceFactory.cs">
+      <Link>Common\System\Threading\Tasks\Sources\ManualResetValueTaskSourceFactory.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -53,7 +53,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask t =
                 mode == CtorMode.Result ? default :
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
-                new ValueTask(ManualResetValueTaskSource.Completed(0, null), 0);
+                new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
             Assert.True(t.IsCompleted);
             Assert.True(t.IsCompletedSuccessfully);
             Assert.False(t.IsFaulted);
@@ -69,7 +69,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask<int> t =
                 mode == CtorMode.Result ? new ValueTask<int>(42) :
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
-                new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0);
+                new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
             Assert.True(t.IsCompleted);
             Assert.True(t.IsCompletedSuccessfully);
             Assert.False(t.IsFaulted);
@@ -269,7 +269,7 @@ namespace System.Threading.Tasks.Tests
         public void NonGeneric_CreateFromFaulted_IsFaulted(CtorMode mode)
         {
             InvalidOperationException e = new InvalidOperationException();
-            ValueTask t = mode == CtorMode.Task ? new ValueTask(Task.FromException(e)) : new ValueTask(ManualResetValueTaskSource.Completed<int>(0, e), 0);
+            ValueTask t = mode == CtorMode.Task ? new ValueTask(Task.FromException(e)) : new ValueTask(ManualResetValueTaskSourceFactory.Completed<int>(0, e), 0);
 
             Assert.True(t.IsCompleted);
             Assert.False(t.IsCompletedSuccessfully);
@@ -285,7 +285,7 @@ namespace System.Threading.Tasks.Tests
         public void Generic_CreateFromFaulted_IsFaulted(CtorMode mode)
         {
             InvalidOperationException e = new InvalidOperationException();
-            ValueTask<int> t = mode == CtorMode.Task ? new ValueTask<int>(Task.FromException<int>(e)) : new ValueTask<int>(ManualResetValueTaskSource.Completed<int>(0, e), 0);
+            ValueTask<int> t = mode == CtorMode.Task ? new ValueTask<int>(Task.FromException<int>(e)) : new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed<int>(0, e), 0);
 
             Assert.True(t.IsCompleted);
             Assert.False(t.IsCompletedSuccessfully);
@@ -349,7 +349,7 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public void NonGeneric_CreateFromValueTaskSource_AsTaskIdempotent() // validates unsupported behavior specific to the backing IValueTaskSource
         {
-            var vt = new ValueTask(ManualResetValueTaskSource.Completed<int>(42, null), 0);
+            var vt = new ValueTask(ManualResetValueTaskSourceFactory.Completed<int>(42, null), 0);
             Task t = vt.AsTask();
             Assert.NotNull(t);
             Assert.Same(t, vt.AsTask());
@@ -359,7 +359,7 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public void Generic_CreateFromValueTaskSource_AsTaskNotIdempotent() // validates unsupported behavior specific to the backing IValueTaskSource
         {
-            var t = new ValueTask<int>(ManualResetValueTaskSource.Completed<int>(42, null), 0);
+            var t = new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed<int>(42, null), 0);
             Assert.NotSame(Task.FromResult(42), t.AsTask());
             Assert.NotSame(t.AsTask(), t.AsTask());
         }
@@ -369,7 +369,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(true)]
         public async Task NonGeneric_CreateFromValueTaskSource_Success(bool sync)
         {
-            var vt = new ValueTask(sync ? ManualResetValueTaskSource.Completed(0) : ManualResetValueTaskSource.Delay(1, 0), 0);
+            var vt = new ValueTask(sync ? ManualResetValueTaskSourceFactory.Completed(0) : ManualResetValueTaskSourceFactory.Delay(1, 0), 0);
             Task t = vt.AsTask();
             if (sync)
             {
@@ -383,7 +383,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(true)]
         public async Task Generic_CreateFromValueTaskSource_Success(bool sync)
         {
-            var vt = new ValueTask<int>(sync ? ManualResetValueTaskSource.Completed(42) : ManualResetValueTaskSource.Delay(1, 42), 0);
+            var vt = new ValueTask<int>(sync ? ManualResetValueTaskSourceFactory.Completed(42) : ManualResetValueTaskSourceFactory.Delay(1, 42), 0);
             Task<int> t = vt.AsTask();
             if (sync)
             {
@@ -397,7 +397,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(true)]
         public async Task NonGeneric_CreateFromValueTaskSource_Faulted(bool sync)
         {
-            var vt = new ValueTask(sync ? ManualResetValueTaskSource.Completed(0, new FormatException()) : ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0);
+            var vt = new ValueTask(sync ? ManualResetValueTaskSourceFactory.Completed(0, new FormatException()) : ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0);
             Task t = vt.AsTask();
             if (sync)
             {
@@ -415,7 +415,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(true)]
         public async Task Generic_CreateFromValueTaskSource_Faulted(bool sync)
         {
-            var vt = new ValueTask<int>(sync ? ManualResetValueTaskSource.Completed(0, new FormatException()) : ManualResetValueTaskSource.Delay(1, 0, new FormatException()), 0);
+            var vt = new ValueTask<int>(sync ? ManualResetValueTaskSourceFactory.Completed(0, new FormatException()) : ManualResetValueTaskSourceFactory.Delay(1, 0, new FormatException()), 0);
             Task<int> t = vt.AsTask();
             if (sync)
             {
@@ -433,7 +433,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(true)]
         public async Task NonGeneric_CreateFromValueTaskSource_Canceled(bool sync)
         {
-            var vt = new ValueTask(sync ? ManualResetValueTaskSource.Completed(0, new OperationCanceledException()) : ManualResetValueTaskSource.Delay(1, 0, new OperationCanceledException()), 0);
+            var vt = new ValueTask(sync ? ManualResetValueTaskSourceFactory.Completed(0, new OperationCanceledException()) : ManualResetValueTaskSourceFactory.Delay(1, 0, new OperationCanceledException()), 0);
             Task t = vt.AsTask();
             if (sync)
             {
@@ -451,7 +451,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(true)]
         public async Task Generic_CreateFromValueTaskSource_Canceled(bool sync)
         {
-            var vt = new ValueTask<int>(sync ? ManualResetValueTaskSource.Completed(0, new OperationCanceledException()) : ManualResetValueTaskSource.Delay(1, 0, new OperationCanceledException()), 0);
+            var vt = new ValueTask<int>(sync ? ManualResetValueTaskSourceFactory.Completed(0, new OperationCanceledException()) : ManualResetValueTaskSourceFactory.Delay(1, 0, new OperationCanceledException()), 0);
             Task<int> t = vt.AsTask();
             if (sync)
             {
@@ -483,7 +483,7 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public void NonGeneric_Preserve_FromValueTaskSource_TransitionedToTask()
         {
-            ValueTask vt1 = new ValueTask(ManualResetValueTaskSource.Completed(42), 0);
+            ValueTask vt1 = new ValueTask(ManualResetValueTaskSourceFactory.Completed(42), 0);
             ValueTask vt2 = vt1.Preserve();
             ValueTask vt3 = vt2.Preserve();
             Assert.True(vt1 != vt2);
@@ -510,7 +510,7 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public void Generic_Preserve_FromValueTaskSource_TransitionedToTask()
         {
-            ValueTask<int> vt1 = new ValueTask<int>(ManualResetValueTaskSource.Completed(42), 0);
+            ValueTask<int> vt1 = new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42), 0);
             ValueTask<int> vt2 = vt1.Preserve();
             ValueTask<int> vt3 = vt2.Preserve();
             Assert.True(vt1 != vt2);
@@ -527,7 +527,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask Create() =>
                 mode == CtorMode.Result ? new ValueTask() :
                 mode == CtorMode.Task ? new ValueTask(Task.FromResult(42)) :
-                new ValueTask(ManualResetValueTaskSource.Completed(0, null), 0);
+                new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
             int thread = Environment.CurrentManagedThreadId;
 
@@ -550,7 +550,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask<int> Create() =>
                 mode == CtorMode.Result ? new ValueTask<int>(42) :
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
-                new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0);
+                new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
             int thread = Environment.CurrentManagedThreadId;
 
@@ -633,7 +633,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask t =
                 mode == CtorMode.Result ? new ValueTask() :
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
-                new ValueTask(ManualResetValueTaskSource.Completed(0, null), 0);
+                new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
             var tcs = new TaskCompletionSource<bool>();
             t.GetAwaiter().OnCompleted(() => tcs.SetResult(true));
@@ -649,7 +649,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask t =
                 mode == CtorMode.Result ? new ValueTask() :
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
-                new ValueTask(ManualResetValueTaskSource.Completed(0, null), 0);
+                new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
             var tcs = new TaskCompletionSource<bool>();
             t.GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult(true));
@@ -665,7 +665,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask<int> t =
                 mode == CtorMode.Result ? new ValueTask<int>(42) :
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
-                new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0);
+                new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
             var tcs = new TaskCompletionSource<bool>();
             t.GetAwaiter().OnCompleted(() => tcs.SetResult(true));
@@ -681,7 +681,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask<int> t =
                 mode == CtorMode.Result ? new ValueTask<int>(42) :
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
-                new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0);
+                new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
             var tcs = new TaskCompletionSource<bool>();
             t.GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult(true));
@@ -700,7 +700,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask t =
                 mode == CtorMode.Result ? new ValueTask() :
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
-                new ValueTask(ManualResetValueTaskSource.Completed(0, null), 0);
+                new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
             var tcs = new TaskCompletionSource<bool>();
             t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => tcs.SetResult(true));
@@ -719,7 +719,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask t =
                 mode == CtorMode.Result ? new ValueTask() :
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
-                new ValueTask(ManualResetValueTaskSource.Completed(0, null), 0);
+                new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
             var tcs = new TaskCompletionSource<bool>();
             t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult(true));
@@ -738,7 +738,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask<int> t =
                 mode == CtorMode.Result ? new ValueTask<int>(42) :
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
-                new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0);
+                new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
             var tcs = new TaskCompletionSource<bool>();
             t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => tcs.SetResult(true));
@@ -757,7 +757,7 @@ namespace System.Threading.Tasks.Tests
             ValueTask<int> t =
                 mode == CtorMode.Result ? new ValueTask<int>(42) :
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
-                new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0);
+                new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
             var tcs = new TaskCompletionSource<bool>();
             t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult(true));
@@ -779,7 +779,7 @@ namespace System.Threading.Tasks.Tests
                     ValueTask t =
                         mode == CtorMode.Result ? new ValueTask() :
                         mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
-                        new ValueTask(ManualResetValueTaskSource.Completed(0, null), 0);
+                        new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
                     var mres = new ManualResetEventSlim();
                     t.GetAwaiter().OnCompleted(() => mres.Set());
@@ -810,7 +810,7 @@ namespace System.Threading.Tasks.Tests
                     ValueTask<int> t =
                         mode == CtorMode.Result ? new ValueTask<int>(42) :
                         mode == CtorMode.Task ? new ValueTask<int>(sync ? Task.FromResult(42) : Task.Delay(1).ContinueWith(_ => 42)) :
-                        new ValueTask<int>(sync ? ManualResetValueTaskSource.Completed(42, null) : ManualResetValueTaskSource.Delay(1, 42, null), 0);
+                        new ValueTask<int>(sync ? ManualResetValueTaskSourceFactory.Completed(42, null) : ManualResetValueTaskSourceFactory.Delay(1, 42, null), 0);
 
                     var mres = new ManualResetEventSlim();
                     t.GetAwaiter().OnCompleted(() => mres.Set());
@@ -846,7 +846,7 @@ namespace System.Threading.Tasks.Tests
                     ValueTask t =
                         mode == CtorMode.Result ? new ValueTask() :
                         mode == CtorMode.Task ? new ValueTask(sync ? Task.CompletedTask : Task.Delay(1)) :
-                        new ValueTask(sync ? ManualResetValueTaskSource.Completed(0, null) : ManualResetValueTaskSource.Delay(42, 0, null), 0);
+                        new ValueTask(sync ? ManualResetValueTaskSourceFactory.Completed(0, null) : ManualResetValueTaskSourceFactory.Delay(42, 0, null), 0);
 
                     var mres = new ManualResetEventSlim();
                     t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => mres.Set());
@@ -882,7 +882,7 @@ namespace System.Threading.Tasks.Tests
                     ValueTask<int> t =
                         mode == CtorMode.Result ? new ValueTask<int>(42) :
                         mode == CtorMode.Task ? new ValueTask<int>(sync ? Task.FromResult(42) : Task.Delay(1).ContinueWith(_ => 42)) :
-                        new ValueTask<int>(sync ? ManualResetValueTaskSource.Completed(42, null) : ManualResetValueTaskSource.Delay(1, 42, null), 0);
+                        new ValueTask<int>(sync ? ManualResetValueTaskSourceFactory.Completed(42, null) : ManualResetValueTaskSourceFactory.Delay(1, 42, null), 0);
 
                     var mres = new ManualResetEventSlim();
                     t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => mres.Set());
@@ -929,7 +929,7 @@ namespace System.Threading.Tasks.Tests
             }
             else
             {
-                var t = ManualResetValueTaskSource.Completed(42, null);
+                var t = ManualResetValueTaskSourceFactory.Completed(42, null);
                 vt = new ValueTask(t, 0);
                 obj = t;
             }
@@ -952,7 +952,7 @@ namespace System.Threading.Tasks.Tests
             }
             else
             {
-                ManualResetValueTaskSource<int> t = ManualResetValueTaskSource.Completed(42, null);
+                ManualResetValueTaskSource<int> t = ManualResetValueTaskSourceFactory.Completed(42, null);
                 vt = new ValueTask<int>(t, 0);
                 obj = t;
             }
@@ -966,7 +966,7 @@ namespace System.Threading.Tasks.Tests
             var completedTcs = new TaskCompletionSource<int>();
             completedTcs.SetResult(42);
 
-            var completedVts = ManualResetValueTaskSource.Completed(42, null);
+            var completedVts = ManualResetValueTaskSourceFactory.Completed(42, null);
 
             Assert.True(new ValueTask() == new ValueTask());
             Assert.True(new ValueTask(Task.CompletedTask) == new ValueTask(Task.CompletedTask));
@@ -983,7 +983,7 @@ namespace System.Threading.Tasks.Tests
         public void Generic_OperatorEquals()
         {
             var completedTask = Task.FromResult(42);
-            var completedVts = ManualResetValueTaskSource.Completed(42, null);
+            var completedVts = ManualResetValueTaskSourceFactory.Completed(42, null);
 
             Assert.True(new ValueTask<int>(42) == new ValueTask<int>(42));
             Assert.True(new ValueTask<int>(completedTask) == new ValueTask<int>(completedTask));
@@ -998,7 +998,7 @@ namespace System.Threading.Tasks.Tests
 
             Assert.False(new ValueTask<int>(42) == new ValueTask<int>(Task.FromResult(42)));
             Assert.False(new ValueTask<int>(Task.FromResult(42)) == new ValueTask<int>(42));
-            Assert.False(new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0) == new ValueTask<int>(42));
+            Assert.False(new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0) == new ValueTask<int>(42));
             Assert.False(new ValueTask<int>(completedTask) == new ValueTask<int>(completedVts, 0));
             Assert.False(new ValueTask<int>(completedVts, 17) == new ValueTask<int>(completedVts, 18));
         }
@@ -1009,7 +1009,7 @@ namespace System.Threading.Tasks.Tests
             var completedTcs = new TaskCompletionSource<int>();
             completedTcs.SetResult(42);
 
-            var completedVts = ManualResetValueTaskSource.Completed(42, null);
+            var completedVts = ManualResetValueTaskSourceFactory.Completed(42, null);
 
             Assert.False(new ValueTask() != new ValueTask());
             Assert.False(new ValueTask(Task.CompletedTask) != new ValueTask(Task.CompletedTask));
@@ -1026,7 +1026,7 @@ namespace System.Threading.Tasks.Tests
         public void Generic_OperatorNotEquals()
         {
             var completedTask = Task.FromResult(42);
-            var completedVts = ManualResetValueTaskSource.Completed(42, null);
+            var completedVts = ManualResetValueTaskSourceFactory.Completed(42, null);
 
             Assert.False(new ValueTask<int>(42) != new ValueTask<int>(42));
             Assert.False(new ValueTask<int>(completedTask) != new ValueTask<int>(completedTask));
@@ -1041,7 +1041,7 @@ namespace System.Threading.Tasks.Tests
 
             Assert.True(new ValueTask<int>(42) != new ValueTask<int>(Task.FromResult(42)));
             Assert.True(new ValueTask<int>(Task.FromResult(42)) != new ValueTask<int>(42));
-            Assert.True(new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0) != new ValueTask<int>(42));
+            Assert.True(new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0) != new ValueTask<int>(42));
             Assert.True(new ValueTask<int>(completedTask) != new ValueTask<int>(completedVts, 0));
             Assert.True(new ValueTask<int>(completedVts, 17) != new ValueTask<int>(completedVts, 18));
         }
@@ -1053,10 +1053,10 @@ namespace System.Threading.Tasks.Tests
 
             Assert.False(new ValueTask().Equals(new ValueTask(Task.CompletedTask)));
             Assert.False(new ValueTask(Task.CompletedTask).Equals(new ValueTask()));
-            Assert.False(new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0).Equals(new ValueTask()));
-            Assert.False(new ValueTask().Equals(new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0)));
-            Assert.False(new ValueTask(Task.CompletedTask).Equals(new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0)));
-            Assert.False(new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0).Equals(new ValueTask(Task.CompletedTask)));
+            Assert.False(new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0).Equals(new ValueTask()));
+            Assert.False(new ValueTask().Equals(new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0)));
+            Assert.False(new ValueTask(Task.CompletedTask).Equals(new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0)));
+            Assert.False(new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0).Equals(new ValueTask(Task.CompletedTask)));
         }
 
         [Fact]
@@ -1073,7 +1073,7 @@ namespace System.Threading.Tasks.Tests
 
             Assert.False(new ValueTask<int>(42).Equals(new ValueTask<int>(Task.FromResult(42))));
             Assert.False(new ValueTask<int>(Task.FromResult(42)).Equals(new ValueTask<int>(42)));
-            Assert.False(new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0).Equals(new ValueTask<int>(42)));
+            Assert.False(new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0).Equals(new ValueTask<int>(42)));
         }
 
         [Fact]
@@ -1083,15 +1083,15 @@ namespace System.Threading.Tasks.Tests
 
             Assert.False(new ValueTask().Equals((object)new ValueTask(Task.CompletedTask)));
             Assert.False(new ValueTask(Task.CompletedTask).Equals((object)new ValueTask()));
-            Assert.False(new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0).Equals((object)new ValueTask()));
-            Assert.False(new ValueTask().Equals((object)new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0)));
-            Assert.False(new ValueTask(Task.CompletedTask).Equals((object)new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0)));
-            Assert.False(new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0).Equals((object)new ValueTask(Task.CompletedTask)));
+            Assert.False(new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0).Equals((object)new ValueTask()));
+            Assert.False(new ValueTask().Equals((object)new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0)));
+            Assert.False(new ValueTask(Task.CompletedTask).Equals((object)new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0)));
+            Assert.False(new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0).Equals((object)new ValueTask(Task.CompletedTask)));
 
             Assert.False(new ValueTask().Equals(null));
             Assert.False(new ValueTask().Equals("12345"));
             Assert.False(new ValueTask(Task.CompletedTask).Equals("12345"));
-            Assert.False(new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0).Equals("12345"));
+            Assert.False(new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0).Equals("12345"));
         }
 
         [Fact]
@@ -1108,7 +1108,7 @@ namespace System.Threading.Tasks.Tests
 
             Assert.False(new ValueTask<int>(42).Equals((object)new ValueTask<int>(Task.FromResult(42))));
             Assert.False(new ValueTask<int>(Task.FromResult(42)).Equals((object)new ValueTask<int>(42)));
-            Assert.False(new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0).Equals((object)new ValueTask<int>(42)));
+            Assert.False(new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0).Equals((object)new ValueTask<int>(42)));
 
             Assert.False(new ValueTask<int>(42).Equals((object)null));
             Assert.False(new ValueTask<int>(42).Equals(new object()));
@@ -1120,7 +1120,7 @@ namespace System.Threading.Tasks.Tests
         {
             Assert.Equal("System.Threading.Tasks.ValueTask", new ValueTask().ToString());
             Assert.Equal("System.Threading.Tasks.ValueTask", new ValueTask(Task.CompletedTask).ToString());
-            Assert.Equal("System.Threading.Tasks.ValueTask", new ValueTask(ManualResetValueTaskSource.Completed(42, null), 0).ToString());
+            Assert.Equal("System.Threading.Tasks.ValueTask", new ValueTask(ManualResetValueTaskSourceFactory.Completed(42, null), 0).ToString());
         }
 
         [Fact]
@@ -1128,19 +1128,19 @@ namespace System.Threading.Tasks.Tests
         {
             Assert.Equal("Hello", new ValueTask<string>("Hello").ToString());
             Assert.Equal("Hello", new ValueTask<string>(Task.FromResult("Hello")).ToString());
-            Assert.Equal("Hello", new ValueTask<string>(ManualResetValueTaskSource.Completed("Hello", null), 0).ToString());
+            Assert.Equal("Hello", new ValueTask<string>(ManualResetValueTaskSourceFactory.Completed("Hello", null), 0).ToString());
 
             Assert.Equal("42", new ValueTask<int>(42).ToString());
             Assert.Equal("42", new ValueTask<int>(Task.FromResult(42)).ToString());
-            Assert.Equal("42", new ValueTask<int>(ManualResetValueTaskSource.Completed(42, null), 0).ToString());
+            Assert.Equal("42", new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0).ToString());
 
             Assert.Same(string.Empty, new ValueTask<string>(string.Empty).ToString());
             Assert.Same(string.Empty, new ValueTask<string>(Task.FromResult(string.Empty)).ToString());
-            Assert.Same(string.Empty, new ValueTask<string>(ManualResetValueTaskSource.Completed(string.Empty, null), 0).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>(ManualResetValueTaskSourceFactory.Completed(string.Empty, null), 0).ToString());
 
             Assert.Same(string.Empty, new ValueTask<string>(Task.FromException<string>(new InvalidOperationException())).ToString());
             Assert.Same(string.Empty, new ValueTask<string>(Task.FromException<string>(new OperationCanceledException())).ToString());
-            Assert.Same(string.Empty, new ValueTask<string>(ManualResetValueTaskSource.Completed<string>(null, new InvalidOperationException()), 0).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>(ManualResetValueTaskSourceFactory.Completed<string>(null, new InvalidOperationException()), 0).ToString());
 
             Assert.Same(string.Empty, new ValueTask<string>(Task.FromCanceled<string>(new CancellationToken(true))).ToString());
 
@@ -1148,7 +1148,7 @@ namespace System.Threading.Tasks.Tests
             Assert.Same(string.Empty, default(ValueTask<string>).ToString());
             Assert.Same(string.Empty, new ValueTask<string>((string)null).ToString());
             Assert.Same(string.Empty, new ValueTask<string>(Task.FromResult<string>(null)).ToString());
-            Assert.Same(string.Empty, new ValueTask<string>(ManualResetValueTaskSource.Completed<string>(null, null), 0).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>(ManualResetValueTaskSourceFactory.Completed<string>(null, null), 0).ToString());
 
             Assert.Same(string.Empty, new ValueTask<DateTime>(new TaskCompletionSource<DateTime>().Task).ToString());
         }
@@ -1272,7 +1272,7 @@ namespace System.Threading.Tasks.Tests
 
             // _obj is an IValueTaskSource but other fields are from Task construction
             vtBoxed = new ValueTask(Task.CompletedTask);
-            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, ManualResetValueTaskSource.Completed(42));
+            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, ManualResetValueTaskSourceFactory.Completed(42));
             Record.Exception(() =>
             {
                 bool completed = ((ValueTask)vtBoxed).IsCompleted;
@@ -1307,7 +1307,7 @@ namespace System.Threading.Tasks.Tests
 
             // _obj is an IValueTaskSource but other fields are from Task construction
             vtBoxed = new ValueTask<int>(Task.FromResult(42));
-            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, ManualResetValueTaskSource.Completed(42));
+            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, ManualResetValueTaskSourceFactory.Completed(42));
             Record.Exception(() =>
             {
                 bool completed = ((ValueTask)vtBoxed).IsCompleted;


### PR DESCRIPTION
In .NET Core 2.1 we added the public `IValueTaskSource` and `IValueTaskSource<T>` interfaces, with associated support in `ValueTask` and `ValueTask<T>`, and while we implemented the interfaces on several types internally, we didn't expose any public implementations.

We should consider exposing several in the future, including a manual-reset and an auto-reset IValueTaskSource implementation.  We already have a ManualResetValueTaskSource implementation in our tests.  This commit improves upon it in a few ways:
- Separates out the logic into a separate public struct.  The ManualResetValueTaskSource class wraps the struct, giving developers a choice to either use the class directly, or to embed the struct in their own implementation.
- Fixes context capture to behave more similarly to Task, handling both SynchronizationContext and TaskSchedulers
- Adds a prototype implementation of an IAsyncEnumerable, demonstrating how the compiler could utilize ManualResetValueTaskSourceLogic in its implementation.

This is all still prototype, used only in tests.

cc: @jcouv, @davidfowl, @kouvel, @tarekgh 