### PR TITLE
Override Read/WriteByte on BrotliStream

### DIFF
--- a/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
+++ b/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,6 +19,13 @@ namespace System.IO.Compression
         {
             ValidateParameters(buffer, offset, count);
             return Read(new Span<byte>(buffer, offset, count));
+        }
+
+        public override int ReadByte()
+        {
+            byte b = default;
+            int numRead = Read(MemoryMarshal.CreateSpan(ref b, 1));
+            return numRead != 0 ? b : -1;
         }
 
         public override int Read(Span<byte> buffer)

--- a/src/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
+++ b/src/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +23,11 @@ namespace System.IO.Compression
         {
             ValidateParameters(buffer, offset, count);
             WriteCore(new ReadOnlySpan<byte>(buffer, offset, count));
+        }
+
+        public override void WriteByte(byte value)
+        {
+            WriteCore(MemoryMarshal.CreateReadOnlySpan(ref value, 1));
         }
 
         public override void Write(ReadOnlySpan<byte> buffer)


### PR DESCRIPTION
The base Stream.Read/WriteByte allocate a byte[1] array and delegate to the corresponding array-based Read/Write methods.  We can do much better on BrolitStream (as we can on most of our Stream-derived types), especially since we already have span-based Read/Write methods, so we can just call those with a span for the single byte.

cc: @ianhays, @joshfree 