### PR TITLE
Remove StringBuilder marshaling from X509Certificates

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -302,15 +302,22 @@ namespace Internal.Cryptography.Pal
         {
             get
             {
-                int cbData = 0;
-                if (!Interop.crypt32.CertGetCertificateContextPropertyString(_certContext, CertContextPropId.CERT_FRIENDLY_NAME_PROP_ID, null, ref cbData))
-                    return string.Empty;
+                unsafe
+                {
+                    int cbData = 0;
+                    if (!Interop.crypt32.CertGetCertificateContextPropertyString(_certContext, CertContextPropId.CERT_FRIENDLY_NAME_PROP_ID, null, ref cbData))
+                        return string.Empty;
 
-                StringBuilder sb = new StringBuilder((cbData + 1) / 2);
-                if (!Interop.crypt32.CertGetCertificateContextPropertyString(_certContext, CertContextPropId.CERT_FRIENDLY_NAME_PROP_ID, sb, ref cbData))
-                    return string.Empty;
+                    int spanLength = (cbData + 1) / 2;
+                    Span<char> buffer = spanLength <= 128 ? stackalloc char[spanLength] : new char[spanLength];
+                    fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
+                    {
+                        if (!Interop.crypt32.CertGetCertificateContextPropertyString(_certContext, CertContextPropId.CERT_FRIENDLY_NAME_PROP_ID, (byte*)ptr, ref cbData))
+                            return string.Empty;
+                    }
 
-                return sb.ToString();
+                    return new string(buffer.Slice(0, (cbData / 2) - 1));
+                }
             }
 
             set
@@ -386,22 +393,12 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        public string GetNameInfo(X509NameType nameType, bool forIssuer)
-        {
-            CertNameType certNameType = MapNameType(nameType);
-            CertNameFlags certNameFlags = forIssuer ? CertNameFlags.CERT_NAME_ISSUER_FLAG : CertNameFlags.None;
-            CertNameStrTypeAndFlags strType = CertNameStrTypeAndFlags.CERT_X500_NAME_STR | CertNameStrTypeAndFlags.CERT_NAME_STR_REVERSE_FLAG;
-
-            int cchCount = Interop.crypt32.CertGetNameString(_certContext, certNameType, certNameFlags, ref strType, null, 0);
-            if (cchCount == 0)
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
-
-            StringBuilder sb = new StringBuilder(cchCount);
-            if (Interop.crypt32.CertGetNameString(_certContext, certNameType, certNameFlags, ref strType, sb, cchCount) == 0)
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
-
-            return sb.ToString();
-        }
+        public unsafe string GetNameInfo(X509NameType nameType, bool forIssuer) =>
+            Interop.crypt32.CertGetNameString(
+                _certContext,
+                MapNameType(nameType),
+                forIssuer ? CertNameFlags.CERT_NAME_ISSUER_FLAG : CertNameFlags.None,
+                (int)(CertNameStrTypeAndFlags.CERT_X500_NAME_STR | CertNameStrTypeAndFlags.CERT_NAME_STR_REVERSE_FLAG));
 
         public void AppendPrivateKeyInfo(StringBuilder sb)
         {
@@ -526,22 +523,12 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        private string GetIssuerOrSubject(bool issuer)
-        {
-            CertNameFlags flags = issuer ? CertNameFlags.CERT_NAME_ISSUER_FLAG : CertNameFlags.None;
-            CertNameStringType stringType = CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG;
-
-            int cchCount = Interop.crypt32.CertGetNameString(_certContext, CertNameType.CERT_NAME_RDN_TYPE, flags, ref stringType, null, 0);
-            if (cchCount == 0)
-                throw Marshal.GetHRForLastWin32Error().ToCryptographicException();;
-
-            StringBuilder sb = new StringBuilder(cchCount);
-            cchCount = Interop.crypt32.CertGetNameString(_certContext, CertNameType.CERT_NAME_RDN_TYPE, flags, ref stringType, sb, cchCount);
-            if (cchCount == 0)
-                throw Marshal.GetHRForLastWin32Error().ToCryptographicException();;
-
-            return sb.ToString();
-        }
+        private unsafe string GetIssuerOrSubject(bool issuer) =>
+            Interop.crypt32.CertGetNameString(
+                _certContext,
+                CertNameType.CERT_NAME_RDN_TYPE,
+                issuer ? CertNameFlags.CERT_NAME_ISSUER_FLAG : CertNameFlags.None,
+                (int)(CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG));
 
         private CertificatePal(CertificatePal copyFrom)
         {

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -309,7 +309,7 @@ namespace Internal.Cryptography.Pal
                         return string.Empty;
 
                     int spanLength = (cbData + 1) / 2;
-                    Span<char> buffer = spanLength <= 128 ? stackalloc char[spanLength] : new char[spanLength];
+                    Span<char> buffer = spanLength <= 256 ? stackalloc char[spanLength] : new char[spanLength];
                     fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
                     {
                         if (!Interop.crypt32.CertGetCertificateContextPropertyString(_certContext, CertContextPropId.CERT_FRIENDLY_NAME_PROP_ID, (byte*)ptr, ref cbData))
@@ -398,7 +398,7 @@ namespace Internal.Cryptography.Pal
                 _certContext,
                 MapNameType(nameType),
                 forIssuer ? CertNameFlags.CERT_NAME_ISSUER_FLAG : CertNameFlags.None,
-                (int)(CertNameStrTypeAndFlags.CERT_X500_NAME_STR | CertNameStrTypeAndFlags.CERT_NAME_STR_REVERSE_FLAG));
+                CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG);
 
         public void AppendPrivateKeyInfo(StringBuilder sb)
         {
@@ -528,7 +528,7 @@ namespace Internal.Cryptography.Pal
                 _certContext,
                 CertNameType.CERT_NAME_RDN_TYPE,
                 issuer ? CertNameFlags.CERT_NAME_ISSUER_FLAG : CertNameFlags.None,
-                (int)(CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG));
+                CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG);
 
         private CertificatePal(CertificatePal copyFrom)
         {

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/FindPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/FindPal.cs
@@ -384,21 +384,14 @@ namespace Internal.Cryptography.Pal
             return true;
         }
 
-        private static string GetCertNameInfo(SafeCertContextHandle pCertContext, CertNameType dwNameType, CertNameFlags dwNameFlags)
+        private static unsafe string GetCertNameInfo(SafeCertContextHandle pCertContext, CertNameType dwNameType, CertNameFlags dwNameFlags)
         {
             Debug.Assert(dwNameType != CertNameType.CERT_NAME_ATTR_TYPE);
-
-            CertNameStringType stringType = CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG;
-
-            int cch = Interop.crypt32.CertGetNameString(pCertContext, dwNameType, dwNameFlags, ref stringType, null, 0);
-            if (cch == 0)
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
-
-            StringBuilder sb = new StringBuilder(cch);
-            if (0 == Interop.crypt32.CertGetNameString(pCertContext, dwNameType, dwNameFlags, ref stringType, sb, cch))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
-
-            return sb.ToString();
+            return Interop.crypt32.CertGetNameString(
+                pCertContext,
+                dwNameType,
+                dwNameFlags,
+                (int)(CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG));
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/FindPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/FindPal.cs
@@ -391,7 +391,7 @@ namespace Internal.Cryptography.Pal
                 pCertContext,
                 dwNameType,
                 dwNameFlags,
-                (int)(CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG));
+                CertNameStringType.CERT_X500_NAME_STR | CertNameStringType.CERT_NAME_STR_REVERSE_FLAG);
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -93,7 +93,7 @@ internal static partial class Interop
             SafeCertContextHandle certContext,
             CertNameType certNameType,
             CertNameFlags certNameFlags,
