### PR TITLE
Minor tweaks in NativeMemoryManager

### DIFF
--- a/src/Common/tests/System/Buffers/NativeMemoryManager.cs
+++ b/src/Common/tests/System/Buffers/NativeMemoryManager.cs
@@ -16,6 +16,11 @@ namespace System.Buffers
 
         public NativeMemoryManager(int length)
         {
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
             _length = length;
             _ptr = Marshal.AllocHGlobal(length);
         }

--- a/src/Common/tests/System/Buffers/NativeMemoryManager.cs
+++ b/src/Common/tests/System/Buffers/NativeMemoryManager.cs
@@ -59,6 +59,8 @@ namespace System.Buffers
 
         public override unsafe MemoryHandle Pin(int elementIndex = 0)
         {
+            // Note that this intentionally allows elementIndex == _length to
+            // support pinning zero-length instances.
             if ((uint)elementIndex > (uint)_length)
             {
                 throw new ArgumentOutOfRangeException(nameof(elementIndex));

--- a/src/Common/tests/System/Buffers/NativeMemoryManager.cs
+++ b/src/Common/tests/System/Buffers/NativeMemoryManager.cs
@@ -54,8 +54,10 @@ namespace System.Buffers
 
         public override unsafe MemoryHandle Pin(int elementIndex = 0)
         {
-            if (elementIndex < 0 || elementIndex > _length)
+            if ((uint)elementIndex > (uint)_length)
+            {
                 throw new ArgumentOutOfRangeException(nameof(elementIndex));
+            }
 
             lock (this)
             {


### PR DESCRIPTION
It was previously possible to pin an element one beyond the end of the unmanaged memory, which would compute an out of bounds pointer.

This class is only used in support of unit tests, so the impact of this bug within this repo is limited. However this code is likely to be copy/pasted by developers looking for a similar implementation.

**EDIT** I was wrong. See discussion.