### PR TITLE
Clarify how DiagnosticsSource filtering works

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -56,9 +56,24 @@ namespace System.Diagnostics
 
         // Subscription implementation 
         /// <summary>
-        /// Add a subscriber (Observer).  If 'IsEnabled' == null (or not present), then the Source's IsEnabled 
-        /// will always return true.  
+        /// Add a subscriber (Observer).  If the isEnabled parameter is non-null it indicates that some events are 
+        /// uninteresting can be skipped for efficiency.  
+        /// 
+        /// Note that the isEnabled predicate an OPTIONAL OPTIMIZATION to allow the instrumentation site to avoid 
+        /// setting up the payload  and calling 'Write' when no subscriber cares about it. In particular the 
+        /// instrumentation site has the option of ignoring the IsEnabled() predicate (not calling it) and simply
+        /// calling Write().   Thus if the subscriber requires the filtering, it needs to do it itself.  
         /// </summary>
+        /// <param name="observer">Subscriber (IObserver)</param>
+        /// <param name="isEnabled">Filters events based on their name (string). Should return true if the event is enabled.  
+        /// 
+        /// Note that the isEnabled predicate an OPTIONAL OPTIMIZATION to allow the instrumentation site to avoid 
+        /// setting up the payload and calling 'Write' when no subscriber cares about it. In particular the 
+        /// instrumentation site has the option of ignoring the IsEnabled() predicate (not calling it) and simply
+        /// calling Write().   Thus if the subscriber requires the filtering, it needs to do it itself. 
+        /// 
+        /// If this parameter is null, no filtering is done (all overloads of DiagnosticSource.IsEnabled return true).   
+        /// </param>
         public virtual IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Predicate<string> isEnabled)
         {
             IDisposable subscription;
@@ -76,15 +91,33 @@ namespace System.Diagnostics
         }
 
         /// <summary>
-        /// Add a subscriber (Observer).  If 'IsEnabled' == null (or not present), then the Source's IsEnabled 
-        /// will always return true.  
+        /// Add a subscriber (Observer).  If the isEnabled parameter is non-null indicates that some events are 
+        /// uninteresting can be skipped for efficiency.  
         /// </summary>
         /// <param name="observer">Subscriber (IObserver)</param>
