### PR TITLE
Remove StringBuilder in System.IO.Pipes marshaling

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetNamedPipeHandleState.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetNamedPipeHandleState.cs
@@ -5,7 +5,6 @@
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal partial class Interop
 {
@@ -24,13 +23,13 @@ internal partial class Interop
 
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false, EntryPoint = "GetNamedPipeHandleStateW")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool GetNamedPipeHandleState(
+        internal static extern unsafe bool GetNamedPipeHandleState(
             SafePipeHandle hNamedPipe,
             IntPtr lpState,
             IntPtr lpCurInstances,
             IntPtr lpMaxCollectionCount,
             IntPtr lpCollectDataTimeout,
-            [Out] StringBuilder lpUserName,
+            char* lpUserName,
             int nMaxUserNameSize);
 
         [DllImport(Libraries.Kernel32, SetLastError = true, EntryPoint="GetNamedPipeHandleStateW")]
@@ -43,6 +42,5 @@ internal partial class Interop
             IntPtr lpCollectDataTimeout,
             IntPtr lpUserName,
             int nMaxUserNameSize);
-
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -169,19 +169,20 @@ namespace System.IO.Pipes
         // Gets the username of the connected client.  Not that we will not have access to the client's 
         // username until it has written at least once to the pipe (and has set its impersonationLevel 
         // argument appropriately). 
-        public String GetImpersonationUserName()
+        public unsafe string GetImpersonationUserName()
         {
             CheckWriteOperations();
 
-            StringBuilder userName = new StringBuilder(Interop.Kernel32.CREDUI_MAX_USERNAME_LENGTH + 1);
+            const int UserNameMaxLength = Interop.Kernel32.CREDUI_MAX_USERNAME_LENGTH + 1;
+            char* userName = stackalloc char[UserNameMaxLength]; // ~1K
 
             if (!Interop.Kernel32.GetNamedPipeHandleState(InternalHandle, IntPtr.Zero, IntPtr.Zero,
-                IntPtr.Zero, IntPtr.Zero, userName, userName.Capacity))
+                IntPtr.Zero, IntPtr.Zero, userName, UserNameMaxLength))
             {
                 throw WinIOError(Marshal.GetLastWin32Error());
             }
 
-            return userName.ToString();
+            return new string(userName);
         }
 
         // -----------------------------

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -166,7 +166,7 @@ namespace System.IO.Pipes
             State = PipeState.Disconnected;
         }
 
-        // Gets the username of the connected client.  Not that we will not have access to the client's 
+        // Gets the username of the connected client.  Note that we will not have access to the client's 
         // username until it has written at least once to the pipe (and has set its impersonationLevel 
         // argument appropriately). 
         public unsafe string GetImpersonationUserName()


### PR DESCRIPTION
To get the impersonated user name, we can just stackalloc space for the Win32 call and then create a string from that, instead of allocating a StringBuilder and its underlying char[], paying the associated StringBuilder marshaling costs, and then creating the string from that.

cc: @JeremyKuhne, @pjanotti 