### PR TITLE
Ensure Reflection.Context tests find the correct results.

### DIFF
--- a/src/System.Reflection.Context/tests/CustomAssemblyTests.cs
+++ b/src/System.Reflection.Context/tests/CustomAssemblyTests.cs
@@ -48,6 +48,7 @@ namespace System.Reflection.Context.Tests
         public void GetCustomAttributesDataTest()
         {
             IList<CustomAttributeData> customAttributesData = _customAssembly.GetCustomAttributesData();
+            Assert.NotEmpty(customAttributesData);
             Assert.All(customAttributesData,
                 cad => Assert.Equal(ProjectionConstants.ProjectingCustomAttributeData, cad.GetType().FullName));
         }
@@ -91,6 +92,7 @@ namespace System.Reflection.Context.Tests
         {
             IEnumerable<ManifestResourceInfo> manifestResourceInfos = _customAssembly.GetManifestResourceNames()
                 .Select(mrn => _customAssembly.GetManifestResourceInfo(mrn));
+            Assert.NotEmpty(manifestResourceInfos);
             Assert.All(manifestResourceInfos,
                 (mri) => Assert.Equal(ProjectionConstants.ProjectingManifestResourceInfo, mri.GetType().FullName));
         }
@@ -135,6 +137,7 @@ namespace System.Reflection.Context.Tests
         public void GetTypesTest()
         {
             Type[] types = _customAssembly.GetTypes();
+            Assert.NotEmpty(types);
             Assert.All(types,
                 (type) => Assert.Equal(ProjectionConstants.CustomType, type.GetType().FullName));
         }

--- a/src/System.Reflection.Context/tests/Properties/Resources.Designer.cs
+++ b/src/System.Reflection.Context/tests/Properties/Resources.Designer.cs
@@ -62,7 +62,7 @@ namespace Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This manifest is discovered by one of the projection tests. Do not delete!.
+        ///   Looks up a localized string similar to This manifest is discovered by the CustomAssemblyTests.GetManifestResourceInfoTest. Do not delete!.
         /// </summary>
         internal static string Reason {
             get {

--- a/src/System.Reflection.Context/tests/Properties/Resources.resx
+++ b/src/System.Reflection.Context/tests/Properties/Resources.resx
@@ -59,6 +59,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Reason" xml:space="preserve">
-    <value>This manifest is discovered by one of the projection tests. Do not delete!</value>
+    <value>This manifest is discovered by the CustomAssemblyTests.GetManifestResourceInfoTest. Do not delete!</value>
   </data>
 </root>


### PR DESCRIPTION
Assert.All on an empty collection will pass.

Also, update the .resx message to mention which test requires the resource.