### PR TITLE
Revert "Fix Uri.Host for IPv6 Link-local address (#29829)"

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
@@ -263,8 +263,7 @@ namespace System.Net.Http
                 Uri requestUri = _requestMessage.RequestUri;
 
                 long scopeId;
-                bool isLinkLocal = false;
-                if ((isLinkLocal = IsLinkLocal(requestUri, out scopeId)))
+                if (IsLinkLocal(requestUri, out scopeId))
                 {
                     // Uri.AbsoluteUri doesn't include the ScopeId/ZoneID, so if it is link-local,
                     // we separately pass the scope to libcurl.
@@ -273,11 +272,10 @@ namespace System.Net.Http
                 }
 
                 EventSourceTrace("Url: {0}", requestUri);
-                int scopeIdIndex = 0;
                 string idnHost = requestUri.IdnHost;
-                string url = requestUri.Host == idnHost ?
-                             requestUri.AbsoluteUri :
-                             new UriBuilder(requestUri){ Host = isLinkLocal && (scopeIdIndex = idnHost.IndexOf("%")) != -1 ? idnHost.Substring(0, scopeIdIndex) : idnHost}.Uri.AbsoluteUri;
+                string url = requestUri.Host == idnHost ? 
+                                requestUri.AbsoluteUri : 
+                                new UriBuilder(requestUri) { Host = idnHost }.Uri.AbsoluteUri;
 
                 SetCurlOption(CURLoption.CURLOPT_URL, url);
                 SetCurlOption(CURLoption.CURLOPT_PROTOCOLS, (long)(CurlProtocols.CURLPROTO_HTTP | CurlProtocols.CURLPROTO_HTTPS));

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -22,7 +22,7 @@ namespace System
 
         // methods
 
-        internal static string ParseCanonicalName(string str, int start, ref bool isLoopback, ref bool linkLocalAddress, ref string scopeId)
+        internal static string ParseCanonicalName(string str, int start, ref bool isLoopback, ref string scopeId)
         {
             unsafe
             {
@@ -31,8 +31,7 @@ namespace System
                 ((long*)numbers)[0] = 0L;
                 ((long*)numbers)[1] = 0L;
                 isLoopback = Parse(str, numbers, start, ref scopeId);
-                linkLocalAddress = numbers[0] == 0xfe80;
-                return "[" + CreateCanonicalName(numbers) + (linkLocalAddress ? scopeId : "") + "]";
+                return '[' + CreateCanonicalName(numbers) + ']';
             }
         }
 

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -114,7 +114,6 @@ namespace System
             FragmentIriCanonical = 0x40000000000,
             IriCanonical = 0x78000000000,
             UnixPath = 0x100000000000,
-            IPv6LinkLocalAddress = 0x200000000000
         }
 
         private Flags _flags;
@@ -1194,9 +1193,7 @@ namespace System
                 if (HostType == Flags.IPv6HostType)
                 {
                     ret = ret.Substring(1, ret.Length - 2);
-
-                    //To avoid duplicated ScopeId on Ipv6 local link address
-                    if ((object)_info.ScopeId != null && (_flags & Flags.IPv6LinkLocalAddress) == 0)
+                    if ((object)_info.ScopeId != null)
                     {
                         ret += _info.ScopeId;
                     }
@@ -2568,7 +2565,6 @@ namespace System
         private static string CreateHostStringHelper(string str, ushort idx, ushort end, ref Flags flags, ref string scopeId)
         {
             bool loopback = false;
-            bool linkLocalAddress = false;
             string host;
             switch (flags & Flags.HostTypeMask)
             {
@@ -2578,7 +2574,7 @@ namespace System
 
                 case Flags.IPv6HostType:
                     // The helper will return [...] string that is not suited for Dns.Resolve()
-                    host = IPv6AddressHelper.ParseCanonicalName(str, idx, ref loopback, ref linkLocalAddress, ref scopeId);
+                    host = IPv6AddressHelper.ParseCanonicalName(str, idx, ref loopback, ref scopeId);
                     break;
 
                 case Flags.IPv4HostType:
@@ -2620,12 +2616,6 @@ namespace System
             {
                 flags |= Flags.LoopbackHost;
             }
-
-            if (linkLocalAddress)
-            {
-                flags |= Flags.IPv6LinkLocalAddress;
-            }
-
             return host;
         }
 

--- a/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IdnDnsSafeHostTest.cs
@@ -46,21 +46,6 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]        
-        public void IdnDnsSafeHost_IPv6HostLinkLocalAddress_ScopeIdCorrectlyFormatted()
-        {
-            const string ScopedLiteralIpv6 = "fe80::e077:c9a3:eeba:b8e9%18";
-
-            string scopedLiteralIpv6Brackets = "[" + ScopedLiteralIpv6 + "]";
-            string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
-            Uri test = new Uri(literalIpV6Uri);
-
-            Assert.Equal(ScopedLiteralIpv6, test.DnsSafeHost);
-            Assert.Equal(ScopedLiteralIpv6, test.IdnHost);
-            Assert.Equal(scopedLiteralIpv6Brackets, test.Host);
-        }
-
-        [Fact]
         public void IdnDnsSafeHost_MixedCase_ToLowerCase()
         {
             Uri test = new Uri("HTTPS://www.xn--pck.COM/");

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -234,36 +234,6 @@ namespace System.PrivateUri.Tests
 
         #region IPv6
 
-        [Theory]
-        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%18")]
-        [InlineData("Fe80::e077:c9a3:eeba:b8e9", "%18")]
-        [InlineData("fE80::e077:c9a3:eeba:b8e9", "%18")]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%18")]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%eth10")]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "")]
-        [InlineData("FE80::e077:c9a3:eeba:b8e9", "%")]
-        [InlineData("fe80::e077:c9a3:eeba:b8e9", "%\u30AF\u20E7")]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public void Host_IPv6LinkLocalAddress_HasScopeId(string address, string zoneIndex)
-        {
-            string scopedLiteralIpv6Brackets = "[" + address + zoneIndex + "]";
-            string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
-            var uri = new Uri(literalIpV6Uri);
-            Assert.Equal(scopedLiteralIpv6Brackets, uri.Host, ignoreCase: true);
-        }
-        
-        [Fact]
-        public void Host_NonIPv6LinkLocalAddress_NoScopeId()
-        {
-            const string Address = "fe81::e077:c9a3:eeba:b8e9";
-            const string ZoneIndex = "%18";
-
-            string scopedLiteralIpv6Brackets = "[" + Address + ZoneIndex + "]";
-            string literalIpV6Uri = "http://" + scopedLiteralIpv6Brackets;
-            var uri = new Uri(literalIpV6Uri);
-            Assert.Equal("[" + Address + "]", uri.Host);
-        }
-       
         [Fact]
         public void UriIPv6Host_CanonicalCollonHex_Success()
         {


### PR DESCRIPTION
This reverts commit f7a8cf12a89dafccbc98cff160346c2ff3e15ba0, which regressed ASP.NET. (https://github.com/dotnet/corefx/issues/28863#issuecomment-393993963)

We need to reconsider how to solve #28863