### PR TITLE
Use UTC for cookie timestamps

### DIFF
--- a/src/System.Net.Http/src/uap/System/Net/cookie.cs
+++ b/src/System.Net.Http/src/uap/System/Net/cookie.cs
@@ -85,7 +85,7 @@ namespace System.Net
         int[] m_port_list = null;
         bool m_secure = false;
         bool m_httpOnly = false;
-        DateTime m_timeStamp = DateTime.Now;
+        DateTime m_timeStamp = DateTime.UtcNow;
         string m_value = string.Empty;
         int m_version = 0;
 
@@ -240,13 +240,13 @@ namespace System.Net
         {
             get
             {
-                return (m_expires != DateTime.MinValue) && (m_expires.ToLocalTime() <= DateTime.Now);
+                return (m_expires != DateTime.MinValue) && (m_expires.ToUniversalTime() <= DateTime.UtcNow);
             }
             set
             {
                 if (value == true)
                 {
-                    m_expires = DateTime.Now;
+                    m_expires = DateTime.UtcNow;
                 }
             }
         }
@@ -913,7 +913,7 @@ namespace System.Net
             }
             if (Expires != DateTime.MinValue)
             {
-                int seconds = (int)(Expires.ToLocalTime() - DateTime.Now).TotalSeconds;
+                int seconds = (int)(Expires.ToUniversalTime() - DateTime.UtcNow).TotalSeconds;
                 if (seconds < 0)
                 {
                     // This means that the cookie has already expired. Set Max-Age to 0
@@ -1680,7 +1680,7 @@ namespace System.Net
                                         int parsed;
                                         if (int.TryParse(CheckQuoted(m_tokenizer.Value), out parsed))
                                         {
-                                            cookie.Expires = DateTime.Now.AddSeconds((double)parsed);
+                                            cookie.Expires = DateTime.UtcNow.AddSeconds((double)parsed);
                                         }
                                         else
                                         {

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -60,7 +60,7 @@ namespace System.Net
         private bool m_secure = false; // Do not rename (binary serialization)
         [System.Runtime.Serialization.OptionalField]
         private bool m_httpOnly = false; // Do not rename (binary serialization)
-        private DateTime m_timeStamp = DateTime.Now; // Do not rename (binary serialization)
+        private DateTime m_timeStamp = DateTime.UtcNow; // Do not rename (binary serialization)
         private string m_value = string.Empty; // Do not rename (binary serialization)
         private int m_version = 0; // Do not rename (binary serialization)
 
@@ -203,13 +203,13 @@ namespace System.Net
         {
             get
             {
-                return (m_expires != DateTime.MinValue) && (m_expires.ToLocalTime() <= DateTime.Now);
+                return (m_expires != DateTime.MinValue) && (m_expires.ToUniversalTime() <= DateTime.UtcNow);
             }
             set
             {
                 if (value == true)
                 {
-                    m_expires = DateTime.Now;
+                    m_expires = DateTime.UtcNow;
                 }
             }
         }
@@ -876,7 +876,7 @@ namespace System.Net
             }
             if (Expires != DateTime.MinValue)
             {
-                int seconds = (int)(Expires.ToLocalTime() - DateTime.Now).TotalSeconds;
+                int seconds = (int)(Expires.ToUniversalTime() - DateTime.UtcNow).TotalSeconds;
                 if (seconds < 0)
                 {
                     // This means that the cookie has already expired. Set Max-Age to 0

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -163,7 +163,7 @@ namespace System.Net
             switch (how)
             {
                 case Stamp.Set:
-                    m_TimeStamp = DateTime.Now;
+                    m_TimeStamp = DateTime.UtcNow;
                     break;
                 case Stamp.SetToMaxUsed:
                     m_TimeStamp = DateTime.MaxValue;


### PR DESCRIPTION
Happen to notice that local time was being used for cookie expiration.  This is problematic for a few reasons:

- The local time zone of the server will impact the result.
- `DateTime.UtcNow` is faster than `DateTime.Now` because it doesn't have to calculate the time zone.
- Addition and subtraction on `DateTime` does not take time zone transitions into account, thus would give incorrect results when crossing transition (such for DST).

Note that `.ToUniversalTime()` is a no-op for `DateTime` values with `DateTimeKind.Utc`, but it's still needed because the `Expires` setter is public, and could be passed a `DateTime` with `DateTimeKind.Unspecified` or `DateTimeKind.Local`.