### PR TITLE
Enable MicroBuild Signing in CoreFx 1.0.0

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -9,6 +9,29 @@
     <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)**\*.nupkg</PublishPattern>
   </PropertyGroup>
 
+   <PropertyGroup>
+     <PackageDownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)AzureTransfer\$(ConfigurationGroup)</PackageDownloadDirectory>
+     <FinalPublishPattern>$(PackageDownloadDirectory)\**\*.nupkg</FinalPublishPattern>
+     <FinalPublishPrivatePattern>$(PackageDownloadDirectory)\**\*Private*.nupkg</FinalPublishPrivatePattern>
+     <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
+    <!-- The SignFiles target needs OutDir to be defined -->
+    <OutDir>$(PackageDownloadDirectory)</OutDir>
+  </PropertyGroup>
+
+  <Target Name="GetPackagesToSign">
+    <ItemGroup>
+      <FilesToSign Include="$(FinalPublishPattern)" Exclude="$(FinalPublishPrivatePattern);$(FinalSymbolsPackagesPattern)">
+        <Authenticode>NuGet</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+    <Message Importance="High" Text="Attempting to sign package '%(FilesToSign.Identity)'" />
+  </Target>
+
+  <Target Name="SignPackages"
+          Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'public'"
+          DependsOnTargets="GetPackagesToSign;SignFiles">
+  </Target>
+
   <Target Name="CreateContainerName"
           DependsOnTargets="CreateVersionFileDuringBuild"
           Condition="'$(ContainerName)' == ''">


### PR DESCRIPTION
This will also require the following changes in the 1.0.0 pipebuild:

- Add a `MicroBuild Signing` Plugin step that mirrors `Install Signing Plugin` here: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=5123
- Add a `Command Line` step that mirrors `Sign Packages` in the same definition as above

@weshaggard @MattGal PTAL

For dotnet/core-eng#3393, and the same changeset in publish.proj as https://github.com/dotnet/corefx/pull/29615/files