### PR TITLE
Exclude tests that require gdiplus to not produce errors

### DIFF
--- a/src/Common/tests/Performance/BenchmarkFilter.cs
+++ b/src/Common/tests/Performance/BenchmarkFilter.cs
@@ -5,11 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-[assembly: TestCaseOrderer("Xunit.NetCore.Extensions.BenchmarkFilter", "System.Drawing.Common.Performance.Tests")]
+// Usage: [assembly: TestCaseOrderer("Xunit.NetCore.Extensions.BenchmarkFilter", "System.Drawing.Common.Performance.Tests")]
 
 namespace Xunit.NetCore.Extensions
 {

--- a/src/System.Drawing.Common/tests/Performance/BenchmarkFilter.cs
+++ b/src/System.Drawing.Common/tests/Performance/BenchmarkFilter.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestCaseOrderer("Xunit.NetCore.Extensions.BenchmarkFilter", "System.Drawing.Common.Performance.Tests")]
+
+namespace Xunit.NetCore.Extensions
+{
+    public class BenchmarkFilter : ITestCaseOrderer
+    {
+        private static MethodInfo LookupConditionalMethod(Type t, string name)
+        {
+            if (t == null || name == null)
+                return null;
+
+            TypeInfo ti = t.GetTypeInfo();
+
+            MethodInfo mi = ti.GetDeclaredMethod(name);
+            if (mi != null && mi.IsStatic && mi.GetParameters().Length == 0 && mi.ReturnType == typeof(bool))
+                return mi;
+
+            PropertyInfo pi = ti.GetDeclaredProperty(name);
+            if (pi != null && pi.PropertyType == typeof(bool) && pi.GetMethod != null && pi.GetMethod.IsStatic && pi.GetMethod.GetParameters().Length == 0)
+                return pi.GetMethod;
+
+            return LookupConditionalMethod(ti.BaseType, name);
+        }
+
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+            where TTestCase : ITestCase
+        {
+            foreach (TTestCase testCase in testCases)
+            {
+                bool success = true;
+
+                IEnumerable<IAttributeInfo> attributes = testCase.TestMethod.Method.GetCustomAttributes(typeof(ConditionalBenchmarkAttribute).AssemblyQualifiedName);
+                foreach (IAttributeInfo attributeInfo in attributes)
+                {
+                    Type calleeType = attributeInfo.GetNamedArgument<Type>("CalleeType");
+                    string[] conditionMemberNames = attributeInfo.GetNamedArgument<string[]>("ConditionMemberNames");
+                    foreach (string conditionMemberName in conditionMemberNames)
+                    {
+                        MethodInfo conditionMethodInfo = LookupConditionalMethod(calleeType, conditionMemberName);
+                        if (conditionMethodInfo == null)
+                            throw new Exception($"Conditional method with name '{conditionMemberName}' not found");
+
+                        if (!(bool)conditionMethodInfo.Invoke(null, null))
+                            success = false;
+                    }
+                }
+
+                if (success)
+                    yield return testCase;
+            }
+        }
+    }
+
+    public class ConditionalBenchmarkAttribute : Attribute
+    {
+        public ConditionalBenchmarkAttribute(Type calleeType, params string[] conditionMemberNames)
+        {
+            CalleeType = calleeType;
+            ConditionMemberNames = conditionMemberNames;
+        }
+
+        public Type CalleeType { get; }
+
+        public string[] ConditionMemberNames { get; }
+    }
+}

--- a/src/System.Drawing.Common/tests/Performance/CustomAssemblyAttributes.cs
+++ b/src/System.Drawing.Common/tests/Performance/CustomAssemblyAttributes.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+[assembly: TestCaseOrderer("Xunit.NetCore.Extensions.BenchmarkFilter", "System.Drawing.Common.Performance.Tests")]

