### PR TITLE
Override CopyTo on DeflateStream

### DIFF
--- a/src/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -618,6 +618,21 @@ namespace System.IO.Compression
             }
         }
 
+        [Theory]
+        [InlineData(CompressionMode.Compress)]
+        [InlineData(CompressionMode.Decompress)]
+        public void CopyTo_ArgumentValidation(CompressionMode mode)
+        {
+            using (Stream compressor = CreateStream(new MemoryStream(), mode))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("destination", () => { compressor.CopyTo(null); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("bufferSize", () => { compressor.CopyTo(new MemoryStream(), 0); });
+                Assert.Throws<NotSupportedException>(() => { compressor.CopyTo(new MemoryStream(new byte[1], writable: false)); });
+                compressor.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => { compressor.CopyTo(new MemoryStream()); });
+            }
+        }
+
         public enum ReadWriteMode
         {
             SyncArray,

--- a/src/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/System.IO.Compression/ref/System.IO.Compression.cs
@@ -49,6 +49,7 @@ namespace System.IO.Compression
         public override void Write(System.ReadOnlySpan<byte> buffer) { }
         public override System.Threading.Tasks.Task WriteAsync(byte[] array, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+        public override void CopyTo(Stream destination, int bufferSize) { }
     }
     public partial class GZipStream : System.IO.Stream
     {

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -801,7 +801,7 @@ namespace System.IO.Compression
                         int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
                         if (bytesRead > 0)
                         {
-                            _destination.Write(new ReadOnlySpan<byte>(_arrayPoolBuffer, 0, bytesRead));
+                            _destination.Write(_arrayPoolBuffer, 0, bytesRead);
                         }
                         else
                         {
@@ -879,7 +879,7 @@ namespace System.IO.Compression
                     int bytesRead = _deflateStream._inflater.Inflate(new Span<byte>(_arrayPoolBuffer));
                     if (bytesRead > 0)
                     {
-                        _destination.Write(new ReadOnlySpan<byte>(_arrayPoolBuffer, 0, bytesRead));
+                        _destination.Write(_arrayPoolBuffer, 0, bytesRead);
                     }
                     else
                     {

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -706,6 +706,16 @@ namespace System.IO.Compression
             }
         }
 
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
+
+            EnsureDecompressionMode();
+            EnsureNotDisposed();
+
+            new CopyToStream(this, destination, bufferSize).CopyFromSourceToDestination();
+        }
+
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             // Validation as base CopyToAsync would do
@@ -723,17 +733,22 @@ namespace System.IO.Compression
             }
 
             // Do the copy
-            return new CopyToAsyncStream(this, destination, bufferSize, cancellationToken).CopyFromSourceToDestination();
+            return new CopyToStream(this, destination, bufferSize, cancellationToken).CopyFromSourceToDestinationAsync();
         }
 
-        private sealed class CopyToAsyncStream : Stream
+        private sealed class CopyToStream : Stream
         {
             private readonly DeflateStream _deflateStream;
             private readonly Stream _destination;
             private readonly CancellationToken _cancellationToken;
             private byte[] _arrayPoolBuffer;
 
-            public CopyToAsyncStream(DeflateStream deflateStream, Stream destination, int bufferSize, CancellationToken cancellationToken)
+            public CopyToStream(DeflateStream deflateStream, Stream destination, int bufferSize) :
+                this(deflateStream, destination, bufferSize, CancellationToken.None)
+            {
+            }
+
+            public CopyToStream(DeflateStream deflateStream, Stream destination, int bufferSize, CancellationToken cancellationToken)
             {
                 Debug.Assert(deflateStream != null);
                 Debug.Assert(destination != null);
@@ -745,7 +760,7 @@ namespace System.IO.Compression
                 _arrayPoolBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
             }
 
-            public async Task CopyFromSourceToDestination()
+            public async Task CopyFromSourceToDestinationAsync()
             {
                 _deflateStream.AsyncOperationStarting();
                 try
@@ -758,7 +773,10 @@ namespace System.IO.Compression
                         {
                             await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), _cancellationToken).ConfigureAwait(false);
                         }
