### PR TITLE
Fix race in TaskCancelWaitTestCases.TaskCancelWait1()

### DIFF
--- a/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
@@ -70,6 +70,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
                 {
                     case API.Cancel:
                         _taskTree.CancellationTokenSource.Cancel();
+                        _taskTree.Task.Wait();
                         break;
 
                     case API.Wait:
@@ -131,8 +132,11 @@ namespace System.Threading.Tasks.Tests.CancelWait
 
                     if (current.IsLeaf)
                     {
-                        if (!_countdownEvent.IsSet)
-                            _countdownEvent.Signal();
+                        lock (_countdownEvent)
+                        {
+                            if (!_countdownEvent.IsSet)
+                                _countdownEvent.Signal();
+                        }
                     }
                     else
                     {
@@ -162,10 +166,13 @@ namespace System.Threading.Tasks.Tests.CancelWait
                         }
                         finally
                         {
-                            // stop the tree creation and let the main thread proceed
-                            if (!_countdownEvent.IsSet)
+                            lock (_countdownEvent)
                             {
-                                _countdownEvent.Signal(_countdownEvent.CurrentCount);
+                                // stop the tree creation and let the main thread proceed
+                                if (!_countdownEvent.IsSet)
+                                {
+                                    _countdownEvent.Signal(_countdownEvent.CurrentCount);
+                                }
                             }
                         }
                     }
@@ -208,6 +215,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
                         VerifyCancel(current);
                         VerifyResult(current);
                     });
+                    Assert.Null(_caughtException);
                     break;
 
                 //root task was calling wait


### PR DESCRIPTION
When `CancelChildren` is enabled (currently only in the `TaskCancelWait1` test) we're hitting a race in `TaskCancelWaitTest.CreateTask()`:

1. Let's assume Task A is processing `node`
2. Task A spawns a new Task B for processing `node_1`
3. Task B starts and signals the `_countdownEvent`
4. `RealRun()` on the main thread exits the wait on `_countdownEvent`
5. `RealRun()` calls `Verify()` which loops through all the nodes and calls `VerifyCancel()`
6. We get an assertion because `CancellationToken.IsCancellationRequested` is false
7. Task A continues and sets the CancellationToken on the child(ren), but it is already too late by this point

To fix this race we wait on the task in `RealRun()` before proceeding to the verification step.

This uncovered another issue:
Since `_countdownEvent` is accessed by multiple threads we have another race between checking `_countdownEvent.IsSet` and `_countdownEvent.Signal()`.

This caused a `System.InvalidOperationException: Invalid attempt made to decrement the event's count below zero.` Fixed it by locking access to the `_countdownEvent`.

Fixes https://github.com/dotnet/corefx/issues/20457
Fixes https://github.com/mono/mono/issues/6920

/cc @stephentoub 