### PR TITLE
Exclude private framework packages from stable update

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -31,7 +31,11 @@
           BeforeTargets="BuildAllProjects"
           Condition="'$(IncludePreReleaseLabelInPackageVersion)' != 'true'">
     <ItemGroup>
-      <PkgProjects Include="$(MSBuildThisFileDirectory)..\pkg\*\*.pkgproj" />
+      <!--
+      The private packages don't get stabilized so they don't need to be included
+      in the set of packages that we are gathering stable versions from.
+      -->
+      <PkgProjects Include="$(MSBuildThisFileDirectory)..\pkg\*\*.pkgproj" Exclude="$(MSBuildThisFileDirectory)..\pkg\*Private*\*.pkgproj" />
       <PkgProjects Include="*\pkg\**\*.pkgproj" />
     </ItemGroup>
 


### PR DESCRIPTION
We don't need to update the package index with the
private framework packages because they aren't interesting
from a stable prospective. They always remain non-stable
because they are only for transporting to core-setup.

Port of https://github.com/dotnet/corefx/pull/29491

cc @mmitche 