### PR TITLE
Fix AIX build of PAL because of GCC system header mangling

### DIFF
--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#ifdef _AIX
-// For getline (declare this before stdio)
-#define _GETDELIM 1
-#endif
-
 #include "pal_compiler.h"
 #include "pal_config.h"
 #include "pal_errno.h"
@@ -47,6 +42,11 @@
 // Somehow, AIX mangles the definition for this behind a C++ def
 // Redeclare it here
 extern int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
+// GCC "fix"includes removes this definition from stdio.h entirely, even if you
+// opt into using getline via the `_GETDELIM` definition. (as it can conflict
+// with some existing code, so it's hidden behind a define) As such, redefine
+// it from the system headers into here.
+extern ssize_t  getline(char **, size_t *, FILE *);
 #endif
 
 #if HAVE_STAT64

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -44,8 +44,11 @@
 extern int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
 // GCC "fix"includes removes this definition from stdio.h entirely, even if you
 // opt into using getline via the `_GETDELIM` definition. (as it can conflict
-// with some existing code, so it's hidden behind a define) As such, redefine
-// it from the system headers into here.
+// with some existing code, so it's hidden behind a define) Adding to the
+// tragedy, the define we need for the runtime (`_ALL_SOURCE`) sets the other
+// necessary definition (`_XOPEN_SOURCE=700`) to 600, overriding it. As such,
+// redefine getline function declaration here and cut the gordian knot caused
+// by commercial Unix and GNU.
 extern ssize_t  getline(char **, size_t *, FILE *);
 #endif
 

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -42,13 +42,10 @@
 // Somehow, AIX mangles the definition for this behind a C++ def
 // Redeclare it here
 extern int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
-// GCC "fix"includes removes this definition from stdio.h entirely, even if you
-// opt into using getline via the `_GETDELIM` definition. (as it can conflict
-// with some existing code, so it's hidden behind a define) Adding to the
-// tragedy, the define we need for the runtime (`_ALL_SOURCE`) sets the other
-// necessary definition (`_XOPEN_SOURCE=700`) to 600, overriding it. As such,
-// redefine getline function declaration here and cut the gordian knot caused
-// by commercial Unix and GNU.
+// This function declaration is hidden behind `_XOPEN_SOURCE=700`, but we need
+// `_ALL_SOURCE` to build the runtime, and that resets that definition to 600.
+// Instead of trying to wrangle ifdefs in system headers with more definitions,
+// just declare it here.
 extern ssize_t  getline(char **, size_t *, FILE *);
 #endif
 


### PR DESCRIPTION
GCC's "fix"includes tool claims another function as its victim. Import the func definition from the headers; we can't trust GCC to not replace them with "fixed" versions.

(FreeBSD people: `_WITH_GETLINE` to replace what was removed would help you)