### PR TITLE
Fix tests to use Assert.Throw instead of Assert.ThrowsAsync when relevant

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
@@ -82,12 +82,11 @@ namespace System.Data.SqlClient.Tests
             });
         }
 
+        [ActiveIssue(30144)]
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework doesn't throw the Not Supported Exception")]
-        public void TestNotSupportedExceptionForTransactionScopeAsync()
+        public async Task TestNotSupportedExceptionForTransactionScopeAsync()
         {
-            Assert.ThrowsAsync<NotSupportedException>(() => ConnectToServerInTransactionScopeTask(s_connectionStringWithEnlistAsDefault));
+            await Assert.ThrowsAsync<NotSupportedException>(() => ConnectToServerInTransactionScopeTask(s_connectionStringWithEnlistAsDefault));
         }
-
     }
 }

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTest.Linux.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTest.Linux.cs
@@ -380,9 +380,10 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [ActiveIssue(30150)]
         [Fact, OuterLoop]
         [PlatformSpecific(TestPlatforms.Linux)]
-        public void NegotiateStream_StreamToStream_KerberosAuthDefaultCredentialsNoSeed_Failure()
+        public async Task NegotiateStream_StreamToStream_KerberosAuthDefaultCredentialsNoSeed_Failure()
         {
             if (!_isKrbAvailable)
             {
@@ -399,13 +400,14 @@ namespace System.Net.Security.Tests
 
                 string user = string.Format("{0}@{1}", TestConfiguration.KerberosUser, TestConfiguration.Realm);
                 string target = string.Format("{0}@{1}", TestConfiguration.HostTarget, TestConfiguration.Realm);
-                Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(CredentialCache.DefaultNetworkCredentials, target));
+                await Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(CredentialCache.DefaultNetworkCredentials, target));
             }
         }
 
+        [ActiveIssue(30150)]
         [Fact, OuterLoop]
         [PlatformSpecific(TestPlatforms.Linux)]
-        public void NegotiateStream_StreamToStream_KerberosAuthInvalidUser_Failure()
+        public async Task NegotiateStream_StreamToStream_KerberosAuthInvalidUser_Failure()
         {
             if (!_isKrbAvailable)
             {
@@ -425,14 +427,15 @@ namespace System.Net.Security.Tests
                 string user = string.Format("{0}@{1}", TestConfiguration.KerberosUser, TestConfiguration.Realm);
                 string target = string.Format("{0}@{1}", TestConfiguration.HostTarget, TestConfiguration.Realm);
                 NetworkCredential credential = new NetworkCredential(user.Substring(1), _fixture.password);
-                Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(credential, target));
-                Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync());
+                await Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(credential, target));
+                await Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync());
             }
         }
 
+        [ActiveIssue(30150)]
         [Fact, OuterLoop]
         [PlatformSpecific(TestPlatforms.Linux)]
-        public void NegotiateStream_StreamToStream_KerberosAuthInvalidPassword_Failure()
+        public async Task NegotiateStream_StreamToStream_KerberosAuthInvalidPassword_Failure()
         {
             if (!_isKrbAvailable)
             {
@@ -453,14 +456,15 @@ namespace System.Net.Security.Tests
                 string target = string.Format("{0}@{1}", TestConfiguration.HostTarget, TestConfiguration.Realm);
                 NetworkCredential credential = new NetworkCredential(user, _fixture.password.Substring(1));
                 Task serverAuth = server.AuthenticateAsServerAsync();
-                Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(credential, target));
-                Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync());
+                await Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(credential, target));
+                await Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync());
             }
         }
 
+        [ActiveIssue(30150)]
         [Fact, OuterLoop]
         [PlatformSpecific(TestPlatforms.Linux)]
-        public void NegotiateStream_StreamToStream_KerberosAuthInvalidTarget_Failure()
+        public async Task NegotiateStream_StreamToStream_KerberosAuthInvalidTarget_Failure()
         {
             if (!_isKrbAvailable)
             {
@@ -478,7 +482,7 @@ namespace System.Net.Security.Tests
                 string user = string.Format("{0}@{1}", TestConfiguration.KerberosUser, TestConfiguration.Realm);
                 string target = string.Format("{0}@{1}", TestConfiguration.HostTarget, TestConfiguration.Realm);
                 NetworkCredential credential = new NetworkCredential(user, _fixture.password);
-                Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(credential, target.Substring(1)));
+                await Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(credential, target.Substring(1)));
             }
         }
 
