### PR TITLE
Add properties Now and Today

### DIFF
--- a/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
+++ b/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
@@ -5,6 +5,8 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.VisualBasic
 {
     public enum CallType
@@ -55,6 +57,13 @@ namespace Microsoft.VisualBasic
         public const char Tab = '\t';
         public const char VerticalTab = '\v';
         public ControlChars() { }
+    }
+    [Microsoft.VisualBasic.CompilerServices.StandardModuleAttribute]
+    public sealed partial class DateAndTime
+    {
+        internal DateAndTime() { }
+        public static DateTime Now { get; }
+        public static DateTime Today { get; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=false, Inherited=false)]
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]

--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.vbproj
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.vbproj
@@ -46,6 +46,7 @@
     <Compile Include="Microsoft\VisualBasic\Constants.vb" />
     <Compile Include="Microsoft\VisualBasic\ControlChars.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\DoubleType.vb" />
+    <Compile Include="Microsoft\VisualBasic\DateAndTime.vb" />
     <Compile Include="Microsoft\VisualBasic\HideModuleNameAttribute.vb" />
     <Compile Include="Microsoft\VisualBasic\Information.vb" />
     <Compile Include="Microsoft\VisualBasic\Interaction.vb" />

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/DateAndTime.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/DateAndTime.vb
@@ -1,0 +1,21 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System
+
+Namespace Microsoft.VisualBasic
+    Public Module DateAndTime
+        Public ReadOnly Property Now As DateTime
+            Get
+                Return DateTime.Now
+            End Get
+        End Property
+
+        Public ReadOnly Property Today As DateTime
+            Get
+                Return DateTime.Today
+            End Get
+        End Property
+    End Module
+End Namespace

--- a/src/Microsoft.VisualBasic/tests/DateAndTimeTests.cs
+++ b/src/Microsoft.VisualBasic/tests/DateAndTimeTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.VisualBasic.Tests
+{
+    public class DateAndTimeTests
+    {
+        [Fact]
+        public void Now_ReturnsDateTimeNow()
+        {
+            var dateTimeNowBefore = DateTime.Now;
+            var now = DateAndTime.Now;
+            var dateTimeNowAfter = DateTime.Now;
+
+            Assert.InRange(now, dateTimeNowBefore, dateTimeNowAfter);
+        }
+
+        [Fact]
+        public void Today_ReturnsDateTimeToday()
+        {
+            var dateTimeTodayBefore = DateTime.Today;
+            var today = DateAndTime.Today;
+            var dateTimeTodayAfter = DateTime.Today;
+
+            Assert.InRange(today, dateTimeTodayBefore, dateTimeTodayAfter);
+            Assert.Equal(TimeSpan.Zero, today.TimeOfDay);
+        }
+    }
+}

--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="Microsoft/VisualBasic/Devices/NetworkAvailableEventArgsTests.cs" />
     <Compile Include="ConversionsTests.cs" />
     <Compile Include="OperatorsTests.cs" />
+    <Compile Include="DateAndTimeTests.cs" />
     <Compile Include="InformationTests.cs" />
     <Compile Include="UtilsTests.cs" />
     <Compile Include="StringsTests.cs" />


### PR DESCRIPTION
Newly added module DateAndTime with read-only properties Now and Today. Implementation is the same as in netfx.

Property Today is writable in netfx and uses kernel32.dll. That's not possible in corefx, thus property is read-only.

I tried to add tests, but experienced two problems:
- Faking DateTime.Now requires the use of ShimsContext. Then it's no longer safe to run tests in parallel, which is what probably happens.
- I couldn't find out how to add the fakes assembly, because I couldn't see the netstandard assembly in the reference list.
