### PR TITLE
Change IsSynchronized and SyncRoot of CryptographicAttributeObjectCollection class from explicitly implementing the interface to implicitly implementing the interface.

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
+++ b/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
@@ -20,8 +20,8 @@ namespace System.Security.Cryptography
         public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
         public int Count { get { throw null; } }
         public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
         public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
         public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
         public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }

--- a/src/System.Security.Cryptography.Pkcs/src/MatchingRefApiCompatBaseline.netstandard.txt
+++ b/src/System.Security.Cryptography.Pkcs/src/MatchingRefApiCompatBaseline.netstandard.txt
@@ -1,6 +1,3 @@
 # These members don't belong in netstandard reference because of type unification with netfx (the members are new in net472).
 MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignerInfo.GetSignature()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignerInfo.SignatureAlgorithm.get()' does not exist in the reference but it does exist in the implementation.
-
-MembersMustExist : Member 'System.Security.Cryptography.CryptographicAttributeObjectCollection.IsSynchronized.get()' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'System.Security.Cryptography.CryptographicAttributeObjectCollection.SyncRoot.get()' does not exist in the reference but it does exist in the implementation.

--- a/src/System.Security.Cryptography.Pkcs/src/MatchingRefApiCompatBaseline.netstandard.txt
+++ b/src/System.Security.Cryptography.Pkcs/src/MatchingRefApiCompatBaseline.netstandard.txt
@@ -1,3 +1,6 @@
 # These members don't belong in netstandard reference because of type unification with netfx (the members are new in net472).
 MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignerInfo.GetSignature()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignerInfo.SignatureAlgorithm.get()' does not exist in the reference but it does exist in the implementation.
+
+MembersMustExist : Member 'System.Security.Cryptography.CryptographicAttributeObjectCollection.IsSynchronized.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.CryptographicAttributeObjectCollection.SyncRoot.get()' does not exist in the reference but it does exist in the implementation.

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObjectCollection.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObjectCollection.cs
@@ -102,6 +102,22 @@ namespace System.Security.Cryptography
             }
         }
 
+        public bool IsSynchronized
+        {
+            get
+            {
+                return ((ICollection)_list).IsSynchronized;
+            }
+        }
+
+        public object SyncRoot
+        {
+            get
+            {
+                return this;
+            }
+        }
+
         public CryptographicAttributeObjectEnumerator GetEnumerator()
         {
             return new CryptographicAttributeObjectEnumerator(this);
@@ -140,22 +156,6 @@ namespace System.Security.Cryptography
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
             _list.CopyTo(array, index);
-        }
-
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                return this;
-            }
         }
 
         private readonly List<CryptographicAttributeObject> _list;

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObjectCollection.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObjectCollection.cs
@@ -106,7 +106,7 @@ namespace System.Security.Cryptography
         {
             get
             {
-                return ((ICollection)_list).IsSynchronized;
+                return false;
             }
         }
 


### PR DESCRIPTION
Fixes #29607