### PR TITLE
Remove StringBuilderCache usage from System.Text.RegularExpressions

### DIFF
--- a/src/Common/src/CoreLib/System/Text/ValueStringBuilder.cs
+++ b/src/Common/src/CoreLib/System/Text/ValueStringBuilder.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Text
 {
-    internal ref struct ValueStringBuilder
+    internal ref partial struct ValueStringBuilder
     {
         private char[] _arrayToReturnToPool;
         private Span<char> _chars;

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>System.Text.RegularExpressions</AssemblyName>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_COMPILED</DefineConstants>
     <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
@@ -50,12 +51,13 @@
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\System\Text\StringBuilderCache.cs">
-      <Link>Common\System\Text\StringBuilderCache.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\CoreLib\System\Collections\Generic\ValueListBuilder.cs">
       <Link>Common\System\Collections\Generic\ValueListBuilder.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\System\Text\ValueStringBuilder.cs">
+      <Link>Common\System\Text\ValueStringBuilder.cs</Link>
+    </Compile>
+    <Compile Include="System\Text\ValueStringBuilder.Reverse.cs" />
   </ItemGroup>
   <!-- Files that enable compiled feature -->
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -35,6 +35,7 @@ namespace System.Text.RegularExpressions
     /// </summary>
     public class Match : Group
     {
+        private const int ReplaceBufferSize = 256;
         internal GroupCollection _groupcoll;
 
         // input to the match
@@ -128,8 +129,12 @@ namespace System.Text.RegularExpressions
             // Gets the weakly cached replacement helper or creates one if there isn't one already.
             RegexReplacement repl = RegexReplacement.GetOrCreate(_regex._replref, replacement, _regex.caps, _regex.capsize,
                 _regex.capnames, _regex.roptions);
+            Span<char> charInitSpan = stackalloc char[ReplaceBufferSize];
+            var vsb = new ValueStringBuilder(charInitSpan);
 
-            return repl.Replacement(this);
+            repl.ReplacementImpl(ref vsb, this);
+
+            return vsb.ToString();
         }
 
         internal virtual ReadOnlySpan<char> GroupToStringImpl(int groupnum)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -13,6 +13,8 @@ namespace System.Text.RegularExpressions
 
     public partial class Regex
     {
+        private const int ReplaceBufferSize = 256;
+
         /// <summary>
         /// Replaces all occurrences of the pattern with the <paramref name="replacement"/> pattern, starting at
         /// the first character in the input string.
@@ -171,7 +173,9 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                StringBuilder sb = StringBuilderCache.Acquire();
+                ReadOnlySpan<char> inputSpan = input.AsSpan();
+                Span<char> charInitSpan = stackalloc char[ReplaceBufferSize];
+                var vsb = new ValueStringBuilder(charInitSpan);
 
                 if (!regex.RightToLeft)
                 {
@@ -180,11 +184,10 @@ namespace System.Text.RegularExpressions
                     do
                     {
                         if (match.Index != prevat)
-                            sb.Append(input, prevat, match.Index - prevat);
+                            vsb.Append(inputSpan.Slice(prevat, match.Index - prevat));
 
                         prevat = match.Index + match.Length;
-
-                        sb.Append(evaluator(match));
+                        vsb.Append(evaluator(match));
 
                         if (--count == 0)
                             break;
@@ -193,21 +196,23 @@ namespace System.Text.RegularExpressions
                     } while (match.Success);
 
                     if (prevat < input.Length)
-                        sb.Append(input, prevat, input.Length - prevat);
+                        vsb.Append(inputSpan.Slice(prevat, input.Length - prevat));
                 }
                 else
                 {
-                    List<string> al = new List<string>();
+                    // In right to left mode append all the inputs in reversed order to avoid an extra dynamic data structure
+                    // and to be able to work with Spans. A final reverse of the transformed reversed input string generates
+                    // the desired output. Similar to Tower of Hanoi.
+
                     int prevat = input.Length;
 
                     do
                     {
                         if (match.Index + match.Length != prevat)
-                            al.Add(input.Substring(match.Index + match.Length, prevat - match.Index - match.Length));
+                            vsb.AppendReversed(inputSpan.Slice(match.Index + match.Length, prevat - match.Index - match.Length));
 
                         prevat = match.Index;
-
-                        al.Add(evaluator(match));
+                        vsb.AppendReversed(evaluator(match));
 
                         if (--count == 0)
                             break;
@@ -216,15 +221,12 @@ namespace System.Text.RegularExpressions
                     } while (match.Success);
 
                     if (prevat > 0)
-                        sb.Append(input, 0, prevat);
+                        vsb.AppendReversed(inputSpan.Slice(0, prevat));
 
-                    for (int i = al.Count - 1; i >= 0; i--)
-                    {
-                        sb.Append(al[i]);
-                    }
+                    vsb.Reverse();
                 }
 
-                return StringBuilderCache.GetStringAndRelease(sb);
+                return vsb.ToString();
             }
         }
     }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -173,7 +173,6 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                ReadOnlySpan<char> inputSpan = input.AsSpan();
                 Span<char> charInitSpan = stackalloc char[ReplaceBufferSize];
                 var vsb = new ValueStringBuilder(charInitSpan);
 
