### PR TITLE
use separate kevent() calls on FreeBSD for read and write event notifications.

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -2222,6 +2222,7 @@ static int32_t TryChangeSocketEventRegistrationInner(
                0,
                GetKeventUdata(data));
 #if defined(__FreeBSD__)
+        // Issue: #30698
         // FreeBSD seems to have some issue when setting read/write events together.
         // As a workaround use separate kevent() calls.
         if (writeChanged)


### PR DESCRIPTION
This is somewhat speculative change but it impacts only FreeBSD.
We got bootstrap cli working on FreeBSD but msbuild and Roslyn were sometimes hanging.

Investigation pointed to some problems with kqueue and named pipes. 
When socket buffer is filled, send() fails with EWOULDBLOCK.
We would use kevent() to ask kernel to notify when socket is writable but the notification would never come. Unit tests from System.IO.Pipes were also failing. 

After some experiments I found out that kevent() works as expected if I separate requests fore read and write notifications to two separate calls. From reading docs it should work as it was written but it does not. 

I can open issue to track this and investigate more. But this changes allows msbuild and Roslyn to function and we can build coreclr and corefx using source-build. All named pipe tests are passing now on FreeBSD.
