### PR TITLE
Enable testing against NetFX for S.S.C.X509Certificates.Tests

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.X509Certificates
         private IStorePal _storePal;
 
         public X509Store()
-            : this(StoreName.My, StoreLocation.CurrentUser)
+            : this("MY", StoreLocation.CurrentUser)
         {
         }
 
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509Store(StoreLocation storeLocation)
-            : this(StoreName.My, storeLocation)
+            : this("MY", storeLocation)
         {
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/Cert.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/Cert.cs
@@ -17,7 +17,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         // netcoreapp-OSX: DefaultKeySet
         // netcoreapp-other: EphemeralKeySet
         internal static readonly X509KeyStorageFlags EphemeralIfPossible =
+#if !NO_EPHEMERALKEYSET_AVAILABLE
             !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? X509KeyStorageFlags.EphemeralKeySet :
+#endif
             X509KeyStorageFlags.DefaultKeySet;
         //
         // The Import() methods have an overload for each X509Certificate2Collection.Import() overload.

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -289,9 +289,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 // State held on X509Certificate
                 Assert.ThrowsAny<CryptographicException>(() => c.GetCertHash());
-                Assert.ThrowsAny<CryptographicException>(() => c.GetCertHash(HashAlgorithmName.SHA256));
                 Assert.ThrowsAny<CryptographicException>(() => c.GetCertHashString());
+#if HAVE_THUMBPRINT_OVERLOADS
+                Assert.ThrowsAny<CryptographicException>(() => c.GetCertHash(HashAlgorithmName.SHA256));
                 Assert.ThrowsAny<CryptographicException>(() => c.GetCertHashString(HashAlgorithmName.SHA256));
+#endif
                 Assert.ThrowsAny<CryptographicException>(() => c.GetKeyAlgorithm());
                 Assert.ThrowsAny<CryptographicException>(() => c.GetKeyAlgorithmParameters());
                 Assert.ThrowsAny<CryptographicException>(() => c.GetKeyAlgorithmParametersString());
@@ -302,8 +304,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.ThrowsAny<CryptographicException>(() => c.NotBefore);
                 Assert.ThrowsAny<CryptographicException>(() => c.NotAfter);
 
+#if HAVE_THUMBPRINT_OVERLOADS
                 Assert.ThrowsAny<CryptographicException>(
                     () => c.TryGetCertHash(HashAlgorithmName.SHA256, Array.Empty<byte>(), out _));
+#endif
 
                 // State held on X509Certificate2
                 Assert.ThrowsAny<CryptographicException>(() => c.RawData);

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
@@ -310,6 +310,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if !NO_EPHEMERALKEYSET_AVAILABLE
         [Fact]
         public static void InvalidStorageFlags()
         {
@@ -327,7 +328,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // No test is performed here for the ephemeral flag failing downlevel, because the live
             // binary is always used by default, meaning it doesn't know EphemeralKeySet doesn't exist.
         }
-        
+
         [Fact]
         public static void InvalidStorageFlags_PersistedEphemeral()
         {
@@ -345,16 +346,19 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 "keyStorageFlags",
                 () => coll.Import(string.Empty, string.Empty, PersistedEphemeral));
         }
+#endif
 
         public static IEnumerable<object[]> StorageFlags
         {
             get
             {
                 yield return new object[] { X509KeyStorageFlags.DefaultKeySet };
+
+#if !NO_EPHEMERALKEYSET_AVAILABLE
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                     yield return new object[] { X509KeyStorageFlags.EphemeralKeySet };
+#endif
             }
         }
-
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -228,7 +228,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Throws<ArgumentNullException>(() => ilist.Remove(null));
             }
 
-            Assert.Throws<ArgumentNullException>(() => new X509CertificateCollection.X509CertificateEnumerator(null));
+            if (PlatformDetection.IsFullFramework)
+            {
+                Assert.Throws<NullReferenceException>(
+                    () => new X509CertificateCollection.X509CertificateEnumerator(null));
+            }
+            else
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new X509CertificateCollection.X509CertificateEnumerator(null));
+            }
         }
 
         [Fact]
@@ -364,7 +373,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 // has been deliberately changed to no longer throw to match the behavior of
                 // X509CertificateCollection.Contains and the IList.Contains implementation, which do not
                 // throw.
