### PR TITLE
fix FromBase64Transform for oversize buffers

### DIFF
--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -200,7 +200,8 @@ namespace System.Security.Cryptography
             }
 
             // If there's nothing to do, leave early
-            if (iCount == 0 && inputOffset == 0)
+            if (iCount == 0 && inputOffset == 0 &&
+                inputOffset == 0 && inputCount == inputBuffer.Length)
             {
                 return inputBuffer;
             }

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -201,7 +201,7 @@ namespace System.Security.Cryptography
 
             // If there's nothing to do, leave early
             if (iCount == 0 && inputOffset == 0 &&
-                inputOffset == 0 && inputCount == inputBuffer.Length)
+                inputCount == inputBuffer.Length)
             {
                 return inputBuffer;
             }

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -110,11 +110,22 @@ namespace System.Security.Cryptography.Encoding.Tests
             byte[] inputBytes = Text.Encoding.ASCII.GetBytes(data);
             byte[] outputBytes = new byte[100];
 
+            // Verify read mode
             using (var ms = new MemoryStream(inputBytes))
             using (var cs = new CryptoStream(ms, transform, CryptoStreamMode.Read))
             {
                 int bytesRead = cs.Read(outputBytes, 0, outputBytes.Length);
                 string outputString = Text.Encoding.ASCII.GetString(outputBytes, 0, bytesRead);
+                Assert.Equal(expected, outputString);
+            }
+
+            // Verify write mode
+            using (var ms = new MemoryStream(outputBytes))
+            using (var cs = new CryptoStream(ms, transform, CryptoStreamMode.Write))
+            {
+                cs.Write(inputBytes, 0, inputBytes.Length);
+                cs.FlushFinalBlock();
+                string outputString = Text.Encoding.ASCII.GetString(outputBytes, 0, (int)ms.Position);
                 Assert.Equal(expected, outputString);
             }
         }

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -177,6 +177,23 @@ namespace System.Security.Cryptography.Encoding.Tests
             }
         }
 
+        [Fact]
+        public static void ValidateFromBase64_OversizeBuffer()
+        {
+            using (var transform = new FromBase64Transform())
+            {
+                byte[] inputBytes = Text.Encoding.ASCII.GetBytes("/Zm9v/");
+                byte[] outputBytes = new byte[6];
+
+                // skip the first and last byte
+                int bytesWritten = transform.TransformBlock(inputBytes, 1, 4, outputBytes, 0);
+
+                string outputText = Text.Encoding.ASCII.GetString(outputBytes, 0, bytesWritten);
+
+                Assert.Equal("foo", outputText);
+            }
+        }
+
         [Theory, MemberData(nameof(TestData_Ascii_Whitespace))]
         public static void ValidateWhitespace(string expected, string data)
         {

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -45,9 +45,9 @@ namespace System.Security.Cryptography.Encoding.Tests
 
         public static IEnumerable<object[]> TestData_Oversize()
         {
-            yield return new object[] { "Zm9v/", 0, 4, "foo" };
-            yield return new object[] { "/Zm9v", 1, 4, "foo" };
-            yield return new object[] { "/Zm9v/", 1, 4, "foo" };
+            yield return new object[] { "Zm9v////", 0, 4, "foo" };
+            yield return new object[] { "////Zm9v", 4, 4, "foo" };
+            yield return new object[] { "////Zm9v////", 4, 4, "foo" };
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -45,6 +45,7 @@ namespace System.Security.Cryptography.Encoding.Tests
 
         public static IEnumerable<object[]> TestData_Oversize()
         {
+            // test data with extra chunks of data outside the selected range
             yield return new object[] { "Zm9v////", 0, 4, "foo" };
             yield return new object[] { "////Zm9v", 4, 4, "foo" };
             yield return new object[] { "////Zm9v////", 4, 4, "foo" };
@@ -192,7 +193,6 @@ namespace System.Security.Cryptography.Encoding.Tests
                 byte[] inputBytes = Text.Encoding.ASCII.GetBytes(input);
                 byte[] outputBytes = new byte[100];
 
-                // skip the first and last byte
                 int bytesWritten = transform.TransformBlock(inputBytes, offset, count, outputBytes, 0);
 
                 string outputText = Text.Encoding.ASCII.GetString(outputBytes, 0, bytesWritten);


### PR DESCRIPTION
This change is extracted from #29675.

I found a bug where `FromBase64Transform` would error about invalid characters when using a `CryptoStream` in write mode and ignoring whitespace characters if your input didn't actually contain whitespace characters. The code assumed `GetTempBuffer` would return an array containing exactly the bytes to convert, but when ignoring whitespace, if the selected range of the buffer did not actually contain any whitespace, the input buffer would be returned instead, and any caller-provided offset or count would be lost, resulting in either the wrong data or (more likely) an error about invalid characters.

This bug does not seem to exist in the .NET Framework implementation of `FromBase64Transform`.

The easy fix is to be more selective about when to return the input buffer from `GetTempBuffer`