### PR TITLE
Skipping test on uap because metadata removed for perf reason

### DIFF
--- a/src/System.Composition/tests/CustomerReportedMetadataBug.cs
+++ b/src/System.Composition/tests/CustomerReportedMetadataBug.cs
@@ -38,6 +38,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
+        [ActiveIssue(29652, TargetFrameworkMonikers.UapAot)]
         [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
         public void SampleServicesCorrectlyImported()
         {


### PR DESCRIPTION
Fixes: #29652 

Note, I wasn't not able to reproduce locally.

cc: @danmosemsft 