### PR TITLE
Copy CoreLib (and respective PDBs) to IL and NI folders

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -124,7 +124,7 @@
           <CrossGenAssemblyPath>%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/native/</CrossGenAssemblyPath>
         </CoreCLRILFiles>
         <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename)%(Extension)')" />
-        <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).ni.pdb')" />
+        <CoreCLRCrossGenFiles Condition="'$(OSGroup)'=='Windows_NT'" Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).ni.pdb')" />
         <CoreCLRILFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).pdb')" />
       </ItemGroup>
   </Target>
@@ -142,7 +142,7 @@
       <CoreCLRILFiles Include="$(CoreCLROverridePath)/IL/*.*" />
       <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '$(CoreCLROverridePath)/%(Filename)%(Extension)')" />
       <CoreCLRILFiles Include="@(CoreCLRILFiles -> '$(CoreCLRPDBOverridePath)/%(Filename).pdb')" />
-      <CoreCLRCrossGenFiles Include="@(CoreCLRCrossGenFiles -> '$(CoreCLRPDBOverridePath)/%(Filename).ni.pdb')" />
+      <CoreCLRCrossGenFiles Condition="'$(OSGroup)'=='Windows_NT'" Include="@(CoreCLRCrossGenFiles -> '$(CoreCLRPDBOverridePath)/%(Filename).ni.pdb')" />
       <CoreCLRPDBFiles Condition="'$(CoreCLRPDBOverridePath)' != ''" Include="$(CoreCLRPDBOverridePath)/*.pdb" />
 
       <_ReferenceCopyLocalPathsToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -124,8 +124,8 @@
           <CrossGenAssemblyPath>%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/native/</CrossGenAssemblyPath>
         </CoreCLRILFiles>
         <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename)%(Extension)')" />
-        <CoreCLRILFiles Include="@(CoreCLRILFiles -> '%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/%(Filename).pdb')" />
         <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).ni.pdb')" />
+        <CoreCLRILFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).pdb')" />
       </ItemGroup>
   </Target>
 

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -137,11 +137,14 @@
     <!-- For coverage runs of any crossgen dll from CoreClr we need the respective IL, the pdbs are already in place -->
     <Copy SourceFiles="@(CoreCLRILFiles)"
           DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)/il"
-          SkipUnchangedFiles="true" />
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="$(BinPlaceUseHardlinksIfPossible)" />
+
     <!-- Make backups of the crossgen dlls that do not have .ni. in their names, so they can be restored after coverage runs  -->
     <Copy SourceFiles="@(CoreCLRILFiles -> '$(CoreCLROverridePath)/%(Filename)%(Extension)')"
           DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)/ni"
-          SkipUnchangedFiles="true" />
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="$(BinPlaceUseHardlinksIfPossible)" />
 
   </Target>
 </Project>

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -46,6 +46,19 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
+  <ItemGroup>
+    <!-- For coverage runs of any crossgen dll from CoreClr we need the respective IL, the pdbs are already in place -->
+    <!-- Make backups of the crossgen dlls that do not have .ni. in their names, so they can be restored after coverage runs  -->
+    <BinPlaceConfiguration Condition="'$(BinPlaceTestSharedFramework)' == 'true'" Include="$(Configuration)">
+      <ItemName>CoreCLRILFiles</ItemName>
+      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)/il</RuntimePath>
+    </BinPlaceConfiguration>
+    <BinPlaceConfiguration Condition="'$(BinPlaceTestSharedFramework)' == 'true'" Include="$(Configuration)">
+      <ItemName>CoreCLRCrossGenFiles</ItemName>
+      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)/ni</RuntimePath>
+    </BinPlaceConfiguration>
+  </ItemGroup>
+  
   <!-- Setup the testing shared framework host -->
   <Target Name="SetupTestingHost" AfterTargets="ResolveNuGetPackages" Condition="'$(BinPlaceTestSharedFramework)' == 'true'">
 
@@ -106,6 +119,11 @@
         <_CoreCLRSymbolFiles Include="%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/native/*.pdb" />
         <_CoreCLRSymbolFiles Include="%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/native/*.dbg" />
         <ReferenceCopyLocalPaths Include="@(_CoreCLRSymbolFiles)"/>
+
+        <CoreCLRILFiles Include="%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/il/*.*">
+          <CrossGenAssemblyPath>%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/native/</CrossGenAssemblyPath>
+        </CoreCLRILFiles>
+        <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename)%(Extension)')" />
       </ItemGroup>
   </Target>
 
@@ -120,6 +138,7 @@
     <ItemGroup>
       <CoreCLRFiles Include="$(CoreCLROverridePath)/*.*" />
       <CoreCLRILFiles Include="$(CoreCLROverridePath)/IL/*.*" />
+      <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '$(CoreCLROverridePath)/%(Filename)%(Extension)')" />
       <CoreCLRPDBFiles Condition="'$(CoreCLRPDBOverridePath)' != ''" Include="$(CoreCLRPDBOverridePath)/*.pdb" />
 
       <_ReferenceCopyLocalPathsToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
