### PR TITLE
Fix Uri.Host for IPv6 Link-local address

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
@@ -263,7 +263,8 @@ namespace System.Net.Http
                 Uri requestUri = _requestMessage.RequestUri;
 
                 long scopeId;
-                if (IsLinkLocal(requestUri, out scopeId))
+                bool isLinkLocal = false;
+                 if ((isLinkLocal = IsLinkLocal(requestUri, out scopeId)))
                 {
                     // Uri.AbsoluteUri doesn't include the ScopeId/ZoneID, so if it is link-local,
                     // we separately pass the scope to libcurl.
@@ -272,10 +273,11 @@ namespace System.Net.Http
                 }
 
                 EventSourceTrace("Url: {0}", requestUri);
+                int scopeIdIndex = 0;
                 string idnHost = requestUri.IdnHost;
-                string url = requestUri.Host == idnHost ? 
-                                requestUri.AbsoluteUri : 
-                                new UriBuilder(requestUri) { Host = idnHost }.Uri.AbsoluteUri;
+                string url = requestUri.Host == idnHost ?
+                             requestUri.AbsoluteUri :
+                             new UriBuilder(requestUri){ Host = isLinkLocal && (scopeIdIndex = idnHost.IndexOf("%", StringComparison.OrdinalIgnoreCase)) != -1 ? idnHost.Substring(0, scopeIdIndex) : idnHost}.Uri.AbsoluteUri;
 
                 SetCurlOption(CURLoption.CURLOPT_URL, url);
                 SetCurlOption(CURLoption.CURLOPT_PROTOCOLS, (long)(CurlProtocols.CURLPROTO_HTTP | CurlProtocols.CURLPROTO_HTTPS));

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
@@ -264,7 +264,7 @@ namespace System.Net.Http
 
                 long scopeId;
                 bool isLinkLocal = false;
-                 if ((isLinkLocal = IsLinkLocal(requestUri, out scopeId)))
+                if ((isLinkLocal = IsLinkLocal(requestUri, out scopeId)))
                 {
                     // Uri.AbsoluteUri doesn't include the ScopeId/ZoneID, so if it is link-local,
                     // we separately pass the scope to libcurl.
@@ -277,7 +277,7 @@ namespace System.Net.Http
                 string idnHost = requestUri.IdnHost;
                 string url = requestUri.Host == idnHost ?
                              requestUri.AbsoluteUri :
-                             new UriBuilder(requestUri){ Host = isLinkLocal && (scopeIdIndex = idnHost.IndexOf("%", StringComparison.OrdinalIgnoreCase)) != -1 ? idnHost.Substring(0, scopeIdIndex) : idnHost}.Uri.AbsoluteUri;
+                             new UriBuilder(requestUri){ Host = isLinkLocal && (scopeIdIndex = idnHost.IndexOf("%")) != -1 ? idnHost.Substring(0, scopeIdIndex) : idnHost}.Uri.AbsoluteUri;
 
                 SetCurlOption(CURLoption.CURLOPT_URL, url);
                 SetCurlOption(CURLoption.CURLOPT_PROTOCOLS, (long)(CurlProtocols.CURLPROTO_HTTP | CurlProtocols.CURLPROTO_HTTPS));

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -32,7 +32,7 @@ namespace System
                 ((long*)numbers)[1] = 0L;
                 isLoopback = Parse(str, numbers, start, ref scopeId);
                 linkLocalAddress = numbers[0] == 0xfe80;
-                return '[' + CreateCanonicalName(numbers) + (linkLocalAddress ? scopeId : "") + ']';
+                return "[" + CreateCanonicalName(numbers) + (linkLocalAddress ? scopeId : "") + "]";
             }
         }
 

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -22,7 +22,7 @@ namespace System
 
         // methods
 
-        internal static string ParseCanonicalName(string str, int start, ref bool isLoopback, ref string scopeId)
+        internal static string ParseCanonicalName(string str, int start, ref bool isLoopback, ref bool linkLocalAddress, ref string scopeId)
         {
             unsafe
             {
@@ -31,7 +31,8 @@ namespace System
                 ((long*)numbers)[0] = 0L;
                 ((long*)numbers)[1] = 0L;
                 isLoopback = Parse(str, numbers, start, ref scopeId);
-                return '[' + CreateCanonicalName(numbers) + ']';
+                linkLocalAddress = numbers[0] == 0xfe80;
+                return '[' + CreateCanonicalName(numbers) + (linkLocalAddress ? scopeId : "") + ']';
             }
         }
 

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -114,7 +114,7 @@ namespace System
             FragmentIriCanonical = 0x40000000000,
             IriCanonical = 0x78000000000,
             UnixPath = 0x100000000000,
