### PR TITLE
Tests for Creating and opening mutex, semaphore and waithandles with long names

### DIFF
--- a/src/System.Threading/tests/EventWaitHandleTests.cs
+++ b/src/System.Threading/tests/EventWaitHandleTests.cs
@@ -26,6 +26,13 @@ namespace System.Threading.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new EventWaitHandle(true, (EventResetMode)12345));
         }
 
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Full framework throws argument exception on long names")]
+        [Fact]
+        public void Ctor_InvalidNames()
+        {
+            AssertExtensions.Throws<ArgumentException>("name", null, () => new EventWaitHandle(true, EventResetMode.AutoReset, new string('a', 1000)));
+        }
+
         [PlatformSpecific(TestPlatforms.Windows)]  // names aren't supported on Unix
         [Theory]
         [MemberData(nameof(GetValidNames))]
@@ -227,10 +234,14 @@ namespace System.Threading.Tests
             return SuccessExitCode;
         }
 
-        public static TheoryData<string> GetValidNames => new TheoryData<string>()
+        public static TheoryData<string> GetValidNames()
         {
-            { Guid.NewGuid().ToString("N") },
-            { Guid.NewGuid().ToString("N") + new string('a', 1000) }
-        };
+            var names  =  new TheoryData<string>() { Guid.NewGuid().ToString("N") };
+
+            if (!PlatformDetection.IsFullFramework)
+                names.Add(Guid.NewGuid().ToString("N") + new string('a', 1000));
+
+            return names;
+        }
     }
 }

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -36,6 +36,20 @@ namespace System.Threading.Tests
             }
         }
 
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Full framework throws argument exception on long names")]
+        [Fact]
+        public void Ctor_InvalidNames_Windows()
+        {
+            AssertExtensions.Throws<ArgumentException>("name", null, () => new Mutex(false, new string('a', 1000), out bool createdNew));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void Ctor_InvalidNames_Unix()
+        {
+            AssertExtensions.Throws<ArgumentException>("name", null, () => new Mutex(false, new string('a', 1000), out bool createdNew));
+        }
+
         [Theory]
         [MemberData(nameof(GetValidNames))]
         public void Ctor_ValidName(string name)
@@ -262,11 +276,15 @@ namespace System.Threading.Tests
             }
         }
 
-        public static TheoryData<string> GetValidNames => new TheoryData<string>()
+        public static TheoryData<string> GetValidNames()
         {
-            { Guid.NewGuid().ToString("N") },
-            { Guid.NewGuid().ToString("N") + new string('a', 1000) }
-        };
+            var names  =  new TheoryData<string>() { Guid.NewGuid().ToString("N") };
+
+            if (PlatformDetection.IsWindows && !PlatformDetection.IsFullFramework)
+                names.Add(Guid.NewGuid().ToString("N") + new string('a', 1000));
+
+            return names;
+        }
 
         [DllImport("kernel32.dll")]
         private static extern IntPtr GetCurrentThread();

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -36,16 +36,10 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
-        public void Ctor_InvalidName()
+        [Theory]
+        [MemberData(nameof(GetValidNames))]
+        public void Ctor_ValidName(string name)
         {
-            AssertExtensions.Throws<ArgumentException>("name", null, () => new Mutex(false, new string('a', 1000)));
-        }
-
-        [Fact]
-        public void Ctor_ValidName()
-        {
-            string name = Guid.NewGuid().ToString("N");
             bool createdNew;
             using (Mutex m1 = new Mutex(false, name, out createdNew))
             {
@@ -96,11 +90,10 @@ namespace System.Threading.Tests
                 Assert.Throws<UnauthorizedAccessException>(() => new Mutex(false, "Global\\" + Guid.NewGuid().ToString("N"))));
         }
 
-        [Fact]
-        public void OpenExisting()
+        [Theory]
+        [MemberData(nameof(GetValidNames))]
+        public void OpenExisting(string name)
         {
-            string name = Guid.NewGuid().ToString("N");
-
             Mutex resultHandle;
             Assert.False(Mutex.TryOpenExisting(name, out resultHandle));
 
@@ -128,7 +121,6 @@ namespace System.Threading.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("name", () => Mutex.OpenExisting(null));
             AssertExtensions.Throws<ArgumentException>("name", null, () => Mutex.OpenExisting(string.Empty));
-            AssertExtensions.Throws<ArgumentException>("name", null, () => Mutex.OpenExisting(new string('a', 10000)));
         }
 
         [Fact]
@@ -269,6 +261,12 @@ namespace System.Threading.Tests
                 finally { mutex.ReleaseMutex(); }
             }
         }
+
+        public static TheoryData<string> GetValidNames => new TheoryData<string>()
+        {
+            { Guid.NewGuid().ToString("N") },
+            { Guid.NewGuid().ToString("N") + new string('a', 1000) }
+        };
 
         [DllImport("kernel32.dll")]
         private static extern IntPtr GetCurrentThread();

