### PR TITLE
Moving sign.builds to run on full .NET Framework.

### DIFF
--- a/Documentation/coding-guidelines/project-guidelines.md
+++ b/Documentation/coding-guidelines/project-guidelines.md
@@ -15,8 +15,8 @@ once before you can iterate and work on a given library project.
 - Build product
  - Build src\src.builds which builds all the source library projects. For source library project information see [src](#src).
 - Sign product
- - Build src\sign.builds
-//**CONSIDER**: We should make this as part of the src.builds file instead of a separate .builds file.
+ - Build src\sign.proj
+//**CONSIDER**: We should make this as part of the src.builds file instead of a separate project file.
 
 ## Behind the scenes with build-test.cmd/sh
 - build-test.cmd cannot be ran successfully until build.cmd has been ran at least once for a `BuildConfiguration`.

--- a/build.proj
+++ b/build.proj
@@ -18,7 +18,7 @@
     <Project Include="src\dirs.proj" />
     <Project Include="src\tests.builds" Condition="'$(BuildTests)'=='true'" />
     <!-- signing must happen before packaging -->
-    <Project Include="src\sign.builds" />
+    <Project Include="src\sign.proj" />
     <Project Include="src\packages.builds" Condition="'$(BuildPackages)'=='true'" />
   </ItemGroup>
 

--- a/src/sign.builds
+++ b/src/sign.builds
@@ -36,7 +36,6 @@
   </Target>
 
   <Target Name="Build"
-          Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'public'"
           DependsOnTargets="GetFilesToSignItems;SignFiles">
 
     <!-- now that the files have been signed delete the marker files -->

--- a/src/sign.proj
+++ b/src/sign.proj
@@ -12,6 +12,7 @@
       <SignBuildArgs Include="/p:ConfigurationGroup=$(ConfigurationGroup)" />
       <SignBuildArgs Include="/p:RuntimeOS=$(RuntimeOS)" />
       <SignBuildArgs Include="/p:OfficialBuildId=$(OfficialBuildId)" />
+      <SignBuildArgs Include="/p:SignType=$(SignType)" />
     </ItemGroup>
     
     <!-- MicroBuild signing only supports being called from the full framework MSBuild -->

--- a/src/sign.proj
+++ b/src/sign.proj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="dir.props" />
+  <Import Project="..\dir.targets" />
+
+  <Target Name="Build"
+          Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'public'">
+
+    <ItemGroup>
+      <SignBuildArgs Include="/p:ArchGroup=$(ArchGroup)" />
+      <SignBuildArgs Include="/p:ConfigurationGroup=$(ConfigurationGroup)" />
+      <SignBuildArgs Include="/p:RuntimeOS=$(RuntimeOS)" />
+      <SignBuildArgs Include="/p:OfficialBuildId=$(OfficialBuildId)" />
+    </ItemGroup>
+    
+    <!-- MicroBuild signing only supports being called from the full framework MSBuild -->
+    <!-- Use the msbuild.exe that is on the %PATH% from run.cmd -->
+    <Exec Command="msbuild.exe sign.builds @(SignBuildArgs, ' ')"
+          LogStandardErrorAsError="true" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
MicroBuild signing doesn't work when MSBuild is running on .NET Core. So move the signing piece to use MSBuild on full framework.