### PR TITLE
WMI: make DMTF and DateTime match netfx behavior

### DIFF
--- a/src/System.Management/tests/System/Management/ManagementDateTimeConverterTests.cs
+++ b/src/System.Management/tests/System/Management/ManagementDateTimeConverterTests.cs
@@ -24,6 +24,15 @@ namespace System.Management.Tests
         }
 
         [ConditionalFact(typeof(WmiTestHelper), nameof(WmiTestHelper.IsWmiSupported))]
+        public void DateTime_MinValue_RoundTrip()
+        {
+            string dmtfFromDateTimeMinValue = ManagementDateTimeConverter.ToDmtfDateTime(DateTime.MinValue);
+            DateTime convertedDate = ManagementDateTimeConverter.ToDateTime(dmtfFromDateTimeMinValue);
+            Assert.Equal(DateTimeKind.Unspecified, convertedDate.Kind);
+            Assert.Equal(DateTime.MinValue, convertedDate);
+        }
+
+        [ConditionalFact(typeof(WmiTestHelper), nameof(WmiTestHelper.IsWmiSupported))]
         public void TimeSpan_RoundTrip()
         {
             var timeSpan = new TimeSpan(10, 12, 25, 32, 123);


### PR DESCRIPTION
Fixes #29712 the idea here is to match netfx behavior for ManagementDateTimeConverter. A prior PR (#27683) introduced some slight differences: 

* Started to return a DateTime of Kind Local while netfx returns Unspecified
* Switched ToDateTime from TimeZone to TimeZoneInfo but didn't do the same for the symmetrical ToDmtfDateTime (TimeZoneInfo is the correct one, so this change does the same for TimeZoneInfo)
* Delegated part of the calculation of the offset to ToLocalTime, while this is preferable in general, it can cause out-of-range for values near DateTime.MinValue depending on the current time zone.