### PR TITLE
Switched to as cast in ImplicitMachineConfig Init

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/Resources/System.Configuration.ConfigurationManager.rd.xml
+++ b/src/System.Configuration.ConfigurationManager/src/Resources/System.Configuration.ConfigurationManager.rd.xml
@@ -5,6 +5,8 @@
        <!--Both types are instantiated using CreateInstance from TypeUtil.CreateInstance -->
        <Type Name="System.Configuration.ClientConfigurationHost" Dynamic="Required All" />
        <Type Name="System.Configuration.ProtectedConfigurationSection" Dynamic="Required All" />
+       <Type Name="System.Configuration.Internal.InternalConfigHost" Dynamic="Required All" />
+       <Type Name="System.Configuration.Internal.InternalConfigConfigurationFactory" Dynamic="Required All" />
     </Assembly>
   </Library>
 </Directives>

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
@@ -23,14 +23,14 @@ namespace System.Configuration
             out string locationConfigPath, IInternalConfigRoot configRoot, params object[] hostInitConfigurationParams)
         {
             // Stash the filemap so we can see if the machine config was explicitly specified
-            _fileMap = (ConfigurationFileMap)hostInitConfigurationParams[0];
+            _fileMap = hostInitConfigurationParams[0] as ConfigurationFileMap;
             base.InitForConfiguration(ref locationSubPath, out configPath, out locationConfigPath, configRoot, hostInitConfigurationParams);
         }
 
         public override void Init(IInternalConfigRoot configRoot, params object[] hostInitParams)
         {
             // Stash the filemap so we can see if the machine config was explicitly specified
-            _fileMap = (ConfigurationFileMap)hostInitParams[0];
+            _fileMap = hostInitParams[0] as ConfigurationFileMap;
             base.Init(configRoot, hostInitParams);
         }
 

--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="System\Configuration\SmokeTest.cs" />
     <Compile Include="System\Configuration\StringUtilTests.cs" />
     <Compile Include="System\Configuration\TempConfig.cs" />
+    <Compile Include="System\Configuration\TempConfigurationHost.cs" />
     <Compile Include="System\Configuration\TestData.cs" />
     <Compile Include="System\Configuration\StringValidatorTests.cs" />
     <Compile Include="System\Configuration\SubclassTypeValidatorAttributeTests.cs" />

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ImplicitMachineConfigTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ImplicitMachineConfigTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Configuration;
+using System.Configuration.Internal;
 using System.IO;
 using Xunit;
 
@@ -59,6 +61,25 @@ namespace System.ConfigurationTests
                 Assert.NotNull(config);
 
                 Assert.Null(config.AppSettings);
+            }
+        }
+
+        [Fact]
+        public void EnsureInitWithDifferentOrderHostParams() 
+        {
+            string assemblyName = PlatformDetection.IsFullFramework ? "System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" : "System.Configuration.ConfigurationManager";
+
+            // InternalConfigFactory allows you to specify your own host / hostInitParams
+            // Ensure ImplictMachineConfigHost can init within this process and not throw an Invalid cast exception 
+            using (var temp = new TempConfig(TestData.EmptyConfig)) 
+            {
+                string typeName = "System.Configuration.Internal.InternalConfigConfigurationFactory, " + assemblyName;
+
+                Type type = Type.GetType(typeName, true);
+                var configFactory = (IInternalConfigConfigurationFactory) Activator.CreateInstance(type, true);
+                var config = configFactory.Create(typeof(TempConfigurationHost), "test", new ConfigurationFileMap(temp.ConfigPath), "test");
+
+                Assert.NotNull(config);
             }
         }
     }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TempConfigurationHost.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TempConfigurationHost.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Configuration;
+using System.Configuration.Internal;
+using System.Reflection;
+
+public class TempConfigurationHost : DelegatingConfigHost 
+{
+    private static string s_assemblyName = PlatformDetection.IsFullFramework ? "System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" : "System.Configuration.ConfigurationManager";
+    private static IInternalConfigConfigurationFactory s_configurationFactory;
+    
+    private ConfigurationFileMap _fileMap;
+
+    public TempConfigurationHost() 
+    {
+        Type type = Type.GetType(InternalHostTypeName, true);
+        Host = (IInternalConfigHost) Activator.CreateInstance(type, true);
+    }
+
+    public override void Init(IInternalConfigRoot configRoot, params object[] hostInitParams) 
+    {
+        Host.Init(configRoot, hostInitParams);
+    }
+
+    public override void InitForConfiguration(ref string locationSubPath, out string configPath, out string locationConfigPath,
+                        IInternalConfigRoot configRoot, params object[] hostInitConfigurationParams) 
+    {
+
+        Host.Init(configRoot, hostInitConfigurationParams);
+
+        _fileMap = hostInitConfigurationParams[1] as ConfigurationFileMap;
+        
+        locationSubPath = ConfigurationFactory.NormalizeLocationSubPath(locationSubPath, null);
+        configPath = "MACHINE/EXE";
+        locationConfigPath = locationSubPath;
+    }
+
+    public override bool IsTrustedConfigPath(string configPath) 
+    {
+        return true;
+    }
+
+    public override bool IsLocationApplicable(string configPath) 
+    {
+        return true;
+    }
+
+    public override bool IsFullTrustSectionWithoutAptcaAllowed(IInternalConfigRecord configRecord) 
+    {
+        return true;
+    }
+
+    public override bool PrefetchAll(string configPath, string streamName)
+    {
+        return false;
+    }
+
+    public override bool PrefetchSection(string sectionGroupName, string sectionName)
+    {
+        return false;
+    }
+
+    public override string GetStreamName(string configPath) 
+    {
+        return _fileMap.MachineConfigFilename;
+    }
+
+    static string InternalConfigConfigurationFactoryTypeName 
+    {
+        get { return "System.Configuration.Internal.InternalConfigConfigurationFactory, " + s_assemblyName; }
+    }
+
+    static string InternalHostTypeName 
+    {
+        get { return "System.Configuration.Internal.InternalConfigHost, " + s_assemblyName; }
+    }
+
+    static internal IInternalConfigConfigurationFactory ConfigurationFactory 
+    {
+        get 
+        {    
+            if (s_configurationFactory == null) 
+            {
+                Type type = Type.GetType(InternalConfigConfigurationFactoryTypeName, true);
+                s_configurationFactory = (IInternalConfigConfigurationFactory) Activator.CreateInstance(type, true);
+            }
+
+            return s_configurationFactory;
+        }
+    }
+}


### PR DESCRIPTION
Some callers to init hosts do not have the file map at the beginning of the param list (or not have it at all) and an unnecessary exception would occur.