### PR TITLE
Fix creating subdirectories under directories with trailing separator…

### DIFF
--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -89,14 +89,38 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory + "/path").CreateSubdirectory("../../path2"));
         }
 
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void SubdirectoryOverlappingName_ThrowsArgumentException()
+        {
+            // What we're looking for here is trying to create C:\FooBar under C:\Foo by passing "..\FooBar"
+            DirectoryInfo info = Directory.CreateDirectory(GetTestFilePath());
+
+            string overlappingName = ".." + Path.DirectorySeparatorChar + info.Name + "overlap";
+
+            Assert.Throws<ArgumentException>(() => info.CreateSubdirectory(overlappingName));
+
+            // Now try with an info with a trailing separator
+            info = new DirectoryInfo(info.FullName + Path.DirectorySeparatorChar);
+            Assert.Throws<ArgumentException>(() => info.CreateSubdirectory(overlappingName));
+        }
+
         [Theory,
             MemberData(nameof(ValidPathComponentNames))]
         public void ValidPathWithTrailingSlash(string component)
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
-            string path = IOServices.AddTrailingSlashIfNeeded(component);
+            string path = component + Path.DirectorySeparatorChar;
             DirectoryInfo result = new DirectoryInfo(testDir.FullName).CreateSubdirectory(path);
+
+            Assert.Equal(Path.Combine(testDir.FullName, path), result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
+
+            // Now try creating subdirectories when the directory info itself has a slash
+            testDir = Directory.CreateDirectory(GetTestFilePath() + Path.DirectorySeparatorChar);
+
+            result = new DirectoryInfo(testDir.FullName).CreateSubdirectory(path);
 
             Assert.Equal(Path.Combine(testDir.FullName, path), result.FullName);
             Assert.True(Directory.Exists(result.FullName));
@@ -114,6 +138,13 @@ namespace System.IO.Tests
             Assert.Equal(Path.Combine(testDir.FullName, path), result.FullName);
             Assert.True(Directory.Exists(result.FullName));
 
+            // Now try creating subdirectories when the directory info itself has a slash
+            testDir = Directory.CreateDirectory(GetTestFilePath() + Path.DirectorySeparatorChar);
+
+            result = new DirectoryInfo(testDir.FullName).CreateSubdirectory(path);
+
+            Assert.Equal(Path.Combine(testDir.FullName, path), result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
         }
 
         [Fact]


### PR DESCRIPTION
This change ports PR #30293, which fixes #30283.

* Fix creating subdirectories under directories with trailing separators

This broke with #27810. Reworked the logic in an attempt to be clearer and added test cases.

This addresses #30283.

* Flip the logic to make it a little easier to follow.
(Reduces the number of nots.)

* Skip new test on desktop