### PR TITLE
Remove dependency for IBindableVector Type

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
@@ -102,7 +102,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         const string WinRTNotifyCollectionChangedEventArgsName = "Windows.UI.Xaml.Interop.NotifyCollectionChangedEventArgs";
 
         // IBindableVector Guid
-        static Guid IBindableVectorID = new Guid("393de7de-6fd0-4c0d-bb71-47244a113e93");
+        static Guid IID_IBindableVector = new Guid("393de7de-6fd0-4c0d-bb71-47244a113e93");
 
         static INotifyCollectionChangedEventArgsFactory s_EventArgsFactory;
 
@@ -121,7 +121,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 if (managedArgs.NewItems != null)
                 {
                     IntPtr unkPtr = Marshal.GetIUnknownForObject(managedArgs.NewItems);
-                    int hr = Marshal.QueryInterface(unkPtr, ref IBindableVectorID, out newItemsIP);
+                    int hr = Marshal.QueryInterface(unkPtr, ref IID_IBindableVector, out newItemsIP);
                     Marshal.Release(unkPtr);
                     if (hr < 0)
                         throw Marshal.GetExceptionForHR(hr);
@@ -130,7 +130,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 if (managedArgs.OldItems != null)
                 {
                     IntPtr unkPtr = Marshal.GetIUnknownForObject(managedArgs.OldItems);
-                    int hr = Marshal.QueryInterface(unkPtr, ref IBindableVectorID, out oldItemsIP);
+                    int hr = Marshal.QueryInterface(unkPtr, ref IID_IBindableVector, out oldItemsIP);
                     Marshal.Release(unkPtr);
                     if (hr < 0)
                         throw Marshal.GetExceptionForHR(hr);

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
@@ -101,6 +101,9 @@ namespace System.Runtime.InteropServices.WindowsRuntime
     {
         const string WinRTNotifyCollectionChangedEventArgsName = "Windows.UI.Xaml.Interop.NotifyCollectionChangedEventArgs";
 
+        // IBindableVector Guid
+        static Guid IBindableVectorID = new Guid("393de7de-6fd0-4c0d-bb71-47244a113e93");
+
         static INotifyCollectionChangedEventArgsFactory s_EventArgsFactory;
 
         // Extracts properties from a managed NotifyCollectionChangedEventArgs and passes them to
@@ -116,9 +119,22 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             try
             {
                 if (managedArgs.NewItems != null)
-                    newItemsIP = Marshal.GetComInterfaceForObject(managedArgs.NewItems, typeof(IBindableVector));
+                {
+                    IntPtr unkPtr = Marshal.GetIUnknownForObject(managedArgs.NewItems);
+                    int hr = Marshal.QueryInterface(unkPtr, ref IBindableVectorID, out newItemsIP);
+                    Marshal.Release(unkPtr);
+                    if (hr < 0)
+                        throw Marshal.GetExceptionForHR(hr);
+
+                }
                 if (managedArgs.OldItems != null)
-                    oldItemsIP = Marshal.GetComInterfaceForObject(managedArgs.OldItems, typeof(IBindableVector));
+                {
+                    IntPtr unkPtr = Marshal.GetIUnknownForObject(managedArgs.OldItems);
+                    int hr = Marshal.QueryInterface(unkPtr, ref IBindableVectorID, out oldItemsIP);
+                    Marshal.Release(unkPtr);
+                    if (hr < 0)
+                        throw Marshal.GetExceptionForHR(hr);
+                }
 
                 return CreateNativeNCCEventArgsInstanceHelper((int)managedArgs.Action, newItemsIP, oldItemsIP, managedArgs.NewStartingIndex, managedArgs.OldStartingIndex);
             }


### PR DESCRIPTION
Type IBindableVector is declared as internal in S.P.Corelib and S.R.WR want to use this type. There are couple ways to solve this:
1. Change IBindableVector visibility from internal to public in S.P.Corelib
    con: currently all of these types are internal only. 
2. Copy IBindableVector definition into S.R.WR
   con: duplicate code
3. [Current]Use QI instead

