### PR TITLE
Allow EnvelopedCms to round-trip correctly cross platform when ContentInfo is not Pkcs7Data

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
@@ -157,18 +157,37 @@ namespace Internal.Cryptography.Pal.AnyOS
                 }
                 else
                 {
-                    using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+                    try
                     {
-                        writer.PushSequence();
-                        AsnReader reader = new AsnReader(decrypted, AsnEncodingRules.BER);
-
-                        while (reader.HasData)
+                        using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
                         {
-                            writer.WriteEncodedValue(reader.GetEncodedValue());
-                        }
+                            writer.PushSequence();
+                            AsnReader reader = new AsnReader(decrypted, AsnEncodingRules.BER);
 
-                        writer.PopSequence();
-                        decrypted = writer.Encode();
+                            while (reader.HasData)
+                            {
+                                writer.WriteEncodedValue(reader.GetEncodedValue());
+                            }
+
+                            writer.PopSequence();
+                            decrypted = writer.Encode();
+                        }
+                    }
+                    catch (CryptographicException)
+                    {
+                        // Decrypted data is not ASN.1 as expected.
+                        // For compatibility with Windows we will wrap it with the sequence tag
+                        // and create invalid sequence (content is not ASN.1)
+                        using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+                        {
+                            // Writer does not have a way to create an invalid ASN.1.
+                            // We will encode it as octet string to bypass validation
+                            // and replace octet string tag (0x04) with sequence tag (0x30)
+                            writer.WriteOctetString(decrypted);
+                            decrypted = writer.Encode();
+                            Debug.Assert(decrypted[0] == 0x04);
+                            decrypted[0] = 0x30;
+                        }
                     }
                 }
 

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
@@ -155,6 +155,22 @@ namespace Internal.Cryptography.Pal.AnyOS
                         }
                     }
                 }
