### PR TITLE
BufferSegment inline WritableBytes

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.IO.Pipelines
 {
@@ -93,7 +94,11 @@ namespace System.IO.Pipelines
         /// <summary>
         /// The amount of writable bytes in this segment. It is the amount of bytes between Length and End
         /// </summary>
-        public int WritableBytes => AvailableMemory.Length - End;
+        public int WritableBytes
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => AvailableMemory.Length - End;
+        }
 
         public void SetNext(BufferSegment segment)
         {

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -151,7 +151,11 @@ namespace System.IO.Pipelines
                 }
             }
 
-            return _writingHead.AvailableMemory.Slice(_writingHead.End, _writingHead.WritableBytes);
+            // Slice the AvailableMemory to the WritableBytes size
+            int end = _writingHead.End;
+            Memory<byte> availableMemory = _writingHead.AvailableMemory;
+            availableMemory = availableMemory.Slice(end, availableMemory.Length - end);
+            return availableMemory;
         }
 
         private BufferSegment AllocateWriteHeadUnsynchronized(int sizeHint)


### PR DESCRIPTION
Is a fairly simple method; but on a very hot path and is currently unprofitable 
```
[FAILED: unprofitable inline] BufferSegment:get_WritableBytes():int:this
```
And is not insignificant due to the number of times it is called
![image](https://user-images.githubusercontent.com/1142958/40075950-8b135540-5875-11e8-94e1-21becba13b0b.png)

/cc @pakrym 