### PR TITLE
Minor test fixes for UAP runs

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -138,6 +138,10 @@ namespace System.Diagnostics
         protected static readonly string TestConsoleApp;
         protected RemoteExecutorTestBase() { }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Action method, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
+        public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Action<string> method, string arg1, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
+        public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Action<string, string> method, string arg1, string arg2, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
+        public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Action<string, string, string> method, string arg1, string arg2, string arg3, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
+        public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Action<string, string, string, string> method, string arg1, string arg2, string arg3, string arg4, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<int> method, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, int> method, string arg, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, string, int> method, string arg1, string arg2, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -36,6 +36,73 @@ namespace System.Diagnostics
             return RemoteInvoke(GetMethodInfo(method), Array.Empty<string>(), options);
         }
 
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle RemoteInvoke(
+            Action<string> method,
+            string arg,
+            RemoteInvokeOptions options = null)
+        {
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
+
+            return RemoteInvoke(GetMethodInfo(method), new[] { arg }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle RemoteInvoke(
+            Action<string, string> method,
+            string arg1,
+            string arg2,
+            RemoteInvokeOptions options = null)
+        {
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
+
+            return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle RemoteInvoke(
+            Action<string, string, string> method,
+            string arg1,
+            string arg2,
+            string arg3,
+            RemoteInvokeOptions options = null)
+        {
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
+
+            return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2, arg3 }, options);
+        }   
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle RemoteInvoke(
+            Action<string, string, string, string> method,
+            string arg1,
+            string arg2,
+            string arg3,
+            string arg4,
+            RemoteInvokeOptions options = null)
+        {
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
+
+            return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4 }, options);
+        }
+
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="options">Options to use for the invocation.</param>

--- a/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -45,5 +45,11 @@
     <Compile Include="System\ComponentModel\DataAnnotations\ValidationResultTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\ValidatorTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
+  </ItemGroup>  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RangeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RangeAttributeTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Threading;
 using Xunit;
 
@@ -181,23 +182,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
             {
                 Thread.CurrentThread.CurrentCulture = _original;
             }
-        }
+        }      
 
         [Theory]
         [MemberData(nameof(DotDecimalRanges))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void ParseDotSeparatorExtremaInCommaSeparatorCultures(Type type, string min, string max)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2) =>
             {
-                Assert.True(new RangeAttribute(type, min, max).IsValid(null));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max);
+                Assert.True(new RangeAttribute(Type.GetType(t), m1, m2).IsValid(null));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");               
+
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2);
                 AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(null));
-            }
+            }, type.ToString(), min, max).Dispose();
         }
 
         [Theory]
@@ -205,23 +207,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void ParseDotSeparatorInvariantExtremaInCommaSeparatorCultures(Type type, string min, string max)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2) =>
             {
-                Assert.True(
-                    new RangeAttribute(type, min, max)
-                    {
-                        ParseLimitsInInvariantCulture = true
-                    }.IsValid(null));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
                 Assert.True(
-                    new RangeAttribute(type, min, max)
+                    new RangeAttribute(Type.GetType(t), m1, m2)
                     {
                         ParseLimitsInInvariantCulture = true
                     }.IsValid(null));
-            }
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                Assert.True(
+                    new RangeAttribute(Type.GetType(t), m1, m2)
+                    {
+                        ParseLimitsInInvariantCulture = true
+                    }.IsValid(null));
+            }, type.ToString(), min, max).Dispose();
         }
 
         [Theory]
@@ -229,16 +232,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void ParseCommaSeparatorExtremaInCommaSeparatorCultures(Type type, string min, string max)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max);
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(null));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                Assert.True(new RangeAttribute(type, min, max).IsValid(null));
-            }
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2);
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(null));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                Assert.True(new RangeAttribute(Type.GetType(t), m1, m2).IsValid(null));
+            }, type.ToString(), min, max).Dispose();
         }
 
         [Theory]
