### PR TITLE
Fix HttpWebRequest Connection header test

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -474,8 +474,8 @@ namespace System.Net.Tests
                 List<string> requestLines = await serverTask;
                 if (!keepAlive.HasValue || keepAlive.Value)
                 {
-                    // Validate that the request doesn't contain Connection: "close", but we can't validate
-                    // that it does contain Connection: "keep-alive", as that's optional as of HTTP 1.1.
+                    // Validate that the request doesn't contain "Connection: close", but we can't validate
+                    // that it does contain "Connection: Keep-Alive", as that's optional as of HTTP 1.1.
                     Assert.DoesNotContain("Connection: close", requestLines, StringComparer.OrdinalIgnoreCase);
                 }
                 else

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -455,32 +455,35 @@ namespace System.Net.Tests
         [InlineData(null)]
         [InlineData(false)]
         [InlineData(true)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19225")]
-        public void KeepAlive_CorrectConnectionHeaderSent(bool? keepAlive)
+        public async Task KeepAlive_CorrectConnectionHeaderSent(bool? keepAlive)
         {
-            HttpWebRequest request = WebRequest.CreateHttp(Test.Common.Configuration.Http.RemoteEchoServer);
-
-            if (keepAlive.HasValue)
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
-                request.KeepAlive = keepAlive.Value;
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(url);
+                request.Proxy = null; // Don't use a proxy since it might interfere with the Connection: headers.
+                if (keepAlive.HasValue)
+                {
+                    request.KeepAlive = keepAlive.Value;
+                }
 
-            using (var response = (HttpWebResponse)request.GetResponse())
-            using (var body = new StreamReader(response.GetResponseStream()))
-            {
-                string content = body.ReadToEnd();
+                Task<WebResponse> getResponseTask = request.GetResponseAsync();
+                Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
+
+                await TaskTimeoutExtensions.WhenAllOrAnyFailed(new Task[] { getResponseTask, serverTask });
+
+                List<string> requestLines = await serverTask;
                 if (!keepAlive.HasValue || keepAlive.Value)
                 {
                     // Validate that the request doesn't contain Connection: "close", but we can't validate
                     // that it does contain Connection: "keep-alive", as that's optional as of HTTP 1.1.
-                    Assert.DoesNotContain("\"Connection\": \"close\"", content, StringComparison.OrdinalIgnoreCase);
+                    Assert.DoesNotContain("Connection: close", requestLines, StringComparer.OrdinalIgnoreCase);
                 }
                 else
                 {
-                    Assert.Contains("\"Connection\": \"close\"", content, StringComparison.OrdinalIgnoreCase);
-                    Assert.DoesNotContain("\"Keep-Alive\"", content, StringComparison.OrdinalIgnoreCase);
+                    Assert.Contains("Connection: close", requestLines, StringComparer.OrdinalIgnoreCase);
+                    Assert.DoesNotContain("Keep-Alive", requestLines, StringComparer.OrdinalIgnoreCase);
                 }
-            }
+            });
         }
 
         [Theory, MemberData(nameof(EchoServers))]


### PR DESCRIPTION
Change the test to use a loopback server instead of an external server. And make sure to
not use a proxy since it isn't needed anyway. These changes will improve the test reliability.

Fixes #19225
Fixes #28437