### PR TITLE
Fix auto decompression behavior in Http handlers

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
@@ -52,6 +53,9 @@ namespace System.Net.Http
         internal static readonly Version HttpVersion20 = new Version(2, 0);
         internal static readonly Version HttpVersionUnknown = new Version(0, 0);
         private static readonly TimeSpan s_maxTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
+
+        private static readonly StringWithQualityHeaderValue s_gzipHeaderValue = new StringWithQualityHeaderValue("gzip");
+        private static readonly StringWithQualityHeaderValue s_deflateHeaderValue = new StringWithQualityHeaderValue("deflate");
 
         [ThreadStatic]
         private static StringBuilder t_requestHeadersBuilder;
@@ -607,7 +611,8 @@ namespace System.Net.Http
         private static void AddRequestHeaders(
             SafeWinHttpHandle requestHandle,
             HttpRequestMessage requestMessage,
-            CookieContainer cookies)
+            CookieContainer cookies,
+            DecompressionMethods manuallyProcessedDecompressionMethods)
         {
             // Get a StringBuilder to use for creating the request headers.
             // We cache one in TLS to avoid creating a new one for each request.
@@ -619,6 +624,26 @@ namespace System.Net.Http
             else
             {
                 t_requestHeadersBuilder = requestHeadersBuffer = new StringBuilder();
+            }
+
+            // Normally WinHttpHandler will let native WinHTTP add 'Accept-Encoding' request headers
+            // for gzip and/or default as needed based on whether the handler should do automatic
+            // decompression of response content. But on Windows 7, WinHTTP doesn't support this feature.
+            // So, we need to manually add these headers since WinHttpHandler still supports automatic
+            // decompression (by doing it within the handler).
+            if (manuallyProcessedDecompressionMethods != DecompressionMethods.None)
+            {
+                if ((manuallyProcessedDecompressionMethods & DecompressionMethods.GZip) == DecompressionMethods.GZip &&
+                    !requestMessage.Headers.AcceptEncoding.Contains(s_gzipHeaderValue))
+                {
+                    requestMessage.Headers.AcceptEncoding.Add(s_gzipHeaderValue);
+                }
+
+                if ((manuallyProcessedDecompressionMethods & DecompressionMethods.Deflate) == DecompressionMethods.Deflate &&
+                         !requestMessage.Headers.AcceptEncoding.Contains(s_deflateHeaderValue))
+                {
+                    requestMessage.Headers.AcceptEncoding.Add(s_deflateHeaderValue);
+                }
             }
 
             // Manually add cookies.
@@ -831,7 +856,8 @@ namespace System.Net.Http
                 AddRequestHeaders(
                     state.RequestHandle,
                     state.RequestMessage,
-                    _cookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer ? _cookieContainer : null);
+                    _cookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer ? _cookieContainer : null,
+                    _doManualDecompressionCheck ? _automaticDecompression : DecompressionMethods.None);
 
                 uint proxyAuthScheme = 0;
                 uint serverAuthScheme = 0;
@@ -882,7 +908,8 @@ namespace System.Net.Http
                 uint optionData = unchecked((uint)_receiveDataTimeout.TotalMilliseconds);
                 SetWinHttpOption(state.RequestHandle, Interop.WinHttp.WINHTTP_OPTION_RECEIVE_TIMEOUT, ref optionData);
 
