### PR TITLE
pal_signal: add missing mutex unlock when SIGCHLD==SIG_IGN

### DIFF
--- a/src/Native/Unix/System.Native/pal_signal.c
+++ b/src/Native/Unix/System.Native/pal_signal.c
@@ -146,6 +146,7 @@ static void* SignalHandlerLoop(void* arg)
                         } while (pid > 0);
                     }
                 }
+                pthread_mutex_unlock(&lock);
             }
 
             if (callback != NULL)


### PR DESCRIPTION
Child reapping was changed to be triggered by the SIGCHLD signal (https://github.com/dotnet/corefx/pull/26291).
As part of that change, code was added to handle the original handler being SIG_IGN.
In that case, there was a missing mutex unlock.

Fixes https://github.com/dotnet/corefx/issues/29841.

cc: @wfurt @janvorli @mateusrodrigues