### PR TITLE
Fix WinHttpHandler when using authenticating proxies

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -147,7 +147,7 @@ namespace System.Net.Http
                         out authTarget))
                     {
                         // WinHTTP returns an error for schemes it doesn't handle.
-                        // So, we need to ignore the error and just let it stay at 401.
+                        // So, we need to ignore the error and just let it stay at 407.
                         break;
                     }
 
@@ -155,7 +155,13 @@ namespace System.Net.Http
                     // But we can validate with assert.
                     Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY);
 
-                    proxyAuthScheme = ChooseAuthScheme(supportedSchemes, state.Proxy.GetProxy(state.RequestMessage.RequestUri), proxyCreds);
+                    proxyAuthScheme = ChooseAuthScheme(
+                        supportedSchemes,
+                        // TODO: Issue #6997. If Proxy==null, we're using the system proxy which is possibly
+                        // discovered/calculated with a PAC file. So, we can't determine the actual proxy uri at
+                        // this point since it is calculated internally in WinHTTP. For now, pass in null for the uri.
+                        state.Proxy?.GetProxy(state.RequestMessage.RequestUri),
+                        proxyCreds);
                     state.RetryRequest = true;
                     break;
 
@@ -375,6 +381,15 @@ namespace System.Net.Http
         {
             if (credentials == null)
             {
+                return 0;
+            }
+
+            if (uri == null && !(credentials is NetworkCredential))
+            {
+                // TODO: Issue #6997.
+                // If the credentials are a NetworkCredential, the uri isn't used when calling .GetCredential() since
+                // it will work against all uri's. Otherwise, credentials is probably a CredentialCache and passing in
+                // null for a uri is invalid.
                 return 0;
             }
 


### PR DESCRIPTION
This was a regression from .NET Core 2.0 due to PR #28105.

Proxy authentication using system default proxy settings that involve a PAC file
(either autodiscovery or explicit PAC file) cause a NullReferenceException in WinHttpHandler in the
CheckResponseForAuthentication() method.

This problem is only discovered when using an authenticating proxy server (any auth scheme) that is
discovered using PAC files. This is considered the "system default" proxy. When this occurs, the
handler's Proxy property is null and dereferencing it caused the exception.

Due to the problems described in #6997, the uri of the proxy can't be determined yet since it is only
known to WinHTTP. Fixing #6997 is complicated and impacts performance. However, in most cases, as
long as the credentials are a NetworkCredential object, knowing the uri of the proxy is not needed.

I tested this manually using the steps I described in #30191. I did not add any tests to this PR since
they can't be run in CI. However, I am working on a task that will eventually add Enterprise-Scenario
testing like this (PAC files, authenticating proxies, etc.) to our systems.

Fixes #30191
Contributes to #6997