### PR TITLE
Don't move System.Reflection.TypeExtensions during harvesting

### DIFF
--- a/external/harvestPackages/harvestPackages.depproj
+++ b/external/harvestPackages/harvestPackages.depproj
@@ -29,6 +29,13 @@
         PackageIndexes="$(PackageIndexFile)">
         <Output  TaskParameter="LastStablePackages" ItemName="_NewPackageReferences" />
     </GetLastStablePackage>
+    
+    <ItemGroup>
+      <_NewPackageReferences Condition="'%(Identity)' == 'System.Reflection.TypeExtensions'">
+        <!-- harvest from 4.4.0 until we ship a new stable package -->
+        <Version Condition="'%(Version)' == '4.5.0'">4.4.0</Version>
+      </_NewPackageReferences>
+    </ItemGroup>
 
     <ItemGroup>
       <_Lines Include="&lt;Project xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;" />

--- a/external/harvestPackages/harvestPackages.props
+++ b/external/harvestPackages/harvestPackages.props
@@ -28,7 +28,7 @@
 <PackageReference Include="System.Numerics.Vectors">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.Reflection.DispatchProxy">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.Reflection.Metadata">  <Version>1.6.0</Version></PackageReference>
-<PackageReference Include="System.Reflection.TypeExtensions">  <Version>4.5.0</Version></PackageReference>
+<PackageReference Include="System.Reflection.TypeExtensions">  <Version>4.4.0</Version></PackageReference>
 <PackageReference Include="System.Runtime.CompilerServices.Unsafe">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.Security.AccessControl">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.Security.Cryptography.Cng">  <Version>4.5.0</Version></PackageReference>

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageVersion>4.5.1</PackageVersion>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.TypeExtensions.csproj">
       <SupportedFramework>net461;netcoreapp2.1;$(AllXamarinFrameworks)</SupportedFramework>

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -10,10 +10,7 @@
     <HarvestIncludePaths Include="lib/netcore50;runtimes/aot/lib/netcore50" />
     <HarvestIncludePaths Include="ref/netstandard1.3" />
     <HarvestIncludePaths Include="ref/netstandard1.5" />
-    <HarvestIncludePaths Include="lib/netstandard1.5">
-      <!-- this assembly used types / members not exposed by netstandard1.5-->
-      <TargetPath>lib/netcoreapp1.0</TargetPath>
-    </HarvestIncludePaths>
+    <HarvestIncludePaths Include="lib/netcoreapp1.0" />
   </ItemGroup>
   <ItemGroup>
     <InboxOnTargetFramework Include="netcoreapp2.0" />
@@ -31,5 +28,16 @@
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
+  
+  <PropertyGroup>
+    <HarvestVersion>4.4.0</HarvestVersion>
+  </PropertyGroup>
+  <Target Name="_checkForNewerHarvestPackage" AfterTargets="HarvestStablePackage">
+    <GetLastStablePackage LatestPackages="@(_latestPackage)" PackageIndexes="@(PackageIndex)">
+      <Output TaskParameter="LastStablePackages" ItemName="_lastStablePackage" />
+    </GetLastStablePackage>
+    <Error Condition="'%(_lastStablePackage.Version)' &gt; '4.5.0'"
+           Text="This target and the hardcoded HarvestVersion should be removed from this project.  Please ensure that the harvested package contains a valid lib/netcoreapp1.0 asset." />
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -36,6 +36,9 @@
     <Project Include="*\pkg\**\System.Reflection.DispatchProxy.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="*\pkg\**\System.Reflection.TypeExtensions.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
     <Project Include="*\pkg\**\System.Runtime.CompilerServices.Unsafe.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>


### PR DESCRIPTION
When building the netcoreapp2.0 version of the package we needed
to move the netstandard1.5 asset since it was actually netcoreapp1.0
specific.

After we shipped this version of the package, the netstandard1.5
asset was a not supported asset. We should have stopped moving it
at this point, and instead harvest the previously moved asset
from netcoreapp1.0.

#30506