### PR TITLE
Improve code coverage for NegoState class

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/NegoState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegoState.cs
@@ -53,6 +53,8 @@ namespace System.Net.Security
 
         internal NegoState(Stream innerStream, bool leaveStreamOpen)
         {
+            Debug.Assert(innerStream != null);
+
             _innerStream = innerStream;
             _leaveStreamOpen = leaveStreamOpen;
         }

--- a/src/System.Net.Security/src/System/Net/Security/NegoState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegoState.cs
@@ -53,11 +53,6 @@ namespace System.Net.Security
 
         internal NegoState(Stream innerStream, bool leaveStreamOpen)
         {
-            if (innerStream == null)
-            {
-                throw new ArgumentNullException("stream");
-            }
-
             _innerStream = innerStream;
             _leaveStreamOpen = leaveStreamOpen;
         }

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamInvalidOperationTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamInvalidOperationTest.cs
@@ -303,24 +303,14 @@ namespace System.Net.Security.Tests
             using (var client = new NegotiateStream(clientStream))
             using (var server = new NegotiateStream(serverStream))
             {
-                try
-                {
-                    // ProtectionLevel not match.
-                    await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                // ProtectionLevel not match.
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                    Assert.ThrowsAsync<AuthenticationException>(() =>
                         client.AuthenticateAsClientAsync((NetworkCredential)CredentialCache.DefaultCredentials,
-                            TargetName, ProtectionLevel.None, TokenImpersonationLevel.Identification),
+                            TargetName, ProtectionLevel.None, TokenImpersonationLevel.Identification)),
+                    Assert.ThrowsAsync<AuthenticationException>(() =>
                         server.AuthenticateAsServerAsync((NetworkCredential)CredentialCache.DefaultCredentials,
-                            ProtectionLevel.Sign, TokenImpersonationLevel.Identification));
-                }
-                catch (AggregateException e)
-                {
-                    ReadOnlyCollection<Exception> exceptions = e.InnerExceptions;
-                    Assert.Equal(2, exceptions.Count);
-                    foreach (Exception ex in exceptions)
-                    {
-                        Assert.Equal(typeof(AuthenticationException), ex.InnerException.GetType());
-                    }
-                }
+                            ProtectionLevel.Sign, TokenImpersonationLevel.Identification)));
 
                 Assert.Throws<AuthenticationException>(() => client.Write(s_sampleMsg, 0, s_sampleMsg.Length));
             }

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -90,6 +90,8 @@ namespace System.Net.Security.Tests
             {
                 Assert.False(client.IsAuthenticated);
                 Assert.False(server.IsAuthenticated);
+                Assert.Equal(false, client.IsMutuallyAuthenticated);
+                Assert.Equal(false, server.IsMutuallyAuthenticated);
 
                 Task[] auth = new Task[2];
 

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -90,8 +90,8 @@ namespace System.Net.Security.Tests
             {
                 Assert.False(client.IsAuthenticated);
                 Assert.False(server.IsAuthenticated);
-                Assert.Equal(false, client.IsMutuallyAuthenticated);
-                Assert.Equal(false, server.IsMutuallyAuthenticated);
+                Assert.False(client.IsMutuallyAuthenticated);
+                Assert.False(server.IsMutuallyAuthenticated);
 
                 Task[] auth = new Task[2];
 


### PR DESCRIPTION
Contributes to #17099

Before the PR:

System.Net.Security | 6025 | 2721 | 8746 | 32749 | 68.8% |  55.2%
-- | -- | -- | -- | -- | --  | --
System.Net.Security.NegoState | 267 | 229 | 496 | 843 | **_53.8%_** | **_46.5%_**


After PR:

System.Net.Security | 6311 | 2432 | 8743 | 32744 | 72.1% | 58.1%
-- | -- | -- | -- | -- | --  | --
System.Net.Security.NegoState | 392 | 101 | 493 | 838 | _**79.5%**_ | _**71.7%**_

Summary:
- Clean a redundant check in `NegoState`.
- Add more test cases for corner cases check in `NegoState` class.