### PR TITLE
Check for IsByRefLike in MakeNewDelegate

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
@@ -155,7 +155,7 @@ namespace System.Linq.Expressions.Compiler
                 for (int i = 0; i < types.Length; i++)
                 {
                     Type type = types[i];
-                    if (type.IsByRef || type.IsPointer)
+                    if (type.IsByRef || type.IsByRefLike || type.IsPointer)
                     {
                         needCustom = true;
                         break;

--- a/src/System.Linq.Expressions/tests/DelegateType/DelegateCreationTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/DelegateCreationTests.cs
@@ -52,6 +52,11 @@ namespace System.Linq.Expressions.Tests
             yield return new object[] { Enumerable.Repeat(typeof(double).MakeByRefType(), 20).ToArray() };
         }
 
+        protected static IEnumerable<object> ByRefLikeTypeArgs()
+        {
+            yield return new object[] { new[] { typeof(Span<char>) } };
+        }
+
         protected static IEnumerable<object> PointerTypeArgs()
         {
             yield return new object[] { new[] { typeof(int).MakePointerType() } };

--- a/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
@@ -53,6 +53,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ExcessiveLengthTypeArgs))]
         [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
         [MemberData(nameof(ByRefTypeArgs))]
+        [MemberData(nameof(ByRefLikeTypeArgs))]
         [MemberData(nameof(PointerTypeArgs))]
         [MemberData(nameof(ManagedPointerTypeArgs))]
         public void CantBeFunc(Type[] typeArgs)
@@ -74,6 +75,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ExcessiveLengthTypeArgs))]
         [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
         [MemberData(nameof(ByRefTypeArgs))]
+        [MemberData(nameof(ByRefLikeTypeArgs))]
         [MemberData(nameof(PointerTypeArgs))]
         [MemberData(nameof(ManagedPointerTypeArgs))]
         public void CantBeAction(Type[] typeArgs)


### PR DESCRIPTION
`MakeNewDelegate` currently fails when used with `Span` since it tries to create a `Func` or `Action`. This change makes it call `MakeNewCustomDelegate` instead.