### PR TITLE
Remove Is AppDomainUnloadedException check

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
@@ -201,7 +201,7 @@ namespace System.Threading
                     // that IAsyncInfo, because there's nothing Post can do with it (since Post returns void).
                     // So, to avoid these exceptions being lost forever, we post them to the ThreadPool.
                     //
-                    if (!(ex is ThreadAbortException) && !(ex is AppDomainUnloadedException))
+                    if (!(ex is ThreadAbortException))
                     {
                         if (!ExceptionSupport.ReportUnhandledError(ex))
                         {


### PR DESCRIPTION
According to Jan(https://github.com/dotnet/coreclr/pull/18681),  CLR won't throw AppDomainUnloadedException -- so it is OK to remove "is AppDomainUnloadedException" check.