### PR TITLE
build stub assemblies on FreeBSD from *UnknownUnix*

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/Configurations.props
+++ b/src/System.IO.FileSystem.Watcher/src/Configurations.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      netcoreapp-FreeBSD;
       netcoreapp-Linux;
       netcoreapp-OSX;
       netcoreapp-Windows_NT;

--- a/src/System.IO.FileSystem.Watcher/src/Configurations.props
+++ b/src/System.IO.FileSystem.Watcher/src/Configurations.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp-FreeBSD;
       netcoreapp-Linux;
       netcoreapp-OSX;
+      netcoreapp-Unix;
       netcoreapp-Windows_NT;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Net.NetworkInformation/src/Configurations.props
+++ b/src/System.Net.NetworkInformation/src/Configurations.props
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap-Windows_NT;
-      netcoreapp-FreeBSD;
       netcoreapp-Linux;
       netcoreapp-OSX;
+      netcoreapp-Unix;
       netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Net.NetworkInformation/src/Configurations.props
+++ b/src/System.Net.NetworkInformation/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap-Windows_NT;
+      netcoreapp-FreeBSD;
       netcoreapp-Linux;
       netcoreapp-OSX;
       netcoreapp-Windows_NT;

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
@@ -27,10 +27,6 @@ namespace System.Net.NetworkInformation
         private static Timer s_availabilityTimer;
         private static bool s_availabilityHasChanged;
 
-        // Introduced for supporting design-time loading of System.Windows.dll
-        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        public static void RegisterNetworkChange(NetworkChange nc) { }
-
         public static event NetworkAddressChangedEventHandler NetworkAddressChanged
         {
             add

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -41,10 +41,6 @@ namespace System.Net.NetworkInformation
         private static readonly AutoResetEvent s_runLoopStartedEvent = new AutoResetEvent(false);
         private static readonly AutoResetEvent s_runLoopEndedEvent = new AutoResetEvent(false);
 
-        //introduced for supporting design-time loading of System.Windows.dll
-        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        public static void RegisterNetworkChange(NetworkChange nc) { }
-
         public static event NetworkAddressChangedEventHandler NetworkAddressChanged
         {
             add

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.UnknownUnix.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.UnknownUnix.cs
@@ -6,15 +6,12 @@ namespace System.Net.NetworkInformation
 {
     public partial class NetworkChange
     {
-        // Introduced for supporting design-time loading of System.Windows.dll
-       [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-       public static void RegisterNetworkChange(NetworkChange nc) { }
-
         public static event NetworkAddressChangedEventHandler NetworkAddressChanged
         {
             add { throw new PlatformNotSupportedException(); }
             remove { throw new PlatformNotSupportedException(); }
         }
+
         public static event NetworkAvailabilityChangedEventHandler NetworkAvailabilityChanged
         {
             add { throw new PlatformNotSupportedException(); }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.UnknownUnix.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.UnknownUnix.cs
@@ -6,7 +6,16 @@ namespace System.Net.NetworkInformation
 {
     public partial class NetworkChange
     {
+        // Introduced for supporting design-time loading of System.Windows.dll
+       [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+       public static void RegisterNetworkChange(NetworkChange nc) { }
+
         public static event NetworkAddressChangedEventHandler NetworkAddressChanged
+        {
+            add { throw new PlatformNotSupportedException(); }
+            remove { throw new PlatformNotSupportedException(); }
+        }
+        public static event NetworkAvailabilityChangedEventHandler NetworkAvailabilityChanged
         {
             add { throw new PlatformNotSupportedException(); }
             remove { throw new PlatformNotSupportedException(); }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
@@ -12,10 +12,6 @@ namespace System.Net.NetworkInformation
 {
     public partial class NetworkChange
     {
-        //introduced for supporting design-time loading of System.Windows.dll
-        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        public static void RegisterNetworkChange(NetworkChange nc) { }
-        
         private static readonly object s_globalLock = new object();
 
         public static event NetworkAvailabilityChangedEventHandler NetworkAvailabilityChanged

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.cs
@@ -23,6 +23,10 @@ namespace System.Net.NetworkInformation
         private static readonly ContextCallback s_runHandlerNotAvailable = new ContextCallback(RunAvailabilityHandlerNotAvailable);
         private static readonly ContextCallback s_runAddressChangedHandler = new ContextCallback(RunAddressChangedHandler);
 
+        // Introduced for supporting design-time loading of System.Windows.dll
+        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        public static void RegisterNetworkChange(NetworkChange nc) { }
+
         private static void RunAddressChangedHandler(object state)
         {
             ((NetworkAddressChangedEventHandler)state)(null, EventArgs.Empty);


### PR DESCRIPTION
With this change ` ./build.sh  -skiptests   -OS=FreeBSD` can complete and source-build does not break on missing assemblies. 

NetworkAddressChange.UnknownUnix.cs was failing to build without adding required API. 