### PR TITLE
Expose and Add tests for StringBuilder overloads of TextWriter

### DIFF
--- a/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -50,6 +52,63 @@ namespace System.IO.Tests
                 var rs = new Memory<char>(TestDataProvider.CharData, 4, 6);
                 await tw.WriteLineAsync(rs);
                 Assert.Equal(new string(rs.Span) + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WriteStringBuilderTest(bool isSynchronized)
+        {
+            using (CharArrayTextWriter ctw = NewTextWriter)
+            {
+                TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
+                tw.Write(new StringBuilder(new string(TestDataProvider.CharData)));
+                tw.Flush();
+                Assert.Equal(new string(TestDataProvider.CharData), ctw.Text);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WriteLineStringBuilderTest(bool isSynchronized)
+        {
+            using (CharArrayTextWriter ctw = NewTextWriter)
+            {
+                TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
+                tw.Write(new StringBuilder(new string(TestDataProvider.CharData)));
+                tw.Flush();
+                Assert.Equal(new string(TestDataProvider.CharData), ctw.Text);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+
+        public async void WriteAsyncStringBuilderTest(bool isSynchronized)
+        {
+            using (CharArrayTextWriter ctw = NewTextWriter)
+            {
+                TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
+                await tw.WriteAsync(new StringBuilder(new string(TestDataProvider.CharData)));
+                tw.Flush();
+                Assert.Equal(new string(TestDataProvider.CharData), ctw.Text);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async void WriteLineAsyncStringBuilderTest(bool isSynchronized)
+        {
+            using (CharArrayTextWriter ctw = NewTextWriter)
+            {
+                TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
+                await tw.WriteLineAsync(new StringBuilder(new string(TestDataProvider.CharData)));
+                tw.Flush();
+                Assert.Equal(new string(TestDataProvider.CharData) + tw.NewLine, ctw.Text);
             }
         }
     }

--- a/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
@@ -86,7 +86,6 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-
         public async void WriteAsyncStringBuilderTest(bool isSynchronized)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)

--- a/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
@@ -56,58 +56,65 @@ namespace System.IO.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void WriteStringBuilderTest(bool isSynchronized)
+        [MemberData(nameof(GetStringBuilderTestData))]
+        public void WriteStringBuilderTest(bool isSynchronized, string testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
-                tw.Write(new StringBuilder(new string(TestDataProvider.CharData)));
+                tw.Write(new StringBuilder(testData));
                 tw.Flush();
-                Assert.Equal(new string(TestDataProvider.CharData), ctw.Text);
+                Assert.Equal(testData, ctw.Text);
             }
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void WriteLineStringBuilderTest(bool isSynchronized)
+        [MemberData(nameof(GetStringBuilderTestData))]
+        public void WriteLineStringBuilderTest(bool isSynchronized, string testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
-                tw.Write(new StringBuilder(new string(TestDataProvider.CharData)));
+                tw.WriteLine(new StringBuilder(new string(testData)));
                 tw.Flush();
-                Assert.Equal(new string(TestDataProvider.CharData), ctw.Text);
+                Assert.Equal(testData + tw.NewLine, ctw.Text);
             }
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async void WriteAsyncStringBuilderTest(bool isSynchronized)
+        [MemberData(nameof(GetStringBuilderTestData))]
+        public async void WriteAsyncStringBuilderTest(bool isSynchronized, string testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
-                await tw.WriteAsync(new StringBuilder(new string(TestDataProvider.CharData)));
+                await tw.WriteAsync(new StringBuilder(testData));
                 tw.Flush();
-                Assert.Equal(new string(TestDataProvider.CharData), ctw.Text);
+                Assert.Equal(testData, ctw.Text);
             }
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async void WriteLineAsyncStringBuilderTest(bool isSynchronized)
+        [MemberData(nameof(GetStringBuilderTestData))]
+        public async void WriteLineAsyncStringBuilderTest(bool isSynchronized, string testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
-                await tw.WriteLineAsync(new StringBuilder(new string(TestDataProvider.CharData)));
+                await tw.WriteLineAsync(new StringBuilder(testData));
                 tw.Flush();
-                Assert.Equal(new string(TestDataProvider.CharData) + tw.NewLine, ctw.Text);
+                Assert.Equal(testData + tw.NewLine, ctw.Text);
+            }
+        }
+
+        // Generate data for TextWriter.Write* methods that take a stringBuilder.  
+        // We test both the synchronized and unsynchronized variation, on strinbuilder swith 0, small and large values.    
+        public static IEnumerable<object[]> GetStringBuilderTestData()
+        {
+            foreach (string testData in new string[] { "", new string(TestDataProvider.CharData), new string(TestDataProvider.LargeData) })
+            {
+                foreach (bool isSynchronized in new bool[] { true, false })
+                    yield return new object[] { isSynchronized, testData };
             }
         }
     }

--- a/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
@@ -57,51 +57,51 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(GetStringBuilderTestData))]
-        public void WriteStringBuilderTest(bool isSynchronized, string testData)
+        public void WriteStringBuilderTest(bool isSynchronized, StringBuilder testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
-                tw.Write(new StringBuilder(testData));
+                tw.Write(testData);
                 tw.Flush();
-                Assert.Equal(testData, ctw.Text);
+                Assert.Equal(testData.ToString(), ctw.Text);
             }
         }
 
         [Theory]
         [MemberData(nameof(GetStringBuilderTestData))]
