### PR TITLE
Increase test coverage of `BuffersExtensions`

### DIFF
--- a/src/System.Memory/tests/BuffersExtensions/BuffersExtensions.cs
+++ b/src/System.Memory/tests/BuffersExtensions/BuffersExtensions.cs
@@ -1,0 +1,113 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class BuffersExtensionsTests
+    {
+        [Fact]
+        public void WritingToSingleSegmentBuffer()
+        {
+            IBufferWriter<byte> bufferWriter = new TestBufferWriterSingleSegment();
+            bufferWriter.Write(Encoding.UTF8.GetBytes("Hello"));
+            bufferWriter.Write(Encoding.UTF8.GetBytes(" World!"));
+            Assert.Equal("Hello World!", bufferWriter.ToString());
+        }
+
+        [Fact]
+        public void WritingToMultiSegmentBuffer()
+        {
+            IBufferWriter<byte> bufferWriter = new TestBufferWriterMultiSegment();
+            bufferWriter.Write(Encoding.UTF8.GetBytes("Hello"));
+            bufferWriter.Write(Encoding.UTF8.GetBytes(" World!"));
+            Assert.Equal("Hello World!", bufferWriter.ToString());
+        }
+
+        private class TestBufferWriterSingleSegment : IBufferWriter<byte>
+        {
+            byte[] _buffer = new byte[1000];
+            int _written = 0;
+
+            public Span<byte> GetBuffer => _buffer;
+
+            public void Advance(int bytes)
+            {
+                _written += bytes;
+            }
+
+            public Memory<byte> GetMemory(int minimumLength = 0)
+            {
+                return ((Memory<byte>)_buffer).Slice(_written);
+            }
+
+            public Span<byte> GetSpan(int minimumLength)
+            {
+                return ((Span<byte>)_buffer).Slice(_written);
+            }
+
+            public int MaxBufferSize { get; } = Int32.MaxValue;
+
+            public override string ToString()
+            {
+                return Encoding.UTF8.GetString(_buffer.AsSpan(0, _written));
+            }
+        }
+
+        private class TestBufferWriterMultiSegment : IBufferWriter<byte>
+        {
+            private byte[] _current = new byte[0];
+            private List<byte[]> _commited = new List<byte[]>();
+
+            public void Advance(int bytes)
+            {
+                if (bytes == 0)
+                    return;
+                _commited.Add(_current.AsSpan(0, bytes).ToArray());
+                _current = new byte[0];
+            }
+
+            public Memory<byte> GetMemory(int minimumLength = 0)
+            {
+                if (minimumLength == 0)
+                    minimumLength = _current.Length + 1;
+                if (minimumLength < _current.Length)
+                    throw new InvalidOperationException();
+                var newBuffer = new byte[minimumLength];
+                _current.CopyTo(newBuffer.AsSpan());
+                _current = newBuffer;
+                return _current;
+            }
+
+            public Span<byte> GetSpan(int minimumLength)
+            {
+                if (minimumLength == 0)
+                    minimumLength = _current.Length + 1;
+                if (minimumLength < _current.Length)
+                    throw new InvalidOperationException();
+                var newBuffer = new byte[minimumLength];
+                _current.CopyTo(newBuffer.AsSpan());
+                _current = newBuffer;
+                return _current;
+            }
+
+            public int MaxBufferSize { get; } = Int32.MaxValue;
+
+            public override string ToString()
+            {
+                var builder = new StringBuilder();
+                foreach (var buffer in _commited)
+                {
+                    builder.Append(Encoding.UTF8.GetString(buffer));
+                }
+                return builder.ToString();
+            }
+        }
+    }
+
+  
+}

--- a/src/System.Memory/tests/BuffersExtensions/BuffersExtensionsTests.cs
+++ b/src/System.Memory/tests/BuffersExtensions/BuffersExtensionsTests.cs
@@ -30,31 +30,21 @@ namespace System.Buffers.Tests
 
         private class TestBufferWriterSingleSegment : IBufferWriter<byte>
         {
-            byte[] _buffer = new byte[1000];
-            int _written = 0;
-
-            public Span<byte> GetBuffer => _buffer;
+            private byte[] _buffer = new byte[1000];
+            private int _written = 0;
 
             public void Advance(int bytes)
             {
                 _written += bytes;
             }
 
-            public Memory<byte> GetMemory(int minimumLength = 0)
-            {
-                return ((Memory<byte>)_buffer).Slice(_written);
-            }
+            public Memory<byte> GetMemory(int sizeHint  = 0) => _buffer.AsMemory().Slice(_written);
 
-            public Span<byte> GetSpan(int minimumLength)
-            {
-                return ((Span<byte>)_buffer).Slice(_written);
-            }
-
-            public int MaxBufferSize { get; } = Int32.MaxValue;
+            public Span<byte> GetSpan(int sizeHint) => _buffer.AsSpan().Slice(_written);
 
             public override string ToString()
             {
-                return Encoding.UTF8.GetString(_buffer.AsSpan(0, _written));
+                return Encoding.UTF8.GetString(_buffer.AsSpan(0, _written).ToArray());
             }
         }
 
