### PR TITLE
Fix GH Issue 29609 Set correct client process ID

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -455,7 +455,9 @@
     <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.DiagnosticSource" />
+    <Reference Include="System.Diagnostics.Process" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Diagnostics.Tracing" />
     <Reference Include="System.Linq" />
     <Reference Include="System.ObjectModel" />
     <Reference Include="System.Runtime.Extensions" />
@@ -477,7 +479,6 @@
     <Reference Include="System.Net.Security" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Net.NameResolution" />
-    <Reference Include="System.Diagnostics.Tracing" />
   </ItemGroup>
   <ItemGroup Condition="('$(OSGroup)' != 'AnyOS' AND '$(IsUAPAssembly)' == 'true') OR '$(TargetGroup)' == 'netcoreapp'">
     <Reference Include="System.Transactions.Local" />

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStaticMethods.cs
@@ -63,8 +63,12 @@ namespace System.Data.SqlClient
             {
                 // Pick up the process Id from the current process instead of randomly generating it.
                 // This would be helpful while tracing application related issues.
-                int processId = System.Diagnostics.Process.GetCurrentProcess().Id;
-                Threading.Interlocked.CompareExchange(ref s_currentProcessId, processId, NoProcessId);
+                int processId;
+                using (System.Diagnostics.Process p = System.Diagnostics.Process.GetCurrentProcess())
+                {
+                    processId = p.Id;
+                }
+                System.Threading.Volatile.Write(ref s_currentProcessId, processId);
             }
             return s_currentProcessId;
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStaticMethods.cs
@@ -61,11 +61,9 @@ namespace System.Data.SqlClient
         {
             if (s_currentProcessId == NoProcessId)
             {
-                // In ProjectK\CoreCLR we don't want to take a dependency on an assembly
-                // just to grab the real Process Id that the server doesn't really use
-                // So, instead, pick a random number and use that for all connections
-                Random rand = new Random();
-                int processId = rand.Next();
+                // Pick up the process Id from the current process instead of randomly generating it.
+                // This would be helpful while tracing application related issues.
+                int processId = System.Diagnostics.Process.GetCurrentProcess().Id;
                 Threading.Interlocked.CompareExchange(ref s_currentProcessId, processId, NoProcessId);
             }
             return s_currentProcessId;


### PR DESCRIPTION
This code change fixes issues #29609 and https://github.com/Microsoft/sqlopsstudio/issues/1380
It sets the Process Id for the current application by using property `System.Diagnostics.Process.GetCurrentProcess().Id` instead of randomly generating and assigning the Process Id