### PR TITLE
Add HTTP/2.0 test server

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -9,12 +9,13 @@ namespace System.Net.Test.Common
         public static partial class Http
         {
             private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";
+            private static readonly string DefaultHttp2AzureServer = "corefx-net-http2.azurewebsites.net";
 
             public static string Host => GetValue("COREFX_HTTPHOST", DefaultAzureServer);
 
             public static string SecureHost => GetValue("COREFX_SECUREHTTPHOST", DefaultAzureServer);
 
-            public static string Http2Host => GetValue("COREFX_HTTP2HOST", "http2.akamai.com");
+            public static string Http2Host => GetValue("COREFX_HTTP2HOST", DefaultHttp2AzureServer);
 
             // This server doesn't use HTTP/2 server push (push promise) feature. Some HttpClient implementations
             // don't support servers that use push right now.
@@ -52,17 +53,21 @@ namespace System.Net.Test.Common
 
             public static readonly Uri RemoteEchoServer = new Uri("http://" + Host + "/" + EchoHandler);
             public static readonly Uri SecureRemoteEchoServer = new Uri("https://" + SecureHost + "/" + EchoHandler);
+            public static readonly Uri Http2RemoteEchoServer = new Uri("https://" + Http2Host + "/" + EchoHandler);
 
             public static readonly Uri RemoteVerifyUploadServer = new Uri("http://" + Host + "/" + VerifyUploadHandler);
             public static readonly Uri SecureRemoteVerifyUploadServer = new Uri("https://" + SecureHost + "/" + VerifyUploadHandler);
+            public static readonly Uri Http2RemoteVerifyUploadServer = new Uri("https://" + Http2Host + "/" + VerifyUploadHandler);
 
             public static readonly Uri RemoteEmptyContentServer = new Uri("http://" + Host + "/" + EmptyContentHandler);
             public static readonly Uri RemoteDeflateServer = new Uri("http://" + Host + "/" + DeflateHandler);
             public static readonly Uri RemoteGZipServer = new Uri("http://" + Host + "/" + GZipHandler);
+            public static readonly Uri Http2RemoteDeflateServer = new Uri("https://" + Http2Host + "/" + DeflateHandler);
+            public static readonly Uri Http2RemoteGZipServer = new Uri("https://" + Http2Host + "/" + GZipHandler);
 
-            public static readonly object[][] EchoServers = { new object[] { RemoteEchoServer }, new object[] { SecureRemoteEchoServer } };
-            public static readonly object[][] VerifyUploadServers = { new object[] { RemoteVerifyUploadServer }, new object[] { SecureRemoteVerifyUploadServer } };
-            public static readonly object[][] CompressedServers = { new object[] { RemoteDeflateServer }, new object[] { RemoteGZipServer } };
+            public static readonly object[][] EchoServers = { new object[] { RemoteEchoServer }, new object[] { SecureRemoteEchoServer }, new object[] { Http2RemoteEchoServer } };
+            public static readonly object[][] VerifyUploadServers = { new object[] { RemoteVerifyUploadServer }, new object[] { SecureRemoteVerifyUploadServer }, new object[] { Http2RemoteVerifyUploadServer } };
+            public static readonly object[][] CompressedServers = { new object[] { RemoteDeflateServer }, new object[] { RemoteGZipServer }, new object[] { Http2RemoteDeflateServer }, new object[] { Http2RemoteGZipServer } };
             public static readonly object[][] Http2Servers = { new object[] { new Uri("https://" + Http2Host) } };
             public static readonly object[][] Http2NoPushServers = { new object[] { new Uri("https://" + Http2NoPushHost) } };
 

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -54,7 +54,7 @@ namespace System.Net.Http.Functional.Tests
 
                 for (int i = 1; i <= 3; i++)
                 {
-                    HttpResponseMessage response = await client.PutAsync(serverUri, content);
+                    HttpResponseMessage response = await client.PostAsync(serverUri, content);
                     Assert.Equal(requestBody.Length, ms.Position); // Stream left at end after send.
 
                     string responseBody = await response.Content.ReadAsStringAsync();

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1181,7 +1181,7 @@ namespace System.Net.Tests
                 using (var sr = new StreamReader(myStream))
                 {
                     string strContent = sr.ReadToEnd();
-                    Assert.True(strContent.Contains("\"Host\": \"" + System.Net.Test.Common.Configuration.Http.Host + "\""));
+                    Assert.True(strContent.Contains("\"Host\": \"" + remoteServer.Host + "\""));
                 }
             }
         }


### PR DESCRIPTION
To prepare for the work of adding HTTP/2.0 support to SocketsHttpHandler, I deployed a new Azure
server. As with all HTTP/2.0 endpoints, only HTTPS (TLS) is supported.

This server is based on Azure Web Apps instead of Azure Cloud Services (classic). This makes it
easier to scale out and maintain as well as give us a staging environment to validate upgrades to
the test server without affecting the production PR/CI runs.

Although the default for HttpClient/HttpRequestMessage.Version is 2.0, only the older platform handler
stacks (WinHttpHandler, CurlHandler, UAP) will send as HTTP/2.0. SocketsHttpHandler is currently just
ignoring the version value and using HTTP/1.1 as the request version. When SocketsHttpHandler is
modified to support HTTP/2.0, then all default requests by HttpClient will attempt HTTP/2.0.
Our existing Azure test server (and loopback server) will still downgrade to HTTP/1.1. But this
new test server will use HTTP/2.0.