### PR TITLE
Add Dictionary<TKey,TValue>.RemoveAll ref api and tests

### DIFF
--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -96,7 +96,8 @@ namespace System.Collections.Generic
         public virtual void OnDeserialization(object sender) { }
         public bool Remove(TKey key) { throw null; }
         public bool Remove(TKey key, out TValue value) { throw null; }
-        public void TrimExcess(int capacity) { }
+		public int RemoveAll(System.Predicate<System.Collections.Generic.KeyValuePair<TKey, TValue>> match) { throw null; }
+		public void TrimExcess(int capacity) { }
         public void TrimExcess() { }
         public bool TryAdd(TKey key, TValue value) { throw null; }
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
@@ -86,6 +86,67 @@ namespace System.Collections.Tests
 
         #endregion
 
+        #region RemoveAll(Predicate<KeyBaluePair<TKey,TValue>>)
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void Dictionary_Generic_RemoveAll_AllElements(int count)
+        {
+            Dictionary<TKey, TValue> dict = (Dictionary<TKey, TValue>)(GenericIDictionaryFactory(count));
+            int removedCount = dict.RemoveAll((value) => { return true; });
+            Assert.Equal(count, removedCount);
+            Assert.Equal(0, dict.Count);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void Dictionary_Generic_RemoveAll_NoElements(int count)
+        {
+            Dictionary<TKey, TValue> dict = (Dictionary<TKey, TValue>)(GenericIDictionaryFactory(count));
+            int removedCount = dict.RemoveAll((value) => { return false; });
+            Assert.Equal(0, removedCount);
+            Assert.Equal(count, dict.Count);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void RemoveAll_DefaultElements(int count)
+        {
+            Dictionary<TKey, TValue> dict = (Dictionary<TKey, TValue>)(GenericIDictionaryFactory(count));
+            Dictionary<TKey, TValue> beforeDict = new Dictionary<TKey, TValue>(dict);
+            Predicate<KeyValuePair<TKey,TValue>> EqualsDefaultElement = (value) => { return default(TKey) == null ? value.Key == null : default(TKey).Equals(value.Key); };
+            int expectedCount = beforeDict.Count((value) => EqualsDefaultElement(value));
+            int removedCount = dict.RemoveAll(EqualsDefaultElement);
+            Assert.Equal(expectedCount, removedCount);
+        }
+
+        [Fact]
+        public void Dictionary_Generic_RemoveAll_UpdateWhileRemoving()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                {
+                    Dictionary<TKey, TValue> dict = (Dictionary<TKey, TValue>)(GenericIDictionaryFactory(20));
+
+                    dict.RemoveAll(
+                        kvp =>
+                        {
+                            dict[CreateTKey(0)] = CreateTValue(0);
+                            return true;
+                        }
+                    );
+                }
+            );
+        }
+
+        [Fact]
+        public void RemoveAll_NullMatchPredicate()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("match", () => new Dictionary<TKey,TValue>().RemoveAll(null));
+        }
+
+        #endregion
+
         #region EnsureCapacity
 
         [Theory]


### PR DESCRIPTION
Adds ref api entry and tests for RemoveAll(Predicate<KeyValuePair<TKey,TValue>> match) method per approved api issue [corefx##29979](https://github.com/dotnet/corefx/issues/29979). Requires [coreclr##18629](https://github.com/dotnet/coreclr/pull/18629).

Using the simple benchmark cases:
`[Benchmark(Baseline = true)]
public int RemoveOddRef()
{
	var remove = new List<int>(refDict.Count);
	foreach (var key in refDict.Keys)
		if ((key & 1)==1)
			remove.Add(key);
				
	foreach (var key in remove)
		refDict.Remove(key);

	return remove.Count;
}

[Benchmark]
public int RemoveOddDev()
{
	return devDict.RemoveAll(
		(KeyValuePair<int,object> pair) => (pair.Key&1)==1 && !object.ReferenceEquals(pair.Value, null)
	);
}`

Results are:

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i5-7600K CPU 3.80GHz (Kaby Lake), 1 CPU, 4 logical and 4 physical cores
.NET Core SDK=2.1.301
  [Host] : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
  Core   : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT

Job=Core  Runtime=Core  

```
|       Method |      Mean |     Error |    StdDev | Scaled |  Gen 0 | Allocated |
|------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| RemoveOddRef | 19.750 ns | 0.0461 ns | 0.0409 ns |   1.00 | 0.0127 |      40 B |
| RemoveOddDev |  3.007 ns | 0.0113 ns | 0.0106 ns |   0.15 |      - |       0 B |

@safern, @ianhays, @danmosemsft 