### PR TITLE
Revert "Fix Uri.Host for IPv6 Link-local address (#29769)"

### DIFF
--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -31,7 +31,7 @@ namespace System
                 ((long*)numbers)[0] = 0L;
                 ((long*)numbers)[1] = 0L;
                 isLoopback = Parse(str, numbers, start, ref scopeId);
-                return '[' + CreateCanonicalName(numbers) + ((numbers[0] == 0xfe80) ? scopeId : "") + ']';
+                return '[' + CreateCanonicalName(numbers) + ']';
             }
         }
 

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -234,34 +234,6 @@ namespace System.PrivateUri.Tests
 
         #region IPv6
 
-        [Theory]
-        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18")]
-        [InlineData("Fe80::e077:c9a3:eeba:b8e9", "%18")]
-        [InlineData("fE80::e077:c9a3:eeba:b8e9", "%18")]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%18")]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10")]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "")]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%")]
-        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%\u30AF\u20E7")]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex)
-        {
-            string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
-            string literalIpV6Uri = "http://" + scopedLiteralIpv6;
-            var uri = new Uri(literalIpV6Uri);
-            Assert.Equal(scopedLiteralIpv6, uri.Host, ignoreCase: true);
-        }
-
-        [Theory]
-        [InlineData("fe81::e077:c9a3:eeba:b8e9", "%18")]
-        public void Host_NonIPv6LinkLocalAddress_NoScopeId(string address, string zoneIndex)
-        {
-            string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
-            string literalIpV6Uri = "http://" + scopedLiteralIpv6;
-            var uri = new Uri(literalIpV6Uri);
-            Assert.Equal("[" + address + "]", uri.Host);
-        }
-
         [Fact]
         public void UriIPv6Host_CanonicalCollonHex_Success()
         {


### PR DESCRIPTION
This reverts commit e1ded5ac59d5101a19ea549d19aa9532f2074239.

#29769 broke outerloop on both Windows and Linux, specifically the GetAsync_IPv6LinkLocalAddressUri_Success test with both the platform handlers and SocketsHttpHandler.

Fixes https://github.com/dotnet/corefx/issues/29812

cc: @rmkerr, @davidsh, @MarcoRossignoli