### PR TITLE
Throw ArgumentNullException when argument is null

### DIFF
--- a/src/Common/src/CoreLib/System/Text/StringBuilder.cs
+++ b/src/Common/src/CoreLib/System/Text/StringBuilder.cs
@@ -1867,10 +1867,18 @@ namespace System.Text
         [CLSCompliant(false)]
         public unsafe StringBuilder Append(char* value, int valueCount)
         {
-            // We don't check null value as this case will throw null reference exception anyway
             if (valueCount < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(valueCount), SR.ArgumentOutOfRange_NegativeCount);
+            }
+
+            if (value == null)
+            {
+                if (valueCount == 0)
+                {
+                    return this;
+                }
+                throw new ArgumentNullException(nameof(value));
             }
 
             // this is where we can check if the valueCount will put us over m_MaxCapacity

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -582,7 +582,7 @@ namespace System.Text.Tests
         public static unsafe void Append_CharPointer_Null_ThrowsNullReferenceException()
         {
             var builder = new StringBuilder();
-            Assert.Throws<NullReferenceException>(() => builder.Append(null, 2));
+            Assert.Throws<ArgumentNullException>(() => builder.Append(null, 2));
         }
 
         [Fact]


### PR DESCRIPTION
This is also motivated by mono interpreter needing an explicit null check.