### PR TITLE
Exposing CallerArgumentExpressionAttribute from System.Runtime assembly

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -6387,6 +6387,12 @@ namespace System.Runtime.CompilerServices
         public void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) { }
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
     }
+    [System.AttributeUsage((System.AttributeTargets)(2048), AllowMultiple = false, Inherited = false)]
+    public sealed class CallerArgumentExpressionAttribute : System.Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName) { }
+        public string ParameterName { get { throw null; } }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false)]
     public sealed partial class CallerFilePathAttribute : System.Attribute
     {

--- a/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
@@ -1,4 +1,5 @@
 Compat issues with assembly System.Runtime:
 MembersMustExist : Member 'System.Text.StringBuilder.GetChunks()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CallerArgumentExpressionAttribute' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.StringBuilder.ChunkEnumerator' does not exist in the implementation but it does exist in the contract.
 CannotMakeMoreVisible : Visibility of member 'System.Exception.HResult.set(System.Int32)' is 'Family' in the implementation but 'Public' in the contract.

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -56,7 +56,6 @@
       <Link>System\SpanTestHelpers.cs</Link>
     </Compile>
     <Compile Include="CompareToTests.cs" />
-    <Compile Include="System\Runtime\CompilerServices\CallerArgumentExpressionAttributeTests.cs" />
     <Compile Include="System\Runtime\ConstrainedExecution\PrePrepareMethodAttributeTests.cs" />
     <Compile Include="TimeZoneInfoTests.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\CriticalHandleZeroOrMinusOneIsInvalid.cs" />
@@ -231,6 +230,7 @@
     <Compile Include="System\Reflection\SignatureTypes.netcoreapp.cs" />
     <Compile Include="System\Reflection\TypeDelegatorTests.netcoreapp.cs" />
     <Compile Include="System\Reflection\TypeInfoTests.netcoreapp.cs" />
+    <Compile Include="System\Runtime\CompilerServices\CallerArgumentExpressionAttributeTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\ConditionalWeakTableTests.netcoreapp.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpersTests.netcoreapp.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeFeatureTests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -56,6 +56,7 @@
       <Link>System\SpanTestHelpers.cs</Link>
     </Compile>
     <Compile Include="CompareToTests.cs" />
+    <Compile Include="System\Runtime\CompilerServices\CallerArgumentExpressionAttributeTests.cs" />
     <Compile Include="System\Runtime\ConstrainedExecution\PrePrepareMethodAttributeTests.cs" />
     <Compile Include="TimeZoneInfoTests.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\CriticalHandleZeroOrMinusOneIsInvalid.cs" />

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
@@ -80,5 +80,129 @@ namespace System.Runtime.CompilerServices.Tests
         {
             return expr;
         }
+
+        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        public static void SimpleExpression()
+        {
+            int notVal = 0;
+
+            Assert.Equal("notVal", IntParamMethod(notVal));
+        }
+
+        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        public static void ComplexExpression()
+        {
+            int x = 5;
+
+            Assert.Equal("Math.Min(x + 20, x * x)",
+                IntParamMethod(Math.Min(x + 20, x * x)));
+        }
+
+        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        public static void SurroundingWhitespaceHandling()
+        {
+            int notVal = 0;
+
+            Assert.Equal("notVal", IntParamMethod(notVal));
+        }
+
+        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        public static void InternalWhitespaceHandling()
+        {
+            int notVal = 0;
+
+            Assert.Equal("notVal  + 20", IntParamMethod(notVal + 20));
+
+            Assert.Equal(@"Math.Min(notVal * 2,
+                    notVal + 20)",
+                IntParamMethod(Math.Min(notVal * 2,
+                    notVal + 20)));
+        }
+
+        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        public static void InternalCommentHandling()
+        {
+            int notVal = 0;
+
+            Assert.Equal("notVal + /*comment*/20", IntParamMethod(notVal + /*comment*/20));
+            Assert.Equal("notVal + 20 //comment",
+                IntParamMethod(notVal + 20 //comment
+                ));
+        }
+
+        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        public static void OptionalParameterHandling()
+        {
+            string suppliedVal = "supplied value";
+            Assert.Equal("suppliedVal", OptionalParamMethod(suppliedVal));
+            Assert.Equal("suppliedVal", OptionalParamMethod(val: suppliedVal));
+
+            Assert.Equal("StringConst + \" string literal\"", OptionalParamMethod());
+
+            Assert.Equal("\"no file\"", CompilerSuppliedParamMethod());
+        }
+
+        private const string StringConst = "hello";
+        private static string OptionalParamMethod(string val = StringConst + " string literal", [CallerArgumentExpression("val")] string expr = null)
+        {
+            return expr;
+        }
+
+        private static string CompilerSuppliedParamMethod([CallerFilePath] string val = "no file", [CallerArgumentExpression("val")] string expr = null)
+        {
+            return expr;
+        }
+
+        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        public static void ExtensionMethodThisParameterHandling()
+        {
+            int notVal = 0;
+
+            Assert.Equal("notVal", notVal.ExtensionMethod());
+        }
+
+        private static string ExtensionMethod(this int val, [CallerArgumentExpression("val")] string expr = null)
+        {
+            return expr;
+        }
+
+        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        public static void InstanceMethodThisHandling()
+        {
+            var instance = new InstanceTest();
+
+            Assert.Equal("instance", instance.Method());
+            Assert.Equal("new InstanceTest()", new InstanceTest().Method());
+            Assert.Equal("(instance ?? new InstanceTest())", (instance ?? new InstanceTest()).Method());
+
+            Assert.Equal("", instance.NoThisMethodCaller());
+            Assert.Equal("this", instance.ThisMethodCaller());
+        }
+
+        private class InstanceTest
+        {
+            public string NoThisMethodCaller()
+            {
+                return Method();
+            }
+
+            public string ThisMethodCaller()
+            {
+                return this.Method();
+            }
+
+            public string Method([CallerArgumentExpression("this")] string expr = null)
+            {
+                return expr;
+            }
+        }
     }
 }

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
@@ -8,6 +8,11 @@ namespace System.Runtime.CompilerServices.Tests
 {
     public static class CallerArgumentExpressionAttributeTests
     {
+        public static string IntParamMethod(int val, [CallerArgumentExpression("val")] string expr = null)
+        {
+            return expr;
+        }
+
         [Theory, InlineData("testParamName"), InlineData(""), InlineData(null)]
         public static void ArgumentToCallerArgumentExpressionSetsParameterNameProperty(string paramName)
         {
@@ -58,7 +63,20 @@ namespace System.Runtime.CompilerServices.Tests
             return expr;
         }
 
-        public static string IntParamMethod(int val, [CallerArgumentExpression("val")] string expr = null)
+        [Fact]
+        public static void OverloadedMethodPrecedence()
+        {
+            int notVal = 0;
+
+            Assert.Equal(OverloadedMethodReturn, OverloadedMethod(notVal));
+        }
+
+        private const string OverloadedMethodReturn = "not CallerArgumentExpression";
+        private static string OverloadedMethod(int val)
+        {
+            return OverloadedMethodReturn;
+        }
+        private static string OverloadedMethod(int val, [CallerArgumentExpression(null)] string expr = null)
         {
             return expr;
         }

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
@@ -72,10 +72,12 @@ namespace System.Runtime.CompilerServices.Tests
         }
 
         private const string OverloadedMethodReturn = "not CallerArgumentExpression";
+ 
         private static string OverloadedMethod(int val)
         {
             return OverloadedMethodReturn;
         }
+
         private static string OverloadedMethod(int val, [CallerArgumentExpression(null)] string expr = null)
         {
             return expr;
@@ -149,6 +151,7 @@ namespace System.Runtime.CompilerServices.Tests
         }
 
         private const string StringConst = "hello";
+
         private static string OptionalParamMethod(string val = StringConst + " string literal", [CallerArgumentExpression("val")] string expr = null)
         {
             return expr;

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.CompilerServices.Tests
+{
+    public static class CallerArgumentExpressionAttributeTests
+    {
+        [Theory, InlineData("testParamName"), InlineData(""), InlineData(null)]
+        public static void ArgumentToCallerArgumentExpressionSetsParameterNameProperty(string paramName)
+        {
+            var attr = new CallerArgumentExpressionAttribute(paramName);
+
+            Assert.Equal(paramName, attr.ParameterName);
+        }
+
+        [Fact]
+        public static void SuppliedArgumentOverridesExpression()
+        {
+            int notVal = 0;
+
+            string suppliedVal = "supplied value";
+            Assert.Equal(suppliedVal, IntParamMethod(notVal, suppliedVal));
+
+            Assert.Equal(IntParamMethod(notVal), IntParamMethodPassthrough(notVal));
+        }
+
+        private static string IntParamMethodPassthrough(int val, [CallerArgumentExpression("val")] string expr = null)
+        {
+            return IntParamMethod(val, expr);
+        }
+
+        [Fact]
+        public static void InvalidParameterName()
+        {
+            int notVal = 0;
+
+            Assert.Null(InvalidParameterNameMethod(notVal));
+        }
+
+        private static string InvalidParameterNameMethod(int val, [CallerArgumentExpression("notVal")] string expr = null)
+        {
+            return expr;
+        }
+
+        [Fact]
+        public static void NullParameterName()
+        {
+            int notVal = 0;
+
+            Assert.Null(NullParameterNameMethod(notVal));
+        }
+
+        private static string NullParameterNameMethod(int val, [CallerArgumentExpression(null)] string expr = null)
+        {
+            return expr;
+        }
+
+        public static string IntParamMethod(int val, [CallerArgumentExpression("val")] string expr = null)
+        {
+            return expr;
+        }
+    }
+}


### PR DESCRIPTION
This exposes CallerArgumentExpressionAttribute from System.Private.CoreLib. The attribute is proposed in [csharplang#287](https://github.com/dotnet/csharplang/issues/287). Resolves #21809.

I've included basic tests for the attribute, as well as currently-disabled tests to give an idea of the expected behavior.

@danmosemsft 