### PR TITLE
[2.0] Fix -Wzero-as-null-pointer-constant errors on macOS

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -9,7 +9,7 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>e08cc13b2070ba879384ca0428af331c00c5918b</CoreFxCurrentRef>
+    <CoreFxCurrentRef>1329252b9b4e7b5baa657c52feca3cb9253281b7</CoreFxCurrentRef>
     <CoreClrCurrentRef>d899bf2cc64133f4edef3d42a2e658b285e2242b</CoreClrCurrentRef>
     <CoreSetupCurrentRef>aac2e06e201666201a5cfda06a296921a1c7f69d</CoreSetupCurrentRef>
     <ExternalCurrentRef>9be29f5804c4798d8b51bd3fed99ea076041aeb2</ExternalCurrentRef>
@@ -30,8 +30,8 @@
 
   <!-- Tests/infrastructure dependency versions. -->
   <PropertyGroup>
-    <CoreFxExpectedPrerelease>servicing-26308-01</CoreFxExpectedPrerelease>
-    <MicrosoftNETCorePlatformsPackageVersion>2.0.1</MicrosoftNETCorePlatformsPackageVersion>
+    <CoreFxExpectedPrerelease>servicing-26403-03</CoreFxExpectedPrerelease>
+    <MicrosoftNETCorePlatformsPackageVersion>2.0.2</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.0.6-servicing-26109-01</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <ProjectNTfsExpectedPrerelease>beta-25317-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-25317-00</ProjectNTfsTestILCExpectedPrerelease>

--- a/src/Native/Unix/System.Native/pal_console.cpp
+++ b/src/Native/Unix/System.Native/pal_console.cpp
@@ -407,7 +407,7 @@ void* SignalHandlerLoop(void* arg)
                 if (reinterpret_cast<void*>(g_origSigIntHandler.sa_sigaction) != reinterpret_cast<void*>(SIG_IGN))
                 {
                     UninitializeConsole();
-                    sigaction(SIGINT, &g_origSigIntHandler, NULL);
+                    sigaction(SIGINT, &g_origSigIntHandler, nullptr);
                     kill(getpid(), SIGINT);
                 }
             } 
@@ -416,7 +416,7 @@ void* SignalHandlerLoop(void* arg)
                 if (reinterpret_cast<void*>(g_origSigQuitHandler.sa_sigaction) != reinterpret_cast<void*>(SIG_IGN))
                 {
                     UninitializeConsole();
-                    sigaction(SIGQUIT, &g_origSigQuitHandler, NULL);
+                    sigaction(SIGQUIT, &g_origSigQuitHandler, nullptr);
                     kill(getpid(), SIGQUIT);
                 }
             }

--- a/src/Native/Unix/System.Native/pal_random.cpp
+++ b/src/Native/Unix/System.Native/pal_random.cpp
@@ -91,7 +91,7 @@ extern "C" void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* b
 
     if (!sInitializedMRand)
     {
-        srand48(time(NULL));
+        srand48(time(nullptr));
         sInitializedMRand = true;
     }
 

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.cpp
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.cpp
@@ -274,7 +274,7 @@ extern "C" uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
                                                   nullptr,
                                                   nullptr,
                                                   &gssBuffer,
-                                                  0,
+                                                  nullptr,
                                                   nullptr,
                                                   nullptr);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
@@ -78,7 +78,7 @@ extern "C" int32_t CryptoNative_GetX509Thumbprint(X509* x509, uint8_t* pBuf, int
         return -SHA_DIGEST_LENGTH;
     }
 
-    if (!X509_digest(x509, EVP_sha1(), pBuf, NULL))
+    if (!X509_digest(x509, EVP_sha1(), pBuf, nullptr))
     {
         return 0;
     }
@@ -104,7 +104,7 @@ extern "C" ASN1_TIME* CryptoNative_GetX509NotBefore(X509* x509)
         return x509->cert_info->validity->notBefore;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*