-                HttpResponseMessage responseMessage = WinHttpResponseParser.CreateResponseMessage(state, _doManualDecompressionCheck);
+                HttpResponseMessage responseMessage =
+                    WinHttpResponseParser.CreateResponseMessage(state, _doManualDecompressionCheck ? _automaticDecompression : DecompressionMethods.None);
                 state.Tcs.TrySetResult(responseMessage);
 
                 // HttpStatusCode cast is needed for 308 Moved Permenantly, which we support but is not included in NetStandard status codes.

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -640,7 +640,7 @@ namespace System.Net.Http
                 }
 
                 if ((manuallyProcessedDecompressionMethods & DecompressionMethods.Deflate) == DecompressionMethods.Deflate &&
-                         !requestMessage.Headers.AcceptEncoding.Contains(s_deflateHeaderValue))
+                    !requestMessage.Headers.AcceptEncoding.Contains(s_deflateHeaderValue))
                 {
                     requestMessage.Headers.AcceptEncoding.Add(s_deflateHeaderValue);
                 }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -77,16 +77,14 @@ namespace System.Net.Http
 
                     if (contentEncodingLength > 0)
                     {
-                        if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(
-                            EncodingNameGzip, buffer, contentEncodingStartIndex, contentEncodingLength) &&
-                            (manuallyProcessedDecompressionMethods & DecompressionMethods.GZip) == DecompressionMethods.GZip)
+                        if ((manuallyProcessedDecompressionMethods & DecompressionMethods.GZip) == DecompressionMethods.GZip &&
+                            CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(EncodingNameGzip, buffer, contentEncodingStartIndex, contentEncodingLength))
                         {
                             decompressedStream = new GZipStream(responseStream, CompressionMode.Decompress);
                             stripEncodingHeaders = true;
                         }
-                        else if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(
-                            EncodingNameDeflate, buffer, contentEncodingStartIndex, contentEncodingLength) &&
-                            (manuallyProcessedDecompressionMethods & DecompressionMethods.Deflate) == DecompressionMethods.Deflate)
+                        else if ((manuallyProcessedDecompressionMethods & DecompressionMethods.Deflate) == DecompressionMethods.Deflate &&
+                                 CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(EncodingNameDeflate, buffer, contentEncodingStartIndex, contentEncodingLength))
                         {
                             decompressedStream = new DeflateStream(responseStream, CompressionMode.Decompress);
                             stripEncodingHeaders = true;

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestServer.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestServer.cs
@@ -16,6 +16,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public const string ExpectedResponseBody = "This is the response body.";
         public const string FakeServerEndpoint = "http://www.contoso.com/";
         public const string FakeSecureServerEndpoint = "https://www.contoso.com/";
+        public static readonly byte[] ExpectedResponseBodyBytes = Encoding.UTF8.GetBytes(ExpectedResponseBody);
 
         private static MemoryStream requestBody = null;
         private static MemoryStream responseBody = null;
@@ -132,23 +133,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             }
             else
             {
-                using (var memoryStream = new MemoryStream())
-                {
-                    Stream compressedStream = null;
-                    if (compressionKind == DecompressionMethods.Deflate)
-                    {
-                        compressedStream = new DeflateStream(memoryStream, CompressionMode.Compress);
-                    }
-                    else
-                    {
-                        compressedStream = new GZipStream(memoryStream, CompressionMode.Compress);
-                    }
-
-                    compressedStream.Write(responseBodyBytes, 0, responseBodyBytes.Length);
-                    compressedStream.Dispose();
-
-                    compressedBytes = memoryStream.ToArray();
-                }
+                compressedBytes = CompressBytes(responseBodyBytes, compressionKind == DecompressionMethods.GZip);
             }
 
             ResponseBody = compressedBytes;
@@ -168,6 +153,30 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             responseBody = new MemoryStream();
             responseHeaders = null;
             dataAvailablePercentage = 1.0;
+        }
+
+        public static byte[] CompressBytes(byte[] bytes, bool useGZip)
+        {
+            byte[] compressedBytes;
+
+            using (var memoryStream = new MemoryStream())
+            {
+                Stream compressedStream = null;
+                if (useGZip)
+                {
+                    compressedStream = new GZipStream(memoryStream, CompressionMode.Compress);
+                }
+                else
+                {
+                    compressedStream = new DeflateStream(memoryStream, CompressionMode.Compress);
+                }
+
+                compressedStream.Write(bytes, 0, bytes.Length);
+                compressedStream.Dispose();
+                compressedBytes = memoryStream.ToArray();
+            }
+
+            return compressedBytes;
         }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestServer.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestServer.cs