--- a/src/System.Threading/tests/SemaphoreTests.cs
+++ b/src/System.Threading/tests/SemaphoreTests.cs
@@ -26,11 +26,10 @@ namespace System.Threading.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]  // named semaphores aren't supported on Unix
-        [Fact]
-        public void Ctor_ValidName_Windows()
+        [Theory]
+        [MemberData(nameof(GetValidNames))]
+        public void Ctor_ValidName_Windows(string name)
         {
-            string name = Guid.NewGuid().ToString("N");
-
             new Semaphore(0, 1, name).Dispose();
 
             bool createdNew;
@@ -72,15 +71,6 @@ namespace System.Threading.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("initialCount", () => new Semaphore(-2, 1, "CtorSemaphoreTest", out createdNew));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("maximumCount", () => new Semaphore(0, 0, "CtorSemaphoreTest", out createdNew));
             AssertExtensions.Throws<ArgumentException>(null, () => new Semaphore(2, 1, "CtorSemaphoreTest", out createdNew));
-        }
-
-        [PlatformSpecific(TestPlatforms.Windows)]  // named semaphores aren't supported on Unix
-        [Fact]
-        public void Ctor_InvalidNames()
-        {
-            AssertExtensions.Throws<ArgumentException>("name", null, () => new Semaphore(0, 1, new string('a', 10000)));
-            bool createdNew;
-            AssertExtensions.Throws<ArgumentException>("name", null, () => new Semaphore(0, 1, new string('a', 10000), out createdNew));
         }
 
         [Fact]
@@ -214,7 +204,6 @@ namespace System.Threading.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("name", () => Semaphore.OpenExisting(null));
             AssertExtensions.Throws<ArgumentException>("name", null, () => Semaphore.OpenExisting(string.Empty));
-            AssertExtensions.Throws<ArgumentException>("name", null, () => Semaphore.OpenExisting(new string('a', 10000)));
         }
 
         [PlatformSpecific(TestPlatforms.Windows)] // named semaphores aren't supported on Unix
@@ -241,10 +230,10 @@ namespace System.Threading.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)] // named semaphores aren't supported on Unix
-        [Fact]
-        public void OpenExisting_SameAsOriginal_Windows()
+        [Theory]
+        [MemberData(nameof(GetValidNames))]
+        public void OpenExisting_SameAsOriginal_Windows(string name)
         {
-            string name = Guid.NewGuid().ToString("N");
             bool createdNew;
             using (Semaphore s1 = new Semaphore(0, Int32.MaxValue, name, out createdNew))
             {
@@ -317,5 +306,11 @@ namespace System.Threading.Tests
 
             return SuccessExitCode;
         }
+
+        public static TheoryData<string> GetValidNames => new TheoryData<string>()
+        {
+            { Guid.NewGuid().ToString("N") },
+            { Guid.NewGuid().ToString("N") + new string('a', 1000) }
+        };
     }
 }

--- a/src/System.Threading/tests/SemaphoreTests.cs
+++ b/src/System.Threading/tests/SemaphoreTests.cs
@@ -73,6 +73,15 @@ namespace System.Threading.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Semaphore(2, 1, "CtorSemaphoreTest", out createdNew));
         }
 
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Full framework throws argument exception on long names")]
+        [Fact]
+        public void Ctor_InvalidNames()
+        {
+            AssertExtensions.Throws<ArgumentException>("name", null, () => new Semaphore(0, 1, new string('a', 10000)));
+            bool createdNew;
+            AssertExtensions.Throws<ArgumentException>("name", null, () => new Semaphore(0, 1, new string('a', 10000), out createdNew));
+        }
+
         [Fact]
         public void CanWaitWithoutBlockingUntilNoCount()
         {
@@ -307,10 +316,14 @@ namespace System.Threading.Tests
             return SuccessExitCode;
         }
 
-        public static TheoryData<string> GetValidNames => new TheoryData<string>()
+        public static TheoryData<string> GetValidNames()
         {
-            { Guid.NewGuid().ToString("N") },
-            { Guid.NewGuid().ToString("N") + new string('a', 1000) }
-        };
+            var names  =  new TheoryData<string>() { Guid.NewGuid().ToString("N") };
+
+            if (!PlatformDetection.IsFullFramework)
+                names.Add(Guid.NewGuid().ToString("N") + new string('a', 1000));
+
+            return names;
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/3740
Related Coreclr PR https://github.com/dotnet/coreclr/pull/18402

we're letting the API kick back names that are too long rather than pre-validating them. 
This PR includes Tests for long names and removes existing tests which expects the exception to be thrown in these cases.
This squashed commit will need to be added whenever maestro brings the new version of the coreclr with the related changes