### PR TITLE
Switch recently re-enabled tests to run only on new versions of .NET Framework

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -57,6 +57,7 @@ namespace System
         public static bool IsNetfx462OrNewer { get { throw null; } }
         public static bool IsNetfx470OrNewer { get { throw null; } }
         public static bool IsNetfx471OrNewer { get { throw null; } }
+        public static bool IsNetfx472OrNewer { get { throw null; } }
         public static bool IsNetNative { get { throw null; } }
         public static bool IsNonZeroLowerBoundArraySupported { get { throw null; } }
         public static bool IsNotArmProcess { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NetFx.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NetFx.cs
@@ -24,6 +24,8 @@ namespace System
 
         public static bool IsNetfx471OrNewer => GetFrameworkVersion() >= new Version(4, 7, 1);
 
+        public static bool IsNetfx472OrNewer => GetFrameworkVersion() >= new Version(4, 7, 2);
+
         public static string LibcRelease => "";
         public static string LibcVersion => "";
 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NonNetFx.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NonNetFx.cs
@@ -14,6 +14,7 @@ namespace System
         public static bool IsNetfx462OrNewer => false;
         public static bool IsNetfx470OrNewer => false;
         public static bool IsNetfx471OrNewer => false;
+        public static bool IsNetfx472OrNewer => false;
 
 
         [DllImport("libc", ExactSpelling = true, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]

--- a/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -23,7 +23,7 @@ namespace System.PrivateUri.Tests
         private const string FullBaseUriGetLeftPart_Query = "http://user:psw@host:9090/path1/path2/path3/fileA?query";
 
         // A few of these tests depend on bugfixes made in .NET Framework 4.7.1 and must be skipped on older versions.
-        public static bool IsNotNetfx47OrOlder => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx471OrNewer;
+        public static bool IsNetCoreOrIsNetfx472OrLater => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx472OrNewer;
 
         [Fact]
         public void Uri_Relative_BaseVsAbsolute_ReturnsFullAbsolute()
@@ -138,7 +138,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
+        [ConditionalFact(nameof(IsNetCoreOrIsNetfx472OrLater))]
         public void Uri_Relative_SimplePartialPathWithUnknownScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "scheme:\u011E";
@@ -148,7 +148,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
+        [ConditionalFact(nameof(IsNetCoreOrIsNetfx472OrLater))]
         public void Uri_Relative_SimplePartialPathWithScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "http:\u00C7";
@@ -158,7 +158,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
+        [ConditionalFact(nameof(IsNetCoreOrIsNetfx472OrLater))]
         public void Uri_Relative_RightToLeft()
         {
             var loremIpsumArabic = "\u0643\u0644 \u0627\u0644\u0649 \u0627\u0644\u0639\u0627\u0644\u0645";
@@ -170,7 +170,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
+        [ConditionalFact(nameof(IsNetCoreOrIsNetfx472OrLater))]
         public void Uri_Relative_Unicode_Glitchy()
         {
             var glitchy = "4\u0308\u0311\u031A\u030B\u0352\u034A\u030D\u036C\u036C\u036B\u0344\u0312\u0322\u0334\u0328\u0319\u0323\u0359\u0317\u0324\u0319\u032D\u0331\u0319\u031F\u0331\u0330\u0347\u0353\u0318\u032F\u032C\u03162\u0303\u0313\u031A\u0368\u036E\u0368\u0301\u0367\u0368\u0306\u0305\u0350\u036A\u036F\u0307\u0328\u035F\u0321\u0361\u0320\u032F\u032B\u034E\u0326\u033B";
@@ -182,7 +182,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
+        [ConditionalFact(nameof(IsNetCoreOrIsNetfx472OrLater))]
         public void Uri_Unicode_Format_Character_Combinations_Scheme()
         {
             var combinations = CartesianProductAll(_ => CharUnicodeInfo.GetUnicodeCategory(_) == UnicodeCategory.Format && !UriHelper.IsIriDisallowedBidi(_));

--- a/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -22,7 +22,7 @@ namespace System.PrivateUri.Tests
         private const string FullBaseUriGetLeftPart_Authority = "http://user:psw@host:9090";
         private const string FullBaseUriGetLeftPart_Query = "http://user:psw@host:9090/path1/path2/path3/fileA?query";
 
-        // A few of these tests depend on bugfixes made in .NET Framework 4.7.1 and must be skipped on older versions.
+        // A few of these tests depend on bugfixes made in .NET Framework 4.7.2 and must be skipped on older versions.
         public static bool IsNetCoreOrIsNetfx472OrLater => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx472OrNewer;
 
         [Fact]

--- a/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -22,6 +22,9 @@ namespace System.PrivateUri.Tests
         private const string FullBaseUriGetLeftPart_Authority = "http://user:psw@host:9090";
         private const string FullBaseUriGetLeftPart_Query = "http://user:psw@host:9090/path1/path2/path3/fileA?query";
 
+        // A few of these tests depend on bugfixes made in .NET Framework 4.7.1 and must be skipped on older versions.
+        public static bool IsNotNetfx47OrOlder => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx471OrNewer;
+
         [Fact]
         public void Uri_Relative_BaseVsAbsolute_ReturnsFullAbsolute()
         {
@@ -135,7 +138,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
         public void Uri_Relative_SimplePartialPathWithUnknownScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "scheme:\u011E";
@@ -145,7 +148,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
         public void Uri_Relative_SimplePartialPathWithScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "http:\u00C7";
@@ -155,7 +158,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
         public void Uri_Relative_RightToLeft()
         {
             var loremIpsumArabic = "\u0643\u0644 \u0627\u0644\u0649 \u0627\u0644\u0639\u0627\u0644\u0645";
@@ -167,7 +170,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
         public void Uri_Relative_Unicode_Glitchy()
         {
             var glitchy = "4\u0308\u0311\u031A\u030B\u0352\u034A\u030D\u036C\u036C\u036B\u0344\u0312\u0322\u0334\u0328\u0319\u0323\u0359\u0317\u0324\u0319\u032D\u0331\u0319\u031F\u0331\u0330\u0347\u0353\u0318\u032F\u032C\u03162\u0303\u0313\u031A\u0368\u036E\u0368\u0301\u0367\u0368\u0306\u0305\u0350\u036A\u036F\u0307\u0328\u035F\u0321\u0361\u0320\u032F\u032B\u034E\u0326\u033B";
@@ -179,7 +182,7 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotNetfx47OrOlder))]
         public void Uri_Unicode_Format_Character_Combinations_Scheme()
         {
             var combinations = CartesianProductAll(_ => CharUnicodeInfo.GetUnicodeCategory(_) == UnicodeCategory.Format && !UriHelper.IsIriDisallowedBidi(_));


### PR DESCRIPTION
I enabled several tests in #29621 that are dependent on the .NET Framework version. It turns out that there are a few machines in the official runs that still use older versions where the tests will fail. This PR disables the tests only on .NET Framework versions that do not have the fixes required for these tests.

Fixes: #29653