@@ -746,7 +750,7 @@ namespace System.Net.Security.Tests
         [Theory, OuterLoop]
         [MemberData(nameof(InvalidNtlmCredentials))]
         [PlatformSpecific(TestPlatforms.Linux)]
-        public void NegotiateStream_StreamToStream_NtlmAuthentication_NtlmUser_InvalidCredentials_Fail(NetworkCredential credential)
+        public async Task NegotiateStream_StreamToStream_NtlmAuthentication_NtlmUser_InvalidCredentials_Fail(NetworkCredential credential)
         {
             if (!_isNtlmAvailable)
             {
@@ -761,8 +765,8 @@ namespace System.Net.Security.Tests
             using (var server = new UnixGssFakeNegotiateStream(serverStream))
             {
                 Assert.False(client.IsAuthenticated, "client.IsAuthenticated");
-                Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync());
-                Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(credential, _testTarget, ProtectionLevel.None, TokenImpersonationLevel.Identification));
+                await Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync());
+                await Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(credential, _testTarget, ProtectionLevel.None, TokenImpersonationLevel.Identification));
             }
         }
 

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockExtensionTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockExtensionTests.cs
@@ -728,7 +728,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         [Fact]
         public void TestSendAsync_ArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => ((ITargetBlock<int>)null).SendAsync(42));
+            Assert.Throws<ArgumentNullException>(() => { ((ITargetBlock<int>)null).SendAsync(42); });
         }
 
         [Fact]
@@ -1193,31 +1193,31 @@ namespace System.Threading.Tasks.Dataflow.Tests
         [Fact]
         public void TestChoose_ArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int>(null, i => { }, new BufferBlock<int>(), i => { }));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int>(new BufferBlock<int>(), i => { }, null, i => { }));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int>(new BufferBlock<int>(), null, new BufferBlock<int>(), i => { }));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), null));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, null));
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int>(null, i => { }, new BufferBlock<int>(), i => { }); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int>(new BufferBlock<int>(), i => { }, null, i => { }); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int>(new BufferBlock<int>(), null, new BufferBlock<int>(), i => { }); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), null); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, null); });
 
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int, int>(null, i => { }, new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, null, i => { }, new BufferBlock<int>(), i => { }));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, null, i => { }));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), null, new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), null, new BufferBlock<int>(), i => { }));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, new BufferBlock<int>(), null));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, null));
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int, int>(null, i => { }, new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, null, i => { }, new BufferBlock<int>(), i => { }); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, null, i => { }); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), null, new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), null, new BufferBlock<int>(), i => { }); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, new BufferBlock<int>(), null); });
+            Assert.Throws<ArgumentNullException>(
+                () => { DataflowBlock.Choose<int, int, int>(new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, new BufferBlock<int>(), i => { }, null); });
         }
 
         [Fact]
@@ -1843,8 +1843,8 @@ namespace System.Threading.Tasks.Dataflow.Tests
         [Fact]
         public void TestOutputAvailableAsync_ArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => DataflowBlock.OutputAvailableAsync<int>(null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => DataflowBlock.OutputAvailableAsync<int>(null, CancellationToken.None));
+            Assert.Throws<ArgumentNullException>(() => { DataflowBlock.OutputAvailableAsync<int>(null); });
+            Assert.Throws<ArgumentNullException>(() => { DataflowBlock.OutputAvailableAsync<int>(null, CancellationToken.None); });
         }
 
         [Fact]

--- a/src/System.Threading.Tasks/tests/Task/TaskContinueWhenAnyTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskContinueWhenAnyTests.cs
@@ -3,12 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
 
-namespace Test
+namespace System.Threading.Tasks.Tests
 {
     public class TaskContinueWhenAnyTests
     {
@@ -240,21 +237,21 @@ namespace Test
             {
                 if (antecedentsAreFutures)
                 {
-                    Assert.ThrowsAsync<ArgumentNullException>(
-                       () => Task<int>.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => 0, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null));
+                    Assert.Throws<ArgumentNullException>(
+                       () => { Task<int>.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => 0, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null); });
 
-                    Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                       () => Task<int>.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => 0, TaskContinuationOptions.NotOnFaulted));
+                    Assert.Throws<ArgumentOutOfRangeException>(
+                       () => { Task<int>.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => 0, TaskContinuationOptions.NotOnFaulted); });
 