-                Assert.False(collection.Contains(null));
+                if (PlatformDetection.IsFullFramework)
+                {
+                    Assert.Throws<ArgumentNullException>(() => collection.Contains(null));
+                }
+                else
+                {
+                    Assert.False(collection.Contains(null));
+                }
 
                 IList ilist = (IList)collection;
                 Assert.True(ilist.Contains(c1));

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -228,16 +228,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Throws<ArgumentNullException>(() => ilist.Remove(null));
             }
 
-            if (PlatformDetection.IsFullFramework)
-            {
-                Assert.Throws<NullReferenceException>(
-                    () => new X509CertificateCollection.X509CertificateEnumerator(null));
-            }
-            else
-            {
-                Assert.Throws<ArgumentNullException>(
-                    () => new X509CertificateCollection.X509CertificateEnumerator(null));
-            }
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>(
+                () => new X509CertificateCollection.X509CertificateEnumerator(null));
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.X509Certificates/tests/Configurations.props
+++ b/src/System.Security.Cryptography.X509Certificates/tests/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-OSX;
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      netstandard;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -25,7 +24,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             object ignored;
             Assert.Equal(IntPtr.Zero, h);
             Assert.ThrowsAny<CryptographicException>(() => c.GetCertHash());
+#if HAVE_THUMBPRINT_OVERLOADS
             Assert.ThrowsAny<CryptographicException>(() => c.GetCertHash(HashAlgorithmName.SHA256));
+#endif
             Assert.ThrowsAny<CryptographicException>(() => c.GetKeyAlgorithm());
             Assert.ThrowsAny<CryptographicException>(() => c.GetKeyAlgorithmParameters());
             Assert.ThrowsAny<CryptographicException>(() => c.GetKeyAlgorithmParametersString());
@@ -44,7 +45,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.ThrowsAny<CryptographicException>(() => ignored = c.SubjectName);
             Assert.ThrowsAny<CryptographicException>(() => ignored = c.IssuerName);
             Assert.ThrowsAny<CryptographicException>(() => c.GetCertHashString());
+#if HAVE_THUMBPRINT_OVERLOADS
             Assert.ThrowsAny<CryptographicException>(() => c.GetCertHashString(HashAlgorithmName.SHA256));
+#endif
             Assert.ThrowsAny<CryptographicException>(() => c.GetEffectiveDateString());
             Assert.ThrowsAny<CryptographicException>(() => c.GetExpirationDateString());
             Assert.ThrowsAny<CryptographicException>(() => c.GetPublicKeyString());
@@ -56,8 +59,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.ThrowsAny<CryptographicException>(() => c.GetName());
 #pragma warning restore 0618
 
+#if HAVE_THUMBPRINT_OVERLOADS
             Assert.ThrowsAny<CryptographicException>(
                 () => c.TryGetCertHash(HashAlgorithmName.SHA256, Array.Empty<byte>(), out _));
+#endif
         }
 
         [Fact]
@@ -77,8 +82,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 byte[] actualThumbprint = c.GetCertHash();
                 Assert.Equal(expectedThumbPrintSha1, actualThumbprint);
 
+#if HAVE_THUMBPRINT_OVERLOADS
                 byte[] specifiedAlgThumbprint = c.GetCertHash(HashAlgorithmName.SHA1);
                 Assert.Equal(expectedThumbPrintSha1, specifiedAlgThumbprint);
+#endif
             };
 
             using (X509Certificate2 c = new X509Certificate2(TestData.MsCertificate))
@@ -108,8 +115,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 byte[] actualThumbprint = cert.GetCertHash();
                 Assert.Equal(expectedThumbPrintSha1, actualThumbprint);
 
+#if HAVE_THUMBPRINT_OVERLOADS
                 byte[] specifiedAlgThumbprint = cert.GetCertHash(HashAlgorithmName.SHA1);
                 Assert.Equal(expectedThumbPrintSha1, specifiedAlgThumbprint);
+#endif
             };
 
             using (X509Certificate2 c = new X509Certificate2(TestData.MsCertificatePemBytes))
