### PR TITLE
Fix race condition in Sockets' ExecutionContextFlowTest test

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.netcoreapp.cs
@@ -31,8 +31,11 @@ namespace System.Net.Sockets.Tests
                         int executionContextChanges = 0;
                         var asyncLocal = new AsyncLocal<int>(_ =>
                         {
-                            executionContextChanges++;
-                            stackLog.AppendLine($"#{executionContextChanges}: {Environment.StackTrace}");
+                            lock (stackLog)
+                            {
+                                executionContextChanges++;
+                                stackLog.AppendLine($"#{executionContextChanges}: {Environment.StackTrace}");
+                            }
                         });
                         Assert.Equal(0, executionContextChanges);
 


### PR DESCRIPTION
It's possible that the awaited operation continues on another thread,
restoring the ExecutionContext, at the same time that the initial thread
is unwinding out of the async invocation, and thus also restoring an
ExecutionContext, both of which will invoke the AsyncLocal's callback,
and thus we need to synchronize its work to avoid issues like multiple
threads all calling StringBuilder.AppendLine concurrently.

cc: @kouvel, @BruceForstall 