### PR TITLE
Avoid boxing Booleans in SqlBuffer.Value

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBuffer.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBuffer.cs
@@ -842,6 +842,9 @@ namespace System.Data.SqlClient
             }
         }
 
+        private static readonly object s_cachedTrueObject = true;
+        private static readonly object s_cachedFalseObject = false;
+
         internal object Value
         {
             get
@@ -853,7 +856,7 @@ namespace System.Data.SqlClient
                 switch (_type)
                 {
                     case StorageType.Empty: return DBNull.Value;
-                    case StorageType.Boolean: return Boolean;
+                    case StorageType.Boolean: return Boolean ? s_cachedTrueObject : s_cachedFalseObject;
                     case StorageType.Byte: return Byte;
                     case StorageType.DateTime: return DateTime;
                     case StorageType.Decimal: return Decimal;


### PR DESCRIPTION
This was showing up as a non-trivial source of allocation in a customer workload.

cc: @keeratsingh, @afsanehr, @david-engel