--- a/src/System.Drawing.Common/tests/Performance/Perf_Graphics_DrawBeziers.cs
+++ b/src/System.Drawing.Common/tests/Performance/Perf_Graphics_DrawBeziers.cs
@@ -4,17 +4,16 @@
 
 using System.Diagnostics;
 using Microsoft.Xunit.Performance;
+using Xunit.NetCore.Extensions;
 
 namespace System.Drawing.Tests
 {
     public class Perf_Graphics_DrawBeziers : RemoteExecutorTestBase
     {
         [Benchmark(InnerIterationCount = 10000)]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetGdiplusIsAvailable))]
         public void DrawBezier_Point()
         {
-            if (!Helpers.GetGdiplusIsAvailable())
-                return;
-
             Random r = new Random(1942);
 
             using (Bitmap image = new Bitmap(100, 100))
@@ -35,11 +34,9 @@ namespace System.Drawing.Tests
         }
 
         [Benchmark(InnerIterationCount = 10000)]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetGdiplusIsAvailable))]
         public void DrawBezier_Points()
         {
-            if (!Helpers.GetGdiplusIsAvailable())
-                return;
-
             Point[] points =
             {
                 new Point(10, 10), new Point(20, 1), new Point(35, 5), new Point(50, 10),

--- a/src/System.Drawing.Common/tests/Performance/Perf_Graphics_Transforms.cs
+++ b/src/System.Drawing.Common/tests/Performance/Perf_Graphics_Transforms.cs
@@ -5,17 +5,16 @@
 using System.Diagnostics;
 using System.Drawing.Drawing2D;
 using Microsoft.Xunit.Performance;
+using Xunit.NetCore.Extensions;
 
 namespace System.Drawing.Tests
 {
     public class Perf_Graphics_Transforms : RemoteExecutorTestBase
     {
         [Benchmark(InnerIterationCount = 10000)]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetGdiplusIsAvailable))]
         public void TransformPoints()
         {
-            if (!Helpers.GetGdiplusIsAvailable())
-                return;
-
             Point[] points =
             {
                 new Point(10, 10), new Point(20, 1), new Point(35, 5), new Point(50, 10),

--- a/src/System.Drawing.Common/tests/Performance/System.Drawing.Common.Performance.Tests.csproj
+++ b/src/System.Drawing.Common/tests/Performance/System.Drawing.Common.Performance.Tests.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="BenchmarkFilter.cs" />
     <Compile Include="Perf_Graphics_DrawBeziers.cs" />
     <Compile Include="Perf_Graphics_Transforms.cs" />
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">

--- a/src/System.Drawing.Common/tests/Performance/System.Drawing.Common.Performance.Tests.csproj
+++ b/src/System.Drawing.Common/tests/Performance/System.Drawing.Common.Performance.Tests.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="BenchmarkFilter.cs" />
+    <Compile Include="CustomAssemblyAttributes.cs" />
     <Compile Include="Perf_Graphics_DrawBeziers.cs" />
     <Compile Include="Perf_Graphics_Transforms.cs" />
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
@@ -18,6 +18,9 @@
     </ProjectReference>
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\Performance\BenchmarkFilter.cs">
+      <Link>Common\Performance\BenchmarkFilter.cs</Link>
     </Compile>
     <Compile Include="..\Helpers.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/30449

Currently if a benchmark starts but does not invoke any iterations it fails with the following error: `System.Exception : Benchmark did not execute any iterations. Please use one of the iteration methods in Microsoft.Xunit.Performance.Benchmark`. This is a simple workaround to filter tests out that depend on GdiPlus. The `LookupConditionalMethod` method is copied from buildtools.

Xunit-performance doesn't currently provide a ConditionalBenchmarkAttribute but could easily added and recognized by the discoverer: https://github.com/Microsoft/xunit-performance/blob/master/src/xunit.performance.execution/BenchmarkDiscoverer.cs
I can submit that feature addition to xunit-performance or we just wait till the BenchmarkDotNet migration is done. I'm fine with either.