### PR TITLE
untested; zero allocs during Socket.Poll and Socket.Select on Windows…

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
@@ -10,19 +10,19 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern int select(
+        internal static extern unsafe int select(
             [In] int ignoredParameter,
-            [In, Out] IntPtr[] readfds,
-            [In, Out] IntPtr[] writefds,
-            [In, Out] IntPtr[] exceptfds,
+            [In] IntPtr* readfds,
+            [In] IntPtr* writefds,
+            [In] IntPtr* exceptfds,
             [In] ref TimeValue timeout);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern int select(
+        internal static extern unsafe int select(
             [In] int ignoredParameter,
-            [In, Out] IntPtr[] readfds,
-            [In, Out] IntPtr[] writefds,
-            [In, Out] IntPtr[] exceptfds,
+            [In] IntPtr* readfds,
+            [In] IntPtr* writefds,
+            [In] IntPtr* exceptfds,
             [In] IntPtr nullTimeout);
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -122,14 +122,13 @@ namespace System.Net.Sockets
             return transmitPackets(socketHandle, packetArray, elementCount, sendSize, overlapped, flags);
         }
 
-        internal static IntPtr[] SocketListToFileDescriptorSet(IList socketList)
+        internal static void SocketListToFileDescriptorSet(IList socketList, Span<IntPtr> fileDescriptorSet)
         {
             if (socketList == null || socketList.Count == 0)
             {
-                return null;
+                return;
             }
 
-            IntPtr[] fileDescriptorSet = new IntPtr[socketList.Count + 1];
             fileDescriptorSet[0] = (IntPtr)socketList.Count;
             for (int current = 0; current < socketList.Count; current++)
             {
@@ -140,12 +139,11 @@ namespace System.Net.Sockets
 
                 fileDescriptorSet[current + 1] = ((Socket)socketList[current])._handle.DangerousGetHandle();
             }
-            return fileDescriptorSet;
         }
 
         // Transform the list socketList such that the only sockets left are those
         // with a file descriptor contained in the array "fileDescriptorArray".
-        internal static void SelectFileDescriptor(IList socketList, IntPtr[] fileDescriptorSet)
+        internal static void SelectFileDescriptor(IList socketList, Span<IntPtr> fileDescriptorSet)
         {
             // Walk the list in order.
             //


### PR DESCRIPTION
… (aveat: Socket.Select with > cutoff will still allocate)