### PR TITLE
Add type overload for Throws netfx extension

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -34,6 +34,7 @@ namespace System
         public static void Throws<T>(string netCoreParamName, string netFxParamName, System.Action action) where T : System.ArgumentException { }
         public static void Throws<TNetCoreExceptionType, TNetFxExceptionType>(string paramName, System.Action action) where TNetCoreExceptionType : System.ArgumentException where TNetFxExceptionType : System.ArgumentException { }
         public static Exception Throws<TNetCoreExceptionType, TNetFxExceptionType>(Action action) where TNetCoreExceptionType : Exception where TNetFxExceptionType : Exception { throw null; }
+        public static Exception Throws(Type netCoreExceptionType, Type netFxExceptionType, Action action) { throw null; }
         public static void Throws<TNetCoreExceptionType, TNetFxExceptionType>(string netCoreParamName, string netFxParamName, System.Action action) where TNetCoreExceptionType : System.ArgumentException where TNetFxExceptionType : System.ArgumentException { }
     }
     public static partial class PlatformDetection

--- a/src/CoreFx.Private.TestUtilities/src/System/AssertExtensions.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/AssertExtensions.cs
@@ -91,13 +91,18 @@ namespace System
             where TNetCoreExceptionType : Exception
             where TNetFxExceptionType : Exception
         {
+            return Throws(typeof(TNetCoreExceptionType), typeof(TNetFxExceptionType), action);
+        }
+
+        public static Exception Throws(Type netCoreExceptionType, Type netFxExceptionType, Action action)
+        {
             if (IsFullFramework)
             {
-                return Throws<TNetFxExceptionType>(action);
+                return Assert.Throws(netFxExceptionType, action);
             }
             else
             {
-                return Throws<TNetCoreExceptionType>(action);
+                return Assert.Throws(netCoreExceptionType, action);
             }
         }
 


### PR DESCRIPTION
Its not yet used, but I'm writing some cleanups for System.ComponentModel.TypeConverter tests that will use this. I wanted to minimise the diff for that PR

Also helps for consistency