### PR TITLE
Fix SystemColors regression in netcoreapp2.0 caused by removing KnownColor values when we deleted SystemColors from System.Drawing.Primitives

### DIFF
--- a/src/System.Drawing.Primitives/src/System/Drawing/KnownColor.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/KnownColor.cs
@@ -19,8 +19,8 @@ namespace System.Drawing
         // 0 - reserved for "not a known color"
 
         // "System" colors
-        /*
         ActiveBorder = 1,
+        FirstColor = ActiveBorder,
         ActiveCaption,
         ActiveCaptionText,
         AppWorkspace,
@@ -46,11 +46,9 @@ namespace System.Drawing
         Window,
         WindowFrame,
         WindowText,
-        */
 
         // "Web" Colors
-        FirstColor = 0,
-        Transparent = FirstColor,
+        Transparent,
         AliceBlue,
         AntiqueWhite,
         Aqua,
@@ -191,11 +189,8 @@ namespace System.Drawing
         WhiteSmoke,
         Yellow,
         YellowGreen,
-        LastColor = YellowGreen
 
         // NEW ADDITIONS IN WHIDBEY - DO NOT MOVE THESE UP OR IT WILL BE A BREAKING CHANGE
-
-        /*
         ButtonFace,
         ButtonHighlight,
         ButtonShadow,
@@ -203,6 +198,6 @@ namespace System.Drawing
         GradientInactiveCaption,
         MenuBar,
         MenuHighlight,
-        */
+        LastColor = MenuHighlight
     }
 }

