### PR TITLE
[release/2.1] Port nano test fixes

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
@@ -66,7 +66,8 @@ namespace MonoTests.System.Configuration
             Assert.Equal("user.config", fi.Name);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp),
+            nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/corefx/issues/29752
         [ActiveIssue(15065, TestPlatforms.AnyUnix)]
         public void OpenExeConfiguration1_UserLevel_PerUserRoamingAndLocal()
         {
@@ -155,7 +156,8 @@ namespace MonoTests.System.Configuration
             Assert.Equal("user.config", Path.GetFileName(filePath));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp),
+            nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/corefx/issues/29752
         [ActiveIssue(15066, TestPlatforms.AnyUnix)]
         public void exePath_UserLevelPerRoamingAndLocal()
         {

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -494,7 +494,7 @@ namespace System.Diagnostics.Tests
             Assert.False(psi.Environment.Contains(new KeyValuePair<string, string>("NewKey3", "NewValue3")));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Nano does not support these verbs
         [PlatformSpecific(TestPlatforms.Windows)]  // Test case is specific to Windows
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Retrieving information about local processes is not supported on uap")]
         public void Verbs_GetWithExeExtension_ReturnsExpected()
@@ -509,11 +509,8 @@ namespace System.Diagnostics.Tests
             }
 
             Assert.Contains("open", psi.Verbs, StringComparer.OrdinalIgnoreCase);
