### PR TITLE
disable anonymnous cipher suites to match Windows and OSX behavior

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -510,9 +510,9 @@ CryptoNative_SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallba
 // delimiter ":" is used to allow more than one strings
 // below string is corresponding to "AllowNoEncryption"
 #define SSL_TXT_Separator ":"
-#define SSL_TXT_Exsclusion "!"
+#define SSL_TXT_Exclusion "!"
 #define SSL_TXT_AllIncludingNull SSL_TXT_ALL SSL_TXT_Separator SSL_TXT_eNULL
-#define SSL_TXT_NotAnon SSL_TXT_Separator SSL_TXT_Exsclusion SSL_TXT_aNULL
+#define SSL_TXT_NotAnon SSL_TXT_Separator SSL_TXT_Exclusion SSL_TXT_aNULL
 
 extern "C" int32_t CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
 {

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -510,7 +510,9 @@ CryptoNative_SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallba
 // delimiter ":" is used to allow more than one strings
 // below string is corresponding to "AllowNoEncryption"
 #define SSL_TXT_Separator ":"
+#define SSL_TXT_Exsclusion "!"
 #define SSL_TXT_AllIncludingNull SSL_TXT_ALL SSL_TXT_Separator SSL_TXT_eNULL
+#define SSL_TXT_NotAnon SSL_TXT_Separator SSL_TXT_Exsclusion SSL_TXT_aNULL
 
 extern "C" int32_t CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
 {
@@ -518,7 +520,7 @@ extern "C" int32_t CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPoli
     switch (policy)
     {
         case EncryptionPolicy::RequireEncryption:
-            cipherString = SSL_TXT_ALL;
+            cipherString = SSL_TXT_ALL SSL_TXT_NotAnon;
             break;
 
         case EncryptionPolicy::AllowNoEncryption:


### PR DESCRIPTION
The reason why this did not work and callback would have NULL certificate is that server did not sent any. TLS has obscure possibility to encrypt but not authenticate peer. With that, server would do anonymous DH key exchange instead of sending own certificate.  
This happens only when client (SSLStream in this case) offers such option and if server chooses it from the list. Windows do not have it in the list and that is why this happens to be platform difference. 

According to OpenSSL documentation:

> aNULL
> The cipher suites offering no authentication. This is currently the anonymous DH algorithms and anonymous ECDH algorithms. These cipher suites are vulnerable to a "man in the middle" attack and so their use is normally discouraged. These are excluded from the DEFAULT ciphers, but included in the ALL ciphers. Be careful when building cipherlists out of lower-level primitives such as kDHE or AES as these do overlap with the aNULL ciphers. When in doubt, include !aNULL in your cipher list.
> 

This change will take anonymous suite out of normal list used by default. When somebody forces less secure behavior, it would possibly stay in the list - that depends on OpenSSL compilation flags. 

Observer behavior only happens with specific combination of client/server. I did not find good way how to write unit test - since we do not have api to get or set cipher list. If anybody has suggestions, please let me know. 

Fixes #23681