### PR TITLE
Increase code coverage of String

### DIFF
--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -106,6 +106,7 @@ namespace System.Tests
             });
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("ptr", () => new string((char*)null, 0, 1)); // null ptr with non-zero length
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => new string(UIntPtr.Size == 4 ? (char*)uint.MaxValue : (char*)ulong.MaxValue, 42, 0)); // overflowing ptr + startIndex
         }
 
         [Theory]
@@ -476,7 +477,9 @@ namespace System.Tests
 
         [Theory]
         // CurrentCulture
+        [InlineData("", 0, "", 0, 0, StringComparison.CurrentCulture, 0)]
         [InlineData("Hello", 0, "Hello", 0, 5, StringComparison.CurrentCulture, 0)]
+        [InlineData("Hello", 2, "Hello", 3, 1, StringComparison.CurrentCulture, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, StringComparison.CurrentCulture, 1)]
         [InlineData("Goodbye", 0, "Hello", 0, 5, StringComparison.CurrentCulture, -1)]
         [InlineData("HELLO", 2, "hello", 2, 3, StringComparison.CurrentCulture, 1)]
@@ -492,7 +495,9 @@ namespace System.Tests
         [InlineData("foo", -1, null, -1, -1, StringComparison.CurrentCulture, 1)]
         [InlineData(null, -1, "foo", -1, -1, StringComparison.CurrentCulture, -1)]
         // CurrentCultureIgnoreCase
+        [InlineData("", 0, "", 0, 0, StringComparison.CurrentCultureIgnoreCase, 0)]
         [InlineData("HELLO", 0, "hello", 0, 5, StringComparison.CurrentCultureIgnoreCase, 0)]
+        [InlineData("Hello", 2, "Hello", 3, 1, StringComparison.CurrentCultureIgnoreCase, 0)]
         [InlineData("Hello", 0, "Hello", 0, 5, StringComparison.CurrentCultureIgnoreCase, 0)]
         [InlineData("Hello", 2, "Hello", 2, 3, StringComparison.CurrentCultureIgnoreCase, 0)]
         [InlineData("Hello", 2, "Yellow", 2, 3, StringComparison.CurrentCultureIgnoreCase, 0)]
@@ -507,7 +512,9 @@ namespace System.Tests
         [InlineData("foo", -1, null, -1, -1, StringComparison.CurrentCultureIgnoreCase, 1)]
         [InlineData(null, -1, "foo", -1, -1, StringComparison.CurrentCultureIgnoreCase, -1)]
         // InvariantCulture
+        [InlineData("", 0, "", 0, 0, StringComparison.InvariantCulture, 0)]
         [InlineData("Hello", 0, "Hello", 0, 5, StringComparison.InvariantCulture, 0)]
+        [InlineData("Hello", 2, "Hello", 3, 1, StringComparison.InvariantCulture, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, StringComparison.InvariantCulture, 1)]
         [InlineData("Goodbye", 0, "Hello", 0, 5, StringComparison.InvariantCulture, -1)]
         [InlineData("HELLO", 2, "hello", 2, 3, StringComparison.InvariantCulture, 1)]
@@ -516,8 +523,10 @@ namespace System.Tests
         [InlineData("Hello", 0, null, 0, 5, StringComparison.InvariantCulture, 1)]
         [InlineData(null, 0, "Hello", 0, 5, StringComparison.InvariantCulture, -1)]
         // InvariantCultureIgnoreCase
+        [InlineData("", 0, "", 0, 0, StringComparison.InvariantCultureIgnoreCase, 0)]
         [InlineData("HELLO", 0, "hello", 0, 5, StringComparison.InvariantCultureIgnoreCase, 0)]
         [InlineData("Hello", 0, "Hello", 0, 5, StringComparison.InvariantCultureIgnoreCase, 0)]
+        [InlineData("Hello", 2, "Hello", 3, 1, StringComparison.InvariantCultureIgnoreCase, 0)]
         [InlineData("Hello", 2, "Hello", 2, 3, StringComparison.InvariantCultureIgnoreCase, 0)]
         [InlineData("Hello", 2, "Yellow", 2, 3, StringComparison.InvariantCultureIgnoreCase, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, StringComparison.InvariantCultureIgnoreCase, 1)]
@@ -528,7 +537,9 @@ namespace System.Tests
         [InlineData("Hello", 0, null, 0, 5, StringComparison.InvariantCultureIgnoreCase, 1)]
         [InlineData(null, 0, "Hello", 0, 5, StringComparison.InvariantCultureIgnoreCase, -1)]
         // Ordinal
+        [InlineData("", 0, "", 0, 0, StringComparison.Ordinal, 0)]
         [InlineData("Hello", 0, "Hello", 0, 5, StringComparison.Ordinal, 0)]
+        [InlineData("Hello", 2, "Hello", 3, 1, StringComparison.Ordinal, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, StringComparison.Ordinal, 1)]
         [InlineData("Goodbye", 0, "Hello", 0, 5, StringComparison.Ordinal, -1)]
         [InlineData("Hello", 2, "Hello", 2, 3, StringComparison.Ordinal, 0)]
@@ -577,8 +588,10 @@ namespace System.Tests
         [InlineData("foo", -1, null, -1, -1, StringComparison.Ordinal, 1)]
         [InlineData(null, -1, "foo", -1, -1, StringComparison.Ordinal, -1)]
         // OrdinalIgnoreCase
+        [InlineData("", 0, "", 0, 0, StringComparison.OrdinalIgnoreCase, 0)]
         [InlineData("HELLO", 0, "hello", 0, 5, StringComparison.OrdinalIgnoreCase, 0)]
         [InlineData("Hello", 0, "Hello", 0, 5, StringComparison.OrdinalIgnoreCase, 0)]
+        [InlineData("Hello", 2, "Hello", 3, 1, StringComparison.OrdinalIgnoreCase, 0)]
         [InlineData("Hello", 2, "Hello", 2, 3, StringComparison.OrdinalIgnoreCase, 0)]
         [InlineData("Hello", 2, "Yellow", 2, 3, StringComparison.OrdinalIgnoreCase, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, StringComparison.OrdinalIgnoreCase, 1)]
