### PR TITLE
AIX support for System.Native/PAL

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -36,6 +36,7 @@
 #cmakedefine01 HAVE_FDS_BITS
 #cmakedefine01 HAVE_PRIVATE_FDS_BITS
 #cmakedefine01 HAVE_STATFS
+#cmakedefine01 HAVE_POLL
 #cmakedefine01 HAVE_EPOLL
 #cmakedefine01 HAVE_ACCEPT4
 #cmakedefine01 HAVE_KQUEUE

--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -36,7 +36,7 @@
 #cmakedefine01 HAVE_FDS_BITS
 #cmakedefine01 HAVE_PRIVATE_FDS_BITS
 #cmakedefine01 HAVE_STATFS
-#cmakedefine01 HAVE_POLL
+#cmakedefine01 HAVE_SYS_POLL_H
 #cmakedefine01 HAVE_EPOLL
 #cmakedefine01 HAVE_ACCEPT4
 #cmakedefine01 HAVE_KQUEUE

--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -6,6 +6,9 @@
 #cmakedefine01 HAVE_FTRUNCATE64
 #cmakedefine01 HAVE_POSIX_FADVISE64
 #cmakedefine01 HAVE_FLOCK64
+#cmakedefine01 HAVE_F_DUPFD_CLOEXEC
+#cmakedefine01 HAVE_O_CLOEXEC
+#cmakedefine01 HAVE_GETIFADDRS
 #cmakedefine01 HAVE_STAT64
 #cmakedefine01 HAVE_PIPE2
 #cmakedefine01 HAVE_STAT_BIRTHTIME

--- a/src/Native/Unix/System.Native/pal_errno.c
+++ b/src/Native/Unix/System.Native/pal_errno.c
@@ -130,8 +130,10 @@ int32_t SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
             return Error_ENOTCONN;
         case ENOTDIR:
             return Error_ENOTDIR;
+#if !defined(_AIX)
         case ENOTEMPTY:
             return Error_ENOTEMPTY;
+#endif
 #ifdef ENOTRECOVERABLE // not available in NetBSD
         case ENOTRECOVERABLE:
             return Error_ENOTRECOVERABLE;

--- a/src/Native/Unix/System.Native/pal_errno.c
+++ b/src/Native/Unix/System.Native/pal_errno.c
@@ -130,7 +130,7 @@ int32_t SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
             return Error_ENOTCONN;
         case ENOTDIR:
             return Error_ENOTDIR;
-#if !defined(_AIX)
+#if ENOTEMPTY != EEXIST // AIX defines this
         case ENOTEMPTY:
             return Error_ENOTEMPTY;
 #endif

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -301,7 +301,13 @@ int32_t SystemNative_Close(intptr_t fd)
 intptr_t SystemNative_Dup(intptr_t oldfd)
 {
     int result;
+#if defined(F_DUPFD_CLOEXEC)
     while ((result = fcntl(ToFileDescriptor(oldfd), F_DUPFD_CLOEXEC, 0)) < 0 && errno == EINTR);
+#else
+    while ((result = fcntl(ToFileDescriptor(oldfd), F_DUPFD, 0)) < 0 && errno == EINTR);
+    // do CLOEXEC here too
+    fcntl(result, F_SETFD, FD_CLOEXEC);
+#endif
     return result;
 }
 

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -121,12 +121,16 @@ c_static_assert(PAL_SEEK_CUR == SEEK_CUR);
 c_static_assert(PAL_SEEK_END == SEEK_END);
 
 // Validate our PollFlags enum values are correct for the platform
+// HACK: AIX values are different; this file doesn't actually use POLL* yet, so
+// nop out the check there.
+#if !defined(_AIX)
 c_static_assert(PAL_POLLIN == POLLIN);
 c_static_assert(PAL_POLLPRI == POLLPRI);
 c_static_assert(PAL_POLLOUT == POLLOUT);
 c_static_assert(PAL_POLLERR == POLLERR);
 c_static_assert(PAL_POLLHUP == POLLHUP);
 c_static_assert(PAL_POLLNVAL == POLLNVAL);
