### PR TITLE
Cut String Allocations for filtered watcher files in Unix Systems

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.EventStream.cs
+++ b/src/Common/src/Interop/OSX/Interop.EventStream.cs
@@ -82,12 +82,11 @@ internal static partial class Interop
         /// <param name="eventFlags">The events for the corresponding path.</param>
         /// <param name="eventIds">The machine-and-disk-drive-unique Event ID for the specific event.</param>
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void FSEventStreamCallback(
+        internal unsafe delegate void FSEventStreamCallback(
             FSEventStreamRef streamReference,
             IntPtr clientCallBackInfo,
             size_t numEvents,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
-            String[] eventPaths,
+            byte** eventPaths,
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
             FSEventStreamEventFlags[] eventFlags,
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]

--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -16,6 +16,17 @@ namespace System.IO
             return path.Length > 0 && IsDirectorySeparator(path[0]) ? 1 : 0;
         }
 
+        internal static bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
+            => path.Length > 0 && IsDirectorySeparator(path[path.Length - 1]);
+
+        internal static ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path) =>
+            EndsInDirectorySeparator(path) && !IsRoot(path) ?
+                path.Slice(0, path.Length - 1) :
+                path;
+
+        internal static bool IsRoot(ReadOnlySpan<char> path)
+            => path.Length == GetRootLength(path);
+
         internal static bool IsDirectorySeparator(char c)
         {
             // The alternate directory separator char is the same as the directory separator,

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -125,6 +125,12 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RealPath.cs">
       <Link>Common\Interop\Unix\Interop.RealPath.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.Span.cs">
+      <Link>Common\Interop\Unix\Interop.Stat.Span.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\System.Native\Interop.Stat.cs">
+      <Link>Common\Interop\Unix\Interop.Stat.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Sync.cs">
       <Link>Common\Interop\Unix\Interop.Sync.cs</Link>
     </Compile>
@@ -134,12 +140,16 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Text\ValueUtf8Converter.cs">
+      <Link>Common\System\Text\ValueUtf8Converter.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true' OR '$(TargetsUnknownUnix)' == 'true'">
     <Compile Include="System\IO\FileSystemWatcher.UnknownUnix.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
+    <Reference Include="System.Buffers" />
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.ComponentModel.TypeConverter" />

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -110,6 +110,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true'">
     <Compile Include="System\IO\FileSystemWatcher.OSX.cs" />
+    <Compile Include="$(SourceDir)System.IO.FileSystem\src\System\IO\FileSystem.Exists.Unix.cs">
+      <Link>System.IO.FileSystem\src\System\IO\FileSystem.Exists.Unix.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.EventStream.cs">
       <Link>Common\Interop\OSX\Interop.EventStream.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -614,7 +614,7 @@ namespace System.IO
                                 // parent and previousEventName is the name of the directory to be removed.
                                 foreach (WatchedDirectory child in previousEventParent.Children)
                                 {
-                                    if (previousEventName.SequenceEqual(child.Name))
+                                    if (previousEventName.Equals(child.Name, StringComparison.Ordinal))
                                     {
                                         RemoveWatchedDirectory(child);
                                         break;

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -530,7 +530,7 @@ namespace System.IO
                 try
                 {
                     // Previous event information
-                    string previousEventName = null;
+                    ReadOnlySpan<char> previousEventName = ReadOnlySpan<char>.Empty;
                     WatchedDirectory previousEventParent = null;
                     uint previousEventCookie = 0;
 
@@ -549,7 +549,7 @@ namespace System.IO
                         }
 
                         uint mask = nextEvent.mask;
-                        string expandedName = null;
+                        ReadOnlySpan<char> expandedName = ReadOnlySpan<char>.Empty;
                         WatchedDirectory associatedDirectoryEntry = null;
 
                         // An overflow event means that we can't trust our state without restarting since we missed events and 
@@ -581,11 +581,11 @@ namespace System.IO
                                     continue;
                                 }
                             }
-                            expandedName = associatedDirectoryEntry.GetPath(true, nextEvent.name);
+                            expandedName = associatedDirectoryEntry.GetPath(true, nextEvent.name).AsSpan();
                         }
 
                         // To match Windows, ignore all changes that happen on the root folder itself