-                    Assert.ThrowsAsync<ArgumentNullException>(
-                       () => Task<int>.Factory.ContinueWhenAny<int>(null, t => 0));
+                    Assert.Throws<ArgumentNullException>(
+                       () => { Task<int>.Factory.ContinueWhenAny<int>(null, t => 0); });
 
                     var cFuture = Task.Factory.ContinueWhenAny<int, int>((Task<int>[])antecedents, t => 0, ct);
                     CheckForCorrectCT(cFuture, ct);
                     antecedents[0] = null;
 
-                    Assert.ThrowsAsync<ArgumentException>(
-                       () => Task<int>.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => 0));
+                    Assert.Throws<ArgumentException>(
+                       () => { Task<int>.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => 0); });
 
 
                     AssertExtensions.Throws<ArgumentException>("tasks", () => Task<int>.Factory.ContinueWhenAny(new Task<int>[0], t => 0));
@@ -277,26 +274,26 @@ namespace Test
                 else //antecedents are tasks
                 {
                     var dummy = Task.Factory.StartNew(delegate { });
-                    Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                       () => Task<int>.Factory.ContinueWhenAny(new Task[] { dummy }, t => 0, TaskContinuationOptions.LongRunning | TaskContinuationOptions.ExecuteSynchronously));
+                    Assert.Throws<ArgumentOutOfRangeException>(
+                       () => { Task<int>.Factory.ContinueWhenAny(new Task[] { dummy }, t => 0, TaskContinuationOptions.LongRunning | TaskContinuationOptions.ExecuteSynchronously); });
                     dummy.Wait();
 
 
-                    Assert.ThrowsAsync<ArgumentNullException>(
-                       () => Task<int>.Factory.ContinueWhenAny(antecedents, t => 0, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null));
+                    Assert.Throws<ArgumentNullException>(
+                       () => { Task<int>.Factory.ContinueWhenAny(antecedents, t => 0, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null); });
 
-                    Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                       () => Task<int>.Factory.ContinueWhenAny(antecedents, t => 0, TaskContinuationOptions.NotOnFaulted));
+                    Assert.Throws<ArgumentOutOfRangeException>(
+                       () => { Task<int>.Factory.ContinueWhenAny(antecedents, t => 0, TaskContinuationOptions.NotOnFaulted); });
 
-                    Assert.ThrowsAsync<ArgumentNullException>(
-                       () => Task<int>.Factory.ContinueWhenAny(null, t => 0));
+                    Assert.Throws<ArgumentNullException>(
+                       () => { Task<int>.Factory.ContinueWhenAny(null, t => 0); });
 
                     var cTask = Task.Factory.ContinueWhenAny(antecedents, t => 0, ct);
                     CheckForCorrectCT(cTask, ct);
                     antecedents[0] = null;
 
-                    Assert.ThrowsAsync<ArgumentException>(
-                       () => Task<int>.Factory.ContinueWhenAny(antecedents, (t) => 0));
+                    Assert.Throws<ArgumentException>(
+                       () => { Task<int>.Factory.ContinueWhenAny(antecedents, (t) => 0); });
 
 
                     AssertExtensions.Throws<ArgumentException>("tasks", () => Task<int>.Factory.ContinueWhenAny(new Task[0], t => 0));
