### PR TITLE
Fix uap failures in IO

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/Common/src/Interop/Windows/Interop.Errors.cs
@@ -24,6 +24,7 @@ internal partial class Interop
         internal const int ERROR_LOCK_VIOLATION = 0x21;
         internal const int ERROR_HANDLE_EOF = 0x26;
         internal const int ERROR_BAD_NETPATH = 0x35;
+        internal const int ERROR_NETWORK_ACCESS_DENIED = 0x41;
         internal const int ERROR_BAD_NET_NAME = 0x43;
         internal const int ERROR_FILE_EXISTS = 0x50;
         internal const int ERROR_INVALID_PARAMETER = 0x57;

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -209,7 +209,10 @@ namespace System.IO
                         && errorCode != Interop.Errors.ERROR_BAD_NETPATH
                         && errorCode != Interop.Errors.ERROR_BAD_NET_NAME
                         && errorCode != Interop.Errors.ERROR_INVALID_PARAMETER
-                        && errorCode != Interop.Errors.ERROR_NETWORK_UNREACHABLE)
+                        && errorCode != Interop.Errors.ERROR_NETWORK_UNREACHABLE
+                        && errorCode != Interop.Errors.ERROR_NETWORK_ACCESS_DENIED
+                        && errorCode != Interop.Errors.ERROR_INVALID_HANDLE  // eg from \\.\CON
+                        )
                     {
                         // Assert so we can track down other cases (if any) to add to our test suite
                         Debug.Assert(errorCode == Interop.Errors.ERROR_ACCESS_DENIED || errorCode == Interop.Errors.ERROR_SHARING_VIOLATION,

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -114,7 +114,13 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsInAppContainer))] // Can't read root in appcontainer
+        public void RootPath_AppContainer()
+        {
+            string dirName = Path.GetPathRoot(Directory.GetCurrentDirectory());
+            Assert.Throws<DirectoryNotFoundException>(() => Create(dirName));
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer        
         public void RootPath()
         {
@@ -489,7 +495,7 @@ namespace System.IO.Tests
         {
             if (PlatformDetection.IsInAppContainer)
             {
-                Assert.ThrowsAny<UnauthorizedAccessException>(() => Create(Path.Combine(TestDirectory, path)));                
+                AssertExtensions.ThrowsAny<DirectoryNotFoundException, IOException, UnauthorizedAccessException>(() => Create(Path.Combine(TestDirectory, path))); 
             }
             else
             {

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -115,6 +115,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer        
         public void RootPath()
         {
             string dirName = Path.GetPathRoot(Directory.GetCurrentDirectory());
@@ -486,7 +487,14 @@ namespace System.IO.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void PathWithColons_ThrowsIOException_Core(string path)
         {
-            Assert.ThrowsAny<IOException>(() => Create(Path.Combine(TestDirectory, path)));
+            if (PlatformDetection.IsInAppContainer)
+            {
+                Assert.ThrowsAny<UnauthorizedAccessException>(() => Create(Path.Combine(TestDirectory, path)));                
+            }
+            else
+            {
+                Assert.ThrowsAny<IOException>(() => Create(Path.Combine(TestDirectory, path)));
+            }
         }
 
         [Theory,

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -381,6 +381,7 @@ namespace System.IO.Tests
         // We just care that we can access an accessible drive directly, we don't care which one.
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // drive labels
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer        
         public void DriveAsPath()
         {
             Assert.False(Exists(IOServices.GetNonExistentDrive()));
@@ -392,7 +393,9 @@ namespace System.IO.Tests
         public void ExtendedDriveAsPath()
         {
             Assert.False(Exists(IOInputs.ExtendedPrefix + IOServices.GetNonExistentDrive()));
-            Assert.Contains(IOServices.GetReadyDrives(), drive => Exists(IOInputs.ExtendedPrefix + drive));
+
+            if (PlatformDetection.IsNotInAppContainer)
+                Assert.Contains(IOServices.GetReadyDrives(), drive => Exists(IOInputs.ExtendedPrefix + drive));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -379,9 +379,8 @@ namespace System.IO.Tests
         // eg. Create a new volume, bitlocker it, and lock it. This new volume is no longer accessible
         // and any attempt to access this drive will return false.
         // We just care that we can access an accessible drive directly, we don't care which one.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer 
         [PlatformSpecific(TestPlatforms.Windows)] // drive labels
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer        
         public void DriveAsPath()
         {
             Assert.False(Exists(IOServices.GetNonExistentDrive()));

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -37,7 +37,6 @@ namespace System.IO.Tests
             Assert.True(di.Exists);
         }
 
-        [Fact]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         public void Root()
         {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -38,6 +38,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         public void Root()
         {
             Assert.True(new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory())).Exists);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
@@ -37,10 +37,9 @@ namespace System.IO.Tests
             Assert.Equal(path, info.ToString());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
         [PlatformSpecific(TestPlatforms.Windows)]  // Drive letter only
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         public void DriveOnlyReturnsPeriod_Windows_Desktop()
         {
             string path = @"C:";

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
@@ -40,6 +40,7 @@ namespace System.IO.Tests
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
         [PlatformSpecific(TestPlatforms.Windows)]  // Drive letter only
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         public void DriveOnlyReturnsPeriod_Windows_Desktop()
         {
             string path = @"C:";

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -79,6 +79,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         public void PageFileHasTimes()
         {
             // Typically there is a page file on the C: drive, if not, don't bother trying to track it down.

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -77,9 +77,8 @@ namespace System.IO.Tests
                 DateTimeKind.Utc);
         }
 
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void PageFileHasTimes()
         {
             // Typically there is a page file on the C: drive, if not, don't bother trying to track it down.

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -62,9 +62,20 @@ namespace System.IO.Tests
             testFile.Create().Dispose();
 
             if (invalidPath.Contains('\0'.ToString()))
+            {
                 Assert.Throws<ArgumentException>(() => Move(testFile.FullName, invalidPath));
+            }
             else
-                Assert.ThrowsAny<IOException>(() => Move(testFile.FullName, invalidPath));
+            {
+                if (PlatformDetection.IsInAppContainer)
+                {
+                    AssertExtensions.ThrowsAny<IOException, UnauthorizedAccessException>(() => Move(testFile.FullName, invalidPath));
+                }
+                else
+                {
+                    Assert.ThrowsAny<IOException>(() => Move(testFile.FullName, invalidPath));
+                }
+            }
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -168,7 +168,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         [PlatformSpecific(TestPlatforms.Windows)]
         public void PageFileExists()
         {

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -104,6 +104,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         public void PageFileHasTimes()
         {
             // Typically there is a page file on the C: drive, if not, don't bother trying to track it down.

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -101,10 +101,8 @@ namespace System.IO.Tests
             Assert.InRange(fi.CreationTimeUtc, before, fi.LastWriteTimeUtc);
         }
 
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void PageFileHasTimes()
         {
             // Typically there is a page file on the C: drive, if not, don't bother trying to track it down.

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -27,8 +27,14 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             Console.WriteLine($@"### CONFIGURATION: {dvs} OS={osd} OSVer={osv} OSArch={osa} Arch={pra} Framework={frd} LibcRelease={lcr} LibcVersion={lcv}");
 
-            Console.WriteLine($"### BINARIES: {Path.GetDirectoryName(typeof(object).Assembly.Location)} (drive {new DriveInfo(Path.GetDirectoryName(typeof(object).Assembly.Location)).DriveFormat})");
-            Console.WriteLine($"### TEMP PATH: {Path.GetTempPath()} (drive {new DriveInfo(Path.GetTempPath()).DriveFormat})");
+            var binariesLocation = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            var binariesLocationFormat = PlatformDetection.IsInAppContainer ? "Unknown" : new DriveInfo(binariesLocation).DriveFormat;
+            Console.WriteLine($"### BINARIES: {binariesLocation} (drive format {binariesLocationFormat})");
+
+            var tempPathLocation = Path.GetTempPath();
+            var tempPathLocationFormat = PlatformDetection.IsInAppContainer ? "Unknown" : new DriveInfo(tempPathLocation).DriveFormat;
+            Console.WriteLine($"### TEMP PATH: {tempPathLocation} (drive format {tempPathLocationFormat})");
+
             Console.WriteLine($"### CURRENT DIRECTORY: {Environment.CurrentDirectory}");
         }
 

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -27,12 +27,12 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             Console.WriteLine($@"### CONFIGURATION: {dvs} OS={osd} OSVer={osv} OSArch={osa} Arch={pra} Framework={frd} LibcRelease={lcr} LibcVersion={lcv}");
 
-            var binariesLocation = Path.GetDirectoryName(typeof(object).Assembly.Location);
-            var binariesLocationFormat = PlatformDetection.IsInAppContainer ? "Unknown" : new DriveInfo(binariesLocation).DriveFormat;
+            string binariesLocation = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            string binariesLocationFormat = PlatformDetection.IsInAppContainer ? "Unknown" : new DriveInfo(binariesLocation).DriveFormat;
             Console.WriteLine($"### BINARIES: {binariesLocation} (drive format {binariesLocationFormat})");
 
-            var tempPathLocation = Path.GetTempPath();
-            var tempPathLocationFormat = PlatformDetection.IsInAppContainer ? "Unknown" : new DriveInfo(tempPathLocation).DriveFormat;
+            string tempPathLocation = Path.GetTempPath();
+            string tempPathLocationFormat = PlatformDetection.IsInAppContainer ? "Unknown" : new DriveInfo(tempPathLocation).DriveFormat;
             Console.WriteLine($"### TEMP PATH: {tempPathLocation} (drive format {tempPathLocationFormat})");
 
             Console.WriteLine($"### CURRENT DIRECTORY: {Environment.CurrentDirectory}");


### PR DESCRIPTION
Almost all test failures in UWP F5 runs are failures in IO tests due to appcontainer. Fixes all those.

https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fuwp~2F/build/20180521.01/workItem/System.IO.FileSystem.Tests

In the process I noted that unfortunately `Assert.ThrowsAny<T>` means "throws T or derived type" whereas our own `AssertExtensions.ThrowsAny<T, U>`  means "throws T or U specifically". Really the latter should be renamed "ThrowsAnyOneOf".