### PR TITLE
Reflection: Add test verifying ParameterInfo.DefaultValue doesn't throw for optional DateTime parameter

### DIFF
--- a/src/System.Reflection/tests/ParameterInfoTests.cs
+++ b/src/System.Reflection/tests/ParameterInfoTests.cs
@@ -56,6 +56,8 @@ namespace System.Reflection.Tests
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault2", 0, true)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault3", 0, true)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault4", 0, true)]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultDateTime", 0, true)]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultNullableDateTime", 0, true)]
         [InlineData(typeof(GenericClass<int>), "GenericMethodWithDefault", 1, true)]
         [InlineData(typeof(ParameterInfoMetadata), "Method1", 1, false)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithRefParameter", 0, false)]
@@ -109,6 +111,8 @@ namespace System.Reflection.Tests
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault2", 0, "abc")]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault3", 0, false)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault4", 0, '\0')]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultDateTime", 0, null)]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultNullableDateTime", 0, null)]
         public void DefaultValue(Type type, string name, int index, object expected)
         {
             ParameterInfo parameterInfo = GetParameterInfo(type, name, index);
@@ -234,6 +238,9 @@ namespace System.Reflection.Tests
             public int MethodWithDefault2(string str = "abc") { return 1; }
             public int MethodWithDefault3(bool result = false) { return 1; }
             public int MethodWithDefault4(char c = '\0') { return 1; }
+
+            public void MethodWithDefaultDateTime(DateTime arg = default(DateTime)) { }
+            public void MethodWithDefaultNullableDateTime(DateTime? arg = default(DateTime?)) { }
 
             public int MethodWithOptionalAndNoDefault([Optional] object o) { return 1; }
             public int MethodWithOptionalDefaultOutInMarshalParam([MarshalAs(UnmanagedType.LPWStr)][Out][In] string str = "") { return 1; }

--- a/src/System.Reflection/tests/ParameterInfoTests.cs
+++ b/src/System.Reflection/tests/ParameterInfoTests.cs
@@ -56,7 +56,6 @@ namespace System.Reflection.Tests
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault2", 0, true)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault3", 0, true)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault4", 0, true)]
-        [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultDateTime", 0, true)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultNullableDateTime", 0, true)]
         [InlineData(typeof(GenericClass<int>), "GenericMethodWithDefault", 1, true)]
         [InlineData(typeof(ParameterInfoMetadata), "Method1", 1, false)]
@@ -64,6 +63,15 @@ namespace System.Reflection.Tests
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithOutParameter", 1, false)]
         [InlineData(typeof(GenericClass<int>), "GenericMethod", 0, false)]
         public void HasDefaultValue(Type type, string name, int index, bool expected)
+        {
+            ParameterInfo parameterInfo = GetParameterInfo(type, name, index);
+            Assert.Equal(expected, parameterInfo.HasDefaultValue);
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Querying HasDefaultValue of optional DateTime parameter may throw exception on NETFX")]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultDateTime", 0, true)]
+        public void HasDefaultValue_broken_on_NETFX(Type type, string name, int index, bool expected)
         {
             ParameterInfo parameterInfo = GetParameterInfo(type, name, index);
             Assert.Equal(expected, parameterInfo.HasDefaultValue);
@@ -111,9 +119,17 @@ namespace System.Reflection.Tests
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault2", 0, "abc")]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault3", 0, false)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault4", 0, '\0')]
-        [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultDateTime", 0, null)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultNullableDateTime", 0, null)]
         public void DefaultValue(Type type, string name, int index, object expected)
+        {
+            ParameterInfo parameterInfo = GetParameterInfo(type, name, index);
+            Assert.Equal(expected, parameterInfo.DefaultValue);
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Querying DefaultValue of optional DateTime parameter may throw exception on NETFX")]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultDateTime", 0, null)]
+        public void DefaultValue_broken_on_NETFX(Type type, string name, int index, object expected)
         {
             ParameterInfo parameterInfo = GetParameterInfo(type, name, index);
             Assert.Equal(expected, parameterInfo.DefaultValue);


### PR DESCRIPTION
This verifies that `ParameterInfo.DefaultValue` can be queried for optional parameters of type `DateTime` (and `DateTime?` just to be sure).

The defined test cases can succeed only with a version of CoreCLR that includes these:

* [x] https://github.com/dotnet/coreclr/pull/17877: Reflection: Fix FormatException when querying ParameterInfo.DefaultValue of optional DateTime parameter (this is what gets tested)