### PR TITLE
Fix client certificate lifetime handling in tests

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Certificates.cs
+++ b/src/Common/tests/System/Net/Configuration.Certificates.cs
@@ -35,67 +35,54 @@ namespace System.Net.Test.Common
                 }
             }
 
-            public static X509Certificate2 GetServerCertificate() => GetCertWithPrivateKey(GetServerCertificateCollection());
+            public static X509Certificate2 GetServerCertificate() => GetCertificate("testservereku.contoso.com.pfx");
 
-            public static X509Certificate2 GetClientCertificate() => GetCertWithPrivateKey(GetClientCertificateCollection());
+            public static X509Certificate2 GetClientCertificate() => GetCertificate("testclienteku.contoso.com.pfx");
 
-            public static X509Certificate2 GetNoEKUCertificate() => GetCertWithPrivateKey(GetNoEKUCertificateCollection());
+            public static X509Certificate2 GetNoEKUCertificate() => GetCertificate("testnoeku.contoso.com.pfx");
 
-            public static X509Certificate2 GetSelfSignedServerCertificate() => GetCertWithPrivateKey(GetSelfSignedServerCertificateCollection());
+            public static X509Certificate2 GetSelfSignedServerCertificate() => GetCertificate("testselfsignedservereku.contoso.com.pfx");
 
-            public static X509Certificate2 GetSelfSignedClientCertificate() => GetCertWithPrivateKey(GetSelfSignedClientCertificateCollection());
+            public static X509Certificate2 GetSelfSignedClientCertificate() => GetCertificate("testselfsignedclienteku.contoso.com.pfx");
 
-            public static X509Certificate2Collection GetServerCertificateCollection() => GetCertificateCollection("testservereku.contoso.com.pfx");
+            public static X509Certificate2Collection GetServerCertificateCollection()
+            {
+                var certs = new X509Certificate2Collection();
+                certs.Add(GetServerCertificate());
 
-            public static X509Certificate2Collection GetClientCertificateCollection() => GetCertificateCollection("testclienteku.contoso.com.pfx");
+                return certs;
+            }
 
-            public static X509Certificate2Collection GetNoEKUCertificateCollection() => GetCertificateCollection("testnoeku.contoso.com.pfx");
+            public static X509Certificate2Collection GetClientCertificateCollection()
+            {
+                var certs = new X509Certificate2Collection();
+                certs.Add(GetClientCertificate());
 
-            public static X509Certificate2Collection GetSelfSignedServerCertificateCollection() => GetCertificateCollection("testselfsignedservereku.contoso.com.pfx");
+                return certs;
+            }
 
-            public static X509Certificate2Collection GetSelfSignedClientCertificateCollection() => GetCertificateCollection("testselfsignedclienteku.contoso.com.pfx");
-
-            private static X509Certificate2Collection GetCertificateCollection(string certificateFileName)
+            private static X509Certificate2 GetCertificate(string certificateFileName)
             {
                 // On Windows, .NET Core applications should not import PFX files in parallel to avoid a known system-level race condition.
                 // This bug results in corrupting the X509Certificate2 certificate state.
                 Assert.True(m.WaitOne(MutexTimeout), "Cannot acquire the global certificate mutex.");
                 try
                 {
-                    var certCollection = new X509Certificate2Collection();
-                    certCollection.Import(Path.Combine(TestDataFolder, certificateFileName), CertificatePassword, X509KeyStorageFlags.DefaultKeySet);
-
-                    return certCollection;
+                    var cert = new X509Certificate2(
+                        Path.Combine(TestDataFolder, certificateFileName),
+                        CertificatePassword,
+                        X509KeyStorageFlags.DefaultKeySet);
+                    return cert;
                 }
                 catch (Exception ex)
                 {
-                    Debug.Fail(nameof(Configuration.Certificates.GetCertificateCollection) + " threw " + ex.ToString());
+                    Debug.Fail(nameof(Configuration.Certificates.GetCertificate) + " threw " + ex.ToString());
                     throw;
                 }
                 finally
                 {
                     m.ReleaseMutex();
                 }
-            }
-
-            private static X509Certificate2 GetCertWithPrivateKey(X509Certificate2Collection certCollection)
-            {
-                X509Certificate2 certificate = null;
-
-                foreach (X509Certificate2 c in certCollection)
-                {
-                    if (certificate == null && c.HasPrivateKey)
-                    {
-                        certificate = c;
-                    }
-                    else
-                    {
-                        c.Dispose();
-                    }
-                }
-
-                Assert.NotNull(certificate);
-                return certificate;
             }
         }
     }


### PR DESCRIPTION
This was a difficult bug to track down. Our use of importing PFX files into the
tests has problems due to a combination of issues. The summary is that these
issues cause the private key (which is written to a temp file on disk) to get
corrupted/deleted. This is why we would get random errors about "invalid client
credentials" when using client certificates in HttpClient (or SslStream).

Thanks to @bartonjs for helping me work thru this.

The lifetime of the temp file containing the private key is associated with the managed
X509Certificate2 object that is created. However, our use of X509Certificate2Collection
followed by the use of the .Find() API in [GetEligibleClientCertificate](https://github.com/dotnet/corefx/blob/10aa8277de2521fb1e6a5b42d053ad8cc947be81/src/Common/src/System/Net/Security/CertificateHelper.cs#L55-L59) causes new managed objects to get created including both a new collection object and
new certificate objects wrapping the existing native PCCERT_CONTEXT of the old managed
certificate object. This causes lifetime issues for the temp file containing the private
key since the old managed objects are GC'd.

In terms of fixing this for the tests, I've optimized the Configuration.Certificates
helper and removed constructs that we don't actually use in our tests. Switching from
using .Import() on the collection object to actually creating the X509Certificate2
object directly helps with managing the lifetime of the certificate.

I will be doing a follow-up PR to optimze GetEligibleClientCertificate() to switch from
using .Find() and instead directly query the certificates in the original collection.
This will result in less managed objects being created as well as avoid additional private
key lifetime issues for certificates imported that use the default X509KeyStorage.DefaultKeySet
flags.

I also fixed a problem with the test which was always failing on NETFX.

Closes #9543