### PR TITLE
Import dir.targets in publish.proj in 1.1.0

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Packaging.props))\Packaging.props" />
+  <Import Project="..\dir.targets" />
   <Import Project="$(ToolsDir)PublishContent.targets" />
   <Import Project="$(ToolsDir)versioning.targets" />
 


### PR DESCRIPTION
This will ensure we import Build.Common.Targets from BuildTools, which is necessary for getting the `SignFiles` target.

CC @weshaggard 