### PR TITLE
fix raw sockets on IPv6 and enable tests again

### DIFF
--- a/src/Common/src/System/Net/RawSocketPermissions.cs
+++ b/src/Common/src/System/Net/RawSocketPermissions.cs
@@ -23,7 +23,7 @@ namespace System.Net
         {
             try
             {
-                new Socket(addressFamily, SocketType.Raw, ProtocolType.Icmp).Dispose();
+                new Socket(addressFamily, SocketType.Raw, addressFamily == AddressFamily.InterNetwork ? ProtocolType.Icmp : ProtocolType.IcmpV6).Dispose();
                 return true;
             }
             catch

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -304,7 +304,7 @@ namespace System.Net.Sockets
                     errorCode = SocketError.Success;
 
                     // The socket was created successfully; enable IPV6_V6ONLY by default for AF_INET6 sockets.
-                    if (addressFamily == AddressFamily.InterNetworkV6)
+                    if (addressFamily == AddressFamily.InterNetworkV6 && socketType != SocketType.Raw)
                     {
                         int on = 1;
                         error = Interop.Sys.SetSockOpt(fd, SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, (byte*)&on, sizeof(int));

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -303,7 +303,8 @@ namespace System.Net.Sockets
 
                     errorCode = SocketError.Success;
 
-                    // The socket was created successfully; enable IPV6_V6ONLY by default for AF_INET6 sockets.
+                    // The socket was created successfully; enable IPV6_V6ONLY by default for normal AF_INET6 sockets.
+                    // This fails on raw sockets so we just let them be in default state.
                     if (addressFamily == AddressFamily.InterNetworkV6 && socketType != SocketType.Raw)
                     {
                         int on = 1;

--- a/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
@@ -23,13 +23,9 @@ namespace System.Net.Sockets.Tests
             new object[] { SocketType.Seqpacket, ProtocolType.Udp },
             new object[] { SocketType.Stream, ProtocolType.Udp },
             new object[] { SocketType.Unknown, ProtocolType.Udp },
-/*
-    Disabling these test cases because it actually passes in some cases
-    see https://github.com/dotnet/corefx/issues/3726
-            new object[] { SocketType.Raw, ProtocolType.Tcp },
-            new object[] { SocketType.Raw, ProtocolType.Udp },
-*/
         };
+
+        private static bool SupportsRawSockets => AdminHelpers.IsProcessElevated();
 
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(DualModeSuccessInputs))]
@@ -74,12 +70,6 @@ namespace System.Net.Sockets.Tests
             new object[] { AddressFamily.InterNetwork, SocketType.Seqpacket, ProtocolType.Udp },
             new object[] { AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Udp },
             new object[] { AddressFamily.InterNetwork, SocketType.Unknown, ProtocolType.Udp },
-/*
-    Disabling these test cases because it actually passes in some cases
-    see https://github.com/dotnet/corefx/issues/3726
-            new object[] { AddressFamily.InterNetwork, SocketType.Raw, ProtocolType.Tcp },
-            new object[] { AddressFamily.InterNetwork, SocketType.Raw, ProtocolType.Udp },
-*/
         };
 
         [OuterLoop] // TODO: Issue #11345
@@ -87,6 +77,21 @@ namespace System.Net.Sockets.Tests
         public void Ctor_Failure(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
             Assert.Throws<SocketException>(() => new Socket(addressFamily, socketType, protocolType));
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData(AddressFamily.InterNetwork, ProtocolType.Tcp)]
+        [InlineData(AddressFamily.InterNetwork, ProtocolType.Udp)]
+        [InlineData(AddressFamily.InterNetwork, ProtocolType.Icmp)]
+        [InlineData(AddressFamily.InterNetworkV6, ProtocolType.Tcp)]
+        [InlineData(AddressFamily.InterNetworkV6, ProtocolType.Udp)]
+        [InlineData(AddressFamily.InterNetworkV6, ProtocolType.IcmpV6)]
+        [ConditionalTheory(nameof(SupportsRawSockets))]
+        public void Ctor_Raw_Success(AddressFamily addressFamily, ProtocolType protocolType)
+        {
+           using (new Socket(addressFamily, SocketType.Raw, protocolType))
+           {
+           }
         }
     }
 }


### PR DESCRIPTION
fixes #3726 and #30169

Tests pass when executed as root and skipped otherwise. 

 

>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetwork, protocolType: Tcp) [STARTING]
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetwork, protocolType: Tcp) [FINISHED] Time: 0.0002109s
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetwork, protocolType: Udp) [STARTING]
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetwork, protocolType: Udp) [FINISHED] Time: 0.0000186s
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetwork, protocolType: Icmp) [STARTING]
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetwork, protocolType: Icmp) [FINISHED] Time: 0.0000086s
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetworkV6, protocolType: Tcp) [STARTING]
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetworkV6, protocolType: Tcp) [FINISHED] Time: 0.0000101s
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetworkV6, protocolType: Udp) [STARTING]
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetworkV6, protocolType: Udp) [FINISHED] Time: 0.0000079s
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetworkV6, protocolType: IcmpV6) [STARTING]
>      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success(addressFamily: InterNetworkV6, protocolType: IcmpV6) [FINISHED] Time: 0.0000078s