-            if (PlatformDetection.IsNotWindowsNanoServer)
-            {
-                Assert.Contains("runas", psi.Verbs, StringComparer.OrdinalIgnoreCase);
-                Assert.Contains("runasuser", psi.Verbs, StringComparer.OrdinalIgnoreCase);
-            }
+            Assert.Contains("runas", psi.Verbs, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("runasuser", psi.Verbs, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain("printto", psi.Verbs, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain("closed", psi.Verbs, StringComparer.OrdinalIgnoreCase);
         }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -65,9 +65,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
             ProcessPriorityClass originalPriority = _process.PriorityClass;
-
-            var expected = PlatformDetection.IsWindowsNanoServer ? ProcessPriorityClass.BelowNormal : ProcessPriorityClass.Normal; // For some reason we're BelowNormal initially on Nano
-            Assert.Equal(expected, originalPriority);
+            Assert.Equal(ProcessPriorityClass.Normal, originalPriority);
 
             try
             {
@@ -953,6 +951,10 @@ namespace System.Diagnostics.Tests
             catch (ActiveDirectoryObjectNotFoundException)
             {
                 //This will be thrown when the executing machine is not domain-joined, i.e. in CI
+            }
+            catch (TypeInitializationException tie) when (tie.InnerException is ActiveDirectoryOperationException)
+            {
+                //Thrown if the ActiveDirectory module is unavailable
             }
             catch (PlatformNotSupportedException)
             {

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
@@ -25,7 +25,7 @@ namespace BasicEventSourceTests
         /// Tests the EventSource.Write[T] method (can only use the self-describing mechanism).  
         /// 
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/corefx/issues/29754
         public void Test_Write_Fuzzy()
         {
             using (var logger = new EventSource("EventSourceName"))

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
@@ -70,7 +70,7 @@ namespace BasicEventSourceTests
         /// <summary>
         /// Test the 
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/corefx/issues/29754
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Depends on inspecting IL at runtime.")]
         public void Test_BadEventSource_MismatchedIds()
         {

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -36,6 +36,8 @@ namespace BasicEventSourceTests
         // Specifies whether the process is elevated or not.
         private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
         private static bool IsProcessElevated => s_isElevated.Value;
+        private static bool IsProcessElevatedAndNotWindowsNanoServer =>
+            IsProcessElevated && PlatformDetection.IsNotWindowsNanoServer; // ActiveIssue: https://github.com/dotnet/corefx/issues/29754
 #endif // USE_ETW
 
         [EventData]
@@ -74,7 +76,7 @@ namespace BasicEventSourceTests
         /// Tests the EventSource.Write[T] method (can only use the self-describing mechanism).  
         /// Tests the ETW code path
         /// </summary>
-        [ConditionalFact(nameof(IsProcessElevated))]
+        [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
         public void Test_Write_T_ETW()
         {
             using (var listener = new EtwListener())

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
@@ -28,12 +28,14 @@ namespace BasicEventSourceTests
         // Specifies whether the process is elevated or not.
         private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
         private static bool IsProcessElevated => s_isElevated.Value;
+        private static bool IsProcessElevatedAndNotWindowsNanoServer =>
+            IsProcessElevated && PlatformDetection.IsNotWindowsNanoServer; // ActiveIssue: https://github.com/dotnet/corefx/issues/29754
 
         /// <summary>
         /// Tests WriteEvent using the manifest based mechanism.   
         /// Tests the ETW path. 
         /// </summary>
-        [ConditionalFact(nameof(IsProcessElevated))]
+        [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
         public void Test_WriteEvent_Manifest_ETW()
         {
             using (var listener = new EtwListener())
@@ -71,7 +73,7 @@ namespace BasicEventSourceTests
         /// Tests WriteEvent using the self-describing mechanism.   
         /// Tests both the ETW and TraceListener paths. 
         /// </summary>
-        [ConditionalFact(nameof(IsProcessElevated))]
+        [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
         public void Test_WriteEvent_SelfDescribing_ETW()
         {
             using (var listener = new EtwListener())
@@ -450,7 +452,7 @@ namespace BasicEventSourceTests
         /// Tests sending complex data (class, arrays etc) from WriteEvent 
         /// Tests the EventListener case
         /// </summary>
-        [ConditionalFact(nameof(IsProcessElevated))]
+        [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
         public void Test_WriteEvent_ComplexData_SelfDescribing_ETW()
         {
             using (var listener = new EtwListener())
@@ -540,7 +542,7 @@ namespace BasicEventSourceTests
         /// Uses Manifest format
         /// Tests the EventListener case
         /// </summary>
-        [ConditionalFact(nameof(IsProcessElevated))]
+        [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
         public void Test_WriteEvent_ByteArray_Manifest_ETW()
         {
             using (var listener = new EtwListener())
@@ -570,7 +572,7 @@ namespace BasicEventSourceTests
         /// Uses Self-Describing format
         /// Tests the EventListener case 
         /// </summary>
-        [ConditionalFact(nameof(IsProcessElevated))]
+        [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
         public void Test_WriteEvent_ByteArray_SelfDescribing_ETW()
         {
             using (var listener = new EtwListener())

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryInterSiteTransportTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryInterSiteTransportTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.DirectoryServices.ActiveDirectory.Tests
 {
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     public class ActiveDirectoryInterSiteTransportTests
     {
         [Fact]

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryInterSiteTransportTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryInterSiteTransportTests.cs
@@ -7,16 +7,15 @@ using Xunit;
 
 namespace System.DirectoryServices.ActiveDirectory.Tests
 {
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     public class ActiveDirectoryInterSiteTransportTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindByTransportType_NullContext_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("context", () => ActiveDirectoryInterSiteTransport.FindByTransportType(null, ActiveDirectoryTransportType.Rpc));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [OuterLoop]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Getting information about domain is denied inside App")]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/21553", TargetFrameworkMonikers.UapAot)]
@@ -29,14 +28,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindByTransportType_ForestNoDomainAssociatedWithName_ThrowsActiveDirectoryOperationException()
         {
             var context = new DirectoryContext(DirectoryContextType.Forest, "server:port");
             AssertExtensions.Throws<ArgumentException>("context", () => ActiveDirectoryInterSiteTransport.FindByTransportType(context, ActiveDirectoryTransportType.Rpc));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not approved COM object for app")]
         public void FindByTransportType_ForestNoDomainAssociatedWithName_ThrowsActiveDirectoryOperationException_NoUap()
         {
@@ -48,7 +47,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindByTransportType_DomainNoDomainAssociatedWithoutName_ThrowsArgumentException()
         {
             var context = new DirectoryContext(DirectoryContextType.Domain);
@@ -71,7 +70,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
                         $"We got unrecognized exception {exception}");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [OuterLoop]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Getting information about domain is denied inside App")]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/21553", TargetFrameworkMonikers.UapAot)]
@@ -81,7 +80,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ActiveDirectoryOperationException>(() => ActiveDirectoryInterSiteTransport.FindByTransportType(context, ActiveDirectoryTransportType.Rpc));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(ActiveDirectoryTransportType.Rpc - 1)]
         [InlineData(ActiveDirectoryTransportType.Smtp + 1)]
         public void FindByTransportType_InvalidTransport_ThrowsInvalidEnumArgumentException(ActiveDirectoryTransportType transport)

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DirectoryContextTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DirectoryContextTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.DirectoryServices.ActiveDirectory.Tests
 {
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     public class DirectoryContextTests
     {
         [Theory]

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DirectoryContextTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DirectoryContextTests.cs
@@ -7,10 +7,9 @@ using Xunit;
 
 namespace System.DirectoryServices.ActiveDirectory.Tests
 {
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     public class DirectoryContextTests
     {
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.Domain)]
         [InlineData(DirectoryContextType.Forest)]
         public void Ctor_ContextType(DirectoryContextType contextType)
@@ -21,7 +20,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Null(context.UserName);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.Domain, null, null)]
         [InlineData(DirectoryContextType.Forest, "UserName", "Password")]
         public void Ctor_ContextType_UserName_Password(DirectoryContextType contextType, string userName, string password)
@@ -32,7 +31,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Equal(userName, context.UserName);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.ApplicationPartition)]
         [InlineData(DirectoryContextType.ConfigurationSet)]
         [InlineData(DirectoryContextType.DirectoryServer)]
@@ -42,7 +41,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<ArgumentException>("contextType", () => new DirectoryContext(contextType, "username", "password"));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.ApplicationPartition, "Name")]
         [InlineData(DirectoryContextType.ConfigurationSet, "Name")]
         [InlineData(DirectoryContextType.DirectoryServer, "Name")]
@@ -56,7 +55,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Null(context.UserName);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.ApplicationPartition, "Name", null, null)]
         [InlineData(DirectoryContextType.ConfigurationSet, "Name", "", "")]
         [InlineData(DirectoryContextType.DirectoryServer, "Name", "UserName", "Password")]
@@ -70,7 +69,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Equal(userName, context.UserName);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.Domain - 1)]
         [InlineData(DirectoryContextType.ApplicationPartition + 1)]
         public void Ctor_InvalidContextType_ThrowsInvalidEnumArgumentException(DirectoryContextType contextType)
@@ -79,14 +78,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<InvalidEnumArgumentException>("contextType", () => new DirectoryContext(contextType, "name", "userName", "password"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Ctor_NullName_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("name", () => new DirectoryContext(DirectoryContextType.ConfigurationSet, null));
             AssertExtensions.Throws<ArgumentNullException>("name", () => new DirectoryContext(DirectoryContextType.ConfigurationSet, null, "userName", "password"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Ctor_EmptyName_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("name", () => new DirectoryContext(DirectoryContextType.ConfigurationSet, string.Empty));

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DomainControllerTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DomainControllerTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.DirectoryServices.ActiveDirectory.Tests
 {
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     public class DomainControllerTests
     {
         [Fact]

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DomainControllerTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DomainControllerTests.cs
@@ -7,16 +7,15 @@ using Xunit;
 
 namespace System.DirectoryServices.ActiveDirectory.Tests
 {
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     public class DomainControllerTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetDomainController_NullContext_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("context", () => DomainController.GetDomainController(null));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.ApplicationPartition)]
         [InlineData(DirectoryContextType.ConfigurationSet)]
         [InlineData(DirectoryContextType.Domain)]
@@ -54,7 +53,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
                         $"We got unrecognized exception {exception}");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindOne_NullContext_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("context", () => DomainController.FindOne(null));
@@ -63,7 +62,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<ArgumentNullException>("context", () => DomainController.FindOne(null, "siteName", LocatorOptions.AvoidSelf));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.ApplicationPartition)]
         [InlineData(DirectoryContextType.ConfigurationSet)]
         [InlineData(DirectoryContextType.DirectoryServer)]
@@ -77,7 +76,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<ArgumentException>("context", () => DomainController.FindOne(context, "siteName", LocatorOptions.AvoidSelf));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindOne_NullSiteName_ThrowsArgumentNullException()
         {
             var context = new DirectoryContext(DirectoryContextType.Domain);
@@ -85,7 +84,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<ArgumentNullException>("siteName", () => DomainController.FindOne(context, null, LocatorOptions.AvoidSelf));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindOne_EmptySiteName_ThrowsArgumentException()
         {
             var context = new DirectoryContext(DirectoryContextType.Domain);
@@ -93,7 +92,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<ArgumentException>("siteName", () => DomainController.FindOne(context, string.Empty, LocatorOptions.AvoidSelf));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData((LocatorOptions)(-1))]
         [InlineData((LocatorOptions)int.MaxValue)]
         public void FindOne_InvalidFlag_ThrowsArgumentException(LocatorOptions flag)
@@ -103,7 +102,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<ArgumentException>("flag", () => DomainController.FindOne(context, "siteName", flag));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData("\0", typeof(ActiveDirectoryObjectNotFoundException))]
         [InlineData("server:port", typeof(ActiveDirectoryOperationException))]
         public void FindOne_InvalidName_ThrowsException(string name, Type exceptionType)
@@ -113,7 +112,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws(exceptionType, () => DomainController.FindOne(context, "siteName", LocatorOptions.AvoidSelf));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not approved COM object for app")]
         public void FindAll_NoSuchName_ReturnsEmpty()
         {
@@ -126,7 +125,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [OuterLoop]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Getting information about domain is denied inside App")]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/21553", TargetFrameworkMonikers.UapAot)]
@@ -139,14 +138,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindAll_NullContext_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("context", () => DomainController.FindAll(null));
             AssertExtensions.Throws<ArgumentNullException>("context", () => DomainController.FindAll(null, "siteName"));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.ApplicationPartition)]
         [InlineData(DirectoryContextType.ConfigurationSet)]
         [InlineData(DirectoryContextType.DirectoryServer)]
@@ -158,28 +157,28 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<ArgumentException>("context", () => DomainController.FindAll(context, "siteName"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindAll_NullSiteName_ThrowsArgumentNullException()
         {
             var context = new DirectoryContext(DirectoryContextType.Domain);
             AssertExtensions.Throws<ArgumentNullException>("siteName", () => DomainController.FindAll(context, null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindAll_EmptySiteName_ThrowsArgumentException()
         {
             var context = new DirectoryContext(DirectoryContextType.Domain);
             AssertExtensions.Throws<ArgumentException>("siteName", () => DomainController.FindAll(context, string.Empty));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void FindAll_InvalidName_ThrowsActiveDirectoryOperationException()
         {
             var context = new DirectoryContext(DirectoryContextType.Domain, "server:port");
             Assert.Throws<ActiveDirectoryOperationException>(() => DomainController.FindAll(context, "siteName"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void CheckReplicationConsistency_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -188,35 +187,35 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.CheckReplicationConsistency());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void CheckReplicationConsistency_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.CheckReplicationConsistency());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void CurrentTime_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.CurrentTime);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Domain_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.Domain);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Forest_GetWithNoContext_ThrowsActiveDirectoryObjectNotFoundException()
         {
             var controller = new SubController();
             Assert.Throws<ActiveDirectoryObjectNotFoundException>(() => controller.Forest);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void EnableGlobalCatalog_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -225,14 +224,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.EnableGlobalCatalog());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void EnableGlobalCatalog_NoContext_ThrowsActiveDirectoryObjectNotFoundException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.EnableGlobalCatalog());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetAllReplicationNeighbors_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -241,14 +240,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.GetAllReplicationNeighbors());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetAllReplicationNeighbors_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.GetAllReplicationNeighbors());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetDirectoryEntry_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -257,21 +256,21 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.GetDirectoryEntry());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetDirectoryEntry_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.GetDirectoryEntry());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetDirectorySearcher_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.GetDirectorySearcher());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationConnectionFailures_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -280,28 +279,28 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.GetReplicationConnectionFailures());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationConnectionFailures_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.GetReplicationConnectionFailures());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationCursors_NullPartition_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("partition", () => controller.GetReplicationCursors(null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationCursors_EmptyPartition_ThrowsArgumentException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentException>("partition", () => controller.GetReplicationCursors(string.Empty));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationCursors_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -310,28 +309,28 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.GetReplicationCursors("partition"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationCursors_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.GetReplicationCursors("partition"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationMetadata_NullObjectPath_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("objectPath", () => controller.GetReplicationMetadata(null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationMetadata_EmptyObjectPath_ThrowsArgumentException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentException>("objectPath", () => controller.GetReplicationMetadata(string.Empty));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationMetadata_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -340,28 +339,28 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.GetReplicationMetadata("objectPath"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationMetadata_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.GetReplicationMetadata("objectPath"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationNeighbors_NullPartition_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("partition", () => controller.GetReplicationNeighbors(null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationNeighbors_EmptyPartition_ThrowsArgumentException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentException>("partition", () => controller.GetReplicationNeighbors(string.Empty));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationNeighbors_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -370,14 +369,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.GetReplicationNeighbors("partition"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationNeighbors_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.GetReplicationNeighbors("partition"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationOperationInformation_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -386,21 +385,21 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.GetReplicationOperationInformation());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetReplicationOperationInformation_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.GetReplicationOperationInformation());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void HighestCommittedUsn_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.HighestCommittedUsn);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void InboundConnections_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -409,21 +408,21 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.InboundConnections);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void InboundConnections_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.InboundConnections);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void IPAddress_GetWithNoContext_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("hostNameOrAddress", () => controller.IPAddress);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void IsGlobalCatalog_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -432,28 +431,28 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.IsGlobalCatalog());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void IsGlobalCatalog_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.IsGlobalCatalog());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void MoveToAnotherSite_NullSiteName_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("siteName", () => controller.MoveToAnotherSite(null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void MoveToAnotherSite_EmptySiteName_ThrowsArgumentException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentException>("siteName", () => controller.MoveToAnotherSite(string.Empty));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void MoveToAnotherSite_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -462,14 +461,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.MoveToAnotherSite("siteName"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void MoveToAnotherSite_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.MoveToAnotherSite("siteName"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Name_GetWithNoContext_ReturnsNull()
         {
             var controller = new SubController();
@@ -477,7 +476,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Null(controller.ToString());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void OSVersion_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -486,14 +485,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.OSVersion);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void OSVersion_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.OSVersion);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void OutboundConnections_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -502,21 +501,21 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.OutboundConnections);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void OutboundConnections_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.OutboundConnections);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Partitions_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.Partitions);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Roles_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -525,14 +524,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.Roles);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Roles_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.Roles);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SeizeRoleOwnership_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
@@ -543,7 +542,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<NullReferenceException>(() => controller.SeizeRoleOwnership(ActiveDirectoryRole.SchemaRole));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(ActiveDirectoryRole.SchemaRole - 1)]
         [InlineData(ActiveDirectoryRole.InfrastructureRole + 1)]
         public void SeizeRoleOwnership_InvalidRole_ThrowsInvalidEnumArgumentException(ActiveDirectoryRole role)
@@ -552,7 +551,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<InvalidEnumArgumentException>("role", () => controller.SeizeRoleOwnership(role));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SiteName_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -561,14 +560,14 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.SiteName);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SiteName_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.SiteName);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncFromAllServersCallback_Set_GetReturnsExpected()
         {
             SyncUpdateCallback callback = SyncUpdateCallback;
@@ -581,7 +580,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             return true;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncFromAllServersCallback_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -591,42 +590,42 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.SyncFromAllServersCallback = null);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncFromAllServersCallback_GetWithNoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Null(controller.SyncFromAllServersCallback);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromServer_NullPartition_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("partition", () => controller.SyncReplicaFromServer(null, "sourceServer"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromServer_EmptyPartition_ThrowsArgumentException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentException>("partition", () => controller.SyncReplicaFromServer(string.Empty, "sourceServer"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromServer_NullSourceServer_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("sourceServer", () => controller.SyncReplicaFromServer("partition", null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromServer_EmptySourceServer_ThrowsArgumentException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentException>("sourceServer", () => controller.SyncReplicaFromServer("partition", string.Empty));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromServer_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -635,28 +634,28 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.SyncReplicaFromServer("partition", "sourceServer"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromServer_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.SyncReplicaFromServer("partition", "sourceServer"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromAllServers_NullPartition_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("partition", () => controller.SyncReplicaFromAllServers(null, SyncFromAllServersOptions.AbortIfServerUnavailable));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromAllServers_EmptyPartition_ThrowsArgumentException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentException>("partition", () => controller.SyncReplicaFromAllServers(string.Empty, SyncFromAllServersOptions.AbortIfServerUnavailable));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromAllServers_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -665,21 +664,21 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.SyncReplicaFromAllServers("partition", SyncFromAllServersOptions.AbortIfServerUnavailable));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SyncReplicaFromAllServers_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.SyncReplicaFromAllServers("partition", SyncFromAllServersOptions.AbortIfServerUnavailable));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TransferRoleOwnership_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();
             Assert.Throws<NullReferenceException>(() => controller.TransferRoleOwnership(ActiveDirectoryRole.NamingRole));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(ActiveDirectoryRole.SchemaRole - 1)]
         [InlineData(ActiveDirectoryRole.InfrastructureRole + 1)]
         public void TransferRoleOwnership_InvalidRole_ThrowsInvalidEnumArgumentException(ActiveDirectoryRole role)
@@ -688,21 +687,21 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<InvalidEnumArgumentException>("role", () => controller.TransferRoleOwnership(role));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TriggerSyncReplicaFromNeighbors_NullPartition_ThrowsArgumentNullException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentNullException>("partition", () => controller.TriggerSyncReplicaFromNeighbors(null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TriggerSyncReplicaFromNeighbors_EmptyPartition_ThrowsArgumentException()
         {
             var controller = new SubController();
             AssertExtensions.Throws<ArgumentException>("partition", () => controller.TriggerSyncReplicaFromNeighbors(string.Empty));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TriggerSyncReplicaFromNeighbors_Disposed_ThrowsObjectDisposedException()
         {
             var controller = new SubController();
@@ -711,7 +710,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ObjectDisposedException>(() => controller.TriggerSyncReplicaFromNeighbors("partition"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TriggerSyncReplicaFromNeighbors_NoContext_ThrowsNullReferenceException()
         {
             var controller = new SubController();

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ForestTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ForestTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.DirectoryServices.ActiveDirectory.Tests
 {
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     public class ForestTests
     {
         [Fact]

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ForestTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ForestTests.cs
@@ -6,16 +6,15 @@ using Xunit;
 
 namespace System.DirectoryServices.ActiveDirectory.Tests
 {
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     public class ForestTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void GetForest_NullContext_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("context", () => Forest.GetForest(null));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.ApplicationPartition)]
         [InlineData(DirectoryContextType.ConfigurationSet)]
         [InlineData(DirectoryContextType.Domain)]
@@ -25,7 +24,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             AssertExtensions.Throws<ArgumentException>("context", () => Forest.GetForest(context));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [OuterLoop]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not approved COM object for app")]
         public void GetForest_NullNameAndNotRootedDomain_ThrowsActiveDirectoryOperationException()

--- a/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
+++ b/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
@@ -19,7 +19,7 @@ namespace System.IO.Ports.Tests
         /// <summary>
         /// Check that all ports either open correctly or fail with UnauthorizedAccessException (which implies they're already open)
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         private void OpenEveryPortName()
         {
             foreach (string portName in SerialPort.GetPortNames())
@@ -40,7 +40,7 @@ namespace System.IO.Ports.Tests
         /// Test that SerialPort.GetPortNames finds every port that the test helpers have found. 
         /// (On Windows, the latter uses a different technique to SerialPort to find ports).
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         private void AllHelperPortsAreInGetPortNames()
         {
             string[] serialPortNames = SerialPort.GetPortNames();
@@ -55,7 +55,7 @@ namespace System.IO.Ports.Tests
         /// Test that the test helpers have found every port that SerialPort.GetPortNames has found
         /// This catches regressions in the test helpers, eg GH #18928 / #20668
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         private void AllGetPortNamesAreInHelperPorts()
         {
             string[] helperPortNames = PortHelper.GetPorts();

--- a/src/System.IO.Ports/tests/SerialPort/OpenDevices.cs
+++ b/src/System.IO.Ports/tests/SerialPort/OpenDevices.cs
@@ -12,7 +12,7 @@ namespace System.IO.Ports.Tests
 {
     public class OpenDevices : PortsTest
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/corefx/issues/29756
         [ActiveIssue("https://github.com/dotnet/corefx/issues/23294", TargetFrameworkMonikers.Uap)]
         public void OpenDevices01()
         {

--- a/src/System.IO.Ports/tests/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Support/TCSupport.cs
@@ -32,6 +32,12 @@ namespace Legacy.Support
 
         private static void InitializeSerialInfo()
         {
+            if (PlatformDetection.IsWindowsNanoServer)
+            {
+                s_localMachineSerialPortRequirements = SerialPortRequirements.None;
+                return;
+            }
+
             GenerateSerialInfo();
 
             if (s_localMachineSerialInfo.LoopbackPortName != null)

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -84,7 +84,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: dotnet/corefx #29929
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"
@@ -92,7 +92,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: dotnet/corefx #29929
         [PlatformSpecific(TestPlatforms.Windows)] // see comment below
         [ActiveIssue(21327, TargetFrameworkMonikers.Uap)] // UWP Apps are forbidden to send network traffic to the local Computer.
         public async Task MulticastInterface_Set_Loopback_Succeeds()
@@ -151,7 +151,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: dotnet/corefx #29929
         public async Task MulticastInterface_Set_IPv6_AnyInterface_Succeeds()
         {
             if (PlatformDetection.IsFedora || PlatformDetection.IsRedHatFamily7 || PlatformDetection.IsOSX)
@@ -164,7 +164,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: dotnet/corefx #29929
         [PlatformSpecific(TestPlatforms.Windows)]
         [ActiveIssue(21327, TargetFrameworkMonikers.Uap)] // UWP Apps are forbidden to send network traffic to the local Computer.
         public async void MulticastInterface_Set_IPv6_Loopback_Succeeds()

--- a/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
@@ -10,6 +10,7 @@ namespace System.ServiceProcess.Tests
     {
         private const string KeyIsoSvcName = "KEYISO";
 
+        [ActiveIssue(19223)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/19223
         public static void GetServices()
         {


### PR DESCRIPTION
This PR tries to cherry-pick nano fixes already made in master and port them to release/2.1

cc: @stephentoub @pjanotti @caesar1995 @davidsh 

PRs taken so far:

- https://github.com/dotnet/corefx/pull/29857
- https://github.com/dotnet/corefx/pull/29931
- https://github.com/dotnet/corefx/pull/29789
- https://github.com/dotnet/corefx/pull/29793
- https://github.com/dotnet/corefx/pull/29924