@@ -184,7 +183,7 @@ namespace System.Text.RegularExpressions
                     do
                     {
                         if (match.Index != prevat)
-                            vsb.Append(inputSpan.Slice(prevat, match.Index - prevat));
+                            vsb.Append(input.AsSpan(prevat, match.Index - prevat));
 
                         prevat = match.Index + match.Length;
                         vsb.Append(evaluator(match));
@@ -196,7 +195,7 @@ namespace System.Text.RegularExpressions
                     } while (match.Success);
 
                     if (prevat < input.Length)
-                        vsb.Append(inputSpan.Slice(prevat, input.Length - prevat));
+                        vsb.Append(input.AsSpan(prevat, input.Length - prevat));
                 }
                 else
                 {
@@ -209,7 +208,7 @@ namespace System.Text.RegularExpressions
                     do
                     {
                         if (match.Index + match.Length != prevat)
-                            vsb.AppendReversed(inputSpan.Slice(match.Index + match.Length, prevat - match.Index - match.Length));
+                            vsb.AppendReversed(input.AsSpan(match.Index + match.Length, prevat - match.Index - match.Length));
 
                         prevat = match.Index;
                         vsb.AppendReversed(evaluator(match));
@@ -221,7 +220,7 @@ namespace System.Text.RegularExpressions
                     } while (match.Success);
 
                     if (prevat > 0)
-                        vsb.AppendReversed(inputSpan.Slice(0, prevat));
+                        vsb.AppendReversed(input.AsSpan(0, prevat));
 
                     vsb.Reverse();
                 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -40,16 +40,17 @@ namespace System.Text.RegularExpressions
             // We're doing this for your own protection. (Really, for speed.)
             Debug.Assert(pattern.Length != 0, "RegexBoyerMoore called with an empty string. This is bad for perf");
 
-            // We do the ToLower character by character for consistency.  With surrogate chars, doing
-            // a ToLower on the entire string could actually change the surrogate pair.  This is more correct
-            // linguistically, but since Regex doesn't support surrogates, it's more important to be
-            // consistent.
             if (caseInsensitive)
             {
-                StringBuilder sb = StringBuilderCache.Acquire(pattern.Length);
-                for (int i = 0; i < pattern.Length; i++)
-                    sb.Append(culture.TextInfo.ToLower(pattern[i]));
-                pattern = StringBuilderCache.GetStringAndRelease(sb);
+                pattern = string.Create(pattern.Length, (pattern, culture), (span, state) =>
+                {
+                    // We do the ToLower character by character for consistency.  With surrogate chars, doing
+                    // a ToLower on the entire string could actually change the surrogate pair.  This is more correct
+                    // linguistically, but since Regex doesn't support surrogates, it's more important to be
+                    // consistent.
+                    for (int i = 0; i < state.pattern.Length; i++)
+                        span[i] = state.culture.TextInfo.ToLower(state.pattern[i]);
+                });
             }
 
             Pattern = pattern;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -48,8 +48,9 @@ namespace System.Text.RegularExpressions
                     // a ToLower on the entire string could actually change the surrogate pair.  This is more correct
                     // linguistically, but since Regex doesn't support surrogates, it's more important to be
                     // consistent.
+                    TextInfo textInfo = state.culture.TextInfo;
                     for (int i = 0; i < state.pattern.Length; i++)
-                        span[i] = state.culture.TextInfo.ToLower(state.pattern[i]);
+                        span[i] = textInfo.ToLower(state.pattern[i]);
                 });
             }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -685,25 +685,34 @@ namespace System.Text.RegularExpressions
 
         public static string ConvertOldStringsToClass(string set, string category)
         {
-            StringBuilder sb = StringBuilderCache.Acquire(set.Length + category.Length + 3);
+            bool startsWithNulls = set.Length >= 2 && set[0] == '\0' && set[1] == '\0';
+            int strLength = set.Length + category.Length + 3;
+            if (startsWithNulls)
+                strLength -= 2;
 
-            if (set.Length >= 2 && set[0] == '\0' && set[1] == '\0')
+            return string.Create(strLength, (set, category, startsWithNulls), (span, state) =>
             {
-                sb.Append((char)0x1);
-                sb.Append((char)(set.Length - 2));
-                sb.Append((char)category.Length);
-                sb.Append(set.Substring(2));
-            }
-            else
-            {
-                sb.Append((char)0x0);
-                sb.Append((char)set.Length);
-                sb.Append((char)category.Length);
-                sb.Append(set);
-            }
-            sb.Append(category);
+                int index;
 
-            return StringBuilderCache.GetStringAndRelease(sb);
+                if (state.startsWithNulls)
+                {
+                    span[0] = (char)0x1;
+                    span[1] = (char)(state.set.Length - 2);
+                    span[2] = (char)state.category.Length;
+                    state.set.AsSpan(2).CopyTo(span.Slice(3));
+                    index = 3 + state.set.Length - 2;
+                }
+                else
+                {
+                    span[0] = (char)0x0;
+                    span[1] = (char)state.set.Length;
+                    span[2] = (char)state.category.Length;
+                    state.set.AsSpan().CopyTo(span.Slice(3));
+                    index = 3 + state.set.Length;
+                }
+
+                state.category.AsSpan().CopyTo(span.Slice(index));
+            });
         }
 
         /// <summary>
