### PR TITLE
Fix WebSocket.Client tests on UAP

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -382,9 +382,15 @@ namespace System.Net.WebSockets
 
                         bool endOfMessage = false;
                         uint readCount = Math.Min(dataAvailable, (uint) buffer.Count);
-                        var dataBuffer = reader.ReadBuffer(readCount);
-                        // Safe to cast readCount to int as the maximum value that readCount can be is buffer.Count.
-                        dataBuffer.CopyTo(0, buffer.Array, buffer.Offset, (int) readCount);
+
+                        if (readCount > 0)
+                        {
+                            IBuffer dataBuffer = reader.ReadBuffer(readCount);
+
+                            // Safe to cast readCount to int as the maximum value that readCount can be is buffer.Count.
+                            dataBuffer.CopyTo(0, buffer.Array, buffer.Offset, (int) readCount);
+                        }
+
                         if (dataAvailable == readCount)
                         {
                             endOfMessage = !IsPartialMessageEvent(args);

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -29,8 +29,8 @@ namespace System.Net.WebSockets.Client.Tests
                 Assert.Equal(WebSocketError.Success, ex.WebSocketErrorCode);
                 Assert.Equal(WebSocketState.Closed, cws.State);
 
-                // The .NET Native toolchain optimizes away exception messages.
-                if (!PlatformDetection.IsNetNative)
+                // .NET Framework and UAP implmentations have different exception message from .NET Core.
+                if (!PlatformDetection.IsFullFramework && !PlatformDetection.IsUap)
                 {
                     Assert.Equal(exceptionMessage, ex.Message);
                 }

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -466,7 +466,13 @@ namespace System.Net.WebSockets.Client.Tests
                 // Now do a receive to get the payload.
                 var receiveBuffer = new byte[1];
                 t = ReceiveAsync(cws, new ArraySegment<byte>(receiveBuffer), ctsDefault.Token);
-                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+
+                // Skip synchronous completion check on UAP since it uses WinRT APIs underneath.
+                if (!PlatformDetection.IsUap)
+                {
+                    Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                }
+
                 r = await t;
                 Assert.Equal(WebSocketMessageType.Binary, r.MessageType);
                 Assert.Equal(1, r.Count);


### PR DESCRIPTION
Fixed WinRTWebSocket for the edge case of dealing with 0-byte receive calls.

Made a few adjustments to the tests for UAP test runs.

Fixes #28755.