@@ -1419,15 +1432,46 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void EndsWith_StringBoolCultureInfo_Valid()
+        {
+            // Same string
+            string s = "foo";
+            Assert.True(s.EndsWith(s, false, null));
+            Assert.True(s.EndsWith(s, true, null));
+            Assert.True(s.EndsWith(s, false, CultureInfo.InvariantCulture));
+            Assert.True(s.EndsWith(s, true, CultureInfo.InvariantCulture));
+
+            // Different object, same string, no culture
+            Assert.True(s.EndsWith(String.Copy(s), false, null));
+            Assert.True(s.EndsWith(String.Copy(s), true, null));
+
+            // Different object, same string, invariant culture
+            Assert.True(s.EndsWith(String.Copy(s), false, CultureInfo.InvariantCulture));
+            Assert.True(s.EndsWith(String.Copy(s), true, CultureInfo.InvariantCulture));
+
+            // Different object, same string, current culture
+            Assert.True(s.EndsWith(String.Copy(s), false, CultureInfo.InvariantCulture));
+            Assert.True(s.EndsWith(String.Copy(s), true, CultureInfo.InvariantCulture));
+        }
+
+        [Fact]
         public static void EndsWith_Invalid()
         {
             // Value is null
             AssertExtensions.Throws<ArgumentNullException>("value", () => "foo".EndsWith(null));
             AssertExtensions.Throws<ArgumentNullException>("value", () => "foo".EndsWith(null, StringComparison.CurrentCulture));
 
-            // Invalid comparison type
+            // Invalid comparison type with empty string
             AssertExtensions.Throws<ArgumentException>("comparisonType", () => "foo".EndsWith("", StringComparison.CurrentCulture - 1));
             AssertExtensions.Throws<ArgumentException>("comparisonType", () => "foo".EndsWith("", StringComparison.OrdinalIgnoreCase + 1));
+
+            // Invalid comparison type with same string
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => "foo".EndsWith("foo", StringComparison.CurrentCulture - 1));
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => "foo".EndsWith("foo", StringComparison.OrdinalIgnoreCase + 1));
+
+            // Invalid comparison type with non-empty different string
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => "foo".EndsWith("a", StringComparison.CurrentCulture - 1));
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => "foo".EndsWith("a", StringComparison.OrdinalIgnoreCase + 1));
         }
 
         [Fact]
@@ -2225,8 +2269,12 @@ namespace System.Tests
         [InlineData(StringComparison.OrdinalIgnoreCase + 1)]
         public static void Equals_InvalidComparisonType_ThrowsArgumentOutOfRangeException(StringComparison comparisonType)
         {
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => string.Equals("a", "a", comparisonType));
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => string.Equals("a", null, comparisonType));
             AssertExtensions.Throws<ArgumentException>("comparisonType", () => string.Equals("a", "b", comparisonType));
             AssertExtensions.Throws<ArgumentException>("comparisonType", () => "a".Equals("a", comparisonType));
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => "a".Equals(null, comparisonType));
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => "a".Equals("b", comparisonType));
         }
 
         [Fact]
@@ -2829,6 +2877,9 @@ namespace System.Tests
         }
 
         [Theory]
+        [InlineData("Hello", new char[] { 'd' }, 0, 5, -1)]
+        [InlineData("Hello", new char[] { 'o' }, 0, 5, 4)]
+        [InlineData("Hello", new char[] { 'e', 'l', 'o' }, 0, 5, 1)]
         [InlineData("Hello", new char[] { 'd', 'o', 'l' }, 0, 5, 2)]
         [InlineData("Hello", new char[] { 'd', 'e', 'H' }, 0, 0, -1)]
         [InlineData("Hello", new char[] { 'd', 'e', 'f' }, 1, 3, 1)]
@@ -2837,6 +2888,7 @@ namespace System.Tests
         [InlineData("H" + SoftHyphen + "ello", new char[] { 'a', '\u00AD', 'c' }, 0, 2, 1)]
         [InlineData("", new char[] { 'd', 'e', 'f' }, 0, 0, -1)]
         [InlineData("Hello", new char[] { 'o', 'l' }, 0, 5, 2)]
+        [InlineData("Hello", new char[] { 'e', 'o' }, 0, 5, 1)]
         [InlineData("Hello", new char[] { 'e', 'H' }, 0, 0, -1)]
         [InlineData("Hello", new char[] { 'd', 'e' }, 1, 3, 1)]
         [InlineData("Hello", new char[] { 'a', 'b' }, 2, 3, -1)]
@@ -2845,6 +2897,10 @@ namespace System.Tests
         [InlineData("xHello", new char[] { '\0', 'b' }, 0, 6, -1)]   // Null terminator check, even
         [InlineData("Hello", new char[] { '\0', 'o' }, 0, 5, 4)]     // Match last char, odd
         [InlineData("xHello", new char[] { '\0', 'o' }, 0, 6, 5)]    // Match last char, even
+        [InlineData("\x4E16\x754C\x60A8\x597D", new char[] { '\x754C' }, 0, 4, 1)]
+        [InlineData("\x4E16\x754C\x60A8\x597D", new char[] { '\x754C', '\x60A8' }, 0, 4, 1)]
+        [InlineData("\x4E16\x754C\x60A8\x597D", new char[] { '\x754C', '\x60A8', '\x4E16' }, 0, 4, 0)]
+        [InlineData("\x4E16\x754C\x60A8\x597D", new char[] { '\x754C', '\x60A8', '\x4E16', '\x597D' }, 0, 4, 0)]
         public static void IndexOfAny(string s, char[] anyOf, int startIndex, int count, int expected)
         {
             if (startIndex + count == s.Length)
@@ -2855,7 +2911,11 @@ namespace System.Tests
                 }
                 Assert.Equal(expected, s.IndexOfAny(anyOf, startIndex));
             }