@@ -133,18 +152,6 @@
       <ReferenceCopyLocalPathsNativeImages Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::Copy('%(Filename)%(Extension)').Contains('.ni.'))" />
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPathsNativeImages)" />
     </ItemGroup>
-
-    <!-- For coverage runs of any crossgen dll from CoreClr we need the respective IL, the pdbs are already in place -->
-    <Copy SourceFiles="@(CoreCLRILFiles)"
-          DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)/il"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="$(BinPlaceUseHardlinksIfPossible)" />
-
-    <!-- Make backups of the crossgen dlls that do not have .ni. in their names, so they can be restored after coverage runs  -->
-    <Copy SourceFiles="@(CoreCLRILFiles -> '$(CoreCLROverridePath)/%(Filename)%(Extension)')"
-          DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)/ni"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="$(BinPlaceUseHardlinksIfPossible)" />
 
   </Target>
 </Project>

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -119,6 +119,7 @@
     </PropertyGroup>
     <ItemGroup>
       <CoreCLRFiles Include="$(CoreCLROverridePath)/*.*" />
+      <CoreCLRILFiles Include="$(CoreCLROverridePath)/IL/*.*" />
       <CoreCLRPDBFiles Condition="'$(CoreCLRPDBOverridePath)' != ''" Include="$(CoreCLRPDBOverridePath)/*.pdb" />
 
       <_ReferenceCopyLocalPathsToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
@@ -132,6 +133,15 @@
       <ReferenceCopyLocalPathsNativeImages Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::Copy('%(Filename)%(Extension)').Contains('.ni.'))" />
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPathsNativeImages)" />
     </ItemGroup>
+
+    <!-- For coverage runs of any crossgen dll from CoreClr we need the respective IL, the pdbs are already in place -->
+    <Copy SourceFiles="@(CoreCLRILFiles)"
+          DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)/il"
+          SkipUnchangedFiles="true" />
+    <!-- Make backups of the crossgen dlls that do not have .ni. in their names, so they can be restored after coverage runs  -->
+    <Copy SourceFiles="@(CoreCLRILFiles -> '$(CoreCLROverridePath)/%(Filename)%(Extension)')"
+          DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)/ni"
+          SkipUnchangedFiles="true" />
 
   </Target>
 </Project>

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -47,15 +47,15 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
   <ItemGroup>
-    <!-- For coverage runs of any crossgen dll from CoreClr we need the respective IL, the pdbs are already in place -->
-    <!-- Make backups of the crossgen dlls that do not have .ni. in their names, so they can be restored after coverage runs  -->
+    <!-- For IL rewrite tools of crossgen dll from CoreClr we need the respective IL and respective pdbs -->
+    <!-- For crossgen dlls save respective pdbs too -->
     <BinPlaceConfiguration Condition="'$(BinPlaceTestSharedFramework)' == 'true'" Include="$(Configuration)">
       <ItemName>CoreCLRILFiles</ItemName>
-      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)/il</RuntimePath>
+      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)il</RuntimePath>
     </BinPlaceConfiguration>
     <BinPlaceConfiguration Condition="'$(BinPlaceTestSharedFramework)' == 'true'" Include="$(Configuration)">
       <ItemName>CoreCLRCrossGenFiles</ItemName>
-      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)/ni</RuntimePath>
+      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)ni</RuntimePath>
     </BinPlaceConfiguration>
   </ItemGroup>
   
@@ -124,6 +124,8 @@
           <CrossGenAssemblyPath>%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/native/</CrossGenAssemblyPath>
         </CoreCLRILFiles>
         <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename)%(Extension)')" />
+        <CoreCLRILFiles Include="@(CoreCLRILFiles -> '%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(NugetRuntimeIdentifier)/%(Filename).pdb')" />
+        <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).ni.pdb')" />
       </ItemGroup>
   </Target>
 
@@ -139,6 +141,8 @@
       <CoreCLRFiles Include="$(CoreCLROverridePath)/*.*" />
       <CoreCLRILFiles Include="$(CoreCLROverridePath)/IL/*.*" />
       <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '$(CoreCLROverridePath)/%(Filename)%(Extension)')" />
+      <CoreCLRILFiles Include="@(CoreCLRILFiles -> '$(CoreCLRPDBOverridePath)/%(Filename).pdb')" />
+      <CoreCLRCrossGenFiles Include="@(CoreCLRCrossGenFiles -> '$(CoreCLRPDBOverridePath)/%(Filename).ni.pdb')" />
       <CoreCLRPDBFiles Condition="'$(CoreCLRPDBOverridePath)' != ''" Include="$(CoreCLRPDBOverridePath)/*.pdb" />
 
       <_ReferenceCopyLocalPathsToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />


### PR DESCRIPTION
This is part of #23588. This one is just to get the IL of CoreLib when CoreClrOverridePath, in the process also save the native image so later it can be restored. Usage of these files will come later from changes in buildtools.