### PR TITLE
Remove StringBuilder usage from Dns.GetHostName

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.gethostname.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.gethostname.cs
@@ -2,19 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal static partial class Interop
 {
     internal static partial class Winsock
     {
-        [DllImport(Interop.Libraries.Ws2_32, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true, SetLastError = true)]
-        internal static extern SocketError gethostname(
-                                            [Out] StringBuilder hostName,
-                                            [In] int bufferLength
-                                            );
+        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
+        internal static extern unsafe SocketError gethostname(byte* name, int namelen);
     }
 }

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -282,7 +282,7 @@ namespace System.Net
             return hostname.ToString();
         }
 
-        public static string GetHostName()
+        public static unsafe string GetHostName()
         {
             //
             // note that we could cache the result ourselves since you
@@ -291,20 +291,12 @@ namespace System.Net
             // react to that change.
             //
 
-            StringBuilder sb = new StringBuilder(HostNameBufferLength);
-            SocketError errorCode =
-                Interop.Winsock.gethostname(
-                    sb,
-                    HostNameBufferLength);
-
-            //
-            // if the call failed throw a SocketException()
-            //
-            if (errorCode != SocketError.Success)
+            byte* buffer = stackalloc byte[HostNameBufferLength];
+            if (Interop.Winsock.gethostname(buffer, HostNameBufferLength) != SocketError.Success)
             {
                 throw new SocketException();
             }
-            return sb.ToString();
+            return new string((sbyte*)buffer);
         }
 
         public static void EnsureSocketsAreInitialized()


### PR DESCRIPTION
StringBuilder is pure overhead for an operation like this, resulting in more code and more allocation.

On my machine, this reduces the allocation of Dns.GetHostName from ~600 bytes to ~40 bytes.

cc: @davidsh, @geoffkizer 