### PR TITLE
Add support for concatenated GZip streams.

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibNative.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibNative.cs
@@ -137,6 +137,9 @@ namespace System.IO.Compression
                                                           // More is faster and better compression with more memory usage.
         public const int Deflate_NoCompressionMemLevel = 7;
 
+        public const byte GZip_Header_ID1 = 31;
+        public const byte GZip_Header_ID2 = 139;
+
         /**
          * Do not remove the nested typing of types inside of <code>System.IO.Compression.ZLibNative</code>.
          * This was done on purpose to:

--- a/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -32,6 +32,137 @@ namespace System.IO.Compression
             }
         }
 
+        [Fact]
+        public void ConcatenatedGzipStreams()
+        {
+            using (MemoryStream concatStream = new MemoryStream())
+            {
+                using (var gz = new GZipStream(concatStream, CompressionLevel.NoCompression, true))
+                using (var sw = new StreamWriter(gz))
+                    sw.WriteLine("Stream 1");
+
+                using (var gz = new GZipStream(concatStream, CompressionLevel.NoCompression, true))
+                using (var sw = new StreamWriter(gz))
+                    sw.WriteLine("Stream 2");
+
+                new GZipStream(concatStream, CompressionLevel.NoCompression, true).Dispose();
+
+                concatStream.Seek(0, SeekOrigin.Begin);
+                using (var gz = new GZipStream(concatStream, CompressionMode.Decompress))
+                using (var sr = new StreamReader(gz))
+                {
+                    Assert.Equal("Stream 1", sr.ReadLine());
+                    Assert.Equal("Stream 2", sr.ReadLine());
+                    Assert.Empty(sr.ReadToEnd());
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(1000, false, false, 1000, 1)]
+        [InlineData(1000, false, true, 0, 1)]
+        [InlineData(1000, true, false, 1000, 1)]
+        [InlineData(1000, false, false, 1, 1)]
+        [InlineData(1000, true, false, 1, 1)]
+        [InlineData(1000, false, false, 1001 * 24, 1)]
+        [InlineData(1000, true, false, 1001 * 24, 1)]
+        public async void ManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
+        {
+            await TestConcatenatedGzipStreams(streamCount, useAsync, useReadByte, bufferSize, bytesPerStream);
+        }
+
+        [Theory]
+        [OuterLoop("Tests take a very long time to complete")]
+        [InlineData(400000, false, false, 1000, 1)]
+        [InlineData(400000, true, false, 1000, 1)]
+        [InlineData(1000, false, false, 1000, 20000)]
+        [InlineData(1000, false, true, 0, 20000)]
+        [InlineData(1000, true, false, 1000, 9000)]
+        [InlineData(1000, false, false, 1, 9000)]
+        [InlineData(1000, true, false, 1, 9000)]
+        [InlineData(1000, false, false, 1001 * 24, 9000)]
+        [InlineData(1000, true, false, 1001 * 24, 9000)]
+        public async void ManyManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
+        {
+            await TestConcatenatedGzipStreams(streamCount, useAsync, useReadByte, bufferSize, bytesPerStream);
+        }
+
+        private async Task TestConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream = 1)
+        {
+            using (var correctDecompressedOutput = new MemoryStream())
+            using (var compressedStream = new MemoryStream())
+            using (var decompressorOutput = new MemoryStream())
+            {
+                for (int i = 0; i < streamCount; i++)
+                {
+                    using (var gz = new GZipStream(compressedStream, CompressionLevel.NoCompression, true))
+                    {
+                        for (int j = 0; j < bytesPerStream; j++)
+                        {
+                            byte b = (byte)((i * j) % 256);
+                            gz.WriteByte( b);
+                            correctDecompressedOutput.WriteByte(b);
+                        }
+                    }
+                }
+                compressedStream.Seek(0, SeekOrigin.Begin);
+
+                var decompressor = CreateStream(compressedStream, CompressionMode.Decompress);
+                //Thread.Sleep(10000);
+
+                var bytes = new byte[bufferSize];
+                bool finished = false;
+                int retCount = 0, totalRead = 0;
+                while (!finished)
+                {
+                    if (useAsync)
+                    {
+                        try
+                        {
+                            retCount = await decompressor.ReadAsync(bytes, 0, bufferSize);
+                            totalRead += retCount;
+                            if (retCount != 0)
+                                await decompressorOutput.WriteAsync(bytes, 0, retCount);
+                            else
+                                finished = true;
+                        }
+                        catch (Exception)
+                        {
+                            throw new Exception(retCount + " " + totalRead);
+                        }
+                    }
+                    else if (useReadByte)
+                    {
+                        int b = decompressor.ReadByte();
+
+                        if (b != -1)
+                            decompressorOutput.WriteByte((byte)b);
+                        else
+                            finished = true;
+                    }
+                    else
+                    {
+                        retCount = decompressor.Read(bytes, 0, bufferSize);
+
+                        if (retCount != 0)
+                            decompressorOutput.Write(bytes, 0, retCount);
+                        else
+                            finished = true;
+                    }
+                }
+                decompressor.Dispose();
+                decompressorOutput.Position = 0;
+
+                byte[] decompressorOutputBytes = decompressorOutput.ToArray();
+                byte[] correctOutputBytes = correctDecompressedOutput.ToArray();
+
+                Assert.Equal(correctOutputBytes.Length, decompressorOutputBytes.Length);
+                for (int i = 0; i < correctOutputBytes.Length; i++)
+                {
+                    Assert.Equal(correctOutputBytes[i], decompressorOutputBytes[i]);
+                }
+            }
+        }
 
         [Fact]
         public void DerivedStream_ReadWriteSpan_UsesReadWriteArray()


### PR DESCRIPTION
Currently, if you pass two or more concatenated GZipStreams we will read into the second one (to fill a buffer) but not do anything with that information. This PR modifies the Inflater code to instead look at the appended data for the Gzip header magic bytes and treats the rest of the data stream as an additional data segment if they are found.

More info:
- There is no limit to the number of concatenated GZipStreams supported.
- If a GZipStream is appended with garbage that happens to have its first two bytes equal to the GZip header bytes, then an exception will result. This is an acceptable risk, as garbage appended to a valid GZipStream isn't really usable right now anyways since we read past the end of the first stream into that data to fill our input buffer.
- Added exhaustive tests to test buffer boundary behavior
- Concatenated streams are supported using Read, ReadAsync, CopyTo, etc.

resolves https://github.com/dotnet/corefx/issues/27279

PTAL: @stephentoub @ViktorHofer
FYI: @mburbea, @kentalot