@@ -140,7 +149,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var c2 = new X509Certificate2(c1))
             {
                 Assert.Equal(c1.GetCertHash(), c2.GetCertHash());
+#if HAVE_THUMBPRINT_OVERLOADS
                 Assert.Equal(c1.GetCertHash(HashAlgorithmName.SHA256), c2.GetCertHash(HashAlgorithmName.SHA256));
+#endif
                 Assert.Equal(c1.GetKeyAlgorithm(), c2.GetKeyAlgorithm());
                 Assert.Equal(c1.GetKeyAlgorithmParameters(), c2.GetKeyAlgorithmParameters());
                 Assert.Equal(c1.GetKeyAlgorithmParametersString(), c2.GetKeyAlgorithmParametersString());
@@ -157,7 +168,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(c1.SubjectName.Name, c2.SubjectName.Name);
                 Assert.Equal(c1.IssuerName.Name, c2.IssuerName.Name);
                 Assert.Equal(c1.GetCertHashString(), c2.GetCertHashString());
+#if HAVE_THUMBPRINT_OVERLOADS
                 Assert.Equal(c1.GetCertHashString(HashAlgorithmName.SHA256), c2.GetCertHashString(HashAlgorithmName.SHA256));
+#endif
                 Assert.Equal(c1.GetEffectiveDateString(), c2.GetEffectiveDateString());
                 Assert.Equal(c1.GetExpirationDateString(), c2.GetExpirationDateString());
                 Assert.Equal(c1.GetPublicKeyString(), c2.GetPublicKeyString());
@@ -359,6 +372,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if !NO_EPHEMERALKEYSET_AVAILABLE
         [Fact]
         public static void InvalidStorageFlags()
         {
@@ -383,7 +397,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // No test is performed here for the ephemeral flag failing downlevel, because the live
             // binary is always used by default, meaning it doesn't know EphemeralKeySet doesn't exist.
         }
-        
+
         [Fact]
         public static void InvalidStorageFlags_PersistedEphemeral()
         {
@@ -408,5 +422,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 "keyStorageFlags",
                 () => new X509Certificate2(string.Empty, string.Empty, PersistedEphemeral));
         }
+#endif
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/ImportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ImportTests.cs
@@ -29,12 +29,24 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         private static void VerifyImportNotSupported(X509Certificate c)
         {
-            Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>()));
-            Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty));
-            Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>(), string.Empty, X509KeyStorageFlags.DefaultKeySet));
-            Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>(), new SecureString(), X509KeyStorageFlags.DefaultKeySet));
-            Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty, string.Empty, X509KeyStorageFlags.DefaultKeySet));
-            Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty, new SecureString(), X509KeyStorageFlags.DefaultKeySet));
+            if (PlatformDetection.IsFullFramework)
+            {
+                Assert.Throws<ArgumentException>(() => c.Import(Array.Empty<byte>()));
+                Assert.Throws<ArgumentException>(() => c.Import(string.Empty));
+                Assert.Throws<ArgumentException>(() => c.Import(Array.Empty<byte>(), string.Empty, X509KeyStorageFlags.DefaultKeySet));
+                Assert.Throws<ArgumentException>(() => c.Import(Array.Empty<byte>(), new SecureString(), X509KeyStorageFlags.DefaultKeySet));
+                Assert.Throws<ArgumentException>(() => c.Import(string.Empty, string.Empty, X509KeyStorageFlags.DefaultKeySet));
+                Assert.Throws<ArgumentException>(() => c.Import(string.Empty, new SecureString(), X509KeyStorageFlags.DefaultKeySet));
+            }
+            else
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>()));
+                Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty));
+                Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>(), string.Empty, X509KeyStorageFlags.DefaultKeySet));
+                Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>(), new SecureString(), X509KeyStorageFlags.DefaultKeySet));
+                Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty, string.Empty, X509KeyStorageFlags.DefaultKeySet));
+                Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty, new SecureString(), X509KeyStorageFlags.DefaultKeySet));
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -66,6 +66,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if HAVE_THUMBPRINT_OVERLOADS
         [Theory]
         [InlineData("SHA1", false)]
         [InlineData("SHA1", true)]
