### PR TITLE
fix multicast ttl for IPv6 on Unix

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1635,6 +1635,10 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionName, int32_t socketO
                     *optName = IPV6_MULTICAST_IF;
                     return true;
 
+                case SocketOptionName_SO_IP_MULTICAST_TTL:
+                    *optName = IPV6_MULTICAST_HOPS;
+                    return true;
+
                 default:
                     return false;
             }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -166,25 +166,29 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void MulticastTTL_Set_IPv4_Succeeds()
         {
-            Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-            // This should not throw. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
+            using ( Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            {
+                // This should not throw. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
 
-            int ttl = (int)socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive);
-            ttl += 1;
-            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, ttl);
-            Assert.Equal(ttl, (int)socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive));
+                int ttl = (int)socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive);
+                ttl += 1;
+                socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, ttl);
+                Assert.Equal(ttl, (int)socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive));
+            }
         }
 
         [Fact]
         public void MulticastTTL_Set_IPv6_Succeeds()
         {
-            Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
-            // This should not throw. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
+            using (Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp))
+            {
+                // This should not throw. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
 
-            int ttl = (int)socket.GetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive);
-            ttl += 1;
-            socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, ttl);
-            Assert.Equal(ttl, (int)socket.GetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive));
+                int ttl = (int)socket.GetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive);
+                ttl += 1;
+                socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, ttl);
+                Assert.Equal(ttl, (int)socket.GetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive));
+            }
         }
 
         [OuterLoop] // TODO: Issue #11345

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -166,7 +166,7 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void MulticastTTL_Set_IPv4_Succeeds()
         {
-            using ( Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
                 // This should not throw. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -163,6 +163,22 @@ namespace System.Net.Sockets.Tests
             await MulticastInterface_Set_IPv6_Helper(0);
         }
 
+        [Fact]
+        public void MulticastTTL_Set_IPv4_Succeeds()
+        {
+            Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            // This should not thow. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
+            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 2);
+        }
+
+        [Fact]
+        public void MulticastTTL_Set_IPv6_Succeeds()
+        {
+            Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
+            // This should not thow. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
+            socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, 2);
+        }
+
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -167,16 +167,24 @@ namespace System.Net.Sockets.Tests
         public void MulticastTTL_Set_IPv4_Succeeds()
         {
             Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-            // This should not thow. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
-            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 2);
+            // This should not throw. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
+
+            int ttl = (int)socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive);
+            ttl += 1;
+            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, ttl);
+            Assert.Equal(ttl, (int)socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive));
         }
 
         [Fact]
         public void MulticastTTL_Set_IPv6_Succeeds()
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
-            // This should not thow. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
-            socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, 2);
+            // This should not throw. We currently do not have good mechanism how to verify that the TTL/Hops is actually set.
+
+            int ttl = (int)socket.GetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive);
+            ttl += 1;
+            socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, ttl);
+            Assert.Equal(ttl, (int)socket.GetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive));
         }
 
         [OuterLoop] // TODO: Issue #11345


### PR DESCRIPTION
I verified that provided repro works on Windows 10. Using MulticastTimeToLive will set TTL for IPv4 and Hop Limit for IPv6.  This change will match that behavior on Unix. Unix has separate set of options for IPv6 so we need to fix it up.

Aside from the unit test, I verified with Wireshark that Hop limit will be set in outgoing multicast packets. Automatic functional testing is currently difficult with loop-back test but it should work as long as SetSocketOption succeeds. 

Fixes #29781
