### PR TITLE
Make directory enumeration consistent (#29908)

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/Common/src/Interop/Windows/Interop.Errors.cs
@@ -47,6 +47,7 @@ internal partial class Interop
         internal const int ERROR_PIPE_NOT_CONNECTED = 0xE9;
         internal const int ERROR_MORE_DATA = 0xEA;
         internal const int ERROR_NO_MORE_ITEMS = 0x103;
+        internal const int ERROR_DIRECTORY = 0x10B;
         internal const int ERROR_PARTIAL_COPY = 0x12B;
         internal const int ERROR_ARITHMETIC_OVERFLOW = 0x216;
         internal const int ERROR_PIPE_CONNECTED = 0x217;

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
@@ -43,7 +43,7 @@ namespace System.IO.Enumeration
         {
             // We don't have access to any APIs that allow us to pass in a base handle in UAP,
             // just call our "normal" handle open.
-            return CreateDirectoryHandle(fullPath);
+            return CreateDirectoryHandle(fullPath, ignoreNotFound: true);
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -87,7 +88,7 @@ namespace System.IO.Enumeration
         /// <summary>
         /// Simple wrapper to allow creating a file handle for an existing directory.
         /// </summary>
-        private IntPtr CreateDirectoryHandle(string path)
+        private IntPtr CreateDirectoryHandle(string path, bool ignoreNotFound = false)
         {
             IntPtr handle = Interop.Kernel32.CreateFile_IntPtr(
                 path,
@@ -100,8 +101,7 @@ namespace System.IO.Enumeration
             {
                 int error = Marshal.GetLastWin32Error();
 
-                if ((error == Interop.Errors.ERROR_ACCESS_DENIED &&
-                    _options.IgnoreInaccessible) || ContinueOnError(error))
+                if (ContinueOnDirectoryError(error, ignoreNotFound))
                 {
                     return IntPtr.Zero;
                 }
@@ -116,6 +116,17 @@ namespace System.IO.Enumeration
             }
 
             return handle;
+        }
+
+        private bool ContinueOnDirectoryError(int error, bool ignoreNotFound)
+        {
+            // Directories can be removed (ERROR_FILE_NOT_FOUND) or replaced with a file of the same name (ERROR_DIRECTORY) while
+            // we are enumerating. The only reasonable way to handle this is to simply move on. There is no such thing as a "true"
+            // snapshot of filesystem state- our "snapshot" will consider the name non-existent in this rare case.
+
+            return (ignoreNotFound && (error == Interop.Errors.ERROR_FILE_NOT_FOUND || error == Interop.Errors.ERROR_PATH_NOT_FOUND || error == Interop.Errors.ERROR_DIRECTORY))
+                || (error == Interop.Errors.ERROR_ACCESS_DENIED && _options.IgnoreInaccessible)
+                || ContinueOnError(error);
         }
 
         public bool MoveNext()
@@ -195,9 +206,13 @@ namespace System.IO.Enumeration
                 _entry = (Interop.NtDll.FILE_FULL_DIR_INFORMATION*)_pinnedBuffer.AddrOfPinnedObject();
         }
 
-        private void DequeueNextDirectory()
+        private bool DequeueNextDirectory()
         {
+            if (_pending == null || _pending.Count == 0)
+                return false;
+
             (_directoryHandle, _currentPath) = _pending.Dequeue();
+            return true;
         }
 
         private void InternalDispose(bool disposing)

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.cs
@@ -32,8 +32,8 @@ namespace System.IO.Enumeration
         protected virtual void OnDirectoryFinished(ReadOnlySpan<char> directory) { }
 
         /// <summary>
-        /// Called when a native API returns an error. Return true to continue, or false
-        /// to throw the default exception for the given error.
+        /// Called when a native API returns an error that would normally cause a throw.
+        /// Return true to continue, or false to throw the default exception for the given error.
         /// </summary>
         /// <param name="error">The native error code.</param>
         protected virtual bool ContinueOnError(int error) => false;
@@ -50,14 +50,13 @@ namespace System.IO.Enumeration
             CloseDirectoryHandle();
             OnDirectoryFinished(_currentPath);
 
-            if (_pending == null || _pending.Count == 0)
+            // Attempt to grab another directory to process
+            if (!DequeueNextDirectory())
             {
                 _lastEntryFound = true;
             }
             else
             {
-                // Grab the next directory to parse
-                DequeueNextDirectory();
                 FindNextEntry();
             }
         }

--- a/src/System.IO.FileSystem/tests/Enumeration/RemovedDirectoryTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/RemovedDirectoryTests.netcoreapp.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Enumeration;
+using Xunit;
+
+namespace System.IO.Tests.Enumeration
+{
+    public class RemovedDirectoryTests : FileSystemTest
+    {
+        private class DirectoryFinishedEnumerator : FileSystemEnumerator<string>
+        {
+            public DirectoryFinishedEnumerator(string directory, EnumerationOptions options)
+                : base(directory, options)
+            {
+            }
+
+            protected override string TransformEntry(ref FileSystemEntry entry)
+            {
+                return entry.FileName.ToString();
+            }
+
+            public delegate void DirectoryFinishedDelegate(ReadOnlySpan<char> directory);
+
+            public DirectoryFinishedDelegate DirectoryFinishedAction { get; set; }
+
+            protected override void OnDirectoryFinished(ReadOnlySpan<char> directory)
+            {
+                DirectoryFinishedAction?.Invoke(directory);
+            }
+        }
+
+        [Fact]
+        public void RemoveDirectoryBeforeRecursion()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Combine(testDirectory.FullName, "Subdirectory"));
+
+            using (var enumerator = new DirectoryFinishedEnumerator(testDirectory.FullName, new EnumerationOptions { RecurseSubdirectories = true }))
+            {
+                enumerator.DirectoryFinishedAction = (d) =>
+                {
+                    if (d.Equals(testDirectory.FullName, StringComparison.OrdinalIgnoreCase)) testSubdirectory.Delete();
+                };
+
+                // We shouldn't fail because a directory we found got deleted.
+                // No errors here are possible on Windows as by the time of the deletion above, the subdirectory handle is already opened.
+                while (enumerator.MoveNext());
+            }
+        }
+
+        [Fact]
+        public void RemoveDirectoryBeforeHandleCreation()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            FileInfo testFile = new FileInfo(Path.Join(testDirectory.FullName, GetTestFileName()));
+            testFile.Create().Dispose();
+            DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Join(testDirectory.FullName, "Subdirectory"));
+
+            using (var enumerator = new DirectoryFinishedEnumerator(testDirectory.FullName, new EnumerationOptions { RecurseSubdirectories = true }))
+            {
+                // We shouldn't fail because a directory we found got deleted.
+                // If we yank the directory when we have it's data, but BEFORE we create the handle we'll fail internally with not found.
+                while (enumerator.MoveNext())
+                {
+                    // Using a flag file to kill the directory in the middle of processing returned data
+                    if (string.Equals(enumerator.Current, testFile.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        testSubdirectory.Delete();
+                    }
+                };
+            }
+        }
+
+        [Fact]
+        public void RemoveDirectoryBeforeHandleCreationAndReplaceWithFile()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            FileInfo testFile = new FileInfo(Path.Join(testDirectory.FullName, GetTestFileName()));
+            testFile.Create().Dispose();
+            DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Join(testDirectory.FullName, "Subdirectory"));
+
+            using (var enumerator = new DirectoryFinishedEnumerator(testDirectory.FullName, new EnumerationOptions { RecurseSubdirectories = true }))
+            {
+                // We shouldn't fail because a directory we found got deleted.
+                // If replace the directory with a file when we have it's data, but BEFORE we create the handle we'll fail internally trying to create a directory handle on it.
+                while (enumerator.MoveNext())
+                {
+                    // Using a flag file to replace the directory in the middle of processing returned data
+                    if (string.Equals(enumerator.Current, testFile.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        testSubdirectory.Delete();
+                        File.Create(testSubdirectory.FullName).Dispose();
+                    }
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
This ports #29908, which fixes special error case handling in file enumeration in Unix, which is essentially broken. This includes `EnumerationOptions.IgnoreInaccessible` and writing custom error handlers for Unix.

I caught this when investigating other issues in the area. We were missing tests that covered the full scenario. This change includes coverage.

* Make directory enumeration consistent

Directories can disappear or be replaced with files after we find them when recursively enumerating. Fix so we don't throw in these cases.

Also make queue handling consistent between Unix/Windows. In error skipping cases we need to be sure that we don't try to process directories we fail to open but don't care about. This simplifies custom error handling.

Fix error mapping in Unix. Add tests

* Fix typo in WinRT

* Address feedback