### PR TITLE
Remove unused method from System.Text.Encoding.CodePages

### DIFF
--- a/src/System.Text.Encoding.CodePages/src/System/Text/DecoderFallbackBufferHelper.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DecoderFallbackBufferHelper.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Globalization;
 
 namespace System.Text
 {
@@ -141,27 +140,5 @@ namespace System.Text
             // If no fallback return 0
             return 0;
         }
-
-        // private helper methods
-        internal void ThrowLastBytesRecursive(byte[] bytesUnknown)
-        {
-            // Create a string representation of our bytes.
-            StringBuilder strBytes = new StringBuilder(bytesUnknown.Length * 3);
-            int i;
-            for (i = 0; i < bytesUnknown.Length && i < 20; i++)
-            {
-                if (strBytes.Length > 0)
-                    strBytes.Append(" ");
-                strBytes.AppendFormat(CultureInfo.InvariantCulture, "\\x{0:X2}", bytesUnknown[i]);
-            }
-            // In case the string's really long
-            if (i == 20)
-                strBytes.Append(" ...");
-
-            // Throw it, using our complete bytes
-            throw new ArgumentException(
-                SR.Format(SR.Argument_RecursiveFallbackBytes, strBytes.ToString()), nameof(bytesUnknown));
-        }
     }
 }
-


### PR DESCRIPTION
cc: @tarekgh 