@@ -957,14 +966,14 @@ namespace System.Text.RegularExpressions
             if (category == null)
                 return null;
 
-            StringBuilder sb = StringBuilderCache.Acquire(category.Length);
-
-            for (int i = 0; i < category.Length; i++)
+            return string.Create(category.Length, category, (span, _category) =>
             {
-                short ch = (short)category[i];
-                sb.Append(unchecked((char)-ch));
-            }
-            return StringBuilderCache.GetStringAndRelease(sb);
+                for (int i = 0; i < category.Length; i++)
+                {
+                    short ch = (short)_category[i];
+                    span[i] = unchecked((char)-ch);
+                }
+            });
         }
 
         public static RegexCharClass Parse(string charClass)
@@ -1022,35 +1031,36 @@ namespace System.Text.RegularExpressions
             // This is important because if the last range ends in LastChar, we won't append
             // LastChar to the list.
             int rangeLen = _rangelist.Count * 2;
-            StringBuilder sb = StringBuilderCache.Acquire(rangeLen + _categories.Length + 3);
+            int strGuessCount = rangeLen + _categories.Length + 3;
 
-            int flags;
-            if (_negate)
-                flags = 1;
-            else
-                flags = 0;
+            Span<char> buffer = strGuessCount <= 256 ? stackalloc char[strGuessCount] : null;
+            ValueStringBuilder vsb = buffer != null ?
+                new ValueStringBuilder(buffer) :
+                new ValueStringBuilder(strGuessCount);
 
-            sb.Append((char)flags);
-            sb.Append((char)rangeLen);
-            sb.Append((char)_categories.Length);
+            int flags = _negate ? 1 : 0;
+
+            vsb.Append((char)flags);
+            vsb.Append((char)rangeLen);
+            vsb.Append((char)_categories.Length);
 
             for (int i = 0; i < _rangelist.Count; i++)
             {
                 SingleRange currentRange = _rangelist[i];
-                sb.Append(currentRange.First);
+                vsb.Append(currentRange.First);
 
                 if (currentRange.Last != LastChar)
-                    sb.Append((char)(currentRange.Last + 1));
+                    vsb.Append((char)(currentRange.Last + 1));
             }
 
-            sb[SETLENGTH] = (char)(sb.Length - SETSTART);
+            vsb[SETLENGTH] = (char)(vsb.Length - SETSTART);
 
-            sb.Append(_categories);
+            vsb.Append(_categories.ToString());
 
             if (_subtractor != null)