-            int strType) // CertNameStringType or CertNameStrTypeAndFlags
+            CertNameStringType strType)
         {
             int cchCount = CertGetNameString(certContext, certNameType, certNameFlags, strType, null, 0);
             if (cchCount == 0)
@@ -101,7 +101,7 @@ internal static partial class Interop
                 throw Marshal.GetLastWin32Error().ToCryptographicException();
             }
 
-            Span<char> buffer = cchCount <= 128 ? stackalloc char[cchCount] : new char[cchCount];
+            Span<char> buffer = cchCount <= 256 ? stackalloc char[cchCount] : new char[cchCount];
             fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
             {
                 if (CertGetNameString(certContext, certNameType, certNameFlags, strType, ptr, cchCount) == 0)
@@ -115,7 +115,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertGetNameStringW")]
-        private static extern unsafe int CertGetNameString(SafeCertContextHandle pCertContext, CertNameType dwType, CertNameFlags dwFlags, in int pvTypePara, char* pszNameString, int cchNameString);
+        private static extern unsafe int CertGetNameString(SafeCertContextHandle pCertContext, CertNameType dwType, CertNameFlags dwFlags, in CertNameStringType pvTypePara, char* pszNameString, int cchNameString);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern SafeCertContextHandle CertDuplicateCertificateContext(IntPtr pCertContext);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -78,7 +78,7 @@ internal static partial class Interop
         public static extern bool CertGetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, [Out] out IntPtr pvData, [In, Out] ref int pcbData);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertGetCertificateContextProperty")]
