### PR TITLE
Update Japanese Calendar tests

### DIFF
--- a/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
+++ b/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
@@ -16,7 +16,7 @@ namespace System.Globalization.Tests
             Month = 2,
             Day = 8
         }
-        
+
         public static Calendar[] s_calendars = new Calendar[]
         {
             new ThaiBuddhistCalendar(),
@@ -53,6 +53,25 @@ namespace System.Globalization.Tests
                 return calendar.GetYear(calendar.MaxSupportedDateTime);
             }
             return calendar.GetYear(calendar.ToDateTime(1, 1, 1, 0, 0, 0, 0, era + 1).AddDays(-1)) + 1;
+        }
+
+        // Get the max year in the passed era plus the sum of the max year for each subsequent era
+        private static int MaxCalendarYearInEras(Calendar calendar, int era)
+        {
+            int[] eras = calendar.Eras;
+            Assert.InRange(era, 0, eras[0]);
+            if (eras.Length == 1 || era == eras[0] || era == 0)
+            {
+                return MaxCalendarYearInEra(calendar, era);
+            }
+
+            int year = 0;
+            for (int i = era; i <= calendar.Eras[0]; i++)
+            {
+                year += MaxCalendarYearInEra(calendar, i);
+            }
+
+            return year;
         }
 
         private static int MaxGregorianYearInEra(Calendar calendar, int era)
@@ -106,8 +125,8 @@ namespace System.Globalization.Tests
                 {
                     // desktop has a bug in JapaneseLunisolarCalendar which is fixed in .Net Core.
                     // in case of a new era starts in the middle of a month which means part of the month will belong to one
-                    // era and the rest will belong to the new era. When calculating the calendar year number for dates which 
-                    // in the rest of the month and exist in the new started era, we should still use the old era info instead 
+                    // era and the rest will belong to the new era. When calculating the calendar year number for dates which
+                    // in the rest of the month and exist in the new started era, we should still use the old era info instead
                     // of the new era info because the rest of the month still belong to the year of last era.
                     // https://github.com/dotnet/coreclr/pull/3662
                     continue;
@@ -119,7 +138,8 @@ namespace System.Globalization.Tests
                     // Year is invalid
                     yield return new object[] { calendar, -1, month, day, era, "year" };
                     yield return new object[] { calendar, 0, month, day, era, "year" };
-                    yield return new object[] { calendar, MaxCalendarYearInEra(calendar, era) + 1, month, day, era, "year" };
+
+                    yield return new object[] { calendar, MaxCalendarYearInEras(calendar, era) + 1, month, day, era, "year" };
 
                     if ((type & DataType.Month) != 0)
                     {
@@ -158,7 +178,7 @@ namespace System.Globalization.Tests
                 DateTime maxDate = calendar.MaxSupportedDateTime;
                 if (maxDate != DateTime.MaxValue)
                 {
-                    yield return new object[] { calendar, maxDate.AddDays(1) }; 
+                    yield return new object[] { calendar, maxDate.AddDays(1) };
                 }
             }
         }
@@ -334,7 +354,7 @@ namespace System.Globalization.Tests
                 // Year is invalid
                 Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(-1, month, day, hour, minute, second, millisecond, era));
                 Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(0, month, day, hour, minute, second, millisecond, era));
-                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(MaxCalendarYearInEra(calendar, era) + 1, month, day, hour, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(MaxCalendarYearInEras(calendar, era) + 1, month, day, hour, minute, second, millisecond, era));
 
                 // Month is invalid
                 Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, -1, day, hour, minute, second, millisecond, era));
@@ -388,7 +408,7 @@ namespace System.Globalization.Tests
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(-1));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MaxCalendarYearInEra(calendar, MaxEra(calendar)) + 1));
-            
+
             if (!(calendar is JapaneseLunisolarCalendar))
             {
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MinCalendarYearInEra(calendar, MinEra(calendar)) - 2));
@@ -459,6 +479,16 @@ namespace System.Globalization.Tests
             {
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("time", () => calendar.GetDayOfWeek(dt));
             }
+        }
+
+        [Fact]
+        public static void TestJapaneseCalendarDateParsing()
+        {
+            CultureInfo ciJapanese = new CultureInfo("ja-JP") { DateTimeFormat = { Calendar = new JapaneseCalendar() } };
+
+            DateTime dt = new DateTime(1970, 1, 1);
+            string eraName = dt.ToString("gg", ciJapanese);
+            Assert.Equal(new DateTime(1995, 1, 1), DateTime.Parse(eraName + " 70/1/1 0:00:00", ciJapanese));
         }
     }
 }

--- a/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/CalendarTests.cs
+++ b/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/CalendarTests.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Globalization.Tests
+{
+    public static class CalendarTests
+    {
+        [Fact]
+        public static void TestJapaneseCalendarDateParsing()
+        {
+            CultureInfo ciJapanese = new CultureInfo("ja-JP") { DateTimeFormat = { Calendar = new JapaneseCalendar() } };
+
+            DateTime dt = new DateTime(1970, 1, 1);
+            string eraName = dt.ToString("gg", ciJapanese);
+
+            // Legacy behavior which we used to throw when using a year number exceeding the era max year.
+            Assert.ThrowsAny<FormatException>(() => DateTime.Parse(eraName + " 70/1/1 0:00:00", ciJapanese));
+        }
+    }
+}

--- a/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/Configurations.props
+++ b/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netcoreapp;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/System.Globalization.CalendarsWithConfigSwitch.Tests.csproj
+++ b/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/System.Globalization.CalendarsWithConfigSwitch.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{77BE33BB-790D-4D0C-9336-E073001CBD15}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="CalendarTests.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <!--
+        We are overriding the .json config file to include "Switch.System.Globalization.EnforceJapaneseEraYearRanges": true
+    -->
+    <SkipXunitRuntimeConfigCopying>true</SkipXunitRuntimeConfigCopying>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="xunit.console.netcore.runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/xunit.console.netcore.runtimeconfig.json
+++ b/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/xunit.console.netcore.runtimeconfig.json
@@ -1,0 +1,11 @@
+{
+  "runtimeOptions": {
+    "configProperties": {
+      "Switch.System.Globalization.EnforceJapaneseEraYearRanges": true
+    },
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+        "version": "9.9.9"
+	    }
+  }
+}


### PR DESCRIPTION
This change is to have the Japanese calendar tests work as expected with the new introduced era for this calendar.