### PR TITLE
Increase timeout for Http cancellation test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -363,7 +363,7 @@ namespace System.Net.Http.Functional.Tests
                     "Expected cancellation exception, got:" + Environment.NewLine + error);
             }
 
-            Assert.True(stopwatch.Elapsed < new TimeSpan(0, 0, 30), $"Elapsed time {stopwatch.Elapsed} should be less than 30 seconds, was {stopwatch.Elapsed.TotalSeconds}");
+            Assert.True(stopwatch.Elapsed < new TimeSpan(0, 0, 60), $"Elapsed time {stopwatch.Elapsed} should be less than 60 seconds, was {stopwatch.Elapsed.TotalSeconds}");
         }
 
         private static void Cancel(CancellationMode mode, HttpClient client, CancellationTokenSource cts)


### PR DESCRIPTION
We haven't seen this set of tests fail often. But when they do, it seems to take a little more
than 30 seconds (31 in this failure case) for the operation to cancel. The original "30" second
number was a guess. But based on busy CI machines, we'll increase the number in the hope of
getting less test failures.

Closes # 28805