### PR TITLE
fix dereferencing uninitialized byte array in case recv() fails (#30312) (2.1 branch)

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -380,14 +380,15 @@ namespace System.Net.Sockets
 
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
-                ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
             }
 
             if (errno != Interop.Error.SUCCESS)
             {
+                ipPacketInformation = default(IPPacketInformation);
                 return -1;
             }
 
+            ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
             socketAddressLen = sockAddrLen;
             return checked((int)received);
         }
@@ -442,15 +443,16 @@ namespace System.Net.Sockets
 
                     receivedFlags = messageHeader.Flags;
                     int sockAddrLen = messageHeader.SocketAddressLen;
-                    ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
 
                     if (errno == Interop.Error.SUCCESS)
                     {
+                        ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
                         socketAddressLen = sockAddrLen;
                         return checked((int)received);
                     }
                     else
                     {
+                        ipPacketInformation = default(IPPacketInformation);
                         return -1;
                     }
                 }


### PR DESCRIPTION
This is clone of original #30312 for release/2.1 branch.

fixes #29376 [arm32/Ubuntu] corefx test failures: System.Net.NetworkInformation.Functional.Tests, System.Net.Sockets.Tests

The issue was originally reported as ARM test failure but it can impact production code on other platforms as well. 