### PR TITLE
Improved code coverage for System.Net.Security

### DIFF
--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -60,11 +60,11 @@ namespace System.Net.Security.Tests
             var expectedProtectionScenario = ProtectionScenario.TransportSelected;
 
             // Act
-            ExtendedProtectionPolicy sut = new ExtendedProtectionPolicy(expectedPolicyEnforcement);
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(expectedPolicyEnforcement);
 
             // Assert
-            Assert.Equal(expectedPolicyEnforcement, sut.PolicyEnforcement);
-            Assert.Equal(expectedProtectionScenario, sut.ProtectionScenario);
+            Assert.Equal(expectedPolicyEnforcement, extendedProtectionPolicy.PolicyEnforcement);
+            Assert.Equal(expectedProtectionScenario, extendedProtectionPolicy.ProtectionScenario);
         }
 
         [Fact]
@@ -76,12 +76,15 @@ namespace System.Net.Security.Tests
         [Fact]
         public void ExtendedProtectionPolicy_Properties()
         {
+            // Arrange
             var policyEnforcementParam = PolicyEnforcement.Always;
             var protectionScenarioParam = ProtectionScenario.TransportSelected;
             var customChannelBindingParam = new MockCustomChannelBinding();
 
+            // Act
             var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam, customChannelBindingParam);
 
+            // Assert
             Assert.Null(extendedProtectionPolicy.CustomServiceNames);
             Assert.Equal(policyEnforcementParam, extendedProtectionPolicy.PolicyEnforcement);
             Assert.Equal(protectionScenarioParam, extendedProtectionPolicy.ProtectionScenario);
@@ -91,6 +94,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public void ExtendedProtectionPolicy_ToString()
         {
+            // Arrange
             var serviceName1 = "Test1";
             var serviceName2 = "Test2";
             var serviceNameCollectionParam = new ServiceNameCollection(new List<string> { serviceName1, serviceName2 });
@@ -99,8 +103,10 @@ namespace System.Net.Security.Tests
             var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam, protectionScenarioParam, serviceNameCollectionParam);
             var expectedString = $"ProtectionScenario={protectionScenarioParam}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding=<null>; ServiceNames={serviceName1}, {serviceName2}";
 
+            // Act
             var result = extendedProtectionPolicy.ToString();
 
+            // Assert
             Assert.NotNull(result);
             Assert.Equal(expectedString, result);
         }

--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -20,14 +20,14 @@ namespace System.Net.Security.Tests
         [Fact]
         public void Constructor_ServiceNameCollection_ZeroElementsParam()
         {
-            var paramValue = new ServiceNameCollection(new List<string>());
+            ServiceNameCollection paramValue = new ServiceNameCollection(new List<string>());
             AssertExtensions.Throws<ArgumentException>("customServiceNames", () => new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, paramValue));
         }
 
         [Fact]
         public void Constructor_PolicyEnforcementChannelBinding_NeverParam()
         {
-            var customChannelBinding = new MockCustomChannelBinding();
+            MockCustomChannelBinding customChannelBinding = new MockCustomChannelBinding();
             AssertExtensions.Throws<ArgumentException>("policyEnforcement", () => new ExtendedProtectionPolicy(PolicyEnforcement.Never, customChannelBinding));
         }
 
@@ -40,9 +40,9 @@ namespace System.Net.Security.Tests
         [Fact]
         public void Constructor_CollectionParam()
         {
-            var paramValue = new List<string> { "Test1", "Test2" };
-            var expectedServiceNameCollection = new ServiceNameCollection(paramValue);
-            var extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, paramValue);
+            List<string> paramValue = new List<string> { "Test1", "Test2" };
+            ServiceNameCollection expectedServiceNameCollection = new ServiceNameCollection(paramValue);
+            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, paramValue);
 
             Assert.Equal(2, extendedProtectionPolicy.CustomServiceNames.Count);
             Assert.Equal(expectedServiceNameCollection, extendedProtectionPolicy.CustomServiceNames);