-        /// <param name="isEnabled">Filters events based on their name (string) and context objects that could be null.
-        /// Note that producer may first call filter with event name only and null context arguments and filter should
-        /// return true if consumer is interested in any of such events. Producers that support 
-        /// context-based filtering will invoke isEnabled again with context for more prcise filtering.
-        /// Use Subscribe overload with name-based filtering if producer does NOT support context-based filtering</param>
+        /// <param name="isEnabled">Filters events based on their name (string) and up to two context object (which can be null).  
+        /// 
+        /// A particular instrumentation site HAS THE OPTION of calling one or more 'IsEnabled' overloads  in which
+        /// it passes the name of the event and up to two other (instrumentation site specific) objects as arguments.
+        /// If any of these 'IsEnabled' calls are made then this 'isEnabled' predicate is invoked with passed values
+        /// (the if shorter overloads are used, null is passed for missing context objects).   
+        /// 
+        /// This gives any particular instrumentation site the ability to pass up to two pieces of information to the 
+        /// subscriber do sophisticated, efficient filtering.  This requires more coupling between the instrumentation
+        /// site and the subscriber code.  
+        /// 
+        /// It IS expected that a particular instrumentation site may call different overloads of IsEnabled for the 
+        /// same event, first calling IsEnable(string) which calls the filter with two null context objects and if
+        /// 'isEnabled' returns true calling again with context objects.   The isEnabled filter should be designed 
+        /// with this in mind. 
+        /// 
+        /// Note that the isEnabled predicate an OPTIONAL OPTIMIZATION to allow the instrumentation site to avoid 
+        /// setting up the payload  and calling 'Write' when no subscriber cares about it. In particular the 
+        /// instrumentation site has the option of ignoring the IsEnabled() predicate (not calling it) and simply
+        /// calling Write().   Thus if the subscriber requires the filtering, it needs to do it itself.  
+        /// 
+        /// If this parameter is null, no filtering is done (all overloads of DiagnosticSource.IsEnabled return true).   
+        /// </param>
         public virtual IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Func<string, object, object, bool> isEnabled)
         {
             return isEnabled == null ?

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -57,17 +57,12 @@ namespace System.Diagnostics
         // Subscription implementation 
         /// <summary>
         /// Add a subscriber (Observer).  If the isEnabled parameter is non-null it indicates that some events are 
-        /// uninteresting can be skipped for efficiency.  
-        /// 
-        /// Note that the isEnabled predicate an OPTIONAL OPTIMIZATION to allow the instrumentation site to avoid 
-        /// setting up the payload  and calling 'Write' when no subscriber cares about it. In particular the 
-        /// instrumentation site has the option of ignoring the IsEnabled() predicate (not calling it) and simply
-        /// calling Write().   Thus if the subscriber requires the filtering, it needs to do it itself.  
+        /// uninteresting and can be skipped for efficiency.  
         /// </summary>
         /// <param name="observer">Subscriber (IObserver)</param>
         /// <param name="isEnabled">Filters events based on their name (string). Should return true if the event is enabled.  
         /// 
-        /// Note that the isEnabled predicate an OPTIONAL OPTIMIZATION to allow the instrumentation site to avoid 
+        /// Note that the isEnabled predicate is an OPTIONAL OPTIMIZATION to allow the instrumentation site to avoid 
         /// setting up the payload and calling 'Write' when no subscriber cares about it. In particular the 
         /// instrumentation site has the option of ignoring the IsEnabled() predicate (not calling it) and simply
         /// calling Write().   Thus if the subscriber requires the filtering, it needs to do it itself. 
@@ -100,10 +95,10 @@ namespace System.Diagnostics
         /// A particular instrumentation site HAS THE OPTION of calling one or more 'IsEnabled' overloads  in which
         /// it passes the name of the event and up to two other (instrumentation site specific) objects as arguments.
         /// If any of these 'IsEnabled' calls are made then this 'isEnabled' predicate is invoked with passed values
-        /// (the if shorter overloads are used, null is passed for missing context objects).   
+        /// (if shorter overloads are used, null is passed for missing context objects).   
         /// 
         /// This gives any particular instrumentation site the ability to pass up to two pieces of information to the 
-        /// subscriber do sophisticated, efficient filtering.  This requires more coupling between the instrumentation
+        /// subscriber to do sophisticated, efficient filtering.  This requires more coupling between the instrumentation
         /// site and the subscriber code.  
         /// 
         /// It IS expected that a particular instrumentation site may call different overloads of IsEnabled for the 
@@ -111,8 +106,8 @@ namespace System.Diagnostics
         /// 'isEnabled' returns true calling again with context objects.   The isEnabled filter should be designed 
         /// with this in mind. 
         /// 
-        /// Note that the isEnabled predicate an OPTIONAL OPTIMIZATION to allow the instrumentation site to avoid 
-        /// setting up the payload  and calling 'Write' when no subscriber cares about it. In particular the 
+        /// Note that the isEnabled predicate is an OPTIONAL OPTIMIZATION to allow the instrumentation site to avoid 
+        /// setting up the payload and calling 'Write' when no subscriber cares about it. In particular the 
         /// instrumentation site has the option of ignoring the IsEnabled() predicate (not calling it) and simply
         /// calling Write().   Thus if the subscriber requires the filtering, it needs to do it itself.  
         /// 


### PR DESCRIPTION
@brianrob  @stephentoub @eerhardt @terrajobst

I added documentation to explain behavior that Eric found surprising about DiagnosticSource, namely that Clients of a DiagnosticSource CANNOT expect because they provided a Filter predicate when subscribing that they will receive only those events (they must apply the filter to them themselves if desired).  

The solution I am suggesting here is to simply document the behavior.   However I think it is also OK to discuss whether we want to change this behavior.   

First: Why is the behavior the way it is?   

The goal of DiagnosticSource is to simply decouple a source of information (an instrumentation site) from the users of that information (the subscribers of the DiagnosticListener).    Ideally the instrumentation site would be as simple as possible, namely

      source.Write("Name",  informationObject).   

And this works OK for low volume locations, but it is inefficient because you have to construct 'informationObject' and make the call even if there are NO subscribers.     Thus we added an 'IsEnabled' method and ask that in high frequency location that the instrumentation site should be 

      if ( source.IsEnabled("Name")) {
           // Construct informationObject 
           source.Write("Name",  informationObject).   
     } 

This solves the most important issue because IsEnabled() can return false if there are no subscribers, so at least you don't pay when no one is listening.     This was its main value.      

But it also introduces an expectation for clients that if they provide a name filter, they they will only receive events with those names.     This is not guaranteed (since the instrumentation site was not required to call IsEnabled().   The question is 'should DiagnosticSource provide this guarantee or not? 
It was certainly possible for DiagnosticSource to call the filter itself and confirm that it is true before invoking the subscriber callback, thus providing the needed guarantee, but we did not do this for the following reasons.

1.  It is inefficient.   This means in the HIGH VOLUME case the instrumentation site will call the filter in the instrumentation code, and AGAIN by DiagnosticSource itself.     Calling this filter is already not cheap as we would like since it is a string comparison (ideally it is a bit check, but that has usability problems). 

2. It does not likely add value.    When receiving the event the first thing that the subscriber will do with it is a 'switch' on the name to decide how to process it.   Thus subscribers don't gain value by having DiagnosticSource do the filtering.

Thus we decided to effectively make filtering something is for the benefit of the INSTRUMENTATION SITE NOT the subscriber, and thus subscribers should not 'count on it'.  

We doubled down on this design later because we wanted even more efficiency at the instrumentation site.   Thus we added more overloads for 'IsEnabled', so you could pass extra information to the subscribers filter to weed out more things.  Thus a site might do

     if (source.IsEnabled("Name", filterInfo1, filterInfo2))
            source.Write("Name",  informationObject);

Which allows extra information to be passed to the subscribers predicate to cut down on the number of callbacks (The case was HTTP requests, and the filter information were things like the HTTP packet).  

Note at this point, it is now impossible for DiagnosticSource to apply the filter 'itself' because the Write() API was not passed the extra filtering information.   

*********************************

The unfortunate part of this design is that the behavior looks like a bug.   This is because there can be MULTIPLE subscribers.    Thus a subscriber might assume that because it supplied a filter that he only gets the events he asked for, and BECAUSE the instrumentation site has a IsEnabled() it works.   BUT IT ONLY WORKS IF THERE IS ONLY ONE SUBSCRIBER.    If there are two subscribers and one wants EVERYTHING, then the other subscriber will also get everything.     

The solution to this is to simply document that behavior.    It is rather unfortunate that the most likely test environment will be having only one subscriber, which means it would be VERY easy for this bug to slip through the testing of the subscriber code.   Thus it is a pitfall.    This is unfortunate, but I don't see any obvious mitigation (except the one here, which is to document it).

The good news is 

1.  The developers of subscribers of DiagnosticListener are a small group and tend to be more sophisticated (they might actually read the docs).
2. Generally subscriber code will 'naturally' do the right thing (they will test again as they process), so the effect is likely to be a big issue.  (and can be fixed in THEIR code, which is also good).



