### PR TITLE
Dispose sockets from failed static Socket.ConnectAsync calls with non-DnsEndPoints

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
@@ -335,7 +335,7 @@ namespace System.Net.Sockets
                 _internalArgs.Dispose();
             }
 
-            _userArgs.FinishOperationAsyncFailure(e, 0, SocketFlags.None);
+            _userArgs.FinishConnectByNameAsyncFailure(e, 0, SocketFlags.None);
         }
 
         public void Cancel()

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3815,7 +3815,10 @@ namespace System.Net.Sockets
             return pending;
         }
 
-        public bool ConnectAsync(SocketAsyncEventArgs e)
+        public bool ConnectAsync(SocketAsyncEventArgs e) =>
+            ConnectAsync(e, userSocket: true);
+
+        private bool ConnectAsync(SocketAsyncEventArgs e, bool userSocket)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
             bool pending;
@@ -3862,10 +3865,10 @@ namespace System.Net.Sockets
                     throw new NotSupportedException(SR.net_invalidversion);
                 }
 
-                MultipleConnectAsync multipleConnectAsync = new SingleSocketMultipleConnectAsync(this, true);
+                MultipleConnectAsync multipleConnectAsync = new SingleSocketMultipleConnectAsync(this, userSocket: true);
 
                 e.StartOperationCommon(this, SocketAsyncOperation.Connect);
-                e.StartOperationConnect(multipleConnectAsync);
+                e.StartOperationConnect(multipleConnectAsync, userSocket: true);
 
                 pending = multipleConnectAsync.StartConnectAsync(e, dnsEP);
             }
@@ -3903,7 +3906,7 @@ namespace System.Net.Sockets
 
                 // Prepare for the native call.
                 e.StartOperationCommon(this, SocketAsyncOperation.Connect);
-                e.StartOperationConnect();
+                e.StartOperationConnect(multipleConnect: null, userSocket);
 
                 // Make the native call.
                 SocketError socketError = SocketError.Success;
@@ -3962,18 +3965,18 @@ namespace System.Net.Sockets
                 else
                 {
                     attemptSocket = new Socket(dnsEP.AddressFamily, socketType, protocolType);
-                    multipleConnectAsync = new SingleSocketMultipleConnectAsync(attemptSocket, false);
+                    multipleConnectAsync = new SingleSocketMultipleConnectAsync(attemptSocket, userSocket: false);
                 }
 
                 e.StartOperationCommon(attemptSocket, SocketAsyncOperation.Connect);
-                e.StartOperationConnect(multipleConnectAsync);
+                e.StartOperationConnect(multipleConnectAsync, userSocket: false);
 
                 pending = multipleConnectAsync.StartConnectAsync(e, dnsEP);
             }
             else
             {
                 Socket attemptSocket = new Socket(endPointSnapshot.AddressFamily, socketType, protocolType);
-                pending = attemptSocket.ConnectAsync(e);
+                pending = attemptSocket.ConnectAsync(e, userSocket: false);
             }
 
             if (NetEventSource.IsEnabled) NetEventSource.Exit(null, pending);


### PR DESCRIPTION
The static Socket.ConnectAsync manufactures a Socket instance and only hands it back to the developer via the SocketAsyncEventArgs if the operation completes successfully.  If it instead fails, Socket.ConnectAsync should be disposing the instance, to avoid waiting for finalizer to clean up eventually.  It was doing so in the case of a DnsEndPoint, but not for other end points.  This fixes that.

I don't love the fix, but given the APIs exposed, I'm not aware of a better approach.  There's no test here as I'm not aware of a good automated way to verify it, but I did verify it's fixed using PerfView and ETW events emitted for finalized objects.  Using this repro:
```C#
using System;
using System.Linq;
using System.Net;
using System.Net.Sockets;
using System.Threading.Tasks;

class Program
{
    public static void Main()
    {
        Task[] tasks = Enumerable.Range(0, 100).Select(async _ =>
        {
            var tcs = new TaskCompletionSource<bool>();
            using (var e = new SocketAsyncEventArgs())
            {
                e.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 12345);
                e.Completed += delegate { tcs.SetResult(true); };
                if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, e)) await tcs.Task;
            }                
        }).ToArray();
        try { Task.WaitAll(tasks); } catch { }
        GC.Collect();
        GC.WaitForPendingFinalizers();
    }
}
```
before the fix I see this in PerfView for finalized objects:

| Type | Count |
| -- | -- |
| System.Net.Sockets.Socket | 100 |
| System.Net.Sockets.SafeCloseSocket | 100 |
| Microsoft.Win32.SafeHandles.SafeRegistryHandle | 1 |
| System.Gen2GcCallback | 1 |

and after:

| Type | Count |
| -- | -- |
| Microsoft.Win32.SafeHandles.SafeRegistryHandle | 1 |
| System.Gen2GcCallback | 1 |

Fixes https://github.com/dotnet/corefx/issues/29285
I fixed this now as I expect it'll be important for https://github.com/dotnet/corefx/pull/29792.
cc: @davidsh, @geoffkizer, @rmkerr 