### PR TITLE
Fix HttpClient TLS tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -16,7 +16,7 @@ namespace System.Net.Http.Functional.Tests
     using Configuration = System.Net.Test.Common.Configuration;
 
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "SslProtocols not supported on UAP")]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16805")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "SslProtocols property requires .NET 4.7.2")]
     public abstract partial class HttpClientHandler_SslProtocols_Test : HttpClientTestBase
     {
         [Fact]
@@ -46,7 +46,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SetProtocols_AfterRequest_ThrowsException()
         {
@@ -100,7 +99,6 @@ namespace System.Net.Http.Functional.Tests
 #pragma warning restore 0618
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(GetAsync_AllowedSSLVersion_Succeeds_MemberData))]
         public async Task GetAsync_AllowedSSLVersion_Succeeds(SslProtocols acceptedProtocol, bool requestOnlyThisProtocol)
@@ -214,7 +212,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_NoSpecifiedProtocol_DefaultsToTls12()
         {
@@ -242,27 +239,41 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
 #pragma warning disable 0618 // SSL2/3 are deprecated
         [InlineData(SslProtocols.Ssl2, SslProtocols.Tls12)]
         [InlineData(SslProtocols.Ssl3, SslProtocols.Tls12)]
 #pragma warning restore 0618
         [InlineData(SslProtocols.Tls11, SslProtocols.Tls)]
+        [InlineData(SslProtocols.Tls11 | SslProtocols.Tls12, SslProtocols.Tls)] // Skip this on WinHttpHandler.
         [InlineData(SslProtocols.Tls12, SslProtocols.Tls11)]
         [InlineData(SslProtocols.Tls, SslProtocols.Tls12)]
-        public async Task GetAsync_AllowedSSLVersionDiffersFromServer_ThrowsException(
-            SslProtocols allowedProtocol, SslProtocols acceptedProtocol)
+        public async Task GetAsync_AllowedClientSslVersionDiffersFromServer_ThrowsException(
+            SslProtocols allowedClientProtocols, SslProtocols acceptedServerProtocols)
         {
             if (!BackendSupportsSslConfiguration)
+            {
                 return;
+            }
+
+            if (IsWinHttpHandler && 
+                allowedClientProtocols == (SslProtocols.Tls11 | SslProtocols.Tls12) &&
+                acceptedServerProtocols == SslProtocols.Tls)
+            {
+                // Native WinHTTP sometimes uses multiple TCP connections to try other TLS protocols when
+                // getting TLS protocol failures as part of its TLS fallback algorithm. The loopback server
+                // doesn't expect this and stops listening for more connections. This causes unexpected test
+                // failures. See dotnet/corefx #8538.
+                return;
+            }
+
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (var client = new HttpClient(handler))
             {
-                handler.SslProtocols = allowedProtocol;
+                handler.SslProtocols = allowedClientProtocols;
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
 
-                var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };
+                var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedServerProtocols };
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     Task serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
@@ -280,58 +291,6 @@ namespace System.Net.Http.Functional.Tests
                     // We expect negotiation to fail so one or the other expected exception should be thrown.
                     Assert.True(false, "Expected exception did not happen.");
                 }, options);
-            }
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(8538, TestPlatforms.Windows)]
-        [Fact]
-        public async Task GetAsync_DisallowTls10_AllowTls11_AllowTls12()
-        {
-            using (HttpClientHandler handler = CreateHttpClientHandler())
-            using (var client = new HttpClient(handler))
-            {
-                handler.SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12;
-                handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-
-                if (BackendSupportsSslConfiguration)
-                {
-                    LoopbackServer.Options options = new LoopbackServer.Options { UseSsl = true };
-
-                    options.SslProtocols = SslProtocols.Tls;
-                    await LoopbackServer.CreateServerAsync(async (server, url) =>
-                    {
-                        Task serverTask =  server.AcceptConnectionSendResponseAndCloseAsync();
-                        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
-                        try
-                        {
-                            await serverTask;
-                        }
-                        catch (Exception e) when (e is IOException || e is AuthenticationException)
-                        {
-                            // Some SSL implementations simply close or reset connection after protocol mismatch.
-                            // Newer OpenSSL sends Fatal Alert message before closing.
-                            return;
-                        }
-                        // We expect negotiation to fail so one or the other expected exception should be thrown.
-                        Assert.True(false, "Expected exception did not happen.");
-                    }, options);
-
-                    foreach (var prot in new[] { SslProtocols.Tls11, SslProtocols.Tls12 })
-                    {
-                        options.SslProtocols = prot;
-                        await LoopbackServer.CreateServerAsync(async (server, url) =>
-                        {
-                            await TestHelper.WhenAllCompletedOrAnyFailed(
-                                server.AcceptConnectionSendResponseAndCloseAsync(),
-                                client.GetAsync(url));
-                        }, options);
-                    }
-                }
-                else
-                {
-                    await Assert.ThrowsAnyAsync<NotSupportedException>(() => client.GetAsync($"http://{Guid.NewGuid().ToString()}/"));
-                }
             }
         }
     }


### PR DESCRIPTION
Native WinHTTP sometimes uses multiple TCP connections to try other TLS protocols when
getting TLS protocol failures as part of its TLS fallback algorithm. The loopback server
doesn't expect this and stops listening for more connections. This causes unexpected test failures.

I confirmed this investigation comparing with a non-loopback server and WireShark traces. I discussed
this with the WinHTTP team.

SocketsHttpHandler, which uses SslStream for TLS, is able to optimize this and looks directly at
the TLS server-hello to determine if the connection is going to be compatible with the allowed client
TLS protocols. So, it doesn't use multiple TCP connections to determine a final failure outcome.

I also cleaned up the test code removing duplicate tests.

Fixes #8538