-                        if (string.IsNullOrEmpty(expandedName))
+                        if (expandedName.IsEmpty)
                         {
                             watcher = null;
                             continue;
@@ -600,7 +600,7 @@ namespace System.IO
                         // Renames come in the form of two events: IN_MOVED_FROM and IN_MOVED_TO.
                         // In general, these should come as a sequence, one immediately after the other.
                         // So, we delay raising an event for IN_MOVED_FROM until we see what comes next.
-                        if (previousEventName != null && ((mask & (uint)Interop.Sys.NotifyEvents.IN_MOVED_TO) == 0 || previousEventCookie != nextEvent.cookie))
+                        if (!previousEventName.IsEmpty && ((mask & (uint)Interop.Sys.NotifyEvents.IN_MOVED_TO) == 0 || previousEventCookie != nextEvent.cookie))
                         {
                             // IN_MOVED_FROM without an immediately-following corresponding IN_MOVED_TO.
                             // We have to assume that it was moved outside of our root watch path, which
@@ -614,7 +614,7 @@ namespace System.IO
                                 // parent and previousEventName is the name of the directory to be removed.
                                 foreach (WatchedDirectory child in previousEventParent.Children)
                                 {
-                                    if (child.Name == previousEventName)
+                                    if (previousEventName.SequenceEqual(child.Name))
                                     {
                                         RemoveWatchedDirectory(child);
                                         break;
@@ -724,7 +724,7 @@ namespace System.IO
                                     // ago and treated it as a deletion), in which case this is considered a creation.
                                     watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Created, expandedName);
                                 }
-                                previousEventName = null;
+                                previousEventName = ReadOnlySpan<char>.Empty;
                                 previousEventParent = null;
                                 previousEventCookie = 0;
                                 break;

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -581,7 +581,7 @@ namespace System.IO
                                     continue;
                                 }
                             }
-                            expandedName = associatedDirectoryEntry.GetPath(true, nextEvent.name).AsSpan();
+                            expandedName = associatedDirectoryEntry.GetPath(true, nextEvent.name);
                         }
 
                         // To match Windows, ignore all changes that happen on the root folder itself

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -513,6 +513,9 @@ namespace System.IO
 
             private bool CheckIfPathIsNested(ReadOnlySpan<char> eventPath)
             {
+                // If we shouldn't include subdirectories, check if this path's parent is the watch directory
+                // Check if the parent is the root. If so, then we'll continue processing based on the name.
+                // If it isn't, then this will be set to false and we'll skip the name processing since it's irrelevant.
                 return _includeChildren || _fullDirectory.AsSpan().StartsWith(System.IO.Path.GetDirectoryName(eventPath), StringComparison.OrdinalIgnoreCase);
             }
 
@@ -543,10 +546,8 @@ namespace System.IO
                 if (path.IsEmpty || path.Length == 0)
                     return false;
 
-                if(!isFile)
-                {
+                if (!isFile)
                     return  FileSystem.DirectoryExists(path);
-                }
 
                 return PathInternal.IsDirectorySeparator(path[path.Length - 1])
                     ? false

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -342,7 +342,7 @@ namespace System.IO
                     // Match Windows and don't notify us about changes to the Root folder
                     ReadOnlySpan<char> path = eventPaths[i].AsSpan();
 
