### PR TITLE
Remove LStat call in enumeration

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -46,12 +46,9 @@ namespace System.IO.Enumeration
             }
             else if ((directoryEntry.InodeType == Interop.Sys.NodeType.DT_LNK
                 || directoryEntry.InodeType == Interop.Sys.NodeType.DT_UNKNOWN)
-                && (Interop.Sys.Stat(entry.FullPath, out Interop.Sys.FileStatus targetStatus) >= 0
-                    || Interop.Sys.LStat(entry.FullPath, out targetStatus) >= 0))
+                && Interop.Sys.Stat(entry.FullPath, out Interop.Sys.FileStatus targetStatus) >= 0)
             {
-                // Symlink or unknown: Stat to it to see if we can resolve it to a directory. If Stat fails,
-                // it could be because the symlink is broken, we don't have permissions, etc., in which
-                // case fall back to using LStat to evaluate based on the symlink itself.
+                // Symlink or unknown: Stat to it to see if we can resolve it to a directory.
                 isDirectory = (targetStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
             }
 


### PR DESCRIPTION
It shouldn't be necessary. We included it for 2.1 as we made the same call
in 2.0 while enumerating and didn't have time to let removing the call bake.

See https://github.com/dotnet/corefx/pull/29502#discussion_r186104130