### PR TITLE
Add support for custom macOS keychains exposed using X509Store API

### DIFF
--- a/Documentation/architecture/cross-platform-cryptography.md
+++ b/Documentation/architecture/cross-platform-cryptography.md
@@ -244,8 +244,8 @@ The LocalMachine\My store is System.keychain.
 The CurrentUser\Root store on macOS is an interpretation of the SecTrustSettings results for the user trust domain.
 The LocalMachine\Root store on macOS is an interpretation of the SecTrustSettings results for the admin and system trust domains.
 The CurrentUser\Disallowed and LocalMachine\Disallowed stores are interpretations of the appropriate SecTrustSettings results for certificates whose trust is set to Always Deny.
-Keychain creation on macOS requires more input than is captured with the X509Store API, so attempting to create a new store will fail with a `PlatformNotSupportedException`.
-If a keychain is opened by P/Invoke to SecKeychainOpen, the resulting `IntPtr` can be passed to `new X509Store(IntPtr)` to obtain a read/write-capable store (subject to the current user's permissions).
+Custom store creation on macOS with the X509Store API will create a new keychain with no password. To create a keychain with password a P/Invoke to SecKeychainCreate could be used.
+The resulting `IntPtr` can be passed to `new X509Store(IntPtr)` to obtain a read/write-capable store (subject to the current user's permissions).
 
 ### X509Chain
 

--- a/Documentation/architecture/cross-platform-cryptography.md
+++ b/Documentation/architecture/cross-platform-cryptography.md
@@ -244,8 +244,9 @@ The LocalMachine\My store is System.keychain.
 The CurrentUser\Root store on macOS is an interpretation of the SecTrustSettings results for the user trust domain.
 The LocalMachine\Root store on macOS is an interpretation of the SecTrustSettings results for the admin and system trust domains.
 The CurrentUser\Disallowed and LocalMachine\Disallowed stores are interpretations of the appropriate SecTrustSettings results for certificates whose trust is set to Always Deny.
-Custom store creation on macOS with the X509Store API will create a new keychain with no password. To create a keychain with password a P/Invoke to SecKeychainCreate could be used.
-The resulting `IntPtr` can be passed to `new X509Store(IntPtr)` to obtain a read/write-capable store (subject to the current user's permissions).
+Custom store creation on macOS with the X509Store API is supported only for CurrentUser location. It will create a new keychain with no password in the user's keychain
+directory (~/Library/Keychains). To create a keychain with password a P/Invoke to SecKeychainCreate could be used. Similarly, SecKeychainOpen could be used to open keychains
+in different locations. The resulting `IntPtr` can be passed to `new X509Store(IntPtr)` to obtain a read/write-capable store (subject to the current user's permissions).
 
 ### X509Chain
 

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
@@ -176,15 +176,18 @@ internal static partial class Interop
 
         internal static SafeKeychainHandle OpenAndUnlockKeychain(string keychainPath)
         {
+            const int errSecAuthFailed = -25293;
+
             SafeKeychainHandle keychain;
             int osStatus = AppleCryptoNative_SecKeychainOpen(keychainPath, out keychain);
+
             if (osStatus == 0)
             {
                 // Try to unlock with empty password to match our behaviour in CreateKeychain.
-                // If it doesn't work (errSecAuthFailed) then fail silently and fallback to the
+                // If the password doesn't match then ignore it silently and fallback to the
                 // default behavior of user interaction.
                 osStatus = AppleCryptoNative_SecKeychainUnlock(keychain, 0, Array.Empty<byte>());
-                if (osStatus == 0 || osStatus == -25293)
+                if (osStatus == 0 || osStatus == errSecAuthFailed)
                 {
                     return keychain;
                 }

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
@@ -29,6 +29,13 @@ internal static partial class Interop
             out SafeTemporaryKeychainHandle keychain);
 
         [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_SecKeychainCreate(
+            string path,
+            int utf8PassphraseLength,
+            byte[] utf8Passphrase,
+            out SafeKeychainHandle keychain);
+
+        [DllImport(Libraries.AppleCryptoNative)]
         private static extern int AppleCryptoNative_SecKeychainDelete(IntPtr keychain);
 
         [DllImport(Libraries.AppleCryptoNative)]
@@ -38,6 +45,12 @@ internal static partial class Interop
         private static extern int AppleCryptoNative_SecKeychainOpen(
             string keychainPath,
             out SafeKeychainHandle keychain);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_SecKeychainUnlock(
+            SafeKeychainHandle keychain,
+            int utf8PassphraseLength,
+            byte[] utf8Passphrase);
 
         [DllImport(Libraries.AppleCryptoNative)]
         private static extern int AppleCryptoNative_SetKeychainNeverLock(SafeKeychainHandle keychain);
@@ -159,6 +172,44 @@ internal static partial class Interop
 
             Debug.Fail($"Unexpected result from AppleCryptoNative_SecKeychainEnumerateCerts: {result}");
             throw new CryptographicException();
+        }
+
+        internal static SafeKeychainHandle OpenAndUnlockKeychain(string keychainPath)
+        {
+            SafeKeychainHandle keychain;
+            int osStatus = AppleCryptoNative_SecKeychainOpen(keychainPath, out keychain);
+            if (osStatus == 0)
+            {
+                // Try to unlock with empty password to match our behaviour in CreateKeychain.
+                // If it doesn't work (errSecAuthFailed) then fail silently and fallback to the
+                // default behavior of user interaction.
+                osStatus = AppleCryptoNative_SecKeychainUnlock(keychain, 0, Array.Empty<byte>());
+                if (osStatus == 0 || osStatus == -25293)
+                {
+                    return keychain;
+                }
+            }
+
+            keychain.Dispose();
+            throw CreateExceptionForOSStatus(osStatus);
+        }
+
+        internal static SafeKeychainHandle CreateKeychain(string keychainPath)
+        {
+            SafeKeychainHandle keychain;
+            int osStatus = AppleCryptoNative_SecKeychainCreate(
+                keychainPath,
+                0,
+                Array.Empty<byte>(),
+                out keychain);
+
+            if (osStatus == 0)
+            {
+                return keychain;
+            }
+
+            keychain.Dispose();
+            throw CreateExceptionForOSStatus(osStatus);
         }
 
         internal static SafeTemporaryKeychainHandle CreateTemporaryKeychain()

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
@@ -174,7 +174,7 @@ internal static partial class Interop
             throw new CryptographicException();
         }
 
-        internal static SafeKeychainHandle CreateOrOpenKeychain(string keychainPath, bool crateAllowed)
+        internal static SafeKeychainHandle CreateOrOpenKeychain(string keychainPath, bool createAllowed)
         {
             const int errSecAuthFailed = -25293;
             const int errSecDuplicateKeychain = -25296;
@@ -182,7 +182,7 @@ internal static partial class Interop
             SafeKeychainHandle keychain;
             int osStatus;
             
-            if (crateAllowed)
+            if (createAllowed)
             {
                 // Attempt to create first
                 osStatus = AppleCryptoNative_SecKeychainCreate(

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
@@ -67,6 +67,13 @@ int32_t AppleCryptoNative_SecKeychainOpen(const char* pszKeychainPath, SecKeycha
     return SecKeychainOpen(pszKeychainPath, pKeychainOut);
 }
 
+int32_t AppleCryptoNative_SecKeychainUnlock(SecKeychainRef keychain,
+                                            uint32_t passphraseLength,
+                                            const uint8_t* passphraseUtf8)
+{
+    return SecKeychainUnlock(keychain, passphraseLength, passphraseUtf8, true);
+}
+
 int32_t AppleCryptoNative_SetKeychainNeverLock(SecKeychainRef keychain)
 {
     SecKeychainSettings settings = {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.h
@@ -62,6 +62,15 @@ pKeychainOut: Receives the SecKeychainRef for the named keychain.
 DLLEXPORT int32_t AppleCryptoNative_SecKeychainOpen(const char* pszKeychainPath, SecKeychainRef* pKeychainOut);
 
 /*
+Unlock an opened keychain with a given (UTF-8 encoded) lock passphrase.
+
+Returns the result of SecKeychainUnlock.
+*/
+DLLEXPORT int32_t AppleCryptoNative_SecKeychainUnlock(SecKeychainRef keychain,
+                                                      uint32_t passphraseLength,
+                                                      const uint8_t* passphraseUtf8);
+
+/*
 Set a keychain to never (automatically) lock.
 
 Returns the result of SecKeychainSetSettings to a never-auto-lock policy.

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
@@ -89,6 +89,16 @@ namespace Internal.Cryptography.Pal
                 return OpenKeychain(SharedSystemKeychainPath, openFlags);
             }
 
+            public static AppleKeychainStore CreateKeychain(string keychainPath, OpenFlags openFlags)
+            {
+                return new AppleKeychainStore(Interop.AppleCrypto.CreateKeychain(keychainPath), openFlags);
+            }
+
+            public static AppleKeychainStore OpenAndUnlockKeychain(string keychainPath, OpenFlags openFlags)
+            {
+                return new AppleKeychainStore(Interop.AppleCrypto.OpenAndUnlockKeychain(keychainPath), openFlags);
+            }
+
             private static AppleKeychainStore OpenKeychain(string keychainPath, OpenFlags openFlags)
             {
                 return new AppleKeychainStore(Interop.AppleCrypto.SecKeychainOpen(keychainPath), openFlags);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
@@ -89,14 +89,9 @@ namespace Internal.Cryptography.Pal
                 return OpenKeychain(SharedSystemKeychainPath, openFlags);
             }
 
-            public static AppleKeychainStore CreateKeychain(string keychainPath, OpenFlags openFlags)
+            public static AppleKeychainStore CreateOrOpenKeychain(string keychainPath, OpenFlags openFlags)
             {
-                return new AppleKeychainStore(Interop.AppleCrypto.CreateKeychain(keychainPath), openFlags);
-            }
-
-            public static AppleKeychainStore OpenAndUnlockKeychain(string keychainPath, OpenFlags openFlags)
-            {
-                return new AppleKeychainStore(Interop.AppleCrypto.OpenAndUnlockKeychain(keychainPath), openFlags);
+                return new AppleKeychainStore(Interop.AppleCrypto.CreateOrOpenKeychain(keychainPath, !openFlags.HasFlag(OpenFlags.OpenExistingOnly)), openFlags);
             }
 
             private static AppleKeychainStore OpenKeychain(string keychainPath, OpenFlags openFlags)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.cs
@@ -138,14 +138,8 @@ namespace Internal.Cryptography.Pal
             if (!IsValidStoreName(storeName))
                 throw new CryptographicException(SR.Format(SR.Security_InvalidValue, nameof(storeName)));
                         
-            storePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Keychains", storeName + ".keychain");
-            if (File.Exists(storePath))
-                return AppleKeychainStore.OpenAndUnlockKeychain(storePath, openFlags);
-
-            if ((openFlags & OpenFlags.OpenExistingOnly) == OpenFlags.OpenExistingOnly)
-                throw new CryptographicException(SR.Cryptography_X509_StoreNotFound);
-
-            return AppleKeychainStore.CreateKeychain(storePath, openFlags);
+            storePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Keychains", storeName.ToLowerInvariant() + ".keychain");
+            return AppleKeychainStore.CreateOrOpenKeychain(storePath, openFlags);
         }
 
         private static bool IsValidStoreName(string storeName)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.cs
@@ -138,7 +138,12 @@ namespace Internal.Cryptography.Pal
             if (!IsValidStoreName(storeName))
                 throw new CryptographicException(SR.Format(SR.Security_InvalidValue, nameof(storeName)));
                         
-            storePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Keychains", storeName.ToLowerInvariant() + ".keychain");
+            storePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Library",
+                "Keychains",
+                storeName.ToLowerInvariant() + ".keychain");
+
             return AppleKeychainStore.CreateOrOpenKeychain(storePath, openFlags);
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/tests/Resources/Strings.resx
@@ -61,4 +61,7 @@
   <data name="PersistedFiles_NoHomeDirectory" xml:space="preserve">
     <value>The home directory of the current user could not be determined.</value>
   </data>
+  <data name="Cryptography_Unmapped_System_Typed_Error" xml:space="preserve">
+    <value>The system cryptographic library returned error '{0}' of type '{1}'</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -49,7 +49,6 @@
     <Compile Include="TestEnvironmentConfiguration.cs" />
     <Compile Include="X500DistinguishedNameEncodingTests.cs" />
     <Compile Include="X500DistinguishedNameTests.cs" />
-    <Compile Include="X509StoreMutableTests.OSX.cs" />
     <Compile Include="X509StoreTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
@@ -87,6 +86,45 @@
     </Compile>
     <Compile Include="HostnameMatchTests.Unix.cs" />
     <Compile Include="TestEnvironmentConfiguration.Unix.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsOSX)' == 'true'">
+    <Compile Include="X509StoreMutableTests.OSX.cs" />
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFArray.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.CFArray.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFData.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.CFData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFError.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.CFError.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFString.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.CFString.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+      <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
@@ -229,6 +229,83 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
+        public static void CustomStore_ReadWrite()
+        {
+            using (var store = new X509Store("CustomKeyChain_CoreFX", StoreLocation.CurrentUser))
+            using (new TemporaryX509Store(store))
+            using (var cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable))
+            using (var certOnly = new X509Certificate2(cert.RawData))
+            {
+                store.Open(OpenFlags.ReadWrite);
+
+                // Defensive removal.
+                store.Remove(certOnly);
+                Assert.False(IsCertInStore(cert, store), "PfxData certificate was found on pre-condition");
+
+                store.Add(cert);
+                Assert.True(IsCertInStore(certOnly, store), "PfxData certificate was found after add");
+
+                // Cleanup
+                store.Remove(certOnly);
+            }
+        }
+
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
+        public static void CustomStore_ReadOnly()
+        {
+            using (var store = new X509Store("CustomKeyChain_CoreFX", StoreLocation.CurrentUser))
+            using (new TemporaryX509Store(store))
+            using (var cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable))
+            using (var certOnly = new X509Certificate2(cert.RawData))
+            {
+                store.Open(OpenFlags.ReadOnly);
+                Assert.ThrowsAny<CryptographicException>(() => store.Add(certOnly));
+            }
+        }
+
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
+        public static void CustomStore_OpenExistingOnly()
+        {
+            using (var store = new X509Store("CustomKeyChain_CoreFX_" + Guid.NewGuid().ToString(), StoreLocation.CurrentUser))
+            using (new TemporaryX509Store(store))
+            {
+                Assert.ThrowsAny<CryptographicException>(() => store.Open(OpenFlags.OpenExistingOnly));
+            }
+        }
+
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
+        public static void CustomStore_CaseInsensitive()
+        {
+            using (var store1 = new X509Store("CustomKeyChain_CoreFX", StoreLocation.CurrentUser))
+            using (new TemporaryX509Store(store1))
+            using (var store2 = new X509Store("customkeychain_CoreFX", StoreLocation.CurrentUser))
+            using (var cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable))
+            using (var certOnly = new X509Certificate2(cert.RawData))
+            {
+                store1.Open(OpenFlags.ReadWrite);
+                store2.Open(OpenFlags.ReadOnly);
+
+                // Defensive removal.
+                store1.Remove(certOnly);
+                Assert.False(IsCertInStore(cert, store1), "PfxData certificate was found on pre-condition");
+
+                store1.Add(cert);
+                Assert.True(IsCertInStore(certOnly, store1), "PfxData certificate was found after add");
+                Assert.True(IsCertInStore(certOnly, store2), "PfxData certificate was found after add (second store)");
+
+                // Cleanup
+                store1.Remove(certOnly);
+            }
+        }
+
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
+        public static void CustomStore_InvalidFileName()
+        {
+            using (var store = new X509Store("../corefx", StoreLocation.CurrentUser))
+                Assert.ThrowsAny<CryptographicException>(() => store.Open(OpenFlags.ReadWrite));
+        }
+
         private static bool StoreHasPrivateKey(X509Store store, X509Certificate2 forCert)
         {
             using (ImportedCollection coll = new ImportedCollection(store.Certificates))
@@ -267,6 +344,22 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (var coll = new ImportedCollection(store.Certificates))
             {
                 return coll.Collection.Count;
+            }
+        }
+
+        class TemporaryX509Store : IDisposable
+        {
+            private X509Store _store;
+ 
+            public TemporaryX509Store(X509Store store)
+            {
+                _store = store;
+            }
+
+            public void Dispose()
+            {
+                if (_store.IsOpen)
+                    Interop.AppleCrypto.SecKeychainDelete(_store.StoreHandle, throwOnError: false);
             }
         }
     }

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
@@ -347,7 +347,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        class TemporaryX509Store : IDisposable
+        private class TemporaryX509Store : IDisposable
         {
             private X509Store _store;
  


### PR DESCRIPTION
Rationale: The X509Store API is heavily used by Mono unit tests and it is helpful to have it available on all supported platforms. There are already comments in the CoreFX unit tests referencing a similar need.