### PR TITLE
Remove some allocations from SocketAddress.ToString

### DIFF
--- a/src/Common/src/System/Net/SocketAddress.cs
+++ b/src/Common/src/System/Net/SocketAddress.cs
@@ -228,16 +228,18 @@ namespace System.Net.Internals
 
         public override string ToString()
         {
-            StringBuilder bytes = new StringBuilder();
-            for (int i = SocketAddressPal.DataOffset; i < this.Size; i++)
+            var sb = new StringBuilder().Append(Family.ToString()).Append(':').Append(Size).Append(":{");
+
+            for (int i = SocketAddressPal.DataOffset; i < Size; i++)
             {
                 if (i > SocketAddressPal.DataOffset)
                 {
-                    bytes.Append(",");
+                    sb.Append(',');
                 }
-                bytes.Append(this[i].ToString(NumberFormatInfo.InvariantInfo));
+                sb.Append(this[i]);
             }
-            return Family.ToString() + ":" + Size.ToString(NumberFormatInfo.InvariantInfo) + ":{" + bytes.ToString() + "}";
+
+            return sb.Append('}').ToString();
         }
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -65,6 +65,16 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(sa1.ToString(), sa2.ToString());
             Assert.NotEqual(sa1.ToString(), sa3.ToString());
             Assert.NotEqual(sa1.ToString(), sa4.ToString());
+
+            Assert.Equal("InterNetwork:64:{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", sa1.ToString());
+            Assert.Equal("InterNetworkV6:48:{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", sa4.ToString());
+
+            SocketAddress sa5 = new SocketAddress(AddressFamily.InterNetworkV6, 48);
+            for (int i = 2; i < sa5.Size; i++)
+            {
+                sa5[i] = (byte)i;
+            }
+            Assert.EndsWith("2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47}", sa5.ToString());
         }
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -53,6 +53,7 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.NotEqual(sa1, sa4);
         }
 
+        [ActiveIssue(30523, TestPlatforms.AnyUnix)]
         [Fact]
         public static void ToString_Compare_Success()
         {


### PR DESCRIPTION
Avoids a string allocation per byte, plus a few other intermediary strings.

cc: @davidsh