### PR TITLE
Decimal.Remainder tests

### DIFF
--- a/src/System.Runtime/tests/System/DecimalTests.cs
+++ b/src/System.Runtime/tests/System/DecimalTests.cs
@@ -1458,6 +1458,7 @@ namespace System.Tests
         public static class BigIntegerMod
         {
             [Fact]
+            [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework does not have fixes for https://github.com/dotnet/coreclr/issues/12605")]
             public static void Test()
             {
                 int overflowBudget = 1000;
@@ -1865,7 +1866,7 @@ namespace System.Tests
 
             public BigDecimal Mod(BigDecimal den, out bool overflow)
             {
-                if (den.Integer.Sign == 0)
+                if (den.Integer.IsZero)
                 {
                     throw new DivideByZeroException();
                 }
@@ -1920,13 +1921,10 @@ namespace System.Tests
                 // See if the result has crossed 0
                 if (!res.Integer.IsZero && res.Integer.Sign != sign)
                 {
-                    if (res.Scale == 28 && BigInteger.Abs(res.Integer) <= 10 || res.Scale == 27 && BigInteger.Abs(res.Integer) == 1)
+                    if (res.Scale == 28 && BigInteger.Abs(res.Integer) == 1)
                     {
                         // Certain Remainder operations on decimals with 28 significant digits round to [+-]0.0000000000000000000000000001m instead of [+-]0m during the intermediate calculations.
                         // This might give incorrectly rounded results (e.g., 5 % 0.0000000000000000000000000003m = 0.0000000000000000000000000002m but returns 0.0000000000000000000000000001m)
-
-                        // Due to an additional bug in Decimal.Remainder, this check is actually done against scale 27 (not 28) and this might produce more incorrect values.
-                        // e.g., 5.94499443m % 0.0000000000000000000000000007m = 0.0000000000000000000000000005m but returns 0.0000000000000000000000000002m
                         res = -res;
                     }
                     else

--- a/src/System.Runtime/tests/System/DecimalTests.cs
+++ b/src/System.Runtime/tests/System/DecimalTests.cs
@@ -1455,6 +1455,53 @@ namespace System.Tests
             }
         }
 
+        public static class BigIntegerMod
+        {
+            [Fact]
+            public static void Test()
+            {
+                int overflowBudget = 1000;
+                decimal[] decimalValues = GetRandomData(out BigDecimal[] bigDecimals);
+                for (int i = 0; i < decimalValues.Length; i++)
+                {
+                    decimal d1 = decimalValues[i];
+                    BigDecimal b1 = bigDecimals[i];
+                    for (int j = 0; j < decimalValues.Length; j++)
+                    {
+                        decimal d2 = decimalValues[j];
+                        if (Math.Sign(d2) == 0)
+                            continue;
+                        BigDecimal expected = b1.Mod(bigDecimals[j], out bool expectedOverflow);
+                        if (expectedOverflow)
+                        {
+                            if (--overflowBudget < 0)
+                                continue;
+                            try
+                            {
+                                decimal actual = d1 % d2;
+                                throw new Xunit.Sdk.AssertActualExpectedException(typeof(OverflowException), actual, d1 + " % " + d2);
+                            }
+                            catch (OverflowException) { }
+                        }
+                        else
+                            unsafe
+                            {
+                                try
+                                {
+                                    decimal actual = d1 % d2;
+                                    if (expected.Scale != (byte)(*(uint*)&actual >> BigDecimal.ScaleShift) || expected.CompareTo(new BigDecimal(actual)) != 0)
+                                        throw new Xunit.Sdk.AssertActualExpectedException(expected, actual, d1 + " % " + d2);
+                                }
+                                catch (OverflowException actual)
+                                {
+                                    throw new Xunit.Sdk.AssertActualExpectedException(expected, actual, d1 + " % " + d2);
+                                }
+                            }
+                    }
+                }
+            }
+        }
+
         [Fact]
         public static void BigInteger_Floor()
         {
@@ -1815,6 +1862,84 @@ namespace System.Tests
                 }
                 return new BigDecimal(quo, (byte)scale);
             }
+
+            public BigDecimal Mod(BigDecimal den, out bool overflow)
+            {
+                if (den.Integer.Sign == 0)
+                {
+                    throw new DivideByZeroException();
+                }
+                int sign = Integer.Sign;
+                if (sign == 0)
+                {
+                    overflow = false;
+                    return this;
+                }
+                if (den.Integer.Sign != sign)
+                {
+                    den = -den;
+                }
+
+                int cmp = CompareTo(den) * sign;
+                if (cmp <= 0)
+                {
+                    overflow = false;
+                    return cmp < 0 ? this : new BigDecimal(default, Math.Max(Scale, den.Scale));
+                }
+
+                // The obvious solution would be to calculate the integer remainder using the larger scaling factor,
+                // but the current Decimal.Remainder implementation does several intermediate calculations that may round or overflow (e.g., 5 % 0.0000000000000000000000000003m or decimal.MaxValue % 0.1m),
+                // so a similar approach must be used here and the rest of this function matches all Decimal.Remainder quirks.
+                // https://github.com/dotnet/coreclr/issues/12605
+
+                // This piece of code is to work around the fact that Dividing a decimal with 28 digits number by decimal which causes causes the result to be 28 digits, can cause to be incorrectly rounded up.
+                // eg. Decimal.MaxValue / 2 * Decimal.MaxValue will overflow since the division by 2 was rounded instead of being truncked.
+                BigDecimal num = Add(-den, out overflow);
+                if (overflow)
+                {
+                    return default;
+                }
+
+                // Formula:  num - (RoundTowardsZero(num / den) * den)
+                BigDecimal res = num.Div(den, out overflow);
+                if (overflow)
+                {
+                    return default;
+                }
+                res = res.Truncate().Mul(den, out overflow);
+                if (overflow)
+                {
+                    return default;
+                }
+                res = num.Add(-res, out overflow);
+                if (overflow)
+                {
+                    return default;
+                }
+
+                // See if the result has crossed 0
+                if (!res.Integer.IsZero && res.Integer.Sign != sign)
+                {
+                    if (res.Scale == 28 && BigInteger.Abs(res.Integer) <= 10 || res.Scale == 27 && BigInteger.Abs(res.Integer) == 1)
+                    {
+                        // Certain Remainder operations on decimals with 28 significant digits round to [+-]0.0000000000000000000000000001m instead of [+-]0m during the intermediate calculations.
+                        // This might give incorrectly rounded results (e.g., 5 % 0.0000000000000000000000000003m = 0.0000000000000000000000000002m but returns 0.0000000000000000000000000001m)
+
+                        // Due to an additional bug in Decimal.Remainder, this check is actually done against scale 27 (not 28) and this might produce more incorrect values.
+                        // e.g., 5.94499443m % 0.0000000000000000000000000007m = 0.0000000000000000000000000005m but returns 0.0000000000000000000000000002m
+                        res = -res;
+                    }
+                    else
+                    {
+                        // If the division rounds up because it runs out of digits, the multiplied result can end up with a larger absolute value and the result of the formula crosses 0.
+                        // To correct it can add the divisor back.
+                        res = res.Add(den, out overflow);
+                    }
+                }
+                return res;
+            }
+
+            public static BigDecimal operator -(BigDecimal value) => new BigDecimal(-value.Integer, value.Scale);
 
             static readonly BigInteger MaxInteger = (new BigInteger(ulong.MaxValue) << 32) | uint.MaxValue;
             static readonly BigInteger MaxInteger32 = uint.MaxValue;


### PR DESCRIPTION
This adds new tests for https://github.com/dotnet/corert/pull/5926.
Writing these tests uncovered many issues with the current implementation, documented in https://github.com/dotnet/coreclr/issues/12605.