-        public static extern bool CertGetCertificateContextPropertyString(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, [Out] StringBuilder pvData, [In, Out] ref int pcbData);
+        public static extern unsafe bool CertGetCertificateContextPropertyString(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, byte* pvData, ref int pcbData);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern unsafe bool CertSetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, CertSetPropertyFlags dwFlags, [In] CRYPTOAPI_BLOB* pvData);
@@ -89,8 +89,33 @@ internal static partial class Interop
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern unsafe bool CertSetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, CertSetPropertyFlags dwFlags, [In] SafeNCryptKeyHandle keyHandle);
 
+        public static unsafe string CertGetNameString(
+            SafeCertContextHandle certContext,
+            CertNameType certNameType,
+            CertNameFlags certNameFlags,
+            int strType) // CertNameStringType or CertNameStrTypeAndFlags
+        {
+            int cchCount = CertGetNameString(certContext, certNameType, certNameFlags, strType, null, 0);
+            if (cchCount == 0)
+            {
+                throw Marshal.GetLastWin32Error().ToCryptographicException();
+            }
+
+            Span<char> buffer = cchCount <= 128 ? stackalloc char[cchCount] : new char[cchCount];
+            fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
+            {
+                if (CertGetNameString(certContext, certNameType, certNameFlags, strType, ptr, cchCount) == 0)
+                {
+                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                }
+
+                Debug.Assert(buffer[cchCount - 1] == '\0');
+                return new string(buffer.Slice(0, cchCount - 1));
+            }
+        }
+
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertGetNameStringW")]
-        public static extern int CertGetNameString(SafeCertContextHandle pCertContext, CertNameType dwType, CertNameFlags dwFlags, [In] ref CertNameStringType pvTypePara, [Out] StringBuilder pszNameString, int cchNameString);
+        private static extern unsafe int CertGetNameString(SafeCertContextHandle pCertContext, CertNameType dwType, CertNameFlags dwFlags, in int pvTypePara, char* pszNameString, int cchNameString);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern SafeCertContextHandle CertDuplicateCertificateContext(IntPtr pCertContext);
@@ -154,18 +179,18 @@ internal static partial class Interop
         public static extern bool PFXExportCertStore(SafeCertStoreHandle hStore, [In, Out] ref CRYPTOAPI_BLOB pPFX, SafePasswordHandle szPassword, PFXExportFlags dwFlags);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertNameToStrW")]
-        public static extern int CertNameToStr(CertEncodingType dwCertEncodingType, [In] ref CRYPTOAPI_BLOB pName, CertNameStrTypeAndFlags dwStrType, StringBuilder psz, int csz);
+        public static extern unsafe int CertNameToStr(CertEncodingType dwCertEncodingType, [In] ref CRYPTOAPI_BLOB pName, CertNameStrTypeAndFlags dwStrType, char* psz, int csz);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertStrToNameW")]
         public static extern bool CertStrToName(CertEncodingType dwCertEncodingType, string pszX500, CertNameStrTypeAndFlags dwStrType, IntPtr pvReserved, [Out] byte[] pbEncoded, [In, Out] ref int pcbEncoded, IntPtr ppszError);
 
