### PR TITLE
Delete Brotli_External_DecompressesResponse_Success test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
@@ -41,27 +41,5 @@ namespace System.Net.Http.Functional.Tests
                 });
             });
         }
-
-        [OuterLoop("Accessing remote server")]
-        [Fact]
-        public async Task Brotli_External_DecompressesResponse_Success()
-        {
-            const string BrotliUrl = "http://httpbin.org/brotli";
-
-            var message = new HttpRequestMessage(HttpMethod.Get, BrotliUrl);
-            message.Headers.TryAddWithoutValidation("SomeAwesomeHeader", "AndItsAwesomeValue");
-
-            using (HttpClient client = CreateHttpClient())
-            using (HttpResponseMessage response = await client.SendAsync(message))
-            {
-                Assert.Contains("br", response.Content.Headers.ContentEncoding);
-                using (var decodedStream = new BrotliStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress))
-                using (var reader = new StreamReader(decodedStream))
-                {
-                    string respText = await reader.ReadToEndAsync();
-                    Assert.Contains("AndItsAwesomeValue", respText);
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
We have Brotli_DecompressesResponse_Success which just uses a loopback server.  I'd added Brotli_External_DecompressesResponse_Success as a way to test against another Brotli implementation as well, but that's not really something we need to do in the System.Net.Http tests; rather, it's up to the System.IO.Compression.Brotli tests to ensure compliance.  Given that, and this tests ends up causing failures when httpbin.org goes down, I'm just deleting it.

Closes https://github.com/dotnet/corefx/issues/29400
cc: @geoffkizer, @davidsh