### PR TITLE
Remove test TestNotSupportedExceptionForTransactionScopeAsync

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
@@ -81,12 +81,5 @@ namespace System.Data.SqlClient.Tests
                 connectAction(connectionString);
             });
         }
-
-        [ActiveIssue(30144)]
-        [Fact]
-        public async Task TestNotSupportedExceptionForTransactionScopeAsync()
-        {
-            await Assert.ThrowsAsync<NotSupportedException>(() => ConnectToServerInTransactionScopeTask(s_connectionStringWithEnlistAsDefault));
-        }
     }
 }


### PR DESCRIPTION
Removing test `TestNotSupportedExceptionForTransactionScopeAsync` as it is no longer valid as per #30144 

Closes #30144