### PR TITLE
Remove ObjectMarker from OpenSsl

### DIFF
--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
@@ -16,8 +16,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.OpenSsl.cs" />
-    <!-- ApiCompat requires an object reference to determine the core assembly. -->
-    <AssemblyInfoSource Include="internal class ObjectMarker { }" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -15,10 +15,6 @@
     <PackageTargetRuntime>
     </PackageTargetRuntime>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
-    <!-- ApiCompat requires an object reference to determine the core assembly. -->
-    <AssemblyInfoSource Include="internal class ObjectMarker { }" />
-  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />


### PR DESCRIPTION
This class was added to satisfy ApiCompat, but with https://github.com/dotnet/buildtools/pull/1961, ApiCompat no longer runs on the netstandard version of this assembly (since it is a PNSE assembly). Thus, we no longer need the ObjectMarker class.

This also allows buildtools to remove the `@(AssemblyInfoSource)` support, since this was the only place using it.