@@ -157,8 +157,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
         public static byte[] CompressBytes(byte[] bytes, bool useGZip)
         {
-            byte[] compressedBytes;
-
             using (var memoryStream = new MemoryStream())
             {
                 Stream compressedStream = null;
@@ -173,10 +171,9 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
                 compressedStream.Write(bytes, 0, bytes.Length);
                 compressedStream.Dispose();
-                compressedBytes = memoryStream.ToArray();
-            }
 
-            return compressedBytes;
+                return memoryStream.ToArray();
+            }
         }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -590,10 +590,11 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                     TestServer.SetResponse(DecompressionMethods.Deflate, TestServer.ExpectedResponseBody);
                 }))
             {
-                Assert.Null(response.Content.Headers.ContentLength);
-                string responseBody = await response.Content.ReadAsStringAsync();
-                Assert.Equal(0, response.Content.Headers.ContentEncoding.Count);
-                Assert.Equal(TestServer.ExpectedResponseBody, responseBody);
+                await VerifyResponseContent(
+                    TestServer.ExpectedResponseBodyBytes,
+                    response.Content,
+                    responseContentWasOriginallyCompressed: true,
+                    responseContentWasAutoDecompressed: true);
             }
         }
 
@@ -611,10 +612,11 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                     TestServer.SetResponse(DecompressionMethods.GZip, TestServer.ExpectedResponseBody);
                 }))
             {
-                Assert.Null(response.Content.Headers.ContentLength);
-                string responseBody = await response.Content.ReadAsStringAsync();
-                Assert.Equal(0, response.Content.Headers.ContentEncoding.Count);
-                Assert.Equal(TestServer.ExpectedResponseBody, responseBody);
+                await VerifyResponseContent(
+                    TestServer.ExpectedResponseBodyBytes,
+                    response.Content,
+                    responseContentWasOriginallyCompressed: true,
+                    responseContentWasAutoDecompressed: true);
             }
         }
 
@@ -631,9 +633,40 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                     handler.WindowsProxyUsePolicy = WindowsProxyUsePolicy.UseWinInetProxy;
                 }))
             {
-                Assert.NotNull(response.Content.Headers.ContentLength);
-                string responseBody = await response.Content.ReadAsStringAsync();
-                Assert.Equal(TestServer.ExpectedResponseBody, responseBody);
+                await VerifyResponseContent(
+                    TestServer.ExpectedResponseBodyBytes,
+                    response.Content,
+                    responseContentWasOriginallyCompressed: false,
+                    responseContentWasAutoDecompressed: false);
+
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SendAsync_NoWinHttpDecompressionSupport_AutoDecompressionSettingDiffers_ResponseIsNotDecompressed(bool responseIsGZip)
+        {
+            DecompressionMethods decompressionMethods = responseIsGZip ? DecompressionMethods.Deflate : DecompressionMethods.GZip;
+            _output.WriteLine("DecompressionMethods = {0}", decompressionMethods.ToString());
+
+            TestControl.WinHttpDecompressionSupport = false;
+            var handler = new WinHttpHandler();
+
+            using (HttpResponseMessage response = SendRequestHelper.Send(
+                handler,
+                delegate
+                {
+                    handler.AutomaticDecompression = decompressionMethods;
+                    TestServer.SetResponse(responseIsGZip ? DecompressionMethods.GZip : DecompressionMethods.Deflate, TestServer.ExpectedResponseBody);
+                }))
+            {
+                await VerifyResponseContent(
+                    TestServer.CompressBytes(TestServer.ExpectedResponseBodyBytes, useGZip: responseIsGZip),
+                    response.Content,
+                    responseContentWasOriginallyCompressed: true,
+                    responseContentWasAutoDecompressed: false);
+
             }
         }
 
@@ -902,7 +935,41 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                 }
             }
         }
