### PR TITLE
Test enumerating deleted directories.

### DIFF
--- a/src/System.IO.FileSystem/tests/Enumeration/RemovedDirectoryTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/RemovedDirectoryTests.netcoreapp.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO.Enumeration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests.Enumeration
+{
+    public class RemovedDirectoryTests : FileSystemTest
+    {
+        private class DirectoryFinishedEnumerator : FileSystemEnumerator<string>
+        {
+            public DirectoryFinishedEnumerator(string directory, EnumerationOptions options)
+                : base(directory, options)
+            {
+            }
+
+            protected override string TransformEntry(ref FileSystemEntry entry)
+            {
+                return entry.FileName.ToString();
+            }
+
+            public delegate void DirectoryFinishedDelegate(ReadOnlySpan<char> directory);
+
+            public DirectoryFinishedDelegate DirectoryFinishedAction { get; set; }
+
+            protected override void OnDirectoryFinished(ReadOnlySpan<char> directory)
+            {
+                DirectoryFinishedAction?.Invoke(directory);
+            }
+        }
+
+        [Fact]
+        public void RemoveDirectoryBeforeRecursion()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Combine(testDirectory.FullName, "Subdirectory"));
+
+            using (var enumerator = new DirectoryFinishedEnumerator(testDirectory.FullName, new EnumerationOptions { RecurseSubdirectories = true }))
+            {
+                enumerator.DirectoryFinishedAction = (d) => testSubdirectory.Delete();
+                Assert.Throws<DirectoryNotFoundException>(() => { while (enumerator.MoveNext()); });
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Enumeration\AttributeTests.netcoreapp.cs" />
     <Compile Include="Enumeration\MatchTypesTests.netcoreapp.cs" />
     <Compile Include="Enumeration\ExampleTests.netcoreapp.cs" />
+    <Compile Include="Enumeration\RemovedDirectoryTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Rewritten -->


### PR DESCRIPTION
Directories can vanish after we first see them when enumerating. This adds a test that specifically does that behavior.

We used to throw for this case, it is easier to test now that we have extensibility points.