### PR TITLE
Fix deadlock when waiting for process exit in Console.CancelKeyPress

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.RegisterForCtrlC.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.RegisterForCtrlC.cs
@@ -14,7 +14,7 @@ internal partial class Interop
             Break = 1
         }
 
-        internal delegate bool CtrlCallback(CtrlCode ctrlCode);
+        internal delegate void CtrlCallback(CtrlCode ctrlCode);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RegisterForCtrl")]
         internal static extern void RegisterForCtrl(CtrlCallback handler);

--- a/src/Common/src/Interop/Unix/System.Native/Interop.RestoreAndHandleCtrl.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.RestoreAndHandleCtrl.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RestoreAndHandleCtrl")]
+        internal static extern void RestoreAndHandleCtrl(CtrlCode ctrlCode);
+    }
+}

--- a/src/Native/Unix/System.Native/pal_console.h
+++ b/src/Native/Unix/System.Native/pal_console.h
@@ -128,7 +128,7 @@ enum CtrlCode
     Break = 1
 };
 
-typedef int32_t (*CtrlCallback)(enum CtrlCode signalCode);
+typedef void (*CtrlCallback)(enum CtrlCode signalCode);
 /**
  * Called by pal_signal.cpp to reinitialize the console on SIGCONT/SIGCHLD.
  */

--- a/src/Native/Unix/System.Native/pal_signal.c
+++ b/src/Native/Unix/System.Native/pal_signal.c
@@ -112,16 +112,14 @@ static void* SignalHandlerLoop(void* arg)
         {
             // We're now handling SIGQUIT and SIGINT. Invoke the callback, if we have one.
             CtrlCallback callback = g_ctrlCallback;
-            int rv = callback != NULL ? callback(signalCode == SIGQUIT ? Break : Interrupt) : 0;
-            if (rv == 0) // callback removed or was invoked and didn't handle the signal
+            enum CtrlCode ctrlCode = signalCode == SIGQUIT ? Break : Interrupt;
+            if (callback != NULL)
             {
-                // In general, we now want to remove our handler and reissue the signal to
-                // be picked up by the previously registered handler.  In the most common case,
-                // this will be the default handler, causing the process to be torn down.
-                // It could also be a custom handler registered by other code before us.
-                UninitializeConsole();
-                sigaction(signalCode, OrigActionFor(signalCode), NULL);
-                kill(getpid(), signalCode);
+                callback(ctrlCode);
+            }
+            else
+            {
+                SystemNative_RestoreAndHandleCtrl(ctrlCode);
             }
         }
         else if (signalCode == SIGCHLD)
@@ -183,6 +181,14 @@ void SystemNative_UnregisterForCtrl()
 {
     assert(g_ctrlCallback != NULL);
     g_ctrlCallback = NULL;
+}
+
+void SystemNative_RestoreAndHandleCtrl(enum CtrlCode ctrlCode)
+{
+    int signalCode = ctrlCode == Break ? SIGQUIT : SIGINT;
+    UninitializeConsole();
+    sigaction(signalCode, OrigActionFor(signalCode), NULL);
+    kill(getpid(), signalCode);
 }
 
 uint32_t SystemNative_RegisterForSigChld(SigChldCallback callback)

--- a/src/Native/Unix/System.Native/pal_signal.h
+++ b/src/Native/Unix/System.Native/pal_signal.h
@@ -51,4 +51,13 @@ typedef void (*SigChldCallback)(int reapAll);
  */
 DLLEXPORT uint32_t SystemNative_RegisterForSigChld(SigChldCallback callback);
 
+/**
+ * Remove our handler and reissue the signal to be picked up by the previously registered handler.
+ *
+ * In general, we now want to  In the most common case, this will be the default handler,
+ * causing the process to be torn down. It could also be a custom handler registered by other
+ * code before us.
+ */
+DLLEXPORT void SystemNative_RestoreAndHandleCtrl(enum CtrlCode ctrlCode);
+
 END_EXTERN_C

--- a/src/Native/Unix/System.Native/pal_signal.h
+++ b/src/Native/Unix/System.Native/pal_signal.h
@@ -54,9 +54,8 @@ DLLEXPORT uint32_t SystemNative_RegisterForSigChld(SigChldCallback callback);
 /**
  * Remove our handler and reissue the signal to be picked up by the previously registered handler.
  *
- * In general, we now want to  In the most common case, this will be the default handler,
- * causing the process to be torn down. It could also be a custom handler registered by other
- * code before us.
+ * In the most common case, this will be the default handler, causing the process to be torn down.
+ * It could also be a custom handler registered by other code before us.
  */
 DLLEXPORT void SystemNative_RestoreAndHandleCtrl(enum CtrlCode ctrlCode);
 

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -243,6 +243,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RegisterForCtrlC.cs">
       <Link>Common\Interop\Unix\Interop.RegisterForCtrlC.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RestoreAndHandleCtrl.cs">
+      <Link>Common\Interop\Unix\Interop.RestoreAndHandleCtrl.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetSignalForBreak.cs">
       <Link>Common\Interop\Unix\Interop.SetSignalForBreak.cs</Link>
     </Compile>
