### PR TITLE
use dual mode sockets in cases when address family is not set explicitly

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -25,7 +25,6 @@ namespace System.Net.Sockets.Tests
         [InlineData(AddressFamily.DataLink)]
         [InlineData(AddressFamily.NetBios)]
         [InlineData(AddressFamily.Unix)]
-        [InlineData(AddressFamily.Unknown)]
         public void Ctor_InvalidFamily_Throws(AddressFamily family)
         {
             AssertExtensions.Throws<ArgumentException>("family", () => new TcpClient(family));
@@ -427,6 +426,28 @@ namespace System.Net.Sockets.Tests
                 sw.Stop();
 
                 Assert.Null(client.Client); // should be nulled out after Dispose
+            }
+        }
+
+        [Fact]
+        public void Connect_Dual_Success()
+        {
+            if (!Socket.OSSupportsIPv6)
+            {
+                return;
+            }
+
+            using (var server = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
+            {
+                // Set up a server socket to which to connect
+                server.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+                server.Listen(1);
+                var endpoint = (IPEndPoint)server.LocalEndPoint;
+
+                using (TcpClient client = new TcpClient())
+                {
+                    client.Connect(endpoint);
+                }
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -446,7 +446,12 @@ namespace System.Net.Sockets.Tests
 
                 using (TcpClient client = new TcpClient())
                 {
-                    client.Connect(endpoint);
+                    // Some platforms may not support IPv6 dual mode and they should fall-back to IPv4
+                    // without throwing exception. However in such case attempt to connect to IPv6 would still fail.
+                    if (client.Client.AddressFamily == AddressFamily.InterNetworkV6 && client.Client.DualMode)
+                    {
+                        client.Connect(endpoint);
+                    }
                 }
             }
         }


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/26036 Classes inheriting TcpClient or Sockets don't function using correct IP by default.

in essence, this change allows to connect either to IPv4 or IPv6 when instantiated without specific address family. This is done by using dual mode socket if possible or falling back to IPv4 to match existing behavior. 

Note that UDPClient has same problem. I can add it to this PR if we agree on approach or I can open new issue far that. 

Aside from added unit test, I also tried to run sample test code from the issue.