### PR TITLE
Fix Uri.Host for IPv6 Link-local address

### DIFF
--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -31,7 +31,9 @@ namespace System
                 ((long*)numbers)[0] = 0L;
                 ((long*)numbers)[1] = 0L;
                 isLoopback = Parse(str, numbers, start, ref scopeId);
-                return '[' + CreateCanonicalName(numbers) + ']';
+                //Link local address https://tools.ietf.org/html/rfc4291#page-11
+                bool isLinkLocalAddress = (numbers[0] == 0xfe80);
+                return '[' + CreateCanonicalName(numbers) + (isLinkLocalAddress ? scopeId : "") + ']';
             }
         }
 

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -30,7 +30,7 @@ namespace System
                 // optimized zeroing of 8 shorts = 2 longs
                 ((long*)numbers)[0] = 0L;
                 ((long*)numbers)[1] = 0L;
-                isLoopback = Parse(str, numbers, start, ref scopeId);                         
+                isLoopback = Parse(str, numbers, start, ref scopeId);
                 return '[' + CreateCanonicalName(numbers) + ((numbers[0] == 0xfe80) ? scopeId : "") + ']';
             }
         }

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -30,10 +30,8 @@ namespace System
                 // optimized zeroing of 8 shorts = 2 longs
                 ((long*)numbers)[0] = 0L;
                 ((long*)numbers)[1] = 0L;
-                isLoopback = Parse(str, numbers, start, ref scopeId);
-                //Link local address https://tools.ietf.org/html/rfc4291#page-11
-                bool isLinkLocalAddress = (numbers[0] == 0xfe80);
-                return '[' + CreateCanonicalName(numbers) + (isLinkLocalAddress ? scopeId : "") + ']';
+                isLoopback = Parse(str, numbers, start, ref scopeId);                                
+                return '[' + CreateCanonicalName(numbers) + ((numbers[0] == 0xfe80) ? scopeId : "") + ']';
             }
         }
 

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -30,7 +30,7 @@ namespace System
                 // optimized zeroing of 8 shorts = 2 longs
                 ((long*)numbers)[0] = 0L;
                 ((long*)numbers)[1] = 0L;
-                isLoopback = Parse(str, numbers, start, ref scopeId);                                
+                isLoopback = Parse(str, numbers, start, ref scopeId);                         
                 return '[' + CreateCanonicalName(numbers) + ((numbers[0] == 0xfe80) ? scopeId : "") + ']';
             }
         }

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -234,6 +234,20 @@ namespace System.PrivateUri.Tests
 
         #region IPv6
 
