### PR TITLE
 Add missing awaits to XmlTextReaderImplAsync

### DIFF
--- a/src/Common/tests/System/Threading/TrackingSynchronizationContext.cs
+++ b/src/Common/tests/System/Threading/TrackingSynchronizationContext.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Threading.Tests
+{
+    internal sealed class TrackingSynchronizationContext : SynchronizationContext
+    {
+        public readonly List<string> CallStacks = new List<string>();
+
+        public override void OperationStarted() => CallStacks.Add(Environment.StackTrace);
+        public override void OperationCompleted() => CallStacks.Add(Environment.StackTrace);
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            CallStacks.Add(Environment.StackTrace);
+            ThreadPool.QueueUserWorkItem(delegate
+            {
+                SetSynchronizationContext(this);
+                d(state);
+            });
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            CallStacks.Add(Environment.StackTrace);
+            ThreadPool.QueueUserWorkItem(delegate
+            {
+                SynchronizationContext orig = SynchronizationContext.Current;
+                try
+                {
+                    SetSynchronizationContext(this);
+                    d(state);
+                }
+                finally
+                {
+                    SetSynchronizationContext(orig);
+                }
+            });
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
@@ -499,7 +499,7 @@ namespace System.Diagnostics
                         // Wait
                         try
                         {
-                            await Task.Delay(pollingIntervalMs, cancellationToken);
+                            await Task.Delay(pollingIntervalMs, cancellationToken); // no need for ConfigureAwait(false) as we're in a Task.Run
                             pollingIntervalMs = Math.Min(pollingIntervalMs * 2, MaxPollingIntervalMs);
                         }
                         catch (OperationCanceledException) { }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -72,6 +72,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs">
       <Link>Common\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\TrackingSynchronizationContext.cs">
+      <Link>Common\System\Threading\TrackingSynchronizationContext.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -327,7 +327,7 @@ namespace System.Net.WebSockets
                     _webSocketReceiveResultTcs.Task,
                     _closeWebSocketReceiveResultTcs.Task).ConfigureAwait(false);
 
-                WebSocketReceiveResult result = await completedTask;
+                WebSocketReceiveResult result = completedTask.GetAwaiter().GetResult();
 
                 if (result.MessageType == WebSocketMessageType.Close)
                 {

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -745,8 +745,7 @@ namespace System.Xml
                 while (readCount < count && !endOfValue)
                 {
                     int orChars = 0;
-
-                    var tuple_0 = await ParseTextAsync(orChars);
+                    var tuple_0 = await ParseTextAsync(orChars).ConfigureAwait(false);
                     startPos = tuple_0.Item1;
                     endPos = tuple_0.Item2;
                     orChars = tuple_0.Item3;
@@ -3094,7 +3093,7 @@ namespace System.Xml
                 ValueTuple<int, int, int, bool> tuple_9;
                 do
                 {
-                    tuple_9 = await ParseTextAsync(orChars);
+                    tuple_9 = await ParseTextAsync(orChars).ConfigureAwait(false);
                     startPos = tuple_9.Item1;
                     endPos = tuple_9.Item2;
                     orChars = tuple_9.Item3;
@@ -3144,7 +3143,7 @@ namespace System.Xml
                             _stringBuilder.Append(_ps.chars, startPos, endPos - startPos);
                         }
 
-                        tuple_11 = await ParseTextAsync(orChars);
+                        tuple_11 = await ParseTextAsync(orChars).ConfigureAwait(false);
                         startPos = tuple_11.Item1;
                         endPos = tuple_11.Item2;
                         orChars = tuple_11.Item3;
@@ -3190,7 +3189,7 @@ namespace System.Xml
                     }
                     do
                     {
-                        var tuple_12 = await ParseTextAsync(orChars);
+                        var tuple_12 = await ParseTextAsync(orChars).ConfigureAwait(false);
                         startPos = tuple_12.Item1;
                         endPos = tuple_12.Item2;
                         orChars = tuple_12.Item3;
@@ -3214,7 +3213,7 @@ namespace System.Xml
                             ValueTuple<int, int, int, bool> tuple_13;
                             do
                             {
-                                tuple_13 = await ParseTextAsync(orChars);
+                                tuple_13 = await ParseTextAsync(orChars).ConfigureAwait(false);
                                 startPos = tuple_13.Item1;
                                 endPos = tuple_13.Item2;
                                 orChars = tuple_13.Item3;
@@ -3677,7 +3676,7 @@ namespace System.Xml
             int endPos;
             int orChars = 0;
 
-            var tuple_15 = await ParseTextAsync(orChars);
+            var tuple_15 = await ParseTextAsync(orChars).ConfigureAwait(false);
             startPos = tuple_15.Item1;
             endPos = tuple_15.Item2;
             orChars = tuple_15.Item3;
@@ -3686,7 +3685,7 @@ namespace System.Xml
             {
                 _stringBuilder.Append(_ps.chars, startPos, endPos - startPos);
 
-                tuple_15 = await ParseTextAsync(orChars);
+                tuple_15 = await ParseTextAsync(orChars).ConfigureAwait(false);
                 startPos = tuple_15.Item1;
                 endPos = tuple_15.Item2;
                 orChars = tuple_15.Item3;
@@ -3758,7 +3757,7 @@ namespace System.Xml
             ValueTuple<int, int, int, bool> tuple_16;
             do
             {
-                tuple_16 = await ParseTextAsync(orChars);
+                tuple_16 = await ParseTextAsync(orChars).ConfigureAwait(false);
                 startPos = tuple_16.Item1;
                 endPos = tuple_16.Item2;
                 orChars = tuple_16.Item3;
@@ -5587,7 +5586,7 @@ namespace System.Xml
                         // store current line info and parse more text
                         _incReadLineInfo.Set(_ps.LineNo, _ps.LinePos);
 
-                        var tuple_36 = await ParseTextAsync(orChars);
+                        var tuple_36 = await ParseTextAsync(orChars).ConfigureAwait(false);
                         startPos = tuple_36.Item1;
                         endPos = tuple_36.Item2;
                         orChars = tuple_36.Item3;

--- a/src/System.Private.Xml/tests/XmlReader/Tests/System.Xml.RW.XmlReader.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/System.Xml.RW.XmlReader.Tests.csproj
@@ -10,6 +10,9 @@
     <Compile Include="AsyncReaderLateInitTests.cs" />
     <Compile Include="DisposeTests.cs" />
     <Compile Include="BaseUriTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Threading\TrackingSynchronizationContext.cs">
+      <Link>Common\System\Threading\TrackingSynchronizationContext.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -194,7 +194,7 @@ namespace System.Security.Cryptography
             await semaphore.WaitAsync().ForceAsync();
             try
             {
-                return await ReadAsyncCore(buffer, offset, count, cancellationToken, useAsync: true);
+                return await ReadAsyncCore(buffer, offset, count, cancellationToken, useAsync: true); // ConfigureAwait not needed as ForceAsync was used
             }
             finally
             {
@@ -312,7 +312,7 @@ namespace System.Security.Cryptography
                 try
                 {
                     amountRead = useAsync ?
-                        await _stream.ReadAsync(new Memory<byte>(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex), cancellationToken) :
+                        await _stream.ReadAsync(new Memory<byte>(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex), cancellationToken) : // ConfigureAwait not needed, as useAsync is only true if we're already on a TP thread
                         _stream.Read(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex);
 
                     int totalInput = _inputBufferIndex + amountRead;
@@ -378,7 +378,7 @@ namespace System.Security.Cryptography
                 while (_inputBufferIndex < _inputBlockSize)
                 {
                     amountRead = useAsync ?
-                        await _stream.ReadAsync(new Memory<byte>(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex), cancellationToken) :
+                        await _stream.ReadAsync(new Memory<byte>(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex), cancellationToken) : // ConfigureAwait not needed, as useAsync is only true if we're already on a TP thread
                         _stream.Read(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex);
 
                     // first, check to see if we're at the end of the input stream
@@ -461,7 +461,7 @@ namespace System.Security.Cryptography
             await semaphore.WaitAsync().ForceAsync();
             try
             {
-                await WriteAsyncCore(buffer, offset, count, cancellationToken, useAsync: true);
+                await WriteAsyncCore(buffer, offset, count, cancellationToken, useAsync: true); // ConfigureAwait not needed due to earlier ForceAsync
             }
             finally
             {
@@ -520,7 +520,7 @@ namespace System.Security.Cryptography
             if (_outputBufferIndex > 0)
             {
                 if (useAsync)
-                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, _outputBufferIndex), cancellationToken);
+                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, _outputBufferIndex), cancellationToken); // ConfigureAwait not needed, as useAsync is only true if we're already on a TP thread
                 else
                     _stream.Write(_outputBuffer, 0, _outputBufferIndex);
                 _outputBufferIndex = 0;
@@ -533,7 +533,7 @@ namespace System.Security.Cryptography
                 numOutputBytes = _transform.TransformBlock(_inputBuffer, 0, _inputBlockSize, _outputBuffer, 0);
                 // write out the bytes we just got
                 if (useAsync)
-                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, numOutputBytes), cancellationToken);
+                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, numOutputBytes), cancellationToken); // ConfigureAwait not needed, as useAsync is only true if we're already on a TP thread
                 else
                     _stream.Write(_outputBuffer, 0, numOutputBytes);
 
@@ -561,7 +561,7 @@ namespace System.Security.Cryptography
 
                             if (useAsync)
                             {
-                                await _stream.WriteAsync(new ReadOnlyMemory<byte>(tempOutputBuffer, 0, numOutputBytes), cancellationToken);
+                                await _stream.WriteAsync(new ReadOnlyMemory<byte>(tempOutputBuffer, 0, numOutputBytes), cancellationToken); // ConfigureAwait not needed, as useAsync is only true if we're already on a TP thread
                             }
                             else
                             {
@@ -584,7 +584,7 @@ namespace System.Security.Cryptography
                         numOutputBytes = _transform.TransformBlock(buffer, currentInputIndex, _inputBlockSize, _outputBuffer, 0);
 
                         if (useAsync)
-                            await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, numOutputBytes), cancellationToken);
+                            await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, numOutputBytes), cancellationToken); // ConfigureAwait not needed, as useAsync is only true if we're already on a TP thread
                         else
                             _stream.Write(_outputBuffer, 0, numOutputBytes);
 


### PR DESCRIPTION
I did an audit of awaits in corefx.  The only ones I found that were missing `ConfigureAwait(false)` and needed them were a few ones in the UAP build of System.Net.Http, for which I opened https://github.com/dotnet/corefx/issues/29517, and a few in System.Private.Xml, which this PR addresses along with a test that fails before the changes and passes after.  I left comments on some other call sites for future reference, where folks might think ConfigureAwait is needed but it's not.

Fixes https://github.com/dotnet/corefx/issues/29483
cc: @danmosemsft 