### PR TITLE
Clear Configuration property when gathering stable versions

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -41,7 +41,8 @@
 
     <MSBuild Targets="GetPackageIdentityIfStable"
              BuildInParallel="$(BuildInParallel)"
-             Projects="@(PkgProjects)">
+             Projects="@(PkgProjects)"
+             RemoveProperties="Configuration">
       <Output TaskParameter="TargetOutputs"
               ItemName="_StablePackages" />
     </MSBuild>


### PR DESCRIPTION
When building using the traversal logic we end up setting
Configuration as a global property in some cases and thus
it gets propagated to other MSBuild calls. That alters the
package id when trying to gather it for stable versioning.

To avoid this we should clear out the Configuration property
and let it be recomputed by the pkgproj's themselves instead
of overriding.

cc @ericstj @mmitche 