### PR TITLE
Expose SpinWait.SpinOnce(int sleep1Threshold) overload

### DIFF
--- a/src/System.Threading/ref/System.Threading.cs
+++ b/src/System.Threading/ref/System.Threading.cs
@@ -363,6 +363,7 @@ namespace System.Threading
         public bool NextSpinWillYield { get { throw null; } }
         public void Reset() { }
         public void SpinOnce() { }
+        public void SpinOnce(int sleep1Threshold) { }
         public static void SpinUntil(System.Func<bool> condition) { }
         public static bool SpinUntil(System.Func<bool> condition, int millisecondsTimeout) { throw null; }
         public static bool SpinUntil(System.Func<bool> condition, System.TimeSpan timeout) { throw null; }

--- a/src/System.Threading/tests/SpinWaitTests.cs
+++ b/src/System.Threading/tests/SpinWaitTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.Threading.Tests
 {
-    public static class SpinWaitTests
+    public static partial class SpinWaitTests
     {
         [Fact]
         public static void RunSpinWaitTests()
@@ -14,7 +14,7 @@ namespace System.Threading.Tests
             SpinWait spinner = new SpinWait();
 
             spinner.SpinOnce();
-            Assert.Equal(spinner.Count, 1);
+            Assert.Equal(1, spinner.Count);
         }
 
         [Fact]

--- a/src/System.Threading/tests/SpinWaitTests.netcoreapp.cs
+++ b/src/System.Threading/tests/SpinWaitTests.netcoreapp.cs
@@ -13,20 +13,22 @@ namespace System.Threading.Tests
         {
             SpinWait spinner = new SpinWait();
 
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("sleep1Threshold", () => spinner.SpinOnce(-1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("sleep1Threshold", () => spinner.SpinOnce(-2));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("sleep1Threshold", () => spinner.SpinOnce(int.MinValue));
             Assert.Equal(0, spinner.Count);
 
-            spinner.SpinOnce(sleep1Threshold: 0);
+            spinner.SpinOnce(sleep1Threshold: -1);
             Assert.Equal(1, spinner.Count);
-            spinner.SpinOnce(sleep1Threshold: 1);
+            spinner.SpinOnce(sleep1Threshold: 0);
             Assert.Equal(2, spinner.Count);
-            spinner.SpinOnce(sleep1Threshold: int.MaxValue);
+            spinner.SpinOnce(sleep1Threshold: 1);
             Assert.Equal(3, spinner.Count);
-            int i = 4;
+            spinner.SpinOnce(sleep1Threshold: int.MaxValue);
+            Assert.Equal(4, spinner.Count);
+            int i = 5;
             for (; i < 10; ++i)
             {
-                spinner.SpinOnce(sleep1Threshold: 0);
+                spinner.SpinOnce(sleep1Threshold: -1);
                 Assert.Equal(i, spinner.Count);
             }
             for (; i < 20; ++i)

--- a/src/System.Threading/tests/SpinWaitTests.netcoreapp.cs
+++ b/src/System.Threading/tests/SpinWaitTests.netcoreapp.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Tests
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("sleep1Threshold", () => spinner.SpinOnce(-1));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("sleep1Threshold", () => spinner.SpinOnce(int.MinValue));
-            Assert.Equal(spinner.Count, 0);
+            Assert.Equal(0, spinner.Count);
 
             spinner.SpinOnce(sleep1Threshold: 0);
             Assert.Equal(1, spinner.Count);

--- a/src/System.Threading/tests/SpinWaitTests.netcoreapp.cs
+++ b/src/System.Threading/tests/SpinWaitTests.netcoreapp.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Threading.Tests
+{
+    public static partial class SpinWaitTests
+    {
+        [Fact]
+        public static void SpinOnce_Sleep1Threshold()
+        {
+            SpinWait spinner = new SpinWait();
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("sleep1Threshold", () => spinner.SpinOnce(-1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("sleep1Threshold", () => spinner.SpinOnce(int.MinValue));
+            Assert.Equal(spinner.Count, 0);
+
+            spinner.SpinOnce(sleep1Threshold: 0);
+            Assert.Equal(1, spinner.Count);
+            spinner.SpinOnce(sleep1Threshold: 1);
+            Assert.Equal(2, spinner.Count);
+            spinner.SpinOnce(sleep1Threshold: int.MaxValue);
+            Assert.Equal(3, spinner.Count);
+            int i = 4;
+            for (; i < 10; ++i)
+            {
+                spinner.SpinOnce(sleep1Threshold: 0);
+                Assert.Equal(i, spinner.Count);
+            }
+            for (; i < 20; ++i)
+            {
+                spinner.SpinOnce(sleep1Threshold: 15);
+                Assert.Equal(i, spinner.Count);
+            }
+        }
+    }
+}

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="ReaderWriterLockTests.cs" />
     <Compile Include="ReaderWriterLockSlimTests.cs" />
     <Compile Include="SpinWaitTests.cs" />
+    <Compile Include="SpinWaitTests.netcoreapp.cs" Condition="'$(TargetGroup)'=='netcoreapp'" />
     <Compile Include="ThreadLocalTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="ExecutionContextTests.cs" />


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/18204

To allow customizing the spin count threshold for Sleep(1) usage, and to allow disabling the use of Sleep(1).

API review: https://github.com/dotnet/corefx/issues/29623
Part of fix for https://github.com/dotnet/corefx/issues/29595