### PR TITLE
Fixing the names/parameter types for several Bmi1 HWIntrinsic methods

### DIFF
--- a/src/System.Runtime.Intrinsics.Experimental/ref/System.Runtime.Intrinsics.cs
+++ b/src/System.Runtime.Intrinsics.Experimental/ref/System.Runtime.Intrinsics.cs
@@ -793,14 +793,14 @@ namespace System.Runtime.Intrinsics.X86
         public static bool IsSupported { get { throw null; } }
         public static uint AndNot(uint left, uint right) { throw null; }
         public static ulong AndNot(ulong left, ulong right) { throw null; }
-        public static uint BitFieldExtract(uint value, uint start, uint length) { throw null; }
-        public static ulong BitFieldExtract(ulong value, ulong start, ulong length) { throw null; }
-        public static uint BitFieldExtract(uint value, uint control) { throw null; }
-        public static ulong BitFieldExtract(ulong value, ulong control) { throw null; }
+        public static uint BitFieldExtract(uint value, byte start, byte length) { throw null; }
+        public static ulong BitFieldExtract(ulong value, byte start, byte length) { throw null; }
+        public static uint BitFieldExtract(uint value, ushort control) { throw null; }
+        public static ulong BitFieldExtract(ulong value, ushort control) { throw null; }
         public static uint ExtractLowestSetBit(uint value) { throw null; }
         public static ulong ExtractLowestSetBit(ulong value) { throw null; }
-        public static uint GetMaskUptoLowestSetBit(uint value) { throw null; }
-        public static ulong GetMaskUptoLowestSetBit(ulong value) { throw null; }
+        public static uint GetMaskUpToLowestSetBit(uint value) { throw null; }
+        public static ulong GetMaskUpToLowestSetBit(ulong value) { throw null; }
         public static uint ResetLowestSetBit(uint value) { throw null; }
         public static ulong ResetLowestSetBit(ulong value) { throw null; }
         public static uint TrailingZeroCount(uint value) { throw null; }


### PR DESCRIPTION
The CoreFX counterpart to https://github.com/dotnet/coreclr/pull/18718