--- a/src/System.Drawing.Primitives/src/System/Drawing/KnownColorTable.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/KnownColorTable.cs
@@ -21,10 +21,44 @@ namespace System.Drawing
 
         private static void InitColorTable()
         {
-            int[] values = new int[KnownColor.LastColor - KnownColor.FirstColor + 1];
+            int[] values = new int[(int)KnownColor.LastColor + 1];
 
             // just consts...
-            //
+            // Hard-coded constants, based on default Windows settings.
+            values[(int)KnownColor.ActiveBorder] = unchecked((int)0xFFD4D0C8);
+            values[(int)KnownColor.ActiveCaption] = unchecked((int)0xFF0054E3);
+            values[(int)KnownColor.ActiveCaptionText] = unchecked((int)0xFFFFFFFF);
+            values[(int)KnownColor.AppWorkspace] = unchecked((int)0xFF808080);
+            values[(int)KnownColor.ButtonFace] = unchecked((int)0xFFF0F0F0);
+            values[(int)KnownColor.ButtonHighlight] = unchecked((int)0xFFFFFFFF);
+            values[(int)KnownColor.ButtonShadow] = unchecked((int)0xFFA0A0A0);
+            values[(int)KnownColor.Control] = unchecked((int)0xFFECE9D8);
+            values[(int)KnownColor.ControlDark] = unchecked((int)0xFFACA899);
+            values[(int)KnownColor.ControlDarkDark] = unchecked((int)0xFF716F64);
+            values[(int)KnownColor.ControlLight] = unchecked((int)0xFFF1EFE2);
+            values[(int)KnownColor.ControlLightLight] = unchecked((int)0xFFFFFFFF);
+            values[(int)KnownColor.ControlText] = unchecked((int)0xFF000000);
+            values[(int)KnownColor.Desktop] = unchecked((int)0xFF004E98);
+            values[(int)KnownColor.GradientActiveCaption] = unchecked((int)0xFFB9D1EA);
+            values[(int)KnownColor.GradientInactiveCaption] = unchecked((int)0xFFD7E4F2);
+            values[(int)KnownColor.GrayText] = unchecked((int)0xFFACA899);
+            values[(int)KnownColor.Highlight] = unchecked((int)0xFF316AC5);
+            values[(int)KnownColor.HighlightText] = unchecked((int)0xFFFFFFFF);
+            values[(int)KnownColor.HotTrack] = unchecked((int)0xFF000080);
+            values[(int)KnownColor.InactiveBorder] = unchecked((int)0xFFD4D0C8);
+            values[(int)KnownColor.InactiveCaption] = unchecked((int)0xFF7A96DF);
+            values[(int)KnownColor.InactiveCaptionText] = unchecked((int)0xFFD8E4F8);
+            values[(int)KnownColor.Info] = unchecked((int)0xFFFFFFE1);
+            values[(int)KnownColor.InfoText] = unchecked((int)0xFF000000);
+            values[(int)KnownColor.Menu] = unchecked((int)0xFFFFFFFF);
+            values[(int)KnownColor.MenuBar] = unchecked((int)0xFFF0F0F0);
+            values[(int)KnownColor.MenuHighlight] = unchecked((int)0xFF3399FF);
+            values[(int)KnownColor.MenuText] = unchecked((int)0xFF000000);
+            values[(int)KnownColor.ScrollBar] = unchecked((int)0xFFD4D0C8);
+            values[(int)KnownColor.Window] = unchecked((int)0xFFFFFFFF);
+            values[(int)KnownColor.WindowFrame] = unchecked((int)0xFF000000);
+            values[(int)KnownColor.WindowText] = unchecked((int)0xFF000000);
+
             values[(int)KnownColor.Transparent] = 0x00FFFFFF;
             values[(int)KnownColor.AliceBlue] = unchecked((int)0xFFF0F8FF);
             values[(int)KnownColor.AntiqueWhite] = unchecked((int)0xFFFAEBD7);
@@ -181,10 +215,44 @@ namespace System.Drawing
 
         private static void InitColorNameTable()
         {
-            string[] values = new string[KnownColor.LastColor - KnownColor.FirstColor + 1];
+            string[] values = new string[(int)KnownColor.LastColor + 1];
 
             // just consts...
             //
+            values[(int)KnownColor.ActiveBorder] = "ActiveBorder";
+            values[(int)KnownColor.ActiveCaption] = "ActiveCaption";
+            values[(int)KnownColor.ActiveCaptionText] = "ActiveCaptionText";
+            values[(int)KnownColor.AppWorkspace] = "AppWorkspace";
+            values[(int)KnownColor.ButtonFace] = "ButtonFace";
+            values[(int)KnownColor.ButtonHighlight] = "ButtonHighlight";
+            values[(int)KnownColor.ButtonShadow] = "ButtonShadow";
+            values[(int)KnownColor.Control] = "Control";
+            values[(int)KnownColor.ControlDark] = "ControlDark";
+            values[(int)KnownColor.ControlDarkDark] = "ControlDarkDark";
+            values[(int)KnownColor.ControlLight] = "ControlLight";
+            values[(int)KnownColor.ControlLightLight] = "ControlLightLight";
+            values[(int)KnownColor.ControlText] = "ControlText";
+            values[(int)KnownColor.Desktop] = "Desktop";
+            values[(int)KnownColor.GradientActiveCaption] = "GradientActiveCaption";
+            values[(int)KnownColor.GradientInactiveCaption] = "GradientInactiveCaption";
+            values[(int)KnownColor.GrayText] = "GrayText";
+            values[(int)KnownColor.Highlight] = "Highlight";
+            values[(int)KnownColor.HighlightText] = "HighlightText";
+            values[(int)KnownColor.HotTrack] = "HotTrack";
+            values[(int)KnownColor.InactiveBorder] = "InactiveBorder";
+            values[(int)KnownColor.InactiveCaption] = "InactiveCaption";
+            values[(int)KnownColor.InactiveCaptionText] = "InactiveCaptionText";
+            values[(int)KnownColor.Info] = "Info";
+            values[(int)KnownColor.InfoText] = "InfoText";
+            values[(int)KnownColor.Menu] = "Menu";
+            values[(int)KnownColor.MenuBar] = "MenuBar";
+            values[(int)KnownColor.MenuHighlight] = "MenuHighlight";
+            values[(int)KnownColor.MenuText] = "MenuText";
+            values[(int)KnownColor.ScrollBar] = "ScrollBar";
+            values[(int)KnownColor.Window] = "Window";
+            values[(int)KnownColor.WindowFrame] = "WindowFrame";
+            values[(int)KnownColor.WindowText] = "WindowText";
+
             values[(int)KnownColor.Transparent] = "Transparent";
             values[(int)KnownColor.AliceBlue] = "AliceBlue";
             values[(int)KnownColor.AntiqueWhite] = "AntiqueWhite";


### PR DESCRIPTION
This KnownColor values where deleted from System.Drawing.Primitives in .netcoreapp2.0: https://github.com/dotnet/corefx/commit/9eb75a26a32de61fd4b9e51a1e029df1b2d59ff9#diff-f470150884e104603cc2c28148745e85 because we removed SystemColors from `System.Drawing.Primitives` public API. Now that we have added `System.Drawing.Common` back to netcoreapp2.0 through the NuGet package we support [`SystemColors`](https://github.com/dotnet/corefx/blob/master/src/System.Drawing.Common/src/System/Drawing/SystemColors.cs) and we use the KnownColor enums to get them.

The problem here is that in `System.Drawing.Common` we have 1 version of `KnownColor` which contains the values that where deleted from `System.Drawing.Primitives.KnownColor` -- so whenever we try to get a value from `System.Drawing.Primitives.KnownColorTable` running on .netcoreapp2.0 the indexes are messed up causing it to return a wrong `Color` because the enum's between both assemblies are different.

Fixes: https://github.com/dotnet/corefx/issues/29269