+        [Theory]
+        [Trait("MyTrait", "MyTrait")]
+        [InlineData("[fe80::dcbd:a736:baae:b535{0}]", "%2", true)]
+        //[InlineData("[FE80::dcbd:a736:baae:b535{0}]", "eth0")]
+        [InlineData("[FE81::dcbd:a736:baae:b535{0}]", "%18", false)]
+        [InlineData("[fe80::e077:c9a3:eeba:b8e9{0}]", "%18", true)]
+        public void UriIPv6_LinkLocalAddress(string address, string zoneIndex, bool isValidLinkLocalAddress)
+        {
+            string linklocalAddress = string.Format(address, zoneIndex);
+            string ipv6Address = "http://" + linklocalAddress;
+            var uri = new Uri(ipv6Address);
+            Assert.True(isValidLinkLocalAddress ? uri.Host.Trim('[').Trim(']').EndsWith(zoneIndex) : uri.Host == address);
+        }
+
         [Fact]
         public void UriIPv6Host_CanonicalCollonHex_Success()
         {
@@ -326,8 +340,8 @@ namespace System.PrivateUri.Tests
         [InlineData("FFFFF::")] // Hex out of range
         [InlineData(":%12")] // Colon Scope
         [InlineData("%12")] // Just Scope
-        // TODO # 8330 Discrepency: IPAddress doesn't accept bad scopes, Uri does.
-        //[InlineData("::%1a")] // Alpha numeric Scope
+                            // TODO # 8330 Discrepency: IPAddress doesn't accept bad scopes, Uri does.
+                            //[InlineData("::%1a")] // Alpha numeric Scope        
         public void UriIPv6Host_BadAddress(string address)
         {
             ParseBadIPv6Address(address);

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -234,20 +234,29 @@ namespace System.PrivateUri.Tests
 
         #region IPv6
 
-        [Theory]        
-        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18", true)]
-        [InlineData("Fe80::e077:c9a3:eeba:b8e9", "%18", true)]
-        [InlineData("fE80::e077:c9a3:eeba:b8e9", "%18", true)]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%18", true)]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10", true)]
-        [InlineData("fe81::e077:c9a3:eeba:b8e9", "%18", false)]        
+        [Theory]
+        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18")]
+        [InlineData("Fe80::e077:c9a3:eeba:b8e9", "%18")]
+        [InlineData("fE80::e077:c9a3:eeba:b8e9", "%18")]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%18")]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex, bool isValidLinkLocalAddress)
+        public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex)
         {
             string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
             string literalIpV6Uri = "http://" + scopedLiteralIpv6;
             var uri = new Uri(literalIpV6Uri);
-            Assert.Equal(isValidLinkLocalAddress ? scopedLiteralIpv6 : "[" + address + "]", uri.Host, ignoreCase: true);
+            Assert.Equal(scopedLiteralIpv6, uri.Host, ignoreCase: true);
+        }
+
+        [Theory]
+        [InlineData("fe81::e077:c9a3:eeba:b8e9", "%18")]
+        public void Host_NonIPv6LinkLocalAddress_NoScopeId(string address, string zoneIndex)
+        {
+            string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
+            string literalIpV6Uri = "http://" + scopedLiteralIpv6;
+            var uri = new Uri(literalIpV6Uri);
+            Assert.Equal("[" + address + "]", uri.Host);
         }
 
         [Fact]

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -241,6 +241,8 @@ namespace System.PrivateUri.Tests
         [InlineData("FE80::e077:c9a3:eeba:b8e9", "%18")]
         [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10")]
         [InlineData("FE80::e077:c9a3:eeba:b8e9", "")]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%")]
+        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%\u30AF\u20E7")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex)
         {

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -234,18 +234,20 @@ namespace System.PrivateUri.Tests
 
         #region IPv6
 
-        [Theory]
-        [Trait("MyTrait", "MyTrait")]
-        [InlineData("[fe80::dcbd:a736:baae:b535{0}]", "%2", true)]
-        //[InlineData("[FE80::dcbd:a736:baae:b535{0}]", "eth0")]
-        [InlineData("[FE81::dcbd:a736:baae:b535{0}]", "%18", false)]
-        [InlineData("[fe80::e077:c9a3:eeba:b8e9{0}]", "%18", true)]
-        public void UriIPv6_LinkLocalAddress(string address, string zoneIndex, bool isValidLinkLocalAddress)
+        [Theory]        
+        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18", true)]
+        [InlineData("Fe80::e077:c9a3:eeba:b8e9", "%18", true)]
+        [InlineData("fE80::e077:c9a3:eeba:b8e9", "%18", true)]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%18", true)]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10", true)]
+        [InlineData("fe81::e077:c9a3:eeba:b8e9", "%18", false)]        
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void UriIPv6Host_LinkLocalAddress(string address, string zoneIndex, bool isValidLinkLocalAddress)
         {
-            string linklocalAddress = string.Format(address, zoneIndex);
-            string ipv6Address = "http://" + linklocalAddress;
-            var uri = new Uri(ipv6Address);
-            Assert.True(isValidLinkLocalAddress ? uri.Host.Trim('[').Trim(']').EndsWith(zoneIndex) : uri.Host == address);
+            string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
+            string literalIpV6Uri = "http://" + scopedLiteralIpv6;
+            var uri = new Uri(literalIpV6Uri);
+            Assert.Equal(isValidLinkLocalAddress ? scopedLiteralIpv6 : "[" + address + "]", uri.Host, ignoreCase: true);
         }
 
         [Fact]

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -242,7 +242,7 @@ namespace System.PrivateUri.Tests
         [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10", true)]
         [InlineData("fe81::e077:c9a3:eeba:b8e9", "%18", false)]        
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public void UriIPv6Host_LinkLocalAddress(string address, string zoneIndex, bool isValidLinkLocalAddress)
+        public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex, bool isValidLinkLocalAddress)
         {
             string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
             string literalIpV6Uri = "http://" + scopedLiteralIpv6;

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -240,6 +240,7 @@ namespace System.PrivateUri.Tests
         [InlineData("fE80::e077:c9a3:eeba:b8e9", "%18")]
         [InlineData("FE80::e077:c9a3:eeba:b8e9", "%18")]
         [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10")]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex)
         {

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -342,8 +342,8 @@ namespace System.PrivateUri.Tests
         [InlineData("FFFFF::")] // Hex out of range
         [InlineData(":%12")] // Colon Scope
         [InlineData("%12")] // Just Scope
-                            // TODO # 8330 Discrepency: IPAddress doesn't accept bad scopes, Uri does.
-                            //[InlineData("::%1a")] // Alpha numeric Scope        
+        // TODO # 8330 Discrepency: IPAddress doesn't accept bad scopes, Uri does.
+        //[InlineData("::%1a")] // Alpha numeric Scope
         public void UriIPv6Host_BadAddress(string address)
         {
             ParseBadIPv6Address(address);

--- a/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -23,8 +23,7 @@ namespace System.PrivateUri.Tests
         private const string FullBaseUriGetLeftPart_Query = "http://user:psw@host:9090/path1/path2/path3/fileA?query";
 
         // A few of these tests depend on bugfixes made in .NET Framework 4.7.2 and must be skipped on older versions.
-        public static bool IsNetCoreOrIsNetfx472OrLater => !PlatformDetection.IsFullFramework //|| PlatformDetection.IsNetfx472OrNewer
-            ;
+        public static bool IsNetCoreOrIsNetfx472OrLater => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx472OrNewer;
 
         [Fact]
         public void Uri_Relative_BaseVsAbsolute_ReturnsFullAbsolute()

--- a/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -23,7 +23,8 @@ namespace System.PrivateUri.Tests
         private const string FullBaseUriGetLeftPart_Query = "http://user:psw@host:9090/path1/path2/path3/fileA?query";
 
         // A few of these tests depend on bugfixes made in .NET Framework 4.7.2 and must be skipped on older versions.
-        public static bool IsNetCoreOrIsNetfx472OrLater => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx472OrNewer;
+        public static bool IsNetCoreOrIsNetfx472OrLater => !PlatformDetection.IsFullFramework //|| PlatformDetection.IsNetfx472OrNewer
+            ;
 
         [Fact]
         public void Uri_Relative_BaseVsAbsolute_ReturnsFullAbsolute()


### PR DESCRIPTION
contributes to #28863 

this PR address the second part of issue:

2)  `Uri.Host` LLA (Link-local address) IPv6 address doesn't contain `%number` part.
* Currently it returns `[fe80::e077:c9a3:eeba:b8e9]`, it should return `[fe80::e077:c9a3:eeba:b8e9%18]`.
* Note: `Uri.IdnHost` correctly contains the `%number` part.

cc: @rmkerr @caesar1995 @davidsh 