-                        else break;
+                        else
+                        {
+                            break;
+                        }
                     }
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
@@ -768,6 +786,34 @@ namespace System.IO.Compression
                 {
                     _deflateStream.AsyncOperationCompleting();
 
+                    ArrayPool<byte>.Shared.Return(_arrayPoolBuffer);
+                    _arrayPoolBuffer = null;
+                }
+            }
+
+            public void CopyFromSourceToDestination()
+            {
+                try
+                {
+                    // Flush any existing data in the inflater to the destination stream.
+                    while (true)
+                    {
+                        int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
+                        if (bytesRead > 0)
+                        {
+                            _destination.Write(new ReadOnlySpan<byte>(_arrayPoolBuffer, 0, bytesRead));
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
+                    _deflateStream._stream.CopyTo(this, _arrayPoolBuffer.Length);
+                }
+                finally
+                {
                     ArrayPool<byte>.Shared.Return(_arrayPoolBuffer);
                     _arrayPoolBuffer = null;
                 }
@@ -800,14 +846,50 @@ namespace System.IO.Compression
                     {
                         await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), cancellationToken).ConfigureAwait(false);
                     }
-                    else break;
+                    else
+                    {
+                        break;
+                    }
                 }
             }
 
-            public override void Write(byte[] buffer, int offset, int count) => WriteAsync(buffer, offset, count, default(CancellationToken)).GetAwaiter().GetResult();
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                // Validate inputs
+                Debug.Assert(buffer != _arrayPoolBuffer);
+                _deflateStream.EnsureNotDisposed();
+
+                if (count <= 0)
+                {
+                    return;
+                }
+                else if (count > buffer.Length - offset)
+                {
+                    // The buffer stream is either malicious or poorly implemented and returned a number of
+                    // bytes larger than the buffer supplied to it.
+                    throw new InvalidDataException(SR.GenericInvalidData);
+                }
+
+                // Feed the data from base stream into the decompression engine.
+                _deflateStream._inflater.SetInput(buffer, offset, count);
+
+                // While there's more decompressed data available, forward it to the buffer stream.
+                while (true)
+                {
+                    int bytesRead = _deflateStream._inflater.Inflate(new Span<byte>(_arrayPoolBuffer));
+                    if (bytesRead > 0)
+                    {
+                        _destination.Write(new ReadOnlySpan<byte>(_arrayPoolBuffer, 0, bytesRead));
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
             public override bool CanWrite => true;
             public override void Flush() { }
-
             public override bool CanRead => false;
             public override bool CanSeek => false;
             public override long Length { get { throw new NotSupportedException(); } }


### PR DESCRIPTION
For #29478

Should the new CopyTo override contain a check for whether it's being called on a derived class - since it may override Read(...) which this implementation will bypass? I have currently left this out since the existing CopyToAsync method doesn't have this check.

Some measurements are below.  I have not yet got round to testing with custom buffer sizes and time is currently against me - hopefully early next week.

I've not seen any regressions, however interestingly the observed level of improvement is very strongly correlated with how compressible the source data is.  The less compressible the data the greater the gains.

I have done limited testing on 1GB and 2GB files however haven't yet gone through all three variations like I did with the rest of them - the pattern did seem to continue though.

| Source Size |   Source Compressibility   |  Improvement  |
| ------------|:--------------------------:| :----------------:|
|1MB | Low  | ~2x |
|1MB | Moderate  | ~1.7x |
|1MB | High | >1x |
|15MB | Low  | ~3x |
|15MB | Moderate  | ~2.5x |
|15MB | High  | >1x |
|30MB | Low  | ~4x |
|30MB | Moderate  | ~2.5x |
|30MB | High  | >1x |
|100MB | Low  | ~7x |
|100MB | Moderate  | ~2x |
|100MB | High  | >1x |
|250MB | Low  | ~3.5x |
|250MB | Moderate  | ~2x |
|250MB | High  | >1x |
|1GB | Moderate  | ~2x |
|2GB | Moderate  | ~2x |