### PR TITLE
Use Public CancellationTokenRegistration.Dispose

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreCLR.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreCLR.cs
@@ -69,7 +69,7 @@ namespace System.Threading.Tasks
                     }
 
                     if (disposeOfCtr)
-                        ctr.Unregister();
+                        ctr.Dispose();
                 }
             }
             catch (Exception ex)
@@ -148,7 +148,7 @@ namespace System.Threading.Tasks
                     ctr = _ctr; // under lock to avoid torn reads
                     _ctr = default(CancellationTokenRegistration);
                 }
-                ctr.Unregister(); // It's ok if we end up unregistering a not-initialized registration; it'll just be a nop.
+                ctr.Dispose(); // It's ok if we end up unregistering a not-initialized registration; it'll just be a nop.
 
                 try
                 {

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreCLR.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreCLR.cs
@@ -69,7 +69,7 @@ namespace System.Threading.Tasks
                     }
 
                     if (disposeOfCtr)
-                        ctr.Dispose();
+                        CancellationTokenRegistrationSupport.Unregister(ctr);
                 }
             }
             catch (Exception ex)
@@ -148,7 +148,7 @@ namespace System.Threading.Tasks
                     ctr = _ctr; // under lock to avoid torn reads
                     _ctr = default(CancellationTokenRegistration);
                 }
-                ctr.Dispose(); // It's ok if we end up unregistering a not-initialized registration; it'll just be a nop.
+                CancellationTokenRegistrationSupport.Unregister(ctr); // It's ok if we end up unregistering a not-initialized registration; it'll just be a nop.
 
                 try
                 {


### PR DESCRIPTION
Use Public API CancellationTokenRegistration.Dispose instead of CancellationTokenRegistration.Unregister()
In my mind, Dispose() is correct way but it may take a while to dispose it.