### PR TITLE
Don't move System.Reflection.TypeExtensions during harvesting

### DIFF
--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -10,10 +10,7 @@
     <HarvestIncludePaths Include="lib/netcore50;runtimes/aot/lib/netcore50" />
     <HarvestIncludePaths Include="ref/netstandard1.3" />
     <HarvestIncludePaths Include="ref/netstandard1.5" />
-    <HarvestIncludePaths Include="lib/netstandard1.5">
-      <!-- this assembly used types / members not exposed by netstandard1.5-->
-      <TargetPath>lib/netcoreapp1.0</TargetPath>
-    </HarvestIncludePaths>
+    <HarvestIncludePaths Include="lib/netcoreapp1.0" />
   </ItemGroup>
   <ItemGroup>
     <InboxOnTargetFramework Include="netcoreapp2.0" />
@@ -26,5 +23,16 @@
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
+  
+  <PropertyGroup>
+    <HarvestVersion>4.4.0</HarvestVersion>
+  </PropertyGroup>
+  <Target Name="_checkForNewerHarvestPackage" AfterTargets="HarvestStablePackage">
+    <GetLastStablePackage LatestPackages="@(_latestPackage)" PackageIndexes="@(PackageIndex)">
+      <Output TaskParameter="LastStablePackages" ItemName="_lastStablePackage" />
+    </GetLastStablePackage>
+    <Error Condition="'%(_lastStablePackage.Version)' &gt; '4.5.0'"
+           Text="This target and the hardcoded HarvestVersion should be removed from this project.  Please ensure that the harvested package contains a valid lib/netcoreapp1.0 asset." />
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
When building the netcoreapp2.0 version of the package we needed
to move the netstandard1.5 asset since it was actually netcoreapp1.0
specific.

After we shipped this version of the package, the netstandard1.5
asset was a not supported asset.  We should have stopped moving it
at this point, and instead harvest the previously moved asset
from netcoreapp1.0.

#30506 