### PR TITLE
Fixed comment for the Stopwatch class from having inaccurate information

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
@@ -6,8 +6,8 @@ namespace System.Diagnostics
 {
     // This class uses high-resolution performance counter if the installed
     // hardware supports it. Otherwise, the class will fall back to DateTime
-    // class and uses ticks as a measurement.
-    
+    // and uses ticks as a measurement.
+
     public partial class Stopwatch
     {
         private const long TicksPerMillisecond = 10000;

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
@@ -4,10 +4,10 @@
 
 namespace System.Diagnostics
 {
-    // This class uses high-resolution performance counter if installed hardware 
-    // does not support it. Otherwise, the class will fall back to DateTime class
-    // and uses ticks as a measurement.
-
+    // This class uses high-resolution performance counter if the installed
+    // hardware supports it. Otherwise, the class will fall back to DateTime
+    // class and uses ticks as a measurement.
+    
     public partial class Stopwatch
     {
         private const long TicksPerMillisecond = 10000;


### PR DESCRIPTION
This is a fix for #30016