@@ -125,7 +125,7 @@ extern "C" ASN1_TIME* CryptoNative_GetX509NotAfter(X509* x509)
         return x509->cert_info->validity->notAfter;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*
@@ -146,7 +146,7 @@ extern "C" ASN1_TIME* CryptoNative_GetX509CrlNextUpdate(X509_CRL* crl)
         return X509_CRL_get_nextUpdate(crl);
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*
@@ -192,7 +192,7 @@ extern "C" ASN1_OBJECT* CryptoNative_GetX509PublicKeyAlgorithm(X509* x509)
         return x509->cert_info->key->algor->algorithm;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*
@@ -213,7 +213,7 @@ extern "C" ASN1_OBJECT* CryptoNative_GetX509SignatureAlgorithm(X509* x509)
         return x509->sig_alg->algorithm;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*
@@ -241,10 +241,10 @@ extern "C" int32_t CryptoNative_GetX509PublicKeyParameterBytes(X509* x509, uint8
     {
         // If pBuf is NULL we're asking for the length, so return 0 (which is negative-zero)
         // If pBuf is non-NULL we're asking to fill the data, in which case we return 1.
-        return pBuf != NULL;
+        return pBuf != nullptr;
     }
     
-    int len = i2d_ASN1_TYPE(parameter, NULL);
+    int len = i2d_ASN1_TYPE(parameter, nullptr);
 
     if (cBuf < len)
     {
@@ -280,7 +280,7 @@ extern "C" ASN1_BIT_STRING* CryptoNative_GetX509PublicKeyBytes(X509* x509)
         return x509->cert_info->key->public_key;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*
@@ -439,7 +439,7 @@ extern "C" BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32
 
     if (!x509 || !x509->cert_info || nameType < NAME_TYPE_SIMPLE || nameType > NAME_TYPE_URL)
     {
-        return NULL;
+        return nullptr;
     }
 
     // Algorithm behaviors (pseudocode).  When forIssuer is true, replace "Subject" with "Issuer" and
@@ -458,11 +458,11 @@ extern "C" BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32
 
         if (name)
         {
-            ASN1_STRING* cn = NULL;
-            ASN1_STRING* ou = NULL;
-            ASN1_STRING* o = NULL;
-            ASN1_STRING* e = NULL;
-            ASN1_STRING* firstRdn = NULL;
+            ASN1_STRING* cn = nullptr;
+            ASN1_STRING* ou = nullptr;
+            ASN1_STRING* o = nullptr;
+            ASN1_STRING* e = nullptr;
+            ASN1_STRING* firstRdn = nullptr;
 
             // Walk the list backwards because it is stored in stack order
             for (int i = X509_NAME_entry_count(name) - 1; i >= 0; --i)
@@ -564,7 +564,7 @@ extern "C" BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32
         }
 
         STACK_OF(GENERAL_NAME)* altNames = static_cast<STACK_OF(GENERAL_NAME)*>(
-            X509_get_ext_d2i(x509, forIssuer ? NID_issuer_alt_name : NID_subject_alt_name, NULL, NULL));
+            X509_get_ext_d2i(x509, forIssuer ? NID_issuer_alt_name : NID_subject_alt_name, nullptr, nullptr));
 
         if (altNames)
         {
@@ -576,7 +576,7 @@ extern "C" BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32
 
                 if (altName && altName->type == expectedType)
                 {
-                    ASN1_STRING* str = NULL;
+                    ASN1_STRING* str = nullptr;
 
                     switch (nameType)
                     {
@@ -674,7 +674,7 @@ extern "C" BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*
@@ -820,7 +820,7 @@ extern "C" int32_t CryptoNative_CheckX509Hostname(X509* x509, const char* hostna
     int subjectNid = NID_commonName;
     int sanGenType = GEN_DNS;
     GENERAL_NAMES* san = static_cast<GENERAL_NAMES*>(
-        X509_get_ext_d2i(x509, NID_subject_alt_name, NULL, NULL));
+        X509_get_ext_d2i(x509, NID_subject_alt_name, nullptr, nullptr));
     char readSubject = 1;
     int success = 0;
 
@@ -908,7 +908,7 @@ extern "C" int32_t CryptoNative_CheckX509IpAddress(
 
     int subjectNid = NID_commonName;
     int sanGenType = GEN_IPADD;
-    GENERAL_NAMES* san = static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(x509, NID_subject_alt_name, NULL, NULL));
+    GENERAL_NAMES* san = static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(x509, NID_subject_alt_name, nullptr, nullptr));
     int success = 0;
 
     if (san)
@@ -1069,7 +1069,7 @@ otherwise NULL.
 */
 extern "C" X509* CryptoNative_ReadX509AsDerFromBio(BIO* bio)
 {
-    return d2i_X509_bio(bio, NULL);
+    return d2i_X509_bio(bio, nullptr);
 }
 
 /*
@@ -1342,7 +1342,7 @@ extern "C" int32_t CryptoNative_EnsureOpenSslInitialized()
     // Initialize each of the locks
     for (locksInitialized = 0; locksInitialized < numLocks; locksInitialized++)
     {
-        if (pthread_mutex_init(&g_locks[locksInitialized], NULL) != 0)
+        if (pthread_mutex_init(&g_locks[locksInitialized], nullptr) != 0)
         {
             ret = 3;
             goto done;
@@ -1383,7 +1383,7 @@ done:
                 pthread_mutex_destroy(&g_locks[i]); // ignore failures
             }
             delete[] g_locks;
-            g_locks = NULL;
+            g_locks = nullptr;
         }
     }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
@@ -134,7 +134,7 @@ extern "C" int32_t CryptoNative_GetECKeyParameters(
 
 error:
     *cbQx = *cbQy = 0;
-    *qx = *qy = 0;
+    *qx = *qy = nullptr;
     if (d) *d = nullptr;
     if (cbD) *cbD = 0;
     if (xBn) BN_free(xBn);
@@ -246,13 +246,13 @@ extern "C" int32_t CryptoNative_GetECCurveParameters(
 #if HAVE_OPENSSL_EC2M
     if (API_EXISTS(EC_POINT_get_affine_coordinates_GF2m) && (*curveType == ECCurveType::Characteristic2))
     {
-        if (!EC_POINT_get_affine_coordinates_GF2m(group, G, xBn, yBn, NULL)) 
+        if (!EC_POINT_get_affine_coordinates_GF2m(group, G, xBn, yBn, nullptr)) 
             goto error;
     }
     else
 #endif
     {
-        if (!EC_POINT_get_affine_coordinates_GFp(group, G, xBn, yBn, NULL)) 
+        if (!EC_POINT_get_affine_coordinates_GFp(group, G, xBn, yBn, nullptr)) 
             goto error;
     }
 
@@ -268,7 +268,7 @@ extern "C" int32_t CryptoNative_GetECCurveParameters(
     if (EC_GROUP_get0_seed(group))
     {
         seedBn = BN_bin2bn(EC_GROUP_get0_seed(group), 
-            static_cast<int>(EC_GROUP_get_seed_len(group)), NULL);
+            static_cast<int>(EC_GROUP_get_seed_len(group)), nullptr);
         
         *seed = seedBn;
         *cbSeed = BN_num_bytes(seedBn);
@@ -406,7 +406,7 @@ extern "C" EC_KEY* CryptoNative_EcKeyCreateByExplicitParameters(
     {
         // qx, qy, d and seed are optional
         assert(false);
-        return 0;
+        return nullptr;
     }
 
     EC_KEY* key = nullptr;


### PR DESCRIPTION
`release/2.0.0` currently fails to build on macOS 10.13.4 because Apple LLVM version 9.1.0 (clang-902.0.39.1) added a  `-Wzero-as-null-pointer-constant` check.

Not sure what the policy is for this kind of fixes for release branches, so feel free to close if not appropriate.