@@ -246,32 +250,34 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void ParseCommaSeparatorInvariantExtremaInCommaSeparatorCultures(Type type, string min, string max)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max);
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(null));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                Assert.True(new RangeAttribute(type, min, max).IsValid(null));
-            }
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2);
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(null));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                Assert.True(new RangeAttribute(Type.GetType(t), m1, m2).IsValid(null));
+            }, type.ToString(), min, max).Dispose();
         }
 
         [Theory][MemberData(nameof(DotDecimalValidValues))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndValues(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                Assert.True(new RangeAttribute(type, min, max).IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max);
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Assert.True(new RangeAttribute(Type.GetType(t), m1, m2).IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2);
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -279,23 +285,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndValuesInvariantParse(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
+
                 Assert.True(
-                    new RangeAttribute(type, min, max)
+                    new RangeAttribute(Type.GetType(t), m1, m2)
                     {
                         ParseLimitsInInvariantCulture = true
-                    }.IsValid(value));
-            }
+                    }.IsValid(v));
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -303,23 +310,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndValuesInvariantConvert(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
+
                 Assert.True(
-                    new RangeAttribute(type, min, max)
+                    new RangeAttribute(Type.GetType(t), m1, m2)
                     {
                         ConvertValueInInvariantCulture = true
-                    }.IsValid(value));
-            }
+                    }.IsValid(v));
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -327,27 +335,27 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndValuesInvariantBoth(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                Assert.True(
-                    new RangeAttribute(type, min, max)
-                    {
-                        ConvertValueInInvariantCulture = true,
-                        ParseLimitsInInvariantCulture = true
-                    }.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
                 Assert.True(
-                    new RangeAttribute(type, min, max)
+                    new RangeAttribute(Type.GetType(t), m1, m2)
                     {
                         ConvertValueInInvariantCulture = true,
                         ParseLimitsInInvariantCulture = true
-                    }.IsValid(value));
-            }
+                    }.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                Assert.True(
+                    new RangeAttribute(Type.GetType(t), m1, m2)
+                    {
+                        ConvertValueInInvariantCulture = true,
+                        ParseLimitsInInvariantCulture = true
+                    }.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
-
         [Theory]
         [MemberData(nameof(DotDecimalNonStringValidValues))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
@@ -528,21 +536,23 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
+
         [Theory]
         [MemberData(nameof(DotDecimalInvalidValues))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndInvalidValues(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                Assert.False(new RangeAttribute(type, min, max).IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max);
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Assert.False(new RangeAttribute(Type.GetType(t), m1, m2).IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2);
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -550,23 +560,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndInvalidValuesInvariantParse(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
+
                 Assert.False(
-                    new RangeAttribute(type, min, max)
+                    new RangeAttribute(Type.GetType(t), m1, m2)
                     {
                         ParseLimitsInInvariantCulture = true
-                    }.IsValid(value));
-            }
+                    }.IsValid(v));
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -574,23 +585,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndInvalidValuesInvariantConvert(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
+
                 Assert.False(
-                    new RangeAttribute(type, min, max)
+                    new RangeAttribute(Type.GetType(t), m1, m2)
                     {
                         ConvertValueInInvariantCulture = true
-                    }.IsValid(value));
-            }
+                    }.IsValid(v));
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -598,25 +610,26 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndInvalidValuesInvariantBoth(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                Assert.False(
-                    new RangeAttribute(type, min, max)
-                    {
-                        ConvertValueInInvariantCulture = true,
-                        ParseLimitsInInvariantCulture = true
-                    }.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
                 Assert.False(
-                    new RangeAttribute(type, min, max)
+                    new RangeAttribute(Type.GetType(t), m1, m2)
                     {
                         ConvertValueInInvariantCulture = true,
                         ParseLimitsInInvariantCulture = true
-                    }.IsValid(value));
-            }
+                    }.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                Assert.False(
+                    new RangeAttribute(Type.GetType(t), m1, m2)
+                    {
+                        ConvertValueInInvariantCulture = true,
+                        ParseLimitsInInvariantCulture = true
+                    }.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -624,16 +637,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndValues(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max);
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                Assert.True(new RangeAttribute(type, min, max).IsValid(value));
-            }
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2);
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+  
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                Assert.True(new RangeAttribute(Type.GetType(t), m1, m2).IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -641,23 +655,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndValuesInvariantParse(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max)
-                {
-                    ParseLimitsInInvariantCulture = true
-                };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                range = new RangeAttribute(Type.GetType(t), m1, m2)
+                {
+                    ParseLimitsInInvariantCulture = true
+                };
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -665,23 +680,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndValuesInvariantConvert(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max)
-                {
-                    ConvertValueInInvariantCulture = true
-                };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                range = new RangeAttribute(Type.GetType(t), m1, m2)
+                {
+                    ConvertValueInInvariantCulture = true
+                };
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -689,25 +705,26 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndValuesInvariantBoth(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max)
-                {
-                    ConvertValueInInvariantCulture = true,
-                    ParseLimitsInInvariantCulture = true
-                };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ConvertValueInInvariantCulture = true,
                     ParseLimitsInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                range = new RangeAttribute(Type.GetType(t), m1, m2)
+                {
+                    ConvertValueInInvariantCulture = true,
+                    ParseLimitsInInvariantCulture = true
+                };
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -715,16 +732,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndInvalidValues(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max);
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                Assert.False(new RangeAttribute(type, min, max).IsValid(value));
-            }
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2);
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                Assert.False(new RangeAttribute(Type.GetType(t), m1, m2).IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -732,23 +750,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndInvalidValuesInvariantParse(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max)
-                {
-                    ParseLimitsInInvariantCulture = true
-                };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                range = new RangeAttribute(Type.GetType(t), m1, m2)
+                {
+                    ParseLimitsInInvariantCulture = true
+                };
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -756,23 +775,24 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndInvalidValuesInvariantConvert(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max)
-                {
-                    ConvertValueInInvariantCulture = true
-                };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                range = new RangeAttribute(Type.GetType(t), m1, m2)
+                {
+                    ConvertValueInInvariantCulture = true
+                };
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]
@@ -780,25 +800,26 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndInvalidValuesInvariantBoth(Type type, string min, string max, string value)
         {
-            using (new TempCulture("en-US"))
+            RemoteInvoke((t, m1, m2, v) =>
             {
-                RangeAttribute range = new RangeAttribute(type, min, max)
-                {
-                    ConvertValueInInvariantCulture = true,
-                    ParseLimitsInInvariantCulture = true
-                };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-US");
 
-            using (new TempCulture("fr-FR"))
-            {
-                RangeAttribute range = new RangeAttribute(type, min, max)
+                RangeAttribute range = new RangeAttribute(Type.GetType(t), m1, m2)
                 {
                     ConvertValueInInvariantCulture = true,
                     ParseLimitsInInvariantCulture = true
                 };
-                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(value));
-            }
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+
+                range = new RangeAttribute(Type.GetType(t), m1, m2)
+                {
+                    ConvertValueInInvariantCulture = true,
+                    ParseLimitsInInvariantCulture = true
+                };
+                AssertExtensions.Throws<ArgumentException>("value", () => range.IsValid(v));
+            }, type.ToString(), min, max, value).Dispose();
         }
 
         [Theory]

