### PR TITLE
[release/2.1] pal_signal: add missing mutex unlock when SIGCHLD==SIG_IGN (#29843)

### DIFF
--- a/src/Native/Unix/System.Native/pal_signal.c
+++ b/src/Native/Unix/System.Native/pal_signal.c
@@ -148,6 +148,7 @@ void* SignalHandlerLoop(void* arg)
                         } while (pid > 0);
                     }
                 }
+                pthread_mutex_unlock(&lock);
             }
 
             if (callback != NULL)


### PR DESCRIPTION
Port #29843 to release/2.1
Fixes https://github.com/dotnet/corefx/issues/29841
cc: @tmds, @joperezr, @wtgodbe 