@@ -148,6 +149,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
+#endif
 
         [Fact]
         public static void TestGetFormat()

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -37,6 +37,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue(30543, TargetFrameworkMonikers.NetFramework)]
         public static void TestSerial()
         {
             string expectedSerialHex = "B00000000100DD9F3BD08B0AAF11B000000033";
@@ -211,6 +212,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Fact]
         [ActiveIssue(2910, TestPlatforms.AnyUnix)]
+        [ActiveIssue(30544, TargetFrameworkMonikers.NetFramework)]
         public static void TestLoadSignedFile()
         {
             // X509Certificate2 can also extract the certificate from a signed file.

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -129,8 +129,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 VerifyPrivateKey((RSA)alg);
 
                 // Currently unable to set PrivateKey
-                Assert.Throws<PlatformNotSupportedException>(() => c.PrivateKey = null);
-                Assert.Throws<PlatformNotSupportedException>(() => c.PrivateKey = alg);
+                if (!PlatformDetection.IsFullFramework)
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => c.PrivateKey = null);
+                    Assert.Throws<PlatformNotSupportedException>(() => c.PrivateKey = alg);
+                }
             }
         }
 
@@ -185,12 +188,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Null(pubOnly.PrivateKey);
 
                 // Currently unable to set PrivateKey
-                Assert.Throws<PlatformNotSupportedException>(() => cert.PrivateKey = null);
+                if (!PlatformDetection.IsFullFramework)
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => cert.PrivateKey = null);
+                }
 
                 using (var privKey = cert.GetECDsaPrivateKey())
                 {
-                    Assert.Throws<PlatformNotSupportedException>(() => cert.PrivateKey = privKey);
-                    Assert.Throws<PlatformNotSupportedException>(() => pubOnly.PrivateKey = privKey);
+                    Assert.ThrowsAny<NotSupportedException>(() => cert.PrivateKey = privKey);
+                    Assert.ThrowsAny<NotSupportedException>(() => pubOnly.PrivateKey = privKey);
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -195,6 +195,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if !NO_DSA_AVAILABLE
         [Fact]
         public static void DsaPrivateKeyProperty()
         {
@@ -216,6 +217,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.False(dsa.VerifyData(data, sig, HashAlgorithmName.SHA1), "Key verifies tampered data signature");
             }
         }
+#endif
 
         private static void Verify_ECDsaPrivateKey_WindowsPfx(ECDsa ecdsa)
         {
@@ -279,7 +281,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
-        
+
+#if !NO_DSA_AVAILABLE
         [Fact]
         public static void ReadDSAPrivateKey()
         {
@@ -301,7 +304,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.ThrowsAny<CryptographicException>(() => pubKey.SignData(data, HashAlgorithmName.SHA1));
             }
         }
+#endif
 
+#if !NO_EPHEMERALKEYSET_AVAILABLE
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes
         public static void EphemeralImport_HasNoKeyName()
@@ -371,6 +376,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.NotNull(key.KeyName);
             }
         }
+#endif
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -415,48 +415,56 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue(30561, TargetFrameworkMonikers.NetFramework)]
         public static void ComplexGetNameInfo_UpnName_Cert()
         {
             TestComplexGetNameInfo("subjectupn1@example.org", X509NameType.UpnName, false);
         }
 
         [Fact]
+        [ActiveIssue(30561, TargetFrameworkMonikers.NetFramework)]
         public static void ComplexGetNameInfo_UpnName_Issuer()
         {
             TestComplexGetNameInfo("issuerupn1@example.org", X509NameType.UpnName, true);
         }
 
         [Fact]
+        [ActiveIssue(30561, TargetFrameworkMonikers.NetFramework)]
         public static void ComplexGetNameInfo_DnsName_Cert()
         {
             TestComplexGetNameInfo("dns1.subject.example.org", X509NameType.DnsName, false);
         }
 
         [Fact]
+        [ActiveIssue(30561, TargetFrameworkMonikers.NetFramework)]
         public static void ComplexGetNameInfo_DnsName_Issuer()
         {
             TestComplexGetNameInfo("dns1.issuer.example.org", X509NameType.DnsName, true);
         }
 
         [Fact]