@@ -51,16 +51,10 @@ namespace System.Net.Security.Tests
         [Fact]
         public void Constructor_PolicyEnforcement_MembersAreSet()
         {
-            // Arrange
-            var expectedPolicyEnforcement = PolicyEnforcement.Never;
-            var expectedProtectionScenario = ProtectionScenario.TransportSelected;
+            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
 
-            // Act
-            var extendedProtectionPolicy = new ExtendedProtectionPolicy(expectedPolicyEnforcement);
-
-            // Assert
-            Assert.Equal(expectedPolicyEnforcement, extendedProtectionPolicy.PolicyEnforcement);
-            Assert.Equal(expectedProtectionScenario, extendedProtectionPolicy.ProtectionScenario);
+            Assert.Equal(PolicyEnforcement.Never, extendedProtectionPolicy.PolicyEnforcement);
+            Assert.Equal(ProtectionScenario.TransportSelected, extendedProtectionPolicy.ProtectionScenario);
         }
 
         [Fact]
@@ -72,73 +66,52 @@ namespace System.Net.Security.Tests
         [Fact]
         public void ExtendedProtectionPolicy_Properties()
         {
-            // Arrange
-            var policyEnforcementParam = PolicyEnforcement.Always;
-            var protectionScenarioParam = ProtectionScenario.TransportSelected;
-            var customChannelBindingParam = new MockCustomChannelBinding();
+            MockCustomChannelBinding customChannelBindingParam = new MockCustomChannelBinding();
 
-            // Act
-            var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam, customChannelBindingParam);
+            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, customChannelBindingParam);
 
-            // Assert
             Assert.Null(extendedProtectionPolicy.CustomServiceNames);
-            Assert.Equal(policyEnforcementParam, extendedProtectionPolicy.PolicyEnforcement);
-            Assert.Equal(protectionScenarioParam, extendedProtectionPolicy.ProtectionScenario);
+            Assert.Equal(PolicyEnforcement.Always, extendedProtectionPolicy.PolicyEnforcement);
+            Assert.Equal(ProtectionScenario.TransportSelected, extendedProtectionPolicy.ProtectionScenario);
             Assert.Equal(customChannelBindingParam, extendedProtectionPolicy.CustomChannelBinding);
         }
 
         [Fact]
         public void ExtendedProtectionPolicy_ToString()
         {
-            // Arrange
-            var serviceName1 = "Test1";
-            var serviceName2 = "Test2";
-            var serviceNameCollectionParam = new ServiceNameCollection(new List<string> { serviceName1, serviceName2 });
-            var policyEnforcementParam = PolicyEnforcement.Always;
-            var protectionScenarioParam = ProtectionScenario.TransportSelected;
-            var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam, protectionScenarioParam, serviceNameCollectionParam);
-            var expectedString = $"ProtectionScenario={protectionScenarioParam}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding=<null>; ServiceNames={serviceName1}, {serviceName2}";
+            string serviceName1 = "Test1";
+            string serviceName2 = "Test2";
+            ServiceNameCollection serviceNameCollectionParam = new ServiceNameCollection(new List<string> { serviceName1, serviceName2 });
+            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, serviceNameCollectionParam);
+            string expectedResult = $"ProtectionScenario={ProtectionScenario.TransportSelected}; PolicyEnforcement={PolicyEnforcement.Always}; CustomChannelBinding=<null>; ServiceNames={serviceName1}, {serviceName2}";
 
-            // Act
-            var result = extendedProtectionPolicy.ToString();
+            string result = extendedProtectionPolicy.ToString();
 
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedString, result);
+            Assert.Equal(expectedResult, result);
         }
 
         [Fact]
         public void ExtendedProtectionPolicy_NoCustomServiceNamesAndNoCustomChannelBinding_ToString()
         {
-            // Arrange
-            var policyEnforcementParam = PolicyEnforcement.Always;
-            var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam);
-            var expectedString = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding=<null>; ServiceNames=<null>";
+            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always);
+            string expectedResult = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={PolicyEnforcement.Always}; CustomChannelBinding=<null>; ServiceNames=<null>";
 
