### PR TITLE
Remove obsolete build error suppression for uapaot in System.Runtime

### DIFF
--- a/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
@@ -2,4 +2,3 @@ Compat issues with assembly System.Runtime:
 MembersMustExist : Member 'System.Text.StringBuilder.GetChunks()' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.StringBuilder.ChunkEnumerator' does not exist in the implementation but it does exist in the contract.
 CannotMakeMoreVisible : Visibility of member 'System.Exception.HResult.set(System.Int32)' is 'Family' in the implementation but 'Public' in the contract.
-MembersMustExist : Member 'System.FormattableString.CurrentCulture(System.FormattableString)' does not exist in the implementation but it does exist in the contract.


### PR DESCRIPTION
The API is now in ProjectN: https://github.com/dotnet/corert/pull/5882#issuecomment-394280472