+#endif
 
 // Validate our FileAdvice enum values are correct for the platform
 #if HAVE_POSIX_ADVISE

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -122,7 +122,7 @@ c_static_assert(PAL_SEEK_END == SEEK_END);
 
 // Validate our PollFlags enum values are correct for the platform
 // HACK: AIX values are different; we convert them between PAL_POLL and POLL now
-#ifndef (_AIX)
+#ifndef _AIX
 c_static_assert(PAL_POLLIN == POLLIN);
 c_static_assert(PAL_POLLPRI == POLLPRI);
 c_static_assert(PAL_POLLOUT == POLLOUT);

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -367,21 +367,36 @@ static void ConvertDirent(const struct dirent* entry, struct DirectoryEntry* out
     /* AIX has no d_type, make a substitute */
     struct stat s;
     stat(entry->d_name, &s);
-    if (S_ISDIR(s.st_mode)) {
+    if (S_ISDIR(s.st_mode))
+    {
         outputEntry->InodeType = PAL_DT_DIR;
-    } else if (S_ISFIFO(s.st_mode)) {
+    }
+    else if (S_ISFIFO(s.st_mode))
+    {
         outputEntry->InodeType = PAL_DT_FIFO;
-    } else if (S_ISCHR(s.st_mode)) {
+    }
+    else if (S_ISCHR(s.st_mode))
+    {
         outputEntry->InodeType = PAL_DT_CHR;
-    } else if (S_ISBLK(s.st_mode)) {
+    }
+    else if (S_ISBLK(s.st_mode))
+    {
         outputEntry->InodeType = PAL_DT_BLK;
-    } else if (S_ISREG(s.st_mode)) {
+    }
+    else if (S_ISREG(s.st_mode))
+    {
         outputEntry->InodeType = PAL_DT_REG;
-    } else if (S_ISLNK(s.st_mode)) {
+    }
+    else if (S_ISLNK(s.st_mode))
+    {
         outputEntry->InodeType = PAL_DT_LNK;
-    } else if (S_ISSOCK(s.st_mode)) {
+    }
+    else if (S_ISSOCK(s.st_mode))
+    {
         outputEntry->InodeType = PAL_DT_SOCK;
-    } else {
+    }
+    else
+    {
         outputEntry->InodeType = PAL_DT_UNKNOWN;
     }
 #else

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -42,7 +42,7 @@
 #include <sys/inotify.h>
 #endif
 
-#if defined(_AIX)
+#ifdef _AIX
 #include <alloca.h>
 // Somehow, AIX mangles the definition for this behind a C++ def
 // Redeclare it here
@@ -121,9 +121,8 @@ c_static_assert(PAL_SEEK_CUR == SEEK_CUR);
 c_static_assert(PAL_SEEK_END == SEEK_END);
 
 // Validate our PollFlags enum values are correct for the platform
-// HACK: AIX values are different; this file doesn't actually use POLL* yet, so
-// nop out the check there.
-#if !defined(_AIX)
+// HACK: AIX values are different; we convert them between PAL_POLL and POLL now
+#ifndef (_AIX)
 c_static_assert(PAL_POLLIN == POLLIN);
 c_static_assert(PAL_POLLPRI == POLLPRI);
 c_static_assert(PAL_POLLOUT == POLLOUT);

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -91,7 +91,7 @@ c_static_assert(PAL_S_IFSOCK == S_IFSOCK);
 // Validate that our enum for inode types is the same as what is
 // declared by the dirent.h header on the local system.
 // (AIX doesn't have dirent d_type, so none of this there)
-#if !defined(DT_UNKNOWN)
+#if defined(DT_UNKNOWN)
 c_static_assert(PAL_DT_UNKNOWN == DT_UNKNOWN);
 c_static_assert(PAL_DT_FIFO == DT_FIFO);
 c_static_assert(PAL_DT_CHR == DT_CHR);

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -273,12 +273,22 @@ enum SysConfName
  */
 enum PollEvents
 {
+#if defined(_AIX)
+/* of course AIX is different */
+    PAL_POLLIN = 0x0001,   /* non-urgent readable data available */
+    PAL_POLLPRI = 0x0004,  /* urgent readable data available */
+    PAL_POLLOUT = 0x0002,  /* data can be written without blocked */
+    PAL_POLLERR = 0x4000,  /* an error occurred */
+    PAL_POLLHUP = 0x2000,  /* the file descriptor hung up */
+    PAL_POLLNVAL = 0x8000, /* the requested events were invalid */
+#else
     PAL_POLLIN = 0x0001,   /* non-urgent readable data available */
     PAL_POLLPRI = 0x0002,  /* urgent readable data available */
     PAL_POLLOUT = 0x0004,  /* data can be written without blocked */
     PAL_POLLERR = 0x0008,  /* an error occurred */
     PAL_POLLHUP = 0x0010,  /* the file descriptor hung up */
     PAL_POLLNVAL = 0x0020, /* the requested events were invalid */
+#endif
 };
 
 /**

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -15,6 +15,17 @@ BEGIN_EXTERN_C
 #include <dirent.h>
 #include <sys/types.h>
 
+#if defined(_AIX) && !defined(O_CLOEXEC)
+// HACK: Try to get AIX 6.1 & i 7.1 working; AIX 7.1 & i (claims) 7.2 has these but we target
+// these older versions too.
+// We ifdef it out for the open call in .c and simulate with fcntl, but for SystemNative_Pipe,
+// since we also don't have pipe2 on AIX/i, it'll fall back to using FD_CLOEXEC.
+// (i 7.2 at least defines O_CLOEXEC as 0x0000001000000000LL)
+#define 0x0000001000000000LL
+// Nop this out
+#define F_DUPFD_CLOEXEC 0
+#endif
+
 /**
  * File status returned by Stat or FStat.
  */

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -18,10 +18,7 @@ BEGIN_EXTERN_C
 #if defined(_AIX) && !defined(O_CLOEXEC)
 // HACK: Try to get AIX 6.1 & i 7.1 working; AIX 7.1 & i (claims) 7.2 has these but we target
 // these older versions too.
-// We ifdef it out for the open call in .c and simulate with fcntl, but for SystemNative_Pipe,
-// since we also don't have pipe2 on AIX/i, it'll fall back to using FD_CLOEXEC.
 // (i 7.2 at least defines O_CLOEXEC as 0x0000001000000000LL)
-#define 0x0000001000000000LL
 // Nop this out
 #define F_DUPFD_CLOEXEC 0
 #endif

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -18,7 +18,6 @@ BEGIN_EXTERN_C
 #if defined(_AIX) && !defined(O_CLOEXEC)
 // HACK: Try to get AIX 6.1 & i 7.1 working; AIX 7.1 & i (claims) 7.2 has these but we target
 // these older versions too.
-// (i 7.2 at least defines O_CLOEXEC as 0x0000001000000000LL)
 // Nop this out
 #define F_DUPFD_CLOEXEC 0
 #endif

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -15,12 +15,6 @@ BEGIN_EXTERN_C
 #include <dirent.h>
 #include <sys/types.h>
 
-#if defined(_AIX) && !defined(F_DUPFD_CLOEXEC)
-// HACK: Try to get AIX 6.1 & i 7.1 working; AIX 7.1 & i (claims) 7.2 has these but we target
-// these older versions too, so nop this define out.
-#define F_DUPFD_CLOEXEC 0
-#endif
-
 /**
  * File status returned by Stat or FStat.
  */

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -267,22 +267,12 @@ enum SysConfName
  */
 enum PollEvents
 {
-#if defined(_AIX)
-/* of course AIX is different */
-    PAL_POLLIN = 0x0001,   /* non-urgent readable data available */
-    PAL_POLLPRI = 0x0004,  /* urgent readable data available */
-    PAL_POLLOUT = 0x0002,  /* data can be written without blocked */
-    PAL_POLLERR = 0x4000,  /* an error occurred */
-    PAL_POLLHUP = 0x2000,  /* the file descriptor hung up */
-    PAL_POLLNVAL = 0x8000, /* the requested events were invalid */
-#else
     PAL_POLLIN = 0x0001,   /* non-urgent readable data available */
     PAL_POLLPRI = 0x0002,  /* urgent readable data available */
     PAL_POLLOUT = 0x0004,  /* data can be written without blocked */
     PAL_POLLERR = 0x0008,  /* an error occurred */
     PAL_POLLHUP = 0x0010,  /* the file descriptor hung up */
     PAL_POLLNVAL = 0x0020, /* the requested events were invalid */
-#endif
 };
 
 /**

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -15,10 +15,9 @@ BEGIN_EXTERN_C
 #include <dirent.h>
 #include <sys/types.h>
 
-#if defined(_AIX) && !defined(O_CLOEXEC)
+#if defined(_AIX) && !defined(F_DUPFD_CLOEXEC)
 // HACK: Try to get AIX 6.1 & i 7.1 working; AIX 7.1 & i (claims) 7.2 has these but we target
-// these older versions too.
-// Nop this out
+// these older versions too, so nop this define out.
 #define F_DUPFD_CLOEXEC 0
 #endif
 

--- a/src/Native/Unix/System.Native/pal_maphardwaretype.c
+++ b/src/Native/Unix/System.Native/pal_maphardwaretype.c
@@ -76,8 +76,10 @@ uint16_t MapHardwareType(uint16_t nativeType)
             return NetworkInterfaceType_Atm;
         case IFT_MODEM:
             return NetworkInterfaceType_GenericModem;
+#if defined(IFT_IEEE1394)
         case IFT_IEEE1394:
             return NetworkInterfaceType_HighPerformanceSerialBus;
+#endif
         default:
             return NetworkInterfaceType_Unknown;
     }

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -804,6 +804,9 @@ static int32_t GetIPv4PacketInformation(struct cmsghdr* controlMessage, struct I
         }
         freeifaddrs(addrs_head);
     }
+#else
+    // assume the first interface, we have no other methods
+    packetInfo->InterfaceIndex = 0;
 #endif
 
     return 1;

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -41,16 +41,14 @@
 #endif
 #include <unistd.h>
 #include <pwd.h>
-#if !defined(_AIX)
 #if HAVE_SENDFILE_4
 #include <sys/sendfile.h>
 #elif HAVE_SENDFILE_6
 #include <sys/uio.h>
 #endif
-#endif
 #if !HAVE_IN_PKTINFO
 #include <net/if.h>
-#if !defined(_AIX)
+#if HAVE_GETIFADDRS
 #include <ifaddrs.h>
 #endif
 #endif
@@ -788,9 +786,7 @@ static int32_t GetIPv4PacketInformation(struct cmsghdr* controlMessage, struct I
     ConvertInAddrToByteArray(&packetInfo->Address.Address[0], NUM_BYTES_IN_IPV4_ADDRESS, &pktinfo->ipi_addr);
 #if HAVE_IN_PKTINFO
     packetInfo->InterfaceIndex = (int32_t)pktinfo->ipi_ifindex;
-#elif defined(_AIX)
-    // TODO: SIOCGIFCONF based fallback
-#else
+#elif HAVE_GETIFADDRS
     packetInfo->InterfaceIndex = 0;
 
     struct ifaddrs* addrs;
@@ -2446,7 +2442,7 @@ int32_t SystemNative_SendFile(intptr_t out_fd, intptr_t in_fd, int64_t offset, i
     *sent = 0;
     return SystemNative_ConvertErrorPlatformToPal(errno);
 
-#elif HAVE_SENDFILE_6 && !defined(_AIX) /* why is AIX getting this? */
+#elif HAVE_SENDFILE_6
     *sent = 0;
     while (1) // in case we need to retry for an EINTR
     {

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -20,7 +20,7 @@
 #include <sys/types.h>
 #include <sys/event.h>
 #include <sys/time.h>
-#elif HAVE_POLL
+#elif HAVE_SYS_POLL_H
 #include <sys/poll.h>
 #endif
 #include <errno.h>

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -20,7 +20,7 @@
 #include <sys/types.h>
 #include <sys/event.h>
 #include <sys/time.h>
-#else
+#elif HAVE_POLL
 #include <sys/poll.h>
 #endif
 #include <errno.h>

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -2251,8 +2251,8 @@ static int32_t WaitForSocketEventsInner(int32_t port, struct SocketEvent* buffer
 }
 
 #else
-// TODO: Poll fallback
-static const size_t SocketEventBufferElementSize = sizeof(struct pollmsg);
+#warning epoll/kqueue not detected; building with stub socket events support
+static const size_t SocketEventBufferElementSize = sizeof(struct pollfd);
 
 static enum SocketEvents GetSocketEvents(int16_t filter, uint16_t flags)
 {

--- a/src/Native/Unix/System.Native/pal_random.c
+++ b/src/Native/Unix/System.Native/pal_random.c
@@ -40,7 +40,12 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 
             do
             {
+#ifdef O_CLOEXEC
                 fd = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
+#else
+                fd = open("/dev/urandom", O_RDONLY, NULL);
+                fcntl(fd, F_SETFD, FD_CLOEXEC);
+#endif
             }
             while ((fd == -1) && (errno == EINTR));
 

--- a/src/Native/Unix/System.Native/pal_random.c
+++ b/src/Native/Unix/System.Native/pal_random.c
@@ -40,7 +40,7 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 
             do
             {
-#ifdef HAVE_O_CLOEXEC
+#if HAVE_O_CLOEXEC
                 fd = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
 #else
                 fd = open("/dev/urandom", O_RDONLY);

--- a/src/Native/Unix/System.Native/pal_random.c
+++ b/src/Native/Unix/System.Native/pal_random.c
@@ -40,7 +40,7 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 
             do
             {
-#ifdef O_CLOEXEC
+#ifdef HAVE_O_CLOEXEC
                 fd = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
 #else
                 fd = open("/dev/urandom", O_RDONLY);

--- a/src/Native/Unix/System.Native/pal_random.c
+++ b/src/Native/Unix/System.Native/pal_random.c
@@ -43,7 +43,7 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 #ifdef O_CLOEXEC
                 fd = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
 #else
-                fd = open("/dev/urandom", O_RDONLY, NULL);
+                fd = open("/dev/urandom", O_RDONLY);
                 fcntl(fd, F_SETFD, FD_CLOEXEC);
 #endif
             }

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -87,6 +87,20 @@ check_c_source_compiles(
     "
     HAVE_FLOCK64)
 
+check_symbol_exists(
+    O_CLOEXEC
+    fcntl.h
+    HAVE_O_CLOEXEC)
+
+check_symbol_exists(
+    F_DUPFD_CLOEXEC
+    fcntl.h
+    HAVE_F_DUPFD_CLOEXEC)
+
+check_function_exists(
+    getifaddrs
+    HAVE_GETIFADDRS)
+
 check_function_exists(
     lseek64
     HAVE_LSEEK64)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -316,9 +316,9 @@ check_function_exists(
     fcopyfile
     HAVE_FCOPYFILE)
 
-check_function_exists(
-    poll
-    HAVE_POLL)
+check_include_files(
+     "sys/poll.h"
+     HAVE_SYS_POLL_H)
 
 check_function_exists(
     epoll_create1

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -317,6 +317,10 @@ check_function_exists(
     HAVE_FCOPYFILE)
 
 check_function_exists(
+    poll
+    HAVE_POLL)
+
+check_function_exists(
     epoll_create1
     HAVE_EPOLL)
 


### PR DESCRIPTION
Somewhat incomplete, but at least on Mono version, gets it compiling,
so work on it can be done; as I believe the nopped out functions aren't
hooked up to Mono's BCL yet. For now, if merged, would let me get back
to working on a patch for UnicodeEncoding ;)

See mono/corefx#69 for the description.

This is for Mono, as CoreCLR doesn't run under AIX or I. (Mono downstream would prefer if this is merged here.)