### PR TITLE
Fix ImageFormat.ToString by using it's Guid when comparing to static ImageFormats

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
@@ -161,16 +161,16 @@ namespace System.Drawing.Imaging
         /// </summary>
         public override string ToString()
         {
-            if (this == s_memoryBMP) return "MemoryBMP";
-            if (this == s_bmp) return "Bmp";
-            if (this == s_emf) return "Emf";
-            if (this == s_wmf) return "Wmf";
-            if (this == s_gif) return "Gif";
-            if (this == s_jpeg) return "Jpeg";
-            if (this == s_png) return "Png";
-            if (this == s_tiff) return "Tiff";
-            if (this == s_exif) return "Exif";
-            if (this == s_icon) return "Icon";
+            if (this.Guid == s_memoryBMP.Guid) return "MemoryBMP";
+            if (this.Guid == s_bmp.Guid) return "Bmp";
+            if (this.Guid == s_emf.Guid) return "Emf";
+            if (this.Guid == s_wmf.Guid) return "Wmf";
+            if (this.Guid == s_gif.Guid) return "Gif";
+            if (this.Guid == s_jpeg.Guid) return "Jpeg";
+            if (this.Guid == s_png.Guid) return "Png";
+            if (this.Guid == s_tiff.Guid) return "Tiff";
+            if (this.Guid == s_exif.Guid) return "Exif";
+            if (this.Guid == s_icon.Guid) return "Icon";
             return "[ImageFormat: " + _guid + "]";
         }
     }

--- a/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests
@@ -57,6 +58,18 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        public static IEnumerable<object[]> ImageFromFileToStringTestData
+        {
+            get
+            {
+                yield return new object[] { Path.Combine("bitmaps", "nature24bits.gif"), "Gif" };
+                yield return new object[] { Path.Combine("bitmaps", "nature24bits.jpg"), "Jpeg" };
+                yield return new object[] { Path.Combine("bitmaps", "VisualPng.ico"), "Icon"};
+                yield return new object[] { Path.Combine("bitmaps", "almogaver32bits.tif"), "Tiff" };
+                yield return new object[] { Path.Combine("bitmaps", "almogaver-os2.bmp"), "Bmp" };
+            }
+        }
+
         public static IEnumerable<object[]> ImageFormatEqualsTestData
         {
             get
@@ -80,6 +93,14 @@ namespace System.Drawing.Imaging.Tests
         public void ToString_ReturnsExpected(string expected, ImageFormat imageFormat)
         {
             Assert.Equal(expected, imageFormat.ToString());
+        }
+
+        [ConditionalTheory(Helpers.GdiplusIsAvailable)]
+        [MemberData(nameof(ImageFromFileToStringTestData))]
+        public void Image_RawFormat_ToString(string path, string expected)
+        {
+            var img = Image.FromFile(path);
+            Assert.Same(img.RawFormat.ToString(), expected);
         }
 
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]

--- a/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
@@ -100,7 +100,7 @@ namespace System.Drawing.Imaging.Tests
         public void Image_RawFormat_ToString(string path, string expected)
         {
             var img = Image.FromFile(path);
-            Assert.Same(img.RawFormat.ToString(), expected);
+            Assert.Same(expected, img.RawFormat.ToString());
         }
 
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]

--- a/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
@@ -66,7 +66,6 @@ namespace System.Drawing.Imaging.Tests
                 yield return new object[] { Path.Combine("bitmaps", "nature24bits.jpg"), "Jpeg" };
                 yield return new object[] { Path.Combine("bitmaps", "VisualPng.ico"), "Icon"};
                 yield return new object[] { Path.Combine("bitmaps", "almogaver32bits.tif"), "Tiff" };
-                yield return new object[] { Path.Combine("bitmaps", "almogaver-os2.bmp"), "Bmp" };
             }
         }
 
@@ -95,6 +94,7 @@ namespace System.Drawing.Imaging.Tests
             Assert.Equal(expected, imageFormat.ToString());
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Bug fix in .NET Core that is not in NETFX yet, dotnet/corefx 16463")]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ImageFromFileToStringTestData))]
         public void Image_RawFormat_ToString(string path, string expected)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/16463

cc: @danmosemsft 