### PR TITLE
Clean style in Graphics/GraphicsPath

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.cs
@@ -28,8 +28,8 @@ namespace System.Drawing.Drawing2D
         {
             IntPtr nativeLineCap;
             int status = SafeNativeMethods.Gdip.GdipCreateCustomLineCap(
-                                new HandleRef(fillPath, (fillPath == null) ? IntPtr.Zero : fillPath.nativePath),
-                                new HandleRef(strokePath, (strokePath == null) ? IntPtr.Zero : strokePath.nativePath),
+                                new HandleRef(fillPath, (fillPath == null) ? IntPtr.Zero : fillPath._nativePath),
+                                new HandleRef(strokePath, (strokePath == null) ? IntPtr.Zero : strokePath._nativePath),
                                 baseCap, baseInset, out nativeLineCap);
 
             if (status != SafeNativeMethods.Gdip.Ok)

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
@@ -43,22 +43,22 @@ namespace System.Drawing.Drawing2D
         // 1/4 is the FlatnessDefault as defined in GdiPlusEnums.h
         private const float FlatnessDefault = 1.0f / 4.0f;
 
-        internal IntPtr nativePath = IntPtr.Zero;
+        internal IntPtr _nativePath = IntPtr.Zero;
 
         GraphicsPath(IntPtr ptr)
         {
-            nativePath = ptr;
+            _nativePath = ptr;
         }
 
         public GraphicsPath()
         {
-            int status = SafeNativeMethods.Gdip.GdipCreatePath(FillMode.Alternate, out nativePath);
+            int status = SafeNativeMethods.Gdip.GdipCreatePath(FillMode.Alternate, out _nativePath);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public GraphicsPath(FillMode fillMode)
         {
-            int status = SafeNativeMethods.Gdip.GdipCreatePath(fillMode, out nativePath);
+            int status = SafeNativeMethods.Gdip.GdipCreatePath(fillMode, out _nativePath);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -79,7 +79,7 @@ namespace System.Drawing.Drawing2D
             if (pts.Length != types.Length)
                 throw new ArgumentException("Invalid parameter passed. Number of points and types must be same.");
 
-            int status = SafeNativeMethods.Gdip.GdipCreatePath2I(pts, types, pts.Length, fillMode, out nativePath);
+            int status = SafeNativeMethods.Gdip.GdipCreatePath2I(pts, types, pts.Length, fillMode, out _nativePath);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -90,7 +90,7 @@ namespace System.Drawing.Drawing2D
             if (pts.Length != types.Length)
                 throw new ArgumentException("Invalid parameter passed. Number of points and types must be same.");
 
-            int status = SafeNativeMethods.Gdip.GdipCreatePath2(pts, types, pts.Length, fillMode, out nativePath);
+            int status = SafeNativeMethods.Gdip.GdipCreatePath2(pts, types, pts.Length, fillMode, out _nativePath);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -98,7 +98,7 @@ namespace System.Drawing.Drawing2D
         {
             IntPtr clone;
 
-            int status = SafeNativeMethods.Gdip.GdipClonePath(nativePath, out clone);
+            int status = SafeNativeMethods.Gdip.GdipClonePath(_nativePath, out clone);
             SafeNativeMethods.Gdip.CheckStatus(status);
 
             return new GraphicsPath(clone);
@@ -118,12 +118,12 @@ namespace System.Drawing.Drawing2D
         void Dispose(bool disposing)
         {
             int status;
-            if (nativePath != IntPtr.Zero)
+            if (_nativePath != IntPtr.Zero)
             {
-                status = SafeNativeMethods.Gdip.GdipDeletePath(nativePath);
+                status = SafeNativeMethods.Gdip.GdipDeletePath(_nativePath);
                 SafeNativeMethods.Gdip.CheckStatus(status);
 
-                nativePath = IntPtr.Zero;
+                _nativePath = IntPtr.Zero;
             }
         }
 
@@ -132,7 +132,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 FillMode mode;
-                int status = SafeNativeMethods.Gdip.GdipGetPathFillMode(nativePath, out mode);
+                int status = SafeNativeMethods.Gdip.GdipGetPathFillMode(_nativePath, out mode);
                 SafeNativeMethods.Gdip.CheckStatus(status);
 
                 return mode;
@@ -142,7 +142,7 @@ namespace System.Drawing.Drawing2D
                 if ((value < FillMode.Alternate) || (value > FillMode.Winding))
                     throw new InvalidEnumArgumentException("FillMode", (int)value, typeof(FillMode));
 
-                int status = SafeNativeMethods.Gdip.GdipSetPathFillMode(nativePath, value);
+                int status = SafeNativeMethods.Gdip.GdipSetPathFillMode(_nativePath, value);
                 SafeNativeMethods.Gdip.CheckStatus(status);
             }
         }
@@ -152,7 +152,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int count;
-                int status = SafeNativeMethods.Gdip.GdipGetPointCount(nativePath, out count);
+                int status = SafeNativeMethods.Gdip.GdipGetPointCount(_nativePath, out count);
                 SafeNativeMethods.Gdip.CheckStatus(status);
 
                 PointF[] points = new PointF[count];
@@ -162,10 +162,10 @@ namespace System.Drawing.Drawing2D
                 // anyway that would only mean two unrequired unmanaged calls
                 if (count > 0)
                 {
-                    status = SafeNativeMethods.Gdip.GdipGetPathPoints(nativePath, points, count);
+                    status = SafeNativeMethods.Gdip.GdipGetPathPoints(_nativePath, points, count);
                     SafeNativeMethods.Gdip.CheckStatus(status);
 
-                    status = SafeNativeMethods.Gdip.GdipGetPathTypes(nativePath, types, count);
+                    status = SafeNativeMethods.Gdip.GdipGetPathTypes(_nativePath, types, count);
                     SafeNativeMethods.Gdip.CheckStatus(status);
                 }
 
@@ -181,13 +181,13 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int count;
-                int status = SafeNativeMethods.Gdip.GdipGetPointCount(nativePath, out count);
+                int status = SafeNativeMethods.Gdip.GdipGetPointCount(_nativePath, out count);
                 SafeNativeMethods.Gdip.CheckStatus(status);
                 if (count == 0)
                     throw new ArgumentException("PathPoints");
 
                 PointF[] points = new PointF[count];
-                status = SafeNativeMethods.Gdip.GdipGetPathPoints(nativePath, points, count);
+                status = SafeNativeMethods.Gdip.GdipGetPathPoints(_nativePath, points, count);
                 SafeNativeMethods.Gdip.CheckStatus(status);
 
                 return points;
@@ -199,13 +199,13 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int count;
-                int status = SafeNativeMethods.Gdip.GdipGetPointCount(nativePath, out count);
+                int status = SafeNativeMethods.Gdip.GdipGetPointCount(_nativePath, out count);
                 SafeNativeMethods.Gdip.CheckStatus(status);
                 if (count == 0)
                     throw new ArgumentException("PathTypes");
 
                 byte[] types = new byte[count];
-                status = SafeNativeMethods.Gdip.GdipGetPathTypes(nativePath, types, count);
+                status = SafeNativeMethods.Gdip.GdipGetPathTypes(_nativePath, types, count);
                 SafeNativeMethods.Gdip.CheckStatus(status);
 
                 return types;
@@ -217,7 +217,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int count;
-                int status = SafeNativeMethods.Gdip.GdipGetPointCount(nativePath, out count);
+                int status = SafeNativeMethods.Gdip.GdipGetPointCount(_nativePath, out count);
                 SafeNativeMethods.Gdip.CheckStatus(status);
 
                 return count;
@@ -228,11 +228,11 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                return nativePath;
+                return _nativePath;
             }
             set
             {
-                nativePath = value;
+                _nativePath = value;
             }
         }
 
