### PR TITLE
[release/2.1] Port fix getting attributes for sharing violation files (#29790)

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/Common/src/Interop/Windows/Interop.Errors.cs
@@ -23,6 +23,8 @@ internal partial class Interop
         internal const int ERROR_SHARING_VIOLATION = 0x20;
         internal const int ERROR_LOCK_VIOLATION = 0x21;
         internal const int ERROR_HANDLE_EOF = 0x26;
+        internal const int ERROR_BAD_NETPATH = 0x35;
+        internal const int ERROR_BAD_NET_NAME = 0x43;
         internal const int ERROR_FILE_EXISTS = 0x50;
         internal const int ERROR_INVALID_PARAMETER = 0x57;
         internal const int ERROR_BROKEN_PIPE = 0x6D;
@@ -59,6 +61,7 @@ internal partial class Interop
         internal const int ERROR_DDE_FAIL = 0x484;
         internal const int ERROR_DLL_NOT_FOUND = 0x485;
         internal const int ERROR_NOT_FOUND = 0x490;
+        internal const int ERROR_NETWORK_UNREACHABLE = 0x4CF;
         internal const int ERROR_NON_ACCOUNT_SID = 0x4E9;
         internal const int ERROR_NOT_ALL_ASSIGNED = 0x514;
         internal const int ERROR_UNKNOWN_REVISION = 0x519;

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -200,12 +201,32 @@ namespace System.IO
                 if (!Interop.Kernel32.GetFileAttributesEx(path, Interop.Kernel32.GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, ref data))
                 {
                     errorCode = Marshal.GetLastWin32Error();
-                    if (errorCode == Interop.Errors.ERROR_ACCESS_DENIED)
+                    if (errorCode != Interop.Errors.ERROR_FILE_NOT_FOUND
+                        && errorCode != Interop.Errors.ERROR_PATH_NOT_FOUND
+                        && errorCode != Interop.Errors.ERROR_NOT_READY
+                        && errorCode != Interop.Errors.ERROR_INVALID_NAME
+                        && errorCode != Interop.Errors.ERROR_BAD_PATHNAME
+                        && errorCode != Interop.Errors.ERROR_BAD_NETPATH
+                        && errorCode != Interop.Errors.ERROR_BAD_NET_NAME
+                        && errorCode != Interop.Errors.ERROR_INVALID_PARAMETER
+                        && errorCode != Interop.Errors.ERROR_NETWORK_UNREACHABLE)
                     {
+                        // Assert so we can track down other cases (if any) to add to our test suite
+                        Debug.Assert(errorCode == Interop.Errors.ERROR_ACCESS_DENIED || errorCode == Interop.Errors.ERROR_SHARING_VIOLATION,
+                            $"Unexpected error code getting attributes {errorCode}");
+
                         // Files that are marked for deletion will not let you GetFileAttributes,
                         // ERROR_ACCESS_DENIED is given back without filling out the data struct.
                         // FindFirstFile, however, will. Historically we always gave back attributes
                         // for marked-for-deletion files.
+                        //
+                        // Another case where enumeration works is with special system files such as
+                        // pagefile.sys that give back ERROR_SHARING_VIOLATION on GetAttributes.
+                        //
+                        // Ideally we'd only try again for known cases due to the potential performance
+                        // hit. The last attempt to do so baked for nearly a year before we found the
+                        // pagefile.sys case. As such we're probably stuck filtering out specific 
+                        // cases that we know we don't want to retry on.
 
                         var findData = new Interop.Kernel32.WIN32_FIND_DATA();
                         using (SafeFindHandle handle = Interop.Kernel32.FindFirstFile(path, ref findData))

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.Tests
@@ -74,6 +75,22 @@ namespace System.IO.Tests
                 ((path, time) => File.SetLastWriteTimeUtc(path, time)),
                 ((path) => File.GetLastWriteTimeUtc(path)),
                 DateTimeKind.Utc);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void PageFileHasTimes()
+        {
+            // Typically there is a page file on the C: drive, if not, don't bother trying to track it down.
+            string pageFilePath = Directory.EnumerateFiles(@"C:\", "pagefile.sys").FirstOrDefault();
+            if (pageFilePath != null)
+            {
+                Assert.All(TimeFunctions(), (item) =>
+                {
+                    var time = item.Getter(pageFilePath);
+                    Assert.NotEqual(DateTime.FromFileTime(0), time);
+                });
+            }
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.InteropServices;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.Tests
@@ -129,6 +129,56 @@ namespace System.IO.Tests
             linkPathFI.Delete();
             linkPathFI.Refresh();
             Assert.False(linkPathFI.Exists, "linkPath should no longer exist");
+        }
+
+        [Fact]
+        public void UnsharedFileExists()
+        {
+            string path = GetTestFilePath();
+            using (FileStream stream = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None))
+            {
+                RemoteInvoke((p) =>
+                {
+                    FileInfo info = new FileInfo(p);
+                    Assert.True(info.Exists);
+                    return SuccessExitCode;
+                }, path).Dispose();
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.OSX)]
+        public void LockedFileExists()
+        {
+            string path = GetTestFilePath();
+            File.WriteAllBytes(path, new byte[10]);
+
+            using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                stream.Lock(0, 10);
+
+                RemoteInvoke((p) =>
+                {
+                    FileInfo info = new FileInfo(p);
+                    Assert.True(info.Exists);
+                    return SuccessExitCode;
+                }, path).Dispose();
+
+                stream.Unlock(0, 10);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void PageFileExists()
+        {
+            // Typically there is a page file on the C: drive, if not, don't bother trying to track it down.
+            string pageFilePath = Directory.EnumerateFiles(@"C:\", "pagefile.sys").FirstOrDefault();
+            if (pageFilePath != null)
+            {
+                FileInfo info = new FileInfo(pageFilePath);
+                Assert.True(info.Exists);
+            }
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -100,5 +100,22 @@ namespace System.IO.Tests
             // Assert.InRange is inclusive
             Assert.InRange(fi.CreationTimeUtc, before, fi.LastWriteTimeUtc);
         }
+
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void PageFileHasTimes()
+        {
+            // Typically there is a page file on the C: drive, if not, don't bother trying to track it down.
+            string pageFilePath = Directory.EnumerateFiles(@"C:\", "pagefile.sys").FirstOrDefault();
+            if (pageFilePath != null)
+            {
+                Assert.All(TimeFunctions(), (item) =>
+                {
+                    var time = item.Getter(new FileInfo(pageFilePath));
+                    Assert.NotEqual(DateTime.FromFileTime(0), time);
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
Ports #29790 to 2.1 for servicing (once open).

* Fix getting attributes for sharing violation files

Some files, such as the pagefile, refuse to allow you to get attributes directly.
You need to enumerate to get the attributes.

Enumerating is expensive, so we had changed from an opt-out to an opt-in. As
it took nearly a year to find this case, switching back to an opt-out with a
larger set of known cases where we get no value from trying again.

Also add an assert to flush out other error codes and scenarios.

* Skip lock test on MacOS (not supported)

* Nano was getting ERROR_NETWORK_UNREACHABLE