-                    if (_fullDirectory.Length >= path.Length && path.SequenceEqual(_fullDirectory.AsSpan().Slice(0, path.Length)))
+                    if (_fullDirectory.Length >= path.Length && path.CompareTo(_fullDirectory.AsSpan(0, path.Length), StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         continue;
                     }
@@ -364,7 +364,7 @@ namespace System.IO
                         // The base FileSystemWatcher does a match check against the relative path before combining with 
                         // the root dir; however, null is special cased to signify the root dir, so check if we should use that.
                         ReadOnlySpan<char> relativePath = ReadOnlySpan<char>.Empty;
-                        if (path.SequenceEqual(_fullDirectory) == false)
+                        if (path.CompareTo(_fullDirectory, StringComparison.OrdinalIgnoreCase) != 0)
                         {
                             // Remove the root directory to get the relative path
                             relativePath = path.Slice(_fullDirectory.Length);
@@ -409,7 +409,7 @@ namespace System.IO
                             {
                                 // Remove the base directory prefix and add the paired event to the list of 
                                 // events to skip and notify the user of the rename 
-                                ReadOnlySpan<char> newPathRelativeName = eventPaths[pairedId].AsSpan().Slice(_fullDirectory.Length);
+                                ReadOnlySpan<char> newPathRelativeName = eventPaths[pairedId].AsSpan(_fullDirectory.Length);
                                 watcher.NotifyRenameEventArgs(WatcherChangeTypes.Renamed, newPathRelativeName, relativePath);
 
                                 // Create a new list, if necessary, and add the event
@@ -490,7 +490,7 @@ namespace System.IO
                     // Check if the parent is the root. If so, then we'll continue processing based on the name.
                     // If it isn't, then this will be set to false and we'll skip the name processing since it's irrelevant.
                     ReadOnlySpan<char> parent = System.IO.Path.GetDirectoryName(eventPath);
-                    doesPathPass = _fullDirectory.Length < parent.Length ? false : parent.SequenceEqual(_fullDirectory.AsSpan().Slice(0, parent.Length));
+                    doesPathPass = _fullDirectory.Length < parent.Length ? false : parent.CompareTo(_fullDirectory.AsSpan(0, parent.Length), StringComparison.OrdinalIgnoreCase) == 0;
                 }
 
                 return doesPathPass;

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -342,7 +342,7 @@ namespace System.IO
                     // Match Windows and don't notify us about changes to the Root folder
                     ReadOnlySpan<char> path = eventPaths[i].AsSpan();
 
-                    if (_fullDirectory.Length >= path.Length && path.CompareTo(_fullDirectory.AsSpan(0, path.Length), StringComparison.OrdinalIgnoreCase) == 0)
+                    if (_fullDirectory.Length >= path.Length && path.Equals(_fullDirectory.AsSpan(0, path.Length), StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
                     }
@@ -364,7 +364,7 @@ namespace System.IO
                         // The base FileSystemWatcher does a match check against the relative path before combining with 
                         // the root dir; however, null is special cased to signify the root dir, so check if we should use that.
                         ReadOnlySpan<char> relativePath = ReadOnlySpan<char>.Empty;
-                        if (path.CompareTo(_fullDirectory, StringComparison.OrdinalIgnoreCase) != 0)
+                        if (!path.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase))
                         {
                             // Remove the root directory to get the relative path
                             relativePath = path.Slice(_fullDirectory.Length);
@@ -490,7 +490,7 @@ namespace System.IO
                     // Check if the parent is the root. If so, then we'll continue processing based on the name.
                     // If it isn't, then this will be set to false and we'll skip the name processing since it's irrelevant.
                     ReadOnlySpan<char> parent = System.IO.Path.GetDirectoryName(eventPath);
-                    doesPathPass = _fullDirectory.Length < parent.Length ? false : parent.CompareTo(_fullDirectory.AsSpan(0, parent.Length), StringComparison.OrdinalIgnoreCase) == 0;
+                    doesPathPass = _fullDirectory.Length < parent.Length ? false : parent.Equals(_fullDirectory.AsSpan(0, parent.Length), StringComparison.OrdinalIgnoreCase);
                 }
 
                 return doesPathPass;

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -411,20 +411,6 @@ namespace System.IO
         /// <summary>
         /// Raises the event to each handler in the list.
         /// </summary>
-        private void NotifyRenameEventArgs(WatcherChangeTypes action, string name, string oldName)
-        {
-            // filter if there's no handler or neither new name or old name match a specified pattern
-            RenamedEventHandler handler = _onRenamedHandler;
-            if (handler != null &&
-                (MatchPattern(name) || MatchPattern(oldName)))
-            {
-                handler(this, new RenamedEventArgs(action, _directory, name, oldName));
-            }
-        }
-
-        /// <summary>
-        /// Raises the event to each handler in the list.
-        /// </summary>
         private void NotifyRenameEventArgs(WatcherChangeTypes action, ReadOnlySpan<char> name, ReadOnlySpan<char> oldName)
         {
             // filter if there's no handler or neither new name or old name match a specified pattern

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -238,6 +238,7 @@
     <Compile Include="System\IO\Enumeration\FileSystemEnumerator.Unix.cs" />
     <Compile Include="System\IO\FileSystemInfo.Unix.cs" />
     <Compile Include="System\IO\FileSystem.Unix.cs" />
+    <Compile Include="System\IO\FileSystem.Exists.Unix.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Exists.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Exists.Unix.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.IO
+{
+    /// <summary>Provides an implementation of FileSystem for Unix systems.</summary>
+    internal static partial class FileSystem
+    {
+        public static bool DirectoryExists(ReadOnlySpan<char> fullPath)
+        {
+            Interop.ErrorInfo ignored;
+            return DirectoryExists(fullPath, out ignored);
+        }
+
+        private static bool DirectoryExists(ReadOnlySpan<char> fullPath, out Interop.ErrorInfo errorInfo)
+        {
+            return FileExists(fullPath, Interop.Sys.FileTypes.S_IFDIR, out errorInfo);
+        }
+
+        public static bool FileExists(ReadOnlySpan<char> fullPath)
+        {
+            Interop.ErrorInfo ignored;    
+            // File.Exists() explicitly checks for a trailing separator and returns false if found. FileInfo.Exists and all other
+            // internal usages do not check for the trailing separator. Historically we've always removed the trailing separator
+            // when getting attributes as trailing separators are generally not accepted by Windows APIs. Unix will take
+            // trailing separators, but it infers that the path must be a directory (it effectively appends "."). To align with
+            // our historical behavior (outside of File.Exists()), we need to trim.
+            //
+            // See http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap04.html#tag_04_11 for details.
+            return FileExists(PathInternal.TrimEndingDirectorySeparator(fullPath), Interop.Sys.FileTypes.S_IFREG, out ignored);
+        }
+
+        private static bool FileExists(ReadOnlySpan<char> fullPath, int fileType, out Interop.ErrorInfo errorInfo)
+        {
+            Debug.Assert(fileType == Interop.Sys.FileTypes.S_IFREG || fileType == Interop.Sys.FileTypes.S_IFDIR);
+
+            Interop.Sys.FileStatus fileinfo;
+            errorInfo = default(Interop.ErrorInfo);
+
+            // First use stat, as we want to follow symlinks.  If that fails, it could be because the symlink
+            // is broken, we don't have permissions, etc., in which case fall back to using LStat to evaluate
+            // based on the symlink itself.
+            if (Interop.Sys.Stat(fullPath, out fileinfo) < 0 &&
+                Interop.Sys.LStat(fullPath, out fileinfo) < 0)
+            {
+                errorInfo = Interop.Sys.GetLastErrorInfo();
+                return false;
+            }
+
+            // Something exists at this path.  If the caller is asking for a directory, return true if it's
+            // a directory and false for everything else.  If the caller is asking for a file, return false for
+            // a directory and true for everything else.
+            return
+                (fileType == Interop.Sys.FileTypes.S_IFDIR) ==
+                ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
+        } 
+    }
+}

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -397,51 +397,6 @@ namespace System.IO
             }
         }
 
-        public static bool DirectoryExists(string fullPath)
-        {
-            Interop.ErrorInfo ignored;
-            return DirectoryExists(fullPath, out ignored);
-        }
-
-        private static bool DirectoryExists(string fullPath, out Interop.ErrorInfo errorInfo)
-        {
-            return FileExists(fullPath, Interop.Sys.FileTypes.S_IFDIR, out errorInfo);
-        }
-
-        public static bool FileExists(string fullPath)
-        {
-            Interop.ErrorInfo ignored;
-
-            // Input allows trailing separators in order to match Windows behavior
-            // Unix does not accept trailing separators, so must be trimmed
-            return FileExists(PathInternal.TrimEndingDirectorySeparator(fullPath), Interop.Sys.FileTypes.S_IFREG, out ignored);
-        }
-
-        private static bool FileExists(string fullPath, int fileType, out Interop.ErrorInfo errorInfo)
-        {
-            Debug.Assert(fileType == Interop.Sys.FileTypes.S_IFREG || fileType == Interop.Sys.FileTypes.S_IFDIR);
-
-            Interop.Sys.FileStatus fileinfo;
-            errorInfo = default(Interop.ErrorInfo);
-
-            // First use stat, as we want to follow symlinks.  If that fails, it could be because the symlink
-            // is broken, we don't have permissions, etc., in which case fall back to using LStat to evaluate
-            // based on the symlink itself.
-            if (Interop.Sys.Stat(fullPath, out fileinfo) < 0 &&
-                Interop.Sys.LStat(fullPath, out fileinfo) < 0)
-            {
-                errorInfo = Interop.Sys.GetLastErrorInfo();
-                return false;
-            }
-
-            // Something exists at this path.  If the caller is asking for a directory, return true if it's
-            // a directory and false for everything else.  If the caller is asking for a file, return false for
-            // a directory and true for everything else.
-            return
-                (fileType == Interop.Sys.FileTypes.S_IFDIR) ==
-                ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
-        }
-
         /// <summary>Determines whether the specified directory name should be ignored.</summary>
         /// <param name="name">The name to evaluate.</param>
         /// <returns>true if the name is "." or ".."; otherwise, false.</returns>


### PR DESCRIPTION
Fixes #29288 