-        public void WriteLineStringBuilderTest(bool isSynchronized, string testData)
+        public void WriteLineStringBuilderTest(bool isSynchronized, StringBuilder testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
-                tw.WriteLine(new StringBuilder(new string(testData)));
+                tw.WriteLine(testData);
                 tw.Flush();
-                Assert.Equal(testData + tw.NewLine, ctw.Text);
+                Assert.Equal(testData.ToString() + tw.NewLine, ctw.Text);
             }
         }
 
         [Theory]
         [MemberData(nameof(GetStringBuilderTestData))]
-        public async void WriteAsyncStringBuilderTest(bool isSynchronized, string testData)
+        public async void WriteAsyncStringBuilderTest(bool isSynchronized, StringBuilder testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
-                await tw.WriteAsync(new StringBuilder(testData));
+                await tw.WriteAsync(testData);
                 tw.Flush();
-                Assert.Equal(testData, ctw.Text);
+                Assert.Equal(testData.ToString(), ctw.Text);
             }
         }
 
         [Theory]
         [MemberData(nameof(GetStringBuilderTestData))]
-        public async void WriteLineAsyncStringBuilderTest(bool isSynchronized, string testData)
+        public async void WriteLineAsyncStringBuilderTest(bool isSynchronized, StringBuilder testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
-                await tw.WriteLineAsync(new StringBuilder(testData));
+                await tw.WriteLineAsync(testData);
                 tw.Flush();
                 Assert.Equal(testData + tw.NewLine, ctw.Text);
             }
@@ -111,10 +111,17 @@ namespace System.IO.Tests
         // We test both the synchronized and unsynchronized variation, on strinbuilder swith 0, small and large values.    
         public static IEnumerable<object[]> GetStringBuilderTestData()
         {
-            foreach (string testData in new string[] { "", new string(TestDataProvider.CharData), new string(TestDataProvider.LargeData) })
+            // Make a string that has 10 or so 8K chunks (probably).  
+            StringBuilder complexStringBuilder = new StringBuilder();
+            for (int i = 0; i < 4000; i++)
+                complexStringBuilder.Append(TestDataProvider.CharData); // CharData ~ 25 chars
+
+            foreach (StringBuilder testData in new StringBuilder[] { new StringBuilder(""), new StringBuilder(new string(TestDataProvider.CharData)), complexStringBuilder })
             {
                 foreach (bool isSynchronized in new bool[] { true, false })
+                {
                     yield return new object[] { isSynchronized, testData };
+                }
             }
         }
     }

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1560,6 +1560,7 @@ namespace System.IO
         public virtual void Write(string format, object arg0, object arg1) { }
         public virtual void Write(string format, object arg0, object arg1, object arg2) { }
         public virtual void Write(string format, params object[] arg) { }
+        public virtual void Write(System.Text.StringBuilder value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void Write(uint value) { }
         [System.CLSCompliantAttribute(false)]
@@ -1570,6 +1571,7 @@ namespace System.IO
         public virtual System.Threading.Tasks.Task WriteAsync(char[] buffer, int index, int count) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(System.ReadOnlyMemory<char> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(string value) { throw null; }
+        public virtual System.Threading.Tasks.Task WriteAsync(System.Text.StringBuilder value, System.Threading.CancellationToken cancellationToken = default) { throw null;  }
         public virtual void WriteLine() { }
         public virtual void WriteLine(bool value) { }
         public virtual void WriteLine(char value) { }
@@ -1586,6 +1588,7 @@ namespace System.IO
         public virtual void WriteLine(string format, object arg0, object arg1) { }
         public virtual void WriteLine(string format, object arg0, object arg1, object arg2) { }
         public virtual void WriteLine(string format, params object[] arg) { }
+        public virtual void WriteLine(System.Text.StringBuilder value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void WriteLine(uint value) { }
         [System.CLSCompliantAttribute(false)]
@@ -1597,6 +1600,7 @@ namespace System.IO
         public virtual System.Threading.Tasks.Task WriteLineAsync(char[] buffer, int index, int count) { throw null; }
         public virtual System.Threading.Tasks.Task WriteLineAsync(System.ReadOnlyMemory<char> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task WriteLineAsync(string value) { throw null; }
+        public virtual System.Threading.Tasks.Task WriteLineAsync(System.Text.StringBuilder value, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
 }
 namespace System.Net

--- a/src/System.Runtime.Extensions/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime.Extensions/src/ApiCompatBaseline.uapaot.txt
@@ -1,3 +1,7 @@
 Compat issues with assembly System.Runtime:
 MembersMustExist : Member 'System.IO.Path.Join(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.IO.Path.Join(System.String, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.TextWriter.Write(System.Text.StringBuilder)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.TextWriter.WriteAsync(System.Text.StringBuilder, System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.TextWriter.WriteLine(System.Text.StringBuilder)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.TextWriter.WriteLineAsync(System.Text.StringBuilder, System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
@@ -1,5 +1,4 @@
 Compat issues with assembly System.Runtime:
-MembersMustExist : Member 'System.Text.StringBuilder.GetChunks()' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.CompilerServices.CallerArgumentExpressionAttribute' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Text.StringBuilder.ChunkEnumerator' does not exist in the implementation but it does exist in the contract.
 CannotMakeMoreVisible : Visibility of member 'System.Exception.HResult.set(System.Int32)' is 'Family' in the implementation but 'Public' in the contract.
+


### PR DESCRIPTION
Add tests for implementation in https://github.com/dotnet/coreclr/pull/18281
This supports the issue https://github.com/dotnet/corefx/issues/30048

I also removed now unneeded API error suppression entries src/System.Runtime/src/ApiCompatBaseline.uapaot.txt.
