### PR TITLE
Reflection & Reflection.Emit: Add tests for nullable enum parameters

### DIFF
--- a/src/System.Reflection.Emit/tests/ParameterBuilder/ParameterBuilderSetConstant.cs
+++ b/src/System.Reflection.Emit/tests/ParameterBuilder/ParameterBuilderSetConstant.cs
@@ -70,17 +70,31 @@ namespace System.Reflection.Emit.Tests
             SetConstant_Null(parameterType);
         }
 
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Passing non-null value for SetConstant on nullable enum types not supported on NETFX")]
+        [InlineData(typeof(AttributeTargets?), AttributeTargets.All, (int)AttributeTargets.All)]
+        [InlineData(typeof(AttributeTargets?), (int)AttributeTargets.All, (int)AttributeTargets.All)]
+        public void SetConstant_NonNull_on_nullable_enum_not_supported_on_NETFX(Type parameterType, object valueToWrite, object expectedValueWhenRead)
+        {
+            SetConstant(parameterType, valueToWrite, expectedValueWhenRead);
+        }
+
         private void SetConstant_Null(Type parameterType)
+        {
+            SetConstant(parameterType, null, null);
+        }
+
+        private void SetConstant(Type parameterType, object valueToWrite, object expectedValueWhenRead)
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.Interface | TypeAttributes.Abstract);
             MethodBuilder method = type.DefineMethod("TestMethod", MethodAttributes.Public | MethodAttributes.Abstract | MethodAttributes.Virtual, typeof(void), new Type[] { parameterType });
             ParameterBuilder parameter = method.DefineParameter(1, ParameterAttributes.Optional | ParameterAttributes.HasDefault, "arg");
 
-            parameter.SetConstant(null);
+            parameter.SetConstant(valueToWrite);
 
             ParameterInfo createdParameter = GetCreatedParameter(type, "TestMethod", 1);
             Assert.Equal(true, createdParameter.HasDefaultValue);
-            Assert.Equal(null, createdParameter.DefaultValue);
+            Assert.Equal(expectedValueWhenRead, createdParameter.DefaultValue);
         }
 
         private static ParameterInfo GetCreatedParameter(TypeBuilder type, string methodName, int parameterIndex)

--- a/src/System.Reflection/tests/ParameterInfoTests.cs
+++ b/src/System.Reflection/tests/ParameterInfoTests.cs
@@ -62,6 +62,8 @@ namespace System.Reflection.Tests
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithRefParameter", 0, false)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithOutParameter", 1, false)]
         [InlineData(typeof(GenericClass<int>), "GenericMethod", 0, false)]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithEnum", 0, true)]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithNullableEnum", 0, true)]
         public void HasDefaultValue(Type type, string name, int index, bool expected)
         {
             ParameterInfo parameterInfo = GetParameterInfo(type, name, index);
@@ -120,6 +122,8 @@ namespace System.Reflection.Tests
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault3", 0, false)]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefault4", 0, '\0')]
         [InlineData(typeof(ParameterInfoMetadata), "MethodWithDefaultNullableDateTime", 0, null)]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithEnum", 0, AttributeTargets.All)]
+        [InlineData(typeof(ParameterInfoMetadata), "MethodWithNullableEnum", 0, (int)AttributeTargets.All)]
         public void DefaultValue(Type type, string name, int index, object expected)
         {
             ParameterInfo parameterInfo = GetParameterInfo(type, name, index);
@@ -257,6 +261,9 @@ namespace System.Reflection.Tests
 
             public void MethodWithDefaultDateTime(DateTime arg = default(DateTime)) { }
             public void MethodWithDefaultNullableDateTime(DateTime? arg = default(DateTime?)) { }
+
+            public void MethodWithEnum(AttributeTargets arg = AttributeTargets.All) { }
+            public void MethodWithNullableEnum(AttributeTargets? arg = AttributeTargets.All) { }
 
             public int MethodWithOptionalAndNoDefault([Optional] object o) { return 1; }
             public int MethodWithOptionalDefaultOutInMarshalParam([MarshalAs(UnmanagedType.LPWStr)][Out][In] string str = "") { return 1; }


### PR DESCRIPTION
These tests accompany https://github.com/dotnet/coreclr/pull/17977. Half of these tests won't pass if that PR isn't merged. Tested methods:

* `ParameterInfo.DefaultValue` on parameters of type `TSomeEnum` and `TSomeEnum?`
* `ParameterBuilder.SetConstant(nonNullValue)` on parameters of type `TSomeEnum` and `TSomeEnum?`

/cc @AtsushiKan