-        
+
+        private async Task VerifyResponseContent(
+            byte[] expectedResponseBodyBytes,
+            HttpContent responseContent,
+            bool responseContentWasOriginallyCompressed,
+            bool responseContentWasAutoDecompressed)
+        {
+            Nullable<long> contentLength = responseContent.Headers.ContentLength;
+            ICollection<string> contentEncoding = responseContent.Headers.ContentEncoding;
+
+            _output.WriteLine("Response Content.Headers.ContentLength = {0}", contentLength.HasValue ? contentLength.Value.ToString() : "(null)");
+            _output.WriteLine("Response Content.Headers.ContentEncoding = {0}", contentEncoding.Count > 0 ? contentEncoding.ToString() : "(null)");
+            byte[] responseBodyBytes = await responseContent.ReadAsByteArrayAsync();
+            _output.WriteLine($"Response Body          = {BitConverter.ToString(responseBodyBytes)}");
+            _output.WriteLine($"Expected Response Body = {BitConverter.ToString(expectedResponseBodyBytes)}");
+
+            if (!responseContentWasOriginallyCompressed)
+            {
+                Assert.True(contentLength > 0);
+            }
+            else if (responseContentWasAutoDecompressed)
+            {
+                
+                Assert.Null(contentLength);
+                Assert.Equal(0, contentEncoding.Count);
+            }
+            else
+            {
+                Assert.True(contentLength > 0);
+                Assert.True(contentEncoding.Count > 0);
+            }
+
+            Assert.Equal<byte>(expectedResponseBodyBytes, responseBodyBytes);
+        }
+
         // Commented out as the test relies on finalizer for cleanup and only has value as written
         // when run on its own and manual analysis is done of logs.
         //[Fact]

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
@@ -39,15 +39,17 @@ namespace System.Net.Http
 
         protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (GZipEnabled)
+            if (GZipEnabled && !request.Headers.AcceptEncoding.Contains(s_gzipHeaderValue))
             {
                 request.Headers.AcceptEncoding.Add(s_gzipHeaderValue);
             }
-            if (DeflateEnabled)
+
+            if (DeflateEnabled && !request.Headers.AcceptEncoding.Contains(s_deflateHeaderValue))
             {
                 request.Headers.AcceptEncoding.Add(s_deflateHeaderValue);
             }
