### PR TITLE
Remove intermediate char[] allocation from ToHexStringUpper

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -25,20 +25,24 @@ namespace Internal.Cryptography
         public static char[] ToHexArrayUpper(this byte[] bytes)
         {
             char[] chars = new char[bytes.Length * 2];
+            ToHexArrayUpper(bytes, chars);
+            return chars;
+        }
+
+        private static void ToHexArrayUpper(byte[] bytes, Span<char> chars)
+        {
+            Debug.Assert(chars.Length >= bytes.Length * 2);
             int i = 0;
             foreach (byte b in bytes)
             {
                 chars[i++] = NibbleToHex((byte)(b >> 4));
                 chars[i++] = NibbleToHex((byte)(b & 0xF));
             }
-            return chars;
         }
 
         // Encode a byte array as an upper case hex string.
-        public static string ToHexStringUpper(this byte[] bytes)
-        {
-            return new string(ToHexArrayUpper(bytes));
-        }
+        public static string ToHexStringUpper(this byte[] bytes) =>
+            string.Create(bytes.Length * 2, bytes, (chars, src) => ToHexArrayUpper(src, chars));
 
         // Decode a hex string-encoded byte array passed to various X509 crypto api.
         // The parsing rules are overly forgiving but for compat reasons, they cannot be tightened.


### PR DESCRIPTION
Use the new String.Create overload to write the hex representation directly into the target string rather than first writing into an allocated char[] and then creating a string from that.

cc: @bartonjs 