### PR TITLE
Move to netcoreapp3.0

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageVersion>2.2.0</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageVersion>2.2.0</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworkName>netcoreapp</TargetFrameworkName>
-    <TargetFrameworkVersion>2.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>3.0</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
 
     <RefBinDir>$(NETCoreAppPackageRefPath)</RefBinDir>

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -589,7 +589,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
-        "netcoreapp2.2": "4.0.4.0",
+        "netcoreapp3.0": "4.0.4.0",
         "uap10.0.16299": "4.0.3.0",
         "uap10.0.16300": "4.0.4.0"
       },
@@ -703,7 +703,7 @@
       "InboxOn": {
         "netcoreapp2.0": "1.2.2.0",
         "netcoreapp2.1": "1.2.3.0",
-        "netcoreapp2.2": "1.2.4.0",
+        "netcoreapp3.0": "1.2.4.0",
         "uap10.0.16299": "1.2.3.0",
         "uap10.0.16300": "1.2.4.0"
       },
@@ -820,7 +820,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.2.0.0",
         "netcoreapp2.1": "4.2.1.0",
-        "netcoreapp2.2": "4.2.2.0",
+        "netcoreapp3.0": "4.2.2.0",
         "net45": "4.0.0.0",
         "net46": "4.0.10.0",
         "portable46-net451+win81": "4.0.0.0",
@@ -1367,7 +1367,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.1",
         "netcoreapp2.1": "4.0.3.0",
-        "netcoreapp2.2": "4.0.4.0"
+        "netcoreapp3.0": "4.0.4.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -2444,7 +2444,7 @@
     "System.Memory": {
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0",
-        "netcoreapp2.2": "4.1.0.0",
+        "netcoreapp3.0": "4.1.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16300": "4.1.0.0",
@@ -3006,7 +3006,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.1.3.0",
         "netcoreapp2.1": "4.1.4.0",
-        "netcoreapp2.2": "4.1.5.0",
+        "netcoreapp3.0": "4.1.5.0",
         "net46": "4.0.0.0",
         "net461": "4.1.2.0",
         "monoandroid10": "Any",
@@ -3199,7 +3199,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.0.3.0",
         "netcoreapp2.1": "4.0.4.0",
-        "netcoreapp2.2": "4.0.5.0",
+        "netcoreapp3.0": "4.0.5.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.0.4.0",
@@ -3342,7 +3342,7 @@
       "InboxOn": {
         "netcoreapp2.0": "1.4.2.0",
         "netcoreapp2.1": "1.4.3.0",
-        "netcoreapp2.2": "1.4.4.0",
+        "netcoreapp3.0": "1.4.4.0",
         "uap10.0.16299": "1.4.3.0",
         "uap10.0.16300": "1.4.4.0"
       },
@@ -3408,7 +3408,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.1.2.0",
         "netcoreapp2.1": "4.1.3.0",
-        "netcoreapp2.2": "4.1.4.0",
+        "netcoreapp3.0": "4.1.4.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.1.3.0",
@@ -4956,7 +4956,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.6.2.0",
         "netcoreapp2.1": "4.6.3.0",
-        "netcoreapp2.2": "4.6.4.0",
+        "netcoreapp3.0": "4.6.4.0",
         "uap10.0.16299": "4.6.3.0",
         "uap10.0.16300": "4.6.4.0"
       },
@@ -4981,7 +4981,7 @@
         "monotouch10": "Any",
         "netcoreapp2.0": "4.1.1.0",
         "netcoreapp2.1": "4.3.0.0",
-        "netcoreapp2.2": "4.3.0.0",
+        "netcoreapp3.0": "4.3.0.0",
         "uap10.0.16300": "4.3.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
@@ -5137,7 +5137,7 @@
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
-        "netcoreapp2.2": "4.0.4.0",
+        "netcoreapp3.0": "4.0.4.0",
         "netstandard2.0": "4.0.2.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",

--- a/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
+++ b/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Enable targeting netcoreapp3.0 even in an older CLI -->
+    <NETCoreAppMaximumVersion>3.0</NETCoreAppMaximumVersion>
+    <!-- use the most recent MS.NETCore.App we have from upstack -->
+    <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
PTAL @ericstj @eerhardt 

I thought about bumping the versions of Microsoft.NETCore.Platforms/Targets to 3.0 as well but I don't think it is necessary. What do you guys think? Should we keep them consistent or just let them version independently?