-                sb.Append(_subtractor.ToStringClass());
+                vsb.Append(_subtractor.ToStringClass());
 
-            return StringBuilderCache.GetStringAndRelease(sb);
+            return vsb.ToString();
         }
 
         /// <summary>

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1033,7 +1033,7 @@ namespace System.Text.RegularExpressions
             int rangeLen = _rangelist.Count * 2;
             int strGuessCount = rangeLen + _categories.Length + 3;
 
-            Span<char> buffer = strGuessCount <= 256 ? stackalloc char[strGuessCount] : null;
+            Span<char> buffer = strGuessCount <= 256 ? stackalloc char[256] : null;
             ValueStringBuilder vsb = buffer != null ?
                 new ValueStringBuilder(buffer) :
                 new ValueStringBuilder(strGuessCount);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -968,7 +968,7 @@ namespace System.Text.RegularExpressions
 
             return string.Create(category.Length, category, (span, _category) =>
             {
-                for (int i = 0; i < category.Length; i++)
+                for (int i = 0; i < _category.Length; i++)
                 {
                     short ch = (short)_category[i];
                     span[i] = unchecked((char)-ch);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1055,7 +1055,11 @@ namespace System.Text.RegularExpressions
 
             vsb[SETLENGTH] = (char)(vsb.Length - SETSTART);
 
-            vsb.Append(_categories.ToString());
+            // Append the categories string
+            foreach (ReadOnlyMemory<char> chunk in _categories.GetChunks())
+            {
+                vsb.Append(chunk.Span);
+            }
 
             if (_subtractor != null)
                 vsb.Append(_subtractor.ToStringClass());

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -122,7 +122,7 @@ namespace System.Text.RegularExpressions
             // characters need to be encoded.
             // For larger string we rent the input string's length plus a fixed 
             // conservative amount of chars from the ArrayPool.
-            Span<char> buffer = input.Length <= 80 ? stackalloc char[EscapeMaxBufferSize] : default;
+            Span<char> buffer = input.Length <= (EscapeMaxBufferSize / 3) ? stackalloc char[EscapeMaxBufferSize] : default;
             ValueStringBuilder vsb = !buffer.IsEmpty ?
                 new ValueStringBuilder(buffer) :
                 new ValueStringBuilder(input.Length + 200);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -117,22 +117,20 @@ namespace System.Text.RegularExpressions
 
         private static string EscapeImpl(string input, int i)
         {
-            ReadOnlySpan<char> inputSpan = input.AsSpan();
-
             // For small inputs we allocate on the stack. In most cases a buffer three 
             // times larger the original string should be sufficient as usually not all 
             // characters need to be encoded.
             // For larger string we rent the input string's length plus a fixed 
             // conservative amount of chars from the ArrayPool.
-            Span<char> buffer = inputSpan.Length <= 80 ? stackalloc char[EscapeMaxBufferSize] : null;
-            ValueStringBuilder vsb = buffer != null ?
+            Span<char> buffer = input.Length <= 80 ? stackalloc char[EscapeMaxBufferSize] : default;
+            ValueStringBuilder vsb = !buffer.IsEmpty ?
                 new ValueStringBuilder(buffer) :
-                new ValueStringBuilder(inputSpan.Length + 200);
+                new ValueStringBuilder(input.Length + 200);
 
-            char ch = inputSpan[i];
+            char ch = input[i];
             int lastpos;
 
-            vsb.Append(inputSpan.Slice(0, i));
+            vsb.Append(input.AsSpan(0, i));
             do
             {
                 vsb.Append('\\');
@@ -155,17 +153,17 @@ namespace System.Text.RegularExpressions
                 i++;
                 lastpos = i;
 
-                while (i < inputSpan.Length)
+                while (i < input.Length)
                 {
-                    ch = inputSpan[i];
+                    ch = input[i];
                     if (IsMetachar(ch))
                         break;
 
                     i++;
                 }
 
-                vsb.Append(inputSpan.Slice(lastpos, i - lastpos));
-            } while (i < inputSpan.Length);
+                vsb.Append(input.AsSpan(lastpos, i - lastpos));
+            } while (i < input.Length);
 
             return vsb.ToString();
         }
@@ -188,31 +186,30 @@ namespace System.Text.RegularExpressions
 
         private static string UnescapeImpl(string input, int i)
         {
-            ReadOnlySpan<char> inputSpan = input.AsSpan();
             RegexParser p = new RegexParser(CultureInfo.InvariantCulture);
             int lastpos;
             p.SetPattern(input);
 
             // In the worst case the escaped string has the same length.
             // For small inputs we use stack allocation.
-            Span<char> buffer = inputSpan.Length <= EscapeMaxBufferSize ? stackalloc char[EscapeMaxBufferSize] : null;
-            ValueStringBuilder vsb = buffer != null ?
+            Span<char> buffer = input.Length <= EscapeMaxBufferSize ? stackalloc char[EscapeMaxBufferSize] : default;
+            ValueStringBuilder vsb = !buffer.IsEmpty ?
                 new ValueStringBuilder(buffer) :
-                new ValueStringBuilder(inputSpan.Length);
+                new ValueStringBuilder(input.Length);
 
-            vsb.Append(inputSpan.Slice(0, i));
+            vsb.Append(input.AsSpan(0, i));
             do
             {
                 i++;
                 p.Textto(i);
-                if (i < inputSpan.Length)
+                if (i < input.Length)
                     vsb.Append(p.ScanCharEscape());
                 i = p.Textpos();
                 lastpos = i;
-                while (i < inputSpan.Length && inputSpan[i] != '\\')
+                while (i < input.Length && input[i] != '\\')
                     i++;
-                vsb.Append(inputSpan.Slice(lastpos, i - lastpos));
-            } while (i < inputSpan.Length);
+                vsb.Append(input.AsSpan(lastpos, i - lastpos));
+            } while (i < input.Length);
 
             return vsb.ToString();
         }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -20,6 +20,7 @@ namespace System.Text.RegularExpressions
 {
     internal sealed class RegexParser
     {
+        private const int EscapeMaxBufferSize = 256;
         private const int MaxValueDiv10 = int.MaxValue / 10;
         private const int MaxValueMod10 = int.MaxValue % 10;
 
@@ -114,7 +115,7 @@ namespace System.Text.RegularExpressions
                     // characters need to be encoded.
                     // For larger string we rent the input string's length plus a fixed 
                     // conservative amount of chars from the ArrayPool.
-                    Span<char> buffer = input.Length <= 80 ? stackalloc char[256] : null;
+                    Span<char> buffer = input.Length <= 80 ? stackalloc char[EscapeMaxBufferSize] : null;
                     ValueStringBuilder vsb = buffer != null ?
                         new ValueStringBuilder(buffer) :
                         new ValueStringBuilder(input.Length + 200);
@@ -180,7 +181,7 @@ namespace System.Text.RegularExpressions
                     
                     // In the worst case the escaped string has the same length.
                     // For small inputs we use stack allocation.
-                    Span<char> buffer = input.Length <= 256 ? stackalloc char[input.Length] : null;
+                    Span<char> buffer = input.Length <= EscapeMaxBufferSize ? stackalloc char[EscapeMaxBufferSize] : null;
                     ValueStringBuilder vsb = buffer != null ?
                         new ValueStringBuilder(buffer) :
                         new ValueStringBuilder(input.Length);
@@ -2092,8 +2093,9 @@ namespace System.Text.RegularExpressions
                         // a ToLower on the entire string could actually change the surrogate pair.  This is more correct
                         // linguistically, but since Regex doesn't support surrogates, it's more important to be
                         // consistent.
+                        TextInfo textInfo = state._culture.TextInfo;
                         for (int i = 0; i < input.Length; i++)
-                            span[i] = state._culture.TextInfo.ToLower(input[i]);
+                            span[i] = textInfo.ToLower(input[i]);
                     });
                 }
                 else

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -13,7 +13,7 @@ namespace System.Text.RegularExpressions
 {
     internal sealed class RegexReplacement
     {
-        private const int ReplaceBufferSize = 256;
+        private const int ReplaceMaxBufferSize = 256;
 
         // Constants for special insertion patterns
         private const int Specials = 4;
@@ -35,7 +35,7 @@ namespace System.Text.RegularExpressions
             if (concat.Type() != RegexNode.Concatenate)
                 throw new ArgumentException(SR.ReplacementError);
 
-            Span<char> buffer = stackalloc char[256];
+            Span<char> buffer = stackalloc char[ReplaceMaxBufferSize];
             ValueStringBuilder vsb = new ValueStringBuilder(buffer);
             List<string> strings = new List<string>();
             List<int> rules = new List<int>();
@@ -206,7 +206,7 @@ namespace System.Text.RegularExpressions
             else
             {
                 ReadOnlySpan<char> inputSpan = input.AsSpan();
-                Span<char> charInitSpan = stackalloc char[ReplaceBufferSize];
+                Span<char> charInitSpan = stackalloc char[ReplaceMaxBufferSize];
                 var vsb = new ValueStringBuilder(charInitSpan);
 
                 if (!regex.RightToLeft)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -8,13 +8,13 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 
 namespace System.Text.RegularExpressions
 {
     internal sealed class RegexReplacement
     {
+        private const int ReplaceBufferSize = 256;
+
         // Constants for special insertion patterns
         private const int Specials = 4;
         public const int LeftPortion = -1;
@@ -35,7 +35,8 @@ namespace System.Text.RegularExpressions
             if (concat.Type() != RegexNode.Concatenate)
                 throw new ArgumentException(SR.ReplacementError);
 
-            StringBuilder sb = StringBuilderCache.Acquire();
+            Span<char> buffer = stackalloc char[256];
+            ValueStringBuilder vsb = new ValueStringBuilder(buffer);
             List<string> strings = new List<string>();
             List<int> rules = new List<int>();
 
@@ -46,19 +47,19 @@ namespace System.Text.RegularExpressions
                 switch (child.Type())
                 {
                     case RegexNode.Multi:
-                        sb.Append(child.Str);
+                        vsb.Append(child.Str);
                         break;
 
                     case RegexNode.One:
-                        sb.Append(child.Ch);
+                        vsb.Append(child.Ch);
                         break;
 
                     case RegexNode.Ref:
-                        if (sb.Length > 0)
+                        if (vsb.Length > 0)
                         {
                             rules.Add(strings.Count);
-                            strings.Add(sb.ToString());
-                            sb.Length = 0;
+                            strings.Add(vsb.ToString());
+                            vsb.Length = 0;
                         }
                         int slot = child.M;
 
@@ -73,13 +74,11 @@ namespace System.Text.RegularExpressions
                 }
             }
 
-            if (sb.Length > 0)
+            if (vsb.Length > 0)
             {
                 rules.Add(strings.Count);
-                strings.Add(sb.ToString());
+                strings.Add(vsb.ToString());
             }
-
-            StringBuilderCache.Release(sb);
 
             Pattern = rep;
             _strings = strings;
@@ -113,80 +112,68 @@ namespace System.Text.RegularExpressions
         /// Given a Match, emits into the StringBuilder the evaluated
         /// substitution pattern.
         /// </summary>
-        private void ReplacementImpl(StringBuilder sb, Match match)
+        public void ReplacementImpl(ref ValueStringBuilder vsb, Match match)
         {
             for (int i = 0; i < _rules.Count; i++)
             {
                 int r = _rules[i];
                 if (r >= 0)   // string lookup
-                    sb.Append(_strings[r]);
+                    vsb.Append(_strings[r]);
                 else if (r < -Specials) // group lookup
-                    sb.Append(match.GroupToStringImpl(-Specials - 1 - r));
+                    vsb.Append(match.GroupToStringImpl(-Specials - 1 - r));
                 else
                 {
                     switch (-Specials - 1 - r)
                     { // special insertion patterns
                         case LeftPortion:
-                            sb.Append(match.GetLeftSubstring());
+                            vsb.Append(match.GetLeftSubstring());
                             break;
                         case RightPortion:
-                            sb.Append(match.GetRightSubstring());
+                            vsb.Append(match.GetRightSubstring());
                             break;
                         case LastGroup:
-                            sb.Append(match.LastGroupToStringImpl());
+                            vsb.Append(match.LastGroupToStringImpl());
                             break;
                         case WholeString:
-                            sb.Append(match.Text);
+                            vsb.Append(match.Text);
                             break;
                     }
                 }
             }
         }
 
-        /// <summary>
-        /// Given a Match, emits into the List<string> the evaluated
+       /// <summary>
+        /// Given a Match, emits into the ValueStringBuilder the evaluated
         /// Right-to-Left substitution pattern.
         /// </summary>
-        private void ReplacementImplRTL(List<string> al, Match match)
+        public void ReplacementImplRTL(ref ValueStringBuilder vsb, Match match)
         {
             for (int i = _rules.Count - 1; i >= 0; i--)
             {
                 int r = _rules[i];
                 if (r >= 0)  // string lookup
-                    al.Add(_strings[r]);
+                    vsb.AppendReversed(_strings[r]);
                 else if (r < -Specials) // group lookup
-                    al.Add(match.GroupToStringImpl(-Specials - 1 - r).ToString());
+                    vsb.AppendReversed(match.GroupToStringImpl(-Specials - 1 - r));
                 else
                 {
                     switch (-Specials - 1 - r)
                     { // special insertion patterns
                         case LeftPortion:
-                            al.Add(match.GetLeftSubstring().ToString());
+                            vsb.AppendReversed(match.GetLeftSubstring());
                             break;
                         case RightPortion:
-                            al.Add(match.GetRightSubstring().ToString());
+                            vsb.AppendReversed(match.GetRightSubstring());
                             break;
                         case LastGroup:
-                            al.Add(match.LastGroupToStringImpl().ToString());
+                            vsb.AppendReversed(match.LastGroupToStringImpl());
                             break;
                         case WholeString:
-                            al.Add(match.Text);
+                            vsb.AppendReversed(match.Text);
                             break;
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Returns the replacement result for a single match
-        /// </summary>
-        public string Replacement(Match match)
-        {
-            StringBuilder sb = StringBuilderCache.Acquire();
-
-            ReplacementImpl(sb, match);
-
-            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         // Three very similar algorithms appear below: replace (pattern),
@@ -218,7 +205,9 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                StringBuilder sb = StringBuilderCache.Acquire();
+                ReadOnlySpan<char> inputSpan = input.AsSpan();
+                Span<char> charInitSpan = stackalloc char[ReplaceBufferSize];
+                var vsb = new ValueStringBuilder(charInitSpan);
 
                 if (!regex.RightToLeft)
                 {
@@ -227,10 +216,10 @@ namespace System.Text.RegularExpressions
                     do
                     {
                         if (match.Index != prevat)
-                            sb.Append(input, prevat, match.Index - prevat);
+                            vsb.Append(inputSpan.Slice(prevat, match.Index - prevat));
 
                         prevat = match.Index + match.Length;
-                        ReplacementImpl(sb, match);
+                        ReplacementImpl(ref vsb, match);
                         if (--count == 0)
                             break;
 
@@ -238,20 +227,23 @@ namespace System.Text.RegularExpressions
                     } while (match.Success);
 
                     if (prevat < input.Length)
-                        sb.Append(input, prevat, input.Length - prevat);
+                        vsb.Append(inputSpan.Slice(prevat, input.Length - prevat));
                 }
                 else
                 {
-                    List<string> al = new List<string>();
+                    // In right to left mode append all the inputs in reversed order to avoid an extra dynamic data structure
+                    // and to be able to work with Spans. A final reverse of the transformed reversed input string generates
+                    // the desired output. Similar to Tower of Hanoi.
+
                     int prevat = input.Length;
 
                     do
                     {
                         if (match.Index + match.Length != prevat)
-                            al.Add(input.Substring(match.Index + match.Length, prevat - match.Index - match.Length));
+                            vsb.AppendReversed(inputSpan.Slice(match.Index + match.Length, prevat - match.Index - match.Length));
 
                         prevat = match.Index;
-                        ReplacementImplRTL(al, match);
+                        ReplacementImplRTL(ref vsb, match);
                         if (--count == 0)
                             break;
 
@@ -259,15 +251,12 @@ namespace System.Text.RegularExpressions
                     } while (match.Success);
 
                     if (prevat > 0)
-                        sb.Append(input, 0, prevat);
+                        vsb.AppendReversed(inputSpan.Slice(0, prevat));
 
-                    for (int i = al.Count - 1; i >= 0; i--)
-                    {
-                        sb.Append(al[i]);
-                    }
+                    vsb.Reverse();
                 }
 
-                return StringBuilderCache.GetStringAndRelease(sb);
+                return vsb.ToString();
             }
         }
     }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -13,8 +13,6 @@ namespace System.Text.RegularExpressions
 {
     internal sealed class RegexReplacement
     {
-        private const int ReplaceMaxBufferSize = 256;
-
         // Constants for special insertion patterns
         private const int Specials = 4;
         public const int LeftPortion = -1;
@@ -35,7 +33,7 @@ namespace System.Text.RegularExpressions
             if (concat.Type() != RegexNode.Concatenate)
                 throw new ArgumentException(SR.ReplacementError);
 
-            Span<char> buffer = stackalloc char[ReplaceMaxBufferSize];
+            Span<char> buffer = stackalloc char[256];
             ValueStringBuilder vsb = new ValueStringBuilder(buffer);
             List<string> strings = new List<string>();
             List<int> rules = new List<int>();
@@ -205,7 +203,7 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                Span<char> charInitSpan = stackalloc char[ReplaceMaxBufferSize];
+                Span<char> charInitSpan = stackalloc char[256];
                 var vsb = new ValueStringBuilder(charInitSpan);
 
                 if (!regex.RightToLeft)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -205,7 +205,6 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                ReadOnlySpan<char> inputSpan = input.AsSpan();
                 Span<char> charInitSpan = stackalloc char[ReplaceMaxBufferSize];
                 var vsb = new ValueStringBuilder(charInitSpan);
 
@@ -216,7 +215,7 @@ namespace System.Text.RegularExpressions
                     do
                     {
                         if (match.Index != prevat)
-                            vsb.Append(inputSpan.Slice(prevat, match.Index - prevat));
+                            vsb.Append(input.AsSpan(prevat, match.Index - prevat));
 
                         prevat = match.Index + match.Length;
                         ReplacementImpl(ref vsb, match);
@@ -227,7 +226,7 @@ namespace System.Text.RegularExpressions
                     } while (match.Success);
 
                     if (prevat < input.Length)
-                        vsb.Append(inputSpan.Slice(prevat, input.Length - prevat));
+                        vsb.Append(input.AsSpan(prevat, input.Length - prevat));
                 }
                 else
                 {
@@ -240,7 +239,7 @@ namespace System.Text.RegularExpressions
                     do
                     {
                         if (match.Index + match.Length != prevat)
-                            vsb.AppendReversed(inputSpan.Slice(match.Index + match.Length, prevat - match.Index - match.Length));
+                            vsb.AppendReversed(input.AsSpan(match.Index + match.Length, prevat - match.Index - match.Length));
 
                         prevat = match.Index;
                         ReplacementImplRTL(ref vsb, match);
@@ -251,7 +250,7 @@ namespace System.Text.RegularExpressions
                     } while (match.Success);
 
                     if (prevat > 0)
-                        vsb.AppendReversed(inputSpan.Slice(0, prevat));
+                        vsb.AppendReversed(input.AsSpan(0, prevat));
 
                     vsb.Reverse();
                 }

--- a/src/System.Text.RegularExpressions/src/System/Text/ValueStringBuilder.Reverse.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/ValueStringBuilder.Reverse.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text
+{
+    internal ref partial struct ValueStringBuilder
+    {
+        public void AppendReversed(ReadOnlySpan<char> value)
+        {
+            Span<char> span = AppendSpan(value.Length);
+            value.CopyTo(span);
+            span.Reverse();
+        }
+
+        public void Reverse()
+        {
+            _chars.Slice(0, _pos).Reverse();
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/ValueStringBuilder.Reverse.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/ValueStringBuilder.Reverse.cs
@@ -9,7 +9,7 @@ namespace System.Text
         public void AppendReversed(ReadOnlySpan<char> value)
         {
             Span<char> span = AppendSpan(value.Length);
-            for (int i = 0; i < value.Length; i++)
+            for (int i = 0; i < span.Length; i++)
             {
                 span[i] = value[value.Length - i - 1];
             }

--- a/src/System.Text.RegularExpressions/src/System/Text/ValueStringBuilder.Reverse.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/ValueStringBuilder.Reverse.cs
@@ -9,8 +9,10 @@ namespace System.Text
         public void AppendReversed(ReadOnlySpan<char> value)
         {
             Span<char> span = AppendSpan(value.Length);
-            value.CopyTo(span);
-            span.Reverse();
+            for (int i = 0; i < value.Length; i++)
+            {
+                span[i] = value[value.Length - i - 1];
+            }
         }
 
         public void Reverse()


### PR DESCRIPTION
Porting some of my changes over from https://github.com/ViktorHofer/corefx/pull/2/