### PR TITLE
Sockets on Windows: reduce array allocations during Select, Poll, Receive, Send

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -13,19 +13,18 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static unsafe extern SocketError WSARecv(
+        private static unsafe extern SocketError WSARecv(
             IntPtr socketHandle,
-            WSABuffer* buffer,
+            ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
-        internal static unsafe SocketError WSARecv(
+        internal static unsafe SocketError WSARecvSingle(
             IntPtr socketHandle,
             ref WSABuffer buffer,
-            int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
             NativeOverlapped* overlapped,
@@ -35,23 +34,20 @@ internal static partial class Interop
             // We don't want to cause a race in async scenarios.
             // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
-            return WSARecv(socketHandle, &localBuffer, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+            return WSARecv(socketHandle, ref localBuffer, 1, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
         }
 
         internal static unsafe SocketError WSARecv(
             IntPtr socketHandle,
-            WSABuffer[] buffers,
-            int bufferCount,
+            Span<WSABuffer> buffers,
+            int bufferCount, // this is *not* necessarily #the same as buffers.Length; the field on SocketAsyncEventArgs can be over-sized
             out int bytesTransferred,
             ref SocketFlags socketFlags,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
-            Debug.Assert(buffers != null && buffers.Length > 0 );
-            fixed (WSABuffer* buffersPtr = &buffers[0])
-            {
-                return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
-            }
+            Debug.Assert(!buffers.IsEmpty);
+            return WSARecv(socketHandle, ref MemoryMarshal.GetReference(buffers), bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
         }
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -40,15 +40,15 @@ internal static partial class Interop
 
         internal static unsafe SocketError WSARecv(
             IntPtr socketHandle,
-            WSABuffer[] buffers,
+            Span<WSABuffer> buffers,
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
-            Debug.Assert(buffers != null && buffers.Length > 0 );
-            fixed (WSABuffer* buffersPtr = &buffers[0])
+            Debug.Assert(!buffers.IsEmpty);
+            fixed (WSABuffer* buffersPtr = &buffers[0]) // deliberately not using GetReference - want this to explode if empty
             {
                 return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
             }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
             IntPtr completionRoutine)
         {
             Debug.Assert(!buffers.IsEmpty);
-            fixed (WSABuffer* buffersPtr = &buffers[0]) // deliberately not using GetReference - want this to explode if empty
+            fixed (WSABuffer* buffersPtr = &MemoryMarshal.GetReference(buffers))
             {
                 return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
             }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -13,18 +13,19 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        private static unsafe extern SocketError WSARecv(
+        internal static unsafe extern SocketError WSARecv(
             IntPtr socketHandle,
-            ref WSABuffer buffer,
+            WSABuffer* buffer,
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
-        internal static unsafe SocketError WSARecvSingle(
+        internal static unsafe SocketError WSARecv(
             IntPtr socketHandle,
             ref WSABuffer buffer,
+            int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
             NativeOverlapped* overlapped,
@@ -34,20 +35,23 @@ internal static partial class Interop
             // We don't want to cause a race in async scenarios.
             // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
-            return WSARecv(socketHandle, ref localBuffer, 1, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+            return WSARecv(socketHandle, &localBuffer, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
         }
 
         internal static unsafe SocketError WSARecv(
             IntPtr socketHandle,
-            Span<WSABuffer> buffers,
-            int bufferCount, // this is *not* necessarily #the same as buffers.Length; the field on SocketAsyncEventArgs can be over-sized
+            WSABuffer[] buffers,
+            int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
-            Debug.Assert(!buffers.IsEmpty);
-            return WSARecv(socketHandle, ref MemoryMarshal.GetReference(buffers), bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+            Debug.Assert(buffers != null && buffers.Length > 0 );
+            fixed (WSABuffer* buffersPtr = &buffers[0])
+            {
+                return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+            }
         }
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
@@ -40,15 +40,15 @@ internal static partial class Interop
 
         internal static unsafe SocketError WSASend(
             IntPtr socketHandle,
-            WSABuffer[] buffers,
+            Span<WSABuffer> buffers,
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
-            Debug.Assert(buffers != null && buffers.Length > 0);
-            fixed (WSABuffer* buffersPtr = &buffers[0])
+            Debug.Assert(!buffers.IsEmpty);
+            fixed (WSABuffer* buffersPtr = &buffers[0]) // deliberately not using GetReference - want this to explode if empty
             {
                 return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
             }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
             IntPtr completionRoutine)
         {
             Debug.Assert(!buffers.IsEmpty);
-            fixed (WSABuffer* buffersPtr = &buffers[0]) // deliberately not using GetReference - want this to explode if empty
+            fixed (WSABuffer* buffersPtr = &MemoryMarshal.GetReference(buffers))
             {
                 return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
             }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
@@ -10,19 +10,19 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern int select(
+        internal static extern unsafe int select(
             [In] int ignoredParameter,
-            [In, Out] IntPtr[] readfds,
-            [In, Out] IntPtr[] writefds,
-            [In, Out] IntPtr[] exceptfds,
+            [In] IntPtr* readfds,
+            [In] IntPtr* writefds,
+            [In] IntPtr* exceptfds,
             [In] ref TimeValue timeout);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern int select(
+        internal static extern unsafe int select(
             [In] int ignoredParameter,
-            [In, Out] IntPtr[] readfds,
-            [In, Out] IntPtr[] writefds,
-            [In, Out] IntPtr[] exceptfds,
+            [In] IntPtr* readfds,
+            [In] IntPtr* writefds,
+            [In] IntPtr* exceptfds,
             [In] IntPtr nullTimeout);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
@@ -12,17 +12,17 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern unsafe int select(
             [In] int ignoredParameter,
-            [In] IntPtr* readfds,
-            [In] IntPtr* writefds,
-            [In] IntPtr* exceptfds,
+            [In] ref IntPtr readfds,
+            [In] ref IntPtr writefds,
+            [In] ref IntPtr exceptfds,
             [In] ref TimeValue timeout);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern unsafe int select(
             [In] int ignoredParameter,
-            [In] IntPtr* readfds,
-            [In] IntPtr* writefds,
-            [In] IntPtr* exceptfds,
+            [In] ref IntPtr readfds,
+            [In] ref IntPtr writefds,
+            [In] ref IntPtr exceptfds,
             [In] IntPtr nullTimeout);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern int select(
+        internal static extern unsafe int select(
             [In] int ignoredParameter,
             [In] ref IntPtr readfds,
             [In] ref IntPtr writefds,
@@ -18,7 +18,7 @@ internal static partial class Interop
             [In] ref TimeValue timeout);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern int select(
+        internal static extern unsafe int select(
             [In] int ignoredParameter,
             [In] ref IntPtr readfds,
             [In] ref IntPtr writefds,

--- a/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern unsafe int select(
+        internal static extern int select(
             [In] int ignoredParameter,
             [In] ref IntPtr readfds,
             [In] ref IntPtr writefds,
@@ -18,7 +18,7 @@ internal static partial class Interop
             [In] ref TimeValue timeout);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern unsafe int select(
+        internal static extern int select(
             [In] int ignoredParameter,
             [In] ref IntPtr readfds,
             [In] ref IntPtr writefds,

--- a/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.select.cs
@@ -10,19 +10,19 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern int select(
+        internal static extern unsafe int select(
             [In] int ignoredParameter,
-            [In] ref IntPtr readfds,
-            [In] ref IntPtr writefds,
-            [In] ref IntPtr exceptfds,
+            [In] IntPtr* readfds,
+            [In] IntPtr* writefds,
+            [In] IntPtr* exceptfds,
             [In] ref TimeValue timeout);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern int select(
+        internal static extern unsafe int select(
             [In] int ignoredParameter,
-            [In] ref IntPtr readfds,
-            [In] ref IntPtr writefds,
-            [In] ref IntPtr exceptfds,
+            [In] IntPtr* readfds,
+            [In] IntPtr* writefds,
+            [In] IntPtr* exceptfds,
             [In] IntPtr nullTimeout);
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Win32.SafeHandles;
 using System.Collections;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -130,6 +131,8 @@ namespace System.Net.Sockets
                 return;
             }
 
+            Debug.Assert(fileDescriptorSet.Length >= count + 1);
+
             fileDescriptorSet[0] = (IntPtr)count;
             for (int current = 0; current < count; current++)
             {
@@ -156,6 +159,8 @@ namespace System.Net.Sockets
             {
                 return;
             }
+
+            Debug.Assert(fileDescriptorSet.Length >= count + 1);
 
             int returnedCount = (int)fileDescriptorSet[0];
             if (returnedCount == 0)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -122,14 +122,13 @@ namespace System.Net.Sockets
             return transmitPackets(socketHandle, packetArray, elementCount, sendSize, overlapped, flags);
         }
 
-        internal static IntPtr[] SocketListToFileDescriptorSet(IList socketList)
+        internal static void SocketListToFileDescriptorSet(IList socketList, Span<IntPtr> fileDescriptorSet)
         {
             if (socketList == null || socketList.Count == 0)
             {
-                return null;
+                return;
             }
 
-            IntPtr[] fileDescriptorSet = new IntPtr[socketList.Count + 1];
             fileDescriptorSet[0] = (IntPtr)socketList.Count;
             for (int current = 0; current < socketList.Count; current++)
             {
@@ -140,12 +139,11 @@ namespace System.Net.Sockets
 
                 fileDescriptorSet[current + 1] = ((Socket)socketList[current])._handle.DangerousGetHandle();
             }
-            return fileDescriptorSet;
         }
 
         // Transform the list socketList such that the only sockets left are those
         // with a file descriptor contained in the array "fileDescriptorArray".
-        internal static void SelectFileDescriptor(IList socketList, IntPtr[] fileDescriptorSet)
+        internal static void SelectFileDescriptor(IList socketList, Span<IntPtr> fileDescriptorSet)
         {
             // Walk the list in order.
             //

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -304,9 +304,10 @@ namespace System.Net.Sockets
                     var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
                     SocketFlags flags = _socketFlags;
-                    SocketError socketError = Interop.Winsock.WSARecvSingle(
+                    SocketError socketError = Interop.Winsock.WSARecv(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref wsaBuffer,
+                        1,
                         out int bytesTransferred,
                         ref flags,
                         overlapped,
@@ -570,9 +571,10 @@ namespace System.Net.Sockets
                     _singleBufferHandleState = SingleBufferHandleState.InProcess;
                     var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
-                    SocketError socketError = Interop.Winsock.WSASendSingle(
+                    SocketError socketError = Interop.Winsock.WSASend(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref wsaBuffer,
+                        1,
                         out int bytesTransferred,
                         _socketFlags,
                         overlapped,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -304,10 +304,9 @@ namespace System.Net.Sockets
                     var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
                     SocketFlags flags = _socketFlags;
-                    SocketError socketError = Interop.Winsock.WSARecv(
+                    SocketError socketError = Interop.Winsock.WSARecvSingle(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref wsaBuffer,
-                        1,
                         out int bytesTransferred,
                         ref flags,
                         overlapped,
@@ -571,10 +570,9 @@ namespace System.Net.Sockets
                     _singleBufferHandleState = SingleBufferHandleState.InProcess;
                     var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
-                    SocketError socketError = Interop.Winsock.WSASend(
+                    SocketError socketError = Interop.Winsock.WSASendSingle(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref wsaBuffer,
-                        1,
                         out int bytesTransferred,
                         _socketFlags,
                         overlapped,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -131,14 +131,14 @@ namespace System.Net.Sockets
             {
                 WSABuffers = stackalloc WSABuffer[StackThreshold];
                 objectsToPin = stackalloc GCHandle[StackThreshold];
-                objectsToPin.Clear(); // note touched in "finally"
             }
             else
             {
                 WSABuffers = leasedWSA = ArrayPool<WSABuffer>.Shared.Rent(count);
                 objectsToPin = leasedGC = ArrayPool<GCHandle>.Shared.Rent(count);
-                Array.Clear(leasedGC, 0, count);
             }
+            objectsToPin = objectsToPin.Slice(0, count);
+            objectsToPin.Clear(); // note: touched in finally
 
             try
             {
@@ -269,14 +269,14 @@ namespace System.Net.Sockets
             {
                 WSABuffers = stackalloc WSABuffer[StackThreshold];
                 objectsToPin = stackalloc GCHandle[StackThreshold];
-                objectsToPin.Clear(); // note touched in "finally"
             }
             else
             {
                 WSABuffers = leasedWSA = ArrayPool<WSABuffer>.Shared.Rent(count);
                 objectsToPin = leasedGC = ArrayPool<GCHandle>.Shared.Rent(count);
-                Array.Clear(leasedGC, 0, count);
             }
+            objectsToPin = objectsToPin.Slice(0, count);
+            objectsToPin.Clear(); // note: touched in finally
 
             try
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -748,7 +748,6 @@ namespace System.Net.Sockets
             // retains that behavior so that any app working around the original bug with, 
             // for example, (-2) specified for microseconds, will continue to get the same behavior.
 
-
             int socketCount;
             if (microseconds != -1)
             {


### PR DESCRIPTION
Addresses #30475

Passes all tests locally.

Uses arbitrary cutoff of 80 (inherited from unix) to choose between `stackalloc` and array allocation. There is some discussion to be had, perhaps, about the decision whether to use `ref Foo` or `Foo*` (via `fixed`) in the P/Invoke API - /cc @jkotas perhaps.