### PR TITLE
Sync SR class with the CoreRT copy

### DIFF
--- a/src/Common/src/System/SR.cs
+++ b/src/Common/src/System/SR.cs
@@ -14,8 +14,12 @@ namespace System
         private static ResourceManager ResourceManager
             => s_resourceManager ?? (s_resourceManager = new ResourceManager(ResourceType));
 
-        // This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format.
+        // This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format. 
         // by default it returns false.
+        // Native code generators can replace the value this returns based on user input at the time of native code generation.
+        // Marked as NoInlining because if this is used in an AoT compiled app that is not compiled into a single file, the user
+        // could compile each module with a different setting for this. We want to make sure there's a consistent behavior
+        // that doesn't depend on which native module this method got inlined into.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool UsingResourceKeys()
         {
@@ -24,6 +28,9 @@ namespace System
 
         internal static string GetResourceString(string resourceKey, string defaultString)
         {
+            if (UsingResourceKeys())
+                return defaultString ?? resourceKey;
+
             string resourceString = null;
             try { resourceString = ResourceManager.GetString(resourceKey); }
             catch (MissingManifestResourceException) { }

--- a/src/Common/src/System/SR.vb
+++ b/src/Common/src/System/SR.vb
@@ -32,14 +32,20 @@ Namespace System
         End Property
 
         ' This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format. 
-        ' by default it returns false. We overwrite the implementation of this method to return true through IL transformer 
-        ' when compiling ProjectN app as retail build. 
+        ' by default it returns false.
+        ' Native code generators can replace the value this returns based on user input at the time of native code generation.
+        ' Marked as NoInlining because if this is used in an AoT compiled app that is not compiled into a single file, the user
+        ' could compile each module with a different setting for this. We want to make sure there's a consistent behavior
+        ' that doesn't depend on which native module this method got inlined into.
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>
         Public Shared Function UsingResourceKeys() As Boolean
             Return False
         End Function
 
         Friend Shared Function GetResourceString(ByVal resourceKey As String, ByVal defaultString As String) As String
+            If (UsingResourceKeys()) Then
+                Return If(defaultString, resourceKey)
+            End If
 
             Dim resourceString As String = Nothing
             Try


### PR DESCRIPTION
This ports over the change from
https://github.com/dotnet/corert/commit/0ac83cb8d6f9ab10df616a608fcf6fdfa6eabe2b.

When UsingResourceKeys is true and we stripped the resources, the
existing code would have returned null.

Contributes to #30597.