### PR TITLE
Add test for IncompleteAsyncMethod async event

### DIFF
--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -12,7 +12,7 @@ using System.Diagnostics;
 
 namespace System.Threading.Tasks.Tests
 {
-    public class AsyncTaskMethodBuilderTests
+    public partial class AsyncTaskMethodBuilderTests
     {
         // Test captured sync context with successful completion (SetResult)
         [Fact]

--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.netcoreapp.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.netcoreapp.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests
+{
+    public partial class AsyncTaskMethodBuilderTests : RemoteExecutorTestBase
+    {
+        [OuterLoop]
+        [Fact]
+        public static void DroppedIncompleteStateMachine_RaisesIncompleteAsyncMethodEvent()
+        {
+            RemoteInvoke(() =>
+            {
+                using (var listener = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose))
+                {
+                    var events = new ConcurrentQueue<EventWrittenEventArgs>();
+                    listener.RunWithCallback(events.Enqueue, () =>
+                    {
+                        NeverCompletes();
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                    });
+
+                    Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself
+                    EventWrittenEventArgs iam = events.SingleOrDefault(e => e.EventName == "IncompleteAsyncMethod");
+                    Assert.NotNull(iam);
+                    Assert.NotNull(iam.Payload);
+
+                    string description = iam.Payload[0] as string;
+                    Assert.NotNull(description);
+                    Assert.Contains(nameof(NeverCompletesAsync), description);
+                    Assert.Contains("__state", description);
+                    Assert.Contains("local1", description);
+                    Assert.Contains("local2", description);
+                    Assert.Contains("42", description);
+                    Assert.Contains("stored data", description);
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void NeverCompletes() { var ignored = NeverCompletesAsync(); }
+
+        private static async Task NeverCompletesAsync()
+        {
+            int local1 = 42;
+            string local2 = "stored data";
+            await new TaskCompletionSource<bool>().Task; // await will never complete
+            GC.KeepAlive(local1);
+            GC.KeepAlive(local2);
+        }
+    }
+}

--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.netcoreapp.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.netcoreapp.cs
@@ -27,6 +27,7 @@ namespace System.Threading.Tasks.Tests
                         NeverCompletes();
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
+                        GC.WaitForPendingFinalizers();
                     });
 
                     Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -57,6 +57,16 @@
     <Compile Include="CancellationTokenTests.netcoreapp.cs" />
     <Compile Include="Task\TaskCanceledExceptionTests.netcoreapp.cs" />
     <Compile Include="Task\TaskStatusTest.netcoreapp.cs" />
+    <Compile Include="System.Runtime.CompilerServices\AsyncTaskMethodBuilderTests.netcoreapp.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
In 2.1, I added an event that's fired when an async method state machine object gets garbage collected without having reached a completed state.  Apparently I never added a test for that behavior.  This does.

cc: @kouvel 