@@ -241,25 +241,25 @@ namespace System.Drawing.Drawing2D
         //
         public void AddArc(Rectangle rect, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathArcI(nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathArcI(_nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddArc(RectangleF rect, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathArc(nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathArc(_nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddArc(int x, int y, int width, int height, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathArcI(nativePath, x, y, width, height, startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathArcI(_nativePath, x, y, width, height, startAngle, sweepAngle);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddArc(float x, float y, float width, float height, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathArc(nativePath, x, y, width, height, startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathArc(_nativePath, x, y, width, height, startAngle, sweepAngle);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -268,7 +268,7 @@ namespace System.Drawing.Drawing2D
         //
         public void AddBezier(Point pt1, Point pt2, Point pt3, Point pt4)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathBezierI(nativePath, pt1.X, pt1.Y,
+            int status = SafeNativeMethods.Gdip.GdipAddPathBezierI(_nativePath, pt1.X, pt1.Y,
                             pt2.X, pt2.Y, pt3.X, pt3.Y, pt4.X, pt4.Y);
 
             SafeNativeMethods.Gdip.CheckStatus(status);
@@ -276,7 +276,7 @@ namespace System.Drawing.Drawing2D
 
         public void AddBezier(PointF pt1, PointF pt2, PointF pt3, PointF pt4)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathBezier(nativePath, pt1.X, pt1.Y,
+            int status = SafeNativeMethods.Gdip.GdipAddPathBezier(_nativePath, pt1.X, pt1.Y,
                             pt2.X, pt2.Y, pt3.X, pt3.Y, pt4.X, pt4.Y);
 
             SafeNativeMethods.Gdip.CheckStatus(status);
@@ -284,13 +284,13 @@ namespace System.Drawing.Drawing2D
 
         public void AddBezier(int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathBezierI(nativePath, x1, y1, x2, y2, x3, y3, x4, y4);
+            int status = SafeNativeMethods.Gdip.GdipAddPathBezierI(_nativePath, x1, y1, x2, y2, x3, y3, x4, y4);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddBezier(float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathBezier(nativePath, x1, y1, x2, y2, x3, y3, x4, y4);
+            int status = SafeNativeMethods.Gdip.GdipAddPathBezier(_nativePath, x1, y1, x2, y2, x3, y3, x4, y4);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -301,7 +301,7 @@ namespace System.Drawing.Drawing2D
         {
             if (points == null)
                 throw new ArgumentNullException("points");
-            int status = SafeNativeMethods.Gdip.GdipAddPathBeziersI(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathBeziersI(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -309,7 +309,7 @@ namespace System.Drawing.Drawing2D
         {
             if (points == null)
                 throw new ArgumentNullException("points");
-            int status = SafeNativeMethods.Gdip.GdipAddPathBeziers(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathBeziers(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -318,25 +318,25 @@ namespace System.Drawing.Drawing2D
         //
         public void AddEllipse(RectangleF rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathEllipse(nativePath, rect.X, rect.Y, rect.Width, rect.Height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathEllipse(_nativePath, rect.X, rect.Y, rect.Width, rect.Height);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddEllipse(float x, float y, float width, float height)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathEllipse(nativePath, x, y, width, height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathEllipse(_nativePath, x, y, width, height);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddEllipse(Rectangle rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathEllipseI(nativePath, rect.X, rect.Y, rect.Width, rect.Height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathEllipseI(_nativePath, rect.X, rect.Y, rect.Width, rect.Height);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddEllipse(int x, int y, int width, int height)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathEllipseI(nativePath, x, y, width, height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathEllipseI(_nativePath, x, y, width, height);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -346,13 +346,13 @@ namespace System.Drawing.Drawing2D
         //
         public void AddLine(Point pt1, Point pt2)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathLineI(nativePath, pt1.X, pt1.Y, pt2.X, pt2.Y);
+            int status = SafeNativeMethods.Gdip.GdipAddPathLineI(_nativePath, pt1.X, pt1.Y, pt2.X, pt2.Y);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddLine(PointF pt1, PointF pt2)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathLine(nativePath, pt1.X, pt1.Y, pt2.X,
+            int status = SafeNativeMethods.Gdip.GdipAddPathLine(_nativePath, pt1.X, pt1.Y, pt2.X,
                             pt2.Y);
 
             SafeNativeMethods.Gdip.CheckStatus(status);
@@ -360,13 +360,13 @@ namespace System.Drawing.Drawing2D
 
         public void AddLine(int x1, int y1, int x2, int y2)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathLineI(nativePath, x1, y1, x2, y2);
+            int status = SafeNativeMethods.Gdip.GdipAddPathLineI(_nativePath, x1, y1, x2, y2);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddLine(float x1, float y1, float x2, float y2)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathLine(nativePath, x1, y1, x2,
+            int status = SafeNativeMethods.Gdip.GdipAddPathLine(_nativePath, x1, y1, x2,
                             y2);
 
             SafeNativeMethods.Gdip.CheckStatus(status);
@@ -382,7 +382,7 @@ namespace System.Drawing.Drawing2D
             if (points.Length == 0)
                 throw new ArgumentException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathLine2I(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathLine2I(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -393,7 +393,7 @@ namespace System.Drawing.Drawing2D
             if (points.Length == 0)
                 throw new ArgumentException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathLine2(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathLine2(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -403,19 +403,19 @@ namespace System.Drawing.Drawing2D
         public void AddPie(Rectangle rect, float startAngle, float sweepAngle)
         {
             int status = SafeNativeMethods.Gdip.GdipAddPathPie(
-                    nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
+                    _nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddPie(int x, int y, int width, int height, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathPieI(nativePath, x, y, width, height, startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathPieI(_nativePath, x, y, width, height, startAngle, sweepAngle);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddPie(float x, float y, float width, float height, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathPie(nativePath, x, y, width, height, startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathPie(_nativePath, x, y, width, height, startAngle, sweepAngle);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -427,7 +427,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathPolygonI(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathPolygonI(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -436,7 +436,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathPolygon(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathPolygon(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -445,13 +445,13 @@ namespace System.Drawing.Drawing2D
         //
         public void AddRectangle(Rectangle rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathRectangleI(nativePath, rect.X, rect.Y, rect.Width, rect.Height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathRectangleI(_nativePath, rect.X, rect.Y, rect.Width, rect.Height);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void AddRectangle(RectangleF rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathRectangle(nativePath, rect.X, rect.Y, rect.Width, rect.Height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathRectangle(_nativePath, rect.X, rect.Y, rect.Width, rect.Height);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -465,7 +465,7 @@ namespace System.Drawing.Drawing2D
             if (rects.Length == 0)
                 throw new ArgumentException("rects");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathRectanglesI(nativePath, rects, rects.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathRectanglesI(_nativePath, rects, rects.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -476,7 +476,7 @@ namespace System.Drawing.Drawing2D
             if (rects.Length == 0)
                 throw new ArgumentException("rects");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathRectangles(nativePath, rects, rects.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathRectangles(_nativePath, rects, rects.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -488,14 +488,14 @@ namespace System.Drawing.Drawing2D
             if (addingPath == null)
                 throw new ArgumentNullException("addingPath");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathPath(nativePath, addingPath.nativePath, connect);
+            int status = SafeNativeMethods.Gdip.GdipAddPathPath(_nativePath, addingPath._nativePath, connect);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public PointF GetLastPoint()
         {
             PointF pt;
-            int status = SafeNativeMethods.Gdip.GdipGetPathLastPoint(nativePath, out pt);
+            int status = SafeNativeMethods.Gdip.GdipGetPathLastPoint(_nativePath, out pt);
             SafeNativeMethods.Gdip.CheckStatus(status);
 
             return pt;
@@ -509,7 +509,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurveI(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurveI(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -518,7 +518,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -527,7 +527,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve2I(nativePath, points, points.Length, tension);
+            int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve2I(_nativePath, points, points.Length, tension);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -536,7 +536,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve2(nativePath, points, points.Length, tension);
+            int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve2(_nativePath, points, points.Length, tension);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -548,7 +548,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathCurveI(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathCurveI(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -557,7 +557,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathCurve(nativePath, points, points.Length);
+            int status = SafeNativeMethods.Gdip.GdipAddPathCurve(_nativePath, points, points.Length);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -566,7 +566,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathCurve2I(nativePath, points, points.Length, tension);
+            int status = SafeNativeMethods.Gdip.GdipAddPathCurve2I(_nativePath, points, points.Length, tension);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -575,7 +575,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathCurve2(nativePath, points, points.Length, tension);
+            int status = SafeNativeMethods.Gdip.GdipAddPathCurve2(_nativePath, points, points.Length, tension);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -584,7 +584,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathCurve3I(nativePath, points, points.Length,
+            int status = SafeNativeMethods.Gdip.GdipAddPathCurve3I(_nativePath, points, points.Length,
                             offset, numberOfSegments, tension);
 
             SafeNativeMethods.Gdip.CheckStatus(status);
@@ -595,7 +595,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException("points");
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathCurve3(nativePath, points, points.Length,
+            int status = SafeNativeMethods.Gdip.GdipAddPathCurve3(_nativePath, points, points.Length,
                             offset, numberOfSegments, tension);
 
             SafeNativeMethods.Gdip.CheckStatus(status);
@@ -603,13 +603,13 @@ namespace System.Drawing.Drawing2D
 
         public void Reset()
         {
-            int status = SafeNativeMethods.Gdip.GdipResetPath(nativePath);
+            int status = SafeNativeMethods.Gdip.GdipResetPath(_nativePath);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void Reverse()
         {
-            int status = SafeNativeMethods.Gdip.GdipReversePath(nativePath);
+            int status = SafeNativeMethods.Gdip.GdipReversePath(_nativePath);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -618,7 +618,7 @@ namespace System.Drawing.Drawing2D
             if (matrix == null)
                 throw new ArgumentNullException("matrix");
 
-            int status = SafeNativeMethods.Gdip.GdipTransformPath(nativePath, matrix.nativeMatrix);
+            int status = SafeNativeMethods.Gdip.GdipTransformPath(_nativePath, matrix.nativeMatrix);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -645,7 +645,7 @@ namespace System.Drawing.Drawing2D
 
             IntPtr sformat = (format == null) ? IntPtr.Zero : format.nativeFormat;
             // note: the NullReferenceException on s.Length is the expected (MS) exception
-            int status = SafeNativeMethods.Gdip.GdipAddPathStringI(nativePath, s, s.Length, family.NativeFamily, style, emSize, ref layoutRect, sformat);
+            int status = SafeNativeMethods.Gdip.GdipAddPathStringI(_nativePath, s, s.Length, family.NativeFamily, style, emSize, ref layoutRect, sformat);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -656,27 +656,27 @@ namespace System.Drawing.Drawing2D
 
             IntPtr sformat = (format == null) ? IntPtr.Zero : format.nativeFormat;
             // note: the NullReferenceException on s.Length is the expected (MS) exception
-            int status = SafeNativeMethods.Gdip.GdipAddPathString(nativePath, s, s.Length, family.NativeFamily, style, emSize, ref layoutRect, sformat);
+            int status = SafeNativeMethods.Gdip.GdipAddPathString(_nativePath, s, s.Length, family.NativeFamily, style, emSize, ref layoutRect, sformat);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
         public void ClearMarkers()
         {
-            int s = SafeNativeMethods.Gdip.GdipClearPathMarkers(nativePath);
+            int s = SafeNativeMethods.Gdip.GdipClearPathMarkers(_nativePath);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
         }
 
         public void CloseAllFigures()
         {
-            int s = SafeNativeMethods.Gdip.GdipClosePathFigures(nativePath);
+            int s = SafeNativeMethods.Gdip.GdipClosePathFigures(_nativePath);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
         }
 
         public void CloseFigure()
         {
-            int s = SafeNativeMethods.Gdip.GdipClosePathFigure(nativePath);
+            int s = SafeNativeMethods.Gdip.GdipClosePathFigure(_nativePath);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
         }
@@ -694,7 +694,7 @@ namespace System.Drawing.Drawing2D
         public void Flatten(Matrix matrix, float flatness)
         {
             IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.nativeMatrix;
-            int status = SafeNativeMethods.Gdip.GdipFlattenPath(nativePath, m, flatness);
+            int status = SafeNativeMethods.Gdip.GdipFlattenPath(_nativePath, m, flatness);
 
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
@@ -715,7 +715,7 @@ namespace System.Drawing.Drawing2D
             IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.nativeMatrix;
             IntPtr p = (pen == null) ? IntPtr.Zero : pen.NativePen;
 
-            int s = SafeNativeMethods.Gdip.GdipGetPathWorldBounds(nativePath, out retval, m, p);
+            int s = SafeNativeMethods.Gdip.GdipGetPathWorldBounds(_nativePath, out retval, m, p);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
 
@@ -760,7 +760,7 @@ namespace System.Drawing.Drawing2D
             bool result;
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.nativeObject;
 
-            int s = SafeNativeMethods.Gdip.GdipIsOutlineVisiblePathPointI(nativePath, x, y, pen.NativePen, g, out result);
+            int s = SafeNativeMethods.Gdip.GdipIsOutlineVisiblePathPointI(_nativePath, x, y, pen.NativePen, g, out result);
             SafeNativeMethods.Gdip.CheckStatus(s);
 
             return result;
@@ -774,7 +774,7 @@ namespace System.Drawing.Drawing2D
             bool result;
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.nativeObject;
 
-            int s = SafeNativeMethods.Gdip.GdipIsOutlineVisiblePathPoint(nativePath, x, y, pen.NativePen, g, out result);
+            int s = SafeNativeMethods.Gdip.GdipIsOutlineVisiblePathPoint(_nativePath, x, y, pen.NativePen, g, out result);
             SafeNativeMethods.Gdip.CheckStatus(s);
 
             return result;
@@ -816,7 +816,7 @@ namespace System.Drawing.Drawing2D
 
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.nativeObject;
 
-            int s = SafeNativeMethods.Gdip.GdipIsVisiblePathPointI(nativePath, x, y, g, out retval);
+            int s = SafeNativeMethods.Gdip.GdipIsVisiblePathPointI(_nativePath, x, y, g, out retval);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
 
@@ -829,7 +829,7 @@ namespace System.Drawing.Drawing2D
 
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.nativeObject;
 
-            int s = SafeNativeMethods.Gdip.GdipIsVisiblePathPoint(nativePath, x, y, g, out retval);
+            int s = SafeNativeMethods.Gdip.GdipIsVisiblePathPoint(_nativePath, x, y, g, out retval);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
 
@@ -838,14 +838,14 @@ namespace System.Drawing.Drawing2D
 
         public void SetMarkers()
         {
-            int s = SafeNativeMethods.Gdip.GdipSetPathMarker(nativePath);
+            int s = SafeNativeMethods.Gdip.GdipSetPathMarker(_nativePath);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
         }
 
         public void StartFigure()
         {
-            int s = SafeNativeMethods.Gdip.GdipStartPathFigure(nativePath);
+            int s = SafeNativeMethods.Gdip.GdipStartPathFigure(_nativePath);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
         }
@@ -872,7 +872,7 @@ namespace System.Drawing.Drawing2D
 
             IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.nativeMatrix;
 
-            int s = SafeNativeMethods.Gdip.GdipWarpPath(nativePath, m, destPoints, destPoints.Length,
+            int s = SafeNativeMethods.Gdip.GdipWarpPath(_nativePath, m, destPoints, destPoints.Length,
                             srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height, warpMode, flatness);
 
             SafeNativeMethods.Gdip.CheckStatus(s);
@@ -896,7 +896,7 @@ namespace System.Drawing.Drawing2D
                 return;
             IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.nativeMatrix;
 
-            int s = SafeNativeMethods.Gdip.GdipWidenPath(nativePath, pen.NativePen, m, flatness);
+            int s = SafeNativeMethods.Gdip.GdipWidenPath(_nativePath, pen.NativePen, m, flatness);
             SafeNativeMethods.Gdip.CheckStatus(s);
         }
     }

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Windows.cs
@@ -12,19 +12,18 @@ namespace System.Drawing.Drawing2D
 {
     public sealed class GraphicsPath : MarshalByRefObject, ICloneable, IDisposable
     {
-        internal IntPtr nativePath;
+        internal IntPtr _nativePath;
 
         public GraphicsPath() : this(FillMode.Alternate) { }
 
         public GraphicsPath(FillMode fillMode)
         {
-            IntPtr nativePath;
-            int status = SafeNativeMethods.Gdip.GdipCreatePath(unchecked((int)fillMode), out nativePath);
+            int status = SafeNativeMethods.Gdip.GdipCreatePath(unchecked((int)fillMode), out IntPtr nativePath);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
 
-            this.nativePath = nativePath;
+            _nativePath = nativePath;
         }
 
         public GraphicsPath(PointF[] pts, byte[] types) : this(pts, types, FillMode.Alternate) { }
@@ -32,33 +31,33 @@ namespace System.Drawing.Drawing2D
         public GraphicsPath(PointF[] pts, byte[] types, FillMode fillMode)
         {
             if (pts == null)
-                throw new ArgumentNullException("pts");
-
+                throw new ArgumentNullException(nameof(pts));
             if (pts.Length != types.Length)
                 throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.InvalidParameter);
 
             int count = types.Length;
             IntPtr ptbuf = SafeNativeMethods.Gdip.ConvertPointToMemory(pts);
             IntPtr typebuf = Marshal.AllocHGlobal(count);
-            IntPtr nativePath = IntPtr.Zero;
             try
             {
                 Marshal.Copy(types, 0, typebuf, count);
 
-                int status = SafeNativeMethods.Gdip.GdipCreatePath2(new HandleRef(null, ptbuf), new HandleRef(null, typebuf), count,
-                                                     unchecked((int)fillMode), out nativePath);
-
+                int status = SafeNativeMethods.Gdip.GdipCreatePath2(
+                    new HandleRef(null, ptbuf),
+                    new HandleRef(null, typebuf),
+                    count,
+                    unchecked((int)fillMode),
+                    out IntPtr nativePath);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
+                _nativePath = nativePath;
             }
             finally
             {
                 Marshal.FreeHGlobal(ptbuf);
                 Marshal.FreeHGlobal(typebuf);
             }
-
-            this.nativePath = nativePath;
         }
 
         public GraphicsPath(Point[] pts, byte[] types) : this(pts, types, FillMode.Alternate) { }
@@ -66,7 +65,7 @@ namespace System.Drawing.Drawing2D
         public GraphicsPath(Point[] pts, byte[] types, FillMode fillMode)
         {
             if (pts == null)
-                throw new ArgumentNullException("pts");
+                throw new ArgumentNullException(nameof(pts));
 
             if (pts.Length != types.Length)
                 throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.InvalidParameter);
@@ -74,29 +73,32 @@ namespace System.Drawing.Drawing2D
             int count = types.Length;
             IntPtr ptbuf = SafeNativeMethods.Gdip.ConvertPointToMemory(pts);
             IntPtr typebuf = Marshal.AllocHGlobal(count);
-            IntPtr nativePath = IntPtr.Zero;
             try
             {
                 Marshal.Copy(types, 0, typebuf, count);
 
-                int status = SafeNativeMethods.Gdip.GdipCreatePath2I(new HandleRef(null, ptbuf), new HandleRef(null, typebuf), count,
-                                                      unchecked((int)fillMode), out nativePath);
+                int status = SafeNativeMethods.Gdip.GdipCreatePath2I(
+                    new HandleRef(null, ptbuf),
+                    new HandleRef(null, typebuf),
+                    count,
+                    unchecked((int)fillMode),
+                    out IntPtr nativePath);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
+
+                _nativePath = nativePath;
             }
             finally
             {
                 Marshal.FreeHGlobal(ptbuf);
                 Marshal.FreeHGlobal(typebuf);
             }
-
-            this.nativePath = nativePath;
         }
 
         public object Clone()
         {
-            IntPtr clonedPath = IntPtr.Zero;
-            int status = SafeNativeMethods.Gdip.GdipClonePath(new HandleRef(this, nativePath), out clonedPath);
+            int status = SafeNativeMethods.Gdip.GdipClonePath(new HandleRef(this, _nativePath), out IntPtr clonedPath);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -107,9 +109,9 @@ namespace System.Drawing.Drawing2D
         private GraphicsPath(IntPtr nativePath, int extra)
         {
             if (nativePath == IntPtr.Zero)
-                throw new ArgumentNullException("nativePath");
+                throw new ArgumentNullException(nameof(nativePath));
 
-            this.nativePath = nativePath;
+            _nativePath = nativePath;
         }
 
         public void Dispose()
@@ -120,14 +122,14 @@ namespace System.Drawing.Drawing2D
 
         private void Dispose(bool disposing)
         {
-            if (nativePath != IntPtr.Zero)
+            if (_nativePath != IntPtr.Zero)
             {
                 try
                 {
 #if DEBUG
                     int status =
 #endif
-                    SafeNativeMethods.Gdip.GdipDeletePath(new HandleRef(this, nativePath));
+                    SafeNativeMethods.Gdip.GdipDeletePath(new HandleRef(this, _nativePath));
 #if DEBUG
                     Debug.Assert(status == SafeNativeMethods.Gdip.Ok, "GDI+ returned an error status: " + status.ToString(CultureInfo.InvariantCulture));
 #endif        
@@ -143,7 +145,7 @@ namespace System.Drawing.Drawing2D
                 }
                 finally
                 {
-                    nativePath = IntPtr.Zero;
+                    _nativePath = IntPtr.Zero;
                 }
             }
         }
@@ -152,7 +154,7 @@ namespace System.Drawing.Drawing2D
 
         public void Reset()
         {
-            int status = SafeNativeMethods.Gdip.GdipResetPath(new HandleRef(this, nativePath));
+            int status = SafeNativeMethods.Gdip.GdipResetPath(new HandleRef(this, _nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -162,7 +164,7 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                int status = SafeNativeMethods.Gdip.GdipGetPathFillMode(new HandleRef(this, nativePath), out int fillmode);
+                int status = SafeNativeMethods.Gdip.GdipGetPathFillMode(new HandleRef(this, _nativePath), out int fillmode);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -176,7 +178,7 @@ namespace System.Drawing.Drawing2D
                     throw new InvalidEnumArgumentException(nameof(value), unchecked((int)value), typeof(FillMode));
                 }
 
-                int status = SafeNativeMethods.Gdip.GdipSetPathFillMode(new HandleRef(this, nativePath), (int)value);
+                int status = SafeNativeMethods.Gdip.GdipSetPathFillMode(new HandleRef(this, _nativePath), (int)value);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -206,7 +208,7 @@ namespace System.Drawing.Drawing2D
                     Types = t
                 };
 
-                int status = SafeNativeMethods.Gdip.GdipGetPathData(new HandleRef(this, nativePath), &data);
+                int status = SafeNativeMethods.Gdip.GdipGetPathData(new HandleRef(this, _nativePath), &data);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                 {
@@ -221,7 +223,7 @@ namespace System.Drawing.Drawing2D
 
         public void StartFigure()
         {
-            int status = SafeNativeMethods.Gdip.GdipStartPathFigure(new HandleRef(this, nativePath));
+            int status = SafeNativeMethods.Gdip.GdipStartPathFigure(new HandleRef(this, _nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -229,7 +231,7 @@ namespace System.Drawing.Drawing2D
 
         public void CloseFigure()
         {
-            int status = SafeNativeMethods.Gdip.GdipClosePathFigure(new HandleRef(this, nativePath));
+            int status = SafeNativeMethods.Gdip.GdipClosePathFigure(new HandleRef(this, _nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -237,7 +239,7 @@ namespace System.Drawing.Drawing2D
 
         public void CloseAllFigures()
         {
-            int status = SafeNativeMethods.Gdip.GdipClosePathFigures(new HandleRef(this, nativePath));
+            int status = SafeNativeMethods.Gdip.GdipClosePathFigures(new HandleRef(this, _nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -245,7 +247,7 @@ namespace System.Drawing.Drawing2D
 
         public void SetMarkers()
         {
-            int status = SafeNativeMethods.Gdip.GdipSetPathMarker(new HandleRef(this, nativePath));
+            int status = SafeNativeMethods.Gdip.GdipSetPathMarker(new HandleRef(this, _nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -253,7 +255,7 @@ namespace System.Drawing.Drawing2D
 
         public void ClearMarkers()
         {
-            int status = SafeNativeMethods.Gdip.GdipClearPathMarkers(new HandleRef(this, nativePath));
+            int status = SafeNativeMethods.Gdip.GdipClearPathMarkers(new HandleRef(this, _nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -261,7 +263,7 @@ namespace System.Drawing.Drawing2D
 
         public void Reverse()
         {
-            int status = SafeNativeMethods.Gdip.GdipReversePath(new HandleRef(this, nativePath));
+            int status = SafeNativeMethods.Gdip.GdipReversePath(new HandleRef(this, _nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -270,7 +272,7 @@ namespace System.Drawing.Drawing2D
         public PointF GetLastPoint()
         {
             GPPOINTF gppt = new GPPOINTF();
-            int status = SafeNativeMethods.Gdip.GdipGetPathLastPoint(new HandleRef(this, nativePath), gppt);
+            int status = SafeNativeMethods.Gdip.GdipGetPathLastPoint(new HandleRef(this, _nativePath), gppt);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -286,12 +288,11 @@ namespace System.Drawing.Drawing2D
 
         public bool IsVisible(PointF pt, Graphics graphics)
         {
-            int status = SafeNativeMethods.Gdip.GdipIsVisiblePathPoint(new HandleRef(this, nativePath),
-                                                        pt.X,
-                                                        pt.Y,
-                                                        new HandleRef(graphics, (graphics != null) ?
-                                                            graphics.NativeGraphics : IntPtr.Zero),
-                                                        out int isVisible);
+            int status = SafeNativeMethods.Gdip.GdipIsVisiblePathPoint(
+                new HandleRef(this, _nativePath),
+                pt.X, pt.Y,
+                new HandleRef(graphics, (graphics != null) ? graphics.NativeGraphics : IntPtr.Zero),
+                out int isVisible);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -307,12 +308,11 @@ namespace System.Drawing.Drawing2D
 
         public bool IsVisible(Point pt, Graphics graphics)
         {
-            int status = SafeNativeMethods.Gdip.GdipIsVisiblePathPointI(new HandleRef(this, nativePath),
-                                                         pt.X,
-                                                         pt.Y,
-                                                         new HandleRef(graphics, (graphics != null) ?
-                                                             graphics.NativeGraphics : IntPtr.Zero),
-                                                         out int isVisible);
+            int status = SafeNativeMethods.Gdip.GdipIsVisiblePathPointI(
+                new HandleRef(this, _nativePath),
+                pt.X, pt.Y,
+                new HandleRef(graphics, (graphics != null) ? graphics.NativeGraphics : IntPtr.Zero),
+                out int isVisible);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -332,15 +332,14 @@ namespace System.Drawing.Drawing2D
         public bool IsOutlineVisible(PointF pt, Pen pen, Graphics graphics)
         {
             if (pen == null)
-                throw new ArgumentNullException("pen");
+                throw new ArgumentNullException(nameof(pen));
 
-            int status = SafeNativeMethods.Gdip.GdipIsOutlineVisiblePathPoint(new HandleRef(this, nativePath),
-                                                               pt.X,
-                                                               pt.Y,
-                                                               new HandleRef(pen, pen.NativePen),
-                                                               new HandleRef(graphics, (graphics != null) ?
-                                                                   graphics.NativeGraphics : IntPtr.Zero),
-                                                               out int isVisible);
+            int status = SafeNativeMethods.Gdip.GdipIsOutlineVisiblePathPoint(
+                new HandleRef(this, _nativePath),
+                pt.X, pt.Y,
+                new HandleRef(pen, pen.NativePen),
+                new HandleRef(graphics, (graphics != null) ? graphics.NativeGraphics : IntPtr.Zero),
+                out int isVisible);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -360,15 +359,14 @@ namespace System.Drawing.Drawing2D
         public bool IsOutlineVisible(Point pt, Pen pen, Graphics graphics)
         {
             if (pen == null)
-                throw new ArgumentNullException("pen");
+                throw new ArgumentNullException(nameof(pen));
 
-            int status = SafeNativeMethods.Gdip.GdipIsOutlineVisiblePathPointI(new HandleRef(this, nativePath),
-                                                                pt.X,
-                                                                pt.Y,
-                                                                new HandleRef(pen, pen.NativePen),
-                                                                new HandleRef(graphics, (graphics != null) ?
-                                                                    graphics.NativeGraphics : IntPtr.Zero),
-                                                                out int isVisible);
+            int status = SafeNativeMethods.Gdip.GdipIsOutlineVisiblePathPointI(
+                new HandleRef(this, _nativePath),
+                pt.X, pt.Y,
+                new HandleRef(pen, pen.NativePen),
+                new HandleRef(graphics, (graphics != null) ? graphics.NativeGraphics : IntPtr.Zero),
+                out int isVisible);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -380,7 +378,7 @@ namespace System.Drawing.Drawing2D
 
         public void AddLine(float x1, float y1, float x2, float y2)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathLine(new HandleRef(this, nativePath), x1, y1, x2, y2);
+            int status = SafeNativeMethods.Gdip.GdipAddPathLine(new HandleRef(this, _nativePath), x1, y1, x2, y2);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -389,11 +387,12 @@ namespace System.Drawing.Drawing2D
         public void AddLines(PointF[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathLine2(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathLine2(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -407,7 +406,7 @@ namespace System.Drawing.Drawing2D
 
         public void AddLine(int x1, int y1, int x2, int y2)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathLineI(new HandleRef(this, nativePath), x1, y1, x2, y2);
+            int status = SafeNativeMethods.Gdip.GdipAddPathLineI(new HandleRef(this, _nativePath), x1, y1, x2, y2);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -416,11 +415,12 @@ namespace System.Drawing.Drawing2D
         public void AddLines(Point[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathLine2I(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathLine2I(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -435,11 +435,13 @@ namespace System.Drawing.Drawing2D
             AddArc(rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
         }
 
-        public void AddArc(float x, float y, float width, float height,
-                           float startAngle, float sweepAngle)
+        public void AddArc(float x, float y, float width, float height, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathArc(new HandleRef(this, nativePath), x, y, width, height,
-                                                startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathArc(
+                new HandleRef(this, _nativePath),
+                x, y, width, height,
+                startAngle,
+                sweepAngle);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -450,11 +452,13 @@ namespace System.Drawing.Drawing2D
             AddArc(rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
         }
 
-        public void AddArc(int x, int y, int width, int height,
-                           float startAngle, float sweepAngle)
+        public void AddArc(int x, int y, int width, int height, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathArcI(new HandleRef(this, nativePath), x, y, width, height,
-                                                 startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathArcI(
+                new HandleRef(this, _nativePath),
+                x, y, width, height,
+                startAngle,
+                sweepAngle);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -465,11 +469,11 @@ namespace System.Drawing.Drawing2D
             AddBezier(pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y, pt4.X, pt4.Y);
         }
 
-        public void AddBezier(float x1, float y1, float x2, float y2,
-                              float x3, float y3, float x4, float y4)
+        public void AddBezier(float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathBezier(new HandleRef(this, nativePath), x1, y1, x2, y2,
-                                                   x3, y3, x4, y4);
+            int status = SafeNativeMethods.Gdip.GdipAddPathBezier(
+                new HandleRef(this, _nativePath),
+                x1, y1, x2, y2, x3, y3, x4, y4);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -478,11 +482,12 @@ namespace System.Drawing.Drawing2D
         public void AddBeziers(PointF[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathBeziers(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathBeziers(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -497,11 +502,11 @@ namespace System.Drawing.Drawing2D
             AddBezier(pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y, pt4.X, pt4.Y);
         }
 
-        public void AddBezier(int x1, int y1, int x2, int y2,
-                              int x3, int y3, int x4, int y4)
+        public void AddBezier(int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathBezierI(new HandleRef(this, nativePath), x1, y1, x2, y2,
-                                                    x3, y3, x4, y4);
+            int status = SafeNativeMethods.Gdip.GdipAddPathBezierI(
+                new HandleRef(this, _nativePath),
+                x1, y1, x2, y2, x3, y3, x4, y4);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -510,11 +515,12 @@ namespace System.Drawing.Drawing2D
         public void AddBeziers(params Point[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathBeziersI(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathBeziersI(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -524,17 +530,22 @@ namespace System.Drawing.Drawing2D
             }
         }
 
-        /*
-         * Add cardinal splines to the path object
-         */
+        /// <summary>
+        /// Add cardinal splines to the path object
+        /// </summary>
         public void AddCurve(PointF[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathCurve(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathCurve(
+                    new HandleRef(this, _nativePath),
+                    new HandleRef(null, buf),
+                    points.Length);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -547,12 +558,17 @@ namespace System.Drawing.Drawing2D
         public void AddCurve(PointF[] points, float tension)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathCurve2(new HandleRef(this, nativePath), new HandleRef(null, buf),
-                                                   points.Length, tension);
+                int status = SafeNativeMethods.Gdip.GdipAddPathCurve2(
+                    new HandleRef(this, _nativePath),
+                    new HandleRef(null, buf),
+                    points.Length,
+                    tension);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -565,13 +581,19 @@ namespace System.Drawing.Drawing2D
         public void AddCurve(PointF[] points, int offset, int numberOfSegments, float tension)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathCurve3(new HandleRef(this, nativePath), new HandleRef(null, buf),
-                                                   points.Length, offset,
-                                                   numberOfSegments, tension);
+                int status = SafeNativeMethods.Gdip.GdipAddPathCurve3(
+                    new HandleRef(this, _nativePath),
+                    new HandleRef(null, buf),
+                    points.Length,
+                    offset,
+                    numberOfSegments,
+                    tension);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -584,11 +606,13 @@ namespace System.Drawing.Drawing2D
         public void AddCurve(Point[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathCurveI(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathCurveI(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -601,12 +625,17 @@ namespace System.Drawing.Drawing2D
         public void AddCurve(Point[] points, float tension)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathCurve2I(new HandleRef(this, nativePath), new HandleRef(null, buf),
-                                                    points.Length, tension);
+                int status = SafeNativeMethods.Gdip.GdipAddPathCurve2I(
+                    new HandleRef(this, _nativePath),
+                    new HandleRef(null, buf),
+                    points.Length,
+                    tension);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -619,13 +648,19 @@ namespace System.Drawing.Drawing2D
         public void AddCurve(Point[] points, int offset, int numberOfSegments, float tension)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathCurve3I(new HandleRef(this, nativePath), new HandleRef(null, buf),
-                                                    points.Length, offset,
-                                                    numberOfSegments, tension);
+                int status = SafeNativeMethods.Gdip.GdipAddPathCurve3I(
+                    new HandleRef(this, _nativePath),
+                    new HandleRef(null, buf),
+                    points.Length,
+                    offset,
+                    numberOfSegments,
+                    tension);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -638,11 +673,12 @@ namespace System.Drawing.Drawing2D
         public void AddClosedCurve(PointF[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -655,11 +691,17 @@ namespace System.Drawing.Drawing2D
         public void AddClosedCurve(PointF[] points, float tension)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve2(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length, tension);
+                int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve2(
+                    new HandleRef(this, _nativePath),
+                    new HandleRef(null, buf),
+                    points.Length,
+                    tension);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -672,11 +714,12 @@ namespace System.Drawing.Drawing2D
         public void AddClosedCurve(Point[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurveI(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurveI(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -689,11 +732,17 @@ namespace System.Drawing.Drawing2D
         public void AddClosedCurve(Point[] points, float tension)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve2I(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length, tension);
+                int status = SafeNativeMethods.Gdip.GdipAddPathClosedCurve2I(
+                    new HandleRef(this, _nativePath),
+                    new HandleRef(null, buf),
+                    points.Length,
+                    tension);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -705,8 +754,9 @@ namespace System.Drawing.Drawing2D
 
         public void AddRectangle(RectangleF rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathRectangle(new HandleRef(this, nativePath), rect.X, rect.Y,
-                                                      rect.Width, rect.Height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathRectangle(
+                new HandleRef(this, _nativePath),
+                rect.X, rect.Y, rect.Width, rect.Height);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -715,11 +765,12 @@ namespace System.Drawing.Drawing2D
         public void AddRectangles(RectangleF[] rects)
         {
             if (rects == null)
-                throw new ArgumentNullException("rects");
+                throw new ArgumentNullException(nameof(rects));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertRectangleToMemory(rects);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathRectangles(new HandleRef(this, nativePath), new HandleRef(null, buf), rects.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathRectangles(new HandleRef(this, _nativePath), new HandleRef(null, buf), rects.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -731,8 +782,9 @@ namespace System.Drawing.Drawing2D
 
         public void AddRectangle(Rectangle rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathRectangleI(new HandleRef(this, nativePath), rect.X, rect.Y,
-                                                       rect.Width, rect.Height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathRectangleI(
+                new HandleRef(this, _nativePath),
+                rect.X, rect.Y, rect.Width, rect.Height);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -741,11 +793,12 @@ namespace System.Drawing.Drawing2D
         public void AddRectangles(Rectangle[] rects)
         {
             if (rects == null)
-                throw new ArgumentNullException("rects");
+                throw new ArgumentNullException(nameof(rects));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertRectangleToMemory(rects);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathRectanglesI(new HandleRef(this, nativePath), new HandleRef(null, buf), rects.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathRectanglesI(new HandleRef(this, _nativePath), new HandleRef(null, buf), rects.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -762,7 +815,7 @@ namespace System.Drawing.Drawing2D
 
         public void AddEllipse(float x, float y, float width, float height)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathEllipse(new HandleRef(this, nativePath), x, y, width, height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathEllipse(new HandleRef(this, _nativePath), x, y, width, height);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -772,7 +825,7 @@ namespace System.Drawing.Drawing2D
 
         public void AddEllipse(int x, int y, int width, int height)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathEllipseI(new HandleRef(this, nativePath), x, y, width, height);
+            int status = SafeNativeMethods.Gdip.GdipAddPathEllipseI(new HandleRef(this, _nativePath), x, y, width, height);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -783,21 +836,25 @@ namespace System.Drawing.Drawing2D
             AddPie(rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
         }
 
-        public void AddPie(float x, float y, float width, float height,
-                           float startAngle, float sweepAngle)
+        public void AddPie(float x, float y, float width, float height, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathPie(new HandleRef(this, nativePath), x, y, width, height,
-                                                startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathPie(
+                new HandleRef(this, _nativePath),
+                x, y, width, height,
+                startAngle,
+                sweepAngle);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        public void AddPie(int x, int y, int width, int height,
-                           float startAngle, float sweepAngle)
+        public void AddPie(int x, int y, int width, int height, float startAngle, float sweepAngle)
         {
-            int status = SafeNativeMethods.Gdip.GdipAddPathPieI(new HandleRef(this, nativePath), x, y, width, height,
-                                                 startAngle, sweepAngle);
+            int status = SafeNativeMethods.Gdip.GdipAddPathPieI(
+                new HandleRef(this, _nativePath),
+                x, y, width, height,
+                startAngle,
+                sweepAngle);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -806,11 +863,12 @@ namespace System.Drawing.Drawing2D
         public void AddPolygon(PointF[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathPolygon(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathPolygon(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -820,19 +878,18 @@ namespace System.Drawing.Drawing2D
             }
         }
 
-        // int version
-        /// <include file='doc\GraphicsPath.uex' path='docs/doc[@for="GraphicsPath.AddPolygon1"]/*' />
-        /// <devdoc>
-        ///    Adds a polygon to the current figure.
-        /// </devdoc>
+        /// <summary>
+        /// Adds a polygon to the current figure.
+        /// </summary>
         public void AddPolygon(Point[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
+
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipAddPathPolygonI(new HandleRef(this, nativePath), new HandleRef(null, buf), points.Length);
+                int status = SafeNativeMethods.Gdip.GdipAddPathPolygonI(new HandleRef(this, _nativePath), new HandleRef(null, buf), points.Length);
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -845,79 +902,79 @@ namespace System.Drawing.Drawing2D
         public void AddPath(GraphicsPath addingPath, bool connect)
         {
             if (addingPath == null)
-                throw new ArgumentNullException("addingPath");
+                throw new ArgumentNullException(nameof(addingPath));
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathPath(new HandleRef(this, nativePath), new HandleRef(addingPath, addingPath.nativePath), connect);
+            int status = SafeNativeMethods.Gdip.GdipAddPathPath(new HandleRef(this, _nativePath), new HandleRef(addingPath, addingPath._nativePath), connect);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        public void AddString(string s, FontFamily family, int style, float emSize,
-                              PointF origin, StringFormat format)
+        public void AddString(string s, FontFamily family, int style, float emSize, PointF origin, StringFormat format)
         {
             GPRECTF rectf = new GPRECTF(origin.X, origin.Y, 0, 0);
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathString(new HandleRef(this, nativePath),
-                                                   s,
-                                                   s.Length,
-                                                   new HandleRef(family, (family != null) ? family.NativeFamily : IntPtr.Zero),
-                                                   style,
-                                                   emSize,
-                                                   ref rectf,
-                                                   new HandleRef(format, (format != null) ? format.nativeFormat : IntPtr.Zero));
+            int status = SafeNativeMethods.Gdip.GdipAddPathString(
+                new HandleRef(this, _nativePath),
+                s,
+                s.Length,
+                new HandleRef(family, family?.NativeFamily ?? IntPtr.Zero),
+                style,
+                emSize,
+                ref rectf,
+                new HandleRef(format, format?.nativeFormat ?? IntPtr.Zero));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        public void AddString(string s, FontFamily family, int style, float emSize,
-                              Point origin, StringFormat format)
+        public void AddString(string s, FontFamily family, int style, float emSize, Point origin, StringFormat format)
         {
             var rect = new GPRECT(origin.X, origin.Y, 0, 0);
 
-            int status = SafeNativeMethods.Gdip.GdipAddPathStringI(new HandleRef(this, nativePath),
-                                                    s,
-                                                    s.Length,
-                                                    new HandleRef(family, (family != null) ? family.NativeFamily : IntPtr.Zero),
-                                                    style,
-                                                    emSize,
-                                                    ref rect,
-                                                    new HandleRef(format, (format != null) ? format.nativeFormat : IntPtr.Zero));
+            int status = SafeNativeMethods.Gdip.GdipAddPathStringI(
+                new HandleRef(this, _nativePath),
+                s,
+                s.Length,
+                new HandleRef(family, family?.NativeFamily ?? IntPtr.Zero),
+                style,
+                emSize,
+                ref rect,
+                new HandleRef(format, format?.nativeFormat ?? IntPtr.Zero));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        public void AddString(string s, FontFamily family, int style, float emSize,
-                              RectangleF layoutRect, StringFormat format)
+        public void AddString(string s, FontFamily family, int style, float emSize, RectangleF layoutRect, StringFormat format)
         {
             GPRECTF rectf = new GPRECTF(layoutRect);
-            int status = SafeNativeMethods.Gdip.GdipAddPathString(new HandleRef(this, nativePath),
-                                                   s,
-                                                   s.Length,
-                                                   new HandleRef(family, (family != null) ? family.NativeFamily : IntPtr.Zero),
-                                                   style,
-                                                   emSize,
-                                                   ref rectf,
-                                                   new HandleRef(format, (format != null) ? format.nativeFormat : IntPtr.Zero));
+            int status = SafeNativeMethods.Gdip.GdipAddPathString(
+                new HandleRef(this, _nativePath),
+                s,
+                s.Length,
+                new HandleRef(family, family?.NativeFamily ?? IntPtr.Zero),
+                style,
+                emSize,
+                ref rectf,
+                new HandleRef(format, format?.nativeFormat ?? IntPtr.Zero));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        public void AddString(string s, FontFamily family, int style, float emSize,
-                              Rectangle layoutRect, StringFormat format)
+        public void AddString(string s, FontFamily family, int style, float emSize, Rectangle layoutRect, StringFormat format)
         {
             GPRECT rect = new GPRECT(layoutRect);
-            int status = SafeNativeMethods.Gdip.GdipAddPathStringI(new HandleRef(this, nativePath),
-                                                   s,
-                                                   s.Length,
-                                                   new HandleRef(family, (family != null) ? family.NativeFamily : IntPtr.Zero),
-                                                   style,
-                                                   emSize,
-                                                   ref rect,
-                                                   new HandleRef(format, (format != null) ? format.nativeFormat : IntPtr.Zero));
+            int status = SafeNativeMethods.Gdip.GdipAddPathStringI(
+                new HandleRef(this, _nativePath),
+                s,
+                s.Length,
+                new HandleRef(family, family?.NativeFamily ?? IntPtr.Zero),
+                style,
+                emSize,
+                ref rect,
+                new HandleRef(format, format?.nativeFormat ?? IntPtr.Zero));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -926,19 +983,19 @@ namespace System.Drawing.Drawing2D
         public void Transform(Matrix matrix)
         {
             if (matrix == null)
-                throw new ArgumentNullException("matrix");
-
+                throw new ArgumentNullException(nameof(matrix));
             if (matrix.nativeMatrix == IntPtr.Zero)
                 return;
 
-            int status = SafeNativeMethods.Gdip.GdipTransformPath(new HandleRef(this, nativePath),
-                                                   new HandleRef(matrix, matrix.nativeMatrix));
+            int status = SafeNativeMethods.Gdip.GdipTransformPath(
+                new HandleRef(this, _nativePath),
+                new HandleRef(matrix, matrix.nativeMatrix));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        public RectangleF GetBounds() => GetBounds(null);   
+        public RectangleF GetBounds() => GetBounds(null);
 
         public RectangleF GetBounds(Matrix matrix) => GetBounds(matrix, null);
 
@@ -946,18 +1003,11 @@ namespace System.Drawing.Drawing2D
         {
             GPRECTF gprectf = new GPRECTF();
 
-            IntPtr nativeMatrix = IntPtr.Zero, nativePen = IntPtr.Zero;
-
-            if (matrix != null)
-                nativeMatrix = matrix.nativeMatrix;
-
-            if (pen != null)
-                nativePen = pen.NativePen;
-
-            int status = SafeNativeMethods.Gdip.GdipGetPathWorldBounds(new HandleRef(this, nativePath),
-                                                        ref gprectf,
-                                                        new HandleRef(matrix, nativeMatrix),
-                                                        new HandleRef(pen, nativePen));
+            int status = SafeNativeMethods.Gdip.GdipGetPathWorldBounds(
+                new HandleRef(this, _nativePath),
+                ref gprectf,
+                new HandleRef(matrix, matrix?.nativeMatrix ?? IntPtr.Zero),
+                new HandleRef(pen, pen?.NativePen ?? IntPtr.Zero));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -971,9 +1021,10 @@ namespace System.Drawing.Drawing2D
 
         public void Flatten(Matrix matrix, float flatness)
         {
-            int status = SafeNativeMethods.Gdip.GdipFlattenPath(new HandleRef(this, nativePath),
-                                                           new HandleRef(matrix, (matrix == null) ? IntPtr.Zero : matrix.nativeMatrix),
-                                                           flatness);
+            int status = SafeNativeMethods.Gdip.GdipFlattenPath(
+                new HandleRef(this, _nativePath),
+                new HandleRef(matrix, matrix?.nativeMatrix ?? IntPtr.Zero),
+                flatness);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -981,41 +1032,37 @@ namespace System.Drawing.Drawing2D
 
         public void Widen(Pen pen)
         {
-            float flatness = (float)2.0 / (float)3.0;
+            const float flatness = (float)2.0 / (float)3.0;
             Widen(pen, null, flatness);
         }
 
         public void Widen(Pen pen, Matrix matrix)
         {
-            float flatness = (float)2.0 / (float)3.0;
+            const float flatness = (float)2.0 / (float)3.0;
             Widen(pen, matrix, flatness);
         }
 
         public void Widen(Pen pen, Matrix matrix, float flatness)
         {
-            IntPtr nativeMatrix;
-
-            if (matrix == null)
-                nativeMatrix = IntPtr.Zero;
-            else
-                nativeMatrix = matrix.nativeMatrix;
+            IntPtr nativeMatrix = matrix?.nativeMatrix ?? IntPtr.Zero;
 
             if (pen == null)
-                throw new ArgumentNullException("pen");
+                throw new ArgumentNullException(nameof(pen));
 
             // GDI+ wrongly returns an out of memory status 
             // when there is nothing in the path, so we have to check 
             // before calling the widen method and do nothing if we dont have
             // anything in the path
-            SafeNativeMethods.Gdip.GdipGetPointCount(new HandleRef(this, nativePath), out int pointCount);
+            SafeNativeMethods.Gdip.GdipGetPointCount(new HandleRef(this, _nativePath), out int pointCount);
 
             if (pointCount == 0)
                 return;
 
-            int status = SafeNativeMethods.Gdip.GdipWidenPath(new HandleRef(this, nativePath),
-                                new HandleRef(pen, pen.NativePen),
-                                new HandleRef(matrix, nativeMatrix),
-                                flatness);
+            int status = SafeNativeMethods.Gdip.GdipWidenPath(
+                new HandleRef(this, _nativePath),
+                new HandleRef(pen, pen.NativePen),
+                new HandleRef(matrix, nativeMatrix),
+                flatness);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -1024,7 +1071,7 @@ namespace System.Drawing.Drawing2D
         public void Warp(PointF[] destPoints, RectangleF srcRect) => Warp(destPoints, srcRect, null);
 
         public void Warp(PointF[] destPoints, RectangleF srcRect, Matrix matrix) => Warp(destPoints, srcRect, matrix, WarpMode.Perspective);
-        
+
         public void Warp(PointF[] destPoints, RectangleF srcRect, Matrix matrix, WarpMode warpMode)
         {
             Warp(destPoints, srcRect, matrix, warpMode, 0.25f);
@@ -1033,21 +1080,20 @@ namespace System.Drawing.Drawing2D
         public void Warp(PointF[] destPoints, RectangleF srcRect, Matrix matrix, WarpMode warpMode, float flatness)
         {
             if (destPoints == null)
-                throw new ArgumentNullException("destPoints");
+                throw new ArgumentNullException(nameof(destPoints));
 
             IntPtr buf = SafeNativeMethods.Gdip.ConvertPointToMemory(destPoints);
             try
             {
-                int status = SafeNativeMethods.Gdip.GdipWarpPath(new HandleRef(this, nativePath),
-                                              new HandleRef(matrix, (matrix == null) ? IntPtr.Zero : matrix.nativeMatrix),
-                                              new HandleRef(null, buf),
-                                              destPoints.Length,
-                                              srcRect.X,
-                                              srcRect.Y,
-                                              srcRect.Width,
-                                              srcRect.Height,
-                                              warpMode,
-                                              flatness);
+                int status = SafeNativeMethods.Gdip.GdipWarpPath(
+                    new HandleRef(this, _nativePath),
+                    new HandleRef(matrix, (matrix == null) ? IntPtr.Zero : matrix.nativeMatrix),
+                    new HandleRef(null, buf),
+                    destPoints.Length,
+                    srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
+                    warpMode,
+                    flatness);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
             }
@@ -1061,7 +1107,7 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                int status = SafeNativeMethods.Gdip.GdipGetPointCount(new HandleRef(this, nativePath), out int count);
+                int status = SafeNativeMethods.Gdip.GdipGetPointCount(new HandleRef(this, _nativePath), out int count);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -1069,6 +1115,7 @@ namespace System.Drawing.Drawing2D
                 return count;
             }
         }
+
         public byte[] PathTypes
         {
             get
@@ -1076,7 +1123,7 @@ namespace System.Drawing.Drawing2D
                 int count = PointCount;
                 byte[] types = new byte[count];
 
-                int status = SafeNativeMethods.Gdip.GdipGetPathTypes(new HandleRef(this, nativePath), types, count);
+                int status = SafeNativeMethods.Gdip.GdipGetPathTypes(new HandleRef(this, _nativePath), types, count);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -1090,9 +1137,9 @@ namespace System.Drawing.Drawing2D
             get
             {
                 PointF[] points = new PointF[PointCount];
-                fixed(PointF* p = points)
+                fixed (PointF* p = points)
                 {
-                    int status = SafeNativeMethods.Gdip.GdipGetPathPoints(new HandleRef(this, nativePath), p, points.Length);
+                    int status = SafeNativeMethods.Gdip.GdipGetPathPoints(new HandleRef(this, _nativePath), p, points.Length);
 
                     if (status != SafeNativeMethods.Gdip.Ok)
                     {

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
@@ -13,7 +13,7 @@ namespace System.Drawing.Drawing2D
         public GraphicsPathIterator(GraphicsPath path)
         {
             IntPtr nativeIter = IntPtr.Zero;
-            int status = SafeNativeMethods.Gdip.GdipCreatePathIter(out nativeIter, new HandleRef(path, (path == null) ? IntPtr.Zero : path.nativePath));
+            int status = SafeNativeMethods.Gdip.GdipCreatePathIter(out nativeIter, new HandleRef(path, (path == null) ? IntPtr.Zero : path._nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -78,7 +78,7 @@ namespace System.Drawing.Drawing2D
         public int NextSubpath(GraphicsPath path, out bool isClosed)
         {
             int status = SafeNativeMethods.Gdip.GdipPathIterNextSubpathPath(new HandleRef(this, nativeIter), out int resultCount,
-                        new HandleRef(path, (path == null) ? IntPtr.Zero : path.nativePath), out isClosed);
+                        new HandleRef(path, (path == null) ? IntPtr.Zero : path._nativePath), out isClosed);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -111,7 +111,7 @@ namespace System.Drawing.Drawing2D
         public int NextMarker(GraphicsPath path)
         {
             int status = SafeNativeMethods.Gdip.GdipPathIterNextMarkerPath(new HandleRef(this, nativeIter), out int resultCount,
-                        new HandleRef(path, (path == null) ? IntPtr.Zero : path.nativePath));
+                        new HandleRef(path, (path == null) ? IntPtr.Zero : path._nativePath));
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/Matrix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/Matrix.cs
@@ -13,8 +13,7 @@ namespace System.Drawing.Drawing2D
 
         public Matrix()
         {
-            IntPtr nativeMatrix;
-            int status = SafeNativeMethods.Gdip.GdipCreateMatrix(out nativeMatrix);
+            int status = SafeNativeMethods.Gdip.GdipCreateMatrix(out IntPtr nativeMatrix);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -24,8 +23,7 @@ namespace System.Drawing.Drawing2D
 
         public Matrix(float m11, float m12, float m21, float m22, float dx, float dy)
         {
-            IntPtr nativeMatrix;
-            int status = SafeNativeMethods.Gdip.GdipCreateMatrix2(m11, m12, m21, m22, dx, dy, out nativeMatrix);
+            int status = SafeNativeMethods.Gdip.GdipCreateMatrix2(m11, m12, m21, m22, dx, dy, out IntPtr nativeMatrix);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -49,8 +47,7 @@ namespace System.Drawing.Drawing2D
             try
             {
                 GPRECTF gprectf = new GPRECTF(rect);
-                IntPtr nativeMatrix;
-                int status = SafeNativeMethods.Gdip.GdipCreateMatrix3(ref gprectf, new HandleRef(null, buf), out nativeMatrix);
+                int status = SafeNativeMethods.Gdip.GdipCreateMatrix3(ref gprectf, new HandleRef(null, buf), out IntPtr nativeMatrix);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                 {
@@ -81,8 +78,7 @@ namespace System.Drawing.Drawing2D
             try
             {
                 GPRECT gprect = new GPRECT(rect);
-                IntPtr nativeMatrix;
-                int status = SafeNativeMethods.Gdip.GdipCreateMatrix3I(ref gprect, new HandleRef(null, buf), out nativeMatrix);
+                int status = SafeNativeMethods.Gdip.GdipCreateMatrix3I(ref gprect, new HandleRef(null, buf), out IntPtr nativeMatrix);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                 {
@@ -116,15 +112,14 @@ namespace System.Drawing.Drawing2D
 
         public Matrix Clone()
         {
-            IntPtr clonedMatrix;
-            int status = SafeNativeMethods.Gdip.GdipCloneMatrix(new HandleRef(this, nativeMatrix), out clonedMatrix);
+            int status = SafeNativeMethods.Gdip.GdipCloneMatrix(new HandleRef(this, nativeMatrix), out IntPtr clonedMatrix);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
 
             return new Matrix(clonedMatrix);
         }
-    
+
         public float[] Elements
         {
             get
@@ -367,7 +362,8 @@ namespace System.Drawing.Drawing2D
         public override bool Equals(object obj)
         {
             Matrix matrix2 = obj as Matrix;
-            if (matrix2 == null) return false;
+            if (matrix2 == null)
+                return false;
 
 
             int status = SafeNativeMethods.Gdip.GdipIsMatrixEqual(new HandleRef(this, nativeMatrix),

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -19,7 +19,7 @@ namespace System.Drawing.Drawing2D
             {
                 throw new ArgumentNullException(nameof(points));
             }
-            
+
             if (wrapMode < WrapMode.Tile || wrapMode > WrapMode.Clamp)
             {
                 throw new InvalidEnumArgumentException(nameof(wrapMode), unchecked((int)wrapMode), typeof(WrapMode));
@@ -28,11 +28,10 @@ namespace System.Drawing.Drawing2D
             IntPtr pointsBuf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                IntPtr nativeBrush;
                 int status = SafeNativeMethods.Gdip.GdipCreatePathGradient(new HandleRef(null, pointsBuf),
                                                             points.Length,
                                                             unchecked((int)wrapMode),
-                                                            out nativeBrush);
+                                                            out IntPtr nativeBrush);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -68,11 +67,10 @@ namespace System.Drawing.Drawing2D
             IntPtr pointsBuf = SafeNativeMethods.Gdip.ConvertPointToMemory(points);
             try
             {
-                IntPtr nativeBrush;
                 int status = SafeNativeMethods.Gdip.GdipCreatePathGradientI(new HandleRef(null, pointsBuf),
                                                              points.Length,
                                                              unchecked((int)wrapMode),
-                                                             out nativeBrush);
+                                                             out IntPtr nativeBrush);
 
                 if (status != SafeNativeMethods.Gdip.Ok)
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -98,8 +96,7 @@ namespace System.Drawing.Drawing2D
                 throw new ArgumentNullException(nameof(path));
             }
 
-            IntPtr nativeBrush;
-            int status = SafeNativeMethods.Gdip.GdipCreatePathGradientFromPath(new HandleRef(path, path.nativePath), out nativeBrush);
+            int status = SafeNativeMethods.Gdip.GdipCreatePathGradientFromPath(new HandleRef(path, path._nativePath), out IntPtr nativeBrush);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
@@ -115,8 +112,7 @@ namespace System.Drawing.Drawing2D
 
         public override object Clone()
         {
-            IntPtr clonedBrush;
-            int status = SafeNativeMethods.Gdip.GdipCloneBrush(new HandleRef(this, NativeBrush), out clonedBrush);
+            int status = SafeNativeMethods.Gdip.GdipCloneBrush(new HandleRef(this, NativeBrush), out IntPtr clonedBrush);
 
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);

--- a/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -80,11 +80,10 @@ namespace System.Drawing
                 PlatformInitialize();
 
                 StartupInput input = StartupInput.GetDefault();
-                StartupOutput output;
 
                 // GDI+ ref counts multiple calls to Startup in the same process, so calls from multiple
                 // domains are ok, just make sure to pair each w/GdiplusShutdown
-                int status = GdiplusStartup(out s_initToken, ref input, out output);
+                int status = GdiplusStartup(out s_initToken, ref input, out StartupOutput output);
                 CheckStatus(status);
 
                 Debug.Unindent();
@@ -139,7 +138,7 @@ namespace System.Drawing
 
             /// <summary>
             /// Shutsdown GDI+
-            /// </summary>            
+            /// </summary>
             private static void Shutdown()
             {
                 Debug.WriteLineIf(s_gdiPlusInitialization.TraceVerbose, "Shutdown GDI+ [" + AppDomain.CurrentDomain.FriendlyName + "]");
@@ -200,7 +199,7 @@ namespace System.Drawing
             {
             }
 
-            //----------------------------------------------------------------------------------------                                                           
+            //----------------------------------------------------------------------------------------
             // Initialization methods (GdiplusInit.h)
             //----------------------------------------------------------------------------------------
 
@@ -229,7 +228,7 @@ namespace System.Drawing
             internal static int GdipDeleteFont(HandleRef font) => Initialized ? IntGdipDeleteFont(font) : Ok;
             internal static int GdipDeleteStringFormat(HandleRef format) => Initialized ? IntGdipDeleteStringFormat(format) : Ok;
 
-            //----------------------------------------------------------------------------------------                                                           
+            //----------------------------------------------------------------------------------------
             // Status codes
             //----------------------------------------------------------------------------------------
             internal const int Ok = 0;
@@ -257,9 +256,7 @@ namespace System.Drawing
             internal static void CheckStatus(int status)
             {
                 if (status != Ok)
-                {
                     throw StatusException(status);
-                }
             }
 
             internal static Exception StatusException(int status)
@@ -321,17 +318,15 @@ namespace System.Drawing
                 return new ExternalException(SR.GdiplusUnknown, E_UNEXPECTED);
             }
 
-            //----------------------------------------------------------------------------------------                                                           
+            //----------------------------------------------------------------------------------------
             // Helper function:  Convert PointF[] to native memory block GpPointF*
             //----------------------------------------------------------------------------------------
             internal static IntPtr ConvertPointToMemory(PointF[] points)
             {
                 if (points == null)
-                {
                     throw new ArgumentNullException(nameof(points));
-                }
 
-                int size = (int)Marshal.SizeOf(typeof(GPPOINTF));
+                int size = Marshal.SizeOf(typeof(GPPOINTF));
                 int count = points.Length;
                 IntPtr memory = Marshal.AllocHGlobal(checked(count * size));
 
@@ -343,15 +338,13 @@ namespace System.Drawing
                 return memory;
             }
 
-            //----------------------------------------------------------------------------------------                                                           
+            //----------------------------------------------------------------------------------------
             // Helper function:  Convert Point[] to native memory block GpPoint*
             //----------------------------------------------------------------------------------------
             internal static IntPtr ConvertPointToMemory(Point[] points)
             {
                 if (points == null)
-                {
                     throw new ArgumentNullException(nameof(points));
-                }
 
                 int size = Marshal.SizeOf(typeof(GPPOINT));
                 int count = points.Length;
@@ -365,15 +358,13 @@ namespace System.Drawing
                 return memory;
             }
 
-            //----------------------------------------------------------------------------------------                                                           
+            //----------------------------------------------------------------------------------------
             // Helper function:  Convert RectangleF[] to native memory block GpRectF*
             //----------------------------------------------------------------------------------------
             internal static IntPtr ConvertRectangleToMemory(RectangleF[] rect)
             {
                 if (rect == null)
-                {
                     throw new ArgumentNullException(nameof(rect));
-                }
 
                 int size = Marshal.SizeOf(typeof(GPRECTF));
                 int count = rect.Length;
@@ -387,17 +378,15 @@ namespace System.Drawing
                 return memory;
             }
 
-            //----------------------------------------------------------------------------------------                                                           
+            //----------------------------------------------------------------------------------------
             // Helper function:  Convert Rectangle[] to native memory block GpRect*
             //----------------------------------------------------------------------------------------
             internal static IntPtr ConvertRectangleToMemory(Rectangle[] rect)
             {
                 if (rect == null)
-                {
                     throw new ArgumentNullException(nameof(rect));
-                }
 
-                int size = (int)Marshal.SizeOf(typeof(GPRECT));
+                int size = Marshal.SizeOf(typeof(GPRECT));
                 int count = rect.Length;
                 IntPtr memory = Marshal.AllocHGlobal(checked(count * size));
 
@@ -799,11 +788,12 @@ namespace System.Drawing
         {
             return IntGlobalAlloc(uFlags, new UIntPtr(dwBytes));
         }
-        
+
         static internal unsafe void ZeroMemory(byte* ptr, ulong length)
         {
             byte* end = ptr + length;
-            while (ptr != end) *ptr++ = 0;
+            while (ptr != end)
+                *ptr++ = 0;
         }
 
         public const int ERROR_ACCESS_DENIED = 5;

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -1046,7 +1046,7 @@ namespace System.Drawing
                 throw new ArgumentNullException("pen");
             if (path == null)
                 throw new ArgumentNullException("path");
-            int status = SafeNativeMethods.Gdip.GdipDrawPath(nativeObject, pen.NativePen, path.nativePath);
+            int status = SafeNativeMethods.Gdip.GdipDrawPath(nativeObject, pen.NativePen, path._nativePath);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -1467,7 +1467,7 @@ namespace System.Drawing
                 throw new ArgumentNullException("brush");
             if (path == null)
                 throw new ArgumentNullException("path");
-            int status = SafeNativeMethods.Gdip.GdipFillPath(nativeObject, brush.NativeBrush, path.nativePath);
+            int status = SafeNativeMethods.Gdip.GdipFillPath(nativeObject, brush.NativeBrush, path._nativePath);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -23,8 +23,7 @@ namespace System.Drawing
         public IntPtr GetHdc()
         {
             IntPtr hdc = IntPtr.Zero;
-            int status = SafeNativeMethods.Gdip.GdipGetDC(new HandleRef(this, NativeGraphics), out hdc);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipGetDC(new HandleRef(this, NativeGraphics), out hdc));
 
             _nativeHdc = hdc; // need to cache the hdc to be able to release with a call to IDeviceContext.ReleaseHdc().
             return _nativeHdc;
@@ -45,9 +44,7 @@ namespace System.Drawing
         /// </summary>
         public void Flush(FlushIntention intention)
         {
-            int status = SafeNativeMethods.Gdip.GdipFlush(new HandleRef(this, NativeGraphics), intention);
-            SafeNativeMethods.Gdip.CheckStatus(status);
-
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipFlush(new HandleRef(this, NativeGraphics), intention));
             FlushCore();
         }
 
@@ -56,30 +53,32 @@ namespace System.Drawing
         public void SetClip(Graphics g, CombineMode combineMode)
         {
             if (g == null)
-            {
                 throw new ArgumentNullException(nameof(g));
-            }
 
-            int status = SafeNativeMethods.Gdip.GdipSetClipGraphics(new HandleRef(this, NativeGraphics), new HandleRef(g, g.NativeGraphics), combineMode);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipGraphics(
+                new HandleRef(this, NativeGraphics),
+                new HandleRef(g, g.NativeGraphics),
+                combineMode));
         }
 
         public void SetClip(Rectangle rect) => SetClip(rect, CombineMode.Replace);
 
         public void SetClip(Rectangle rect, CombineMode combineMode)
         {
-            int status = SafeNativeMethods.Gdip.GdipSetClipRectI(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
-                                                  rect.Width, rect.Height, combineMode);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipRectI(
+                new HandleRef(this, NativeGraphics),
+                rect.X, rect.Y, rect.Width, rect.Height,
+                combineMode));
         }
 
         public void SetClip(RectangleF rect) => SetClip(rect, CombineMode.Replace);
 
         public void SetClip(RectangleF rect, CombineMode combineMode)
         {
-            int status = SafeNativeMethods.Gdip.GdipSetClipRect(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
-                                                 rect.Width, rect.Height, combineMode);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipRect(
+                new HandleRef(this, NativeGraphics),
+                rect.X, rect.Y, rect.Width, rect.Height,
+                combineMode));
         }
 
         public void SetClip(GraphicsPath path) => SetClip(path, CombineMode.Replace);
@@ -87,87 +86,84 @@ namespace System.Drawing
         public void SetClip(GraphicsPath path, CombineMode combineMode)
         {
             if (path == null)
-            {
                 throw new ArgumentNullException(nameof(path));
-            }
 
-            int status = SafeNativeMethods.Gdip.GdipSetClipPath(new HandleRef(this, NativeGraphics), new HandleRef(path, path.nativePath), combineMode);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipPath(
+                new HandleRef(this, NativeGraphics),
+                new HandleRef(path, path._nativePath),
+                combineMode));
         }
 
         public void SetClip(Region region, CombineMode combineMode)
         {
             if (region == null)
-            {
                 throw new ArgumentNullException(nameof(region));
-            }
 
-            int status = SafeNativeMethods.Gdip.GdipSetClipRegion(new HandleRef(this, NativeGraphics), new HandleRef(region, region._nativeRegion), combineMode);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipRegion(
+                new HandleRef(this, NativeGraphics),
+                new HandleRef(region, region._nativeRegion),
+                combineMode));
         }
 
         public void IntersectClip(Rectangle rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipSetClipRectI(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
-                                                  rect.Width, rect.Height, CombineMode.Intersect);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipRectI(
+                new HandleRef(this, NativeGraphics),
+                rect.X, rect.Y, rect.Width, rect.Height,
+                CombineMode.Intersect));
         }
 
         public void IntersectClip(RectangleF rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipSetClipRect(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
-                                                 rect.Width, rect.Height, CombineMode.Intersect);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipRect(
+                new HandleRef(this, NativeGraphics),
+                rect.X, rect.Y, rect.Width, rect.Height,
+                CombineMode.Intersect));
         }
 
         public void IntersectClip(Region region)
         {
             if (region == null)
-            {
                 throw new ArgumentNullException(nameof(region));
-            }
 
-            int status = SafeNativeMethods.Gdip.GdipSetClipRegion(new HandleRef(this, NativeGraphics), new HandleRef(region, region._nativeRegion),
-                                                   CombineMode.Intersect);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipRegion(
+                new HandleRef(this, NativeGraphics),
+                new HandleRef(region, region._nativeRegion),
+                CombineMode.Intersect));
         }
 
         public void ExcludeClip(Rectangle rect)
         {
-            int status = SafeNativeMethods.Gdip.GdipSetClipRectI(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
-                                                  rect.Width, rect.Height, CombineMode.Exclude);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipRectI(
+                new HandleRef(this, NativeGraphics),
+                rect.X, rect.Y, rect.Width, rect.Height,
+                CombineMode.Exclude));
         }
 
         public void ExcludeClip(Region region)
         {
             if (region == null)
-            {
                 throw new ArgumentNullException(nameof(region));
-            }
 
-            int status = SafeNativeMethods.Gdip.GdipSetClipRegion(new HandleRef(this, NativeGraphics),
-                                                   new HandleRef(region, region._nativeRegion),
-                                                   CombineMode.Exclude);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetClipRegion(
+                new HandleRef(this, NativeGraphics),
+                new HandleRef(region, region._nativeRegion),
+                CombineMode.Exclude));
         }
 
         public void ResetClip()
         {
-            int status = SafeNativeMethods.Gdip.GdipResetClip(new HandleRef(this, NativeGraphics));
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipResetClip(new HandleRef(this, NativeGraphics)));
         }
 
         public void TranslateClip(float dx, float dy)
         {
-            int status = SafeNativeMethods.Gdip.GdipTranslateClip(new HandleRef(this, NativeGraphics), dx, dy);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipTranslateClip(new HandleRef(this, NativeGraphics), dx, dy));
         }
 
         public void TranslateClip(int dx, int dy)
         {
-            int status = SafeNativeMethods.Gdip.GdipTranslateClip(new HandleRef(this, NativeGraphics), dx, dy);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipTranslateClip(new HandleRef(this, NativeGraphics), dx, dy));
         }
 
         public Region Clip
@@ -175,8 +171,9 @@ namespace System.Drawing
             get
             {
                 var region = new Region();
-                int status = SafeNativeMethods.Gdip.GdipGetClip(new HandleRef(this, NativeGraphics), new HandleRef(region, region._nativeRegion));
-                SafeNativeMethods.Gdip.CheckStatus(status);
+                SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipGetClip(
+                    new HandleRef(this, NativeGraphics),
+                    new HandleRef(region, region._nativeRegion)));
 
                 return region;
             }
@@ -188,8 +185,7 @@ namespace System.Drawing
             get
             {
                 var rect = new GPRECTF();
-                int status = SafeNativeMethods.Gdip.GdipGetClipBounds(new HandleRef(this, NativeGraphics), ref rect);
-                SafeNativeMethods.Gdip.CheckStatus(status);
+                SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipGetClipBounds(new HandleRef(this, NativeGraphics), ref rect));
 
                 return rect.ToRectangleF();
             }
@@ -199,9 +195,7 @@ namespace System.Drawing
         {
             get
             {
-                int isEmpty;
-                int status = SafeNativeMethods.Gdip.GdipIsClipEmpty(new HandleRef(this, NativeGraphics), out isEmpty);
-                SafeNativeMethods.Gdip.CheckStatus(status);
+                SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipIsClipEmpty(new HandleRef(this, NativeGraphics), out int isEmpty));
 
                 return isEmpty != 0;
             }
@@ -211,22 +205,20 @@ namespace System.Drawing
         {
             get
             {
-                int isEmpty;
-                int status = SafeNativeMethods.Gdip.GdipIsVisibleClipEmpty(new HandleRef(this, NativeGraphics), out isEmpty);
-                SafeNativeMethods.Gdip.CheckStatus(status);
+                SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipIsVisibleClipEmpty(new HandleRef(this, NativeGraphics), out int isEmpty));
 
                 return isEmpty != 0;
             }
         }
 
-
         public bool IsVisible(int x, int y) => IsVisible(new Point(x, y));
 
         public bool IsVisible(Point point)
         {
-            int isVisible;
-            int status = SafeNativeMethods.Gdip.GdipIsVisiblePointI(new HandleRef(this, NativeGraphics), point.X, point.Y, out isVisible);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipIsVisiblePointI(
+                new HandleRef(this, NativeGraphics),
+                point.X, point.Y,
+                out int isVisible));
 
             return isVisible != 0;
         }
@@ -235,9 +227,10 @@ namespace System.Drawing
 
         public bool IsVisible(PointF point)
         {
-            int isVisible;
-            int status = SafeNativeMethods.Gdip.GdipIsVisiblePoint(new HandleRef(this, NativeGraphics), point.X, point.Y, out isVisible);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipIsVisiblePoint(
+                new HandleRef(this, NativeGraphics),
+                point.X, point.Y,
+                out int isVisible));
 
             return isVisible != 0;
         }
@@ -249,10 +242,10 @@ namespace System.Drawing
 
         public bool IsVisible(Rectangle rect)
         {
-            int isVisible;
-            int status = SafeNativeMethods.Gdip.GdipIsVisibleRectI(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
-                                                    rect.Width, rect.Height, out isVisible);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipIsVisibleRectI(
+                new HandleRef(this, NativeGraphics),
+                rect.X, rect.Y, rect.Width, rect.Height,
+                out int isVisible));
 
             return isVisible != 0;
         }
@@ -264,10 +257,10 @@ namespace System.Drawing
 
         public bool IsVisible(RectangleF rect)
         {
-            int isVisible;
-            int status = SafeNativeMethods.Gdip.GdipIsVisibleRect(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
-                                                   rect.Width, rect.Height, out isVisible);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipIsVisibleRect(
+                new HandleRef(this, NativeGraphics),
+                rect.X, rect.Y, rect.Width, rect.Height,
+                out int isVisible));
 
             return isVisible != 0;
         }
@@ -280,17 +273,17 @@ namespace System.Drawing
             get
             {
                 var matrix = new Matrix();
-                int status = SafeNativeMethods.Gdip.GdipGetWorldTransform(new HandleRef(this, NativeGraphics),
-                                                           new HandleRef(matrix, matrix.nativeMatrix));
-                SafeNativeMethods.Gdip.CheckStatus(status);
+                SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipGetWorldTransform(
+                    new HandleRef(this, NativeGraphics),
+                    new HandleRef(matrix, matrix.nativeMatrix)));
 
                 return matrix;
             }
             set
             {
-                int status = SafeNativeMethods.Gdip.GdipSetWorldTransform(new HandleRef(this, NativeGraphics),
-                                                           new HandleRef(value, value.nativeMatrix));
-                SafeNativeMethods.Gdip.CheckStatus(status);
+                SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipSetWorldTransform(
+                    new HandleRef(this, NativeGraphics),
+                    new HandleRef(value, value.nativeMatrix)));
             }
         }
 
@@ -299,8 +292,7 @@ namespace System.Drawing
         /// </summary>
         public void ResetTransform()
         {
-            int status = SafeNativeMethods.Gdip.GdipResetWorldTransform(new HandleRef(this, NativeGraphics));
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipResetWorldTransform(new HandleRef(this, NativeGraphics)));
         }
 
         /// <summary>
@@ -314,38 +306,33 @@ namespace System.Drawing
         public void MultiplyTransform(Matrix matrix, MatrixOrder order)
         {
             if (matrix == null)
-            {
                 throw new ArgumentNullException(nameof(matrix));
-            }
 
-            int status = SafeNativeMethods.Gdip.GdipMultiplyWorldTransform(new HandleRef(this, NativeGraphics),
-                                                            new HandleRef(matrix, matrix.nativeMatrix),
-                                                            order);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipMultiplyWorldTransform(
+                new HandleRef(this, NativeGraphics),
+                new HandleRef(matrix, matrix.nativeMatrix),
+                order));
         }
 
         public void TranslateTransform(float dx, float dy) => TranslateTransform(dx, dy, MatrixOrder.Prepend);
 
         public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
-            int status = SafeNativeMethods.Gdip.GdipTranslateWorldTransform(new HandleRef(this, NativeGraphics), dx, dy, order);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipTranslateWorldTransform(new HandleRef(this, NativeGraphics), dx, dy, order));
         }
 
         public void ScaleTransform(float sx, float sy) => ScaleTransform(sx, sy, MatrixOrder.Prepend);
 
         public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
-            int status = SafeNativeMethods.Gdip.GdipScaleWorldTransform(new HandleRef(this, NativeGraphics), sx, sy, order);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipScaleWorldTransform(new HandleRef(this, NativeGraphics), sx, sy, order));
         }
 
         public void RotateTransform(float angle) => RotateTransform(angle, MatrixOrder.Prepend);
 
         public void RotateTransform(float angle, MatrixOrder order)
         {
-            int status = SafeNativeMethods.Gdip.GdipRotateWorldTransform(new HandleRef(this, NativeGraphics), angle, order);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            SafeNativeMethods.Gdip.CheckStatus(SafeNativeMethods.Gdip.GdipRotateWorldTransform(new HandleRef(this, NativeGraphics), angle, order));
         }
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Region.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Region.cs
@@ -54,7 +54,7 @@ namespace System.Drawing
             }
 
             IntPtr region = IntPtr.Zero;
-            int status = SafeNativeMethods.Gdip.GdipCreateRegionPath(new HandleRef(path, path.nativePath), out region);
+            int status = SafeNativeMethods.Gdip.GdipCreateRegionPath(new HandleRef(path, path._nativePath), out region);
             SafeNativeMethods.Gdip.CheckStatus(status);
 
             SetNativeRegion(region);
@@ -175,7 +175,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(path));
             }
 
-            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path.nativePath), CombineMode.Intersect);
+            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path._nativePath), CombineMode.Intersect);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -211,7 +211,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(path));
             }
 
-            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path.nativePath), CombineMode.Union);
+            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path._nativePath), CombineMode.Union);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -247,7 +247,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(path));
             }
 
-            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path.nativePath), CombineMode.Xor);
+            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path._nativePath), CombineMode.Xor);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 
@@ -283,7 +283,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(path));
             }
 
-            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path.nativePath),
+            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path._nativePath),
                                                        CombineMode.Exclude);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
@@ -321,7 +321,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(path));
             }
 
-            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path.nativePath), CombineMode.Complement);
+            int status = SafeNativeMethods.Gdip.GdipCombineRegionPath(new HandleRef(this, _nativeRegion), new HandleRef(path, path._nativePath), CombineMode.Complement);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
 

--- a/src/System.Drawing.Common/src/misc/GDI/SafeNativeMethods.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/SafeNativeMethods.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.Security;
 
 namespace System.Drawing.Internal
 {
@@ -16,7 +15,7 @@ namespace System.Drawing.Internal
         public sealed class CommonHandles
         {
             static CommonHandles() { }
-            
+
             /// <summary>
             /// Handle type for GDI objects.
             /// </summary>
@@ -37,6 +36,6 @@ namespace System.Drawing.Internal
             IntPtr hRgn = System.Internal.HandleCollector.Add(IntCreateRectRgn(x1, y1, x2, y2), CommonHandles.GDI);
             DbgUtil.AssertWin32(hRgn != IntPtr.Zero, "IntCreateRectRgn([x1={0}, y1={1}, x2={2}, y2={3}]) failed.", x1, y1, x2, y2);
             return hRgn;
-        }        
+        }
     }
 }


### PR DESCRIPTION
Make a consistency pass through Graphics & GraphicsPath.

Plan is to follow up with a change that removes the rest of the unnecessary allocations.

This change focuses on the Windows specific code. Some Unix code will be able to be unified with the Windows code once further changes happen. Rather than reformat the Unix code preemptively, leaving for final follow-up.