+        [ActiveIssue(30561, TargetFrameworkMonikers.NetFramework)]
         public static void ComplexGetNameInfo_DnsFromAlternativeName_Cert()
         {
             TestComplexGetNameInfo("dns1.subject.example.org", X509NameType.DnsFromAlternativeName, false);
         }
 
         [Fact]
+        [ActiveIssue(30561, TargetFrameworkMonikers.NetFramework)]
         public static void ComplexGetNameInfo_DnsFromAlternativeName_Issuer()
         {
             TestComplexGetNameInfo("dns1.issuer.example.org", X509NameType.DnsFromAlternativeName, true);
         }
 
         [Fact]
+        [ActiveIssue(30561, TargetFrameworkMonikers.NetFramework)]
         public static void ComplexGetNameInfo_UrlName_Cert()
         {
             TestComplexGetNameInfo("http://uri1.subject.example.org/", X509NameType.UrlName, false);
         }
 
         [Fact]
+        [ActiveIssue(30561, TargetFrameworkMonikers.NetFramework)]
         public static void ComplexGetNameInfo_UrlName_Issuer()
         {
             TestComplexGetNameInfo("http://uri1.issuer.example.org/", X509NameType.UrlName, true);

--- a/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -474,7 +474,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
-        
+
+#if !NO_DSA_AVAILABLE
         [Fact]
         public static void TestDSAPublicKey()
         {
@@ -524,6 +525,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Null(pubKey);
             }
         }
+#endif
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes

--- a/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -310,6 +310,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Theory, MemberData(nameof(BrainpoolCurves))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "brainpool GetECDsaPublicKey fails on current netfx")]
         public static void TestKey_ECDsabrainpool_PublicKey(byte[] curveData, byte[] notUsed)
         {
             byte[] helloBytes = Encoding.ASCII.GetBytes("Hello");
@@ -390,6 +391,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Theory, MemberData(nameof(BrainpoolCurves))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "brainpool GetECDsaPublicKey fails on current netfx")]
         public static void TestECDsaPublicKey_BrainpoolP160r1_ValidatesSignature(byte[] curveData, byte[] existingSignature)
         {
             byte[] helloBytes = Encoding.ASCII.GetBytes("Hello");
@@ -550,6 +552,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "brainpool GetECDsaPublicKey fails on current netfx")]
         public static void TestKey_BrainpoolP160r1()
         {
             if (PlatformDetection.WindowsVersion >= 10)

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -4,7 +4,13 @@
   <PropertyGroup>
     <ProjectGuid>{A28B0064-EFB2-4B77-B97C-DECF5DAB074E}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HaveDSA Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap' OR '$(TargetGroup)'=='net462'">true</HaveDSA>
+    <HaveCertificateCreation Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap' OR '$(TargetGroup)'=='net472'">true</HaveCertificateCreation>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='uap'">$(DefineConstants);uap</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'!='netcoreapp' AND '$(TargetGroup)'!='uap' AND '$(TargetGroup)'!='net462'">$(DefineConstants);NO_DSA_AVAILABLE</DefineConstants>
+    <DefineConstants Condition="'$(HaveCertificateCreation)'!='true'">$(DefineConstants);NO_EPHEMERALKEYSET_AVAILABLE</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap'">$(DefineConstants);HAVE_THUMBPRINT_OVERLOADS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Release|AnyCPU'" />
@@ -12,20 +18,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Cert.cs" />
-    <Compile Include="CertificateCreation\CertificateRequestApiTests.cs" />
-    <Compile Include="CertificateCreation\CertificateRequestChainTests.cs" />
-    <Compile Include="CertificateCreation\CertificateRequestUsageTests.cs" />
-    <Compile Include="CertificateCreation\DSAX509SignatureGenerator.cs" />
-    <Compile Include="CertificateCreation\EccTestData.cs" />
-    <Compile Include="CertificateCreation\ECDsaX509SignatureGeneratorTests.cs" />
-    <Compile Include="CertificateCreation\PrivateKeyAssociationTests.cs" />
-    <Compile Include="CertificateCreation\RSAPkcs1X509SignatureGeneratorTests.cs" />
-    <Compile Include="CertificateCreation\RSAPssX509SignatureGeneratorTests.cs" />
-    <Compile Include="CertificateCreation\SubjectAltNameBuilderTests.cs" />
     <Compile Include="CertTests.cs" />
     <Compile Include="ChainHolder.cs" />
     <Compile Include="ChainTests.cs" />
@@ -33,8 +31,6 @@
     <Compile Include="CollectionTests.cs" />
     <Compile Include="ContentTypeTests.cs" />
     <Compile Include="CtorTests.cs" />
-    <Compile Include="DSAOther.cs" />
-    <Compile Include="ECDsaOther.cs" />
     <Compile Include="ExportTests.cs" />
     <Compile Include="ExtensionsTests.cs" />
     <Compile Include="FindTests.cs" />
@@ -44,7 +40,6 @@
     <Compile Include="PfxTests.cs" />
     <Compile Include="PropsTests.cs" />
     <Compile Include="PublicKeyTests.cs" />
-    <Compile Include="RSAOther.cs" />
     <Compile Include="TestData.cs" />
     <Compile Include="TestEnvironmentConfiguration.cs" />
     <Compile Include="X500DistinguishedNameEncodingTests.cs" />
@@ -58,6 +53,21 @@
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(HaveCertificateCreation)'=='true'">
+    <Compile Include="CertificateCreation\CertificateRequestApiTests.cs" />
+    <Compile Include="CertificateCreation\CertificateRequestChainTests.cs" />
+    <Compile Include="CertificateCreation\CertificateRequestUsageTests.cs" />
+    <Compile Include="CertificateCreation\DSAX509SignatureGenerator.cs" />
+    <Compile Include="CertificateCreation\EccTestData.cs" />
+    <Compile Include="CertificateCreation\ECDsaX509SignatureGeneratorTests.cs" />
+    <Compile Include="CertificateCreation\PrivateKeyAssociationTests.cs" />
+    <Compile Include="CertificateCreation\RSAPkcs1X509SignatureGeneratorTests.cs" />
+    <Compile Include="CertificateCreation\RSAPssX509SignatureGeneratorTests.cs" />
+    <Compile Include="CertificateCreation\SubjectAltNameBuilderTests.cs" />
+    <Compile Include="DSAOther.cs" />
+    <Compile Include="ECDsaOther.cs" />
+    <Compile Include="RSAOther.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true' ">
     <Compile Include="X509FilesystemTests.Unix.cs" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -21,6 +21,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
             {
                 store.Open(OpenFlags.ReadOnly);
+                Assert.Equal("My", store.Name);
             }
         }
 
