### PR TITLE
fix setting TTL on IPv6 socket on Unix

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1645,6 +1645,9 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionName, int32_t socketO
                 case SocketOptionName_SO_IP_MULTICAST_TTL:
                     *optName = IPV6_MULTICAST_HOPS;
                     return true;
+                case SocketOptionName_SO_IP_TTL:
+                    *optName = IPV6_UNICAST_HOPS;
+                    return true;
 
                 default:
                     return false;

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -191,6 +191,21 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [Theory]
+        [InlineData(AddressFamily.InterNetwork)]
+        [InlineData(AddressFamily.InterNetworkV6)]
+        public void TtlSet_Succeeds(AddressFamily af)
+        {
+            using (Socket socket = new Socket(af, SocketType.Dgram, ProtocolType.Udp))
+            {
+                short newTtl = socket.Ttl;
+                // Change default ttl.
+                newTtl += (short)((newTtl < 255) ? 1 : -1);
+                socket.Ttl = newTtl;
+                Assert.Equal(newTtl, socket.Ttl);
+            }
+        }
+
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: dotnet/corefx #29929
         [PlatformSpecific(TestPlatforms.Windows)]

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -194,7 +194,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
-        public void TtlSet_Succeeds(AddressFamily af)
+        public void Ttl_Set_Succeeds(AddressFamily af)
         {
             using (Socket socket = new Socket(af, SocketType.Dgram, ProtocolType.Udp))
             {

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -313,6 +313,21 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [Theory]
+        [InlineData(AddressFamily.InterNetwork)]
+        [InlineData(AddressFamily.InterNetworkV6)]
+        public void Ttl_Set_GetEqualsSet(AddressFamily af)
+        {
+            using (TcpClient client = new TcpClient(af))
+            {
+                short newTtl = client.Client.Ttl;
+                // Change default ttl.
+                newTtl += (short)((newTtl < 255) ? 1 : -1);
+                client.Client.Ttl = newTtl;
+                Assert.Equal(newTtl, client.Client.Ttl);
+            }
+        }
+
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Roundtrip_ReceiveBufferSize_GetEqualsSet()


### PR DESCRIPTION
fixes #30168 

On Unix there is separate set of options for IPv6 e.g. HOP_LIMIT instead of TTL. 
Trying to use SO_IP_TTL will cause failure. (works OK on Windows)

