### PR TITLE
Reflection.Emit: Add test for `ParameterBuilder.SetConstant(null)`

### DIFF
--- a/src/System.Reflection.Emit/tests/ParameterBuilder/ParameterBuilderSetConstant.cs
+++ b/src/System.Reflection.Emit/tests/ParameterBuilder/ParameterBuilderSetConstant.cs
@@ -57,8 +57,20 @@ namespace System.Reflection.Emit.Tests
         [Theory]
         [MemberData(nameof(SetConstant_ReferenceTypes_TestData))]
         [MemberData(nameof(SetConstant_NullableValueTypes_TestData))]
+        public void SetConstant_Null_fully_supported(Type parameterType)
+        {
+            SetConstant_Null(parameterType);
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Passing null for SetConstant on value types not supported on NETFX")]
         [MemberData(nameof(SetConstant_ValueTypes_TestData))]
-        public void SetConstant_Null(Type parameterType)
+        public void SetConstant_Null_not_supported_on_NETFX(Type parameterType)
+        {
+            SetConstant_Null(parameterType);
+        }
+
+        private void SetConstant_Null(Type parameterType)
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.Interface | TypeAttributes.Abstract);
             MethodBuilder method = type.DefineMethod("TestMethod", MethodAttributes.Public | MethodAttributes.Abstract | MethodAttributes.Virtual, typeof(void), new Type[] { parameterType });

--- a/src/System.Reflection.Emit/tests/ParameterBuilder/ParameterBuilderSetConstant.cs
+++ b/src/System.Reflection.Emit/tests/ParameterBuilder/ParameterBuilderSetConstant.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Reflection.Emit.Tests
+{
+    public class ParameterBuilderSetConstant
+    {
+        public static IEnumerable<object[]> SetConstant_ReferenceTypes_TestData()
+        {
+            yield return new object[] { typeof(object) };
+            yield return new object[] { typeof(string) };
+            yield return new object[] { typeof(UserDefinedClass) };
+        }
+
+        public static IEnumerable<object[]> SetConstant_NullableValueTypes_TestData()
+        {
+            yield return new object[] { typeof(bool?) };
+            yield return new object[] { typeof(byte?) };
+            yield return new object[] { typeof(char?) };
+            yield return new object[] { typeof(DateTime?) };
+            yield return new object[] { typeof(decimal?) };
+            yield return new object[] { typeof(double?) };
+            yield return new object[] { typeof(float?) };
+            yield return new object[] { typeof(int?) };
+            yield return new object[] { typeof(long?) };
+            yield return new object[] { typeof(sbyte?) };
+            yield return new object[] { typeof(short?) };
+            yield return new object[] { typeof(uint?) };
+            yield return new object[] { typeof(ulong?) };
+            yield return new object[] { typeof(UserDefinedStruct?) };
+            yield return new object[] { typeof(ushort?) };
+        }
+
+        public static IEnumerable<object[]> SetConstant_ValueTypes_TestData()
+        {
+            yield return new object[] { typeof(bool) };
+            yield return new object[] { typeof(byte) };
+            yield return new object[] { typeof(char) };
+            yield return new object[] { typeof(DateTime) };
+            yield return new object[] { typeof(decimal) };
+            yield return new object[] { typeof(double) };
+            yield return new object[] { typeof(float) };
+            yield return new object[] { typeof(int) };
+            yield return new object[] { typeof(long) };
+            yield return new object[] { typeof(sbyte) };
+            yield return new object[] { typeof(short) };
+            yield return new object[] { typeof(uint) };
+            yield return new object[] { typeof(ulong) };
+            yield return new object[] { typeof(UserDefinedStruct) };
+            yield return new object[] { typeof(ushort) };
+        }
+
+        [Theory]
+        [MemberData(nameof(SetConstant_ReferenceTypes_TestData))]
+        [MemberData(nameof(SetConstant_NullableValueTypes_TestData))]
+        [MemberData(nameof(SetConstant_ValueTypes_TestData))]
+        public void SetConstant_Null(Type parameterType)
+        {
+            TypeBuilder type = Helpers.DynamicType(TypeAttributes.Interface | TypeAttributes.Abstract);
+            MethodBuilder method = type.DefineMethod("TestMethod", MethodAttributes.Public | MethodAttributes.Abstract | MethodAttributes.Virtual, typeof(void), new Type[] { parameterType });
+            ParameterBuilder parameter = method.DefineParameter(1, ParameterAttributes.Optional | ParameterAttributes.HasDefault, "arg");
+
+            parameter.SetConstant(null);
+
+            ParameterInfo createdParameter = GetCreatedParameter(type, "TestMethod", 1);
+            Assert.Equal(true, createdParameter.HasDefaultValue);
+            Assert.Equal(null, createdParameter.DefaultValue);
+        }
+
+        private static ParameterInfo GetCreatedParameter(TypeBuilder type, string methodName, int parameterIndex)
+        {
+            Type createdType = type.CreateTypeInfo().AsType();
+            MethodInfo createdMethod = createdType.GetMethod(methodName);
+            if (parameterIndex > 0)
+            {
+                return createdMethod.GetParameters()[parameterIndex - 1];
+            }
+            else
+            {
+                return createdMethod.ReturnParameter;
+            }
+        }
+
+        private class UserDefinedClass
+        {
+        }
+
+        private struct UserDefinedStruct
+        {
+        }
+    }
+}

--- a/src/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
+++ b/src/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="ModuleBuilder\ModuleBuilderDefineUninitializedData.cs" />
     <Compile Include="ModuleBuilder\ModuleBuilderGetArrayMethod.cs" />
     <Compile Include="ModuleBuilder\ModuleBuilderSetCustomAttribute.cs" />
+    <Compile Include="ParameterBuilder\ParameterBuilderSetConstant.cs" />
     <Compile Include="PropertyBuilder\PropertyBuilderAddOtherMethod.cs" />
     <Compile Include="PropertyBuilder\PropertyBuilderAttributes.cs" />
     <Compile Include="PropertyBuilder\PropertyBuilderCanRead.cs" />


### PR DESCRIPTION
Verifies that `ParameterBuilder.SetConstant(null)` works for any type, including non-nullable value types.

The defined test cases can succeed only on a version of CoreCLR including these PRs:

* [x] https://github.com/dotnet/coreclr/pull/17887: Reflection.Emit: Allow `ParameterBuilder.SetConstant(null)` for value-typed parameters (this is what gets tested)
* [x] https://github.com/dotnet/coreclr/pull/17877: Reflection: Fix FormatException when querying ParameterInfo.DefaultValue of optional DateTime parameter (required for verification)