### PR TITLE
Add tests for Type.FilterName{IgnoreCase} and Module.FilterTypeName{IgnoreCase}

### DIFF
--- a/src/System.Reflection/tests/ModuleTests.cs
+++ b/src/System.Reflection/tests/ModuleTests.cs
@@ -79,6 +79,66 @@ namespace System.Reflection.Tests
             Assert.Null(module.GetType(className.ToLower(), false, false));
             Assert.Throws<TypeLoadException>(() => module.GetType(className.ToLower(), true, false));
         }
+
+        [Fact]
+        public void FilterTypeName_DelegateFiltersExpectedTypes()
+        {
+            Assert.NotNull(Module.FilterTypeName);
+            Assert.Same(Module.FilterTypeName, Module.FilterTypeName);
+            Assert.NotSame(Module.FilterTypeName, Module.FilterTypeNameIgnoreCase);
+
+            Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), null));
+            Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), new object()));
+
+            Assert.Empty(typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "out*"));
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "Out*").Length);
+            Assert.Empty(typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "outside"));
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "Outside").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "Inside").Length);
+
+            Assert.True(Module.FilterTypeName(typeof(string), "String"));
+            Assert.True(Module.FilterTypeName(typeof(string), "*"));
+            Assert.True(Module.FilterTypeName(typeof(string), "S*"));
+            Assert.True(Module.FilterTypeName(typeof(string), "Strin*"));
+            Assert.True(Module.FilterTypeName(typeof(string), "String"));
+            Assert.True(Module.FilterTypeName(typeof(string), "String*"));
+
+            Assert.False(Module.FilterTypeName(typeof(string), ""));
+            Assert.False(Module.FilterTypeName(typeof(string), "S"));
+            Assert.False(Module.FilterTypeName(typeof(string), " String"));
+            Assert.False(Module.FilterTypeName(typeof(string), "String "));
+            Assert.False(Module.FilterTypeName(typeof(string), "Strings"));
+        }
+
+        [Fact]
+        public void FilterTypeNameIgnoreCase_DelegateFiltersExpectedTypes()
+        {
+            Assert.NotNull(Module.FilterTypeNameIgnoreCase);
+            Assert.Same(Module.FilterTypeNameIgnoreCase, Module.FilterTypeNameIgnoreCase);
+            Assert.NotSame(Module.FilterTypeNameIgnoreCase, Module.FilterTypeName);
+
+            Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), null));
+            Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), new object()));
+
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "out*").Length);
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "Out*").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "oUtside").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "Outside").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "inSIDE").Length);
+
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "string"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "*"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "s*"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "stRIn*"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "sTrInG"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "STRING*"));
+
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), ""));
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), "s"));
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), " string"));
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), "string "));
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), "strings"));
+        }
     }
 }
 

--- a/src/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="ParameterInfoTests.cs" />
     <Compile Include="PropertyInfoTests.cs" />
     <Compile Include="ReflectionContextTests.cs" />
+    <Compile Include="TypeTests.cs" />
     <Compile Include="TypeInfoTests.cs" />
     <Compile Include="ExceptionTests.cs" />
   </ItemGroup>

