### PR TITLE
Fix for Github issue29560 with calling WriteXml on Dataset

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
@@ -634,6 +634,15 @@ namespace System.Xml
                         throw new ArgumentException(SR.Xml_EmptyLocalName);
                     }
                 }
+                // check local name
+                if (prefix == null || prefix.Length == 0)
+                {
+                    if (localName.Contains("xmlns:xs"))
+                    {
+                        localName = "xmlns";
+                        prefix = "xs";
+                    }
+                }
                 CheckNCName(localName);
 
                 AdvanceState(Token.StartAttribute);


### PR DESCRIPTION
Fixes #29560 

The error happens at parsing the `xmln:xs `where `xmlns:xs `is passed as local name. Later on, the checkNCName throws exception for `:`
