### PR TITLE
Cross compile compat pack shims against 2.0 and use the 2.1 inbox ones

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -259,6 +259,7 @@
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
 
     <RuntimePath Condition="'$(RuntimePath)' == ''">$(BinDir)runtime/$(BuildConfiguration)/</RuntimePath>
+    <ShimsTargetRuntimePath>$(BinDir)shimsTargetRuntime/netcoreapp2.0/</ShimsTargetRuntimePath>
     <TestPath Condition="'$(TestPath)' == ''">$(TestWorkingDir)$(MSBuildProjectName)/$(BuildConfiguration)/</TestPath>
     <RefRootPath>$(BinDir)ref/</RefRootPath>
     <BuildConfigurationRefPath>$(RefRootPath)$(_bc_TargetGroup)/</BuildConfigurationRefPath>

--- a/dir.targets
+++ b/dir.targets
@@ -76,6 +76,9 @@
     <BinPlaceConfiguration Condition="'$(BuildingNETCoreAppVertical)' == 'true'" Include="netcoreapp2.0">
       <RefPath>$(RefRootPath)netcoreapp2.0/</RefPath>
     </BinPlaceConfiguration>
+    <BinPlaceConfiguration Include="netcoreapp2.0-Windows_NT">
+      <RuntimePath>$(ShimsTargetRuntimePath)</RuntimePath>
+    </BinPlaceConfiguration>
     <!-- some libraries that produce packages will remain targeting uap10.0.16299 -->
     <BinPlaceConfiguration Condition="'$(BuildingUAPVertical)' == 'true' OR '$(BuildingUAPAOTVertical)' == 'true'" Include="uap10.0.16299">
       <RefPath>$(RefRootPath)uap10.0.16299/</RefPath>

--- a/external/netcoreapp/Configurations.props
+++ b/external/netcoreapp/Configurations.props
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp2.0
+      netcoreapp2.0;
+      netcoreapp2.0-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/external/netcoreapp/netcoreapp.depproj
+++ b/external/netcoreapp/netcoreapp.depproj
@@ -6,8 +6,15 @@
   <PropertyGroup>
     <BinPlaceRef>true</BinPlaceRef>
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
-    <NETCoreAppPackageVersion>2.0.0</NETCoreAppPackageVersion>
+    <NETCoreAppPackageVersion>2.0.7</NETCoreAppPackageVersion>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
+    <NugetRuntimeIdentifier>$(PackageRID)</NugetRuntimeIdentifier>
+    <RidSpecificAssets>true</RidSpecificAssets>
+    <BinPlaceRuntime>true</BinPlaceRuntime>
+    <NuGetDeploySourceItem>ReferenceCopyLocalPaths</NuGetDeploySourceItem>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +26,8 @@
   <ItemGroup>
     <!-- for all configurations this project provides refs for that configuration -->
     <BinPlaceConfiguration Include="$(Configuration)">
-      <RefPath>$(RefPath)</RefPath>
+      <RefPath Condition="'$(TargetsWindows)' != 'true'">$(RefPath)</RefPath>
+      <RuntimePath Condition="'$(TargetsWindows)' == 'true'">$(ShimsTargetRuntimePath)</RuntimePath>
     </BinPlaceConfiguration>
 
     <FileToExclude Include="System.ComponentModel.Composition" />

--- a/pkg/Microsoft.Windows.Compatibility.Shims/Microsoft.Windows.Compatibility.Shims.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility.Shims/Microsoft.Windows.Compatibility.Shims.pkgproj
@@ -5,41 +5,24 @@
   <PropertyGroup>
     <PackageVersion>$(CompatibilityShimsPackageVersion)</PackageVersion>
     <_ShimsLocationPath>$(BaseIntermediateOutputPath)shims/netcoreapp/facades/</_ShimsLocationPath>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
 
   <ItemGroup>
-    <ShimsToInclude Include="mscorlib.dll" />
-    <ShimsToInclude Include="System.dll" />
-    <ShimsToInclude Include="System.Configuration.dll" />
-    <ShimsToInclude Include="System.Core.dll" />
-    <ShimsToInclude Include="System.Data.dll" />
-    <ShimsToInclude Include="System.Drawing.dll" />
-    <ShimsToInclude Include="System.Net.dll" />
-    <ShimsToInclude Include="System.Security.dll" />
-    <ShimsToInclude Include="System.ServiceModel.Web.dll" />
-    <ShimsToInclude Include="System.ServiceProcess.dll" />
-    <ShimsToInclude Include="System.Transactions.dll" />
-    <ShimsToInclude Include="WindowsBase.dll" />
+
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>/lib/netstandard2.0</TargetPath>
+    </File>
+
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>/lib/netcoreapp2.1</TargetPath>
+    </File>
+
+    <ProjectReference Include="..\..\src\shims\shims.proj" />
+    <ProjectReference Include="..\..\src\shims\manual\mscorlib.csproj" />
+    <ProjectReference Include="..\..\src\shims\manual\System.csproj" />
+    <ProjectReference Include="..\..\src\shims\manual\System.Data.csproj" />
   </ItemGroup>
