### PR TITLE
[WIP] Improve Http authentication logging

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -16,6 +16,7 @@ namespace System.Net
         private const int ClientSendCompletedId = ContentNullId + 1;
         private const int HeadersInvalidValueId = ClientSendCompletedId + 1;
         private const int HandlerMessageId = HeadersInvalidValueId + 1;
+        private const int SelectAuthenticationId = HandlerMessageId + 1;
 
         [NonEvent]
         public static void UriBaseAddress(object obj, Uri baseAddress)
@@ -64,6 +65,19 @@ namespace System.Net
         public void HandlerMessage(int handlerId, int workerId, int requestId, string memberName, string message) =>
             WriteEvent(HandlerMessageId, handlerId, workerId, requestId, memberName, message);
             //Console.WriteLine($"{handlerId}/{workerId}/{requestId}: ({memberName}): {message}");  // uncomment for debugging only
+
+        [NonEvent]
+        public static void AuthenticationInfo(Uri uri, string message)
+        {
+            if (IsEnabled)
+            {
+                Log.AuthenticationInfo(uri?.ToString(), message);
+            }
+        }
+
+        [Event(SelectAuthenticationId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        public void AuthenticationInfo(string uri, string message) =>
+            WriteEvent(SelectAuthenticationId, uri, message);
 
         [NonEvent]
         private unsafe void WriteEvent(int eventId, int arg1, int arg2, int arg3, string arg4, string arg5)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -72,10 +72,18 @@ namespace System.Net.Http
             {
                 // We have no credential for this auth type, so we can't respond to the challenge.
                 // We'll continue to look for a different auth type that we do have a credential for.
+                if (NetEventSource.IsEnabled)
+                {
+                    NetEventSource.AuthenticationInfo(uri, $"Authentication scheme '{scheme}' supported by server, but not by client.");
+                }
                 return false;
             }
 
             challenge = new AuthenticationChallenge(authenticationType, scheme, credential, challengeData);
+            if (NetEventSource.IsEnabled)
+            {
+                NetEventSource.AuthenticationInfo(uri, $"Authentication scheme '{scheme}' selected. Client username={challenge.Credential.UserName}");
+            }
             return true;
         }
 
@@ -89,6 +97,10 @@ namespace System.Net.Http
 
             // Try to get a valid challenge for the schemes we support, in priority order.
             HttpHeaderValueCollection<AuthenticationHeaderValue> authenticationHeaderValues = GetResponseAuthenticationHeaderValues(response, isProxyAuth);
+            if (NetEventSource.IsEnabled)
+            {
+                NetEventSource.AuthenticationInfo(authUri, $"{(isProxyAuth ? "Proxy" : "Server")} authentication requested with WWW-Authenticate header value '{authenticationHeaderValues}'");
+            }
             return
                 TryGetValidAuthenticationChallengeForScheme(NegotiateScheme, AuthenticationType.Negotiate, authUri, credentials, authenticationHeaderValues, out challenge) ||
                 TryGetValidAuthenticationChallengeForScheme(NtlmScheme, AuthenticationType.Ntlm, authUri, credentials, authenticationHeaderValues, out challenge) ||
@@ -159,6 +171,10 @@ namespace System.Net.Http
             // Any errors in obtaining parameter return false and we don't proceed with auth
             if (string.IsNullOrEmpty(parameter))
             {
+                if (NetEventSource.IsEnabled)
+                {
+                    NetEventSource.AuthenticationInfo(authUri, $"Unable to find 'Digest' authentication token when authenticating with {(isProxyAuth ? "proxy" : "server")}");
+                }
                 return false;
             }
 
@@ -231,6 +247,10 @@ namespace System.Net.Http
                     case AuthenticationType.Basic:
                         if (performedBasicPreauth)
                         {
+                            if (NetEventSource.IsEnabled)
+                            {
+                                NetEventSource.AuthenticationInfo(authUri, $"Pre-authentication with {(isProxyAuth ? "proxy" : "server")} failed.");
+                            }
                             break;
                         }
 
@@ -244,6 +264,10 @@ namespace System.Net.Http
                             {
                                 case HttpStatusCode.ProxyAuthenticationRequired:
                                 case HttpStatusCode.Unauthorized:
+                                    if (NetEventSource.IsEnabled)
+                                    {
+                                        NetEventSource.AuthenticationInfo(authUri, $"Pre-authentication with {(isProxyAuth ? "proxy" : "server")} failed.");
+                                    }
                                     break;
 
                                 default:


### PR DESCRIPTION
Opening this unfinished PR to solicit feedback on additional logging scenarios. Currently, this should help developers debug several plausible scenarios:
- Pre-authentication credentials rejected
- No match between client and server supported schemes
- Missing or invalid digest tokens

It also logs the value of the www-authenticate header received and the scheme selected, which should help detect a large number of errors.

Any thoughts on other scenarios we should support? I'm also having trouble diagnosing the important case where credentials are rejected and we return a 401 -- any ideas on where in the stack we detect that?