### PR TITLE
Use FreeAddrInfoExW instead of FreeAddrInfoEx in Dns

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.GetAddrInfoExW.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.GetAddrInfoExW.cs
@@ -30,7 +30,7 @@ internal static partial class Interop
         );
 
         [DllImport("ws2_32.dll", ExactSpelling = true, SetLastError = true)]
-        internal static extern unsafe void FreeAddrInfoEx([In] AddressInfoEx* pAddrInfo);
+        internal static extern unsafe void FreeAddrInfoExW([In] AddressInfoEx* pAddrInfo);
     }
 }
 

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -504,7 +504,7 @@ namespace System.Net
             public static void FreeContext(GetAddrInfoExContext* context)
             {
                 if (context->Result != null)
-                    Interop.Winsock.FreeAddrInfoEx(context->Result);
+                    Interop.Winsock.FreeAddrInfoExW(context->Result);
 
                 Marshal.FreeHGlobal((IntPtr)context);
             }


### PR DESCRIPTION
We should be using the W version to match the GetAddrInfoExW version we're using explicitly.

cc: @jkotas 