### PR TITLE
Make directory enumeration consistent

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/Common/src/Interop/Windows/Interop.Errors.cs
@@ -47,6 +47,7 @@ internal partial class Interop
         internal const int ERROR_PIPE_NOT_CONNECTED = 0xE9;
         internal const int ERROR_MORE_DATA = 0xEA;
         internal const int ERROR_NO_MORE_ITEMS = 0x103;
+        internal const int ERROR_DIRECTORY = 0x10B;
         internal const int ERROR_PARTIAL_COPY = 0x12B;
         internal const int ERROR_ARITHMETIC_OVERFLOW = 0x216;
         internal const int ERROR_PIPE_CONNECTED = 0x217;

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
@@ -66,20 +66,23 @@ namespace System.IO.Enumeration
             }
         }
 
-        private bool InternalContinueOnError(int error)
-            => (_options.IgnoreInaccessible && IsAccessError(error)) || ContinueOnError(error);
+        private bool InternalContinueOnError(Interop.ErrorInfo info)
+            => (_options.IgnoreInaccessible && IsAccessError(info)) || ContinueOnError(info.RawErrno);
 
-        private static bool IsAccessError(int error)
-            => error == (int)Interop.Error.EACCES || error == (int)Interop.Error.EBADF
-                || error == (int)Interop.Error.EPERM;
+        private static bool IsDirectoryNotFound(Interop.ErrorInfo info)
+            => info.Error == Interop.Error.ENOTDIR || info.Error == Interop.Error.ENOENT;
 
