### PR TITLE
Move new SignedCms/EnvelopedCms API to netcoreapp ref

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/ref/Configurations.props
+++ b/src/System.Security.Cryptography.Pkcs/ref/Configurations.props
@@ -5,6 +5,7 @@
       netstandard;
       netcoreapp;
       netfx;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
+++ b/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
@@ -88,10 +88,8 @@ namespace System.Security.Cryptography.Pkcs
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public CmsSigner(CspParameters parameters) => throw null;
         public CmsSigner(SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
-        public CmsSigner(SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.AsymmetricAlgorithm privateKey) => throw null;
         public SubjectIdentifierType SignerIdentifierType { get => throw null; set => throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; set => throw null; }
-        public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get => throw null; set => throw null; }
         public Oid DigestAlgorithm { get => throw null; set => throw null; }
         public CryptographicAttributeObjectCollection SignedAttributes { get => throw null; }
         public CryptographicAttributeObjectCollection UnsignedAttributes { get => throw null; }
@@ -122,7 +120,6 @@ namespace System.Security.Cryptography.Pkcs
         public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
         public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
         public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
-        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
         public byte[] Encode() { throw null; }
         public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
         public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
@@ -256,8 +253,6 @@ namespace System.Security.Cryptography.Pkcs
         public void CheckSignature(bool verifySignatureOnly) => throw null;
         public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) => throw null;
         public void CheckHash() => throw null;
-        public void AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
-        public void RemoveCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
     }
     public sealed partial class SignerInfo
     {
@@ -268,8 +263,6 @@ namespace System.Security.Cryptography.Pkcs
         public Oid DigestAlgorithm => throw null;
         public CryptographicAttributeObjectCollection SignedAttributes => throw null;
         public CryptographicAttributeObjectCollection UnsignedAttributes => throw null;
-        public void AddUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
-        public void RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
         public SignerInfoCollection CounterSignerInfos => throw null;
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void ComputeCounterSignature() => throw null;
@@ -305,7 +298,6 @@ namespace System.Security.Cryptography.Pkcs
         internal SubjectIdentifier() { }
         public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public object Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public bool MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
     }
     public sealed partial class SubjectIdentifierOrKey
     {

--- a/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.csproj
@@ -13,14 +13,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Pkcs.cs" />
-    <Compile Include="System.Security.Cryptography.Pkcs.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Compile Include="System.Security.Cryptography.Pkcs.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Security" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj" />
     <ProjectReference Include="..\..\System.Security.Cryptography.Csp\ref\System.Security.Cryptography.Csp.csproj" />

--- a/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.netcoreapp.cs
@@ -9,6 +9,15 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Security.Cryptography.Pkcs
 {
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.AsymmetricAlgorithm privateKey) => throw null;
+        public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get => throw null; set => throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+    }
     public sealed partial class Pkcs8PrivateKeyInfo
     {
         public Oid AlgorithmId { get; }
@@ -77,9 +86,20 @@ namespace System.Security.Cryptography.Pkcs
         public bool TryEncode(Span<byte> destination, out int bytesWritten) => throw null;
         public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampTokenInfo timestampTokenInfo, out int bytesConsumed) { throw null; }
     }
+    public sealed partial class SignedCms
+    {
+        public void AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+        public void RemoveCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+    }
     public sealed partial class SignerInfo
     {
         public Oid SignatureAlgorithm => throw null;
         public byte[] GetSignature() => throw null;
+        public void AddUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+        public void RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        public bool MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/src/MatchingRefApiCompatBaseline.netstandard.txt
+++ b/src/System.Security.Cryptography.Pkcs/src/MatchingRefApiCompatBaseline.netstandard.txt
@@ -1,3 +1,13 @@
-# These members don't belong in netstandard reference because of type unification with netfx (the members are new in net472).
+Compat issues with assembly System.Security.Cryptography.Pkcs:
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner..ctor(System.Security.Cryptography.Pkcs.SubjectIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.AsymmetricAlgorithm)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.PrivateKey.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.PrivateKey.set(System.Security.Cryptography.AsymmetricAlgorithm)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.EnvelopedCms.Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo, System.Security.Cryptography.AsymmetricAlgorithm)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignedCms.AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignedCms.RemoveCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignerInfo.AddUnsignedAttribute(System.Security.Cryptography.AsnEncodedData)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignerInfo.GetSignature()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignerInfo.RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SignerInfo.SignatureAlgorithm.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Security.Cryptography.Pkcs.SubjectIdentifier.MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 11


### PR DESCRIPTION
The new members on existing types got added to their type definition for netstandard.  This moves them to the netcoreapp-specific ref.cs.

This is the follow-on to  #30233 to clean up the rest of the members not present in netfx.