### PR TITLE
fix rlimit build issue on FreeBSD

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -363,6 +363,7 @@ static int32_t ConvertRLimitResourcesPalToPlatform(RLimitResources value)
 #define LIMIT_MAX(T) _Generic(((T)0), \
   unsigned int: UINT_MAX,             \
   unsigned long: ULONG_MAX,           \
+  long: LONG_MAX,                     \
   unsigned long long: ULLONG_MAX)
 
 // Because RLIM_INFINITY is different per-platform, use the max value of a uint64 (which is RLIM_INFINITY on Ubuntu)


### PR DESCRIPTION

[ 34%] Built target System.IO.Compression.Native
[ 35%] Building C object System.Native/CMakeFiles/System.Native-Static.dir/pal_process.c.o
/usr/home/furt/git/wfurt-corefx/src/Native/Unix/System.Native/pal_process.c:374:40: error: controlling expression type 'rlim_t' (aka 'long') not compatible with any generic association type
    if (value == UINT64_MAX || value > LIMIT_MAX(rlim_t))
                                       ^~~~~~~~~~~~~~~~~
/usr/home/furt/git/wfurt-corefx/src/Native/Unix/System.Native/pal_process.c:363:32: note: expanded from macro 'LIMIT_MAX'
#define LIMIT_MAX(T) _Generic(((T)0), \
                               ^~~~
1 error generated.
*** [System.Native/CMakeFiles/System.Native-Static.dir/pal_process.c.o] Error code 1

cc: @kasper3 