### PR TITLE
Remove libcurl dependency from X509Certificates

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
@@ -3,19 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography.Pal
 {
     internal static class CertificateAssetDownloader
     {
-        private static readonly Interop.Http.ReadWriteCallback s_writeCallback = CurlWriteCallback;
-
         internal static X509Certificate2 DownloadCertificate(string uri, ref TimeSpan remainingDownloadTime)
         {
             byte[] data = DownloadAsset(uri, ref remainingDownloadTime);
@@ -75,99 +73,37 @@ namespace Internal.Cryptography.Pal
 
         private static byte[] DownloadAsset(string uri, ref TimeSpan remainingDownloadTime)
         {
-            if (remainingDownloadTime <= TimeSpan.Zero)
+            if (remainingDownloadTime > TimeSpan.Zero)
             {
-                return null;
-            }
-
-            List<byte[]> dataPieces = new List<byte[]>();
-
-            using (Interop.Http.SafeCurlHandle curlHandle = Interop.Http.EasyCreate())
-            {
-                GCHandle gcHandle = GCHandle.Alloc(dataPieces);
-                Interop.Http.SafeCallbackHandle callbackHandle = new Interop.Http.SafeCallbackHandle();
-
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                object httpClient = null;
                 try
                 {
-                    Interop.Http.EasySetOptionString(curlHandle, Interop.Http.CURLoption.CURLOPT_URL, uri);
-                    Interop.Http.EasySetOptionLong(curlHandle, Interop.Http.CURLoption.CURLOPT_FOLLOWLOCATION, 1L);
-
-                    IntPtr dataHandlePtr = GCHandle.ToIntPtr(gcHandle);
-                    Interop.Http.RegisterReadWriteCallback(
-                        curlHandle,
-                        Interop.Http.ReadWriteFunction.Write,
-                        s_writeCallback,
-                        dataHandlePtr,
-                        ref callbackHandle);
-
-                    Stopwatch stopwatch = Stopwatch.StartNew();
-                    Interop.Http.CURLcode res = Interop.Http.EasyPerform(curlHandle);
-                    stopwatch.Stop();
-
-                    // TimeSpan.Zero isn't a worrisome value on the subtraction, it only
-                    // means "no limit" on the original input.
-                    remainingDownloadTime -= stopwatch.Elapsed;
-
-                    if (res != Interop.Http.CURLcode.CURLE_OK)
+                    // Use reflection to access System.Net.Http:
+                    // Since System.Net.Http.dll explicitly depends on System.Security.Cryptography.X509Certificates.dll,
+                    // the latter can't in turn have an explicit dependency on the former.
+                    Type httpClientType = Type.GetType("System.Net.Http.HttpClient, System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: false);
+                    if (httpClientType != null)
                     {
-                        return null;
+                        MethodInfo getByteArrayAsync = httpClientType.GetMethod("GetByteArrayAsync", new Type[] { typeof(string) });
+                        if (getByteArrayAsync != null)
+                        {
+                            httpClient = Activator.CreateInstance(httpClientType);
+                            return ((Task<byte[]>)getByteArrayAsync.Invoke(httpClient, new object[] { uri })).GetAwaiter().GetResult();
+                        }
                     }
                 }
+                catch { }
                 finally
                 {
-                    gcHandle.Free();
-                    callbackHandle.Dispose();
+                    (httpClient as IDisposable)?.Dispose();
+
+                    // TimeSpan.Zero isn't a worrisome value on the subtraction, it only means "no limit" on the original input.
+                    remainingDownloadTime -= stopwatch.Elapsed;
                 }
             }
 
-            if (dataPieces.Count == 0)
-            {
-                return null;
-            }
-
-            if (dataPieces.Count == 1)
-            {
-                return dataPieces[0];
-            }
-
-            int dataLen = 0;
-
-            for (int i = 0; i < dataPieces.Count; i++)
-            {
-                dataLen += dataPieces[i].Length;
-            }
-
-            byte[] data = new byte[dataLen];
-            int offset = 0;
-
-            for (int i = 0; i < dataPieces.Count; i++)
-            {
-                byte[] piece = dataPieces[i];
-
-                Buffer.BlockCopy(piece, 0, data, offset, piece.Length);
-                offset += piece.Length;
-            }
-
-            return data;
-        }
-
-        private static ulong CurlWriteCallback(IntPtr buffer, ulong size, ulong nitems, IntPtr context)
-        {
-            ulong totalSize = size * nitems;
-
-            if (totalSize == 0)
-            {
-                return 0;
-            }
-
-            GCHandle gcHandle = GCHandle.FromIntPtr(context);
-            List<byte[]> dataPieces = (List<byte[]>)gcHandle.Target;
-            byte[] piece = new byte[totalSize];
-
-            Marshal.Copy(buffer, piece, 0, (int)totalSize);
-            dataPieces.Add(piece);
-
-            return totalSize;
+            return null;
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -181,12 +181,6 @@
     <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\System.Native\Interop.Permissions.cs">
       <Link>Common\CoreLib\Interop\Unix\System.Native\Interop.Permissions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Http.Native\Interop.Initialization.cs">
-      <Link>Common\Interop\Unix\System.Net.Http.Native\Interop.Initialization.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Http.Native\Interop.VersionInfo.cs">
-      <Link>Common\Interop\Unix\System.Net.Http.Native\Interop.VersionInfo.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
@@ -252,12 +246,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Common\CoreLib\Interop\Unix\System.Native\Interop.Stat.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Http.Native\Interop.CURLcode.cs">
-      <Link>Common\Interop\Unix\System.Net.Http.Native\Interop.CURLcode.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Http.Native\Interop.Easy.cs">
-      <Link>Common\Interop\Unix\System.Net.Http.Native\Interop.Easy.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>


### PR DESCRIPTION
We can't reference System.Net.Http from System.Security.Cryptography.X509Certificate, as the former references the latter, so use reflection to access HttpClient.

Contributes to https://github.com/dotnet/corefx/issues/30003
cc: @bartonjs, @davidsh, @karelz 

@bartonjs, are there tests for this?  The PR where this dependency was added (https://github.com/dotnet/corefx/pull/2956) mentions that a test would be added subsequently, but I'm not sure if one ever was.