### PR TITLE
Disable parallelization of System.Transactions tests

### DIFF
--- a/src/System.Transactions.Local/tests/System.Transactions.Local.Tests.csproj
+++ b/src/System.Transactions.Local/tests/System.Transactions.Local.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="HelperFunctions.cs" />
     <Compile Include="TestEnlistments.cs" />
     <Compile Include="TransactionTracingEventListener.cs" />
+    <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />

--- a/src/System.Transactions.Local/tests/XunitAssemblyAttributes.cs
+++ b/src/System.Transactions.Local/tests/XunitAssemblyAttributes.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+// Currently has a bunch of blocking in tests waiting for other operations that post back to the current
+// synchronization context.  With parallelism enabled, that causes deadlocks, especially on single core
+// machines but possibly on higher core counts as well.  Until all of that can be cleaned up, disable
+// parallelization of the tests.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]


### PR DESCRIPTION
I would have bet (a small amount) of money that this was the cause of https://github.com/dotnet/coreclr/issues/17858, but apparently not.  Regardless, there's still an issue here.  The tests do a lot of invoking of async operations and then blocking on them with .Wait, .WaitAll, .Result, etc.  With xunit's SynchronizationContext that limits concurrency, and with those async operations posting back to the sync ctx, this is prone to deadlocks.  Until all of that blocking can be cleaned up, I'm disabling the parallelization, which disables the sync ctx.

cc: @jimcarley, @qizhanMS, @dmetzgar, @danmosemsft 

EDIT:
> I would have bet (a small amount) of money that this was the cause of dotnet/coreclr#17858, but apparently not.

Further investigation shows that my bet probably would have paid off, so:
Fixes dotnet/coreclr#17858
cc: @echesakovMSFT 