@@ -324,22 +321,22 @@ namespace Test
                 {
                     if (antecedentsAreFutures)
                     {
-                        Assert.ThrowsAsync<ArgumentNullException>(
-                           () => Task.Factory.ContinueWhenAny<int, int>((Task<int>[])antecedents, t => 0, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null));
+                        Assert.Throws<ArgumentNullException>(
+                           () => { Task.Factory.ContinueWhenAny<int, int>((Task<int>[])antecedents, t => 0, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null); });
 
-                        Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                           () => Task.Factory.ContinueWhenAny<int, int>((Task<int>[])antecedents, t => 0, TaskContinuationOptions.NotOnFaulted));
+                        Assert.Throws<ArgumentOutOfRangeException>(
+                           () => { Task.Factory.ContinueWhenAny<int, int>((Task<int>[])antecedents, t => 0, TaskContinuationOptions.NotOnFaulted); });
 
-                        Assert.ThrowsAsync<ArgumentNullException>(
-                           () => Task.Factory.ContinueWhenAny<int, int>(null, t => 0));
+                        Assert.Throws<ArgumentNullException>(
+                           () => { Task.Factory.ContinueWhenAny<int, int>(null, t => 0); });
 
                         var cTask = Task.Factory.ContinueWhenAny<int, int>((Task<int>[])antecedents, t => 0, ct);
                         CheckForCorrectCT(cTask, ct);
                         antecedents[0] = null;
 
 
-                        Assert.ThrowsAsync<ArgumentException>(
-                           () => Task.Factory.ContinueWhenAny<int, int>((Task<int>[])antecedents, t => 0));
+                        Assert.Throws<ArgumentException>(
+                           () => { Task.Factory.ContinueWhenAny<int, int>((Task<int>[])antecedents, t => 0); });
 
                         AssertExtensions.Throws<ArgumentException>("tasks", () => Task.Factory.ContinueWhenAny(new Task<int>[0], t => 0));
 
@@ -361,21 +358,21 @@ namespace Test
 
                     else // antecedents are tasks
                     {
-                        Assert.ThrowsAsync<ArgumentNullException>(
-                           () => Task.Factory.ContinueWhenAny<int>(antecedents, t => 0, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null));
+                        Assert.Throws<ArgumentNullException>(
+                           () => { Task.Factory.ContinueWhenAny<int>(antecedents, t => 0, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null); });
 
-                        Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                           () => Task.Factory.ContinueWhenAny<int>(antecedents, t => 0, TaskContinuationOptions.NotOnFaulted));
+                        Assert.Throws<ArgumentOutOfRangeException>(
+                           () => { Task.Factory.ContinueWhenAny<int>(antecedents, t => 0, TaskContinuationOptions.NotOnFaulted); });
 
-                        Assert.ThrowsAsync<ArgumentNullException>(
-                           () => Task.Factory.ContinueWhenAny<int>(null, t => 0));
+                        Assert.Throws<ArgumentNullException>(
+                           () => { Task.Factory.ContinueWhenAny<int>(null, t => 0); });
 
                         var cTask = Task.Factory.ContinueWhenAny(antecedents, delegate (Task t) { }, ct);
                         CheckForCorrectCT(cTask, ct);
                         antecedents[0] = null;
 
-                        Assert.ThrowsAsync<ArgumentException>(
-                           () => Task.Factory.ContinueWhenAny<int>(antecedents, t => 0));
+                        Assert.Throws<ArgumentException>(
+                           () => { Task.Factory.ContinueWhenAny<int>(antecedents, t => 0); });
 
 
                         AssertExtensions.Throws<ArgumentException>("tasks", () => Task.Factory.ContinueWhenAny(new Task[0], t => 0));
@@ -401,22 +398,22 @@ namespace Test
                 {
                     if (antecedentsAreFutures)
                     {
-                        Assert.ThrowsAsync<ArgumentNullException>(
-                           () => Task.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => { }, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null));
+                        Assert.Throws<ArgumentNullException>(
+                           () => { Task.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => { }, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null); });
 
-                        Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                           () => Task.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => { }, TaskContinuationOptions.NotOnFaulted));
+                        Assert.Throws<ArgumentOutOfRangeException>(
+                           () => { Task.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => { }, TaskContinuationOptions.NotOnFaulted); });
 
-                        Assert.ThrowsAsync<ArgumentNullException>(
-                           () => Task.Factory.ContinueWhenAny<int>(null, t => { }));
+                        Assert.Throws<ArgumentNullException>(
+                           () => { Task.Factory.ContinueWhenAny<int>(null, t => { }); });
 
                         var cTask = Task.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => { }, ct);
                         CheckForCorrectCT(cTask, ct);
                         antecedents[0] = null;
 
 
-                        Assert.ThrowsAsync<ArgumentException>(
-                            () => Task.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => { }));
+                        Assert.Throws<ArgumentException>(
+                            () => { Task.Factory.ContinueWhenAny<int>((Task<int>[])antecedents, t => { }); });
 
                         AssertExtensions.Throws<ArgumentException>("tasks", () => Task.Factory.ContinueWhenAny(new Task<int>[] { }, t => { }));
 
@@ -437,22 +434,22 @@ namespace Test
                     }
                     else // antecedents are tasks
                     {
-                        Assert.ThrowsAsync<ArgumentNullException>(
-                           () => Task.Factory.ContinueWhenAny(antecedents, t => { }, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null));
+                        Assert.Throws<ArgumentNullException>(
+                           () => { Task.Factory.ContinueWhenAny(antecedents, t => { }, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null); });
 
-                        Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                           () => Task.Factory.ContinueWhenAny(antecedents, t => { }, TaskContinuationOptions.NotOnFaulted));
+                        Assert.Throws<ArgumentOutOfRangeException>(
+                           () => { Task.Factory.ContinueWhenAny(antecedents, t => { }, TaskContinuationOptions.NotOnFaulted); });
 
