### PR TITLE
Fix BrotliStream decoding buffer handling

### DIFF
--- a/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliDecoder.cs
+++ b/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliDecoder.cs
@@ -40,8 +40,6 @@ namespace System.IO.Compression
                 throw new ObjectDisposedException(nameof(BrotliDecoder), SR.BrotliDecoder_Disposed);
         }
 
-        internal OperationStatus Decompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesConsumed, out int bytesWritten) => Decompress(source.Span, destination.Span, out bytesConsumed, out bytesWritten);
-
         public OperationStatus Decompress(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
         {
             EnsureInitialized();

--- a/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
+++ b/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
@@ -11,6 +11,8 @@ namespace System.IO.Compression
     public sealed partial class BrotliStream : Stream
     {
         private BrotliDecoder _decoder;
+        private int _bufferOffset;
+        private int _bufferCount;
 
         public override int Read(byte[] buffer, int offset, int count)
         {
@@ -24,40 +26,50 @@ namespace System.IO.Compression
                 throw new InvalidOperationException(SR.BrotliStream_Compress_UnsupportedOperation);
             EnsureNotDisposed();
             int totalWritten = 0;
-            Span<byte> source = Span<byte>.Empty;
+
             OperationStatus lastResult = OperationStatus.DestinationTooSmall;
             // We want to continue calling Decompress until we're either out of space for output or until Decompress indicates it is finished.
             while (buffer.Length > 0 && lastResult != OperationStatus.Done)
             {
-                int bytesConsumed = 0;
-                int bytesWritten = 0;
-
                 if (lastResult == OperationStatus.NeedMoreData)
                 {
-                    int readBytes = 0;
-                    int iter = 0;
-                    while (readBytes < _buffer.Length && ((iter = _stream.Read(_buffer, readBytes, _buffer.Length - readBytes)) > 0))
+                    // Ensure any left over data is at the beginning of the array so we can fill the remainder.
+                    if (_bufferCount > 0 && _bufferOffset != 0)
                     {
-                        readBytes += iter;
-                        if (readBytes > _buffer.Length)
+                        _buffer.AsSpan(_bufferOffset, _bufferCount).CopyTo(_buffer);
+                    }
+                    _bufferOffset = 0;
+
+                    int numRead = 0;
+                    while (_bufferCount < _buffer.Length && ((numRead = _stream.Read(_buffer, _bufferCount, _buffer.Length - _bufferCount)) > 0))
+                    {
+                        _bufferCount += numRead;
+                        if (_bufferCount > _buffer.Length)
                         {
                             // The stream is either malicious or poorly implemented and returned a number of
                             // bytes larger than the buffer supplied to it.
                             throw new InvalidDataException(SR.BrotliStream_Decompress_InvalidStream);
                         }
                     }
-                    if (readBytes <= 0)
+
+                    if (_bufferCount <= 0)
                     {
                         break;
                     }
-                    source = new Span<byte>(_buffer, 0, readBytes);
                 }
 
-                lastResult = _decoder.Decompress(source, buffer, out bytesConsumed, out bytesWritten);
+                lastResult = _decoder.Decompress(_buffer.AsSpan(_bufferOffset, _bufferCount), buffer, out int bytesConsumed, out int bytesWritten);
                 if (lastResult == OperationStatus.InvalidData)
+                {
                     throw new InvalidOperationException(SR.BrotliStream_Decompress_InvalidData);
+                }
+
                 if (bytesConsumed > 0)
-                    source = source.Slice(bytesConsumed);
+                {
+                    _bufferOffset += bytesConsumed;
+                    _bufferCount -= bytesConsumed;
+                }
+
                 if (bytesWritten > 0)
                 {
                     totalWritten += bytesWritten;
@@ -105,37 +117,46 @@ namespace System.IO.Compression
                 // We want to continue calling Decompress until we're either out of space for output or until Decompress indicates it is finished.
                 while (buffer.Length > 0 && lastResult != OperationStatus.Done)
                 {
-
-                    int bytesConsumed = 0;
-                    int bytesWritten = 0;
-
                     if (lastResult == OperationStatus.NeedMoreData)
                     {
-                        int readBytes = 0;
-                        int iter = 0;
-                        while (readBytes < _buffer.Length && ((iter = await _stream.ReadAsync(new Memory<byte>(_buffer, readBytes, _buffer.Length - readBytes), cancellationToken).ConfigureAwait(false)) > 0))
+                        // Ensure any left over data is at the beginning of the array so we can fill the remainder.
+                        if (_bufferCount > 0 && _bufferOffset != 0)
                         {
-                            readBytes += iter;
-                            if (readBytes > _buffer.Length)
+                            _buffer.AsSpan(_bufferOffset, _bufferCount).CopyTo(_buffer);
+                        }
+                        _bufferOffset = 0;
+
+                        int numRead = 0;
+                        while (_bufferCount < _buffer.Length && ((numRead = await _stream.ReadAsync(new Memory<byte>(_buffer, _bufferCount, _buffer.Length - _bufferCount)).ConfigureAwait(false)) > 0))
+                        {
+                            _bufferCount += numRead;
+                            if (_bufferCount > _buffer.Length)
                             {
                                 // The stream is either malicious or poorly implemented and returned a number of
                                 // bytes larger than the buffer supplied to it.
                                 throw new InvalidDataException(SR.BrotliStream_Decompress_InvalidStream);
                             }
                         }
-                        if (readBytes <= 0)
+
+                        if (_bufferCount <= 0)
                         {
                             break;
                         }
-                        source = new Memory<byte>(_buffer, 0, readBytes);
                     }
 
                     cancellationToken.ThrowIfCancellationRequested();
-                    lastResult = _decoder.Decompress(source, buffer, out bytesConsumed, out bytesWritten);
+                    lastResult = _decoder.Decompress(_buffer.AsSpan(_bufferOffset, _bufferCount), buffer.Span, out int bytesConsumed, out int bytesWritten);
                     if (lastResult == OperationStatus.InvalidData)
+                    {
                         throw new InvalidOperationException(SR.BrotliStream_Decompress_InvalidData);
+                    }
+
                     if (bytesConsumed > 0)
-                        source = source.Slice(bytesConsumed);
+                    {
+                        _bufferOffset += bytesConsumed;
+                        _bufferCount -= bytesConsumed;
+                    }
+
                     if (bytesWritten > 0)
                     {
                         totalWritten += bytesWritten;


### PR DESCRIPTION
When we read data from the input stream and then pass that data off to the BrotliDecoder, the output buffer may be small enough that the BrotliDecoder consumes some but not all of the input data.  Since we've then run out of room to store any further output, we return to the caller, with unconsumed data still in our input buffer... and at that point, that data is lost.  While the data is still in _buffer, the next time Read is called on the stream, we behave as if _buffer is empty.

Contributes to https://github.com/dotnet/corefx/issues/30030
cc: @ianhays, @joshfree 