### PR TITLE
Fix proxy connect tunnel test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2221,7 +2221,6 @@ namespace System.Net.Http.Functional.Tests
             server => server.AcceptConnectionSendResponseAndCloseAsync());
         }
 
-        [OuterLoop("Multiple connections")]
         [Fact]
         public async Task Dispose_DisposingHandlerCancelsActiveOperationsWithoutResponses()
         {
@@ -3215,7 +3214,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
 
-            await TaskTimeoutExtensions.WhenAllOrAnyFailed(new Task[] { proxyTask }, TestHelper.PassingTestTimeoutMilliseconds);
+            await proxyTask.TimeoutAfter(TestHelper.PassingTestTimeoutMilliseconds);
             LoopbackGetRequestHttpProxy.ProxyResult proxyResult = proxyTask.Result;
             _output.WriteLine($"Proxy request line: {proxyResult.RequestLine}");
             Assert.Contains("CONNECT", proxyResult.RequestLine);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -252,7 +252,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
-        [OuterLoop]
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task DefaultHeaders_SetCredentials_ClearedOnRedirect(int statusCode)
         {
@@ -303,7 +303,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task SendAsync_SimpleGet_Success(Uri remoteServer)
         {
@@ -320,7 +320,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -342,7 +342,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task SendAsync_GetWithInvalidHostHeader_ThrowsException()
         {
@@ -362,7 +362,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(22158, TargetFrameworkMonikers.Uap)]
-        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // TODO: make unconditional after #26813 and #26476 are fixed
         public async Task GetAsync_IPv6LinkLocalAddressUri_Success()
         {
@@ -380,7 +379,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(GetAsync_IPBasedUri_Success_MemberData))]
         public async Task GetAsync_IPBasedUri_Success(IPAddress address)
@@ -409,7 +407,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task SendAsync_MultipleRequestsReusingSameClient_Success()
         {
@@ -425,7 +423,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_ResponseContentAfterClientAndHandlerDispose_Success()
         {
@@ -441,7 +439,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task SendAsync_Cancel_CancellationTokenPropagates()
         {
@@ -461,7 +459,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(CompressedServers))]
         public async Task GetAsync_SetAutomaticDecompression_ContentDecompressed(Uri server)
         {
@@ -548,7 +546,7 @@ namespace System.Net.Http.Functional.Tests
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
         [Theory]
-        [OuterLoop] // Test uses azure endpoint.
+        [OuterLoop("Uses external server")]
         [MemberData(nameof(DestinationHost_MemberData))]
         public async Task ProxiedRequest_DefaultPort_PortStrippedOffInUri(string host)
         {
@@ -576,7 +574,7 @@ namespace System.Net.Http.Functional.Tests
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
         [Fact]
-        [OuterLoop] // Test uses azure endpoint.
+        [OuterLoop("Uses external server")]
         public async Task ProxyTunnelRequest_PortSpecified_NotStrippedOffInUri()
         {
             // Https proxy request will use CONNECT tunnel, even the default 443 port is specified, it will not be stripped off.
@@ -639,7 +637,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(connectionAccepted);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(CompressedServers))]
         public async Task GetAsync_SetAutomaticDecompression_HeadersRemoved(Uri server)
         {
@@ -725,7 +723,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_ServerNeedsBasicAuthAndSetDefaultCredentials_StatusCodeUnauthorized()
         {
@@ -741,7 +739,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_ServerNeedsAuthAndSetCredential_StatusCodeOK()
         {
@@ -757,7 +755,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void GetAsync_ServerNeedsAuthAndNoCredential_StatusCodeUnauthorized()
         {
@@ -779,7 +777,6 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("WWW-Authenticate: CustomAuth\r\n")]
         [InlineData("")] // RFC7235 requires servers to send this header with 401 but some servers don't.
@@ -803,7 +800,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_AllowAutoRedirectFalse_RedirectFromHttpToHttp_StatusCodeRedirect(int statusCode)
         {
@@ -951,7 +948,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttp_StatusCodeOK(int statusCode)
         {
@@ -973,7 +970,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttps_StatusCodeOK()
         {
@@ -996,7 +993,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework allows HTTPS to HTTP redirection")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpsToHttp_StatusCodeRedirect()
         {
@@ -1047,7 +1044,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectToUriWithParams_RequestMsgUriSet()
         {
@@ -1071,7 +1068,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(3, 2)]
         [InlineData(3, 3)]
@@ -1127,7 +1124,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectWithRelativeLocation()
         {
@@ -1151,7 +1148,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(200)]
         [InlineData(201)]
@@ -1186,7 +1182,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("#origFragment", "", "#origFragment", false)]
         [InlineData("#origFragment", "", "#origFragment", true)]
@@ -1264,7 +1259,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [OuterLoop] // Test uses azure endpoint.
+        [OuterLoop("Uses external server")]
         public async Task GetAsync_CredentialIsNetworkCredentialUriRedirect_StatusCodeUnauthorized()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1285,7 +1280,7 @@ namespace System.Net.Http.Functional.Tests
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
         [Fact]
-        [OuterLoop] // Test uses azure endpoint.
+        [OuterLoop("Uses external server")]
         public async Task HttpClientHandler_CredentialIsNotCredentialCacheAfterRedirect_StatusCodeOK()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1311,7 +1306,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK(int statusCode)
         {
@@ -1346,7 +1341,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
         [Theory]
         [MemberData(nameof(HeaderWithEmptyValueAndUris))]
@@ -1371,7 +1366,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(HeaderValueAndUris))]
         public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndValueSent(string name, string value, Uri uri)
         {
@@ -1714,7 +1709,6 @@ namespace System.Net.Http.Functional.Tests
                 dribble ? new LoopbackServer.Options { StreamWrapper = s => new DribbleStream(s) } : null);
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -1765,7 +1759,6 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_NonTraditionalChunkSizes_Accepted()
         {
@@ -1807,7 +1800,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("")] // missing size
         [InlineData("    ")] // missing size
@@ -1868,7 +1860,6 @@ namespace System.Net.Http.Functional.Tests
                 "\r\n"));
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_InfiniteChunkSize_ThrowsHttpRequestException()
         {
@@ -1920,7 +1911,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_ResponseHeadersRead_ReadFromEachIterativelyDoesntDeadlock()
         {
@@ -1945,7 +1936,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task SendAsync_HttpRequestMsgResponseHeadersRead_StatusCodeOK()
         {
@@ -1966,7 +1957,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx's ConnectStream.ReadAsync tries to read beyond data already buffered, causing hangs #18864")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Slow response")]
         [Fact]
         public async Task SendAsync_ReadFromSlowStreamingServer_PartialDataReturned()
         {
@@ -2230,7 +2221,7 @@ namespace System.Net.Http.Functional.Tests
             server => server.AcceptConnectionSendResponseAndCloseAsync());
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Multiple connections")]
         [Fact]
         public async Task Dispose_DisposingHandlerCancelsActiveOperationsWithoutResponses()
         {
@@ -2298,7 +2289,6 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(99)]
         [InlineData(1000)]
@@ -2327,7 +2317,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework currently does not allow unicode in DNS names")]
-        [OuterLoop]
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_UnicodeHostName_SuccessStatusCodeInResponse()
         {
@@ -2346,7 +2336,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Post Methods Tests
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(VerifyUploadServers))]
         public async Task PostAsync_CallMethodTwice_StringContent(Uri remoteServer)
         {
@@ -2371,7 +2361,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(VerifyUploadServers))]
         public async Task PostAsync_CallMethod_UnicodeStringContent(Uri remoteServer)
         {
@@ -2388,7 +2378,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(VerifyUploadServersStreamsAndExpectedData))]
         public async Task PostAsync_CallMethod_StreamContent(Uri remoteServer, HttpContent content, byte[] expectedData)
         {
@@ -2529,7 +2519,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostAsync_CallMethod_NullContent(Uri remoteServer)
         {
@@ -2550,7 +2540,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostAsync_CallMethod_EmptyContent(Uri remoteServer)
         {
@@ -2572,7 +2562,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(false, "1.0")]
         [InlineData(true, "1.0")]
@@ -2611,7 +2601,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
-        [OuterLoop]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -2648,7 +2637,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -2673,14 +2662,14 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(22191, TargetFrameworkMonikers.Uap)]
-        [OuterLoop] // takes several seconds
+        [OuterLoop("Takes several seconds")]
         [Fact]
         public async Task PostAsync_RedirectWith307_LargePayload()
         {
             await PostAsync_Redirect_LargePayload_Helper(307, true);
         }
 
-        [OuterLoop] // takes several seconds
+        [OuterLoop("Takes several seconds")]
         [Fact]
         public async Task PostAsync_RedirectWith302_LargePayload()
         {
@@ -2711,7 +2700,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(EchoServers))] // NOTE: will not work for in-box System.Net.Http.dll due to disposal of request content
         public async Task PostAsync_ReuseRequestContent_Success(Uri remoteServer)
         {
@@ -2730,7 +2719,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(HttpStatusCode.MethodNotAllowed, "Custom description")]
         [InlineData(HttpStatusCode.MethodNotAllowed, "")]
@@ -2753,7 +2742,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Various HTTP Method Tests
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(HttpMethods))]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithNoContent_MethodCorrectlySent(
             string method,
@@ -2781,7 +2770,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(HttpMethodsThatAllowContent))]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithContent_Success(
             string method,
@@ -2818,7 +2807,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(29802, TargetFrameworkMonikers.Uap)] // Test hangs. But this test seems invalid. An HttpRequestMessage can only be sent once.
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [InlineData("12345678910", 0)]
         [InlineData("12345678910", 5)]
@@ -2852,7 +2841,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(HttpMethodsThatDontAllowContent))]
         public async Task SendAsync_SendRequestUsingNoBodyMethodToEchoServerWithContent_NoBodySent(
             string method,
@@ -2905,7 +2894,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Version tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not allow HTTP/1.0 requests.")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task SendAsync_RequestVersion10_ServerReceivesVersion10Request()
         {
@@ -2913,7 +2902,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(new Version(1, 0), receivedRequestVersion);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task SendAsync_RequestVersion11_ServerReceivesVersion11Request()
         {
@@ -2922,7 +2911,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Throws exception sending request using Version(0,0)")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task SendAsync_RequestVersionNotSpecified_ServerReceivesVersion11Request()
         {
@@ -2940,7 +2929,7 @@ namespace System.Net.Http.Functional.Tests
 
         [ActiveIssue(23037, TestPlatforms.AnyUnix)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Specifying Version(2,0) throws exception on netfx")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [MemberData(nameof(Http2Servers))]
         public async Task SendAsync_RequestVersion20_ResponseVersion20IfHttp2Supported(Uri server)
@@ -3016,7 +3005,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Specifying Version(2,0) throws exception on netfx")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(IsWindows10Version1607OrGreater)), MemberData(nameof(Http2NoPushServers))]
         public async Task SendAsync_RequestVersion20_ResponseVersion20(Uri server)
         {
@@ -3085,7 +3074,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Proxy tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not support custom proxies.")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [MemberData(nameof(CredentialsForProxyRfcCompliant))]
         public async Task Proxy_BypassFalse_GetRequestGoesThroughCustomProxy_RfcCompliant(ICredentials creds, bool wrapCredsInCache)
@@ -3094,7 +3083,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not support custom proxies.")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [MemberData(nameof(CredentialsForProxyNonRfcCompliant))]
         public async Task Proxy_BypassFalse_GetRequestGoesThroughCustomProxy_NonRfcCompliant(ICredentials creds, bool wrapCredsInCache)
@@ -3145,7 +3134,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not support custom proxies.")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [MemberData(nameof(BypassedProxies))]
         public async Task Proxy_BypassTrue_GetRequestDoesntGoesThroughCustomProxy(IWebProxy proxy)
@@ -3164,7 +3153,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not support custom proxies.")]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public async Task Proxy_HaveNoCredsAndUseAuthenticatedCustomProxy_ProxyAuthenticationRequiredStatusCode()
         {
@@ -3205,47 +3194,31 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not support custom proxies.")]
+        [OuterLoop("Uses external server")]
         [Fact]
-        public async Task Proxy_UseSecureProxyTunnel_Success()
+        public async Task Proxy_SendSecureRequestThruProxy_ConnectTunnelUsed()
         {
-            if (IsWinHttpHandler || IsNetfxHandler || IsCurlHandler)
-            {
-                // Issue #27746: WinHttpHandler and netfx hang on this test. 
-                // The same happens consistently on macOS 10.13 Release and with some
-                // frequency on some Linux flavors, disabling the test for curl handler due to that.
-                return;
-            }
-
-            LoopbackServer.Options options = new LoopbackServer.Options { UseSsl = true };
-
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             var ep = (IPEndPoint)listener.Server.LocalEndPoint;
             Uri proxyUrl = new Uri($"http://{ep.Address}:{ep.Port}/");
-            //TODO : refactor once LoopbackGetRequestHttpProxy is merged with LoppbackServer
-            Task proxy = LoopbackGetRequestHttpProxy.StartAsync(listener, false, false);
+            _output.WriteLine($"proxy uri = {proxyUrl.ToString()}");
+            // TODO : refactor once LoopbackGetRequestHttpProxy is merged with LoopbackServer
+            Task<LoopbackGetRequestHttpProxy.ProxyResult> proxyTask =
+                LoopbackGetRequestHttpProxy.StartAsync(listener, false, false);
 
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            HttpClientHandler handler = CreateHttpClientHandler();
+            handler.Proxy = new UseSpecifiedUriWebProxy(proxyUrl);
+            using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.SecureRemoteEchoServer))
             {
-                Task serverTask = server.AcceptConnectionAsync(async connection =>
-                {
-                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "OK\r\n");
-                });
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
 
-                using (HttpClientHandler handler = CreateHttpClientHandler()){
-                    // Point handler at out loopback proxy
-                    handler.Proxy = new UseSpecifiedUriWebProxy(proxyUrl, null);
-                    handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-
-                    using (HttpClient client = new HttpClient(handler))
-                    {
-                        HttpResponseMessage response = await client.GetAsync(url);
-                        Assert.True(response.StatusCode ==  HttpStatusCode.OK);
-                    }
-               }
-               await serverTask;
-            }, options);
-            await proxy;
+            await TaskTimeoutExtensions.WhenAllOrAnyFailed(new Task[] { proxyTask }, TestHelper.PassingTestTimeoutMilliseconds);
+            LoopbackGetRequestHttpProxy.ProxyResult proxyResult = proxyTask.Result;
+            _output.WriteLine($"Proxy request line: {proxyResult.RequestLine}");
+            Assert.Contains("CONNECT", proxyResult.RequestLine);
         }
 
         [ActiveIssue(23702, TargetFrameworkMonikers.NetFramework)]
@@ -3322,7 +3295,6 @@ namespace System.Net.Http.Functional.Tests
         #endregion
 
         #region Uri wire transmission encoding tests
-        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendRequest_UriPathHasReservedChars_ServerReceivedExpectedPath()
         {

--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
@@ -112,26 +112,41 @@ namespace System.Net.Http.Functional.Tests
 
                     Task clientCopyTask = Task.Run(async delegate
                     {
-                        byte[] buffer = new byte[8000];
-                        int bytesRead;
-                        while ((bytesRead = await clientStream.ReadAsync(buffer)) > 0)
+                        try
                         {
-                            await serverStream.WriteAsync(buffer, 0, bytesRead);
+                            byte[] buffer = new byte[8000];
+                            int bytesRead;
+                            while ((bytesRead = await clientStream.ReadAsync(buffer)) > 0)
+                            {
+                                await serverStream.WriteAsync(buffer, 0, bytesRead);
+                            }
+                            serverStream.Flush();
+                            serverSocket.Shutdown(SocketShutdown.Send);
                         }
-                       serverStream.Flush();
-                       serverSocket.Shutdown(SocketShutdown.Send);
+                        catch (IOException)
+                        {
+                            // Ignore rude disconnects from either side.
+                        }
                     });
                     Task serverCopyTask = Task.Run(async delegate
                     {
-                        byte[] buffer = new byte[8000];
-                        int bytesRead;
-                        while ((bytesRead = await serverStream.ReadAsync(buffer)) > 0)
+                        try
                         {
-                            await clientStream.WriteAsync(buffer, 0, bytesRead);
+                            byte[] buffer = new byte[8000];
+                            int bytesRead;
+                            while ((bytesRead = await serverStream.ReadAsync(buffer)) > 0)
+                            {
+                                await clientStream.WriteAsync(buffer, 0, bytesRead);
+                            }
+                            clientStream.Flush();
+                            clientSocket.Shutdown(SocketShutdown.Send);
                         }
-                        clientStream.Flush();
-                        clientSocket.Shutdown(SocketShutdown.Send);
+                        catch (IOException)
+                        {
+                            // Ignore rude disconnects from either side.
+                        }
                     });
+
                     // Relay bidirectional data including close.
                     await new[] { clientCopyTask, serverCopyTask }.WhenAllOrAnyFailed().ConfigureAwait(false);
                     return result;

--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
@@ -20,6 +20,7 @@ namespace System.Net.Http.Functional.Tests
     {
         public struct ProxyResult
         {
+            public string RequestLine;
             public byte[] ResponseContent;
             public string AuthenticationHeaderValue;
         }
@@ -57,7 +58,8 @@ namespace System.Net.Http.Functional.Tests
                     clientReader = new StreamReader(clientStream, Encoding.ASCII);
                     headers.Clear();
 
-                    var requestTokens = clientReader.ReadLine().Split(' ');
+                    result.RequestLine = clientReader.ReadLine();
+                    string[] requestTokens = result.RequestLine.Split(' ');
                     method = requestTokens[0];
                     url = requestTokens[1];
                     string line;


### PR DESCRIPTION
The test was hanging on most handlers except for SocketsHttpHandler. It was hanging because
the await'ed task of connecting to the proxy never happened. Except for SocketsHttpHandler,
the other handlers optimize loopback so that if the destination server is on loopback, then it
ignores any proxy setting. The test was using both a loopback destination server as well as a
loopback proxy server.

This test is one of the few tests that do an end-to-end request/response thru a proxy. So, it's
important that we keep the test and have it work on all handlers. Modified the test to use a real
external server destination. The test still uses a loopback proxy server.

I also moved some of the Outerloop tests to Innerloop since those tests were using loopback.

Fixes #27746