-                        Assert.ThrowsAsync<ArgumentNullException>(
-                           () => Task.Factory.ContinueWhenAny(null, t => { }));
+                        Assert.Throws<ArgumentNullException>(
+                           () => { Task.Factory.ContinueWhenAny(null, t => { }); });
 
                         var task = Task.Factory.ContinueWhenAny(antecedents, t => { }, ct);
                         CheckForCorrectCT(task, ct);
                         antecedents[0] = null;
 
 
-                        Assert.ThrowsAsync<ArgumentException>(
-                           () => Task.Factory.ContinueWhenAny(antecedents, t => { }));
+                        Assert.Throws<ArgumentException>(
+                           () => { Task.Factory.ContinueWhenAny(antecedents, t => { }); });
 
                         AssertExtensions.Throws<ArgumentException>("tasks",() => Task.Factory.ContinueWhenAny(new Task[0], t => { }));
 

--- a/src/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionTests.cs
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
 
-namespace Test
+namespace System.Threading.Tasks.Tests
 {
     public class TaskContinueWith_ContFuncAndActionTests
     {

--- a/src/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionWithArgsTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionWithArgsTests.cs
@@ -3,12 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
 
-namespace Test
+namespace System.Threading.Tasks.Tests
 {
     public class TaskContinueWith_ContFuncAndActionWithArgsTests
     {

--- a/src/System.Threading.Tasks/tests/Task/TaskRtTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskRtTests.cs
@@ -3,12 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using System;
 using System.Collections.Generic;
 using System.Text;
-// TPL namespaces
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -888,23 +884,23 @@ namespace System.Threading.Tasks.Tests
         public static void RunBasicFutureTest_Negative()
         {
             Task<int> future = new Task<int>(() => 1);
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => future.ContinueWith((Action<Task<int>, Object>)null, null, CancellationToken.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-              () => future.ContinueWith((Action<Task<int>, Object>)null, null, TaskContinuationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-              () => future.ContinueWith((Action<Task<int>, Object>)null, null, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default));
-            Assert.ThrowsAsync<ArgumentNullException>(
-              () => future.ContinueWith((t, s) => { }, null, CancellationToken.None, TaskContinuationOptions.None, null));
+            Assert.Throws<ArgumentNullException>(
+               () => { future.ContinueWith((Action<Task<int>, Object>)null, null, CancellationToken.None); });
+            Assert.Throws<ArgumentNullException>(
+              () => { future.ContinueWith((Action<Task<int>, Object>)null, null, TaskContinuationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+              () => { future.ContinueWith((Action<Task<int>, Object>)null, null, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default); });
+            Assert.Throws<ArgumentNullException>(
+              () => { future.ContinueWith((t, s) => { }, null, CancellationToken.None, TaskContinuationOptions.None, null); });
 
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => future.ContinueWith<int>((Func<Task<int>, Object, int>)null, null, CancellationToken.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-              () => future.ContinueWith<int>((Func<Task<int>, Object, int>)null, null, TaskContinuationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-              () => future.ContinueWith<int>((Func<Task<int>, Object, int>)null, null, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default));
-            Assert.ThrowsAsync<ArgumentNullException>(
-              () => future.ContinueWith<int>((t, s) => 2, null, CancellationToken.None, TaskContinuationOptions.None, null));
+            Assert.Throws<ArgumentNullException>(
+               () => { future.ContinueWith<int>((Func<Task<int>, Object, int>)null, null, CancellationToken.None); });
+            Assert.Throws<ArgumentNullException>(
+              () => { future.ContinueWith<int>((Func<Task<int>, Object, int>)null, null, TaskContinuationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+              () => { future.ContinueWith<int>((Func<Task<int>, Object, int>)null, null, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default); });
+            Assert.Throws<ArgumentNullException>(
+              () => { future.ContinueWith<int>((t, s) => 2, null, CancellationToken.None, TaskContinuationOptions.None, null); });
         }
 
         #region Helper Methods / Classes

--- a/src/System.Threading.Tasks/tests/TaskFactory/TaskFactoryTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskFactory/TaskFactoryTests.cs
@@ -3,11 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.Threading.Tasks.Tests
 {
@@ -108,19 +105,19 @@ namespace System.Threading.Tasks.Tests
             Assert.Throws<ArgumentOutOfRangeException>(
                () => tf = new TaskFactory(TaskCreationOptions.None, TaskContinuationOptions.NotOnFaulted));
 
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync(null, (obj) => { }, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync(null, (obj) => { }, TaskCreationOptions.None); });
 
             // testing exceptions in null endMethods
 
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync(new myAsyncResult((obj) => { }, null), null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync(new myAsyncResult((obj) => { }, null), null, TaskCreationOptions.None); });
 
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<int>(new myAsyncResult((obj) => { }, null), null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<int>(new myAsyncResult((obj) => { }, null), null, TaskCreationOptions.None); });
 
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<int>(new myAsyncResult((obj) => { }, null), null, TaskCreationOptions.None, null));
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<int>(new myAsyncResult((obj) => { }, null), null, TaskCreationOptions.None, null); });
 
             TaskFactory<int> tfi = new TaskFactory<int>();
 
@@ -147,42 +144,42 @@ namespace System.Threading.Tasks.Tests
 
             tf = new TaskFactory(TaskCreationOptions.LongRunning, TaskContinuationOptions.None);
 
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-               () => tf.FromAsync(fac.StartWrite, fac.EndWrite, null /* state */));
+            Assert.Throws<ArgumentOutOfRangeException>(
+               () => { tf.FromAsync(fac.StartWrite, fac.EndWrite, null /* state */); });
 
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-               () => tf.FromAsync(fac.StartWrite, fac.EndWrite, "abc", null /* state */));
+            Assert.Throws<ArgumentOutOfRangeException>(
+               () => { tf.FromAsync(fac.StartWrite, fac.EndWrite, "abc", null /* state */); });
 
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-               () => tf.FromAsync(fac.StartWrite, fac.EndWrite, "abc", 2, null /* state */));
+            Assert.Throws<ArgumentOutOfRangeException>(
+               () => { tf.FromAsync(fac.StartWrite, fac.EndWrite, "abc", 2, null /* state */); });
 
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-               () => tf.FromAsync(fac.StartWrite, fac.EndWrite, "abc", 0, 2, null /* state */));
+            Assert.Throws<ArgumentOutOfRangeException>(
+               () => { tf.FromAsync(fac.StartWrite, fac.EndWrite, "abc", 0, 2, null /* state */); });
 
             // testing exceptions in null endMethods or begin method
             //0 parameter
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<string>(fac.StartWrite, null, (Object)null, TaskCreationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<string>(null, fac.EndRead, (Object)null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<string>(fac.StartWrite, null, (Object)null, TaskCreationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<string>(null, fac.EndRead, (Object)null, TaskCreationOptions.None); });
 
             //1 parameter
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<string, int>(fac.StartWrite, null, "arg1", (Object)null, TaskCreationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<string, string>(null, fac.EndRead, "arg1", (Object)null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<string, int>(fac.StartWrite, null, "arg1", (Object)null, TaskCreationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<string, string>(null, fac.EndRead, "arg1", (Object)null, TaskCreationOptions.None); });
 
             //2 parameters
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<string, int, int>(fac.StartWrite, null, "arg1", 1, (Object)null, TaskCreationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<string, string, string>(null, fac.EndRead, "arg1", "arg2", (Object)null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<string, int, int>(fac.StartWrite, null, "arg1", 1, (Object)null, TaskCreationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<string, string, string>(null, fac.EndRead, "arg1", "arg2", (Object)null, TaskCreationOptions.None); });
 
             //3 parameters
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<string, int, int, int>(fac.StartWrite, null, "arg1", 1, 2, (Object)null, TaskCreationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tf.FromAsync<string, string, string, string>(null, fac.EndRead, "arg1", "arg2", "arg3", (Object)null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<string, int, int, int>(fac.StartWrite, null, "arg1", 1, 2, (Object)null, TaskCreationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+               () => { tf.FromAsync<string, string, string, string>(null, fac.EndRead, "arg1", "arg2", "arg3", (Object)null, TaskCreationOptions.None); });
 
             // Checking TF<string> special FromAsync exception handling.
             TaskFactory<string> tfs = new TaskFactory<string>(TaskCreationOptions.LongRunning, TaskContinuationOptions.None);
@@ -208,33 +205,33 @@ namespace System.Threading.Tasks.Tests
             Assert.Throws<ArgumentNullException>(
                () => { tfs.FromAsync(fac.StartRead, null, 64, charbuf, 0, null); });
 
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync(null, (obj) => "", TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync(null, (obj) => "", TaskCreationOptions.None); });
 
             //test null begin or end methods with various overloads
             //0 parameter
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync(fac.StartWrite, null, null, TaskCreationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync(null, fac.EndRead, null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync(fac.StartWrite, null, null, TaskCreationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync(null, fac.EndRead, null, TaskCreationOptions.None); });
 
             //1 parameter
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync<string>(fac.StartWrite, null, "arg1", null, TaskCreationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync<string>(null, fac.EndRead, "arg1", null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync<string>(fac.StartWrite, null, "arg1", null, TaskCreationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync<string>(null, fac.EndRead, "arg1", null, TaskCreationOptions.None); });
 
             //2 parameters
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync<string, int>(fac.StartWrite, null, "arg1", 2, null, TaskCreationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync<string, int>(null, fac.EndRead, "arg1", 2, null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync<string, int>(fac.StartWrite, null, "arg1", 2, null, TaskCreationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync<string, int>(null, fac.EndRead, "arg1", 2, null, TaskCreationOptions.None); });
 
             //3 parameters
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync<string, int, int>(fac.StartWrite, null, "arg1", 2, 3, null, TaskCreationOptions.None));
-            Assert.ThrowsAsync<ArgumentNullException>(
-               () => tfs.FromAsync<string, int, int>(null, fac.EndRead, "arg1", 2, 3, null, TaskCreationOptions.None));
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync<string, int, int>(fac.StartWrite, null, "arg1", 2, 3, null, TaskCreationOptions.None); });
+            Assert.Throws<ArgumentNullException>(
+               () => { tfs.FromAsync<string, int, int>(null, fac.EndRead, "arg1", 2, 3, null, TaskCreationOptions.None); });
         }
 
         #endregion

--- a/src/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
@@ -3,11 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
 
 namespace System.Threading.Tasks.Tests
@@ -239,12 +236,14 @@ namespace System.Threading.Tasks.Tests
             Assert.Equal("4567", s);
 
             // Test Exception handling from beginMethod
-            Assert.ThrowsAsync<NullReferenceException>(() =>
-               t = Task.Factory.FromAsync(
-                   fac.StartWrite,
-                   fac.EndWrite,
-                   (string)null,  // will cause null.Length to be dereferenced
-                   null));
+            Assert.Throws<NullReferenceException>(() =>
+            {
+                t = Task.Factory.FromAsync(
+                    fac.StartWrite,
+                    fac.EndWrite,
+                    (string)null,  // will cause null.Length to be dereferenced
+                    null);
+            });
 
 
             // Test Exception handling from asynchronous logic
@@ -259,11 +258,11 @@ namespace System.Threading.Tasks.Tests
             Assert.Throws<AggregateException>(() =>
                check = f.Result);
 
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-               Task.Factory.FromAsync(fac.StartWrite, fac.EndWrite, null, TaskCreationOptions.LongRunning));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                { Task.Factory.FromAsync(fac.StartWrite, fac.EndWrite, null, TaskCreationOptions.LongRunning); });
 
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-              Task.Factory.FromAsync(fac.StartWrite, fac.EndWrite, null, TaskCreationOptions.PreferFairness));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                { Task.Factory.FromAsync(fac.StartWrite, fac.EndWrite, null, TaskCreationOptions.PreferFairness); });
 
             // Empty the buffer, then inject a few more characters into the buffer
             fac.ResetStateTo("0123456789");


### PR DESCRIPTION
A bunch of asserts in the System.Threading.Tasks tests were nops because they were using Assert.ThrowsAsync and then not awaiting the result.  But they actually should never have been ThrowsAsync in the first place, as they were all validating that exceptions propagated out of the delegate synchronously.  So, I just changed them all to be Assert.Throws instead of Assert.ThrowsAsync.

I searched the rest of the repo as well and fixed up other such cases, in System.Threading.Tasks.Dataflow.Tests, in System.Data.SqlClient.Tests, and in System.Net.Security.Tests.

Addresses https://github.com/dotnet/corefx/pull/2775#discussion_r192925496
cc: @jnm2, @tarekgh 