### PR TITLE
Add System.Data.Common.DataTableMapping unit tests.

### DIFF
--- a/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Data\Common\DataColumnMappingTest.cs" />
+    <Compile Include="System\Data\Common\DataTableMappingTest.cs" />
     <Compile Include="System\Data\Common\DbCommandTests.cs" />
     <Compile Include="System\Data\Common\DbConnectionTests.cs" />
     <Compile Include="System\Data\Common\DbExceptionTests.cs" />

--- a/src/System.Data.Common/tests/System/Data/Common/DataTableMappingTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataTableMappingTest.cs
@@ -1,0 +1,132 @@
+﻿using Xunit;
+
+namespace System.Data.Common
+{
+    public class DataTableMappingTest
+    {
+        private DataTableMapping _dataTableMapping { get; }
+        private DataColumnMapping[] _dataColumnMappings { get; }
+
+        public DataTableMappingTest()
+        {
+            _dataColumnMappings = new DataColumnMapping[2];
+            _dataColumnMappings[0] = new DataColumnMapping("firstSourceColumn", "firstDataSetColumn");
+            _dataColumnMappings[1] = new DataColumnMapping("secondSourceColumn", "secondDataSetColumn");
+            _dataTableMapping = new DataTableMapping("MyCustomSourceTable", "MyCustomDataSetTable", _dataColumnMappings);
+        }
+
+        [Fact]
+        public void GetDataTableBySchemaAction()
+        {
+            // Test method with existing dataset table in dataset
+            DataSet dataSet = new DataSet();
+            DataTable dataTable = new DataTable("MyCustomDataSetTable");
+            dataSet.Tables.Add(dataTable);
+
+            DataTable result = _dataTableMapping.GetDataTableBySchemaAction(dataSet, MissingSchemaAction.Error);
+            Assert.Equal(dataTable.TableName, result.TableName);
+
+            // Test method with missing dataset table from dataset with MissingSchemaAction error.
+            dataSet = new DataSet();
+            dataTable = new DataTable("UnknownDataSet");
+            dataSet.Tables.Add(dataTable);
+            Action missingTableErrorAction = () => _dataTableMapping.GetDataTableBySchemaAction(dataSet, MissingSchemaAction.Error);
+            Assert.Throws<InvalidOperationException>(missingTableErrorAction);
+
+            // Test method with missing dataset table from dataset with MissingSchemaAction add.
+            dataSet = new DataSet();
+            dataTable = new DataTable("UnknownDataSet");
+            dataSet.Tables.Add(dataTable);
+            result = _dataTableMapping.GetDataTableBySchemaAction(dataSet, MissingSchemaAction.Add);
+            Assert.Equal(_dataTableMapping.DataSetTable, result.TableName);
+
+            // Test method with missing dataset table from dataset with MissingSchemaAction add with key.
+            dataSet = new DataSet();
+            dataTable = new DataTable("UnknownDataSet");
+            dataSet.Tables.Add(dataTable);
+            result = _dataTableMapping.GetDataTableBySchemaAction(dataSet, MissingSchemaAction.AddWithKey);
+            Assert.Equal(_dataTableMapping.DataSetTable, result.TableName);
+
+            // Test method with missing dataset table from dataset with invalid MissingSchemaAction.
+            dataSet = new DataSet();
+            dataTable = new DataTable("UnknownDataSet");
+            dataSet.Tables.Add(dataTable);
+            Action invalidMissingSchemaAction = () => _dataTableMapping.GetDataTableBySchemaAction(dataSet, 0);
+            Assert.Throws<ArgumentOutOfRangeException>(invalidMissingSchemaAction);
+        }
+
+        [Fact]
+        public void SourceTableParentValidation()
+        {
+            // Sets dataTableMappingCollection as the dataTableMapping Parent.
+            DataTableMappingCollection dataTableMappingCollection = new DataTableMappingCollection();
+            dataTableMappingCollection.Add(_dataTableMapping);
+
+            // Adds a data table with another source table name.
+            DataTableMapping secondDataTableMapping = new DataTableMapping("AnotherCustomSourceTable", "");
+            dataTableMappingCollection.Add(secondDataTableMapping);
+
+            // Attempts to change the second data table source table with a repeated value.
+            Action invalidSourceTableSetAttempt = () => secondDataTableMapping.SourceTable = "MyCustomSourceTable";
+            Assert.Throws<ArgumentException>(invalidSourceTableSetAttempt);
+        }
+
+        [Fact]
+        public void Clone()
+        {
+            DataTableMapping clonedDataTableMapping = (DataTableMapping)((ICloneable)_dataTableMapping).Clone();
+
+            Assert.Equal(_dataTableMapping.SourceTable, clonedDataTableMapping.SourceTable);
+            Assert.Equal(_dataTableMapping.DataSetTable, clonedDataTableMapping.DataSetTable);
+            Assert.Equal(_dataTableMapping.ColumnMappings.Count, clonedDataTableMapping.ColumnMappings.Count);
+        }
+
+        [Fact]
+        public void SourceTableProperties()
+        {
+            Assert.Equal("MyCustomSourceTable", _dataTableMapping.SourceTable);
+
+            DataTableMapping dataTableMapping = new DataTableMapping(null, "MyCustomDataSetTable");
+            Assert.Equal(string.Empty, dataTableMapping.SourceTable);
+
+            dataTableMapping = new DataTableMapping();
+            Assert.Equal(string.Empty, dataTableMapping.SourceTable);
+        }
+
+        [Fact]
+        public void DataSetTableProperties()
+        {
+            Assert.Equal("MyCustomDataSetTable", _dataTableMapping.DataSetTable);
+
+            DataTableMapping dataTableMapping = new DataTableMapping("MyCustomSourceTable", null);
+            Assert.Equal(string.Empty, dataTableMapping.DataSetTable);
+
+            dataTableMapping = new DataTableMapping();
+            Assert.Equal(string.Empty, dataTableMapping.DataSetTable);
+        }
+
+        [Fact]
+        public void ColumnMappingsProperties()
+        {
+            Assert.Equal(_dataColumnMappings.Length, _dataTableMapping.ColumnMappings.Count);
+
+            DataTableMapping dataTableMapping = new DataTableMapping("MyCustomSourceTable", "MyCustomDataSetTable");
+            Assert.NotNull(dataTableMapping.ColumnMappings);
+            Assert.Equal(0, dataTableMapping.ColumnMappings.Count);
+
+            dataTableMapping = new DataTableMapping("MyCustomSourceTable", "MyCustomDataSetTable", null);
+            Assert.NotNull(dataTableMapping.ColumnMappings);
+            Assert.Equal(0, dataTableMapping.ColumnMappings.Count);
+
+            dataTableMapping = new DataTableMapping();
+            Assert.NotNull(dataTableMapping.ColumnMappings);
+            Assert.Equal(0, dataTableMapping.ColumnMappings.Count);
+        }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            Assert.Equal("MyCustomSourceTable", _dataTableMapping.ToString());
+        }
+    }
+}

