### PR TITLE
Remove obsoleted comment in NameResolutionPal

### DIFF
--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -257,7 +257,6 @@ namespace System.Net
 
             nativeErrorCode = 0;
 
-            // TODO #2891: Remove the copying step to improve performance. This requires a change in the contracts.
             byte[] addressBuffer = new byte[address.Size];
             for (int i = 0; i < address.Size; i++)
             {


### PR DESCRIPTION
We previously decided against doing this TODO item. Cleaning up the comments.

Closes #2891