@@ -285,6 +288,9 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="Microsoft.Win32.Primitives" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Reference Include="System.Threading.Thread" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -1128,7 +1128,7 @@ namespace System
             {
                 // This is called on the native signal handling thread. We need to move to another thread so signal handling is
                 // not blocked. Otherwise we may get deadlocked when the handler depends on work triggered from the signal handling thread.
-                // We spin up a new thread to so the break event is handled promptly.
+                // We spin up a new thread so the break event is handled promptly.
                 Thread handlerThread = new Thread(HandleBreakEvent) { IsBackground = true };
                 handlerThread.Start(ctrlCode);
             }

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -1106,8 +1106,6 @@ namespace System
 
         internal sealed class ControlCHandlerRegistrar
         {
-            private static readonly Interop.Sys.CtrlCallback _handler = 
-                c => Console.HandleBreakEvent(c == Interop.Sys.CtrlCode.Break ? ConsoleSpecialKey.ControlBreak : ConsoleSpecialKey.ControlC);
             private bool _handlerRegistered;
 
             internal void Register()
@@ -1115,7 +1113,7 @@ namespace System
                 EnsureInitialized();
 
                 Debug.Assert(!_handlerRegistered);
-                Interop.Sys.RegisterForCtrl(_handler);
+                Interop.Sys.RegisterForCtrl(OnBreakEvent);
                 _handlerRegistered = true;
             }
 
@@ -1124,6 +1122,26 @@ namespace System
                 Debug.Assert(_handlerRegistered);
                 _handlerRegistered = false;
                 Interop.Sys.UnregisterForCtrl();
+            }
+
+            private static void OnBreakEvent(Interop.Sys.CtrlCode ctrlCode)
+            {
+                // This is called on the native signal handling thread. We need to move to another thread so signal handling is
+                // not blocked. Otherwise we may get deadlocked when the handler depends on work triggered from the signal handling thread.
+                // We spin up a new thread to so the break event is handled promptly.
+                Thread handlerThread = new Thread(HandleBreakEvent) { IsBackground = true };
+                handlerThread.Start(ctrlCode);
+            }
+
+            private static void HandleBreakEvent(object state)
+            {
+                var ctrlCode = (Interop.Sys.CtrlCode)state;
+                ConsoleSpecialKey controlKey = (ctrlCode == Interop.Sys.CtrlCode.Break ? ConsoleSpecialKey.ControlBreak : ConsoleSpecialKey.ControlC);
+                bool cancel = Console.HandleBreakEvent(controlKey);
+                if (!cancel)
+                {
+                    Interop.Sys.RestoreAndHandleCtrl(ctrlCode);
+                }
             }
         }
     }

--- a/src/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/System.Console/tests/CancelKeyPress.Unix.cs
@@ -28,7 +28,7 @@ public partial class CancelKeyPressTests : RemoteExecutorTestBase
     {
         RemoteInvoke(() =>
         {
-            var sempahore = new SemaphoreSlim(0, 1);
+            var mre = new ManualResetEventSlim();
             var tcs = new TaskCompletionSource<object>();
 
             // CancelKeyPress is triggered by SIGINT/SIGQUIT
@@ -36,7 +36,7 @@ public partial class CancelKeyPressTests : RemoteExecutorTestBase
             {
                 tcs.SetResult(null);
                 // Block CancelKeyPress
-                Assert.True(sempahore.Wait(WaitFailTestTimeoutSeconds * 1000));
+                Assert.True(mre.Wait(WaitFailTestTimeoutSeconds * 1000));
             };
 
             // Generate CancelKeyPress
@@ -52,7 +52,7 @@ public partial class CancelKeyPressTests : RemoteExecutorTestBase
             }
 
             // Release CancelKeyPress
-            sempahore.Release();
+            mre.Set();
 
             return SuccessExitCode;
         }).Dispose();

--- a/src/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/System.Console/tests/CancelKeyPress.Unix.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -20,6 +21,41 @@ public partial class CancelKeyPressTests : RemoteExecutorTestBase
     public void HandlerInvokedForSigQuit()
     {
         HandlerInvokedForSignal(SIGQUIT);
+    }
+
+    [PlatformSpecific(TestPlatforms.AnyUnix)]  // events are triggered by Unix signals (SIGINT, SIGQUIT, SIGCHLD).
+    public void ExitDetectionNotBlockedByHandler()
+    {
+        RemoteInvoke(() =>
+        {
+            var sempahore = new SemaphoreSlim(0, 1);
+            var tcs = new TaskCompletionSource<object>();
+
+            // CancelKeyPress is triggered by SIGINT/SIGQUIT
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                tcs.SetResult(null);
+                // Block CancelKeyPress
+                Assert.True(sempahore.Wait(WaitFailTestTimeoutSeconds * 1000));
+            };
+
+            // Generate CancelKeyPress
+            Assert.Equal(0, kill(Process.GetCurrentProcess().Id, SIGINT));
+            // Wait till we block CancelKeyPress
+            Assert.True(tcs.Task.Wait(WaitFailTestTimeoutSeconds * 1000));
+
+            // Create a process and wait for it to exit.
+            using (RemoteInvokeHandle handle = RemoteInvoke(() => SuccessExitCode))
+            {
+                // Process exit is detected on SIGCHLD
+                Assert.Equal(SuccessExitCode, handle.ExitCode);
+            }
+
+            // Release CancelKeyPress
+            sempahore.Release();
+
+            return SuccessExitCode;
+        }).Dispose();
     }
 
     private void HandlerInvokedForSignal(int signalOuter)


### PR DESCRIPTION
This deadlock occurs because the thread invoking CancelKeyPress is also responsible for detecting process exits.
We change to using a dedicated thread for detecting process exit.

Fixes https://github.com/dotnet/corefx/issues/29699

CC @stephentoub @natemcmaster @danmosemsft @ViktorHofer