-            // Act
-            var result = extendedProtectionPolicy.ToString();
+            string result = extendedProtectionPolicy.ToString();
 
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedString, result);
+            Assert.Equal(expectedResult, result);
         }
 
         [Fact]
         public void ExtendedProtectionPolicy_NoCustomServiceNames_ToString()
         {
-            // Arrange
-            var policyEnforcementParam = PolicyEnforcement.Always;
-            var channelBinding = new MockCustomChannelBinding();
-            var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam, channelBinding);
-            var expectedChannelBindingString = channelBinding.ToString();
-            var expectedString = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding={expectedChannelBindingString}; ServiceNames=<null>";
+            MockCustomChannelBinding channelBinding = new MockCustomChannelBinding();
+            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, channelBinding);
+            string expectedChannelBinding = channelBinding.ToString();
+            string expectedResult = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={PolicyEnforcement.Always}; CustomChannelBinding={expectedChannelBinding}; ServiceNames=<null>";
 
-            // Act
-            var result = extendedProtectionPolicy.ToString();
+            string result = extendedProtectionPolicy.ToString();
 
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedString, result);
+            Assert.Equal(expectedResult, result);
         }
 
         public class MockCustomChannelBinding : ChannelBinding

--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -45,6 +45,21 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        public void Constructor_PolicyEnforcement_MembersAreSet()
+        {
+            // Arrange
+            PolicyEnforcement expectedPolicyEnforcement = PolicyEnforcement.Never;
+            ProtectionScenario expectedProtectionScenario = ProtectionScenario.TransportSelected;
+
+            // Act
+            var sut = new ExtendedProtectionPolicy(expectedPolicyEnforcement);
+
+            // Assert
+            Assert.Equal(expectedPolicyEnforcement, sut.PolicyEnforcement);
+            Assert.Equal(expectedProtectionScenario, sut.ProtectionScenario);
+        }
+
+        [Fact]
         public void ExtendedProtectionPolicy_OSSupportsExtendedProtection()
         {
             Assert.True(ExtendedProtectionPolicy.OSSupportsExtendedProtection);

--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -100,12 +100,15 @@ namespace System.Net.Security.Tests
         [Fact]
         public void ExtendedProtectionPolicy_NoCustomServiceNames_ToString()
         {
+            // Arrange
             var policyEnforcementParam = PolicyEnforcement.Always;
             var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam);
             var expectedString = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding=<null>; ServiceNames=<null>";
 
+            // Act
             var result = extendedProtectionPolicy.ToString();
 
+            // Assert
             Assert.NotNull(result);
             Assert.Equal(expectedString, result);
         }

--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -20,14 +20,14 @@ namespace System.Net.Security.Tests
         [Fact]
         public void Constructor_ServiceNameCollection_ZeroElementsParam()
         {
-            ServiceNameCollection paramValue = new ServiceNameCollection(new List<string>());
+            var paramValue = new ServiceNameCollection(new List<string>());
             AssertExtensions.Throws<ArgumentException>("customServiceNames", () => new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, paramValue));
         }
 
         [Fact]
         public void Constructor_PolicyEnforcementChannelBinding_NeverParam()
         {
-            MockCustomChannelBinding customChannelBinding = new MockCustomChannelBinding();
+            var customChannelBinding = new MockCustomChannelBinding();
             AssertExtensions.Throws<ArgumentException>("policyEnforcement", () => new ExtendedProtectionPolicy(PolicyEnforcement.Never, customChannelBinding));
         }
 
@@ -40,9 +40,9 @@ namespace System.Net.Security.Tests
         [Fact]
         public void Constructor_CollectionParam()
         {
-            List<string> paramValue = new List<string> { "Test1", "Test2" };
-            ServiceNameCollection expectedServiceNameCollection = new ServiceNameCollection(paramValue);
-            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, paramValue);
+            var paramValue = new List<string> { "Test1", "Test2" };
+            var expectedServiceNameCollection = new ServiceNameCollection(paramValue);
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, paramValue);
 
             Assert.Equal(2, extendedProtectionPolicy.CustomServiceNames.Count);
             Assert.Equal(expectedServiceNameCollection, extendedProtectionPolicy.CustomServiceNames);