-        public static bool CryptFormatObject(CertEncodingType dwCertEncodingType, FormatObjectType dwFormatType, FormatObjectStringType dwFormatStrType, IntPtr pFormatStruct, FormatObjectStructType lpszStructType, byte[] pbEncoded, int cbEncoded, StringBuilder pbFormat, ref int pcbFormat)
+        public static unsafe bool CryptFormatObject(CertEncodingType dwCertEncodingType, FormatObjectType dwFormatType, FormatObjectStringType dwFormatStrType, IntPtr pFormatStruct, FormatObjectStructType lpszStructType, byte[] pbEncoded, int cbEncoded, byte* pbFormat, ref int pcbFormat)
         {
             return CryptFormatObject(dwCertEncodingType, dwFormatType, dwFormatStrType, pFormatStruct, (IntPtr)lpszStructType, pbEncoded, cbEncoded, pbFormat, ref pcbFormat);
         }
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool CryptFormatObject(CertEncodingType dwCertEncodingType, FormatObjectType dwFormatType, FormatObjectStringType dwFormatStrType, IntPtr pFormatStruct, IntPtr lpszStructType, [In] byte[] pbEncoded, int cbEncoded, [Out] StringBuilder pbFormat, [In, Out] ref int pcbFormat);
+        private static extern unsafe bool CryptFormatObject(CertEncodingType dwCertEncodingType, FormatObjectType dwFormatType, FormatObjectStringType dwFormatStrType, IntPtr pFormatStruct, IntPtr lpszStructType, [In] byte[] pbEncoded, int cbEncoded, byte* pbFormat, [In, Out] ref int pcbFormat);
 
         public static bool CryptDecodeObject(CertEncodingType dwCertEncodingType, CryptDecodeObjectStructType lpszStructType, byte[] pbEncoded, int cbEncoded, CryptDecodeObjectFlags dwFlags, byte[] pvStructInfo, ref int pcbStructInfo)
         {
@@ -233,9 +258,6 @@ internal static partial class Interop
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CryptHashPublicKeyInfo(IntPtr hCryptProv, int algId, int dwFlags, CertEncodingType dwCertEncodingType, [In] ref CERT_PUBLIC_KEY_INFO pInfo, [Out] byte[] pbComputedHash, [In, Out] ref int pcbComputedHash);
-
-        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertGetNameStringW")]
-        public static extern int CertGetNameString(SafeCertContextHandle pCertContext, CertNameType dwType, CertNameFlags dwFlags, [In] ref CertNameStrTypeAndFlags pvPara, [Out] StringBuilder pszNameString, int cchNameString);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CertSaveStore(SafeCertStoreHandle hCertStore, CertEncodingType dwMsgAndCertEncodingType, CertStoreSaveAs dwSaveAs, CertStoreSaveTo dwSaveTo, ref CRYPTOAPI_BLOB pvSaveToPara, int dwFlags);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.X500DistinguishedName.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.X500DistinguishedName.cs
@@ -37,7 +37,7 @@ namespace Internal.Cryptography.Pal
                     if (cchDecoded == 0)
                         throw ErrorCode.CERT_E_INVALID_NAME.ToCryptographicException();
 
-                    Span<char> buffer = cchDecoded <= 128 ? stackalloc char[cchDecoded] : new char[cchDecoded];
+                    Span<char> buffer = cchDecoded <= 256 ? stackalloc char[cchDecoded] : new char[cchDecoded];
                     fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
                     {
                         if (Interop.crypt32.CertNameToStr(CertEncodingType.All, ref nameBlob, dwStrType, ptr, cchDecoded) == 0)
@@ -89,7 +89,7 @@ namespace Internal.Cryptography.Pal
             }
 
             int spanLength = (cbFormat + 1) / 2;
-            Span<char> buffer = spanLength <= 128 ? stackalloc char[spanLength] : new char[spanLength];
+            Span<char> buffer = spanLength <= 256 ? stackalloc char[spanLength] : new char[spanLength];
             fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
             {
                 if (!Interop.crypt32.CryptFormatObject(

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.X500DistinguishedName.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.X500DistinguishedName.cs
@@ -37,11 +37,14 @@ namespace Internal.Cryptography.Pal
                     if (cchDecoded == 0)
                         throw ErrorCode.CERT_E_INVALID_NAME.ToCryptographicException();
 
-                    StringBuilder sb = new StringBuilder(cchDecoded);
-                    if (Interop.crypt32.CertNameToStr(CertEncodingType.All, ref nameBlob, dwStrType, sb, cchDecoded) == 0)
-                        throw ErrorCode.CERT_E_INVALID_NAME.ToCryptographicException();
+                    Span<char> buffer = cchDecoded <= 128 ? stackalloc char[cchDecoded] : new char[cchDecoded];
+                    fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
+                    {
+                        if (Interop.crypt32.CertNameToStr(CertEncodingType.All, ref nameBlob, dwStrType, ptr, cchDecoded) == 0)
+                            throw ErrorCode.CERT_E_INVALID_NAME.ToCryptographicException();
+                    }
 
-                    return sb.ToString();
+                    return new string(buffer.Slice(0, cchDecoded - 1));
                 }
             }
         }
@@ -63,7 +66,7 @@ namespace Internal.Cryptography.Pal
             return encodedName;
         }
 
