### PR TITLE
Fix NotSupportedException from WaitHandle.WaitAll in transactions tests

### DIFF
--- a/src/System.Transactions.Local/tests/LTMEnlistmentTests.cs
+++ b/src/System.Transactions.Local/tests/LTMEnlistmentTests.cs
@@ -203,7 +203,11 @@ namespace System.Transactions.Tests
                 Assert.Equal(expectedTxStatus, TransactionStatus.Aborted);
             }
 
-            Assert.True(AutoResetEvent.WaitAll(outcomeEvents, TimeSpan.FromSeconds(MaxTransactionCommitTimeoutInSeconds)));
+            Task.Run(() => // in case current thread is STA thread, where WaitHandle.WaitAll isn't supported
+            {
+                Assert.True(WaitHandle.WaitAll(outcomeEvents, TimeSpan.FromSeconds(MaxTransactionCommitTimeoutInSeconds)));
+            }).GetAwaiter().GetResult();
+
             Assert.NotNull(tx);
             Assert.Equal(expectedTxStatus, tx.TransactionInformation.Status);
         }


### PR DESCRIPTION
I hit this exception in a .NET Framework run of the System.Transactions.Local tests:
```
Unhandled Exception of Type System.NotSupportedException
Message :
System.NotSupportedException : WaitAll for multiple handles on a STA thread is not supported.
Stack Trace :
   at System.Threading.WaitHandle.WaitMultiple(WaitHandle[] waitHandles, Int32 millisecondsTimeout, Boolean exitContext, Boolean WaitAll)
   at System.Threading.WaitHandle.WaitAll(WaitHandle[] waitHandles, Int32 millisecondsTimeout, Boolean exitContext)
   at System.Threading.WaitHandle.WaitAll(WaitHandle[] waitHandles, TimeSpan timeout, Boolean exitContext)
   at System.Transactions.Tests.LTMEnlistmentTests.EnlistVolatile(Int32 volatileCount, EnlistmentOptions enlistmentOption, Phase1Vote volatilePhase1Vote, Phase1Vote lastPhase1Vote, Boolean commit, EnlistmentOutcome expectedEnlistmentOutcome, TransactionStatus expectedTxStatus)
```
The test is using WaitHandle.WaitAll, which isn't supported on STA threads, and this test must have been executed by xunit on such a thread.  I'm fixing it by offloading the wait ot the thread pool.

cc: @jimcarley, @danmosemsft 