### PR TITLE
Fix handle double-free in recently added WindowsIdentity test

### DIFF
--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -129,12 +129,16 @@ public class WindowsIdentityTests
     {
         using (var mutex = new Mutex())
         {
-            Assert.Throws<ArgumentException>(() =>
+            SafeAccessTokenHandle handle = null;
+            try
             {
-                WindowsIdentity.RunImpersonated(
-                    new SafeAccessTokenHandle(mutex.SafeWaitHandle.DangerousGetHandle()),
-                    () => { });
-            });
+                handle = new SafeAccessTokenHandle(mutex.SafeWaitHandle.DangerousGetHandle());
+                Assert.Throws<ArgumentException>(() => WindowsIdentity.RunImpersonated(handle, () => { }));
+            }
+            finally
+            {
+                handle?.SetHandleAsInvalid();
+            }
         }
     }
 


### PR DESCRIPTION
Hopefully fixes https://github.com/dotnet/corefx/issues/30713.
cc: @kouvel, @jkotas