### PR TITLE
ConcurrentDictionary: improve documentation

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -458,8 +458,8 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Compares the existing value for the specified key with a specified value, and if they're equal,
-        /// updates the key with a third value.
+        /// Compares the existing value for the specified <paramref name="key"/> with <paramref name="comparisonValue"/>, and if they're equal,
+        /// updates the key with <paramref name="newValue"/>.
         /// </summary>
         /// <param name="key">The key whose value is compared with <paramref name="comparisonValue"/> and
         /// possibly replaced.</param>
@@ -479,8 +479,8 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Compares the existing value for the specified key with a specified value, and if they're equal,
-        /// updates the key with a third value.
+        /// Compares the existing value for the specified <paramref name="key"/> with <paramref name="comparisonValue"/>, and if they're equal,
+        /// updates the key with <paramref name="newValue"/>.
         /// </summary>
         /// <param name="key">The key whose value is compared with <paramref name="comparisonValue"/> and
         /// possibly replaced.</param>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -458,8 +458,8 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Compares the existing value for the specified <paramref name="key"/> with <paramref name="comparisonValue"/>, and if they're equal,
-        /// updates the key with <paramref name="newValue"/>.
+        /// Updates the value associated with <paramref name="key"/> to <paramref name="newValue"/> if the existing value is equal
+        /// to <paramref name="comparisonValue"/>.
         /// </summary>
         /// <param name="key">The key whose value is compared with <paramref name="comparisonValue"/> and
         /// possibly replaced.</param>
@@ -479,8 +479,8 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Compares the existing value for the specified <paramref name="key"/> with <paramref name="comparisonValue"/>, and if they're equal,
-        /// updates the key with <paramref name="newValue"/>.
+        /// Updates the value associated with <paramref name="key"/> to <paramref name="newValue"/> if the existing value is equal
+        /// to <paramref name="comparisonValue"/>.
         /// </summary>
         /// <param name="key">The key whose value is compared with <paramref name="comparisonValue"/> and
         /// possibly replaced.</param>


### PR DESCRIPTION
Improve the summary of ConcurrentyDictionary.TryUpdate. The summary mentions parameters in a different order and with different names than they are represented in the method signature. This is confusing:
![image](https://user-images.githubusercontent.com/2090172/39812540-579f1164-538d-11e8-8e2d-cb58b4508a66.png)

To clear things up, I've rephrased the summary to mention parameters in the same order as they occur in the method signature and used `<paramref name="XYZ"/>` to reference them.