### PR TITLE
Remove definition of USE_ETW

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp' And '$(TargetsWindows)' == 'true'">$(DefineConstants);USE_ETW</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />


### PR DESCRIPTION
Fixes #27116.

#30076 removed all uses of USE_ETW.  This PR removes the definition of it.