### PR TITLE
Add packages to packages.builds & mark non-stable for 2.1.1

### DIFF
--- a/src/System.Net.WebSockets.WebSocketProtocol/dir.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/dir.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
+    <PackageVersion>4.5.1</PackageVersion>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -42,6 +42,9 @@
     <Project Include="*\pkg\**\System.Threading.Tasks.Extensions.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)\System.Net.WebSockets.WebSocketProtocol\pkg\System.Net.WebSockets.WebSocketProtocol.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
Relevant PRs & Justifications (@safern @weshaggard please confirm)

- https://github.com/dotnet/corefx/commit/fe653a068c282786766eaffeabdb061946fe3351 touches System.Net.Http, which doesn't have a .pkgproj
- https://github.com/dotnet/corefx/commit/f11f3e1fcf2dc503a784be2637621d2a3fc25180, https://github.com/dotnet/corefx/commit/ed23f5391fd74c647a9b0cbdab7941e187212a1b & https://github.com/dotnet/corefx/commit/bc718499760c1ba8924ae8a730c156f7634432f3 touch Sytem.Console, which doesn't have a .pkgproj
- https://github.com/dotnet/corefx/commit/7ce9270ac70a2deb009ed4b8d82fe1ebabc597df touches System.Net.Sockets, which doesn't have a pkgproj
- https://github.com/dotnet/corefx/commit/1c34018f147e91bd8823baeb1f1e1df19ab26a17 touches System.IO.FileSystem, which doesn't have a pkgproj
- https://github.com/dotnet/corefx/commit/adc1c4d0d5d7886d63b3372559cb2f5cf942ffd9 appears to touch System.Net.WebSockets.WebSocketProtocol, so added to packages.builds (@stephentoub please confirm)

Do I also need to bump https://github.com/dotnet/corefx/blob/release/2.1/src/System.Net.WebSockets.WebSocketProtocol/dir.props#L5 & add it to packageindex.json? How can I determine what the corresponding package version should be?