@@ -71,43 +61,39 @@ namespace System.Buffers.Tests
                 _current = new byte[0];
             }
 
-            public Memory<byte> GetMemory(int minimumLength = 0)
+            public Memory<byte> GetMemory(int sizeHint  = 0)
             {
-                if (minimumLength == 0)
-                    minimumLength = _current.Length + 1;
-                if (minimumLength < _current.Length)
+                if (sizeHint  == 0)
+                    sizeHint  = _current.Length + 1;
+                if (sizeHint  < _current.Length)
                     throw new InvalidOperationException();
-                var newBuffer = new byte[minimumLength];
+                var newBuffer = new byte[sizeHint ];
                 _current.CopyTo(newBuffer.AsSpan());
                 _current = newBuffer;
                 return _current;
             }
 
-            public Span<byte> GetSpan(int minimumLength)
+            public Span<byte> GetSpan(int sizeHint)
             {
-                if (minimumLength == 0)
-                    minimumLength = _current.Length + 1;
-                if (minimumLength < _current.Length)
+                if (sizeHint == 0)
+                    sizeHint = _current.Length + 1;
+                if (sizeHint < _current.Length)
                     throw new InvalidOperationException();
-                var newBuffer = new byte[minimumLength];
+                var newBuffer = new byte[sizeHint];
                 _current.CopyTo(newBuffer.AsSpan());
                 _current = newBuffer;
                 return _current;
             }
-
-            public int MaxBufferSize { get; } = Int32.MaxValue;
 
             public override string ToString()
             {
                 var builder = new StringBuilder();
-                foreach (var buffer in _commited)
+                foreach (byte[] buffer in _commited)
                 {
                     builder.Append(Encoding.UTF8.GetString(buffer));
                 }
                 return builder.ToString();
             }
         }
-    }
-
-  
+    }  
 }

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -20,15 +20,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
-    <Compile Include="BuffersExtensions\BuffersExtensions.cs" />
-    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.char.cs" />
-    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.byte.cs" />
-    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Default.cs" />
-    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Empty.cs" />
     <Compile Include="TInt.cs" />
     <Compile Include="TestException.cs" />
     <Compile Include="TestHelpers.cs" />
     <Compile Include="TestMemory.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BuffersExtensions\BuffersExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Span\AsSpan.cs" />
@@ -87,6 +85,10 @@
     <Compile Include="Span\ToString.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.char.cs" />
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.byte.cs" />
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Default.cs" />
+    <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Empty.cs" />    
     <Compile Include="ReadOnlyBuffer\BufferSegment.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceFactory.byte.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceFactory.char.cs" />
@@ -163,7 +165,7 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\Tests\System\StringTests.cs">
       <Link>ReadOnlySpan\StringTests.cs</Link>
-    </Compile>    
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Memory\AsMemory.cs" />

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
+    <Compile Include="BuffersExtensions\BuffersExtensions.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.char.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.byte.cs" />
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Default.cs" />


### PR DESCRIPTION
I added two `IBufferWriter` test implementations for this.

- TestBufferWriterSingleSegment was copied from https://github.com/dotnet/corefxlab/blob/35e606ea9a6d872307fffb50798a6f4e700e8af7/tests/System.Binary.Base64.Tests/BasicUnitTests.cs and ToString() was added
- TestBufferWriterMultiSegment was copied from https://github.com/dotnet/corefxlab/blob/a93c856db8547166235bd5aa252676b184adf451/tests/System.Buffers.ReaderWriter.Tests/BufferWriterTests_sequence.cs

This takes the line coverage for `System.Buffers.BuffersExtensions` from 69.5% to 100% (which branch coverage from 72.7% to 90.9%)

Part of https://github.com/dotnet/corefx/issues/26768