### PR TITLE
Fix Pen test failures with latest libgdiplus

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -273,35 +273,35 @@ namespace System.Drawing
                 switch (status)
                 {
                     case GenericError:
-                        return new ExternalException(SR.Format(SR.GdiplusGenericError), E_FAIL);
+                        return new ExternalException(SR.GdiplusGenericError, E_FAIL);
                     case InvalidParameter:
-                        return new ArgumentException(SR.Format(SR.GdiplusInvalidParameter));
+                        return new ArgumentException(SR.GdiplusInvalidParameter);
                     case OutOfMemory:
-                        return new OutOfMemoryException(SR.Format(SR.GdiplusOutOfMemory));
+                        return new OutOfMemoryException(SR.GdiplusOutOfMemory);
                     case ObjectBusy:
-                        return new InvalidOperationException(SR.Format(SR.GdiplusObjectBusy));
+                        return new InvalidOperationException(SR.GdiplusObjectBusy);
                     case InsufficientBuffer:
-                        return new OutOfMemoryException(SR.Format(SR.GdiplusInsufficientBuffer));
+                        return new OutOfMemoryException(SR.GdiplusInsufficientBuffer);
                     case NotImplemented:
-                        return new NotImplementedException(SR.Format(SR.GdiplusNotImplemented));
+                        return new NotImplementedException(SR.GdiplusNotImplemented);
                     case Win32Error:
-                        return new ExternalException(SR.Format(SR.GdiplusGenericError), E_FAIL);
+                        return new ExternalException(SR.GdiplusGenericError, E_FAIL);
                     case WrongState:
-                        return new InvalidOperationException(SR.Format(SR.GdiplusWrongState));
+                        return new InvalidOperationException(SR.GdiplusWrongState);
                     case Aborted:
-                        return new ExternalException(SR.Format(SR.GdiplusAborted), E_ABORT);
+                        return new ExternalException(SR.GdiplusAborted, E_ABORT);
                     case FileNotFound:
-                        return new FileNotFoundException(SR.Format(SR.GdiplusFileNotFound));
+                        return new FileNotFoundException(SR.GdiplusFileNotFound);
                     case ValueOverflow:
-                        return new OverflowException(SR.Format(SR.GdiplusOverflow));
+                        return new OverflowException(SR.GdiplusOverflow);
                     case AccessDenied:
-                        return new ExternalException(SR.Format(SR.GdiplusAccessDenied), E_ACCESSDENIED);
+                        return new ExternalException(SR.GdiplusAccessDenied, E_ACCESSDENIED);
                     case UnknownImageFormat:
-                        return new ArgumentException(SR.Format(SR.GdiplusUnknownImageFormat));
+                        return new ArgumentException(SR.GdiplusUnknownImageFormat);
                     case PropertyNotFound:
-                        return new ArgumentException(SR.Format(SR.GdiplusPropertyNotFoundError));
+                        return new ArgumentException(SR.GdiplusPropertyNotFoundError);
                     case PropertyNotSupported:
-                        return new ArgumentException(SR.Format(SR.GdiplusPropertyNotSupportedError));
+                        return new ArgumentException(SR.GdiplusPropertyNotSupportedError);
 
                     case FontFamilyNotFound:
                         Debug.Fail("We should be special casing FontFamilyNotFound so we can provide the font name");
@@ -313,16 +313,16 @@ namespace System.Drawing
 
                     case NotTrueTypeFont:
                         Debug.Fail("We should be special casing NotTrueTypeFont so we can provide the font name");
-                        return new ArgumentException(SR.Format(SR.GdiplusNotTrueTypeFont_NoName));
+                        return new ArgumentException(SR.GdiplusNotTrueTypeFont_NoName);
 
                     case UnsupportedGdiplusVersion:
-                        return new ExternalException(SR.Format(SR.GdiplusUnsupportedGdiplusVersion), E_FAIL);
+                        return new ExternalException(SR.GdiplusUnsupportedGdiplusVersion, E_FAIL);
 
                     case GdiplusNotInitialized:
-                        return new ExternalException(SR.Format(SR.GdiplusNotInitialized), E_FAIL);
+                        return new ExternalException(SR.GdiplusNotInitialized, E_FAIL);
                 }
 
-                return new ExternalException(SR.Format(SR.GdiplusUnknown), E_UNEXPECTED);
+                return new ExternalException(SR.GdiplusUnknown, E_UNEXPECTED);
             }
 
             //----------------------------------------------------------------------------------------                                                           

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -558,6 +558,11 @@ namespace System.Drawing
             {
                 if (_color == Color.Empty)
                 {
+                    if (PenType != PenType.SolidColor)
+                    {
+                        throw new ArgumentException(SR.GdiplusInvalidParameter);
+                    }
+
                     int colorARGB = 0;
                     int status = SafeNativeMethods.Gdip.GdipGetPenColor(new HandleRef(this, NativePen), out colorARGB);
                     SafeNativeMethods.Gdip.CheckStatus(status);

--- a/src/System.Drawing.Common/tests/PenTests.cs
+++ b/src/System.Drawing.Common/tests/PenTests.cs
@@ -302,14 +302,7 @@ namespace System.Drawing.Tests
 
         private void ValidateInitialPenColorState(Pen pen)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Color);
-            }
-            else
-            {
-                Assert.Equal(Color.FromArgb(0), pen.Color);
-            }
+            AssertExtensions.Throws<ArgumentException>(null, () => pen.Color);
         }
 
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]


### PR DESCRIPTION
The latest libgdiplus fixed a compatability bug and now returns InvalidParameter if `GdipGetPenColor` is called for a pen that is not a solid color.

However, the test helper `ValidateInitialPenColorState` expected the old behaviour:

```csharp
            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
            {
                AssertExtensions.Throws<ArgumentException>(null, () => pen.Color);
            }
            else
            {
                Assert.Equal(Color.FromArgb(0), pen.Color);
            }

```

The fix is to manually add code checking for the type when getting `Pen.Color`.

Contributes to #20884