### PR TITLE
Fix unicode on big endian platforms

### DIFF
--- a/src/Common/src/CoreLib/System/Text/UTF8Encoding.cs
+++ b/src/Common/src/CoreLib/System/Text/UTF8Encoding.cs
@@ -720,7 +720,7 @@ namespace System.Text
                         // be careful about the sign extension
                         ch = (int)(((uint)ch) >> 16);
                     }
-		    else
+                    else
                     {
                         ch = (char)ch;
                     }
@@ -1145,8 +1145,8 @@ namespace System.Text
                         }
 
                         // Unfortunately, this is endianess sensitive
-			if (!BitConverter.IsLittleEndian)
-			{
+                        if (!BitConverter.IsLittleEndian)
+                        {
                             *pTarget = (byte)(ch>>16);
                             *(pTarget+1) = (byte)ch;
                             pSrc += 4;
@@ -1154,8 +1154,8 @@ namespace System.Text
                             *(pTarget+3) = (byte)chc;
                             pTarget += 4;
                         }
-			else
-			{
+                        else
+                        {
                             *pTarget = (byte)ch;
                             *(pTarget + 1) = (byte)(ch >> 16);
                             pSrc += 4;
@@ -1168,12 +1168,12 @@ namespace System.Text
 
                 LongCodeWithMask:
                     if (!BitConverter.IsLittleEndian)
-		    { 
+                    {
                         // be careful about the sign extension
                         ch = (int)(((uint)ch) >> 16);
                     }
-		    else
-		    {
+                    else
+                    {
                         ch = (char)ch;
                     }
                     pSrc++;
@@ -1574,24 +1574,24 @@ namespace System.Text
                     break;
 
                 LongCodeWithMask32:
-		    if (!BitConverter.IsLittleEndian)
-		    {
+                    if (!BitConverter.IsLittleEndian)
+                    {
                         // be careful about the sign extension
                         ch = (int)(((uint)ch) >> 16);
-		    }
-		    else
-		    {
+                    }
+                    else
+                    {
                         ch &= 0xFF;
-		    }
+                    }
                 LongCodeWithMask16:
-		    if (!BitConverter.IsLittleEndian)
-		    {
+                    if (!BitConverter.IsLittleEndian)
+                    {
                         ch = (int)(((uint)ch) >> 8);
-		    }
-		    else
-		    {
+                    }
+                    else
+                    {
                         ch &= 0xFF;
-		    }
+                    }
 
                     pSrc++;
                     if (ch <= 0x7F)
@@ -2067,14 +2067,14 @@ namespace System.Text
 
                         // Unfortunately, this is endianess sensitive
                         if (!BitConverter.IsLittleEndian)
-			{
+                        {
                             *pTarget = (char)((ch >> 8) & 0x7F);
                             pSrc += 2;
                             *(pTarget+1) = (char)(ch & 0x7F);
                             pTarget += 2;
                         }
-			else
-			{
+                        else
+                        {
                             *pTarget = (char)(ch & 0x7F);
                             pSrc += 2;
                             *(pTarget + 1) = (char)((ch >> 8) & 0x7F);
@@ -2094,7 +2094,7 @@ namespace System.Text
 
                         // Unfortunately, this is endianess sensitive
                         if (!BitConverter.IsLittleEndian)
-			{
+                        {
                             *pTarget = (char)((ch >> 24) & 0x7F);
                             *(pTarget+1) = (char)((ch >> 16) & 0x7F);
                             *(pTarget+2) = (char)((ch >> 8) & 0x7F);
@@ -2106,8 +2106,8 @@ namespace System.Text
                             *(pTarget+7) = (char)(chb & 0x7F);
                             pTarget += 8;
                         }
-			else
-			{
+                        else
+                        {
                             *pTarget = (char)(ch & 0x7F);
                             *(pTarget + 1) = (char)((ch >> 8) & 0x7F);
                             *(pTarget + 2) = (char)((ch >> 16) & 0x7F);
@@ -2123,12 +2123,12 @@ namespace System.Text
                     break;
 
                 LongCodeWithMask32:
-		    if (!BitConverter.IsLittleEndian)
-		    {
+                    if (!BitConverter.IsLittleEndian)
+                    {
                         // be careful about the sign extension
                         ch = (int)(((uint)ch) >> 16);
                     }
-		    else
+                    else
                     {
                         ch &= 0xFF;
                     }
@@ -2137,7 +2137,7 @@ namespace System.Text
                     {
                         ch = (int)(((uint)ch) >> 8);
                     }
-		    else
+                    else
                     {
                         ch &= 0xFF;
                     }

--- a/src/Common/src/CoreLib/System/Text/UTF8Encoding.cs
+++ b/src/Common/src/CoreLib/System/Text/UTF8Encoding.cs
@@ -715,12 +715,15 @@ namespace System.Text
                     break;
 
                 LongCodeWithMask:
-#if BIGENDIAN
-                    // be careful about the sign extension
-                    ch = (int)(((uint)ch) >> 16);
-#else // BIGENDIAN
-                    ch = (char)ch;
-#endif // BIGENDIAN
+                    if (!BitConverter.IsLittleEndian)
+                    {
+                        // be careful about the sign extension
+                        ch = (int)(((uint)ch) >> 16);
+                    }
+		    else
+                    {
+                        ch = (char)ch;
+                    }
                     pSrc++;
 
                     if (ch <= 0x7F)
@@ -1142,31 +1145,37 @@ namespace System.Text
                         }
 
                         // Unfortunately, this is endianess sensitive
-#if BIGENDIAN
-                        *pTarget = (byte)(ch>>16);
-                        *(pTarget+1) = (byte)ch;
-                        pSrc += 4;
-                        *(pTarget+2) = (byte)(chc>>16);
-                        *(pTarget+3) = (byte)chc;
-                        pTarget += 4;
-#else // BIGENDIAN
-                        *pTarget = (byte)ch;
-                        *(pTarget + 1) = (byte)(ch >> 16);
-                        pSrc += 4;
-                        *(pTarget + 2) = (byte)chc;
-                        *(pTarget + 3) = (byte)(chc >> 16);
-                        pTarget += 4;
-#endif // BIGENDIAN
+			if (!BitConverter.IsLittleEndian)
+			{
+                            *pTarget = (byte)(ch>>16);
+                            *(pTarget+1) = (byte)ch;
+                            pSrc += 4;
+                            *(pTarget+2) = (byte)(chc>>16);
+                            *(pTarget+3) = (byte)chc;
+                            pTarget += 4;
+                        }
+			else
+			{
+                            *pTarget = (byte)ch;
+                            *(pTarget + 1) = (byte)(ch >> 16);
+                            pSrc += 4;
+                            *(pTarget + 2) = (byte)chc;
+                            *(pTarget + 3) = (byte)(chc >> 16);
+                            pTarget += 4;
+                        }
                     }
                     continue;
 
                 LongCodeWithMask:
-#if BIGENDIAN
-                    // be careful about the sign extension
-                    ch = (int)(((uint)ch) >> 16);
-#else // BIGENDIAN
-                    ch = (char)ch;
-#endif // BIGENDIAN
+                    if (!BitConverter.IsLittleEndian)
+		    { 
+                        // be careful about the sign extension
+                        ch = (int)(((uint)ch) >> 16);
+                    }
+		    else
+		    {
+                        ch = (char)ch;
+                    }
                     pSrc++;
 
                     if (ch > 0x7F)
@@ -1564,17 +1573,26 @@ namespace System.Text
                     }
                     break;
 
-#if BIGENDIAN
                 LongCodeWithMask32:
-                    // be careful about the sign extension
-                    ch = (int)(((uint)ch) >> 16);
+		    if (!BitConverter.IsLittleEndian)
+		    {
+                        // be careful about the sign extension
+                        ch = (int)(((uint)ch) >> 16);
+		    }
+		    else
+		    {
+                        ch &= 0xFF;
+		    }
                 LongCodeWithMask16:
-                    ch = (int)(((uint)ch) >> 8);
-#else // BIGENDIAN
-                LongCodeWithMask32:
-                LongCodeWithMask16:
-                    ch &= 0xFF;
-#endif // BIGENDIAN
+		    if (!BitConverter.IsLittleEndian)
+		    {
+                        ch = (int)(((uint)ch) >> 8);
+		    }
+		    else
+		    {
+                        ch &= 0xFF;
+		    }
+
                     pSrc++;
                     if (ch <= 0x7F)
                     {
@@ -2048,17 +2066,20 @@ namespace System.Text
                         }
 
                         // Unfortunately, this is endianess sensitive
-#if BIGENDIAN
-                        *pTarget = (char)((ch >> 8) & 0x7F);
-                        pSrc += 2;
-                        *(pTarget+1) = (char)(ch & 0x7F);
-                        pTarget += 2;
-#else // BIGENDIAN
-                        *pTarget = (char)(ch & 0x7F);
-                        pSrc += 2;
-                        *(pTarget + 1) = (char)((ch >> 8) & 0x7F);
-                        pTarget += 2;
-#endif // BIGENDIAN
+                        if (!BitConverter.IsLittleEndian)
+			{
+                            *pTarget = (char)((ch >> 8) & 0x7F);
+                            pSrc += 2;
+                            *(pTarget+1) = (char)(ch & 0x7F);
+                            pTarget += 2;
+                        }
+			else
+			{
+                            *pTarget = (char)(ch & 0x7F);
+                            pSrc += 2;
+                            *(pTarget + 1) = (char)((ch >> 8) & 0x7F);
+                            pTarget += 2;
+                        }
                     }
 
                     // Run 8 characters at a time!
@@ -2072,43 +2093,54 @@ namespace System.Text
                         }
 
                         // Unfortunately, this is endianess sensitive
-#if BIGENDIAN
-                        *pTarget = (char)((ch >> 24) & 0x7F);
-                        *(pTarget+1) = (char)((ch >> 16) & 0x7F);
-                        *(pTarget+2) = (char)((ch >> 8) & 0x7F);
-                        *(pTarget+3) = (char)(ch & 0x7F);
-                        pSrc += 8;
-                        *(pTarget+4) = (char)((chb >> 24) & 0x7F);
-                        *(pTarget+5) = (char)((chb >> 16) & 0x7F);
-                        *(pTarget+6) = (char)((chb >> 8) & 0x7F);
-                        *(pTarget+7) = (char)(chb & 0x7F);
-                        pTarget += 8;
-#else // BIGENDIAN
-                        *pTarget = (char)(ch & 0x7F);
-                        *(pTarget + 1) = (char)((ch >> 8) & 0x7F);
-                        *(pTarget + 2) = (char)((ch >> 16) & 0x7F);
-                        *(pTarget + 3) = (char)((ch >> 24) & 0x7F);
-                        pSrc += 8;
-                        *(pTarget + 4) = (char)(chb & 0x7F);
-                        *(pTarget + 5) = (char)((chb >> 8) & 0x7F);
-                        *(pTarget + 6) = (char)((chb >> 16) & 0x7F);
-                        *(pTarget + 7) = (char)((chb >> 24) & 0x7F);
-                        pTarget += 8;
-#endif // BIGENDIAN
+                        if (!BitConverter.IsLittleEndian)
+			{
+                            *pTarget = (char)((ch >> 24) & 0x7F);
+                            *(pTarget+1) = (char)((ch >> 16) & 0x7F);
+                            *(pTarget+2) = (char)((ch >> 8) & 0x7F);
+                            *(pTarget+3) = (char)(ch & 0x7F);
+                            pSrc += 8;
+                            *(pTarget+4) = (char)((chb >> 24) & 0x7F);
+                            *(pTarget+5) = (char)((chb >> 16) & 0x7F);
+                            *(pTarget+6) = (char)((chb >> 8) & 0x7F);
+                            *(pTarget+7) = (char)(chb & 0x7F);
+                            pTarget += 8;
+                        }
+			else
+			{
+                            *pTarget = (char)(ch & 0x7F);
+                            *(pTarget + 1) = (char)((ch >> 8) & 0x7F);
+                            *(pTarget + 2) = (char)((ch >> 16) & 0x7F);
+                            *(pTarget + 3) = (char)((ch >> 24) & 0x7F);
+                            pSrc += 8;
+                            *(pTarget + 4) = (char)(chb & 0x7F);
+                            *(pTarget + 5) = (char)((chb >> 8) & 0x7F);
+                            *(pTarget + 6) = (char)((chb >> 16) & 0x7F);
+                            *(pTarget + 7) = (char)((chb >> 24) & 0x7F);
+                            pTarget += 8;
+                        }
                     }
                     break;
 
-#if BIGENDIAN
                 LongCodeWithMask32:
-                    // be careful about the sign extension
-                    ch = (int)(((uint)ch) >> 16);
+		    if (!BitConverter.IsLittleEndian)
+		    {
+                        // be careful about the sign extension
+                        ch = (int)(((uint)ch) >> 16);
+                    }
+		    else
+                    {
+                        ch &= 0xFF;
+                    }
                 LongCodeWithMask16:
-                    ch = (int)(((uint)ch) >> 8);
-#else // BIGENDIAN
-                LongCodeWithMask32:
-                LongCodeWithMask16:
-                    ch &= 0xFF;
-#endif // BIGENDIAN
+                    if (!BitConverter.IsLittleEndian)
+                    {
+                        ch = (int)(((uint)ch) >> 8);
+                    }
+		    else
+                    {
+                        ch &= 0xFF;
+                    }
                     pSrc++;
                     if (ch <= 0x7F)
                     {

--- a/src/Common/src/CoreLib/System/Text/UnicodeEncoding.cs
+++ b/src/Common/src/CoreLib/System/Text/UnicodeEncoding.cs
@@ -31,6 +31,8 @@ namespace System.Text
         // Unicode version 2.0 character size in bytes
         public const int CharSize = 2;
 
+        // endianness-based bit pattern mask.
+        static readonly ulong highLowPatternMask = ((ulong) 0xd800d800d800d800 | (BitConverter.IsLittleEndian ? (ulong) 0x0400000004000000 : (ulong) 0x0000040000000400)); 
 
         public UnicodeEncoding()
             : this(false, true)
@@ -411,11 +413,8 @@ namespace System.Text
                 {
                     // No fallback, maybe we can do it fast
 #if !NO_FAST_UNICODE_LOOP
-#if BIGENDIAN       // If endianess is backwards then each pair of bytes would be backwards.
-                    if ( bigEndian &&
-#else
-                    if (!bigEndian &&
-#endif // BIGENDIAN
+                    // If endianess is backwards then each pair of bytes would be backwards.
+                    if ( (bigEndian ^ BitConverter.IsLittleEndian) && 
 
 #if BIT64           // 64 bit CPU needs to be long aligned for this to work.
                           charLeftOver == 0 && (unchecked((long)chars) & 7) == 0)
@@ -453,11 +452,7 @@ namespace System.Text
 
                                     // If they happen to be high/low/high/low, we may as well continue.  Check the next
                                     // bit to see if its set (low) or not (high) in the right pattern
-#if BIGENDIAN
-                                    if (((0xfc00fc00fc00fc00 & *longChars) ^ 0xd800dc00d800dc00) != 0)
-#else
-                                    if (((0xfc00fc00fc00fc00 & *longChars) ^ 0xdc00d800dc00d800) != 0)
-#endif
+                                    if (((0xfc00fc00fc00fc00 & *longChars) ^ highLowPatternMask) != 0)
                                     {
                                         // Either there weren't 4 surrogates, or the 0x0400 bit was set when a high
                                         // was hoped for or the 0x0400 bit wasn't set where a low was hoped for.
@@ -701,11 +696,8 @@ namespace System.Text
                 {
                     // No fallback, maybe we can do it fast
 #if !NO_FAST_UNICODE_LOOP
-#if BIGENDIAN           // If endianess is backwards then each pair of bytes would be backwards.
-                    if ( bigEndian &&
-#else
-                    if (!bigEndian &&
-#endif // BIGENDIAN
+                    // If endianess is backwards then each pair of bytes would be backwards.
+                    if ( (bigEndian ^ BitConverter.IsLittleEndian) && 
 #if BIT64           // 64 bit CPU needs to be long aligned for this to work, 32 bit CPU needs to be 32 bit aligned
                         (unchecked((long)chars) & 7) == 0 && (unchecked((long)bytes) & 7) == 0 &&
 #else
@@ -752,11 +744,7 @@ namespace System.Text
 
                                     // If they happen to be high/low/high/low, we may as well continue.  Check the next
                                     // bit to see if its set (low) or not (high) in the right pattern
-#if BIGENDIAN
-                                    if (((0xfc00fc00fc00fc00 & *longChars) ^ 0xd800dc00d800dc00) != 0)
-#else
-                                    if (((0xfc00fc00fc00fc00 & *longChars) ^ 0xdc00d800dc00d800) != 0)
-#endif
+                                    if (((0xfc00fc00fc00fc00 & *longChars) ^ highLowPatternMask) != 0)
                                     {
                                         // Either there weren't 4 surrogates, or the 0x0400 bit was set when a high
                                         // was hoped for or the 0x0400 bit wasn't set where a low was hoped for.
@@ -786,11 +774,7 @@ namespace System.Text
                     // Also somehow this optimizes the above loop?  It seems to cause something above
                     // to get enregistered, but I haven't figured out how to make that happen without this loop.
                     else if ((charLeftOver == 0) &&
-#if BIGENDIAN
-                        bigEndian &&
-#else
-                        !bigEndian &&
-#endif // BIGENDIAN
+                        (bigEndian ^ BitConverter.IsLittleEndian) && 
 
 #if BIT64
                         (unchecked((long)chars) & 7) != (unchecked((long)bytes) & 7) &&  // Only do this if chars & bytes are out of line, otherwise faster loop will be faster next time
@@ -1127,11 +1111,7 @@ namespace System.Text
                 // If we're aligned then maybe we can do it fast
                 // That'll hurt if we're unaligned because we'll always test but never be aligned
 #if !NO_FAST_UNICODE_LOOP
-#if BIGENDIAN
-                if (bigEndian &&
-#else // BIGENDIAN
-                if (!bigEndian &&
-#endif // BIGENDIAN
+                if ((bigEndian ^ BitConverter.IsLittleEndian) &&
 #if BIT64 // win64 has to be long aligned
                     (unchecked((long)bytes) & 7) == 0 &&
 #else
@@ -1169,11 +1149,7 @@ namespace System.Text
 
                                 // If they happen to be high/low/high/low, we may as well continue.  Check the next
                                 // bit to see if its set (low) or not (high) in the right pattern
-#if BIGENDIAN
-                                if (((0xfc00fc00fc00fc00 & *longBytes) ^ 0xd800dc00d800dc00) != 0)
-#else
-                                if (((0xfc00fc00fc00fc00 & *longBytes) ^ 0xdc00d800dc00d800) != 0)
-#endif
+                                if (((0xfc00fc00fc00fc00 & *longBytes) ^ highLowPatternMask) != 0)
                                 {
                                     // Either there weren't 4 surrogates, or the 0x0400 bit was set when a high
                                     // was hoped for or the 0x0400 bit wasn't set where a low was hoped for.
@@ -1450,11 +1426,7 @@ namespace System.Text
                 // If we're aligned then maybe we can do it fast
                 // That'll hurt if we're unaligned because we'll always test but never be aligned
 #if !NO_FAST_UNICODE_LOOP
-#if BIGENDIAN
-                if (bigEndian &&
-#else // BIGENDIAN
-                if (!bigEndian &&
-#endif // BIGENDIAN
+                if ((bigEndian ^ BitConverter.IsLittleEndian) &&
 #if BIT64 // win64 has to be long aligned
                     (unchecked((long)chars) & 7) == 0 && (unchecked((long)bytes) & 7) == 0 &&
 #else
@@ -1501,11 +1473,7 @@ namespace System.Text
 
                                 // If they happen to be high/low/high/low, we may as well continue.  Check the next
                                 // bit to see if its set (low) or not (high) in the right pattern
-#if BIGENDIAN
-                                if (((0xfc00fc00fc00fc00 & *longBytes) ^ 0xd800dc00d800dc00) != 0)
-#else
-                                if (((0xfc00fc00fc00fc00 & *longBytes) ^ 0xdc00d800dc00d800) != 0)
-#endif
+                                if (((0xfc00fc00fc00fc00 & *longBytes) ^ highLowPatternMask) != 0)
                                 {
                                     // Either there weren't 4 surrogates, or the 0x0400 bit was set when a high
                                     // was hoped for or the 0x0400 bit wasn't set where a low was hoped for.


### PR DESCRIPTION
Mono had some patches in their fork of referencesource to resolve issues on big endian. Essentially, compile-time endianness handling is no good for big endian platforms, because they have to consume a Monolite intended for all platforms in order to bootstrap. So then, all big endian platforms are now consuming a bootstrap tarball made on little endian systems, and bad things happen as a result.

This makes it so that endianness is checked at runtime by using `System.BitConverter.IsLittleEndian`, not by a compiler definition.

This integrates mono/mono@1f9b218 and mono/mono@92cec46, which won't apply cleanly to current CoreFX.

mono/mono#8679 *may* get fixed by this, but as the comments say, there could be more patches missing. This just integrates the patches known to me on UnicodeEncoding and UTF8Encoding.
