### PR TITLE
Add EnabledDumpling=true to windows build-tests

### DIFF
--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -50,7 +50,7 @@ simpleNode('Windows_NT','latest') {
             additionalArgs += ' -SkipTests'
         }
         if (params.TGroup != 'all') {
-            bat ".\\build-tests.cmd ${framework} -buildArch=${params.AGroup} -${params.CGroup}${additionalArgs} -- /p:RuntimeOS=win10 /p:ArchiveTests=${archiveTests}"
+            bat ".\\build-tests.cmd ${framework} -buildArch=${params.AGroup} -${params.CGroup}${additionalArgs} -- /p:RuntimeOS=win10 /p:ArchiveTests=${archiveTests} /p:EnableDumpling=true"
         }
         else {
             bat ".\\build-tests.cmd ${framework} -${params.CGroup}${additionalArgs}"


### PR DESCRIPTION
Other <OS>.groovy files have this set to true, but windows was missing it for some reason.

cc @DrewScoggins, @mmitche 