### PR TITLE
Regex: reduce allocation slightly, add tests, code cleanup, add parser comments

### DIFF
--- a/src/Common/src/CoreLib/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/Common/src/CoreLib/System/Collections/Generic/ValueListBuilder.cs
@@ -21,7 +21,16 @@ namespace System.Collections.Generic
             _pos = 0;
         }
 
-        public int Length => _pos;
+        public int Length
+        {
+            get => _pos;
+            set
+            {
+                Debug.Assert(value >= 0);
+                Debug.Assert(value <= _span.Length);
+                _pos = value;
+            }
+        }
 
         public ref T this[int index]
         {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -112,16 +112,16 @@ namespace System.Text.RegularExpressions
             internalMatchTimeout = matchTimeout;
 
             // Cache handling. Try to look up this regex in the cache.
-            string cultureKey = (options & RegexOptions.CultureInvariant) != 0 ?
-                    CultureInfo.InvariantCulture.ToString() :
-                    CultureInfo.CurrentCulture.ToString();                        
-            var key = new CachedCodeEntryKey(options, cultureKey, pattern);
+            CultureInfo culture = (options & RegexOptions.CultureInvariant) != 0 ?
+                CultureInfo.InvariantCulture :
+                CultureInfo.CurrentCulture;
+            var key = new CachedCodeEntryKey(options, culture.ToString(), pattern);
             CachedCodeEntry cached = GetCachedCode(key, false);
 
             if (cached == null)
             {
                 // Parse the input
-                RegexTree tree = RegexParser.Parse(pattern, roptions);
+                RegexTree tree = RegexParser.Parse(pattern, roptions, culture);
 
                 // Extract the relevant information
                 capnames = tree.CapNames;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -13,8 +13,6 @@
 
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
-using System.Text;
 
 namespace System.Text.RegularExpressions
 {
@@ -39,12 +37,7 @@ namespace System.Text.RegularExpressions
             // Sorry, you just can't use Boyer-Moore to find an empty pattern.
             // We're doing this for your own protection. (Really, for speed.)
             Debug.Assert(pattern.Length != 0, "RegexBoyerMoore called with an empty string. This is bad for perf");
-
-            if (caseInsensitive)
-            {
-                pattern = string.Create(pattern.Length, (pattern, culture), (span, state) =>
-                    state.pattern.AsSpan().ToLower(span, state.culture));
-            }
+            Debug.Assert(!caseInsensitive || pattern.ToLower(culture) == pattern, "RegexBoyerMoore called with a pattern which is not lowercased with caseInsensitive true.");
 
             Pattern = pattern;
             RightToLeft = rightToLeft;
@@ -221,17 +214,7 @@ namespace System.Text.RegularExpressions
                     return false;
                 }
 
-                TextInfo textinfo = _culture.TextInfo;
-                for (int i = 0; i < Pattern.Length; i++)
-                {
-                    Debug.Assert(textinfo.ToLower(Pattern[i]) == Pattern[i], "pattern should be converted to lower case in constructor!");
-                    if (textinfo.ToLower(text[index + i]) != Pattern[i])
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
+                return (0 == string.Compare(Pattern, 0, text, index, Pattern.Length, CaseInsensitive, _culture));
             }
             else
             {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -43,15 +43,7 @@ namespace System.Text.RegularExpressions
             if (caseInsensitive)
             {
                 pattern = string.Create(pattern.Length, (pattern, culture), (span, state) =>
-                {
-                    // We do the ToLower character by character for consistency.  With surrogate chars, doing
-                    // a ToLower on the entire string could actually change the surrogate pair.  This is more correct
-                    // linguistically, but since Regex doesn't support surrogates, it's more important to be
-                    // consistent.
-                    TextInfo textInfo = state.culture.TextInfo;
-                    for (int i = 0; i < state.pattern.Length; i++)
-                        span[i] = textInfo.ToLower(state.pattern[i]);
-                });
+                    state.pattern.AsSpan().ToLower(span, state.culture));
             }
 
             Pattern = pattern;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -2080,17 +2080,7 @@ namespace System.Text.RegularExpressions
                 if (UseOptionI() && !isReplacement)
                 {
                     str = string.Create(cch, (_pattern, _culture, pos, cch), (span, state) =>
-                    {
-                        ReadOnlySpan<char> input = state._pattern.AsSpan(pos, cch);
-
-                        // We do the ToLower character by character for consistency.  With surrogate chars, doing
-                        // a ToLower on the entire string could actually change the surrogate pair.  This is more correct
-                        // linguistically, but since Regex doesn't support surrogates, it's more important to be
-                        // consistent.
-                        TextInfo textInfo = state._culture.TextInfo;
-                        for (int i = 0; i < input.Length; i++)
-                            span[i] = textInfo.ToLower(input[i]);
-                    });
+                        state._pattern.AsSpan(pos, cch).ToLower(span, state._culture));
                 }
                 else
                 {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1097,13 +1097,10 @@ namespace System.Text.RegularExpressions
             if (CharsRight() == 0)
                 throw MakeException(RegexParseError.IllegalEndEscape, SR.IllegalEndEscape);
 
-            char ch;
-            bool angled = false;
+            int backpos = Textpos();
             char close = '\0';
-            int backpos;
-
-            backpos = Textpos();
-            ch = RightChar();
+            bool angled = false;
+            char ch = RightChar();
 
             // allow \k<foo> instead of \<foo>, which is now deprecated
 
@@ -1366,13 +1363,10 @@ namespace System.Text.RegularExpressions
          */
         private char ScanOctal()
         {
+            // Consume octal chars only up to 3 digits and value 0377
+            int c = 3;
             int d;
             int i;
-            int c;
-
-            // Consume octal chars only up to 3 digits and value 0377
-
-            c = 3;
 
             if (c > CharsRight())
                 c = CharsRight();
@@ -1420,10 +1414,8 @@ namespace System.Text.RegularExpressions
          */
         private char ScanHex(int c)
         {
-            int i;
+            int i = 0;
             int d;
-
-            i = 0;
 
             if (CharsRight() >= c)
             {
@@ -1464,12 +1456,10 @@ namespace System.Text.RegularExpressions
          */
         private char ScanControl()
         {
-            char ch;
-
-            if (CharsRight() <= 0)
+            if (CharsRight() == 0)
                 throw MakeException(RegexParseError.MissingControl, SR.MissingControl);
 
-            ch = RightCharMoveRight();
+            char ch = RightCharMoveRight();
 
             // \ca interpreted as \cA
 
@@ -1487,10 +1477,9 @@ namespace System.Text.RegularExpressions
          */
         private bool IsOnlyTopOption(RegexOptions option)
         {
-            return (option == RegexOptions.RightToLeft
-                || option == RegexOptions.CultureInvariant
-                || option == RegexOptions.ECMAScript
-            );
+            return option == RegexOptions.RightToLeft ||
+                option == RegexOptions.CultureInvariant ||
+                option == RegexOptions.ECMAScript;
         }
 
         /*
@@ -1577,6 +1566,7 @@ namespace System.Text.RegularExpressions
             {
                 throw MakeException(RegexParseError.IncompleteSlashP, SR.IncompleteSlashP);
             }
+
             char ch = RightCharMoveRight();
             if (ch != '{')
             {
@@ -1809,16 +1799,6 @@ namespace System.Text.RegularExpressions
                 _capnames.Add(name, pos);
                 _capnamelist.Add(name);
             }
-        }
-
-        /*
-         * For when all the used captures are known: note them all at once
-         */
-        private void NoteCaptures(Hashtable caps, int capsize, Hashtable capnames)
-        {
-            _caps = caps;
-            _capsize = capsize;
-            _capnames = capnames;
         }
 
         /*
@@ -2069,11 +2049,10 @@ namespace System.Text.RegularExpressions
          */
         private void AddConcatenate(int pos, int cch, bool isReplacement)
         {
-            RegexNode node;
-
             if (cch == 0)
                 return;
 
+            RegexNode node;
             if (cch > 1)
             {
                 string str;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -30,9 +30,9 @@ namespace System.Text.RegularExpressions
         private RegexNode _concatenation;
         private RegexNode _unit;
 
-        private string _pattern;
+        private readonly string _pattern;
         private int _currentPos;
-        private CultureInfo _culture;
+        private readonly CultureInfo _culture;
 
         private int _autocap;
         private int _capcount;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -2059,7 +2059,7 @@ namespace System.Text.RegularExpressions
                 if (UseOptionI() && !isReplacement)
                 {
                     str = string.Create(cch, (_pattern, _culture, pos, cch), (span, state) =>
-                        state._pattern.AsSpan(pos, cch).ToLower(span, state._culture));
+                        state._pattern.AsSpan(state.pos, state.cch).ToLower(span, state._culture));
                 }
                 else
                 {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -2022,9 +2022,7 @@ namespace System.Text.RegularExpressions
 
         private bool IsTrueQuantifier()
         {
-            int nChars = CharsRight();
-            if (nChars == 0)
-                return false;
+            Debug.Assert(CharsRight() > 0, "IsTrueQuantifier requires characters to be read");
 
             int startpos = Textpos();
             char ch = CharAt(startpos);
@@ -2032,6 +2030,7 @@ namespace System.Text.RegularExpressions
                 return ch <= '{' && s_category[ch] >= Q;
 
             int pos = startpos;
+            int nChars = CharsRight();
             while (--nChars > 0 && (ch = CharAt(++pos)) >= '0' && ch <= '9') ;
 
             if (nChars == 0 || pos - startpos == 1)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -349,6 +349,9 @@ namespace System.Text.RegularExpressions
                         break;
 
                     case '\\':
+                        if (CharsRight() == 0)
+                            throw MakeException(RegexParseError.IllegalEndEscape, SR.IllegalEndEscape);
+
                         AddUnitNode(ScanBackslash(scanOnly: false));
                         break;
 
@@ -696,11 +699,6 @@ namespace System.Text.RegularExpressions
          */
         private RegexNode ScanGroupOpen()
         {
-            char ch = '\0';
-            int NodeType;
-            char close = '>';
-
-
             // just return a RegexNode if we have:
             // 1. "(" followed by nothing
             // 2. "(x" where x != ?
@@ -723,6 +721,9 @@ namespace System.Text.RegularExpressions
                 if (CharsRight() == 0)
                     break;
 
+                int NodeType;
+                char close = '>';
+                char ch;
                 switch (ch = RightCharMoveRight())
                 {
                     case ':':
@@ -1007,8 +1008,7 @@ namespace System.Text.RegularExpressions
          */
         private RegexNode ScanBackslash(bool scanOnly)
         {
-            if (CharsRight() == 0)
-                throw MakeException(RegexParseError.IllegalEndEscape, SR.IllegalEndEscape);
+            Debug.Assert(CharsRight() > 0, "The current reading position must not be at the end of the pattern");
 
             char ch;
             switch (ch = RightChar())
@@ -2022,7 +2022,7 @@ namespace System.Text.RegularExpressions
 
         private bool IsTrueQuantifier()
         {
-            Debug.Assert(CharsRight() > 0, "IsTrueQuantifier requires characters to be read");
+            Debug.Assert(CharsRight() > 0, "The current reading position must not be at the end of the pattern");
 
             int startpos = Textpos();
             char ch = CharAt(startpos);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -94,7 +94,7 @@ namespace System.Text.RegularExpressions
 
             if (!replRef.TryGetTarget(out repl) || !repl.Pattern.Equals(replacement))
             {
-                repl = RegexParser.ParseReplacement(replacement, caps, capsize, capnames, roptions);
+                repl = RegexParser.ParseReplacement(replacement, roptions, caps, capsize, capnames);
                 replRef.SetTarget(repl);
             }
 

--- a/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -759,5 +759,22 @@ namespace System.Text.RegularExpressions.Tests
                 return SuccessExitCode;
             }).Dispose();
         }
+
+        [Fact]
+        public void Synchronized_NullGroup_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("inner", () => Group.Synchronized(null));
+        }
+
+        [Theory]
+        [InlineData(@"(cat)([\v]*)(dog)", "cat\v\v\vdog")]
+        [InlineData("abc", "def")] // no match
+        public void Synchronized_ValidGroup_Success(string pattern, string input)
+        {
+            Match match = Regex.Match(input, pattern);
+
+            Group synchronizedGroup = Group.Synchronized(match.Groups[0]);
+            Assert.NotNull(synchronizedGroup);
+        }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -76,7 +76,11 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { "[^0-9]+(?>[0-9]+)3", "abc123", RegexOptions.None, 0, 6, false, string.Empty };
 
             // Using beginning/end of string chars \A, \Z: Actual - "\\Aaaa\\w+zzz\\Z"
-            yield return new object[] { @"\Aaaa\w+zzz\Z", "aaaasdfajsdlfjzzz", RegexOptions.None, 0, 17, true, "aaaasdfajsdlfjzzz" };
+            yield return new object[] { @"\Aaaa\w+zzz\Z", "aaaasdfajsdlfjzzz", RegexOptions.IgnoreCase, 0, 17, true, "aaaasdfajsdlfjzzz" };
+            yield return new object[] { @"\Aaaaaa\w+zzz\Z", "aaaa", RegexOptions.IgnoreCase, 0, 4, false, string.Empty };
+            yield return new object[] { @"\Aaaaaa\w+zzz\Z", "aaaa", RegexOptions.RightToLeft, 0, 4, false, string.Empty };
+            yield return new object[] { @"\Aaaaaa\w+zzzzz\Z", "aaaa", RegexOptions.RightToLeft, 0, 4, false, string.Empty };
+            yield return new object[] { @"\Aaaaaa\w+zzz\Z", "aaaa", RegexOptions.RightToLeft | RegexOptions.IgnoreCase, 0, 4, false, string.Empty };
 
             // Using beginning/end of string chars \A, \Z: Actual - "\\Aaaa\\w+zzz\\Z"
             yield return new object[] { @"\Aaaa\w+zzz\Z", "aaaasdfajsdlfjzzza", RegexOptions.None, 0, 18, false, string.Empty };
@@ -632,6 +636,24 @@ namespace System.Text.RegularExpressions.Tests
                 new CaptureData[]
                 {
                     new CaptureData("aaa", 0, 3)
+                }
+            };
+
+            // RightToLeft with anchor
+            yield return new object[]
+            {
+                "^aaa", "aaabbb", RegexOptions.RightToLeft, 3, 3,
+                new CaptureData[]
+                {
+                    new CaptureData("aaa", 0, 3)
+                }
+            };
+            yield return new object[]
+            {
+                "bbb$", "aaabbb", RegexOptions.RightToLeft, 0, 3,
+                new CaptureData[]
+                {
+                    new CaptureData("bbb", 0, 3)
                 }
             };
         }

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -112,7 +112,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { "aaa(?-i:match this)bbb", "AaAmatch thisBBb", RegexOptions.IgnoreCase, 0, 16, true, "AaAmatch thisBBb" };
 
             // Turning on/off all the options at once : Actual - "aaa(?imnsx-imnsx:match this)bbb", "i"
-            yield return new object[] { "aaa(?-i:match this)bbb", "AaAmatcH thisBBb", RegexOptions.IgnoreCase, 0, 16, false, string.Empty };
+            yield return new object[] { "aaa(?imnsx-imnsx:match this)bbb", "AaAmatcH thisBBb", RegexOptions.IgnoreCase, 0, 16, false, string.Empty };
 
             // Actual - "aaa(?#ignore this completely)bbb"
             yield return new object[] { "aaa(?#ignore this completely)bbb", "aaabbb", RegexOptions.None, 0, 6, true, "aaabbb" };

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -97,7 +97,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { "(abbc)(?(1)111|222)", "abbc222", RegexOptions.None, 0, 7, false, string.Empty };
 
             // "x" option. Removes unescaped whitespace from the pattern: Actual - " ([^/]+) ","x"
-            yield return new object[] { "            ((.)+)      ", "abc", RegexOptions.IgnorePatternWhitespace, 0, 3, true, "abc" };
+            yield return new object[] { "            ((.)+) #comment     ", "abc", RegexOptions.IgnorePatternWhitespace, 0, 3, true, "abc" };
 
             // "x" option. Removes unescaped whitespace from the pattern. : Actual - "\x20([^/]+)\x20","x"
             yield return new object[] { "\x20([^/]+)\x20\x20\x20\x20\x20\x20\x20", " abc       ", RegexOptions.IgnorePatternWhitespace, 0, 10, true, " abc      " };

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -109,13 +109,13 @@ namespace System.Text.RegularExpressions.Tests
             }
 
             // Turning off case insensitive option in mid-pattern : Actual - "aaa(?-i:match this)bbb", "i"
-            yield return new object[] { "aaa(?-i:match this)bbb", "AaAmatch thisBBb", RegexOptions.IgnoreCase, 0, 16, true, "AaAmatch thisBBb" };
+            yield return new object[] { "aAa(?-i:match this)bbb", "AaAmatch thisBBb", RegexOptions.IgnoreCase, 0, 16, true, "AaAmatch thisBBb" };
 
             // Turning on/off all the options at once : Actual - "aaa(?imnsx-imnsx:match this)bbb", "i"
             yield return new object[] { "aaa(?imnsx-imnsx:match this)bbb", "AaAmatcH thisBBb", RegexOptions.IgnoreCase, 0, 16, false, string.Empty };
 
             // Actual - "aaa(?#ignore this completely)bbb"
-            yield return new object[] { "aaa(?#ignore this completely)bbb", "aaabbb", RegexOptions.None, 0, 6, true, "aaabbb" };
+            yield return new object[] { "aAa(?#ignore this completely)bbb", "aAabbb", RegexOptions.None, 0, 6, true, "aAabbb" };
 
             // Trying empty string: Actual "[a-z0-9]+", ""
             yield return new object[] { "[a-z0-9]+", "", RegexOptions.None, 0, 0, false, string.Empty };

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -291,6 +291,9 @@ namespace System.Text.RegularExpressions.Tests
             // \c
             if (!PlatformDetection.IsFullFramework) // missing fix for #26501
                 yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u00FFdogiwod", RegexOptions.None, 0, 15, false, string.Empty };
+
+            // Surrogate pairs splitted up into UTF-16 code units.
+            yield return new object[] { @"(\uD82F[\uDCA0-\uDCA3])", "\uD82F\uDCA2", RegexOptions.CultureInvariant, 0, 2, true, "\uD82F\uDCA2" };
         }
 
         [Theory]

--- a/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -60,6 +60,8 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(hello)\s+(world)", "START hello    world END", "$2 $1 $1 $2 $3$4", RegexOptions.None, 24, 0, "START world hello hello world $3$4 END" };
             yield return new object[] { @"(hello)\s+(world)", "START hello    world END", "$2 $1 $1 $2 $123$234", RegexOptions.None, 24, 0, "START world hello hello world $123$234 END" };
 
+            yield return new object[] { "aAa( CcC )bbb", "AaA CcC BBb", "$`blub$'", RegexOptions.IgnoreCase, 0, 10, "AaAblubBBb" };
+            yield return new object[] { @"aaa", "My dog cat has fleas.", "$01$02$03$04$05$06$07$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My dog cat has fleas." };
             yield return new object[] { @"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", "My dog cat has fleas.", "$01$02$03$04$05$06$07$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My dog cat has fleas." };
             yield return new object[] { @"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", "My dog cat has fleas.", "$05$06$07$04$01$02$03$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My cat dog has fleas." };
 

--- a/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -60,7 +60,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(hello)\s+(world)", "START hello    world END", "$2 $1 $1 $2 $3$4", RegexOptions.None, 24, 0, "START world hello hello world $3$4 END" };
             yield return new object[] { @"(hello)\s+(world)", "START hello    world END", "$2 $1 $1 $2 $123$234", RegexOptions.None, 24, 0, "START world hello hello world $123$234 END" };
 
-            yield return new object[] { "aAa( CcC )bbb", "AaA CcC BBb", "$`blub$'", RegexOptions.IgnoreCase, 0, 10, "AaAblubBBb" };
             yield return new object[] { @"aaa", "My dog cat has fleas.", "$01$02$03$04$05$06$07$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My dog cat has fleas." };
             yield return new object[] { @"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", "My dog cat has fleas.", "$01$02$03$04$05$06$07$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My dog cat has fleas." };
             yield return new object[] { @"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", "My dog cat has fleas.", "$05$06$07$04$01$02$03$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My cat dog has fleas." };

--- a/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -60,7 +60,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(hello)\s+(world)", "START hello    world END", "$2 $1 $1 $2 $3$4", RegexOptions.None, 24, 0, "START world hello hello world $3$4 END" };
             yield return new object[] { @"(hello)\s+(world)", "START hello    world END", "$2 $1 $1 $2 $123$234", RegexOptions.None, 24, 0, "START world hello hello world $123$234 END" };
 
-            yield return new object[] { @"aaa", "My dog cat has fleas.", "$01$02$03$04$05$06$07$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My dog cat has fleas." };
             yield return new object[] { @"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", "My dog cat has fleas.", "$01$02$03$04$05$06$07$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My dog cat has fleas." };
             yield return new object[] { @"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", "My dog cat has fleas.", "$05$06$07$04$01$02$03$08$09$10$11", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, 21, 0, "My cat dog has fleas." };
 

--- a/src/System.Text.RegularExpressions/tests/RegexParserTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexParserTests.cs
@@ -862,6 +862,8 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("a{2147483648,}", RegexOptions.None, RegexParseError.CaptureGroupOutOfRange)]
         [InlineData("a{0,2147483647}", RegexOptions.None, null)]
         [InlineData("a{0,2147483648}", RegexOptions.None, RegexParseError.CaptureGroupOutOfRange)]
+        // Surrogate pair which is parsed as [char,char-char,char] as we operate on UTF-16 code units.
+        [InlineData("[\uD82F\uDCA0-\uD82F\uDCA3]", RegexOptions.IgnoreCase, RegexParseError.ReversedCharRange)]
         public void Parse_NotNetFramework(string pattern, RegexOptions options, object error)
         {
             Parse(pattern, options, error);


### PR DESCRIPTION
- Make RegexParser a ref struct and use ValueListBuilder with Span for the options stack instead of a List<RegexOptions>.
- Add tests for Group.Synchronized & regex comments `#comment` **and other corner cases that weren't covered especially with right to left**.
- Replace some method entry condition checks with Debug Asserts where applicable.
- Code cleanup & simplify code in a few cases (readonly, ToLower on Span instead of single chars, variable declaration moved away from on top of method, some comments replaced with XML comments)
- Add comments to better describe RegexParser behavior.

## Before (master)

|    Method |     Mean |     Error |    StdDev |      Gen 0 | Allocated |
|---------- |---------:|----------:|----------:|-----------:|----------:|
| RegexCtor | 101.8 ms | 0.5352 ms | 0.4179 ms | 56500.0000 | 113.07 MB |
| RegexCtorIgnoreCase | 98.15 ms | 1.913 ms | 2.278 ms | 66312.5000 | 132.64 MB |

## After

|    Method |     Mean |     Error |    StdDev |      Gen 0 | Allocated |
|---------- |---------:|----------:|----------:|-----------:|----------:|
| RegexCtor | 97.78 ms | 0.5337 ms | 0.4731 ms | 53687.5000 | 107.44 MB |
| RegexCtorIgnoreCase | 94.40 ms | 1.030 ms | 0.8600 ms | 62312.5000 | 124.65 MB |

Only minor improvements, I didn't expect anything severe. 5-6% less allocation, ~2-3% better perf.
Contributes towards https://github.com/dotnet/corefx/issues/30507