-            if (BrotliEnabled)
+
+            if (BrotliEnabled && !request.Headers.AcceptEncoding.Contains(s_brotliHeaderValue))
             {
                 request.Headers.AcceptEncoding.Add(s_brotliHeaderValue);
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
@@ -51,14 +51,14 @@ namespace System.Net.Http.Functional.Tests
         public async Task DecompressedResponse_MethodSpecified_DecompressedContentReturned(
             string encodingName, Func<Stream, Stream> compress, DecompressionMethods methods)
         {
-            _output.WriteLine($"encodingName={encodingName}");
-            _output.WriteLine($"methods={methods}");
-
             if (!UseSocketsHttpHandler && encodingName == "br")
             {
                 // Brotli only supported on SocketsHttpHandler.
                 return;
             }
+
+            _output.WriteLine($"encodingName={encodingName}");
+            _output.WriteLine($"methods={methods}");
 
             var expectedContent = new byte[12345];
             new Random(42).NextBytes(expectedContent);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
@@ -8,11 +8,19 @@ using System.IO.Compression;
 using System.Net.Test.Common;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
     public abstract class HttpClientHandler_Decompression_Test : HttpClientTestBase
     {
+        private readonly ITestOutputHelper _output;
+
+        public HttpClientHandler_Decompression_Test(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         public static IEnumerable<object[]> DecompressedResponse_MethodSpecified_DecompressedContentReturned_MemberData()
         {
             foreach (bool specifyAllMethods in new[] { false, true })
@@ -43,6 +51,15 @@ namespace System.Net.Http.Functional.Tests
         public async Task DecompressedResponse_MethodSpecified_DecompressedContentReturned(
             string encodingName, Func<Stream, Stream> compress, DecompressionMethods methods)
         {
+            _output.WriteLine($"encodingName={encodingName}");
+            _output.WriteLine($"methods={methods}");
+
+            if (!UseSocketsHttpHandler && encodingName == "br")
+            {
+                // Brotli only supported on SocketsHttpHandler.
+                return;
+            }
+
             var expectedContent = new byte[12345];
             new Random(42).NextBytes(expectedContent);
 
@@ -95,6 +112,15 @@ namespace System.Net.Http.Functional.Tests
         public async Task DecompressedResponse_MethodNotSpecified_OriginalContentReturned(
             string encodingName, Func<Stream, Stream> compress, DecompressionMethods methods)
         {
+            _output.WriteLine($"encodingName={encodingName}");
+            _output.WriteLine($"methods={methods}");
+
+            if (!UseSocketsHttpHandler && encodingName == "br")
+            {
+                // Brotli only supported on SocketsHttpHandler.
+                return;
+            }
+
             var expectedContent = new byte[12345];
             new Random(42).NextBytes(expectedContent);
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
@@ -57,9 +57,6 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            _output.WriteLine($"encodingName={encodingName}");
-            _output.WriteLine($"methods={methods}");
-
             var expectedContent = new byte[12345];
             new Random(42).NextBytes(expectedContent);
 
@@ -112,15 +109,6 @@ namespace System.Net.Http.Functional.Tests
         public async Task DecompressedResponse_MethodNotSpecified_OriginalContentReturned(
             string encodingName, Func<Stream, Stream> compress, DecompressionMethods methods)
         {
-            _output.WriteLine($"encodingName={encodingName}");
-            _output.WriteLine($"methods={methods}");
-
-            if (!UseSocketsHttpHandler && encodingName == "br")
-            {
-                // Brotli only supported on SocketsHttpHandler.
-                return;
-            }
-
             var expectedContent = new byte[12345];
             new Random(42).NextBytes(expectedContent);
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
@@ -109,6 +109,13 @@ namespace System.Net.Http.Functional.Tests
         public async Task DecompressedResponse_MethodNotSpecified_OriginalContentReturned(
             string encodingName, Func<Stream, Stream> compress, DecompressionMethods methods)
         {
+            if (IsCurlHandler && encodingName == "br")
+            {
+                // 'Content-Encoding' response header with Brotli causes error
+                // with some Linux distros of libcurl.
+                return;
+            }
+
             var expectedContent = new byte[12345];
             new Random(42).NextBytes(expectedContent);
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -679,6 +679,12 @@ namespace System.Net.Http.Functional.Tests
             string encodings,
             string manualAcceptEncodingHeaderValues)
         {
+            if (IsCurlHandler)
+            {
+                // Skip these tests on CurlHandler, dotnet/corefx #29905.
+                return;
+            }
+
             if (!UseSocketsHttpHandler &&
                 (encodings.Contains("br") || manualAcceptEncodingHeaderValues.Contains("br")))
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -13,6 +13,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -654,6 +655,70 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(response.Content.Headers.Contains("Content-Encoding"), "Content-Encoding unexpectedly found");
                 Assert.False(response.Content.Headers.Contains("Content-Length"), "Content-Length unexpectedly found");
             }
+        }
+
+        [Theory]
+#if netcoreapp
+        [InlineData(DecompressionMethods.Brotli, "br", "")]
+        [InlineData(DecompressionMethods.Brotli, "br", "br")]
+        [InlineData(DecompressionMethods.Brotli, "br", "gzip")]
+        [InlineData(DecompressionMethods.Brotli, "br", "gzip, deflate")]
+#endif
+        [InlineData(DecompressionMethods.GZip, "gzip", "")]
+        [InlineData(DecompressionMethods.Deflate, "deflate", "")]
+        [InlineData(DecompressionMethods.GZip | DecompressionMethods.Deflate, "gzip, deflate", "")]
+        [InlineData(DecompressionMethods.GZip, "gzip", "gzip")]
+        [InlineData(DecompressionMethods.Deflate, "deflate", "deflate")]
+        [InlineData(DecompressionMethods.GZip, "gzip", "deflate")]
+        [InlineData(DecompressionMethods.GZip, "gzip", "br")]
+        [InlineData(DecompressionMethods.Deflate, "deflate", "gzip")]
+        [InlineData(DecompressionMethods.Deflate, "deflate", "br")]
+        [InlineData(DecompressionMethods.GZip | DecompressionMethods.Deflate, "gzip, deflate", "gzip, deflate")]
+        public async Task GetAsync_SetAutomaticDecompression_AcceptEncodingHeaderSentWithNoDuplicates(
+            DecompressionMethods methods,
+            string encodings,
+            string manualAcceptEncodingHeaderValues)
+        {
+            if (!UseSocketsHttpHandler &&
+                (encodings.Contains("br") || manualAcceptEncodingHeaderValues.Contains("br")))
+            {
+                // Brotli encoding only supported on SocketsHttpHandler.
+                return;
+            }
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpClientHandler handler = CreateHttpClientHandler();
+                handler.AutomaticDecompression = methods;
+
+                using (var client = new HttpClient(handler))
+                {
+                    if (!string.IsNullOrEmpty(manualAcceptEncodingHeaderValues))
+                    {
+                        client.DefaultRequestHeaders.Add("Accept-Encoding", manualAcceptEncodingHeaderValues);
+                    }
+
+                    Task<HttpResponseMessage> clientTask = client.GetAsync(url);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
+                    await TaskTimeoutExtensions.WhenAllOrAnyFailed(new Task[] { clientTask, serverTask }); 
+
+                    List<string> requestLines = await serverTask;
+                    string requestLinesString = string.Join("\r\n", requestLines);
+                    _output.WriteLine(requestLinesString);
+
+                    Assert.InRange(Regex.Matches(requestLinesString, "Accept-Encoding").Count, 1, 1);
+                    Assert.InRange(Regex.Matches(requestLinesString, encodings).Count, 1, 1);
+                    if (!string.IsNullOrEmpty(manualAcceptEncodingHeaderValues))
+                    {
+                        Assert.InRange(Regex.Matches(requestLinesString, manualAcceptEncodingHeaderValues).Count, 1, 1);
+                    }
+
+                    using (HttpResponseMessage response = await clientTask)
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    }                    
+                }
+            });
         }
 
         [OuterLoop] // TODO: Issue #11345

--- a/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -42,6 +42,12 @@ namespace System.Net.Http.Functional.Tests
     }
 
 #if netcoreapp
+    public sealed class PlatformHandler_HttpClientHandler_Decompression_Tests : HttpClientHandler_Decompression_Test
+    {
+        public PlatformHandler_HttpClientHandler_Decompression_Tests(ITestOutputHelper output) : base(output) { }
+        protected override bool UseSocketsHttpHandler => false;
+    }
+
     public sealed class PlatformHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test
     {
         protected override bool UseSocketsHttpHandler => false;

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -56,6 +56,7 @@ namespace System.Net.Http.Functional.Tests
 
     public sealed class SocketsHttpHandler_HttpClientHandler_Decompression_Tests : HttpClientHandler_Decompression_Test
     {
+        public SocketsHttpHandler_HttpClientHandler_Decompression_Tests(ITestOutputHelper output) : base(output) { }
         protected override bool UseSocketsHttpHandler => true;
     }
 


### PR DESCRIPTION
Fixed a few bugs in both WinHttpHandler and SocketsHttpHandler regarding the behavior of
'Accept-Encoding' request headers and automatic decompression of response body content.

On Windows 7, native WinHTTP doesn't support automatic decompression. That also means it doesn't
automatically append 'Accept-Encoding' request headers. WinHttpHandler was relying on WinHTTP
to add those headers. But it wasn't happening on Windows 7. So, now WinHttpHandler will make
sure those headers are added if not already present. WinHttpHandler was also always decompressing
content even when the encodings in the .AutomaticDecompression property didn't match.

SocketsHttpHandler had a different bug. It would make sure that the 'Accept-Encoding' headers were
present when .AutomaticDecompression was being used. But it wouldn't check for existing headers and
duplicate encodings would be present in the outbound 'Accept-Encoding' request header.  I.e., it would
end up with "Accept-Encoding: gzip, gzip".

In addition to fixing these bugs, I added more tests to both Http Functional and WinHttpHandler Unit
tests (which can simulate running on Windows 7 using the existing mocks).

Fixes #29747
Fixes #26991