### PR TITLE
[WIP] Re-enable URI tests that depend on the behavior of .NET 4.7

### DIFF
--- a/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -136,7 +136,6 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Relative_SimplePartialPathWithUnknownScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "scheme:\u011E";
@@ -147,7 +146,6 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Relative_SimplePartialPathWithScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "http:\u00C7";
@@ -158,7 +156,6 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Relative_RightToLeft()
         {
             var loremIpsumArabic = "\u0643\u0644 \u0627\u0644\u0649 \u0627\u0644\u0639\u0627\u0644\u0645";
@@ -171,7 +168,6 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Relative_Unicode_Glitchy()
         {
             var glitchy = "4\u0308\u0311\u031A\u030B\u0352\u034A\u030D\u036C\u036C\u036B\u0344\u0312\u0322\u0334\u0328\u0319\u0323\u0359\u0317\u0324\u0319\u032D\u0331\u0319\u031F\u0331\u0330\u0347\u0353\u0318\u032F\u032C\u03162\u0303\u0313\u031A\u0368\u036E\u0368\u0301\u0367\u0368\u0306\u0305\u0350\u036A\u036F\u0307\u0328\u035F\u0321\u0361\u0320\u032F\u032B\u034E\u0326\u033B";
@@ -184,7 +180,6 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Unicode_Format_Character_Combinations_Scheme()
         {
             var combinations = CartesianProductAll(_ => CharUnicodeInfo.GetUnicodeCategory(_) == UnicodeCategory.Format && !UriHelper.IsIriDisallowedBidi(_));


### PR DESCRIPTION
Several tests in System.Private.Uri.FunctionalTests were disabled because their behavior was based on the .NET Framework TFM, and we ran our tests targeting 4.6. Now that we're targeting 4.7, I want to check if the test behave as expected.

I can see that the tests pass on my local machine, but I'm marking this as WIP until I ensure they pass on CI.

Fixes: #15145