### PR TITLE
Fix BeginConnect_EndPoint_AddressFamily_Throws_NotSupported test for netfx

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -989,10 +989,23 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void BeginConnect_EndPoint_AddressFamily_Throws_NotSupported()
         {
-            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).BeginConnect(
-                new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6), TheAsyncCallback, null));
-            Assert.Throws<NotSupportedException>(() => { GetSocket(AddressFamily.InterNetwork).ConnectAsync(
-                new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6)); });
+            // Unlike other tests that reuse a static Socket instance, this tests avoids doing so
+            // to work around a behavior of .NET 4.7.2. See https://github.com/dotnet/corefx/issues/29481
+            // for more details.
+
+            using (var s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<NotSupportedException>(() => s.BeginConnect(
+                    new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6),
+                    TheAsyncCallback, null));
+            }
+
+            using (var s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<NotSupportedException>(() => { s.ConnectAsync(
+                    new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6));
+                });
+            }
         }
 
         [Fact]

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -989,7 +989,7 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void BeginConnect_EndPoint_AddressFamily_Throws_NotSupported()
         {
-            // Unlike other tests that reuse a static Socket instance, this tests avoids doing so
+            // Unlike other tests that reuse a static Socket instance, this test avoids doing so
             // to work around a behavior of .NET 4.7.2. See https://github.com/dotnet/corefx/issues/29481
             // for more details.
 


### PR DESCRIPTION
The test fails on .NET 4.7.2 due to trying to use the same Socket instance for a connection attempt after invalid arguments were passed to a previous attempt.  Since that's not what this test is about, I'm just fixing it to avoid reusing the same Socket instance.

Fixes https://github.com/dotnet/corefx/issues/29481
Contributes to https://github.com/dotnet/corefx/pull/29456

cc: @davidsh, @caesar1995 