--- a/src/System.Data.Common/tests/System/Data/Common/DataTableMappingTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataTableMappingTest.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Data.Common
 {

--- a/src/System.Data.Common/tests/System/Data/Common/DataTableMappingTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataTableMappingTest.cs
@@ -30,8 +30,7 @@ namespace System.Data.Common
             dataSet = new DataSet();
             dataTable = new DataTable("UnknownDataSet");
             dataSet.Tables.Add(dataTable);
-            Action missingTableErrorAction = () => _dataTableMapping.GetDataTableBySchemaAction(dataSet, MissingSchemaAction.Error);
-            Assert.Throws<InvalidOperationException>(missingTableErrorAction);
+            Assert.Throws<InvalidOperationException>(() => _dataTableMapping.GetDataTableBySchemaAction(dataSet, MissingSchemaAction.Error));
 
             // Test method with missing dataset table from dataset with MissingSchemaAction add.
             dataSet = new DataSet();
@@ -51,8 +50,7 @@ namespace System.Data.Common
             dataSet = new DataSet();
             dataTable = new DataTable("UnknownDataSet");
             dataSet.Tables.Add(dataTable);
-            Action invalidMissingSchemaAction = () => _dataTableMapping.GetDataTableBySchemaAction(dataSet, 0);
-            Assert.Throws<ArgumentOutOfRangeException>(invalidMissingSchemaAction);
+            Assert.Throws<ArgumentOutOfRangeException>(() => _dataTableMapping.GetDataTableBySchemaAction(dataSet, 0));
         }
 
         [Fact]
@@ -67,8 +65,7 @@ namespace System.Data.Common
             dataTableMappingCollection.Add(secondDataTableMapping);
 
             // Attempts to change the second data table source table with a repeated value.
-            Action invalidSourceTableSetAttempt = () => secondDataTableMapping.SourceTable = "MyCustomSourceTable";
-            Assert.Throws<ArgumentException>(invalidSourceTableSetAttempt);
+            Assert.Throws<ArgumentException>(() => secondDataTableMapping.SourceTable = "MyCustomSourceTable");
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/ReadOnlyExceptionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ReadOnlyExceptionTest.cs
@@ -38,7 +38,7 @@ namespace System.Data.Tests
             DataTable tbl = DataProvider.CreateParentDataTable();
             tbl.Columns[0].ReadOnly = true;
 
-            //chaeck for int column
+            //check for int column
             // ReadOnlyException - EndEdit
             //tbl.Rows[0].BeginEdit();   // this throw an exception but according to MSDN it shouldn't !!!
             //tbl.Rows[0][0] = 99 ;
@@ -53,7 +53,7 @@ namespace System.Data.Tests
                 tbl.Rows[0].ItemArray = new object[] { 99, "value", "value" };
             });
 
-            //chaeck for string column
+            //check for string column
             tbl.Columns[0].ReadOnly = false;
             tbl.Columns[1].ReadOnly = true;
 


### PR DESCRIPTION
This pull request adds unit tests to the class System.Data.Common.DataTableMapping.

I'm currently assigned to the issue [#16337](https://github.com/dotnet/corefx/issues/16337). This PR is intended to not only add these unit tests but to also validate that this is the right coding style for the other PR's I will be making regarding this issue.

I tried to follow the existing tests coding style as closely as possible, feedbacks are welcome.
