### PR TITLE
Fix a test and add a argument check for DiagnosticsHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -38,6 +38,11 @@ namespace System.Net.Http
             //from DiagnosticListener right after the check. So some requests happening right after subscription starts
             //might not be instrumented. Similarly, when consumer unsubscribes, extra requests might be instumented
 
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
+            }
+
             Activity activity = null;
             Guid loggingRequestId = Guid.Empty;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -200,8 +200,8 @@ namespace System.Net.Http.Functional.Tests
 
             if (IsCurlHandler)
             {
-                // Issue #26983
                 // CurlHandler ignores container cookies when custom Cookie header is set.
+                // SocketsHttpHandler behaves the expected way. Not worth fixing in CurlHandler as it is going away.
                 return;
             }
 
@@ -242,8 +242,8 @@ namespace System.Net.Http.Functional.Tests
 
             if (IsCurlHandler)
             {
-                // Issue #26983
                 // CurlHandler ignores container cookies when custom Cookie header is set.
+                // SocketsHttpHandler behaves the expected way. Not worth fixing in CurlHandler as it is going away.
                 return;
             }
 


### PR DESCRIPTION
1. Close #29482. The test issue is that, the sync Exception path for WinHttpHandler is changed in #29337, and the Exception for SocketsHttpHandler is [actually thrown asynchronously](https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs#L339-L343). So no synchronous exception is thrown.
- Modify the test to actually throw synchronous exception.
- I'm still using `Assert.ThrowsAsync<Exception>(() => operation).Wait();` pattern to observe the sync Exception is because, [DiagnosticsHandler `SendAsync`](https://github.com/dotnet/corefx/blob/03df812785e99885efde06a0f88d82578955276e/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L33) method has `async` modifier, and returns `Task<HttpResponseMessage>`. If not await that call, the current test method will continue run before the call is completed: `Assert.Throws<Exception>(() => { client.SendAsync(request); })` will not observe any Exception (`diagnosticListenerObserver` will observe the sync Exception though).

2. It's possible to pass a null request to `DiagnosticsHandler`'s `SendAsync()`, which caused [unexpected `NullReferenceException`](https://github.com/dotnet/corefx/blob/03df812785e99885efde06a0f88d82578955276e/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L77). To fix it, we can add a check for the request in the beginning. Also add a test for this scenario.
3. Close #26983.