### PR TITLE
Disable CustomMethod_SentUppercasedIfKnown on UAP

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -609,6 +609,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [ActiveIssue(29802, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData("get", "GET")]
         [InlineData("head", "HEAD")]


### PR DESCRIPTION
It's not uppercasing any of them.

Closes https://github.com/dotnet/corefx/issues/30164