### PR TITLE
[release/2.1] Ensure SocketsHttpHandler sends known verbs uppercased (#30149)

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Net.Http
@@ -20,6 +21,19 @@ namespace System.Net.Http
         private static readonly HttpMethod s_traceMethod = new HttpMethod("TRACE");
         private static readonly HttpMethod s_patchMethod = new HttpMethod("PATCH");
         private static readonly HttpMethod s_connectMethod = new HttpMethod("CONNECT");
+
+        private static readonly Dictionary<HttpMethod, HttpMethod> s_knownMethods = new Dictionary<HttpMethod, HttpMethod>(9)
+        {
+            { s_getMethod, s_getMethod },
+            { s_putMethod, s_putMethod },
+            { s_postMethod, s_postMethod },
+            { s_deleteMethod, s_deleteMethod },
+            { s_headMethod, s_headMethod },
+            { s_optionsMethod, s_optionsMethod },
+            { s_traceMethod, s_traceMethod },
+            { s_patchMethod, s_patchMethod },
+            { s_connectMethod, s_connectMethod },
+        };
 
         public static HttpMethod Get
         {
@@ -118,12 +132,7 @@ namespace System.Net.Http
         {
             if (_hashcode == 0)
             {
-                // If _method is already uppercase, _method.GetHashCode() can be
-                // used instead of _method.ToUpperInvariant().GetHashCode(),
-                // avoiding the unnecessary extra string allocation.
-                _hashcode = IsUpperAscii(_method) ?
-                    _method.GetHashCode() :
-                    _method.ToUpperInvariant().GetHashCode();
+                _hashcode = StringComparer.OrdinalIgnoreCase.GetHashCode(_method);
             }
 
             return _hashcode;
@@ -136,16 +145,9 @@ namespace System.Net.Http
 
         public static bool operator ==(HttpMethod left, HttpMethod right)
         {
-            if ((object)left == null)
-            {
-                return ((object)right == null);
-            }
-            else if ((object)right == null)
-            {
-                return ((object)left == null);
-            }
-
-            return left.Equals(right);
+            return (object)left == null || (object)right == null ?
+                ReferenceEquals(left, right) :
+                left.Equals(right);
         }
 
         public static bool operator !=(HttpMethod left, HttpMethod right)
@@ -153,18 +155,16 @@ namespace System.Net.Http
             return !(left == right);
         }
 
-        private static bool IsUpperAscii(string value)
+        /// <summary>
+        /// Returns a singleton method instance with a capitalized method name for the supplied method
+        /// if it's known; otherwise, returns the original.
+        /// </summary>
+        internal static HttpMethod Normalize(HttpMethod method)
         {
-            for (int i = 0; i < value.Length; i++)
-            {
-                char c = value[i];
-                if (!(c >= 'A' && c <= 'Z'))
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            Debug.Assert(method != null);
+            return s_knownMethods.TryGetValue(method, out HttpMethod normalized) ?
+                normalized :
+                method;
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -362,7 +362,7 @@ namespace System.Net.Http
             Debug.Assert(RemainingBuffer.Length == 0, "Unexpected data in read buffer");
 
             _currentRequest = request;
-            bool isConnectMethod = (request.Method == HttpMethod.Connect);
+            HttpMethod normalizedMethod = HttpMethod.Normalize(request.Method);
 
             Debug.Assert(!_canRetry);
             _canRetry = true;
@@ -373,10 +373,10 @@ namespace System.Net.Http
             try
             {
                 // Write request line
-                await WriteStringAsync(request.Method.Method).ConfigureAwait(false);
+                await WriteStringAsync(normalizedMethod.Method).ConfigureAwait(false);
                 await WriteByteAsync((byte)' ').ConfigureAwait(false);
 
-                if (isConnectMethod)
+                if (ReferenceEquals(normalizedMethod, HttpMethod.Connect))
                 {
                     // RFC 7231 #section-4.3.6.
                     // Write only CONNECT foo.com:345 HTTP/1.1
@@ -442,7 +442,7 @@ namespace System.Net.Http
                 {
                     // Write out Content-Length: 0 header to indicate no body,
                     // unless this is a method that never has a body.
-                    if (request.Method != HttpMethod.Get && request.Method != HttpMethod.Head && !isConnectMethod)
+                    if (!ReferenceEquals(normalizedMethod, HttpMethod.Get) && !ReferenceEquals(normalizedMethod, HttpMethod.Head) && !ReferenceEquals(normalizedMethod, HttpMethod.Connect))
                     {
                         await WriteBytesAsync(s_contentLength0NewlineAsciiBytes).ConfigureAwait(false);
                     }
@@ -601,12 +601,12 @@ namespace System.Net.Http
 
                 // Create the response stream.
                 HttpContentStream responseStream;
-                if (request.Method == HttpMethod.Head || response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.NotModified)
+                if (ReferenceEquals(normalizedMethod, HttpMethod.Head) || response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.NotModified)
                 {
                     responseStream = EmptyReadStream.Instance;
                     CompleteResponse();
                 }
-                else if (isConnectMethod && response.StatusCode == HttpStatusCode.OK)
+                else if (ReferenceEquals(normalizedMethod, HttpMethod.Connect) && response.StatusCode == HttpStatusCode.OK)
                 {
                     // Successful response to CONNECT does not have body.
                     // What ever comes next should be opaque.

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -22,6 +22,14 @@ namespace System.Net.Http.Functional.Tests
     public sealed class SocketsHttpHandler_HttpProtocolTests : HttpProtocolTests
     {
         protected override bool UseSocketsHttpHandler => true;
+
+        [Theory]
+        [InlineData("delete", "DELETE")]
+        [InlineData("options", "OPTIONS")]
+        [InlineData("trace", "TRACE")]
+        [InlineData("patch", "PATCH")]
+        public Task CustomMethod_SentUppercasedIfKnown_Additional(string specifiedMethod, string expectedMethod) =>
+            CustomMethod_SentUppercasedIfKnown(specifiedMethod, expectedMethod);
     }
 
     public sealed class SocketsHttpHandler_HttpProtocolTests_Dribble : HttpProtocolTests_Dribble


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/30149 to release/2.1
Fixes #30143 