### PR TITLE
Disable FEATURE_DLG_INVOKE and FEATURE_FAST_CREATE on UapAot

### DIFF
--- a/src/System.Composition/tests/CustomerReportedMetadataBug.cs
+++ b/src/System.Composition/tests/CustomerReportedMetadataBug.cs
@@ -38,7 +38,6 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(29652, TargetFrameworkMonikers.UapAot)]
         [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
         public void SampleServicesCorrectlyImported()
         {

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -10,7 +10,10 @@
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <IsInterpreting Condition="'$(TargetGroup)' == 'uapaot'">true</IsInterpreting>
+    
+    <!-- These defines are disabled on UapAot due to https://github.com/dotnet/corefx/issues/29745 -->
     <DefineConstants Condition="'$(TargetGroup)' != 'uapaot'"> $(DefineConstants);FEATURE_DLG_INVOKE;FEATURE_FAST_CREATE</DefineConstants>
+    
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <IsInterpreting Condition="'$(TargetGroup)' == 'uapaot'">true</IsInterpreting>
-    <DefineConstants> $(DefineConstants);FEATURE_DLG_INVOKE;FEATURE_FAST_CREATE</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' != 'uapaot'"> $(DefineConstants);FEATURE_DLG_INVOKE;FEATURE_FAST_CREATE</DefineConstants>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
#28792 broke UapAot platform by introducing reflection on private implementation details of the framework. It's not possible to reflect on non-public classes/members of the framework on AoT platfrorms. While this would be fixable by making `FuncCallInstruction` and friends public (same way `ExpressionCreator` is already public), we need measurements first that demonstrate this is an actual runtime performance improvement on UapAot (e.g. reflection invoke on AoT platforms is 4x faster than on the CLR, but on the other hand `MakeGenericType` random types might make us fall back to universal shared code for the new instantiations, which is pretty bad).

I have reasons to believe enabling FEATURE_DLG_INVOKE and FEATURE_FAST_CREATE also causes a pretty significant size on disk regression.

Fixes #29652.