### PR TITLE
Fix GetMessageUsingEventMessageDLL event log test on RS4

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -346,9 +346,7 @@ namespace System.Diagnostics.Tests
             using (EventLog eventlog = new EventLog("Security"))
             {
                 eventlog.Source = "Security";
-                EventLogEntry eventLogEntry;
-                eventLogEntry = Helpers.RetryOnWin7(() => eventlog.Entries[0]);
-                Assert.Contains("", eventLogEntry.Message);
+                Assert.Contains("", eventlog.Entries.LastOrDefault()?.Message ?? "");
             }
         }
     }


### PR DESCRIPTION
The RS4 machine's security event log is apparently empty, causing the test to throw an index out of range exception.

Contributes to https://github.com/dotnet/corefx/pull/29484

cc: @danmosemsft 