-        public string X500DistinguishedNameFormat(byte[] encodedDistinguishedName, bool multiLine)
+        public unsafe string X500DistinguishedNameFormat(byte[] encodedDistinguishedName, bool multiLine)
         {
             if (encodedDistinguishedName == null || encodedDistinguishedName.Length == 0)
                 return string.Empty;
@@ -85,22 +88,26 @@ namespace Internal.Cryptography.Pal
                 return encodedDistinguishedName.ToHexStringUpper();
             }
 
-            StringBuilder sb = new StringBuilder((cbFormat + 1) / 2);
-            if (!Interop.crypt32.CryptFormatObject(
-                CertEncodingType.X509_ASN_ENCODING,
-                FormatObjectType.None,
-                stringType,
-                IntPtr.Zero,
-                FormatObjectStructType.X509_NAME,
-                encodedDistinguishedName,
-                encodedDistinguishedName.Length,
-                sb,
-                ref cbFormat))
+            int spanLength = (cbFormat + 1) / 2;
+            Span<char> buffer = spanLength <= 128 ? stackalloc char[spanLength] : new char[spanLength];
+            fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
             {
-                return encodedDistinguishedName.ToHexStringUpper();
+                if (!Interop.crypt32.CryptFormatObject(
+                    CertEncodingType.X509_ASN_ENCODING,
+                    FormatObjectType.None,
+                    stringType,
+                    IntPtr.Zero,
+                    FormatObjectStructType.X509_NAME,
+                    encodedDistinguishedName,
+                    encodedDistinguishedName.Length,
+                    (byte*)ptr,
+                    ref cbFormat))
+                {
+                    return encodedDistinguishedName.ToHexStringUpper();
+                }
             }
 
-            return sb.ToString();
+            return new string(buffer.Slice(0, (cbFormat / 2) - 1));
         }
 
         private static CertNameStrTypeAndFlags MapNameToStrFlag(X500DistinguishedNameFlags flag)


### PR DESCRIPTION
Whittling away the remaining StringBuilder marshaling in corefx...

This removes it from X509Certificates. This avoids allocations for the StringBuilder itself, and if the data is small enough to be put on the stack, also underlying the char[].  It also avoids marshaling overheads associated with doing a wstrlen on the resulting data, as we're told exactly how long the string is.

cc: @bartonjs 

Example:
```
[Benchmark]
public static string FriendlyName() => x509Cert.FriendlyName;

       Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
------------- |---------:|---------:|---------:|-------:|----------:|
 Before       | 218.2 ns | 4.432 ns | 5.276 ns | 0.0379 |     160 B |
 After        | 177.8 ns | 1.460 ns | 1.365 ns | 0.0074 |      32 B |
```