### PR TITLE
add test for #26732

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1059,6 +1059,7 @@ namespace System.Net.Http.Functional.Tests
             }, secure.ToString()).Dispose();
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not support custom proxies.")]
         [Fact]
         public async Task ProxyAuth_SameConnection_Succeeds()
         {
@@ -1071,7 +1072,7 @@ namespace System.Net.Http.Functional.Tests
                         "Content-Length: 0\r\n" +
                         "\r\n";
 
-                using  (HttpClientHandler handler = new HttpClientHandler())
+                using  (var handler = new HttpClientHandler())
                 {
                     handler.Proxy = new UseSpecifiedUriWebProxy(proxyUrl, new NetworkCredential("abc", "def"));
 
@@ -1087,12 +1088,12 @@ namespace System.Net.Http.Functional.Tests
                             await connection.ReadRequestHeaderAndSendResponseAsync(content:"OK").ConfigureAwait(false);
                         });
 
-                        String response = await request;
+                        string response = await request;
                         Assert.Equal("OK", response);
                     }
                 }
             });
-            await TaskTimeoutExtensions.WhenAllOrAnyFailed(new Task[] { serverTask }, TestHelper.PassingTestTimeoutMilliseconds);
+            await serverTask.TimeoutAfter(TestHelper.PassingTestTimeoutMilliseconds);
         }
     }
 


### PR DESCRIPTION
closes #26732 Responses to 407 proxy authentication request are always sent on new connection

The reported issue was fixed and manually verified while back during 2.1 development. 

Note, that handlers behave different ways - for example Curl sends credentials immediately without checking anything else.
I did not want to complicate this test with bunch of platforms tests so it will only run for SocketHttpHandler. Also note that #26732 had no functional impact. At least for basic and digest auth, using new connection is functionally equivalent so this test verifies internal behavior of socket http handler. 


