### PR TITLE
Add a static method to create WinRT SynchronizationContext instance

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
@@ -48,7 +48,7 @@ namespace System.Threading
 
     #region class WinRTSynchronizationContextFactory
 
-    internal sealed class WinRTSynchronizationContextFactory : WinRTSynchronizationContextFactoryBase
+    internal sealed class WinRTSynchronizationContextFactory
     {
         //
         // It's important that we always return the same SynchronizationContext object for any particular ICoreDispatcher
@@ -63,7 +63,8 @@ namespace System.Threading
         private static readonly ConditionalWeakTable<IDispatcherQueue, WinRTDispatcherQueueBasedSynchronizationContext> s_dispatcherQueueContextCache =
             new ConditionalWeakTable<IDispatcherQueue, WinRTDispatcherQueueBasedSynchronizationContext>();
 
-        public override SynchronizationContext Create(object dispatcherObj)
+        // System.Private.Corelib will call WinRTSynchronizationContextFactory.Create() via reflection
+        public static SynchronizationContext Create(object dispatcherObj)
         {
             Debug.Assert(dispatcherObj != null);
             Debug.Assert(dispatcherObj is CoreDispatcher || dispatcherObj is IDispatcherQueue);


### PR DESCRIPTION
The change is to add a static method to create WinRT SynchronizationContext instance and also remove the dependency on internal class WinRTSynchronizationContextFactoryBase

CoreCLR PR:https://github.com/dotnet/coreclr/pull/18385