### PR TITLE
Log filesystem of tests and temp

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Reflection;
 using Xunit;
 
@@ -24,7 +25,11 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             string lcr = PlatformDetection.LibcRelease;
             string lcv = PlatformDetection.LibcVersion;
 
-            Console.WriteLine($@"{dvs} OS={osd} OSVer={osv} OSArch={osa} Arch={pra} Framework={frd} LibcRelease={lcr} LibcVersion={lcv}");
+            Console.WriteLine($@"### CONFIGURATION: {dvs} OS={osd} OSVer={osv} OSArch={osa} Arch={pra} Framework={frd} LibcRelease={lcr} LibcVersion={lcv}");
+
+            Console.WriteLine($"### BINARIES: {Path.GetDirectoryName(typeof(object).Assembly.Location)} (drive {new DriveInfo(Path.GetDirectoryName(typeof(object).Assembly.Location)).DriveFormat})");
+            Console.WriteLine($"### TEMP PATH: {Path.GetTempPath()} (drive {new DriveInfo(Path.GetTempPath()).DriveFormat})");
+            Console.WriteLine($"### CURRENT DIRECTORY: {Environment.CurrentDirectory}");
         }
 
         [Fact]


### PR DESCRIPTION
From [ad-hoc logging before](https://github.com/dotnet/corefx/issues/27662#issuecomment-375015547)

* In CI test runs I see ext2 on most distros and XFS on Centos/RHEL
* In official test runs, I see tmpfs on Fedora, ext2 on SLES, OpenSuse, Ubuntu, Debian, RHEL69, XFS on RHEL73/74, Centos 73/74, Overlay on Alpine 36

This surprises me because I would have expected file enumeration to have failed on XFS in CI.

Add proper logging to check.