### PR TITLE
Duplicate the access token passed to WindowsIdentity.RunImpersonated

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.DuplicateHandle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.DuplicateHandle.cs
@@ -19,5 +19,15 @@ internal static partial class Interop
             uint dwDesiredAccess,
             bool bInheritHandle,
             uint dwOptions);
+
+        [DllImport(Interop.Libraries.Kernel32, SetLastError = true)]
+        internal static extern bool DuplicateHandle(
+            IntPtr hSourceProcessHandle,
+            SafeAccessTokenHandle hSourceHandle,
+            IntPtr hTargetProcessHandle,
+            ref SafeAccessTokenHandle lpTargetHandle,
+            uint dwDesiredAccess,
+            bool bInheritHandle,
+            uint dwOptions);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.DuplicateHandle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.DuplicateHandle.cs
@@ -19,15 +19,5 @@ internal static partial class Interop
             uint dwDesiredAccess,
             bool bInheritHandle,
             uint dwOptions);
-
-        [DllImport(Interop.Libraries.Kernel32, SetLastError = true)]
-        internal static extern bool DuplicateHandle(
-            IntPtr hSourceProcessHandle,
-            SafeAccessTokenHandle hSourceHandle,
-            IntPtr hTargetProcessHandle,
-            ref SafeAccessTokenHandle lpTargetHandle,
-            uint dwDesiredAccess,
-            bool bInheritHandle,
-            uint dwOptions);
     }
 }

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -235,21 +235,19 @@ namespace System.Security.Principal
                 return accessToken;
             }
 
-            SafeAccessTokenHandle duplicateAccessToken = SafeAccessTokenHandle.InvalidHandle;
-            IntPtr currentProcessHandle = Interop.Kernel32.GetCurrentProcess();
-            if (!Interop.Kernel32.DuplicateHandle(
-                    currentProcessHandle,
-                    accessToken,
-                    currentProcessHandle,
-                    ref duplicateAccessToken,
-                    0,
-                    true,
-                    Interop.DuplicateHandleOptions.DUPLICATE_SAME_ACCESS))
+            bool refAdded = false;
+            try
             {
-                throw new SecurityException(new Win32Exception().Message);
+                accessToken.DangerousAddRef(ref refAdded);
+                return DuplicateAccessToken(accessToken.DangerousGetHandle());
             }
-
-            return duplicateAccessToken;
+            finally
+            {
+                if (refAdded)
+                {
+                    accessToken.DangerousRelease();
+                }
+            }
         }
 
         private void CreateFromToken(IntPtr userToken)

--- a/src/System.Security.Principal.Windows/tests/System.Security.Principal.Windows.Tests.csproj
+++ b/src/System.Security.Principal.Windows/tests/System.Security.Principal.Windows.Tests.csproj
@@ -14,5 +14,10 @@
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
+      <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
+    </Compile>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -146,7 +146,6 @@ public class WindowsIdentityTests
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void BeginTask(RunImpersonatedAsyncTestInfo testInfo)
     {
-        testInfo.task = null;
         testInfo.continueTask = new SemaphoreSlim(0, 1);
         using (SafeAccessTokenHandle token = WindowsIdentity.GetCurrent().AccessToken)
         {

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -5,8 +5,12 @@
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tests;
 using Xunit;
 
 public class WindowsIdentityTests
@@ -118,6 +122,57 @@ public class WindowsIdentityTests
 
             Assert.Equal(manualCount, autoCount);
         }
+    }
+
+    [Fact]
+    public static void RunImpersonatedAsyncTest()
+    {
+        var testData = new RunImpersonatedAsyncTestInfo();
+        BeginTask(testData);
+
+        // Wait for the SafeHandle that was disposed in BeginTask() to actually be closed
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.WaitForPendingFinalizers();
+
+        testData.continueTask.Release();
+        testData.task.Wait();
+        if (testData.exception != null)
+        {
+            throw new AggregateException(testData.exception);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void BeginTask(RunImpersonatedAsyncTestInfo testInfo)
+    {
+        testInfo.task = null;
+        testInfo.continueTask = new SemaphoreSlim(0, 1);
+        using (SafeAccessTokenHandle token = WindowsIdentity.GetCurrent().AccessToken)
+        {
+            WindowsIdentity.RunImpersonated(token, () =>
+            {
+                testInfo.task = Task.Run(async () =>
+                {
+                    try
+                    {
+                        Task<bool> task = testInfo.continueTask.WaitAsync(ThreadTestHelpers.UnexpectedTimeoutMilliseconds);
+                        Assert.True(await task.ConfigureAwait(false));
+                    }
+                    catch (Exception ex)
+                    {
+                        testInfo.exception = ex;
+                    }
+                });
+            });
+        }
+    }
+
+    private class RunImpersonatedAsyncTestInfo
+    {
+        public Task task;
+        public SemaphoreSlim continueTask;
+        public Exception exception;
     }
 
     private static void CheckDispose(WindowsIdentity identity, bool anonymous = false)

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -136,7 +136,7 @@ public class WindowsIdentityTests
         GC.WaitForPendingFinalizers();
 
         testData.continueTask.Release();
-        testData.task.Wait();
+        testData.task.CheckedWait();
         if (testData.exception != null)
         {
             throw new AggregateException(testData.exception);


### PR DESCRIPTION
So that callbacks for async work initiated while impersonated may continue to impersonate even after the original access token had been disposed.

Fix for https://github.com/dotnet/corefx/issues/30275