### PR TITLE
Update XUnit Console Runner Dependency

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -44,7 +44,7 @@
     <!-- CoreFX-built SNI identity package -->
     <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
 
-    <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
+    <AppXRunnerVersion>2.2.0-preview1-02915-01</AppXRunnerVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0019</XunitPerfAnalysisPackageVersion>
     <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>
     <XunitNetcoreExtensionsVersion>2.2.0-preview1-02919-01</XunitNetcoreExtensionsVersion>


### PR DESCRIPTION
This rolls the runner forward to pick up the changes introduced with https://github.com/dotnet/buildtools/pull/2035 . The changes wrap around the current runner, so this shouldn't have any functional difference to current testing.

I realize the goal is to move away from the custom runner, but until https://github.com/xunit/xunit/pull/1734 is merged and the changes picked up, this will make test exclusions work. 

The goal of this is to be able to run CoreFX tests under CoreCLR ( https://github.com/dotnet/coreclr/pull/18365 ) with a Helix Test payload URL ( without necessarily needing to rebuild tests locally ). 

The size of both versions is 56K so there shouldn't be any impact on payload sizes. 

cc @sergiy-k  @jkotas  @BruceForstall @RussKeldorph 