@@ -29,7 +30,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (X509Store store = new X509Store(StoreLocation.CurrentUser))
             {
-                Assert.Equal("My", store.Name);
+                Assert.Equal("MY", store.Name);
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if netcoreapp || uap
+#define HAVE_STORE_ISOPEN
+#endif
+
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -29,6 +33,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if HAVE_STORE_ISOPEN
         [Fact]
         public static void Constructor_IsNotOpen()
         {
@@ -37,6 +42,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.False(store.IsOpen);
             }
         }
+#endif
 
         [Fact]
         public static void Constructor_DefaultStoreLocation()
@@ -100,6 +106,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Throws<PlatformNotSupportedException>(() => new X509Chain(IntPtr.Zero));
         }
 
+#if HAVE_STORE_ISOPEN
         [Fact]
         public static void Constructor_OpenFlags()
         {
@@ -135,6 +142,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 new X509Store(new Guid().ToString("D"), StoreLocation.CurrentUser, OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly)
             );
         }
+#endif
 
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)] // StoreHandle not supported via OpenSSL
         [Fact]
@@ -177,6 +185,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if HAVE_STORE_ISOPEN
         [Fact]
         public static void Open_IsOpenTrue()
         {
@@ -205,6 +214,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             store.Open(OpenFlags.ReadOnly);
             Assert.True(store.IsOpen);
         }
+#endif
 
         [Fact]
         public static void AddReadOnlyThrows()


### PR DESCRIPTION
Fixes #30552.

@joperezr I couldn't figure out how to actually get a net462 configuration to build and run the tests.  (Added netfx-Windows_NT to Configurations.props, built `msbuild /t:BuildAndTest /p:TargetGroup=net462`, but that tried launching dotnet.exe when it got to the run tests part)