### PR TITLE
Fix websocket partial message receive test

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -32,28 +32,29 @@ namespace System.Net.WebSockets.Client.Tests
 
         public SendReceiveTest(ITestOutputHelper output) : base(output) { }
 
-        [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(9296)]
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_PartialMessageDueToSmallReceiveBuffer_Success(Uri server)
         {
-            var sendBuffer = new byte[1024];
+            const int SendBufferSize = 10;
+            var sendBuffer = new byte[SendBufferSize];
             var sendSegment = new ArraySegment<byte>(sendBuffer);
 
-            var receiveBuffer = new byte[1024];
+            var receiveBuffer = new byte[SendBufferSize / 2];
             var receiveSegment = new ArraySegment<byte>(receiveBuffer);
 
             using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
             {
                 var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
 
-                // The server will read buffers and aggregate it up to 64KB before echoing back a complete message.
-                // But since this test uses a receive buffer that is small, we will get back partial message fragments
-                // as we read them until we read the complete message payload.
-                for (int i = 0; i < 63; i++)
+                // The server will read buffers and aggregate it before echoing back a complete message.
+                // But since this test uses a receive buffer that is smaller than the complete message, we will get
+                // back partial message fragments as we read them until we read the complete message payload.
+                for (int i = 0; i < SendBufferSize*5; i++)
                 {
                     await SendAsync(cws, sendSegment, WebSocketMessageType.Binary, false, ctsDefault.Token);
                 }
+
                 await SendAsync(cws, sendSegment, WebSocketMessageType.Binary, true, ctsDefault.Token);
 
                 WebSocketReceiveResult recvResult = await ReceiveAsync(cws, receiveSegment, ctsDefault.Token);

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -50,7 +50,7 @@ namespace System.Net.WebSockets.Client.Tests
                 // The server will read buffers and aggregate it before echoing back a complete message.
                 // But since this test uses a receive buffer that is smaller than the complete message, we will get
                 // back partial message fragments as we read them until we read the complete message payload.
-                for (int i = 0; i < SendBufferSize*5; i++)
+                for (int i = 0; i < SendBufferSize * 5; i++)
                 {
                     await SendAsync(cws, sendSegment, WebSocketMessageType.Binary, false, ctsDefault.Token);
                 }


### PR DESCRIPTION
This test was originally disabled before we switched from WinHTTP to a managed
implementation on Windows. And any other failure noted on Linux was probably due
to a transient network/environment issue.

I simplified the test to use smaller buffer sizes which might help with any test
environment issues. These updated sizes still meet the requirements of what needs
to be tested. If we find that this test is still failing frequently then we will
switch to a loopback echo websocket server (which we don't have fully implemented yet).

Fixes #9296