### PR TITLE
Remove more number ToStrings from System.Net.Http headers

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
@@ -232,14 +232,14 @@ namespace System.Net.Http.Headers
             {
                 AppendValueWithSeparatorIfRequired(sb, maxAgeString);
                 sb.Append('=');
-                sb.Append(((int)_maxAge.Value.TotalSeconds).ToString(NumberFormatInfo.InvariantInfo));
+                sb.Append((int)_maxAge.Value.TotalSeconds);
             }
 
             if (_sharedMaxAge.HasValue)
             {
                 AppendValueWithSeparatorIfRequired(sb, sharedMaxAgeString);
                 sb.Append('=');
-                sb.Append(((int)_sharedMaxAge.Value.TotalSeconds).ToString(NumberFormatInfo.InvariantInfo));
+                sb.Append((int)_sharedMaxAge.Value.TotalSeconds);
             }
 
             if (_maxStale)
@@ -248,7 +248,7 @@ namespace System.Net.Http.Headers
                 if (_maxStaleLimit.HasValue)
                 {
                     sb.Append('=');
-                    sb.Append(((int)_maxStaleLimit.Value.TotalSeconds).ToString(NumberFormatInfo.InvariantInfo));
+                    sb.Append((int)_maxStaleLimit.Value.TotalSeconds);
                 }
             }
 
@@ -256,7 +256,7 @@ namespace System.Net.Http.Headers
             {
                 AppendValueWithSeparatorIfRequired(sb, minFreshString);
                 sb.Append('=');
-                sb.Append(((int)_minFresh.Value.TotalSeconds).ToString(NumberFormatInfo.InvariantInfo));
+                sb.Append((int)_minFresh.Value.TotalSeconds);
             }
 
             if (_privateField)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
@@ -157,9 +157,9 @@ namespace System.Net.Http.Headers
 
             if (HasRange)
             {
-                sb.Append(_from.Value.ToString(NumberFormatInfo.InvariantInfo));
+                sb.Append(_from.Value);
                 sb.Append('-');
-                sb.Append(_to.Value.ToString(NumberFormatInfo.InvariantInfo));
+                sb.Append(_to.Value);
             }
             else
             {
@@ -169,7 +169,7 @@ namespace System.Net.Http.Headers
             sb.Append('/');
             if (HasLength)
             {
-                sb.Append(_length.Value.ToString(NumberFormatInfo.InvariantInfo));
+                sb.Append(_length.Value);
             }
             else
             {


### PR DESCRIPTION
Previously these wouldn't have helped but also wouldn't really have hurt. However, now that StringBuilder doesn't call ToString() by default on numeric types, these are resulting in unnecessary string allocations.

cc: @davidsh