### PR TITLE
Add HttpClient test for sending rewindable content stream

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -54,7 +54,7 @@ namespace System.Net.Http.Functional.Tests
 
                 for (int i = 1; i <= 3; i++)
                 {
-                    HttpResponseMessage response = client.PutAsync(serverUri, content).Result;
+                    HttpResponseMessage response = await client.PutAsync(serverUri, content);
                     Assert.Equal(requestBody.Length, ms.Position); // Stream left at end after send.
 
                     string responseBody = await response.Content.ReadAsStringAsync();

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -45,7 +45,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostRewindableStreamContentMultipleTimes_StreamContentFullySent(Uri serverUri)
         {
-            string requestBody = "ABC";
+            const string requestBody = "ABC";
 
             using (var client = new HttpClient())
             using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(requestBody)))

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -40,7 +41,30 @@ namespace System.Net.Http.Functional.Tests
             _output = output;
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
+        [Theory, MemberData(nameof(EchoServers))]
+        public async Task PostRewindableStreamContentMultipleTimes_StreamContentFullySent(Uri serverUri)
+        {
+            string requestBody = "ABC";
+
+            using (var client = new HttpClient())
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(requestBody)))
+            {
+                var content = new StreamContent(ms);
+
+                for (int i = 1; i <= 3; i++)
+                {
+                    HttpResponseMessage response = client.PutAsync(serverUri, content).Result;
+                    Assert.Equal(requestBody.Length, ms.Position); // Stream left at end after send.
+
+                    string responseBody = await response.Content.ReadAsStringAsync();
+                    _output.WriteLine(responseBody);
+                    Assert.True(TestHelper.JsonMessageContainsKeyValue(responseBody, "BodyContent", requestBody));
+                }
+            }
+        }
+
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostNoContentUsingContentLengthSemantics_Success(Uri serverUri)
         {
@@ -48,7 +72,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: false);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostEmptyContentUsingContentLengthSemantics_Success(Uri serverUri)
         {
@@ -56,7 +80,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: false);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostEmptyContentUsingChunkedEncoding_Success(Uri serverUri)
         {
@@ -64,7 +88,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: true);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostEmptyContentUsingConflictingSemantics_Success(Uri serverUri)
         {
@@ -72,7 +96,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: true);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostUsingContentLengthSemantics_Success(Uri serverUri)
         {
@@ -80,7 +104,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: false);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostUsingChunkedEncoding_Success(Uri serverUri)
         {
@@ -88,7 +112,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: true);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostSyncBlockingContentUsingChunkedEncoding_Success(Uri serverUri)
         {
@@ -96,7 +120,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: true);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostRepeatedFlushContentUsingChunkedEncoding_Success(Uri serverUri)
         {
@@ -104,7 +128,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: true);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostUsingUsingConflictingSemantics_UsesChunkedSemantics(Uri serverUri)
         {
@@ -112,7 +136,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: true);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx behaves differently and will buffer content and use 'Content-Length' semantics")]
         public async Task PostUsingNoSpecifiedSemantics_UsesChunkedSemantics(Uri serverUri)
@@ -121,7 +145,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: false);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory]
         [InlineData(5 * 1024)]
         [InlineData(63 * 1024)]
@@ -139,7 +163,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: false);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostRewindableContentUsingAuth_NoPreAuthenticate_Success(Uri serverUri)
         {
@@ -148,7 +172,7 @@ namespace System.Net.Http.Functional.Tests
             await PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, false);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostNonRewindableContentUsingAuth_NoPreAuthenticate_ThrowsHttpRequestException(Uri serverUri)
         {
@@ -158,7 +182,7 @@ namespace System.Net.Http.Functional.Tests
                 PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, preAuthenticate: false));
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostNonRewindableContentUsingAuth_PreAuthenticate_Success(Uri serverUri)
         {
@@ -173,7 +197,7 @@ namespace System.Net.Http.Functional.Tests
             await PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, preAuthenticate: true);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostAsync_EmptyContent_ContentTypeHeaderNotSent(Uri serverUri)
         {


### PR DESCRIPTION
Issue #23782 was opened describing a behavior difference in Linux versus
Windows regarding the final position of a stream after being sent. This
turned out to be a behavior in CurlHandler that we decided to not fix.

This PR adds a test to document the behavior of resending a request body
content object (now possible now since we no longer dispose request content
after send). This test is only validating the default HttpClientHandler
which is SocketsHttpHandler now. It also matches .NET Framework behavior.

Closes #23782