-        private IntPtr CreateDirectoryHandle(string path)
+        private static bool IsAccessError(Interop.ErrorInfo info)
+            => info.Error == Interop.Error.EACCES || info.Error == Interop.Error.EBADF
+                || info.Error == Interop.Error.EPERM;
+
+        private IntPtr CreateDirectoryHandle(string path, bool ignoreNotFound = false)
         {
             IntPtr handle = Interop.Sys.OpenDir(path);
             if (handle == IntPtr.Zero)
             {
                 Interop.ErrorInfo info = Interop.Sys.GetLastErrorInfo();
-                if (InternalContinueOnError(info.RawErrno))
+                if (InternalContinueOnError(info) || (ignoreNotFound && IsDirectoryNotFound(info)))
                 {
                     return IntPtr.Zero;
                 }
@@ -185,7 +188,7 @@ namespace System.IO.Enumeration
                     break;
                 default:
                     // Error
-                    if (InternalContinueOnError(result))
+                    if (InternalContinueOnError(new Interop.ErrorInfo(result)))
                     {
                         DirectoryFinished();
                         break;
@@ -197,10 +200,26 @@ namespace System.IO.Enumeration
             }
         }
 
-        private void DequeueNextDirectory()
+        private bool DequeueNextDirectory()
         {
+            if (_pending == null || _pending.Count == 0)
+                return false;
+
             _currentPath = _pending.Dequeue();
-            _directoryHandle = CreateDirectoryHandle(_currentPath);
+            _directoryHandle = CreateDirectoryHandle(_currentPath, ignoreNotFound: true);
+
+            // In Windows we open handles before we queue them, not after. If we fail to create the handle
+            // but are ok with it (IntPtr.Zero), we don't queue them. Unix can't handle having a lot of
+            // open handles, so we open after the fact.
+            //
+            // Doing the same on Windows would create a performance hit as we would no longer have the context
+            // of the parent handle to open from. Keeping the parent handle open would increase the amount of
+            // data we're maintaining, the number of active handles (they're not infinite), and the length
+            // of time we have handles open (preventing some actions such as renaming/deleting/etc.).
+
+            // If we couldn't open and didn't throw, just attempt to move on.
+            return _directoryHandle == IntPtr.Zero
+                ? DequeueNextDirectory() : true;
         }
 
         private void InternalDispose(bool disposing)
@@ -208,7 +227,7 @@ namespace System.IO.Enumeration
             // It is possible to fail to allocate the lock, but the finalizer will still run
             if (_lock != null)
             {
-                lock(_lock)
+                lock (_lock)
                 {
                     _lastEntryFound = true;
                     _pending = null;

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
@@ -43,7 +43,7 @@ namespace System.IO.Enumeration
         {
             // We don't have access to any APIs that allow us to pass in a base handle in UAP,
             // just call our "normal" handle open.
-            return CreateDirectoryHandle(fullPath, ignoreNotFound = true);
+            return CreateDirectoryHandle(fullPath, ignoreNotFound: true);
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
@@ -43,7 +43,7 @@ namespace System.IO.Enumeration
         {
             // We don't have access to any APIs that allow us to pass in a base handle in UAP,
             // just call our "normal" handle open.
-            return CreateDirectoryHandle(fullPath);
+            return CreateDirectoryHandle(fullPath, ignoreNotFound = true);
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -87,7 +88,7 @@ namespace System.IO.Enumeration
         /// <summary>
         /// Simple wrapper to allow creating a file handle for an existing directory.
         /// </summary>
-        private IntPtr CreateDirectoryHandle(string path)
+        private IntPtr CreateDirectoryHandle(string path, bool ignoreNotFound = false)
         {
             IntPtr handle = Interop.Kernel32.CreateFile_IntPtr(
                 path,
@@ -100,8 +101,7 @@ namespace System.IO.Enumeration
             {
                 int error = Marshal.GetLastWin32Error();
 
-                if ((error == Interop.Errors.ERROR_ACCESS_DENIED &&
-                    _options.IgnoreInaccessible) || ContinueOnError(error))
+                if (ContinueOnDirectoryError(error, ignoreNotFound))
                 {
                     return IntPtr.Zero;
                 }
@@ -116,6 +116,17 @@ namespace System.IO.Enumeration
             }
 
             return handle;
+        }
+
+        private bool ContinueOnDirectoryError(int error, bool ignoreNotFound)
+        {
+            // Directories can be removed (ERROR_FILE_NOT_FOUND) or replaced with a file of the same name (ERROR_DIRECTORY) while
+            // we are enumerating. The only reasonable way to handle this is to simply move on. There is no such thing as a "true"
+            // snapshot of filesystem state- our "snapshot" will consider the name non-existent in this rare case.
+
+            return (ignoreNotFound && (error == Interop.Errors.ERROR_FILE_NOT_FOUND || error == Interop.Errors.ERROR_PATH_NOT_FOUND || error == Interop.Errors.ERROR_DIRECTORY))
+                || (error == Interop.Errors.ERROR_ACCESS_DENIED && _options.IgnoreInaccessible)
+                || ContinueOnError(error);
         }
 
         public bool MoveNext()
@@ -195,9 +206,13 @@ namespace System.IO.Enumeration
                 _entry = (Interop.NtDll.FILE_FULL_DIR_INFORMATION*)_pinnedBuffer.AddrOfPinnedObject();
         }
 
-        private void DequeueNextDirectory()
+        private bool DequeueNextDirectory()
         {
+            if (_pending == null || _pending.Count == 0)
+                return false;
+
             (_directoryHandle, _currentPath) = _pending.Dequeue();
+            return true;
         }
 
         private void InternalDispose(bool disposing)

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.cs
@@ -32,8 +32,8 @@ namespace System.IO.Enumeration
         protected virtual void OnDirectoryFinished(ReadOnlySpan<char> directory) { }
 
         /// <summary>
-        /// Called when a native API returns an error. Return true to continue, or false
-        /// to throw the default exception for the given error.
+        /// Called when a native API returns an error that would normally cause a throw.
+        /// Return true to continue, or false to throw the default exception for the given error.
         /// </summary>
         /// <param name="error">The native error code.</param>
         protected virtual bool ContinueOnError(int error) => false;

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.cs
@@ -50,14 +50,13 @@ namespace System.IO.Enumeration
             CloseDirectoryHandle();
             OnDirectoryFinished(_currentPath);
 
-            if (_pending == null || _pending.Count == 0)
+            // Attempt to grab another directory to process
+            if (!DequeueNextDirectory())
             {
                 _lastEntryFound = true;
             }
             else
             {
-                // Grab the next directory to parse
-                DequeueNextDirectory();
                 FindNextEntry();
             }
         }

--- a/src/System.IO.FileSystem/tests/Enumeration/RemovedDirectoryTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/RemovedDirectoryTests.netcoreapp.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.IO.Enumeration;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests.Enumeration
@@ -44,8 +39,61 @@ namespace System.IO.Tests.Enumeration
 
             using (var enumerator = new DirectoryFinishedEnumerator(testDirectory.FullName, new EnumerationOptions { RecurseSubdirectories = true }))
             {
-                enumerator.DirectoryFinishedAction = (d) => testSubdirectory.Delete();
-                Assert.Throws<DirectoryNotFoundException>(() => { while (enumerator.MoveNext()); });
+                enumerator.DirectoryFinishedAction = (d) =>
+                {
+                    if (d.Equals(testDirectory.FullName, StringComparison.OrdinalIgnoreCase)) testSubdirectory.Delete();
+                };
+
+                // We shouldn't fail because a directory we found got deleted.
+                // No errors here are possible on Windows as by the time of the deletion above, the subdirectory handle is already opened.
+                while (enumerator.MoveNext());
+            }
+        }
+
+        [Fact]
+        public void RemoveDirectoryBeforeHandleCreation()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            FileInfo testFile = new FileInfo(Path.Join(testDirectory.FullName, GetTestFileName()));
+            testFile.Create().Dispose();
+            DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Join(testDirectory.FullName, "Subdirectory"));
+
+            using (var enumerator = new DirectoryFinishedEnumerator(testDirectory.FullName, new EnumerationOptions { RecurseSubdirectories = true }))
+            {
+                // We shouldn't fail because a directory we found got deleted.
+                // If we yank the directory when we have it's data, but BEFORE we create the handle we'll fail internally with not found.
+                while (enumerator.MoveNext())
+                {
+                    // Using a flag file to kill the directory in the middle of processing returned data
+                    if (string.Equals(enumerator.Current, testFile.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        testSubdirectory.Delete();
+                    }
+                };
+            }
+        }
+
+        [Fact]
+        public void RemoveDirectoryBeforeHandleCreationAndReplaceWithFile()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            FileInfo testFile = new FileInfo(Path.Join(testDirectory.FullName, GetTestFileName()));
+            testFile.Create().Dispose();
+            DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Join(testDirectory.FullName, "Subdirectory"));
+
+            using (var enumerator = new DirectoryFinishedEnumerator(testDirectory.FullName, new EnumerationOptions { RecurseSubdirectories = true }))
+            {
+                // We shouldn't fail because a directory we found got deleted.
+                // If replace the directory with a file when we have it's data, but BEFORE we create the handle we'll fail internally trying to create a directory handle on it.
+                while (enumerator.MoveNext())
+                {
+                    // Using a flag file to replace the directory in the middle of processing returned data
+                    if (string.Equals(enumerator.Current, testFile.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        testSubdirectory.Delete();
+                        File.Create(testSubdirectory.FullName).Dispose();
+                    }
+                };
             }
         }
     }


### PR DESCRIPTION
Directories can disappear or be replaced with files after we find them when recursively enumerating. Fix so we don't throw in these cases.

Also make queue handling consistent between Unix/Windows. In error skipping cases we need to be sure that we don't try to process directories we fail to open but don't care about. This simplifies custom error handling.

Fix error mapping in Unix. Add tests.

As custom error handling is pretty much broken on Unix I think we should consider for 2.1.1. Risk should be low, and will avoid breaking those that try to work around it if we don't fix.
