### PR TITLE
Attempt to fix crashes due to shared test certificates

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Certificates.cs
+++ b/src/Common/tests/System/Net/Configuration.Certificates.cs
@@ -49,11 +49,10 @@ namespace System.Net.Test.Common
             {
                 try
                 {
-                    var cert = new X509Certificate2(
-                        Path.Combine(TestDataFolder, certificateFileName),
+                    return new X509Certificate2(
+                        File.ReadAllBytes(Path.Combine(TestDataFolder, certificateFileName)),
                         CertificatePassword,
                         X509KeyStorageFlags.DefaultKeySet);
-                    return cert;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
We've been seeing some crashes in tests due to what is believed to be an OS bug related to concurrently loading the same certificate from multiple threads.  In case it's to do with the file path instead of the actual contents of the cert, this uses a unique path for each load.

Maybe fixes https://github.com/dotnet/corefx/issues/30044 and https://github.com/dotnet/corefx/issues/30028?  If it doesn't, we'll look at reverting to the mutex approach that was previously employed.

cc: @davidsh, @bartonjs