--- a/src/System.Reflection/tests/TypeTests.cs
+++ b/src/System.Reflection/tests/TypeTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Reflection.Tests
+{
+    public class TypeTests
+    {
+        [Fact]
+        public void FilterName_DelegateFiltersExpectedMembers()
+        {
+            Assert.NotNull(Type.FilterName);
+            Assert.Same(Type.FilterName, Type.FilterName);
+            Assert.NotSame(Type.FilterName, Type.FilterNameIgnoreCase);
+
+            MethodInfo mi = typeof(TypeTests).GetMethod(nameof(FilterName_DelegateFiltersExpectedMembers));
+
+            Assert.Throws<InvalidFilterCriteriaException>(() => Type.FilterName(mi, null));
+            Assert.Throws<InvalidFilterCriteriaException>(() => Type.FilterName(mi, new object()));
+
+            Assert.Empty(typeof(TypeTests).FindMembers(MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance, Type.FilterName, "HelloWorld"));
+            Assert.Equal(1, typeof(TypeTests).FindMembers(MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance, Type.FilterName, "FilterName_DelegateFiltersExpectedMembers").Length);
+            Assert.Equal(1, typeof(TypeTests).FindMembers(MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance, Type.FilterName, "FilterName_Delegate*").Length);
+            Assert.Equal(0, typeof(TypeTests).FindMembers(MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance, Type.FilterName, "filterName_Delegate*").Length);
+
+            Assert.True(Type.FilterName(mi, "FilterName_DelegateFiltersExpectedMembers"));
+            Assert.True(Type.FilterName(mi, "     FilterName_DelegateFiltersExpectedMembers   "));
+            Assert.True(Type.FilterName(mi, "*"));
+            Assert.True(Type.FilterName(mi, "     *   "));
+            Assert.True(Type.FilterName(mi, "     Filter*   "));
+            Assert.True(Type.FilterName(mi, "FilterName_DelegateFiltersExpectedMembe*"));
+            Assert.True(Type.FilterName(mi, "FilterName_DelegateFiltersExpectedMember*"));
+
+            Assert.False(Type.FilterName(mi, "filterName_DelegateFiltersExpectedMembers"));
+            Assert.False(Type.FilterName(mi, "FilterName_DelegateFiltersExpectedMemberss"));
+            Assert.False(Type.FilterName(mi, "FilterName_DelegateFiltersExpectedMemberss*"));
+            Assert.False(Type.FilterName(mi, "FilterName"));
+            Assert.False(Type.FilterName(mi, "*FilterName"));
+            Assert.False(Type.FilterName(mi, ""));
+            Assert.False(Type.FilterName(mi, "     "));
+        }
+
+        [Fact]
+        public void FilterNameIgnoreCase_DelegateFiltersExpectedMembers()
+        {
+            Assert.NotNull(Type.FilterNameIgnoreCase);
+            Assert.Same(Type.FilterNameIgnoreCase, Type.FilterNameIgnoreCase);
+            Assert.NotSame(Type.FilterNameIgnoreCase, Type.FilterName);
+
+            MethodInfo mi = typeof(TypeTests).GetMethod(nameof(FilterNameIgnoreCase_DelegateFiltersExpectedMembers));
+
+            Assert.Throws<InvalidFilterCriteriaException>(() => Type.FilterNameIgnoreCase(mi, null));
+            Assert.Throws<InvalidFilterCriteriaException>(() => Type.FilterNameIgnoreCase(mi, new object()));
+
+            Assert.Empty(typeof(TypeTests).FindMembers(MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance, Type.FilterNameIgnoreCase, "HelloWorld"));
+            Assert.Equal(1, typeof(TypeTests).FindMembers(MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance, Type.FilterNameIgnoreCase, "FilterNameIgnoreCase_DelegateFiltersExpectedMembers").Length);
+            Assert.Equal(1, typeof(TypeTests).FindMembers(MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance, Type.FilterNameIgnoreCase, "FilterNameIgnoreCase_Delegate*").Length);
+            Assert.Equal(1, typeof(TypeTests).FindMembers(MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance, Type.FilterNameIgnoreCase, "filterName_Delegate*").Length);
+
+            Assert.True(Type.FilterNameIgnoreCase(mi, "FilterNameIgnoreCase_DelegateFiltersExpectedMembers"));
+            Assert.True(Type.FilterNameIgnoreCase(mi, "filternameignorecase_delegatefiltersexpectedmembers"));
+            Assert.True(Type.FilterNameIgnoreCase(mi, "     filterNameIgnoreCase_DelegateFiltersexpectedMembers   "));
+            Assert.True(Type.FilterNameIgnoreCase(mi, "*"));
+            Assert.True(Type.FilterNameIgnoreCase(mi, "     *   "));
+            Assert.True(Type.FilterNameIgnoreCase(mi, "     fIlTeR*   "));
+            Assert.True(Type.FilterNameIgnoreCase(mi, "FilterNameIgnoreCase_delegateFiltersExpectedMembe*"));
+            Assert.True(Type.FilterNameIgnoreCase(mi, "FilterNameIgnoreCase_delegateFiltersExpectedMember*"));
+
+            Assert.False(Type.FilterNameIgnoreCase(mi, "filterName_DelegateFiltersExpectedMembers"));
+            Assert.False(Type.FilterNameIgnoreCase(mi, "filterNameIgnoreCase_DelegateFiltersExpectedMemberss"));
+            Assert.False(Type.FilterNameIgnoreCase(mi, "FilterNameIgnoreCase_DelegateFiltersExpectedMemberss*"));
+            Assert.False(Type.FilterNameIgnoreCase(mi, "filterNameIgnoreCase"));
+            Assert.False(Type.FilterNameIgnoreCase(mi, "*FilterNameIgnoreCase"));
+            Assert.False(Type.FilterNameIgnoreCase(mi, ""));
+            Assert.False(Type.FilterNameIgnoreCase(mi, "     "));
+        }
+    }
+}


### PR DESCRIPTION
I made a change in coreclr that touched these members, and I noticed they didn't have any tests, so I'm adding some.