### PR TITLE
[WIP] Implement the Happy Eyeballs connection algorithm to reduce connection latency

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -52,7 +52,7 @@ namespace System.Net.Http
             Task<(Socket, Stream)> tryConnectAsyncIPv4 = ConnectAsyncInternal(host, port, AddressFamily.InterNetwork, cancelIPv4.Token);
             if (await Task.WhenAny(tryConnectAsyncIPv6, tryConnectAsyncIPv4).ConfigureAwait(false) == tryConnectAsyncIPv6)
             {
-                if(tryConnectAsyncIPv6.IsCompletedSuccessfully)
+                if (tryConnectAsyncIPv6.IsCompletedSuccessfully)
                 {
                     cancelIPv4.Cancel();
                     return await tryConnectAsyncIPv6.ConfigureAwait(false);
@@ -61,7 +61,7 @@ namespace System.Net.Http
             }
             else
             {
-                if(tryConnectAsyncIPv4.IsCompletedSuccessfully)
+                if (tryConnectAsyncIPv4.IsCompletedSuccessfully)
                 {
                     cancelIPv6.Cancel();
                     return await tryConnectAsyncIPv4.ConfigureAwait(false);
@@ -72,6 +72,9 @@ namespace System.Net.Http
 
         public static async Task<(Socket, Stream)> ConnectAsyncInternal(string host, int port, AddressFamily family, CancellationToken cancellationToken)
         {
+            // Rather than creating a new Socket and calling ConnectAsync on it, we use the static
+            // Socket.ConnectAsync with a SocketAsyncEventArgs, as we can then use Socket.CancelConnectAsync
+            // to cancel it if needed. Rent or allocate one.
             ConnectEventArgs saea;
             if (!s_connectEventArgs.TryDequeue(out saea))
             {
@@ -110,7 +113,6 @@ namespace System.Net.Http
             }
             catch (Exception error)
             {
-                //Console.WriteLine(error);
                 throw CancellationHelper.ShouldWrapInOperationCanceledException(error, cancellationToken) ?
                     CancellationHelper.CreateOperationCanceledException(error, cancellationToken) :
                     new HttpRequestException(error.Message, error);


### PR DESCRIPTION
As discussed in #29716, SocketsHttpHandler will currently hang when connecting to an IPv6 server when IPv6 is not supported on the network. This can cause significant delays when sending requests on Windows, and results in an `OperationCanceledException` exception on Unix.

This issue can be reproduced on Windows by editing your host file to contain the following entries:
```
0100:f8b0:400a:809::200e local.test.addr # Some address that doesn't exist
127.0.0.1 local.test.addr # Some address that does exist
```
And then attempting to open a connection to `local.test.addr`. IPv6 must be enabled on your machine for this repro to function.

On both Windows and Linux we attempt to connect to the IPv6 address first. We receive no response, and attempt several SYN re-transmissions.

The [Happy Eyeballs algorithm](https://tools.ietf.org/html/rfc8305) avoids this issue by attempting to connect to via IPv6 and IPv4 in parallel. We prefer IPv6, and will attempt to connect via IPv6 for 200 ms before kicking off a concurrent attempt via IPv4. 

The implementation is functional, but is probably nowhere near as efficient as it could be. I'm trying to learn more about performance, so any feedback there would be greatly appreciated.