-            LinkLocalAddress = 0x200000000000
+            IPv6LinkLocalAddress = 0x200000000000
         }
 
         private Flags _flags;
@@ -1194,7 +1194,7 @@ namespace System
                 if (HostType == Flags.IPv6HostType)
                 {
                     ret = ret.Substring(1, ret.Length - 2);
-                    if ((object)_info.ScopeId != null && (_flags & Flags.LinkLocalAddress) == 0)
+                    if ((object)_info.ScopeId != null && (_flags & Flags.IPv6LinkLocalAddress) == 0)
                     {
                         ret += _info.ScopeId;
                     }
@@ -2618,9 +2618,10 @@ namespace System
             {
                 flags |= Flags.LoopbackHost;
             }
+
             if (linkLocalAddress)
             {
-                flags |= Flags.LinkLocalAddress;
+                flags |= Flags.IPv6LinkLocalAddress;
             }
 
             return host;

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2617,7 +2617,7 @@ namespace System
             if (loopback)
             {
                 flags |= Flags.LoopbackHost;
-            }            
+            }
             if (linkLocalAddress)
             {
                 flags |= Flags.LinkLocalAddress;

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2617,11 +2617,12 @@ namespace System
             if (loopback)
             {
                 flags |= Flags.LoopbackHost;
-            }
-            if(linkLocalAddress)
+            }            
+            if (linkLocalAddress)
             {
                 flags |= Flags.LinkLocalAddress;
             }
+
             return host;
         }
 

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -114,6 +114,7 @@ namespace System
             FragmentIriCanonical = 0x40000000000,
             IriCanonical = 0x78000000000,
             UnixPath = 0x100000000000,
+            LinkLocalAddress = 0x200000000000
         }
 
         private Flags _flags;