-
-  <Target Name="AddShimsToPackage"
-          BeforeTargets="GetPackageFiles">
-
-    <Error Text="Required facade: %(ShimsToInclude.Identity) was not found in $(_ShimsLocationPath)." Condition="!Exists('@(ShimsToInclude->'$(_ShimsLocationPath)%(Identity)')')" />
-
-    <ItemGroup>
-      <File Include="@(ShimsToInclude->'$(_ShimsLocationPath)%(Identity)')">
-        <TargetPath>/lib/netcoreapp2.0</TargetPath>
-        <SkipPackageFileCheck>true</SkipPackageFileCheck>
-      </File>
-      <!-- Include placeholder to be netstandard2.0 compatible -->
-      <File Include="$(PlaceHolderFile)">
-        <TargetPath>/lib/netstandard2.0</TargetPath>
-      </File>
-    </ItemGroup>
-
-    <Message Importance="Low" Text="Added: %(ShimsToInclude.Identity) to package." />
-  </Target>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/shims/dir.props
+++ b/src/shims/dir.props
@@ -16,6 +16,8 @@
   <PropertyGroup>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>
+    <!-- Though we build as windows specific we ship these in the package as RID-less so that we don't have to cross-compile the compat pack shims and move it up the stack -->
+    <PackageTargetRuntime/>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/shims/manual/System.Data.csproj
+++ b/src/shims/manual/System.Data.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Data.forwards.cs" />
-    <ReferencePath Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.*.dll" Exclude="$(RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll;$(RuntimePath)Microsoft.DiaSymReader.Native.*.dll;$(RuntimePath)System.Data.dll" />
+    <ReferencePath Include="$(_RuntimePath)System.*.dll;$(_RuntimePath)Microsoft.*.dll" Exclude="$(_RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll;$(_RuntimePath)Microsoft.DiaSymReader.Native.*.dll;$(_RuntimePath)System.Data.dll" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/shims/manual/System.csproj
+++ b/src/shims/manual/System.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <Compile Include="System.forwards.cs" />
     <ReferencePath
-      Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.*.dll"
-      Exclude="$(RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll;$(RuntimePath)Microsoft.DiaSymReader.Native.*.dll" />
+      Include="$(_RuntimePath)System.*.dll;$(_RuntimePath)Microsoft.*.dll"
+      Exclude="$(_RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll;$(_RuntimePath)Microsoft.DiaSymReader.Native.*.dll" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/shims/manual/dir.props
+++ b/src/shims/manual/dir.props
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <PackageConfigurations>
+      netcoreapp2.0-Windows_NT;
+    </PackageConfigurations>
     <BuildConfigurations>
+      $(PackageConfigurations);
       netcoreapp;
       uap;
     </BuildConfigurations>
@@ -11,6 +15,8 @@
   <!-- need to by-pass the dir.props in the shims directory for this project -->
   <Import Project="..\..\..\dir.props" />
   <PropertyGroup>
+    <_RuntimePath Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">$(RuntimePath)</_RuntimePath>
+    <_RuntimePath Condition="'$(TargetGroup)' == 'netcoreapp2.0'">$(ShimsTargetRuntimePath)</_RuntimePath>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>ECMA</AssemblyKey>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
@@ -19,6 +25,8 @@
     <IsRuntimeAssembly>true</IsRuntimeAssembly>
     <HasMatchingContract>true</HasMatchingContract>
     <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
+    <DefineConstants Condition="'$(TargetsNetCoreApp)' == 'true'">$(DefineConstants);netcoreapp</DefineConstants>
+    <!-- Though we build as windows specific we ship these in the package as RID-less so that we don't have to cross-compile the compat pack shims and move it up the stack -->
+    <PackageTargetRuntime/>
   </PropertyGroup>
 </Project>

--- a/src/shims/manual/mscorlib.csproj
+++ b/src/shims/manual/mscorlib.csproj
@@ -9,8 +9,9 @@
   <ItemGroup>
     <Compile Include="mscorlib.forwards.cs" />
     <ReferencePath
-      Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.*.dll"
-      Exclude="$(RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll;$(RuntimePath)Microsoft.DiaSymReader.Native.*.dll" />
+      Include="$(_RuntimePath)System.*.dll;$(_RuntimePath)Microsoft.*.dll"
+      Exclude="$(_RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll;$(_RuntimePath)Microsoft.DiaSymReader.Native.*.dll;$(_RuntimePath)System.ValueTuple.dll" />
+      <!-- System.ValueTuple has a netstandard configuration so it is bin placed in the target runtime when generating facades for 2.0 and it conflicts with the already defined type in System.Private.CoreLib -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -2,6 +2,28 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="dir.props" />
 
+  <PropertyGroup>
+    <PackageConfigurations>
+      netcoreapp2.0-Windows_NT;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(BuildConfigurations);
+      $(PackageConfigurations);
+    </BuildConfigurations>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ShimsToInclude Include="System.Configuration.dll" />
+    <ShimsToInclude Include="System.Core.dll" />
+    <ShimsToInclude Include="System.Drawing.dll" />
+    <ShimsToInclude Include="System.Net.dll" />
+    <ShimsToInclude Include="System.Security.dll" />
+    <ShimsToInclude Include="System.ServiceModel.Web.dll" />
+    <ShimsToInclude Include="System.ServiceProcess.dll" />
+    <ShimsToInclude Include="System.Transactions.dll" />
+    <ShimsToInclude Include="WindowsBase.dll" />
+  </ItemGroup>
+
   <Target Name="GetGenFacadesInputs">
     <ItemGroup>
       <NetFxContracts Include="@(NetFxReference->'$(NetFxRefPath)%(Identity).dll')" Condition="'$(TargetGroup)' != 'netfx'">
@@ -93,6 +115,13 @@
       <RuntimeBinplaceItem Include="@(BinPlaceItemNames->'$(GenFacadesOutputPath)%(Identity).dll')" />
       <FileWrites Include="@(BinPlaceItem)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="GetCompatibilityShimsToPackage"
+          BeforeTargets="GetFilesToPackage">
+    <PropertyGroup>
+      <TargetPath>@(ShimsToInclude->'$(GenFacadesOutputPath)%(Identity)')</TargetPath>
+    </PropertyGroup>
   </Target>
 </Project>
 


### PR DESCRIPTION
This enables cross compiling the shims included in the compatibility pack.

Also, I added a placeholder file for netcoreapp2.1 to use the inbox shims already built against the 2.1 implementation of this packages. 

I've tested this locally using ApiCompat doing a diff between 2.0.7 closure and 2.0.7+compat pack closure and the issues are gone. The only differences we see are:

```
Compat issues with assembly System:
MembersMustExist : Member 'System.Configuration.ConfigurationSettings..ctor()' does not exist in the implementation but it does exist in the contract.
Compat issues with assembly System.Configuration:
InterfacesShouldHaveSameMembers : Interface member 'System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, System.Security.PermissionSet, System.Boolean)' is present in the implementation but not in the contract.
Compat issues with assembly System.Configuration.ConfigurationManager:
MembersMustExist : Member 'System.Configuration.ConfigurationSettings..ctor()' does not exist in the implementation but it does exist in the contract.
TypesMustExist : Type 'System.Configuration.DateTimeConfigurationCollection' does not exist in the implementation but it does exist in the contract.
TypesMustExist : Type 'System.Configuration.Internal.IInternalConfigHostPaths' does not exist in the implementation but it does exist in the contract.
Compat issues with assembly System.Data:
MembersMustExist : Member 'Microsoft.SqlServer.Server.SqlDataRecord.GetData(System.Int32)' does not exist in the implementation but it does exist in the contract.
Compat issues with assembly System.Security.Cryptography.Xml:
TypesMustExist : Type 'System.Security.Cryptography.Xml.X509IssuerSerial' does not exist in the implementation but it does exist in the contract.
```

All of them are expected since they were not exposed in the 2.0.0 reference assembly and where changed to internal in 2.1. The only one that concerns me but that is not related to the shims generation but it seems like a breaking change is `System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, System.Security.PermissionSet, System.Boolean)` since the interface member didn't exist in 2.0 and we added it in 2.1, which could break costumers that are already implementing that interface and reference the compat pack. System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, System.Security.PermissionSet, System.Boolean)

Fixes: #29899 

cc: @danmosemsft 