--- a/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationAttributeTestBase.cs
+++ b/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationAttributeTestBase.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
 namespace System.ComponentModel.DataAnnotations.Tests
 {
-    public abstract class ValidationAttributeTestBase
+    public abstract class ValidationAttributeTestBase : RemoteExecutorTestBase
     {
         protected abstract IEnumerable<TestCase> ValidValues();
         protected abstract IEnumerable<TestCase> InvalidValues();

--- a/src/System.Threading.Overlapped/tests/HandleFactory.cs
+++ b/src/System.Threading.Overlapped/tests/HandleFactory.cs
@@ -14,21 +14,18 @@ internal static partial class HandleFactory
         return new Win32Handle(handle);
     }
 
-    public static Win32Handle CreateSyncFileHandleForWrite(string fileName = null)
+    public static Win32Handle CreateSyncFileHandleForWrite(string fileName)
     {
         return CreateHandle(async:false, fileName:fileName);
     }
 
-    public static Win32Handle CreateAsyncFileHandleForWrite(string fileName = null)
+    public static Win32Handle CreateAsyncFileHandleForWrite(string fileName)
     {
         return CreateHandle(async:true, fileName:fileName);
     }
 
-    private static unsafe Win32Handle CreateHandle(bool async, string fileName = null)
+    private static unsafe Win32Handle CreateHandle(bool async, string fileName)
     {
-        // Assume the current directory is writable
-        fileName = fileName ?? @"Overlapped.tmp";
-
         Win32Handle handle;
 #if !uap
         handle = DllImport.CreateFile(

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_BindHandleTests.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_BindHandleTests.cs
@@ -98,7 +98,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void BindHandle_DisposedSyncHandleAsHandle_ThrowsArgumentException()
     {
-        Win32Handle handle = HandleFactory.CreateSyncFileHandleForWrite();
+        Win32Handle handle = HandleFactory.CreateSyncFileHandleForWrite(GetTestFilePath());
         handle.Dispose();
 
         AssertExtensions.Throws<ArgumentException>("handle", () =>


### PR DESCRIPTION
1) Threading test was assuming it could write to CWD
2) RangeAttributeTests were changing culture inproc. On UWP, this affects all threads. Note, I only fixed most of the tests: the ones passing 'object' would need more work to marshal it to the child process accurately which I don't have time to do right now.