-            Assert.Equal(expected, s.IndexOfAny(anyOf, startIndex, count));
+
+            foreach (char[] permutedAnyOf in Permute(anyOf))
+            {
+                Assert.Equal(expected, s.IndexOfAny(permutedAnyOf, startIndex, count));
+            }
         }
 
         [Fact]
@@ -3368,6 +3428,8 @@ namespace System.Tests
             Assert.Equal(expected, s.LastIndexOf(value.ToString(), startIndex, count, StringComparison.CurrentCulture));
             Assert.Equal(expected, s.LastIndexOf(value.ToString(), startIndex, count, StringComparison.Ordinal));
             Assert.Equal(expected, s.LastIndexOf(value.ToString(), startIndex, count, StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(expected, s.LastIndexOf(value.ToString(), startIndex, count, StringComparison.InvariantCulture));
+            Assert.Equal(expected, s.LastIndexOf(value.ToString(), startIndex, count, StringComparison.InvariantCultureIgnoreCase));
         }
 
         [Fact]
@@ -3572,13 +3634,22 @@ namespace System.Tests
         }
 
         [Theory]
+        [InlineData("Hello", new char[] { 'd' }, 4, 5, -1)]
+        [InlineData("Hello", new char[] { 'l' }, 4, 5, 3)]
+        [InlineData("Hello", new char[] { 'e', 'l' }, 4, 5, 3)]
         [InlineData("Hello", new char[] { 'd', 'e', 'l' }, 4, 5, 3)]
         [InlineData("Hello", new char[] { 'd', 'e', 'l' }, 4, 0, -1)]
         [InlineData("Hello", new char[] { 'd', 'e', 'f' }, 2, 3, 1)]
         [InlineData("Hello", new char[] { 'a', 'b', 'c' }, 2, 3, -1)]
+        [InlineData("Hello", new char[] { 'a', 'b', 'c', 'd' }, 2, 3, -1)]
+        [InlineData("Hello", new char[] { 'a', 'b', 'c', 'e' }, 2, 3, 1)]
         [InlineData("Hello", new char[0], 2, 3, -1)]
         [InlineData("H" + SoftHyphen + "ello", new char[] { 'a', '\u00AD', 'c' }, 2, 3, 1)]
         [InlineData("", new char[] { 'd', 'e', 'f' }, -1, -1, -1)]
+        [InlineData("\x4E16\x754C\x60A8\x597D", new char[] { '\x754C' }, 3, 4, 1)]
+        [InlineData("\x4E16\x754C\x60A8\x597D", new char[] { '\x754C', '\x60A8' }, 3, 4, 2)]
+        [InlineData("\x4E16\x754C\x60A8\x597D", new char[] { '\x754C', '\x60A8', '\x4E16' }, 3, 4, 2)]
+        [InlineData("\x4E16\x754C\x60A8\x597D", new char[] { '\x754C', '\x60A8', '\x4E16', '\x597D' }, 3, 4, 3)]
         public static void LastIndexOfAny(string s, char[] anyOf, int startIndex, int count, int expected)
         {
             if (count == startIndex + 1)
@@ -3589,7 +3660,11 @@ namespace System.Tests
                 }
                 Assert.Equal(expected, s.LastIndexOfAny(anyOf, startIndex));
             }
-            Assert.Equal(expected, s.LastIndexOfAny(anyOf, startIndex, count));
+
+            foreach (char[] permutedAnyOf in Permute(anyOf))
+            {
+                Assert.Equal(expected, s.LastIndexOfAny(permutedAnyOf, startIndex, count));
+            }
         }
 
         [Fact]
@@ -3968,6 +4043,7 @@ namespace System.Tests
 
         [Theory]
         [InlineData("Hello", 'l', '!', "He!!o")]