@@ -51,7 +51,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public void Constructor_PolicyEnforcement_MembersAreSet()
         {
-            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
 
             Assert.Equal(PolicyEnforcement.Never, extendedProtectionPolicy.PolicyEnforcement);
             Assert.Equal(ProtectionScenario.TransportSelected, extendedProtectionPolicy.ProtectionScenario);
@@ -66,9 +66,9 @@ namespace System.Net.Security.Tests
         [Fact]
         public void ExtendedProtectionPolicy_Properties()
         {
-            MockCustomChannelBinding customChannelBindingParam = new MockCustomChannelBinding();
+            var customChannelBindingParam = new MockCustomChannelBinding();
 
-            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, customChannelBindingParam);
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, customChannelBindingParam);
 
             Assert.Null(extendedProtectionPolicy.CustomServiceNames);
             Assert.Equal(PolicyEnforcement.Always, extendedProtectionPolicy.PolicyEnforcement);
@@ -81,8 +81,8 @@ namespace System.Net.Security.Tests
         {
             string serviceName1 = "Test1";
             string serviceName2 = "Test2";
-            ServiceNameCollection serviceNameCollectionParam = new ServiceNameCollection(new List<string> { serviceName1, serviceName2 });
-            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, serviceNameCollectionParam);
+            var serviceNameCollectionParam = new ServiceNameCollection(new List<string> { serviceName1, serviceName2 });
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, serviceNameCollectionParam);
             string expectedResult = $"ProtectionScenario={ProtectionScenario.TransportSelected}; PolicyEnforcement={PolicyEnforcement.Always}; CustomChannelBinding=<null>; ServiceNames={serviceName1}, {serviceName2}";
 
             string result = extendedProtectionPolicy.ToString();
@@ -93,7 +93,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public void ExtendedProtectionPolicy_NoCustomServiceNamesAndNoCustomChannelBinding_ToString()
         {
-            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always);
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always);
             string expectedResult = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={PolicyEnforcement.Always}; CustomChannelBinding=<null>; ServiceNames=<null>";
 
             string result = extendedProtectionPolicy.ToString();
@@ -104,10 +104,9 @@ namespace System.Net.Security.Tests
         [Fact]
         public void ExtendedProtectionPolicy_NoCustomServiceNames_ToString()
         {
-            MockCustomChannelBinding channelBinding = new MockCustomChannelBinding();
-            ExtendedProtectionPolicy extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, channelBinding);
-            string expectedChannelBinding = channelBinding.ToString();
-            string expectedResult = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={PolicyEnforcement.Always}; CustomChannelBinding={expectedChannelBinding}; ServiceNames=<null>";
+            var channelBinding = new MockCustomChannelBinding();
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, channelBinding);
+            string expectedResult = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={PolicyEnforcement.Always}; CustomChannelBinding={channelBinding.ToString()}; ServiceNames=<null>";
 
             string result = extendedProtectionPolicy.ToString();
 

--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -48,11 +48,11 @@ namespace System.Net.Security.Tests
         public void Constructor_PolicyEnforcement_MembersAreSet()
         {
             // Arrange
-            PolicyEnforcement expectedPolicyEnforcement = PolicyEnforcement.Never;
-            ProtectionScenario expectedProtectionScenario = ProtectionScenario.TransportSelected;
+            var expectedPolicyEnforcement = PolicyEnforcement.Never;
+            var expectedProtectionScenario = ProtectionScenario.TransportSelected;
 
             // Act
-            var sut = new ExtendedProtectionPolicy(expectedPolicyEnforcement);
+            ExtendedProtectionPolicy sut = new ExtendedProtectionPolicy(expectedPolicyEnforcement);
 
             // Assert
             Assert.Equal(expectedPolicyEnforcement, sut.PolicyEnforcement);
@@ -90,6 +90,19 @@ namespace System.Net.Security.Tests
             var protectionScenarioParam = ProtectionScenario.TransportSelected;
             var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam, protectionScenarioParam, serviceNameCollectionParam);
             var expectedString = $"ProtectionScenario={protectionScenarioParam}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding=<null>; ServiceNames={serviceName1}, {serviceName2}";
+
+            var result = extendedProtectionPolicy.ToString();
+
+            Assert.NotNull(result);
+            Assert.Equal(expectedString, result);
+        }
+
+        [Fact]
+        public void ExtendedProtectionPolicy_NoCustomServiceNames_ToString()
+        {
+            var policyEnforcementParam = PolicyEnforcement.Always;
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam);
+            var expectedString = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding=<null>; ServiceNames=<null>";
 
             var result = extendedProtectionPolicy.ToString();
 

