### PR TITLE
[release/2.1] Remove property setters from netstandard ref that are not in NetFx

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
+++ b/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
@@ -91,9 +91,9 @@ namespace System.Security.Cryptography.Pkcs
         public SubjectIdentifierType SignerIdentifierType { get => throw null; set => throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; set => throw null; }
         public Oid DigestAlgorithm { get => throw null; set => throw null; }
-        public CryptographicAttributeObjectCollection SignedAttributes { get => throw null; set => throw null; }
-        public CryptographicAttributeObjectCollection UnsignedAttributes { get => throw null; set => throw null; }
-        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get => throw null; set => throw null; }
+        public CryptographicAttributeObjectCollection SignedAttributes { get => throw null; }
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get => throw null; }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get => throw null; }
         public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get => throw null; set => throw null; }
     }
     public sealed partial class ContentInfo

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -16,12 +16,12 @@ namespace System.Security.Cryptography.Pkcs
         private static readonly Oid s_defaultAlgorithm = Oid.FromOidValue(Oids.Sha256, OidGroup.HashAlgorithm);
 
         public X509Certificate2 Certificate { get; set; }
-        public X509Certificate2Collection Certificates { get; set; } = new X509Certificate2Collection();
+        public X509Certificate2Collection Certificates { get; private set; } = new X509Certificate2Collection();
         public Oid DigestAlgorithm { get; set; }
         public X509IncludeOption IncludeOption { get; set; }
-        public CryptographicAttributeObjectCollection SignedAttributes { get; set; } = new CryptographicAttributeObjectCollection();
+        public CryptographicAttributeObjectCollection SignedAttributes { get; private set; } = new CryptographicAttributeObjectCollection();
         public SubjectIdentifierType SignerIdentifierType { get; set; }
-        public CryptographicAttributeObjectCollection UnsignedAttributes { get; set; } = new CryptographicAttributeObjectCollection();
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get; private set; } = new CryptographicAttributeObjectCollection();
 
         public CmsSigner()
             : this(SubjectIdentifierType.IssuerAndSerialNumber, null)


### PR DESCRIPTION
ApiCompat didn't check the netfx implementation against the netstandard ref,
so we failed to notice that the netstandard contract defined three properties as
get-set which were get-only in .NET Framework.

This change removes the members from the ref (and netcoreapp impl), to avoid
the MissingMethodException which would result from their use.

Fixes #30359.