### PR TITLE
Removes duplicate attributes on Span

### DIFF
--- a/src/System.Memory/src/System/ReadOnlySpan.Portable.cs
+++ b/src/System.Memory/src/System/ReadOnlySpan.Portable.cs
@@ -15,8 +15,6 @@ namespace System
     /// ReadOnlySpan represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
-    [DebuggerTypeProxy(typeof(SpanDebugView<>))]
-    [DebuggerDisplay("{ToString(),raw}")]
     public readonly ref partial struct ReadOnlySpan<T>
     {
         /// <summary>

--- a/src/System.Memory/src/System/Span.Portable.cs
+++ b/src/System.Memory/src/System/Span.Portable.cs
@@ -15,8 +15,6 @@ namespace System
     /// Span represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
-    [DebuggerTypeProxy(typeof(SpanDebugView<>))]
-    [DebuggerDisplay("{ToString(),raw}")]
     public readonly ref partial struct Span<T>
     {
         /// <summary>


### PR DESCRIPTION
Port https://github.com/dotnet/coreclr/pull/18668 to portable Span