### PR TITLE
Fix spacing in HttpConnectionPool.ToString()

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -788,7 +788,7 @@ namespace System.Net.Http
 
         // For diagnostic purposes
         public override string ToString() =>
-            $"{nameof(HttpConnectionPool)}" +
+            $"{nameof(HttpConnectionPool)} " +
             (_proxyUri == null ?
                 (_sslOptions == null ?
                     $"http://{_host}:{_port}" :


### PR DESCRIPTION
This string is output as part of tracing, and the name is getting squished up against the url, e.g. "HttpConnectionPoolhttp://microsoft.com" rather than "HttpConnectionPool http://microsoft.com".

cc: @davidsh