### PR TITLE
[release/2.1] Check SwitchingProtocol before ContentLength (#29948)

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -616,6 +616,10 @@ namespace System.Net.Http
                     _connectionClose = true;
 
                 }
+                else if (response.StatusCode == HttpStatusCode.SwitchingProtocols)
+                {
+                    responseStream = new RawConnectionStream(this);
+                }
                 else if (response.Content.Headers.ContentLength != null)
                 {
                     long contentLength = response.Content.Headers.ContentLength.GetValueOrDefault();
@@ -632,10 +636,6 @@ namespace System.Net.Http
                 else if (response.Headers.TransferEncodingChunked == true)
                 {
                     responseStream = new ChunkedEncodingReadStream(this);
-                }
-                else if (response.StatusCode == HttpStatusCode.SwitchingProtocols)
-                {
-                    responseStream = new RawConnectionStream(this);
                 }
                 else
                 {

--- a/src/System.Net.WebSockets.Client/tests/LoopbackHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/LoopbackHelper.cs
@@ -27,6 +27,7 @@ namespace System.Net.WebSockets.Client.Tests
                         string responseSecurityAcceptValue = ComputeWebSocketHandshakeSecurityAcceptValue(headerValue);
                         serverResponse =
                             "HTTP/1.1 101 Switching Protocols\r\n" +
+                            "Content-Length: 0\r\n" +
                             "Upgrade: websocket\r\n" +
                             "Connection: Upgrade\r\n" +
                             "Sec-WebSocket-Accept: " + responseSecurityAcceptValue + "\r\n\r\n";


### PR DESCRIPTION
fixes #29984

This is back-port of original #29948 to release/2.1