+                else
+                {
+                    using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+                    {
+                        writer.PushSequence();
+                        AsnReader reader = new AsnReader(decrypted, AsnEncodingRules.DER);
+
+                        while (reader.HasData)
+                        {
+                            writer.WriteEncodedValue(reader.GetEncodedValue());
+                        }
+
+                        writer.PopSequence();
+                        decrypted = writer.Encode();
+                    }
+                }
 
                 exception = null;
                 return new ContentInfo(

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
@@ -157,10 +157,10 @@ namespace Internal.Cryptography.Pal.AnyOS
                 }
                 else
                 {
-                    using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+                    using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
                     {
                         writer.PushSequence();
-                        AsnReader reader = new AsnReader(decrypted, AsnEncodingRules.DER);
+                        AsnReader reader = new AsnReader(decrypted, AsnEncodingRules.BER);
 
                         while (reader.HasData)
                         {

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
@@ -182,30 +182,14 @@ namespace Internal.Cryptography.Pal.AnyOS
                 }
                 else
                 {
-                    using (MemoryStream memoryStream = new MemoryStream())
+                    if (contentInfo.Content.Length == 0)
                     {
-                        using (var cryptoStream = new CryptoStream(memoryStream, encryptor, CryptoStreamMode.Write))
-                        {
-                            AsnReader reader = new AsnReader(contentInfo.Content, AsnEncodingRules.BER);
-                            AsnReader innerReader = reader.ReadSequence();
-
-                            if (reader.HasData)
-                            {
-                                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-                            }
-
-                            while (innerReader.HasData)
-                            {
-#if netcoreapp
-                                cryptoStream.Write(innerReader.GetEncodedValue().Span);
-#else
-                                byte[] encoded = innerReader.GetEncodedValue().ToArray();
-                                cryptoStream.Write(encoded, 0, encoded.Length);
-#endif
-                            }
-                        }
-
-                        return memoryStream.ToArray();
+                        return encryptor.OneShot(contentInfo.Content);
+                    }
+                    else
+                    {
+                        AsnReader reader = new AsnReader(contentInfo.Content, AsnEncodingRules.BER);
+                        return encryptor.OneShot(reader.PeekContentBytes().ToArray());
                     }
                 }
             }

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
@@ -186,7 +186,7 @@ namespace Internal.Cryptography.Pal.AnyOS
                     {
                         using (var cryptoStream = new CryptoStream(memoryStream, encryptor, CryptoStreamMode.Write))
                         {
-                            AsnReader reader = new AsnReader(contentInfo.Content, AsnEncodingRules.DER);
+                            AsnReader reader = new AsnReader(contentInfo.Content, AsnEncodingRules.BER);
                             AsnReader innerReader = reader.ReadSequence();
 
                             if (reader.HasData)

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
@@ -196,7 +196,12 @@ namespace Internal.Cryptography.Pal.AnyOS
 
                             while (innerReader.HasData)
                             {
+#if netcoreapp
                                 cryptoStream.Write(innerReader.GetEncodedValue().Span);
+#else
+                                byte[] encoded = innerReader.GetEncodedValue().ToArray();
+                                cryptoStream.Write(encoded, 0, encoded.Length);
+#endif
                             }
                         }
 

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.Encrypt.cs
@@ -21,7 +21,7 @@ namespace Internal.Cryptography.Pal.Windows
 {
     internal sealed partial class PkcsPalWindows : PkcsPal
     {
-        public sealed override byte[] Encrypt(CmsRecipientCollection recipients, ContentInfo contentInfo, AlgorithmIdentifier contentEncryptionAlgorithm, X509Certificate2Collection originatorCerts, CryptographicAttributeObjectCollection unprotectedAttributes)
+        public sealed unsafe override byte[] Encrypt(CmsRecipientCollection recipients, ContentInfo contentInfo, AlgorithmIdentifier contentEncryptionAlgorithm, X509Certificate2Collection originatorCerts, CryptographicAttributeObjectCollection unprotectedAttributes)
         {
             using (SafeCryptMsgHandle hCryptMsg = EncodeHelpers.CreateCryptMsgHandleToEncode(recipients, contentInfo.ContentType, contentEncryptionAlgorithm, originatorCerts, unprotectedAttributes))
             {
@@ -41,16 +41,33 @@ namespace Internal.Cryptography.Pal.Windows
                 else
                 {
                     encodedContent = contentInfo.Content;
+
+                    if (encodedContent.Length > 0)
+                    {
+                        // Windows will throw if it encounters indefinite length encoding.
+                        // Let's reencode if that is the case
+                        ReencodeIfUsingIndefiniteLengthEncodingOnOuterStructure(ref encodedContent);
+                    }
                 }
 
                 if (encodedContent.Length > 0)
                 {
-                    // Windows will throw if it encounters indefinite length encoding.
-                    // Let's reencode if that is the case
-                    ReencodeIfUsingIndefiniteLengthEncodingOnOuterStructure(ref encodedContent);
-
-                    if (!Interop.Crypt32.CryptMsgUpdate(hCryptMsg, encodedContent, encodedContent.Length, fFinal: true))
-                        throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    // Pin to avoid copy during heap compaction
+                    fixed (byte* pinnedContent = encodedContent)
+                    {
+                        try
+                        {
+                            if (!Interop.Crypt32.CryptMsgUpdate(hCryptMsg, encodedContent, encodedContent.Length, fFinal: true))
+                                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                        }
+                        finally
+                        {
+                            if (!object.ReferenceEquals(encodedContent, contentInfo.Content))
+                            {
+                                CryptographicOperations.ZeroMemory(encodedContent);
+                            }
+                        }
+                    }
                 }
 
                 byte[] encodedMessage = hCryptMsg.GetMsgParamAsByteArray(CryptMsgParamType.CMSG_CONTENT_PARAM);
@@ -58,7 +75,7 @@ namespace Internal.Cryptography.Pal.Windows
             }
         }
 
-        private static unsafe void ReencodeIfUsingIndefiniteLengthEncodingOnOuterStructure(ref byte[] encodedContent)
+        private static void ReencodeIfUsingIndefiniteLengthEncodingOnOuterStructure(ref byte[] encodedContent)
         {
             AsnReader reader = new AsnReader(encodedContent, AsnEncodingRules.BER);
             Asn1Tag tag = reader.ReadTagAndLength(out int? contentsLength, out int _);
@@ -69,24 +86,11 @@ namespace Internal.Cryptography.Pal.Windows
                 return;
             }
 
-            byte[] oldContent = encodedContent;
-
-            // Pin the content to prevent it from getting copied during heap compaction.
-            fixed (byte* pinnedOldContent = oldContent)
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
-                try
-                {
-                    using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
-                    {
-                        // Tag doesn't matter here as we won't write it into the document
-                        writer.WriteOctetString(reader.PeekContentBytes().Span);
-                        encodedContent = writer.Encode();
-                    }
-                }
-                finally
-                {
-                    Array.Clear(oldContent, 0, oldContent.Length);
-                }
+                // Tag doesn't matter here as we won't write it into the document
+                writer.WriteOctetString(reader.PeekContentBytes().Span);
+                encodedContent = writer.Encode();
             }
         }
 

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.Encrypt.cs
@@ -64,7 +64,7 @@ namespace Internal.Cryptography.Pal.Windows
                         {
                             if (!object.ReferenceEquals(encodedContent, contentInfo.Content))
                             {
-                                CryptographicOperations.ZeroMemory(encodedContent);
+                                Array.Clear(encodedContent, 0, encodedContent.Length);
                             }
                         }
                     }

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -648,7 +648,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [ConditionalFact(nameof(SupportsIndefiniteLengthEncoding))]
-        public void EncryptEnvelopedEmptyOctetStringWithIndefiniteLength()
+        public void DecryptEnvelopedEmptyOctetStringWithIndefiniteLength()
         {
             byte[] content = "30800000".HexToByteArray();
             byte[] expectedContent = "3000".HexToByteArray();
@@ -660,10 +660,10 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [ConditionalFact(nameof(SupportsIndefiniteLengthEncoding))]
-        public void EncryptEnvelopedOctetStringWithIndefiniteLength()
+        public void DecryptEnvelopedOctetStringWithIndefiniteLength()
         {
             byte[] content = "308004000000".HexToByteArray();
-            byte[] expectedContent = "3000".HexToByteArray();
+            byte[] expectedContent = "30020400".HexToByteArray();
 
             ContentInfo contentInfo = new ContentInfo(new Oid(Oids.Pkcs7Enveloped), content);
             ContentInfo expectedContentInfo = new ContentInfo(new Oid(Oids.Pkcs7Enveloped), expectedContent);

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -680,6 +680,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
             string certSubjectName;
             byte[] encodedMessage;
+            byte[] originalCopy = (byte[])(contentInfo.Content.Clone());
             using (X509Certificate2 certificate = certLoader.GetCertificate())
             {
                 certSubjectName = certificate.Subject;
@@ -687,6 +688,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
                 EnvelopedCms ecms = new EnvelopedCms(contentInfo, alg);
                 CmsRecipient cmsRecipient = new CmsRecipient(type, certificate);
                 ecms.Encrypt(cmsRecipient);
+                Assert.Equal(originalCopy.ByteArrayToHex(), ecms.ContentInfo.Content.ByteArrayToHex());
                 encodedMessage = ecms.Encode();
             }
 

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     {
         private bool _useExplicitPrivateKey;
         public static bool SupportsCngCertificates { get; } = (!PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer);
-        public static bool SupportsIndefiniteLengthEncoding { get; } = !PlatformDetection.IsWindows;
+        public static bool SupportsIndefiniteLengthEncoding { get; } = !PlatformDetection.IsFullFramework;
 
         public DecryptTests(bool useExplicitPrivateKey)
         {
@@ -601,6 +601,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx does not allow it")]
         public void DecryptEnvelopedEmptyArray()
         {
             byte[] content = Array.Empty<byte>();

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -151,7 +151,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(29825)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public void Decrypt_SignedWithinEnveloped()
         {
@@ -179,7 +178,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(29825)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public void Decrypt_EnvelopedWithinEnveloped()
         {
@@ -461,6 +459,108 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public void TestDecryptSimple_Pkcs7Signed_GeneratedOnWindows()
+        {
+            byte[] expectedContent =
+                 ("3082032506092a864886f70d010702a082031630820312020101310b300906052b0e03021a0500301206092a864886f70d01"
+                + "0701a0050403010203a08202103082020c30820179a00302010202105d2ffff863babc9b4d3c80ab178a4cca300906052b0e"
+                + "03021d0500301e311c301a060355040313135253414b65795472616e736665724361706931301e170d313530343135303730"
+                + "3030305a170d3235303431353037303030305a301e311c301a060355040313135253414b65795472616e7366657243617069"
+                + "3130819f300d06092a864886f70d010101050003818d0030818902818100aa272700586c0cc41b05c65c7d846f5a2bc27b03"
+                + "e301c37d9bff6d75b6eb6671ba9596c5c63ba2b1af5c318d9ca39e7400d10c238ac72630579211b86570d1a1d44ec86aa8f6"
+                + "c9d2b4e283ea3535923f398a312a23eaeacd8d34faaca965cd910b37da4093ef76c13b337c1afab7d1d07e317b41a336baa4"
+                + "111299f99424408d0203010001a3533051304f0603551d0104483046801015432db116b35d07e4ba89edb2469d7aa120301e"
+                + "311c301a060355040313135253414b65795472616e73666572436170693182105d2ffff863babc9b4d3c80ab178a4cca3009"
+                + "06052b0e03021d05000381810081e5535d8eceef265acbc82f6c5f8bc9d84319265f3ccf23369fa533c8dc1938952c593166"
+                + "2d9ecd8b1e7b81749e48468167e2fce3d019fa70d54646975b6dc2a3ba72d5a5274c1866da6d7a5df47938e034a075d11957"
+                + "d653b5c78e5291e4401045576f6d4eda81bef3c369af56121e49a083c8d1adb09f291822e99a4296463181d73081d4020101"
+                + "3032301e311c301a060355040313135253414b65795472616e73666572436170693102105d2ffff863babc9b4d3c80ab178a"
+                + "4cca300906052b0e03021a0500300d06092a864886f70d010101050004818031a718ea1483c88494661e1d3dedfea0a3d97e"
+                + "eb64c3e093a628b257c0cfc183ecf11697ac84f2af882b8de0c793572af38dc15d1b6f3d8f2392ba1cc71210e177c146fd16"
+                + "b77a583b6411e801d7a2640d612f2fe99d87e9718e0e505a7ab9536d71dbde329da21816ce7da1416a74a3e0a112b86b33af"
+                + "336a2ba6ae2443d0ab").HexToByteArray();
+
+            ContentInfo expectedContentInfo = new ContentInfo(new Oid(Oids.Pkcs7Signed), expectedContent);
+
+            byte[] encodedMessage = Convert.FromBase64String(
+                "MIIERwYJKoZIhvcNAQcDoIIEODCCBDQCAQAxgcwwgckCAQAwMjAeMRwwGgYDVQQDExNSU0FLZXlU" +
+                "cmFuc2ZlckNhcGkxAhBdL//4Y7q8m008gKsXikzKMA0GCSqGSIb3DQEBAQUABIGAngdmU69zGsgJ" +
+                "mx+hXmTjlefr1oazKRK8VGOeqNMm++J3yHxwz68CLoN4FIEyS/HE3NQE6qb3M80HOpk5fmVVMw7Z" +
+                "3mrsZlPLOEjJIxEFqAC/JFEzvyE/BL+1OvwRoHpxHsAvZNlz5f9g18wQVE7X5TkkbOJV/6F2disK" +
+                "H0jik68wggNeBgkqhkiG9w0BBwIwHQYJYIZIAWUDBAEqBBDr3I8NYAnetX+2h9D/nVAggIIDMOlW" +
+                "7mDuuScuXhCXgZaPy0/zEWy/sYDzxhj1G1X2qBwhB7m6Ez6giibAEYwfRNYaOiVIitIJAUU9LSKg" +
+                "n0FL1o0eCcgvo04w+zoaBH8pFFk78kuR+T73kflz+O3Eno1pIFpy+2cz2B0QvQSC7lYikbZ4J+/C" +
+                "7F/uqRoK7sdafNdyUnKhDL+vvP6ToGf9C4g0TjoFEC2ycyJxIBh1F57pqjht6HMQcYm+/fQoBtkt" +
+                "NrvZxJPlBhbQad/9pSCd0G6NDoPnDuFAicaxGVa7yI2BbvGTCc6NSnbdCzv2EgvsI10Yko+XO4/i" +
+                "oPnk9pquZBzC3p61XRKbBDrd5RsbkvPDXUHJKD5NQ3W3z9Bnc3bjNyilgDSIB01dE4AcWzdg+RGb" +
+                "TA7iAbAQKp2zjxb/prmxw1mhO9g6OkDovSTqmQQt7MlHFYFcX9wH8yEe+huIechmiy7famofluJX" +
+                "vBIz4m3JozlodyNX0nu9QwW58WWcFu6OyoPjFhlB+tLIHUElq9/AAEgwwgfsAj6jEQaHiFG+CYSJ" +
+                "RjX9+DHFJXMDyzW+eJw8Z/mvbZzzKF553xlAGpfUHHq4CywTyVTHn4nu9HPOeFzoirj1lzFvqmQd" +
+                "Dgp3T8NOPrns9ZIUBmdNNs/vUxNZqEeN4d0nD5lBG4aZnjsxr4i25rR3Jpe3kKrFtJQ74efkRM37" +
+                "1ntz9HGiA95G41fuaMw7lgOOfTL+AENNvwRGRCAhinajvQLDkFEuX5ErTtmBxJWU3ZET46u/vRiK" +
+                "NiRteFiN0hLv1jy+RJK+d+B/QEH3FeVMm3Tz5ll2LfO2nn/QR51hth7qFsvtFpwQqkkhMac6dMf/" +
+                "bb62pZY15U3y2x5jSn+MZVrNbL4ZK/JO5JFomqKVRjLH1/IZ+kuFNaaTrKFWB4U2gxrMdcjMCZvx" +
+                "ylbuf01Ajxo74KhPY9sIRztG4BU8ZaE69Ke50wJTE3ulm+g6hzNECdQS/yjuA8AUReGRj2NH/U4M" +
+                "lEUiR/rMHB/Mq/Vj6lsRFEVxHJSzek6jvrQ4UzVgWGrH4KnP3Rca8CfBTQX79RcZPu+0kI3KI+4H" +
+                "0Q+UBbb72FHnWsw3uqPEyA==");
+
+            CertLoader certLoader = Certificates.RSAKeyTransferCapi1;
+            VerifySimpleDecrypt(encodedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public void TestDecryptSimple_Pkcs7Signed_GeneratedOnLinux()
+        {
+            byte[] expectedContent =
+                 ("3082032506092a864886f70d010702a082031630820312020101310b300906052b0e03021a0500301206092a864886f70d01"
+                + "0701a0050403010203a08202103082020c30820179a00302010202105d2ffff863babc9b4d3c80ab178a4cca300906052b0e"
+                + "03021d0500301e311c301a060355040313135253414b65795472616e736665724361706931301e170d313530343135303730"
+                + "3030305a170d3235303431353037303030305a301e311c301a060355040313135253414b65795472616e7366657243617069"
+                + "3130819f300d06092a864886f70d010101050003818d0030818902818100aa272700586c0cc41b05c65c7d846f5a2bc27b03"
+                + "e301c37d9bff6d75b6eb6671ba9596c5c63ba2b1af5c318d9ca39e7400d10c238ac72630579211b86570d1a1d44ec86aa8f6"
+                + "c9d2b4e283ea3535923f398a312a23eaeacd8d34faaca965cd910b37da4093ef76c13b337c1afab7d1d07e317b41a336baa4"
+                + "111299f99424408d0203010001a3533051304f0603551d0104483046801015432db116b35d07e4ba89edb2469d7aa120301e"
+                + "311c301a060355040313135253414b65795472616e73666572436170693182105d2ffff863babc9b4d3c80ab178a4cca3009"
+                + "06052b0e03021d05000381810081e5535d8eceef265acbc82f6c5f8bc9d84319265f3ccf23369fa533c8dc1938952c593166"
+                + "2d9ecd8b1e7b81749e48468167e2fce3d019fa70d54646975b6dc2a3ba72d5a5274c1866da6d7a5df47938e034a075d11957"
+                + "d653b5c78e5291e4401045576f6d4eda81bef3c369af56121e49a083c8d1adb09f291822e99a4296463181d73081d4020101"
+                + "3032301e311c301a060355040313135253414b65795472616e73666572436170693102105d2ffff863babc9b4d3c80ab178a"
+                + "4cca300906052b0e03021a0500300d06092a864886f70d010101050004818031a718ea1483c88494661e1d3dedfea0a3d97e"
+                + "eb64c3e093a628b257c0cfc183ecf11697ac84f2af882b8de0c793572af38dc15d1b6f3d8f2392ba1cc71210e177c146fd16"
+                + "b77a583b6411e801d7a2640d612f2fe99d87e9718e0e505a7ab9536d71dbde329da21816ce7da1416a74a3e0a112b86b33af"
+                + "336a2ba6ae2443d0ab").HexToByteArray();
+
+            ContentInfo expectedContentInfo = new ContentInfo(new Oid(Oids.Pkcs7Signed), expectedContent);
+
+            byte[] encodedMessage = Convert.FromBase64String(
+                "MIIERwYJKoZIhvcNAQcDoIIEODCCBDQCAQAxgcwwgckCAQAwMjAeMRwwGgYDVQQDExNSU0FLZXlU" +
+                "cmFuc2ZlckNhcGkxAhBdL//4Y7q8m008gKsXikzKMA0GCSqGSIb3DQEBAQUABIGAfsH5F4ZlwIcH" +
+                "nzqn8sOn+ZwK884en7HZrQbgEfedy5ti0ituKn70yTDz4iuNJtpguukCfCAsOT/n3eQn+T6etIa9" +
+                "byRGQst3F6QtgjAzdb5P1N6c5Mpz1o6k0mbNP/f0FqAaNtuAOnYwlEMwWOz9x4eEYpOhhlc6agRG" +
+                "qWItNVgwggNeBgkqhkiG9w0BBwIwHQYJYIZIAWUDBAEqBBCA8qaTiT+6IkrO8Ks9WOBggIIDMIkr" +
+                "7OGlPd3CfzO2CfJA3Sis/1ulDm1ioMCS9V5kLHVx4GWDETORG/YTPA54luxJkvIdU5VwO86+QuXf" +
+                "rgaly38XHTLZv+RBxUwCaWI0pgvaykEki5CnDu4j9uRQxqz6iU5bY6SKxG3bwcnUzGhWFdQVcNJn" +
+                "xzuMEcbrix5zfqmoeqemaYyqVqgMPNOnc5kmMOqHrha76qMdbYOSpwx81zYwstBlg+S9+AgOMR+W" +
+                "qrV9aXJTovjiJEVHPEPJFx0v/wCthhXso51mSU091Cs8qVfvokzlzXcK2dPF5d8EdmZCcmHsoq35" +
+                "/DfAL4DkfKucwiP9W7rT1a2BmVMquFTMI+KXyDvNhMVasjhKq5eM2G+oUDc3kGa3akaPZ+hNEHA+" +
+                "BNAS7iIpRft2GMNfTqpkBqnS6pB0+SSf02/JVkcFuHXZ9oZJsvZRm8M1i4WdVauBJ34rInQBdhaO" +
+                "yaFDx69tBvolclYnMzvdHLiP2TZbiR6kM0vqD1DGjEHNDE+m/jxL7HXcNotW84J9CWlDnm9zaNhL" +
+                "sB4PJNiNjKhkAsO+2HaNWlEPrmgmWKvNi/Qyrz1qUryqz2/2HGrFDqmjTeEf1+yy35N3Pqv5uvAj" +
+                "f/ySihknnAh77nI0yOPy0Uto+hbO+xraeujrEifaII8izcz6UG6LHNPxOyscne7HNcqPSAFLsNFJ" +
+                "1oOlKO0SwhPkGQsk4W5tjVfvLvJiPNcL7SY/eof4vVsRRwX6Op5WUjhJIagY1Vij+4hOcn5TqdmU" +
+                "OZDh/FC3x4DI556BeMfbWxHNlGvptROQwQ6BasfdiVWCWzMHwLpz27Y47vKbMQ+8TL9668ilT83f" +
+                "6eo6mHZ590pzuDB+gFrjEK44ov0rvHBK5jHwnSObQvChN0ElizWBdMSUbx9SkcnReH6Fd29SSXdu" +
+                "RaVspnhmFNXWg7qGYHpEChnIGSr/WIKETZ84f7FRCxCNSYoQtrHs0SskiEGJYEbB6KDMFimEZ4YN" +
+                "b4cV8VLC9Pxa1Qe1Oa05FBzG2DAP2PfObeKR34afF5wo6vIZfQE0WWoPo9YS326vz1iA5rE0F6qw" +
+                "zCNmZl8+rW6x73MTEcWhvg==");
+
+            CertLoader certLoader = Certificates.RSAKeyTransferCapi1;
+            VerifySimpleDecrypt(encodedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
         public static void DecryptUsingCertificateWithSameSubjectKeyIdentifierButDifferentKeyPair()
         {
             using (X509Certificate2 recipientCert = Certificates.RSAKeyTransfer4_ExplicitSki.GetCertificate())
@@ -555,7 +655,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
                 }
                 ContentInfo contentInfo = ecms.ContentInfo;
                 Assert.Equal(expectedContent.ContentType.Value, contentInfo.ContentType.Value);
-                Assert.Equal<byte>(expectedContent.Content, contentInfo.Content);
+                Assert.Equal(expectedContent.Content.ByteArrayToHex(), contentInfo.Content.ByteArrayToHex());
             }
         }
     }

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingCertWithPrivateKey.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingCertWithPrivateKey.cs
@@ -67,5 +67,50 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             ContentInfo contentInfo = ecms.ContentInfo;
             Assert.Equal<byte>(content, contentInfo.Content);
         }
+
+        [Fact]
+        public static void DecryptUsingCertificateWithSameSubjectKeyIdentifierButDifferentKeyPair()
+        {
+            using (X509Certificate2 recipientCert = Certificates.RSAKeyTransfer4_ExplicitSki.GetCertificate())
+            using (X509Certificate2 otherRecipientWithSameSki = Certificates.RSAKeyTransfer5_ExplicitSkiOfRSAKeyTransfer4.TryGetCertificateWithPrivateKey())
+            using (X509Certificate2 realRecipientCert = Certificates.RSAKeyTransfer4_ExplicitSki.TryGetCertificateWithPrivateKey())
+            {
+                Assert.Equal(recipientCert, realRecipientCert);
+                Assert.NotEqual(recipientCert, otherRecipientWithSameSki);
+                Assert.Equal(GetSubjectKeyIdentifier(recipientCert), GetSubjectKeyIdentifier(otherRecipientWithSameSki));
+
+                byte[] plainText = new byte[] { 1, 3, 7, 9 };
+
+                ContentInfo content = new ContentInfo(plainText);
+                EnvelopedCms ecms = new EnvelopedCms(content);
+
+                CmsRecipient recipient = new CmsRecipient(SubjectIdentifierType.SubjectKeyIdentifier, recipientCert);
+                ecms.Encrypt(recipient);
+                byte[] encoded = ecms.Encode();
+
+                ecms = new EnvelopedCms();
+                ecms.Decode(encoded);
+
+                Assert.ThrowsAny<CryptographicException>(() => ecms.Decrypt(new X509Certificate2Collection(otherRecipientWithSameSki)));
+                ecms.Decrypt(new X509Certificate2Collection(realRecipientCert));
+
+                Assert.Equal(plainText, ecms.ContentInfo.Content);
+            }
+        }
+
+        private static string GetSubjectKeyIdentifier(X509Certificate2 cert)
+        {
+            foreach (var ext in cert.Extensions)
+            {
+                X509SubjectKeyIdentifierExtension skiExt = ext as X509SubjectKeyIdentifierExtension;
+                if (skiExt != null)
+                {
+                    return skiExt.SubjectKeyIdentifier;
+                }
+            }
+
+            Assert.False(true, "Subject Key Identifier not found");
+            return null;
+        }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -17,8 +17,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         public static bool SupportsCngCertificates { get; } = (!PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer);
 
-        public static bool NotSupportsIndefiniteLengthEncoding { get; } = PlatformDetection.IsWindows;
-
         [ConditionalFact(nameof(SupportsCngCertificates))]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void ImportEdgeCase()
@@ -534,38 +532,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         public static void EncryptEnvelopedOneByteArray()
         {
             byte[] content = "04".HexToByteArray();
-            ContentInfo contentInfo = new ContentInfo(new Oid(Oids.Pkcs7Enveloped), content);
-
-            using (X509Certificate2 certificate = Certificates.RSAKeyTransferCapi1.GetCertificate())
-            {
-                string certSubjectName = certificate.Subject;
-                AlgorithmIdentifier alg = new AlgorithmIdentifier(new Oid(Oids.Aes256));
-                EnvelopedCms ecms = new EnvelopedCms(contentInfo, alg);
-                CmsRecipient cmsRecipient = new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber, certificate);
-                Assert.ThrowsAny<CryptographicException>(() => ecms.Encrypt(cmsRecipient));
-            }
-        }
-
-        [ConditionalFact(nameof(NotSupportsIndefiniteLengthEncoding))]
-        public static void EncryptEnvelopedEmptyOctetStringWithIndefiniteLength()
-        {
-            byte[] content = "30800000".HexToByteArray();
-            ContentInfo contentInfo = new ContentInfo(new Oid(Oids.Pkcs7Enveloped), content);
-
-            using (X509Certificate2 certificate = Certificates.RSAKeyTransferCapi1.GetCertificate())
-            {
-                string certSubjectName = certificate.Subject;
-                AlgorithmIdentifier alg = new AlgorithmIdentifier(new Oid(Oids.Aes256));
-                EnvelopedCms ecms = new EnvelopedCms(contentInfo, alg);
-                CmsRecipient cmsRecipient = new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber, certificate);
-                Assert.ThrowsAny<CryptographicException>(() => ecms.Encrypt(cmsRecipient));
-            }
-        }
-
-        [ConditionalFact(nameof(NotSupportsIndefiniteLengthEncoding))]
-        public static void EncryptEnvelopedOctetStringWithIndefiniteLength()
-        {
-            byte[] content = "308004000000".HexToByteArray();
             ContentInfo contentInfo = new ContentInfo(new Oid(Oids.Pkcs7Enveloped), content);
 
             using (X509Certificate2 certificate = Certificates.RSAKeyTransferCapi1.GetCertificate())


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/29825

This might need to wait until @bartonjs is back from vacation.

We should consider this for 2.1.1 because documents encoded on non-Windows platforms with EnvelopedCms which have ContentInfo Oid different than `1.2.840.113549.1.7.1` will not roundtrip correctly cross platform. Any currently existing document encoded in such way will have additional DER "Sequence" prefix (0x30, `<length>`) after decryption