### PR TITLE
Make WindowsIdentity.RunImpersonated closer in behavior to Netfx

### DIFF
--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -125,6 +125,20 @@ public class WindowsIdentityTests
     }
 
     [Fact]
+    public static void RunImpersonatedTest_InvalidHandle()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            using (var mutex = new Mutex())
+            {
+                WindowsIdentity.RunImpersonated(
+                    new SafeAccessTokenHandle(mutex.SafeWaitHandle.DangerousGetHandle()),
+                    () => { });
+            }
+        });
+    }
+
+    [Fact]
     public static void RunImpersonatedAsyncTest()
     {
         var testData = new RunImpersonatedAsyncTestInfo();

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -127,15 +127,15 @@ public class WindowsIdentityTests
     [Fact]
     public static void RunImpersonatedTest_InvalidHandle()
     {
-        Assert.Throws<ArgumentException>(() =>
+        using (var mutex = new Mutex())
         {
-            using (var mutex = new Mutex())
+            Assert.Throws<ArgumentException>(() =>
             {
                 WindowsIdentity.RunImpersonated(
                     new SafeAccessTokenHandle(mutex.SafeWaitHandle.DangerousGetHandle()),
                     () => { });
-            }
-        });
+            });
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Followup to https://github.com/dotnet/corefx/pull/30346, this is closer to Netfx behavior for invalid handles