--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -14,31 +14,27 @@ namespace System.Net.Security.Tests
         [Fact]
         public void Constructor_PolicyEnforcement_NeverParam()
         {
-            var ex = AssertExtensions.Throws<ArgumentException>("policyEnforcement", () => new ExtendedProtectionPolicy(PolicyEnforcement.Never, ProtectionScenario.TransportSelected, null));
-            Assert.Equal(typeof(ArgumentException), ex.GetType());
+            AssertExtensions.Throws<ArgumentException>("policyEnforcement", () => new ExtendedProtectionPolicy(PolicyEnforcement.Never, ProtectionScenario.TransportSelected, null));
         }
 
         [Fact]
         public void Constructor_ServiceNameCollection_ZeroElementsParam()
         {
             var paramValue = new ServiceNameCollection(new List<string>());
-            var ex = AssertExtensions.Throws<ArgumentException>("customServiceNames", () => new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, paramValue));
-            Assert.Equal(typeof(ArgumentException), ex.GetType());
+            AssertExtensions.Throws<ArgumentException>("customServiceNames", () => new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, paramValue));
         }
 
         [Fact]
         public void Constructor_PolicyEnforcementChannelBinding_NeverParam()
         {
             var customChannelBinding = new MockCustomChannelBinding();
-            var ex = AssertExtensions.Throws<ArgumentException>("policyEnforcement", () => new ExtendedProtectionPolicy(PolicyEnforcement.Never, customChannelBinding));
-            Assert.Equal(typeof(ArgumentException), ex.GetType());
+            AssertExtensions.Throws<ArgumentException>("policyEnforcement", () => new ExtendedProtectionPolicy(PolicyEnforcement.Never, customChannelBinding));
         }
 
         [Fact]
         public void Constructor_ChannelBinding_NullParam()
         {
-            var ex = AssertExtensions.Throws<ArgumentNullException>("customChannelBinding", () => new ExtendedProtectionPolicy(PolicyEnforcement.Always, null));
-            Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+            AssertExtensions.Throws<ArgumentNullException>("customChannelBinding", () => new ExtendedProtectionPolicy(PolicyEnforcement.Always, null));
         }
 
         [Fact]

--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -98,12 +98,30 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        public void ExtendedProtectionPolicy_NoCustomServiceNames_ToString()
+        public void ExtendedProtectionPolicy_NoCustomServiceNamesAndNoCustomChannelBinding_ToString()
         {
             // Arrange
             var policyEnforcementParam = PolicyEnforcement.Always;
             var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam);
             var expectedString = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding=<null>; ServiceNames=<null>";
+
+            // Act
+            var result = extendedProtectionPolicy.ToString();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(expectedString, result);
+        }
+
+        [Fact]
+        public void ExtendedProtectionPolicy_NoCustomServiceNames_ToString()
+        {
+            // Arrange
+            var policyEnforcementParam = PolicyEnforcement.Always;
+            var channelBinding = new MockCustomChannelBinding();
+            var extendedProtectionPolicy = new ExtendedProtectionPolicy(policyEnforcementParam, channelBinding);
+            var expectedChannelBindingString = channelBinding.ToString();
+            var expectedString = $"ProtectionScenario={extendedProtectionPolicy.ProtectionScenario}; PolicyEnforcement={policyEnforcementParam}; CustomChannelBinding={expectedChannelBindingString}; ServiceNames=<null>";
 
             // Act
             var result = extendedProtectionPolicy.ToString();

--- a/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTest.cs
@@ -27,6 +27,14 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        public void Constructor_PolicyEnforcementChannelBinding_NeverParam()
+        {
+            var customChannelBinding = new MockCustomChannelBinding();
+            var ex = AssertExtensions.Throws<ArgumentException>("policyEnforcement", () => new ExtendedProtectionPolicy(PolicyEnforcement.Never, customChannelBinding));
+            Assert.Equal(typeof(ArgumentException), ex.GetType());
+        }
+
+        [Fact]
         public void Constructor_ChannelBinding_NullParam()
         {
             var ex = AssertExtensions.Throws<ArgumentNullException>("customChannelBinding", () => new ExtendedProtectionPolicy(PolicyEnforcement.Always, null));


### PR DESCRIPTION
Worked on following issue https://github.com/dotnet/corefx/issues/17099 by adding more code coverage with simple tests.