### PR TITLE
fix dereferencing uninitialized byte array in case recv() fails

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -380,14 +380,15 @@ namespace System.Net.Sockets
 
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
-                ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
             }
 
             if (errno != Interop.Error.SUCCESS)
             {
+                ipPacketInformation = default(IPPacketInformation);
                 return -1;
             }
 
+            ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
             socketAddressLen = sockAddrLen;
             return checked((int)received);
         }
@@ -442,15 +443,16 @@ namespace System.Net.Sockets
 
                     receivedFlags = messageHeader.Flags;
                     int sockAddrLen = messageHeader.SocketAddressLen;
-                    ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
 
                     if (errno == Interop.Error.SUCCESS)
                     {
+                        ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
                         socketAddressLen = sockAddrLen;
                         return checked((int)received);
                     }
                     else
                     {
+                        ipPacketInformation = default(IPPacketInformation);
                         return -1;
                     }
                 }


### PR DESCRIPTION
fixes #29376 [arm32/Ubuntu] corefx test failures: System.Net.NetworkInformation.Functional.Tests, System.Net.Sockets.Tests

related to #27411 Re-enable initlocals clearing in System.Net.Sockets on Unix

We disabled initialization of local variables for sockets. We pass buffer allocated via stackalloc() to get ancillary data. When recv() call fails (like with EAGAIN) the buffer is uninitialized and it is not safe to parse it and use data or pointers from it. This does not seems ARM specific bug. X86 may be just more lucky getting stack full of zeros. My initial POC was to initialize control buffer (24b) to zeros.so 
That fixes the crash as well (by fining first message has 0 length) but I think this fix is better. 
It would be nice IMHO if we do not need to allocate ipPacketInformation but that is beyond this fix. 

I also briefly scan for other use of stackalloc() in sockets and the other place looks reasonable. 

I re-run all (outerloop) test on ARM system and I see no crash. Four tests timed out - but the ARM system  is MUCH slower so this may not be sign of real problem. 

