### PR TITLE
Fix CacheControlHeaderValue's rendering of negative values

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
@@ -232,14 +232,34 @@ namespace System.Net.Http.Headers
             {
                 AppendValueWithSeparatorIfRequired(sb, maxAgeString);
                 sb.Append('=');
-                sb.Append((int)_maxAge.Value.TotalSeconds);
+                int maxAge = (int)_maxAge.GetValueOrDefault().TotalSeconds;
+                if (maxAge >= 0)
+                {
+                    sb.Append(maxAge);
+                }
+                else
+                {
+                    // In the corner case where the value is negative, ensure it uses
+                    // the invariant's negative sign rather than the current culture's.
+                    sb.Append(maxAge.ToString(NumberFormatInfo.InvariantInfo));
+                }
             }
 
             if (_sharedMaxAge.HasValue)
             {
                 AppendValueWithSeparatorIfRequired(sb, sharedMaxAgeString);
                 sb.Append('=');
-                sb.Append((int)_sharedMaxAge.Value.TotalSeconds);
+                int sharedMaxAge = (int)_sharedMaxAge.GetValueOrDefault().TotalSeconds;
+                if (sharedMaxAge >= 0)
+                {
+                    sb.Append(sharedMaxAge);
+                }
+                else
+                {
+                    // In the corner case where the value is negative, ensure it uses
+                    // the invariant's negative sign rather than the current culture's.
+                    sb.Append(sharedMaxAge.ToString(NumberFormatInfo.InvariantInfo));
+                }
             }
 
             if (_maxStale)
@@ -248,7 +268,17 @@ namespace System.Net.Http.Headers
                 if (_maxStaleLimit.HasValue)
                 {
                     sb.Append('=');
-                    sb.Append((int)_maxStaleLimit.Value.TotalSeconds);
+                    int maxStaleLimit = (int)_maxStaleLimit.GetValueOrDefault().TotalSeconds;
+                    if (maxStaleLimit >= 0)
+                    {
+                        sb.Append(maxStaleLimit);
+                    }
+                    else
+                    {
+                        // In the corner case where the value is negative, ensure it uses
+                        // the invariant's negative sign rather than the current culture's.
+                        sb.Append(maxStaleLimit.ToString(NumberFormatInfo.InvariantInfo));
+                    }
                 }
             }
 
@@ -256,7 +286,17 @@ namespace System.Net.Http.Headers
             {
                 AppendValueWithSeparatorIfRequired(sb, minFreshString);
                 sb.Append('=');
-                sb.Append((int)_minFresh.Value.TotalSeconds);
+                int minFresh = (int)_minFresh.GetValueOrDefault().TotalSeconds;
+                if (minFresh >= 0)
+                {
+                    sb.Append(minFresh);
+                }
+                else
+                {
+                    // In the corner case where the value is negative, ensure it uses
+                    // the invariant's negative sign rather than the current culture's.
+                    sb.Append(minFresh.ToString(NumberFormatInfo.InvariantInfo));
+                }
             }
 
             if (_privateField)


### PR DESCRIPTION
Yesterday I made an optimization in several places to avoid unnecessary Int32.ToString calls / string allocations.  Most of them were valid.  However, even though valid Cache-Control headers don't contain negative values and are properly caught by the parser parsing incoming headers, the setters on CacheControlHeaderValue allow negative values to be specified without validation.  If such negative values were used, my change made it so that in a culture where the current culture's NumberFormatInfo.NegativeSign is not "-", the wrong negative sign would be used when rendering.  This commit fixes that and adds a regression test.

cc: @davidsh, @pentp