### PR TITLE
Remove obsoleted comment from SocketsHttpHandlerTest

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -852,12 +852,6 @@ namespace System.Net.Http.Functional.Tests
     {
         protected override bool UseSocketsHttpHandler => true;
 
-        // TODO: ISSUE #27272
-        // Currently the subsequent tests sometimes fail/hang with WinHttpHandler / CurlHandler.
-        // In theory they should pass with any handler that does appropriate connection pooling.
-        // We should understand why they sometimes fail there and ideally move them to be
-        // used by all handlers this test project tests.
-
         [Fact]
         public async Task MultipleIterativeRequests_SameConnectionReused()
         {


### PR DESCRIPTION
Similar to PR #29988, testing implementation details of SocketsHttpHandler behaviors
doesn't make sense against the other handlers.

Running HTTP tests generally across all the handlers is useful when we're trying to
validate HTTP protocol and API behaviors to be consistent everywhere.

However, testing SocketsHttpHandler implementation details, such as connection-pooling
algorithms, with other handlers leads to brittle tests with random test failures. The
internal code of each handler and native code (i.e. WinHTTP) use different rules
(timeouts, lifetime, etc.) for such low-level connection details.

So it makes sense to only run tests such as this against the code that was written to
match the tests, i.e. SocketsHttpHandler.

Closes #27272