+        [InlineData("Hello", 'e', 'e', "Hello")]
         [InlineData("Hello", 'a', 'b', "Hello")]
         public static void Replace_Char_Char(string s, char oldChar, char newChar, string expected)
         {
@@ -4290,6 +4366,8 @@ namespace System.Tests
         public static void ToString(string s)
         {
             Assert.Same(s, s.ToString());
+            Assert.Same(s, s.ToString(null));
+            Assert.Same(s, s.ToString(CultureInfo.CurrentCulture));
 
             Assert.Equal(s, s.AsSpan().ToString());
         }
@@ -4454,6 +4532,9 @@ namespace System.Tests
         [InlineData("  Hello  ", new char[0], "Hello")]
         [InlineData("      \t      ", null, "")]
         [InlineData("", null, "")]
+        [InlineData("      ", new char[] { ' ' }, "")]
+        [InlineData("aaaaa", new char[] { 'a' }, "")]
+        [InlineData("abaabaa", new char[] { 'b', 'a' }, "")]
         public static void Trim(string s, char[] trimChars, string expected)
         {
             if (trimChars == null || trimChars.Length == 0 || (trimChars.Length == 1 && trimChars[0] == ' '))
@@ -4481,6 +4562,9 @@ namespace System.Tests
         [InlineData("  Hello  ", new char[0], "  Hello")]
         [InlineData("      \t      ", null, "")]
         [InlineData("", null, "")]
+        [InlineData("      ", new char[] { ' ' }, "")]
+        [InlineData("aaaaa", new char[] { 'a' }, "")]
+        [InlineData("abaabaa", new char[] { 'b', 'a' }, "")]
         public static void TrimEnd(string s, char[] trimChars, string expected)
         {
             if (trimChars == null || trimChars.Length == 0 || (trimChars.Length == 1 && trimChars[0] == ' '))
@@ -4508,6 +4592,9 @@ namespace System.Tests
         [InlineData("  Hello  ", new char[0], "Hello  ")]
         [InlineData("      \t      ", null, "")]
         [InlineData("", null, "")]
+        [InlineData("      ", new char[] { ' ' }, "")]
+        [InlineData("aaaaa", new char[] { 'a' }, "")]
+        [InlineData("abaabaa", new char[] { 'b', 'a' }, "")]
         public static void TrimStart(string s, char[] trimChars, string expected)
         {
             if (trimChars == null || trimChars.Length == 0 || (trimChars.Length == 1 && trimChars[0] == ' '))
@@ -4607,14 +4694,17 @@ namespace System.Tests
 
         public static IEnumerable<object[]> StartEndWith_TestData()
         {
-            //                           str1                    Start      End   Culture  ignorecase   expected
-            yield return new object[] { "abcd",                  "AB",      "CD", "en-US",    false,       false  };
-            yield return new object[] { "ABcd",                  "ab",      "CD", "en-US",    false,       false  };
-            yield return new object[] { "abcd",                  "AB",      "CD", "en-US",    true,        true   };
-            yield return new object[] { "i latin i",             "I Latin", "I",  "tr-TR",    false,       false  };
-            yield return new object[] { "i latin i",             "I Latin", "I",  "tr-TR",    true,        false  };
-            yield return new object[] { "\u0130 turkish \u0130", "i",       "i",  "tr-TR",    true,        true   };
-            yield return new object[] { "\u0131 turkish \u0131", "I",       "I",  "tr-TR",    true,        true   };
+            //                           str1                    Start      End     Culture  ignorecase   expected
+            yield return new object[] { "abcd",                  "abcd",    "abcd", "en-US",    false,       true   };
+            yield return new object[] { "abcd",                  "abcd",    "abcd", "en-US",    true,        true   };
+            yield return new object[] { "abcd",                  "AB",      "CD",   "en-US",    false,       false  };
+            yield return new object[] { "abcd",                  "AB",      "CD",   null,       false,       false  };
+            yield return new object[] { "ABcd",                  "ab",      "CD",   "en-US",    false,       false  };
+            yield return new object[] { "abcd",                  "AB",      "CD",   "en-US",    true,        true   };
+            yield return new object[] { "i latin i",             "I Latin", "I",    "tr-TR",    false,       false  };
+            yield return new object[] { "i latin i",             "I Latin", "I",    "tr-TR",    true,        false  };
+            yield return new object[] { "\u0130 turkish \u0130", "i",       "i",    "tr-TR",    true,        true   };
+            yield return new object[] { "\u0131 turkish \u0131", "I",       "I",    "tr-TR",    true,        true   };
         }
 
         [Theory]
@@ -4697,7 +4787,7 @@ namespace System.Tests
         [MemberData(nameof(StartEndWith_TestData))]
         public static void StartEndWithTest(string source, string start, string end, string cultureName, bool ignoreCase, bool expected)
         {
-             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
+             CultureInfo ci = cultureName != null ? CultureInfo.GetCultureInfo(cultureName) : null;
              Assert.Equal(expected, source.StartsWith(start, ignoreCase, ci));
              Assert.Equal(expected, source.EndsWith(end, ignoreCase, ci));
         }
@@ -4710,11 +4800,10 @@ namespace System.Tests
         }
 
         [Fact]
-        public static unsafe void ConstructorsTest()
+        public static unsafe void Ctor_SByte()
         {
             string s = "This is a string constructor test";
             byte [] encodedBytes = Encoding.Default.GetBytes(s);
-
             fixed (byte *pBytes = encodedBytes)
             {
                 Assert.Equal(s, new String((sbyte*) pBytes));
@@ -4724,16 +4813,22 @@ namespace System.Tests
 
             s = "This is some string \u0393\u0627\u3400\u0440\u1100";
             encodedBytes = Encoding.UTF8.GetBytes(s);
-
             fixed (byte *pBytes = encodedBytes)
             {
                 Assert.Equal(s, new String((sbyte*) pBytes, 0, encodedBytes.Length, Encoding.UTF8));
+            }
+
+            fixed (byte *pBytes = new byte[1] { 0 })
+            {
+                Assert.Equal(string.Empty, new String((sbyte*) pBytes));
+                Assert.Equal(string.Empty, new String((sbyte*) pBytes, 0, 0));
+                Assert.Equal(string.Empty, new String((sbyte*) pBytes, 0, 0, Encoding.UTF8));
             }
         }
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // These tests assume that UTF8 is the default encoding
-        public static unsafe void ConstructorsTest_InvalidUTF8()
+        public static unsafe void Ctor_SByte_InvalidUTF8()
         {
             byte[] invalidUTF8Bytes = new byte[] { (byte)'A', (byte)'B', 0xEE, (byte)'C', (byte)'D', 0 };
 
@@ -4746,18 +4841,25 @@ namespace System.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static unsafe void ConstructorsTest_InvalidArguments ()
+        public static unsafe void Ctor_SByte_InvalidArguments()
         {
             AssertExtensions.Throws<ArgumentNullException>("value", () => new String ((sbyte*) null, 0, 1, Encoding.Default));
             AssertExtensions.Throws<ArgumentNullException>("value", () => new String ((sbyte*) null, 1, 1, Encoding.Default));
 
             AssertExtensions.Throws<ArgumentNullException>("value", () => new String ((sbyte*) null, 0, 1, null));
             AssertExtensions.Throws<ArgumentNullException>("value", () => new String ((sbyte*) null, 1, 1, null));
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => new String((sbyte*)null, -1, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => new String((sbyte*)null, -1, 0, Encoding.UTF8));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("length", () => new String((sbyte*)null, 0, -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("length", () => new String((sbyte*)null, 0, -1, Encoding.UTF8));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => new String(UIntPtr.Size == 4 ? (sbyte*)uint.MaxValue : (sbyte*)ulong.MaxValue, 42, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => new String(UIntPtr.Size == 4 ? (sbyte*)uint.MaxValue : (sbyte*)ulong.MaxValue, 42, 0, Encoding.UTF8));
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static unsafe void ConstructorsTest_Empty ()
+        public static unsafe void Ctor_SByte_NullPointer_ReturnsEmptyString()
         {
             Assert.Equal(string.Empty, new String((sbyte*) null));
 
@@ -4773,6 +4875,18 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void CreateStringFromEncoding_0Length_EmptyStringReturned() // basic test for code coverage; more tests in encodings tests
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("hello");
+            Assert.Same(string.Empty, new AsciiEncodingWithZeroReturningGetCharCount().GetString(bytes, 0, 0));
+        }
+
+        private sealed class AsciiEncodingWithZeroReturningGetCharCount : ASCIIEncoding
+        {
+            public override int GetCharCount(byte[] bytes, int index, int count) => 0;
+        }
+
+        [Fact]
         public static unsafe void CloneTest()
         {
             string s = "some string to clone";
@@ -4784,6 +4898,8 @@ namespace System.Tests
         [Fact]
         public static unsafe void CopyTest()
         {
+            AssertExtensions.Throws<ArgumentNullException>("str", () => String.Copy(null));
+
             string s = "some string to copy";
             string copy = String.Copy(s);
             Assert.Equal(s, copy);
@@ -4794,6 +4910,9 @@ namespace System.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, ".NetNative limits interning of literals to the empty string.")]
         public static unsafe void InternTest()
         {
+            AssertExtensions.Throws<ArgumentNullException>("str", () => String.Intern(null));
+            AssertExtensions.Throws<ArgumentNullException>("str", () => String.IsInterned(null));
+
             String s1 = "MyTest";
             String s2 = new StringBuilder().Append("My").Append("Test").ToString(); 
             String s3 = String.Intern(s2);
@@ -4823,7 +4942,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static unsafe void NormalizationTest()
+        public static unsafe void NormalizationTest() // basic test; more tests in globalization tests
         {
             // U+0063  LATIN SMALL LETTER C
             // U+0301  COMBINING ACUTE ACCENT
@@ -4853,6 +4972,18 @@ namespace System.Tests
 
             normalized = s.Normalize(NormalizationForm.FormKD);
             Assert.True(normalized.IsNormalized(NormalizationForm.FormKD), "Expected to have the normalized string with FormKD");
+
+            s = "hello";
+            Assert.True(s.IsNormalized());
+            Assert.True(s.IsNormalized(NormalizationForm.FormC));
+            Assert.True(s.IsNormalized(NormalizationForm.FormD));
+            Assert.True(s.IsNormalized(NormalizationForm.FormKC));
+            Assert.True(s.IsNormalized(NormalizationForm.FormKD));
+            Assert.Same(s, s.Normalize());
+            Assert.Same(s, s.Normalize(NormalizationForm.FormC));
+            Assert.Same(s, s.Normalize(NormalizationForm.FormD));
+            Assert.Same(s, s.Normalize(NormalizationForm.FormKC));
+            Assert.Same(s, s.Normalize(NormalizationForm.FormKD));
         }
 
         [Fact]
@@ -4878,6 +5009,52 @@ namespace System.Tests
             }
 
             Assert.False(chEnum.MoveNext(), "expect to not having any characters to enumerate");
+        }
+        
+        [Fact]
+        public static void IConvertible_ValuesRoundtripThroughString() // basic test; more coverage tests in Convert tests
+        {
+            CultureInfo c = CultureInfo.InvariantCulture;
+            DateTime dt = new DateTime(2018, 6, 5, 1, 2, 0, DateTimeKind.Utc);
+
+            Assert.True(((IConvertible)true.ToString(c)).ToBoolean(c));
+            Assert.Equal(42, ((IConvertible)((byte)42).ToString(c)).ToByte(c));
+            Assert.Equal(42, ((IConvertible)((char)42).ToString(c)).ToChar(c));
+            Assert.Equal(dt, ((IConvertible)dt.ToString(c)).ToDateTime(c));
+            Assert.Equal(42, ((IConvertible)(42m).ToString(c)).ToDecimal(c));
+            Assert.Equal(42, ((IConvertible)(42.0).ToString(c)).ToDouble(c));
+            Assert.Equal(42, ((IConvertible)((short)42).ToString(c)).ToInt16(c));
+            Assert.Equal(42, ((IConvertible)((int)42).ToString(c)).ToInt32(c));
+            Assert.Equal(42, ((IConvertible)((long)42).ToString(c)).ToInt64(c));
+            Assert.Equal(42, ((IConvertible)((sbyte)42).ToString(c)).ToSByte(c));
+            Assert.Equal(42, ((IConvertible)(42.0f).ToString(c)).ToSingle(c));
+            Assert.Equal("42", ((IConvertible)"42".ToString(c)).ToString(c));
+            Assert.Equal((ushort)42, ((IConvertible)((ushort)42).ToString(c)).ToUInt16(c));
+            Assert.Equal((uint)42, ((IConvertible)((uint)42).ToString(c)).ToUInt32(c));
+            Assert.Equal((ulong)42, ((IConvertible)((ulong)42).ToString(c)).ToUInt64(c));
+        }
+
+        private static IEnumerable<T[]> Permute<T>(T[] input)
+        {
+            if (input.Length <= 1)
+            {
+                yield return input;
+                yield break;
+            }
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                var remainder = new T[input.Length - 1];
+                Array.Copy(input, 0, remainder, 0, i);
+                Array.Copy(input, i + 1, remainder, i, input.Length - i - 1);
+                foreach (T[] output in Permute(remainder))
+                {
+                    var result = new T[input.Length];
+                    result[0] = input[i];
+                    Array.Copy(output, 0, result, 1, output.Length);
+                    yield return result;
+                }
+            }
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public class ConvertTests
+    public partial class ConvertTests
     {
         [Fact]
         public static void ChangeTypeTest()

--- a/src/System.Runtime.Extensions/tests/System/Convert.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public class IsDBNullTests
+    public class ConvertTests
     {
         [Fact]
         public static void ChangeTypeTest()

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="System\Runtime\NgenServicingAttributesTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\AttributesTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\ConditionalWeakTableTests.cs" />
+    <Compile Include="System\Runtime\CompilerServices\FormattableStringFactoryTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\StrongBoxTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpersTests.cs" />
     <Compile Include="System\Runtime\ExceptionServices\HandleProcessCorruptedStateExceptions.cs" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -210,6 +210,7 @@
     <Compile Include="System\Collections\Generic\KeyValuePairTests.netcoreapp.cs" />
     <Compile Include="System\LazyTests.netcoreapp.cs" />
     <Compile Include="System\SByteTests.netcoreapp.cs" />
+    <Compile Include="System\StringComparerTests.netcoreapp.cs" />
     <Compile Include="System\StringTests.netcoreapp.cs" />
     <Compile Include="System\TimeSpanTests.netcoreapp.cs" />
     <Compile Include="System\TypeTests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="System\SByteTests.cs" />
     <Compile Include="System\SingleTests.cs" />
     <Compile Include="System\StackOverflowExceptionTests.cs" />
+    <Compile Include="System\StringComparerTests.cs" />
     <Compile Include="System\StringGetHashCodeTests.cs" />
     <Compile Include="System\String.SplitTests.cs" />
     <Compile Include="System\SystemExceptionTests.cs" />

--- a/src/System.Runtime/tests/System/FormattableStringTests.cs
+++ b/src/System.Runtime/tests/System/FormattableStringTests.cs
@@ -31,5 +31,30 @@ namespace System.Tests
                     return SuccessExitCode;
                 }).Dispose();
         }
+
+        [Fact]
+        public static void ToString_ReturnsSameAsStringTargetTyped()
+        {
+            double d = 123.456;
+            string text1 = $"This will be formatted using current culture {d}";
+            string text2 = ((FormattableString)$"This will be formatted using current culture {d}").ToString();
+            Assert.Equal(text1, text2);
+        }
+
+        [Fact]
+        public static void IFormattableToString_UsesSuppliedFormatProvider()
+        {
+            RemoteInvoke(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("nl"); // would be 123,456 in Dutch
+                double d = 123.456;
+                string expected = string.Format(CultureInfo.InvariantCulture, "Invariant culture is used {0}", d);
+                string actual = ((IFormattable)((FormattableString)$"Invariant culture is used {d}")).ToString(null, CultureInfo.InvariantCulture);
+                Assert.Equal(expected, actual);
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
     }
 }

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/FormattableStringFactoryTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/FormattableStringFactoryTests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Runtime.CompilerServices.Tests
+{
+    public class FormattableStringFactoryTests
+    {
+        [Fact]
+        public void Create_InvalidArguments_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("format", () => FormattableStringFactory.Create(null));
+            AssertExtensions.Throws<ArgumentNullException>("arguments", () => FormattableStringFactory.Create("{0}", null));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("hello")]
+        [InlineData("hel{0}o")]
+        public void Create_FormatMatchesExpected(string format)
+        {
+            FormattableString fs = FormattableStringFactory.Create(format);
+            Assert.Equal(format, fs.Format);
+        }
+
+        public static IEnumerable<object[]> Create_ArgumentsMatchExpected_MemberData()
+        {
+            yield return new object[] { new object[0] };
+            yield return new object[] { new object[1] { new object() } };
+            yield return new object[] { new object[2] { new object(), new object() } };
+        }
+
+        [Theory]
+        [MemberData(nameof(Create_ArgumentsMatchExpected_MemberData))]
+        public void Create_ArgumentsMatchExpected(object[] arguments)
+        {
+            FormattableString fs = FormattableStringFactory.Create("", arguments);
+            Assert.Same(arguments, fs.GetArguments());
+            Assert.Equal(arguments.Length, fs.ArgumentCount);
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                Assert.Same(arguments[i], fs.GetArgument(i));
+            }
+        }
+
+        [Fact]
+        public void Create_ToString_MatchesExpected()
+        {
+            Assert.Equal("hello, world", FormattableStringFactory.Create("hello{0} world", ',').ToString(null));
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/String.SplitTests.cs
+++ b/src/System.Runtime/tests/System/String.SplitTests.cs
@@ -429,6 +429,25 @@ namespace System.Tests
             Assert.Equal(expected, value.Split(new[] { separator }, count, options));
             Assert.Equal(expected, value.Split(separator.ToString(), count, options));
             Assert.Equal(expected, value.Split(new[] { separator.ToString() }, count, options));
+            if (count == int.MaxValue)
+            {
+                Assert.Equal(expected, value.Split(separator, options));
+                Assert.Equal(expected, value.Split(new[] { separator }, options));
+                Assert.Equal(expected, value.Split(separator.ToString(), options));
+                Assert.Equal(expected, value.Split(new[] { separator.ToString() }, options));
+            }
+            if (options == StringSplitOptions.None)
+            {
+                Assert.Equal(expected, value.Split(separator, count));
+                Assert.Equal(expected, value.Split(new[] { separator }, count));
+                Assert.Equal(expected, value.Split(separator.ToString(), count));
+            }
+            if (count == int.MaxValue && options == StringSplitOptions.None)
+            {
+                Assert.Equal(expected, value.Split(separator));
+                Assert.Equal(expected, value.Split(new[] { separator }));
+                Assert.Equal(expected, value.Split(separator.ToString()));
+            }
         }
 
         [Theory]
@@ -441,6 +460,19 @@ namespace System.Tests
         {
             Assert.Equal(expected, value.Split(separator, count, options));
             Assert.Equal(expected, value.Split(new[] { separator }, count, options));
+            if (count == int.MaxValue)
+            {
+                Assert.Equal(expected, value.Split(separator, options));
+                Assert.Equal(expected, value.Split(new[] { separator }, options));
+            }
+            if (options == StringSplitOptions.None)
+            {
+                Assert.Equal(expected, value.Split(separator, count));
+            }
+            if (count == int.MaxValue && options == StringSplitOptions.None)
+            {
+                Assert.Equal(expected, value.Split(separator));
+            }
         }
 
         [Fact]
@@ -457,10 +489,16 @@ namespace System.Tests
         [InlineData("a b c", new char[0], M, StringSplitOptions.None, new[] { "a", "b", "c" })]
         [InlineData("a,b,c", null, M, StringSplitOptions.None, new[] { "a,b,c" })]
         [InlineData("a,b,c", new char[0], M, StringSplitOptions.None, new[] { "a,b,c" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ' ' }, M, StringSplitOptions.None, new[] { "this,", "is,", "a,", "string,", "with", "some", "spaces" })]
         [InlineData("this, is, a, string, with some spaces", new[] { ' ', ',' }, M, StringSplitOptions.None, new[] { "this", "", "is", "", "a", "", "string", "", "with", "some", "spaces" })]
         [InlineData("this, is, a, string, with some spaces", new[] { ',', ' ' }, M, StringSplitOptions.None, new[] { "this", "", "is", "", "a", "", "string", "", "with", "some", "spaces" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ',', ' ', 's' }, M, StringSplitOptions.None, new[] { "thi", "", "", "i", "", "", "a", "", "", "tring", "", "with", "", "ome", "", "pace", "" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ',', ' ', 's', 'a' }, M, StringSplitOptions.None, new[] { "thi", "", "", "i", "", "", "", "", "", "", "tring", "", "with", "", "ome", "", "p", "ce", "" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ' ' }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "this,", "is,", "a,", "string,", "with", "some", "spaces" })]
         [InlineData("this, is, a, string, with some spaces", new[] { ' ', ',' }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "this", "is", "a", "string", "with", "some", "spaces" })]
         [InlineData("this, is, a, string, with some spaces", new[] { ',', ' ' }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "this", "is", "a", "string", "with", "some", "spaces" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ',', ' ', 's' }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "thi", "i", "a", "tring", "with", "ome", "pace" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ',', ' ', 's', 'a' }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "thi", "i", "tring", "with", "ome", "p", "ce" })]
         public static void SplitCharArraySeparator(string value, char[] separators, int count, StringSplitOptions options, string[] expected)
         {
             Assert.Equal(expected, value.Split(separators, count, options));
@@ -474,10 +512,16 @@ namespace System.Tests
         [InlineData("a,b,c", new string[0], M, StringSplitOptions.None, new[] { "a,b,c" })]
         [InlineData("a,b,c", new string[] { null }, M, StringSplitOptions.None, new[] { "a,b,c" })]
         [InlineData("a,b,c", new string[] { "" }, M, StringSplitOptions.None, new[] { "a,b,c" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { " " }, M, StringSplitOptions.None, new[] { "this,", "is,", "a,", "string,", "with", "some", "spaces" })]
         [InlineData("this, is, a, string, with some spaces", new[] { " ", ", " }, M, StringSplitOptions.None, new[] { "this", "is", "a", "string", "with", "some", "spaces" })]
         [InlineData("this, is, a, string, with some spaces", new[] { ", ", " " }, M, StringSplitOptions.None, new[] { "this", "is", "a", "string", "with", "some", "spaces" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ",", " ", "s" }, M, StringSplitOptions.None, new[] { "thi", "", "", "i", "", "", "a", "", "", "tring", "", "with", "", "ome", "", "pace", "" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ",", " ", "s", "a" }, M, StringSplitOptions.None, new[] { "thi", "", "", "i", "", "", "", "", "", "", "tring", "", "with", "", "ome", "", "p", "ce", "" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { " " }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "this,", "is,", "a,", "string,", "with", "some", "spaces" })]
         [InlineData("this, is, a, string, with some spaces", new[] { " ", ", " }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "this", "is", "a", "string", "with", "some", "spaces" })]
         [InlineData("this, is, a, string, with some spaces", new[] { ", ", " " }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "this", "is", "a", "string", "with", "some", "spaces" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ",", " ", "s" }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "thi", "i", "a", "tring", "with", "ome", "pace" })]
