### PR TITLE
Minor improvements to SocketsHttpHandler redirect logging

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -19,6 +19,7 @@ namespace System.Net
         private const int HandlerMessageId = HeadersInvalidValueId + 1;
         private const int AuthenticationInfoId = HandlerMessageId + 1;
         private const int AuthenticationErrorId = AuthenticationInfoId + 1;
+        private const int HandlerErrorId = AuthenticationErrorId + 1;
 
         [NonEvent]
         public static void UriBaseAddress(object obj, Uri baseAddress)
@@ -58,9 +59,14 @@ namespace System.Net
             WriteEvent(HeadersInvalidValueId, name, rawValue);
 
         [Event(HandlerMessageId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
-        public void HandlerMessage(int handlerId, int workerId, int requestId, string memberName, string message) =>
-            WriteEvent(HandlerMessageId, handlerId, workerId, requestId, memberName, message);
-            //Console.WriteLine($"{handlerId}/{workerId}/{requestId}: ({memberName}): {message}");  // uncomment for debugging only
+        public void HandlerMessage(int poolId, int workerId, int requestId, string memberName, string message) =>
+            WriteEvent(HandlerMessageId, poolId, workerId, requestId, memberName, message);
+            //Console.WriteLine($"{poolId}/{workerId}/{requestId}: ({memberName}): {message}");  // uncomment for debugging only
+
+        [Event(HandlerErrorId, Keywords = Keywords.Debug, Level = EventLevel.Error)]
+        public void HandlerMessageError(int poolId, int workerId, int requestId, string memberName, string message) =>
+            WriteEvent(HandlerErrorId, poolId, workerId, requestId, memberName, message);
+            //Console.WriteLine($"{poolId}/{workerId}/{requestId}: ({memberName}): {message}");  // uncomment for debugging only
 
         [NonEvent]
         public static void AuthenticationInfo(Uri uri, string message)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -54,6 +54,11 @@ namespace System.Net.Http
                 // Clear the authorization header.
                 request.Headers.Authorization = null;
 
+                if (NetEventSource.IsEnabled)
+                {
+                    NetEventSource.Info(this, $"Redirecting from {request.RequestUri} to {redirectUri} in response to status code {(int)response.StatusCode} '{response.StatusCode}'.");
+                }
+
                 // Set up for the redirect
                 request.RequestUri = redirectUri;
                 if (RequestRequiresForceGet(response.StatusCode, request.Method))
@@ -61,6 +66,10 @@ namespace System.Net.Http
                     request.Method = HttpMethod.Get;
                     request.Content = null;
                     request.Headers.TransferEncodingChunked = false;
+                    if (NetEventSource.IsEnabled)
+                    {
+                        NetEventSource.Info(this, $"Modified request from {request.Method} to GET in response to status code {(int)response.StatusCode} '{response.StatusCode}'.");
+                    }
                 }
 
                 // Issue the redirected request.

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -67,6 +67,7 @@ namespace System.Net.Http
                     {
                         NetEventSource.Info(this, $"Modified request from {request.Method} to {HttpMethod.Get} in response to status code {(int)response.StatusCode} '{response.StatusCode}'.");
                     }
+
                     request.Method = HttpMethod.Get;
                     request.Content = null;
                     request.Headers.TransferEncodingChunked = false;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -63,13 +63,13 @@ namespace System.Net.Http
                 request.RequestUri = redirectUri;
                 if (RequestRequiresForceGet(response.StatusCode, request.Method))
                 {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        NetEventSource.Info(this, $"Modified request from {request.Method} to {HttpMethod.Get} in response to status code {(int)response.StatusCode} '{response.StatusCode}'.");
+                    }
                     request.Method = HttpMethod.Get;
                     request.Content = null;
                     request.Headers.TransferEncodingChunked = false;
-                    if (NetEventSource.IsEnabled)
-                    {
-                        NetEventSource.Info(this, $"Modified request from {request.Method} to GET in response to status code {(int)response.StatusCode} '{response.StatusCode}'.");
-                    }
                 }
 
                 // Issue the redirected request.


### PR DESCRIPTION
Our logging coverage for redirects already covers common error scenarios:
- Too may redirects
- Insecure https to http redirect blocked

To improve our ability to diagnose other issues, I added some more informational logging:
- Logging the original URI, redirect URI, and status code when we redirect.
- Logging when we modify the request method to GET in response to a redirect.