### PR TITLE
Fix EventCounter Demo code to be more robust.

### DIFF
--- a/src/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md
+++ b/src/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md
@@ -19,7 +19,7 @@ public sealed class MinimalEventCounterSource : EventSource
     public static MinimalEventCounterSource Log = new MinimalEventCounterSource();
     private EventCounter requestCounter;
 
-    private MinimalEventCounterSource()
+    private MinimalEventCounterSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat) 
     {
         this.requestCounter = new EventCounter("request", this);
     }


### PR DESCRIPTION
There is a bug in PerfView where it will not decode EventCounter events propertly, and the EventCounter
demo program hits this bug (basically the issue is that EventSources that use both manifest based and
self-describing events trigger the issue).

This bug has been fixed in PerfView 2.0.16, but there are many old versions out there, a simple and
arguably good change to the demo program (to avoid using Manifest based parsing), avoids the problem.