### PR TITLE
Remove Xamarin placeholder for System.Memory package

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2408,13 +2408,7 @@
     "System.Memory": {
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0",
-        "monoandroid10": "Any",
-        "monotouch10": "Any",
-        "uap10.0.16300": "4.1.0.0",
-        "xamarinios10": "Any",
-        "xamarinmac20": "Any",
-        "xamarintvos10": "Any",
-        "xamarinwatchos10": "Any"
+        "uap10.0.16300": "4.1.0.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2412,7 +2412,7 @@
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
-        "4.0.1.0": "4.5.0"
+        "4.0.1.0": "4.5.1"
       }
     },
     "System.Messaging": {

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -3,6 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <PackageVersion>4.5.1</PackageVersion>
     <!-- System.Memory has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.0.* -->
     <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.1.0.0</AssemblyVersion>

--- a/src/System.Memory/pkg/System.Memory.pkgproj
+++ b/src/System.Memory/pkg/System.Memory.pkgproj
@@ -7,7 +7,6 @@
       <SupportedFramework>net45;netcore45;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Memory.csproj" />
-    <InboxOnTargetFramework  Include="$(AllXamarinFrameworks)" />
     <InboxOnTargetFramework  Include="netcoreapp2.1" />
     <InboxOnTargetFramework  Include="$(UAPvNextTFM)" />
   </ItemGroup>


### PR DESCRIPTION
Having Xamarin placeholder in System.Memory package causing using the inbox implementation version of this library which was the original intention of the change. But because of the inbox implementation of the library is not synced with the latest changes we have in 2.1, we revert the placeholder change so we force the package to have assets for the library and not using the inbox version. We are keeping this change in master branch as this what we need for the future.

#29847