@@ -1193,7 +1194,7 @@ namespace System
                 if (HostType == Flags.IPv6HostType)
                 {
                     ret = ret.Substring(1, ret.Length - 2);
-                    if ((object)_info.ScopeId != null)
+                    if ((object)_info.ScopeId != null && (_flags & Flags.LinkLocalAddress) == 0)
                     {
                         ret += _info.ScopeId;
                     }
@@ -2565,6 +2566,7 @@ namespace System
         private static string CreateHostStringHelper(string str, ushort idx, ushort end, ref Flags flags, ref string scopeId)
         {
             bool loopback = false;
+            bool linkLocalAddress = false;
             string host;
             switch (flags & Flags.HostTypeMask)
             {
@@ -2574,7 +2576,7 @@ namespace System
 
                 case Flags.IPv6HostType:
                     // The helper will return [...] string that is not suited for Dns.Resolve()
-                    host = IPv6AddressHelper.ParseCanonicalName(str, idx, ref loopback, ref scopeId);
+                    host = IPv6AddressHelper.ParseCanonicalName(str, idx, ref loopback, ref linkLocalAddress, ref scopeId);
                     break;
 
                 case Flags.IPv4HostType:
@@ -2615,6 +2617,10 @@ namespace System
             if (loopback)
             {
                 flags |= Flags.LoopbackHost;
+            }
+            if(linkLocalAddress)
+            {
+                flags |= Flags.LinkLocalAddress;
             }
             return host;
         }

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -1194,6 +1194,8 @@ namespace System
                 if (HostType == Flags.IPv6HostType)
                 {
                     ret = ret.Substring(1, ret.Length - 2);
+
+                    //To avoid duplicated ScopeId on Ipv6 local link address
                     if ((object)_info.ScopeId != null && (_flags & Flags.IPv6LinkLocalAddress) == 0)
                     {
                         ret += _info.ScopeId;

--- a/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
@@ -48,7 +48,7 @@ namespace System.PrivateUri.Tests
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18")]
-        public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdButNoBrackets(string address, string zoneIndex)
+        public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdCorrectlyFormatted(string address, string zoneIndex)
         {
             string scopedLiteralIpv6 = address + zoneIndex;
             string scopedLiteralIpv6Brackets = "[" + scopedLiteralIpv6 + "]";

--- a/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
@@ -45,7 +45,8 @@ namespace System.PrivateUri.Tests
             Assert.Equal("[::1]", test.Host);
         }
 
-        [Fact]        
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdButNoBrackets()
         {
             Uri test = new Uri("http://[fe80::e077:c9a3:eeba:b8e9%18]/");

--- a/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
@@ -49,16 +49,14 @@ namespace System.PrivateUri.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]        
         public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdCorrectlyFormatted()
         {
-            string address = "fe80::e077:c9a3:eeba:b8e9";
-            string zoneIndex = "%18";
+            const string ScopedLiteralIpv6 = "fe80::e077:c9a3:eeba:b8e9%18";
 
-            string scopedLiteralIpv6 = address + zoneIndex;
-            string scopedLiteralIpv6Brackets = "[" + scopedLiteralIpv6 + "]";
+            string scopedLiteralIpv6Brackets = "[" + ScopedLiteralIpv6 + "]";
             string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
             Uri test = new Uri(literalIpV6Uri);
 
-            Assert.Equal(scopedLiteralIpv6, test.DnsSafeHost);
-            Assert.Equal(scopedLiteralIpv6, test.IdnHost);
+            Assert.Equal(ScopedLiteralIpv6, test.DnsSafeHost);
+            Assert.Equal(ScopedLiteralIpv6, test.IdnHost);
             Assert.Equal(scopedLiteralIpv6Brackets, test.Host);
         }
 

--- a/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
@@ -45,6 +45,16 @@ namespace System.PrivateUri.Tests
             Assert.Equal("[::1]", test.Host);
         }
 
+        [Fact]        
+        public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdButNoBrackets()
+        {
+            Uri test = new Uri("http://[fe80::e077:c9a3:eeba:b8e9%18]/");
+
+            Assert.Equal("fe80::e077:c9a3:eeba:b8e9%18", test.DnsSafeHost);
+            Assert.Equal("fe80::e077:c9a3:eeba:b8e9%18", test.IdnHost);
+            Assert.Equal("[fe80::e077:c9a3:eeba:b8e9%18]", test.Host);
+        }
+
         [Fact]
         public void IdnDnsSafeHost_MixedCase_ToLowerCase()
         {

--- a/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
@@ -45,11 +45,13 @@ namespace System.PrivateUri.Tests
             Assert.Equal("[::1]", test.Host);
         }
 
-        [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18")]
-        public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdCorrectlyFormatted(string address, string zoneIndex)
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]        
+        public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdCorrectlyFormatted()
         {
+            string address = "fe80::e077:c9a3:eeba:b8e9";
+            string zoneIndex = "%18";
+
             string scopedLiteralIpv6 = address + zoneIndex;
             string scopedLiteralIpv6Brackets = "[" + scopedLiteralIpv6 + "]";
             string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;

--- a/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
@@ -45,15 +45,19 @@ namespace System.PrivateUri.Tests
             Assert.Equal("[::1]", test.Host);
         }
 
-        [Fact]
+        [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdButNoBrackets()
+        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18")]
+        public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdButNoBrackets(string address, string zoneIndex)
         {
-            Uri test = new Uri("http://[fe80::e077:c9a3:eeba:b8e9%18]/");
+            string scopedLiteralIpv6 = address + zoneIndex;
+            string scopedLiteralIpv6Brackets = "[" + scopedLiteralIpv6 + "]";
+            string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
+            Uri test = new Uri(literalIpV6Uri);
 
-            Assert.Equal("fe80::e077:c9a3:eeba:b8e9%18", test.DnsSafeHost);
-            Assert.Equal("fe80::e077:c9a3:eeba:b8e9%18", test.IdnHost);
-            Assert.Equal("[fe80::e077:c9a3:eeba:b8e9%18]", test.Host);
+            Assert.Equal(scopedLiteralIpv6, test.DnsSafeHost);
+            Assert.Equal(scopedLiteralIpv6, test.IdnHost);
+            Assert.Equal(scopedLiteralIpv6Brackets, test.Host);
         }
 
         [Fact]

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -246,18 +246,18 @@ namespace System.PrivateUri.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex)
         {
-            string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
-            string literalIpV6Uri = "http://" + scopedLiteralIpv6;
+            string scopedLiteralIpv6Brackets = "[" + address + zoneIndex + "]";
+            string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
             var uri = new Uri(literalIpV6Uri);
-            Assert.Equal(scopedLiteralIpv6, uri.Host, ignoreCase: true);
+            Assert.Equal(scopedLiteralIpv6Brackets, uri.Host, ignoreCase: true);
         }
 
         [Theory]
         [InlineData("fe81::e077:c9a3:eeba:b8e9", "%18")]
         public void Host_NonIPv6LinkLocalAddress_NoScopeId(string address, string zoneIndex)
         {
-            string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
-            string literalIpV6Uri = "http://" + scopedLiteralIpv6;
+            string scopedLiteralIpv6Brackets = "[" + address + zoneIndex + "]";
+            string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
             var uri = new Uri(literalIpV6Uri);
             Assert.Equal("[" + address + "]", uri.Host);
         }

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -251,11 +251,13 @@ namespace System.PrivateUri.Tests
             var uri = new Uri(literalIpV6Uri);
             Assert.Equal(scopedLiteralIpv6Brackets, uri.Host, ignoreCase: true);
         }
-
-        [Theory]
-        [InlineData("fe81::e077:c9a3:eeba:b8e9", "%18")]
-        public void Host_NonIPv6LinkLocalAddress_NoScopeId(string address, string zoneIndex)
+        
+        [Fact]
+        public void Host_NonIPv6LinkLocalAddress_NoScopeId()
         {
+            string address = "fe81::e077:c9a3:eeba:b8e9";
+            string zoneIndex = "%18";
+
             string scopedLiteralIpv6Brackets = "[" + address + zoneIndex + "]";
             string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
             var uri = new Uri(literalIpV6Uri);

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -255,13 +255,13 @@ namespace System.PrivateUri.Tests
         [Fact]
         public void Host_NonIPv6LinkLocalAddress_NoScopeId()
         {
-            string address = "fe81::e077:c9a3:eeba:b8e9";
-            string zoneIndex = "%18";
+            const string Address = "fe81::e077:c9a3:eeba:b8e9";
+            const string ZoneIndex = "%18";
 
-            string scopedLiteralIpv6Brackets = "[" + address + zoneIndex + "]";
+            string scopedLiteralIpv6Brackets = "[" + Address + ZoneIndex + "]";
             string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
             var uri = new Uri(literalIpV6Uri);
-            Assert.Equal("[" + address + "]", uri.Host);
+            Assert.Equal("[" + Address + "]", uri.Host);
         }
        
         [Fact]

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -234,6 +234,34 @@ namespace System.PrivateUri.Tests
 
         #region IPv6
 
+        [Theory]
+        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18")]
+        [InlineData("Fe80::e077:c9a3:eeba:b8e9", "%18")]
+        [InlineData("fE80::e077:c9a3:eeba:b8e9", "%18")]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%18")]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10")]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "")]
+        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%")]
+        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%\u30AF\u20E7")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex)
+        {
+            string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
+            string literalIpV6Uri = "http://" + scopedLiteralIpv6;
+            var uri = new Uri(literalIpV6Uri);
+            Assert.Equal(scopedLiteralIpv6, uri.Host, ignoreCase: true);
+        }
+
+        [Theory]
+        [InlineData("fe81::e077:c9a3:eeba:b8e9", "%18")]
+        public void Host_NonIPv6LinkLocalAddress_NoScopeId(string address, string zoneIndex)
+        {
+            string scopedLiteralIpv6 = "[" + address + zoneIndex + "]";
+            string literalIpV6Uri = "http://" + scopedLiteralIpv6;
+            var uri = new Uri(literalIpV6Uri);
+            Assert.Equal("[" + address + "]", uri.Host);
+        }
+       
         [Fact]
         public void UriIPv6Host_CanonicalCollonHex_Success()
         {


### PR DESCRIPTION
contributes to #28863 
replace PR #29769 after revert #29818 for Outerloop CI fail

this PR address the second part of issue:

2)  `Uri.Host` LLA (Link-local address) IPv6 address doesn't contain `%number` part.
* Currently it returns `[fe80::e077:c9a3:eeba:b8e9]`, it should return `[fe80::e077:c9a3:eeba:b8e9%18]`.
* Note: `Uri.IdnHost` correctly contains the `%number` part.

cc: @rmkerr @caesar1995 @davidsh @stephentoub 