### PR TITLE
Remove string allocation from IPAddress.ToString/TryFormat

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
@@ -47,6 +47,13 @@ namespace System.Net
             return new string(addressString, 0, charsWritten);
         }
 
+        internal static unsafe void IPv4AddressToString(uint address, StringBuilder destination)
+        {
+            char* addressString = stackalloc char[MaxIPv4StringLength];
+            int charsWritten = IPv4AddressToStringHelper(address, addressString);
+            destination.Append(addressString, charsWritten);
+        }
+
         internal static unsafe bool IPv4AddressToString(uint address, Span<char> formatted, out int charsWritten)
         {
             if (formatted.Length < MaxIPv4StringLength)
@@ -124,7 +131,7 @@ namespace System.Net
                 {
                     buffer.Append(':');
                 }
-                buffer.Append(IPAddressParser.IPv4AddressToString(ExtractIPv4Address(address)));
+                IPv4AddressToString(ExtractIPv4Address(address), buffer);
             }
             else
             {


### PR DESCRIPTION
IPv6 addresses with embedded IPv4 addresses were incurring an extra string allocation for the IPv4 address.

cc: @davidsh, @rmkerr 