+        [InlineData("this, is, a, string, with some spaces", new[] { ",", " ", "s", "a" }, M, StringSplitOptions.RemoveEmptyEntries, new[] { "thi", "i", "tring", "with", "ome", "p", "ce" })]
         public static void SplitStringArraySeparator(string value, string[] separators, int count, StringSplitOptions options, string[] expected)
         {
             Assert.Equal(expected, value.Split(separators, count, options));

--- a/src/System.Runtime/tests/System/StringComparerTests.cs
+++ b/src/System.Runtime/tests/System/StringComparerTests.cs
@@ -7,13 +7,12 @@ using Xunit;
 
 namespace System.Tests
 {
-    public class StringComparerTests
+    public partial class StringComparerTests
     {
         [Fact]
         public void Create_InvalidArguments_Throws()
         {
             AssertExtensions.Throws<ArgumentNullException>("culture", () => StringComparer.Create(null, ignoreCase: true));
-            Assert.Throws<ArgumentException>(() => StringComparer.Create(null, CompareOptions.None));
         }
 
         [Fact]
@@ -31,13 +30,6 @@ namespace System.Tests
             Assert.True(c.Equals((object)"hello", (object)String.Copy("hello")));
             Assert.False(c.Equals((object)"hello", (object)"HEllO"));
             Assert.False(c.Equals("hello", "HEllO"));
-            Assert.False(c.Equals((object)"bello", (object)"HEllO"));
-            Assert.False(c.Equals("bello", "HEllO"));
-
-            c = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.IgnoreCase);
-            Assert.NotNull(c);
-            Assert.True(c.Equals((object)"hello", (object)"HEllO"));
-            Assert.True(c.Equals("hello", "HEllO"));
             Assert.False(c.Equals((object)"bello", (object)"HEllO"));
             Assert.False(c.Equals("bello", "HEllO"));
 

--- a/src/System.Runtime/tests/System/StringComparerTests.cs
+++ b/src/System.Runtime/tests/System/StringComparerTests.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public class StringComparerTests
+    {
+        [Fact]
+        public void Create_InvalidArguments_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("culture", () => StringComparer.Create(null, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => StringComparer.Create(null, CompareOptions.None));
+        }
+
+        [Fact]
+        public void Create_CreatesValidComparer()
+        {
+            StringComparer c = StringComparer.Create(CultureInfo.InvariantCulture, ignoreCase: true);
+            Assert.NotNull(c);
+            Assert.True(c.Equals((object)"hello", (object)"HEllO"));
+            Assert.True(c.Equals("hello", "HEllO"));
+            Assert.False(c.Equals((object)"bello", (object)"HEllO"));
+            Assert.False(c.Equals("bello", "HEllO"));
+
+            c = StringComparer.Create(CultureInfo.InvariantCulture, ignoreCase: false);
+            Assert.NotNull(c);
+            Assert.True(c.Equals((object)"hello", (object)String.Copy("hello")));
+            Assert.False(c.Equals((object)"hello", (object)"HEllO"));
+            Assert.False(c.Equals("hello", "HEllO"));
+            Assert.False(c.Equals((object)"bello", (object)"HEllO"));
+            Assert.False(c.Equals("bello", "HEllO"));
+
+            c = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.IgnoreCase);
+            Assert.NotNull(c);
+            Assert.True(c.Equals((object)"hello", (object)"HEllO"));
+            Assert.True(c.Equals("hello", "HEllO"));
+            Assert.False(c.Equals((object)"bello", (object)"HEllO"));
+            Assert.False(c.Equals("bello", "HEllO"));
+
+            object obj = new object();
+            Assert.Equal(c.GetHashCode((object)"hello"), c.GetHashCode((object)"hello"));
+            Assert.Equal(c.GetHashCode("hello"), c.GetHashCode("hello"));
+            Assert.Equal(c.GetHashCode("hello"), c.GetHashCode((object)"hello"));
+            Assert.Equal(obj.GetHashCode(), c.GetHashCode(obj));
+            Assert.Equal(42.CompareTo(84), c.Compare(42, 84));
+            Assert.Throws<ArgumentException>(() => c.Compare("42", 84));
+            Assert.Equal(1, c.Compare("42", null));
+            Assert.Throws<ArgumentException>(() => c.Compare(42, "84"));
+        }
+
+        [Fact]
+        public void Compare_InvalidArguments_Throws()
+        {
+            StringComparer c = StringComparer.Create(CultureInfo.InvariantCulture, ignoreCase: true);
+            Assert.Throws<ArgumentException>(() => c.Compare(new object(), 42));
+        }
+
+        [Fact]
+        public void GetHashCode_InvalidArguments_Throws()
+        {
+            StringComparer c = StringComparer.Create(CultureInfo.InvariantCulture, ignoreCase: true);
+            AssertExtensions.Throws<ArgumentNullException>("obj", () => c.GetHashCode(null));
+            AssertExtensions.Throws<ArgumentNullException>("obj", () => c.GetHashCode((object)null));
+        }
+
+        [Fact]
+        public void Compare_ViaSort_SortsAsExpected()
+        {
+            string[] strings = new[] { "a", "b", "AB", "A", "cde", "abc", "f", "123", "ab" };
+
+            Array.Sort(strings, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal<string>(strings, new[] { "123", "a", "A", "AB", "ab", "abc", "b", "cde", "f" });
+
+            Array.Sort(strings, StringComparer.Ordinal);
+            Assert.Equal<string>(strings, new[] { "123", "A", "AB", "a", "ab", "abc", "b", "cde", "f" });
+        }
+
+        [Fact]
+        public void Compare_ExpectedResults()
+        {
+            StringComparer c = StringComparer.Ordinal;
+
+            Assert.Equal(0, c.Compare((object)"hello", (object)"hello"));
+            Assert.Equal(0, c.Compare((object)"hello", (object)String.Copy("hello")));
+            Assert.Equal(-1, c.Compare(null, (object)"hello"));
+            Assert.Equal(1, c.Compare((object)"hello", null));
+
+            Assert.InRange(c.Compare((object)"hello", (object)"world"), int.MinValue, -1);
+            Assert.InRange(c.Compare((object)"world", (object)"hello"), 1, int.MaxValue);
+        }
+
+        [Fact]
+        public void Equals_ExpectedResults()
+        {
+            StringComparer c = StringComparer.Ordinal;
+
+            Assert.True(c.Equals((object)null, (object)null));
+            Assert.True(c.Equals(null, null));
+            Assert.True(c.Equals((object)"hello", (object)"hello"));
+            Assert.True(c.Equals("hello", "hello"));
+
+            Assert.False(c.Equals((object)null, "hello"));
+            Assert.False(c.Equals(null, "hello"));
+            Assert.False(c.Equals("hello", (object)null));
+            Assert.False(c.Equals("hello", null));
+
+            Assert.True(c.Equals(42, 42));
+            Assert.False(c.Equals(42, 84));
+            Assert.False(c.Equals("42", 84));
+            Assert.False(c.Equals(42, "84"));
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/StringComparerTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/StringComparerTests.netcoreapp.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public partial class StringComparerTests
+    {
+        [Fact]
+        public void CreateCultureOptions_InvalidArguments_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => StringComparer.Create(null, CompareOptions.None));
+        }
+
+        [Fact]
+        public void CreateCultureOptions_CreatesValidComparer()
+        {
+            StringComparer c = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.IgnoreCase);
+            Assert.NotNull(c);
+            Assert.True(c.Equals((object)"hello", (object)"HEllO"));
+            Assert.True(c.Equals("hello", "HEllO"));
+            Assert.False(c.Equals((object)"bello", (object)"HEllO"));
+            Assert.False(c.Equals("bello", "HEllO"));
+
+            object obj = new object();
+            Assert.Equal(c.GetHashCode((object)"hello"), c.GetHashCode((object)"hello"));
+            Assert.Equal(c.GetHashCode("hello"), c.GetHashCode("hello"));
+            Assert.Equal(c.GetHashCode("hello"), c.GetHashCode((object)"hello"));
+            Assert.Equal(obj.GetHashCode(), c.GetHashCode(obj));
+            Assert.Equal(42.CompareTo(84), c.Compare(42, 84));
+            Assert.Throws<ArgumentException>(() => c.Compare("42", 84));
+            Assert.Equal(1, c.Compare("42", null));
+            Assert.Throws<ArgumentException>(() => c.Compare(42, "84"));
+        }
+    }
+}


### PR DESCRIPTION
String line / branch coverage now > 97%.  Majority of remaining code paths are difficult to hit, e.g. OOMs, overflows, race conditions, etc.

FormattableString, FormattableStringFactory, and StringComparer coverage now at 100%.

cc: @danmosemsft 