### PR TITLE
WIP: Support for OpenSSL 1.1 (and BoringSSL)

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
     {
         private static Version s_opensslVersion;
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SSLEayVersion")]
-        private static extern string OpenSslVersionDescription();
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslVersionNumber")]
+        private static extern uint OpenSslVersionNumber();
 
         internal static Version OpenSslVersion
         {
@@ -20,13 +20,8 @@ internal static partial class Interop
             {
                 if (s_opensslVersion == null)
                 {
-                    const string OpenSSL = "OpenSSL ";
-
-                    // Skip OpenSSL part, and get the version string of format x.y.z
-                    if (!Version.TryParse(OpenSslVersionDescription().AsSpan(OpenSSL.Length, 5).ToString(), out s_opensslVersion))
-                    {
-                        s_opensslVersion = new Version(0, 0, 0);
-                    }
+                    uint versionNumber = OpenSslVersionNumber();
+                    s_opensslVersion = new Version((int)(versionNumber >> 28), (int)((versionNumber >> 20) & 0xff), (int)((versionNumber >> 12) & 0xff));
                 }
 
                 return s_opensslVersion;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -2,6 +2,8 @@ project(System.Security.Cryptography.Native.Apple C)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+add_compile_options(-Wno-deprecated-declarations)
+
 add_definitions(-DPIC=1)
 
 find_library(COREFOUNDATION_LIBRARY CoreFoundation)

--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_compile_options(-Wno-cast-align)
 add_compile_options(-Wno-reserved-id-macro)
 add_compile_options(-Wno-documentation)
+add_compile_options(-Wno-used-but-marked-unused)
+add_compile_options(-Wno-cast-qual)
 
 add_definitions(-DPIC=1)
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -153,7 +153,7 @@ ASN1_TIME* CryptoNative_GetX509CrlNextUpdate(X509_CRL* crl)
 {
     if (crl)
     {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(OPENSSL_IS_BORINGSSL)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return X509_CRL_get_nextUpdate(crl);
 #else
         return X509_CRL_get0_nextUpdate(crl);
@@ -1354,13 +1354,13 @@ int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, const char** 
     return 0;
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 // Lock used to make sure EnsureopenSslInitialized itself is thread safe
 static pthread_mutex_t g_initLock = PTHREAD_MUTEX_INITIALIZER;
 
 // Set of locks initialized for OpenSSL
 static pthread_mutex_t* g_locks = NULL;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 /*
 Function:
 LockingCallback
@@ -1423,6 +1423,7 @@ non-zero on failure
 */
 int32_t CryptoNative_EnsureOpenSslInitialized()
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     int ret = 0;
     int numLocks = 0;
     int locksInitialized = 0;
@@ -1470,14 +1471,12 @@ int32_t CryptoNative_EnsureOpenSslInitialized()
         }
     }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
     // Initialize the callback
     CRYPTO_set_locking_callback(LockingCallback);
 
 #ifdef __APPLE__
     // OSX uses an earlier version of OpenSSL which requires setting the CRYPTO_set_id_callback
     CRYPTO_set_id_callback(GetCurrentThreadId);
-#endif
 #endif
 
     // Initialize the random number generator seed
@@ -1512,6 +1511,13 @@ done:
 
     pthread_mutex_unlock(&g_initLock);
     return ret;
+#else
+    // Initialize the random number generator seed
+    int randPollResult = RAND_poll();
+    if (randPollResult < 1)
+        return 4;
+    return 0;
+#endif
 }
 
 /*
@@ -1525,13 +1531,9 @@ Version number as MNNFFRBB major minor fix final beta/patch
 */
 uint32_t CryptoNative_OpenSslVersionNumber()
 {
-#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
-    if (API_EXISTS(OpenSSL_version_num))
-        return (uint32_t)OpenSSL_version_num();
-    if (API_EXISTS(SSLeay))
-        return (uint32_t)SSLeay();
-    return 0;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    return (uint32_t)SSLeay();
 #else
-    return OPENSSL_VERSION_NUMBER;
+    return (uint32_t)OpenSSL_version_num();
 #endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1095,7 +1095,7 @@ int32_t CryptoNative_BioTell(BIO* bio)
         return -1;
     }
 
-    return BIO_tell(bio);
+    return (int32_t)BIO_ctrl(bio, BIO_C_FILE_TELL, 0, NULL);
 }
 
 /*
@@ -1122,7 +1122,7 @@ int32_t CryptoNative_BioSeek(BIO* bio, int32_t ofs)
         return -1;
     }
 
-    return BIO_seek(bio, ofs);
+    return (int32_t)BIO_ctrl(bio, BIO_C_FILE_SEEK, ofs, NULL);
 }
 
 /*
@@ -1209,6 +1209,7 @@ int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, const char** 
 
     if (!oid)
     {
+#ifndef OPENSSL_IS_BORINGSSL
         unsigned long err = ERR_peek_last_error();
 
         // If the most recent error pushed onto the error queue is NOT from OID parsing
@@ -1217,6 +1218,7 @@ int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, const char** 
         {
             return -1;
         }
+#endif
 
         return 0;
     }

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1402,15 +1402,14 @@ done:
 
 /*
 Function:
-SSLEayVersion
+OpenSSL_version_num
 
 Gets the version of openssl library.
 
 Return values:
-Textual description of the version on success.
-"not available" string on failure.
+Version number as MNNFFRBB major minor fix final beta/patch
 */
-char* CryptoNative_SSLEayVersion()
+uint32_t CryptoNative_OpenSslVersionNumber()
 {
-    return strdup(SSLeay_version(SSLEAY_VERSION));
+    return (uint32_t)OpenSSL_version_num();
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -97,12 +97,17 @@ Return values:
 NULL if the validity cannot be determined, a pointer to the ASN1_TIME structure for the NotBefore value
 otherwise.
 */
-ASN1_TIME* CryptoNative_GetX509NotBefore(X509* x509)
+const ASN1_TIME* CryptoNative_GetX509NotBefore(X509* x509)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (x509 && x509->cert_info && x509->cert_info->validity)
     {
         return x509->cert_info->validity->notBefore;
     }
+#else
+    if (x509)
+        return X509_get0_notBefore(x509);
+#endif
 
     return NULL;
 }
@@ -118,12 +123,17 @@ Return values:
 NULL if the validity cannot be determined, a pointer to the ASN1_TIME structure for the NotAfter value
 otherwise.
 */
-ASN1_TIME* CryptoNative_GetX509NotAfter(X509* x509)
+const ASN1_TIME* CryptoNative_GetX509NotAfter(X509* x509)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (x509 && x509->cert_info && x509->cert_info->validity)
     {
         return x509->cert_info->validity->notAfter;
     }
+#else
+    if (x509)
+        return X509_get0_notAfter(x509);
+#endif
 
     return NULL;
 }
@@ -143,7 +153,11 @@ ASN1_TIME* CryptoNative_GetX509CrlNextUpdate(X509_CRL* crl)
 {
     if (crl)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(OPENSSL_IS_BORINGSSL)
         return X509_CRL_get_nextUpdate(crl);
+#else
+        return X509_CRL_get0_nextUpdate(crl);
+#endif
     }
 
     return NULL;
@@ -165,11 +179,16 @@ The encoded value of the version, otherwise:
 */
 int32_t CryptoNative_GetX509Version(X509* x509)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (x509 && x509->cert_info)
     {
         long ver = ASN1_INTEGER_get(x509->cert_info->version);
         return (int32_t)ver;
     }
+#else
+    if (x509)
+        return (int32_t)X509_get_version(x509);
+#endif
 
     return -1;
 }
@@ -187,10 +206,23 @@ describing the object type.
 */
 ASN1_OBJECT* CryptoNative_GetX509PublicKeyAlgorithm(X509* x509)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (x509 && x509->cert_info && x509->cert_info->key && x509->cert_info->key->algor)
     {
         return x509->cert_info->key->algor->algorithm;
     }
+#else
+    if (x509)
+    {
+        X509_PUBKEY* pubkey = X509_get_X509_PUBKEY(x509);        
+        if (pubkey)
+        {
+            ASN1_OBJECT* pkalg;
+            if (X509_PUBKEY_get0_param(&pkalg, NULL, NULL, NULL, pubkey))
+                return pkalg;
+        }
+    }
+#endif
 
     return NULL;
 }
@@ -208,10 +240,19 @@ describing the object type.
 */
 ASN1_OBJECT* CryptoNative_GetX509SignatureAlgorithm(X509* x509)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (x509 && x509->sig_alg && x509->sig_alg->algorithm)
     {
         return x509->sig_alg->algorithm;
     }
+#else
+    if (x509)
+    {
+        X509_ALGOR* sig_alg = X509_get0_tbs_sigalg(x509);
+        if (sig_alg)
+            return sig_alg->algorithm;
+    }    
+#endif
 
     return NULL;
 }
@@ -230,12 +271,27 @@ Any negative value: The input buffer size was reported as insufficient. A buffer
 */
 int32_t CryptoNative_GetX509PublicKeyParameterBytes(X509* x509, uint8_t* pBuf, int32_t cBuf)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!x509 || !x509->cert_info || !x509->cert_info->key || !x509->cert_info->key->algor)
     {
         return 0;
     }
 
     ASN1_TYPE* parameter = x509->cert_info->key->algor->parameter;
+#else
+    if (!x509)
+        return 0;
+
+    X509_PUBKEY* pubkey = X509_get_X509_PUBKEY(x509);        
+    if (!pubkey)
+        return 0;
+
+    X509_ALGOR* algor;
+    if (!X509_PUBKEY_get0_param(NULL, NULL, NULL, &algor, pubkey))
+        return 0;
+
+    ASN1_TYPE* parameter = algor->parameter;
+#endif
 
     if (!parameter)
     {
@@ -275,10 +331,15 @@ the public key.
 */
 ASN1_BIT_STRING* CryptoNative_GetX509PublicKeyBytes(X509* x509)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (x509 && x509->cert_info && x509->cert_info->key)
     {
         return x509->cert_info->key->public_key;
     }
+#else
+    if (x509)
+        return X509_get0_pubkey_bitstr(x509);
+#endif
 
     return NULL;
 }
@@ -353,6 +414,7 @@ Any negative value: The input buffer size was reported as insufficient. A buffer
 */
 int32_t CryptoNative_GetX509NameRawBytes(X509_NAME* x509Name, uint8_t* pBuf, int32_t cBuf)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!x509Name || !x509Name->bytes || cBuf < 0)
     {
         return 0;
@@ -388,6 +450,46 @@ int32_t CryptoNative_GetX509NameRawBytes(X509_NAME* x509Name, uint8_t* pBuf, int
 
     memcpy_s(pBuf, Int32ToSizeT(cBuf), x509Name->bytes->data, Int32ToSizeT(length));
     return 1;
+#else
+    const unsigned char *der;
+    size_t derlen;
+
+    if (!x509Name || cBuf < 0 || !X509_NAME_get0_der(x509Name, &der, &derlen))
+    {
+        return 0;
+    }
+
+    /*
+     * length is size_t on some platforms and int on others, so the comparisons
+     * are not tautological everywhere. We can let the compiler optimize away
+     * any part of the check that is. We split the size checks into two checks
+     * so we can get around the warnings on Linux where the Length is unsigned
+     * whereas Length is signed on OS X. The first check makes sure the variable
+     * value is less than INT_MAX in it's native format; once we know it is not
+     * too large, we can safely cast to an int to make sure it is not negative
+     */
+    if (derlen > INT_MAX)
+    {
+        assert(0 && "Huge length X509_NAME");
+        return 0;
+    }
+
+    int length = (int)derlen;
+
+    if (length < 0)
+    {
+        assert(0 && "Negative length X509_NAME");
+        return 0;
+    }
+
+    if (!pBuf || cBuf < length)
+    {
+        return -length;
+    }
+
+    memcpy_s(pBuf, Int32ToSizeT(cBuf), der, Int32ToSizeT(length));
+    return 1;
+#endif
 }
 
 /*
@@ -437,7 +539,7 @@ BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32_t forIssue
 {
     static const char szOidUpn[] = "1.3.6.1.4.1.311.20.2.3";
 
-    if (!x509 || !x509->cert_info || nameType < NAME_TYPE_SIMPLE || nameType > NAME_TYPE_URL)
+    if (!x509 || /*!x509->cert_info ||*/ nameType < NAME_TYPE_SIMPLE || nameType > NAME_TYPE_URL)
     {
         return NULL;
     }
@@ -454,7 +556,11 @@ BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32_t forIssue
     // UrlName: SAN.Entries.FirstOrDefault(type == GEN_URI);
     if (nameType == NAME_TYPE_SIMPLE)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         X509_NAME* name = forIssuer ? x509->cert_info->issuer : x509->cert_info->subject;
+#else
+        X509_NAME* name = forIssuer ? X509_get_issuer_name(x509) : X509_get_subject_name(x509);
+#endif
 
         if (name)
         {
@@ -629,7 +735,11 @@ BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32_t forIssue
 
     if (nameType == NAME_TYPE_EMAIL || nameType == NAME_TYPE_DNS)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         X509_NAME* name = forIssuer ? x509->cert_info->issuer : x509->cert_info->subject;
+#else
+        X509_NAME* name = forIssuer ? X509_get_issuer_name(x509) : X509_get_subject_name(x509);
+#endif
         int expectedNid = NID_undef;
 
         switch (nameType)
@@ -1250,6 +1360,7 @@ static pthread_mutex_t g_initLock = PTHREAD_MUTEX_INITIALIZER;
 // Set of locks initialized for OpenSSL
 static pthread_mutex_t* g_locks = NULL;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 /*
 Function:
 LockingCallback
@@ -1298,6 +1409,7 @@ static unsigned long GetCurrentThreadId()
     return tid;
 }
 #endif // __APPLE__
+#endif // OPENSSL_VERSION_NUMBER < 0x10100000L
 
 /*
 Function:
@@ -1358,12 +1470,14 @@ int32_t CryptoNative_EnsureOpenSslInitialized()
         }
     }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     // Initialize the callback
     CRYPTO_set_locking_callback(LockingCallback);
 
 #ifdef __APPLE__
     // OSX uses an earlier version of OpenSSL which requires setting the CRYPTO_set_id_callback
     CRYPTO_set_id_callback(GetCurrentThreadId);
+#endif
 #endif
 
     // Initialize the random number generator seed

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1411,5 +1411,13 @@ Version number as MNNFFRBB major minor fix final beta/patch
 */
 uint32_t CryptoNative_OpenSslVersionNumber()
 {
-    return (uint32_t)OpenSSL_version_num();
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
+    if (API_EXISTS(OpenSSL_version_num))
+        return (uint32_t)OpenSSL_version_num();
+    if (API_EXISTS(SSLeay))
+        return (uint32_t)SSLeay();
+    return 0;
+#else
+    return OPENSSL_VERSION_NUMBER;
+#endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
@@ -67,4 +67,4 @@ DLLEXPORT int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, con
 
 DLLEXPORT int32_t CryptoNative_EnsureOpenSslInitialized(void);
 
-DLLEXPORT char* CryptoNative_SSLEayVersion(void);
+DLLEXPORT uint32_t CryptoNative_OpenSslVersionNumber(void);

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
@@ -6,8 +6,7 @@
 #pragma once
 
 #include "pal_compiler.h"
-#include <openssl/x509.h>
-#include <openssl/x509v3.h>
+#include "opensslshim.h"
 
 DLLEXPORT int32_t CryptoNative_GetX509Thumbprint(X509* x509, uint8_t* pBuf, int32_t cBuf);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
@@ -11,9 +11,9 @@
 
 DLLEXPORT int32_t CryptoNative_GetX509Thumbprint(X509* x509, uint8_t* pBuf, int32_t cBuf);
 
-DLLEXPORT ASN1_TIME* CryptoNative_GetX509NotBefore(X509* x509);
+DLLEXPORT const ASN1_TIME* CryptoNative_GetX509NotBefore(X509* x509);
 
-DLLEXPORT ASN1_TIME* CryptoNative_GetX509NotAfter(X509* x509);
+DLLEXPORT const ASN1_TIME* CryptoNative_GetX509NotAfter(X509* x509);
 
 DLLEXPORT ASN1_TIME* CryptoNative_GetX509CrlNextUpdate(X509_CRL* crl);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -6,12 +6,14 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "opensslshim.h"
 
 // Define pointers to all the used ICU functions
 #define PER_FUNCTION_BLOCK(fn, isRequired) __typeof(fn) fn##_ptr;
 FOR_ALL_OPENSSL_FUNCTIONS
+FOR_ALL_OPENSSL_FUNCTIONS_STACK
 #undef PER_FUNCTION_BLOCK
 
 // x.x.x, considering the max number of decimal digits for each component

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -36,6 +36,54 @@
 
 #include "pal_crypto_config.h"
 
+#ifdef OPENSSL_IS_BORINGSSL
+#include "pal_utilities.h"
+#define sk_ASN1_OBJECT_num(stack) SizeTToInt32(sk_ASN1_OBJECT_num(stack))
+#define sk_ASN1_OBJECT_value(stack, i) sk_ASN1_OBJECT_value(stack, Int32ToSizeT(i))
+#define sk_GENERAL_NAME_num(stack) SizeTToInt32(sk_GENERAL_NAME_num(stack))
+#define sk_GENERAL_NAME_value(stack, i) sk_GENERAL_NAME_value(stack, Int32ToSizeT(i))
+#define sk_X509_num(stack) SizeTToInt32(sk_X509_num(stack))
+#define sk_X509_value(stack, i) sk_X509_value(stack, Int32ToSizeT(i))
+#define sk_X509_push(stack, p) SizeTToInt32(sk_X509_push(stack, p))
+#define sk_X509_NAME_num(stack) SizeTToInt32(sk_X509_NAME_num(stack))
+#define sk_X509_NAME_value(stack, i) sk_X509_NAME_value(stack, Int32ToSizeT(i))
+#define BN_bin2bn(in, len, ret) BN_bin2bn(in, Int32ToSizeT(len), ret)
+#define BN_bn2bin(in, out) SizeTToInt32(BN_bn2bin(in, out));
+#define BN_num_bytes(bn) Uint32ToInt32(BN_num_bytes(bn))
+#define RAND_bytes(buf, len) \
+        RAND_bytes(buf, Int32ToSizeT(len))
+#define DSA_generate_parameters_ex(dsa, bits, seed_in, seed_len, out_counter, out_h, cb) \
+        DSA_generate_parameters_ex(dsa, Int32ToUint32(bits), seed_in, seed_len, out_counter, out_h, cb)
+#define DSA_sign(type, digest, digest_len, out_sig, out_siglen, dsa) \
+        DSA_sign(type, digest, Int32ToSizeT(digest_len), out_sig, out_siglen, dsa)
+#define DSA_verify(type, digest, digest_len, sig, siglen, dsa) \
+        DSA_verify(type, digest, Int32ToSizeT(digest_len), sig, Int32ToSizeT(siglen), dsa)
+#define ECDSA_sign(type, digest, digest_len, out_sig, out_siglen, dsa) \
+        ECDSA_sign(type, digest, Int32ToSizeT(digest_len), out_sig, out_siglen, dsa)
+#define ECDSA_verify(type, digest, digest_len, sig, siglen, dsa) \
+        ECDSA_verify(type, digest, Int32ToSizeT(digest_len), sig, Int32ToSizeT(siglen), dsa)
+#define ECDSA_size(key) SizeTToInt32(ECDSA_size(key))
+#define EVP_MD_size(md) SizeTToInt32(EVP_MD_size(md))
+#define d2i_PKCS7(out_p7, ber_bytes, ber_len) \
+        d2i_PKCS7(out_p7, ber_bytes, Int32ToSizeT(ber_len))
+#define d2i_PKCS12(out_p12, ber_bytes, ber_len) \
+        d2i_PKCS12(out_p12, ber_bytes, Int32ToSizeT(ber_len))
+#define EVP_CIPHER_CTX_set_key_length(c, key_len) \
+        EVP_CIPHER_CTX_set_key_length(c, (unsigned)(key_len))
+#define HMAC_Init_ex(ctx, key, key_len, md, impl) \
+        HMAC_Init_ex(ctx, key, Int32ToSizeT(key_len), md, impl)
+#define RSA_size(key) SizeTToInt32(RSA_size(key))
+#define RSA_private_encrypt(flen, from, to, rsa, padding) \
+        RSA_private_encrypt(Int32ToSizeT(flen), from, to, rsa, padding)
+#define RSA_public_decrypt(flen, from, to, rsa, padding) \
+        RSA_public_decrypt(Int32ToSizeT(flen), from, to, rsa, padding)
+#define RSA_public_encrypt(flen, from, to, rsa, padding) \
+        RSA_public_encrypt(Int32ToSizeT(flen), from, to, rsa, padding)
+#define RSA_private_decrypt(flen, from, to, rsa, padding) \
+        RSA_private_decrypt(Int32ToSizeT(flen), from, to, rsa, padding)
+#define EC_GROUP_get_degree(group) (int)EC_GROUP_get_degree(group)
+#endif
+
 #ifdef FEATURE_DISTRO_AGNOSTIC_SSL
 
 #if !HAVE_OPENSSL_EC2M

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -9,6 +9,27 @@
 
 #pragma once
 
+// For OpenSSL 1.1+ we need to redefine the safe stack macros early to make
+// inline functions work.
+#include <openssl/opensslv.h>
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#include <openssl/stack.h>
+extern __typeof(OPENSSL_sk_free)* OPENSSL_sk_free_ptr;
+extern __typeof(OPENSSL_sk_new_null)* OPENSSL_sk_new_null_ptr;
+extern __typeof(OPENSSL_sk_num)* OPENSSL_sk_num_ptr;
+extern __typeof(OPENSSL_sk_pop_free)* OPENSSL_sk_pop_free_ptr;
+extern __typeof(OPENSSL_sk_value)* OPENSSL_sk_value_ptr;
+extern __typeof(OPENSSL_sk_push)* OPENSSL_sk_push_ptr;
+#define OPENSSL_sk_free OPENSSL_sk_free_ptr
+#define OPENSSL_sk_new_null OPENSSL_sk_new_null_ptr
+#define OPENSSL_sk_num OPENSSL_sk_num_ptr
+#define OPENSSL_sk_pop_free OPENSSL_sk_pop_free_ptr
+#define OPENSSL_sk_push OPENSSL_sk_push_ptr
+#define OPENSSL_sk_value OPENSSL_sk_value_ptr
+#endif
+#endif
+
 // All the openssl includes need to be here to ensure that the APIs we use
 // are overriden to be called through our function pointers.
 #include <openssl/asn1.h>
@@ -38,6 +59,8 @@
 
 #ifdef OPENSSL_IS_BORINGSSL
 #include "pal_utilities.h"
+
+// Add int/size_t casts to APIs that differ from OpenSSL
 #define sk_ASN1_OBJECT_num(stack) SizeTToInt32(sk_ASN1_OBJECT_num(stack))
 #define sk_ASN1_OBJECT_value(stack, i) sk_ASN1_OBJECT_value(stack, Int32ToSizeT(i))
 #define sk_GENERAL_NAME_num(stack) SizeTToInt32(sk_GENERAL_NAME_num(stack))
@@ -82,6 +105,18 @@
 #define RSA_private_decrypt(flen, from, to, rsa, padding) \
         RSA_private_decrypt(Int32ToSizeT(flen), from, to, rsa, padding)
 #define EC_GROUP_get_degree(group) (int)EC_GROUP_get_degree(group)
+#define ERR_reason_error_string(e) ERR_reason_error_string((uint32_t)(e))
+#define ERR_error_string_n(e, buf, len) ERR_error_string_n((uint32_t)(e), buf, len)
+
+// Missing API from OpenSSL 1.1
+#define X509_CRL_get0_nextUpdate X509_CRL_get_nextUpdate
+
+// BoringSSL doesn't use function codes for errors
+#define RSA_F_RSA_NULL_PRIVATE_DECRYPT 0
+#define RSA_F_RSA_NULL_PRIVATE_ENCRYPT 0
+#define RSA_F_RSA_SIGN 0
+#define DSA_F_DSA_DO_SIGN 0
+#define ERR_PUT_error ERR_put_error
 #endif
 
 #ifdef FEATURE_DISTRO_AGNOSTIC_SSL
@@ -118,7 +153,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
 // List of all functions from the libssl that are used in the System.Security.Cryptography.Native.
 // Forgetting to add a function here results in build failure with message reporting the function
 // that needs to be added.
-#define FOR_ALL_OPENSSL_FUNCTIONS \
+#define FOR_ALL_OPENSSL_FUNCTIONS_ALL_VERISONS \
     PER_FUNCTION_BLOCK(ASN1_BIT_STRING_free, true) \
     PER_FUNCTION_BLOCK(ASN1_INTEGER_get, true) \
     PER_FUNCTION_BLOCK(ASN1_OBJECT_free, true) \
@@ -145,12 +180,8 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(BN_free, true) \
     PER_FUNCTION_BLOCK(BN_new, true) \
     PER_FUNCTION_BLOCK(BN_num_bits, true) \
-    PER_FUNCTION_BLOCK(CRYPTO_add_lock, true) \
-    PER_FUNCTION_BLOCK(CRYPTO_num_locks, true) \
-    PER_FUNCTION_BLOCK(CRYPTO_set_locking_callback, true) \
     PER_FUNCTION_BLOCK(d2i_ASN1_BIT_STRING, true) \
     PER_FUNCTION_BLOCK(d2i_ASN1_OCTET_STRING, true) \
-    PER_FUNCTION_BLOCK(d2i_ASN1_type_bytes, true) \
     PER_FUNCTION_BLOCK(d2i_BASIC_CONSTRAINTS, true) \
     PER_FUNCTION_BLOCK(d2i_EXTENDED_KEY_USAGE, true) \
     PER_FUNCTION_BLOCK(d2i_PKCS12, true) \
@@ -166,7 +197,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(DSA_generate_key, true) \
     PER_FUNCTION_BLOCK(DSA_generate_parameters_ex, true) \
     PER_FUNCTION_BLOCK(DSA_new, true) \
-    PER_FUNCTION_BLOCK(DSA_OpenSSL, true) \
     PER_FUNCTION_BLOCK(DSA_sign, true) \
     PER_FUNCTION_BLOCK(DSA_size, true) \
     PER_FUNCTION_BLOCK(DSA_up_ref, true) \
@@ -211,7 +241,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(ERR_clear_error, true) \
     PER_FUNCTION_BLOCK(ERR_error_string_n, true) \
     PER_FUNCTION_BLOCK(ERR_get_error, true) \
-    PER_FUNCTION_BLOCK(ERR_load_crypto_strings, true) \
     PER_FUNCTION_BLOCK(ERR_put_error, true) \
     PER_FUNCTION_BLOCK(ERR_peek_error, true) \
     PER_FUNCTION_BLOCK(ERR_peek_last_error, true) \
@@ -222,9 +251,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(EVP_aes_192_ecb, true) \
     PER_FUNCTION_BLOCK(EVP_aes_256_cbc, true) \
     PER_FUNCTION_BLOCK(EVP_aes_256_ecb, true) \
-    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_cleanup, true) \
     PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_ctrl, true) \
-    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_init, true) \
     PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_set_key_length, true) \
     PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_set_padding, true) \
     PER_FUNCTION_BLOCK(EVP_CipherFinal_ex, true) \
@@ -239,8 +266,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(EVP_DigestUpdate, true) \
     PER_FUNCTION_BLOCK(EVP_get_digestbyname, true) \
     PER_FUNCTION_BLOCK(EVP_md5, true) \
-    PER_FUNCTION_BLOCK(EVP_MD_CTX_create, true) \
-    PER_FUNCTION_BLOCK(EVP_MD_CTX_destroy, true) \
     PER_FUNCTION_BLOCK(EVP_MD_size, true) \
     PER_FUNCTION_BLOCK(EVP_PKEY_CTX_free, true) \
     PER_FUNCTION_BLOCK(EVP_PKEY_CTX_new, true) \
@@ -263,8 +288,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(EVP_sha512, true) \
     PER_FUNCTION_BLOCK(EXTENDED_KEY_USAGE_free, true) \
     PER_FUNCTION_BLOCK(GENERAL_NAMES_free, true) \
-    PER_FUNCTION_BLOCK(HMAC_CTX_cleanup, true) \
-    PER_FUNCTION_BLOCK(HMAC_CTX_init, true) \
     PER_FUNCTION_BLOCK(HMAC_Final, true) \
     PER_FUNCTION_BLOCK(HMAC_Init_ex, true) \
     PER_FUNCTION_BLOCK(HMAC_Update, true) \
@@ -283,9 +306,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(OBJ_sn2nid, true) \
     PER_FUNCTION_BLOCK(OBJ_txt2nid, true) \
     PER_FUNCTION_BLOCK(OBJ_txt2obj, true) \
-    PER_FUNCTION_BLOCK(OPENSSL_add_all_algorithms_conf, true) \
     PER_FUNCTION_BLOCK(OPENSSL_cleanse, true) \
-    PER_FUNCTION_BLOCK(OpenSSL_version_num, false) \
     PER_FUNCTION_BLOCK(PEM_read_bio_PKCS7, true) \
     PER_FUNCTION_BLOCK(PEM_read_bio_X509_AUX, true) \
     PER_FUNCTION_BLOCK(PEM_read_bio_X509_CRL, true) \
@@ -312,12 +333,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(RSA_size, true) \
     PER_FUNCTION_BLOCK(RSA_up_ref, true) \
     PER_FUNCTION_BLOCK(RSA_verify, true) \
-    PER_FUNCTION_BLOCK(sk_free, true) \
-    PER_FUNCTION_BLOCK(sk_new_null, true) \
-    PER_FUNCTION_BLOCK(sk_num, true) \
-    PER_FUNCTION_BLOCK(sk_pop_free, true) \
-    PER_FUNCTION_BLOCK(sk_push, true) \
-    PER_FUNCTION_BLOCK(sk_value, true) \
     PER_FUNCTION_BLOCK(SSL_CIPHER_description, true) \
     PER_FUNCTION_BLOCK(SSL_ctrl, true) \
     PER_FUNCTION_BLOCK(SSL_set_quiet_shutdown, true) \
@@ -346,8 +361,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(SSL_get_SSL_CTX, true) \
     PER_FUNCTION_BLOCK(SSL_get_version, true) \
     PER_FUNCTION_BLOCK(SSL_get0_alpn_selected, false) \
-    PER_FUNCTION_BLOCK(SSL_library_init, true) \
-    PER_FUNCTION_BLOCK(SSL_load_error_strings, true) \
     PER_FUNCTION_BLOCK(SSL_new, true) \
     PER_FUNCTION_BLOCK(SSL_read, true) \
     PER_FUNCTION_BLOCK(SSL_renegotiate_pending, true) \
@@ -355,13 +368,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(SSL_set_bio, true) \
     PER_FUNCTION_BLOCK(SSL_set_connect_state, true) \
     PER_FUNCTION_BLOCK(SSL_shutdown, true) \
-    PER_FUNCTION_BLOCK(SSL_state, true) \
-    PER_FUNCTION_BLOCK(SSLeay, false) \
-    PER_FUNCTION_BLOCK(SSLv23_method, true) \
     PER_FUNCTION_BLOCK(SSL_write, true) \
-    PER_FUNCTION_BLOCK(TLSv1_1_method, true) \
-    PER_FUNCTION_BLOCK(TLSv1_2_method, true) \
-    PER_FUNCTION_BLOCK(TLSv1_method, true) \
     PER_FUNCTION_BLOCK(X509_check_issued, true) \
     PER_FUNCTION_BLOCK(X509_check_purpose, true) \
     PER_FUNCTION_BLOCK(X509_CRL_free, true) \
@@ -415,6 +422,92 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(EC_POINT_get_affine_coordinates_GF2m, false) \
     PER_FUNCTION_BLOCK(EC_POINT_set_affine_coordinates_GF2m, false) \
     
+#define FOR_ALL_OPENSSL_FUNCTIONS_1_0 \
+    PER_FUNCTION_BLOCK(CRYPTO_add_lock, true) \
+    PER_FUNCTION_BLOCK(CRYPTO_num_locks, true) \
+    PER_FUNCTION_BLOCK(CRYPTO_set_locking_callback, true) \
+    PER_FUNCTION_BLOCK(DSA_OpenSSL, true) \
+    PER_FUNCTION_BLOCK(ERR_load_crypto_strings, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_cleanup, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_init, true) \
+    PER_FUNCTION_BLOCK(EVP_MD_CTX_create, true) \
+    PER_FUNCTION_BLOCK(EVP_MD_CTX_destroy, true) \
+    PER_FUNCTION_BLOCK(HMAC_CTX_cleanup, true) \
+    PER_FUNCTION_BLOCK(HMAC_CTX_init, true) \
+    PER_FUNCTION_BLOCK(OPENSSL_add_all_algorithms_conf, true) \
+    PER_FUNCTION_BLOCK(sk_free, true) \
+    PER_FUNCTION_BLOCK(sk_new_null, true) \
+    PER_FUNCTION_BLOCK(sk_num, true) \
+    PER_FUNCTION_BLOCK(sk_pop_free, true) \
+    PER_FUNCTION_BLOCK(sk_push, true) \
+    PER_FUNCTION_BLOCK(sk_value, true) \
+    PER_FUNCTION_BLOCK(SSL_library_init, true) \
+    PER_FUNCTION_BLOCK(SSL_load_error_strings, true) \
+    PER_FUNCTION_BLOCK(SSL_state, true) \
+    PER_FUNCTION_BLOCK(SSLeay, true) \
+    PER_FUNCTION_BLOCK(SSLv23_method, true) \
+    PER_FUNCTION_BLOCK(TLSv1_1_method, true) \
+    PER_FUNCTION_BLOCK(TLSv1_2_method, true) \
+    PER_FUNCTION_BLOCK(TLSv1_method, true) \
+
+#define FOR_ALL_OPENSSL_FUNCTIONS_1_1 \
+    PER_FUNCTION_BLOCK(DSA_get0_key, true) \
+    PER_FUNCTION_BLOCK(DSA_get0_pqg, true) \
+    PER_FUNCTION_BLOCK(DSA_set0_key, true) \
+    PER_FUNCTION_BLOCK(DSA_set0_pqg, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_free, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_new, true) \
+    PER_FUNCTION_BLOCK(EVP_MD_CTX_new, true) \
+    PER_FUNCTION_BLOCK(EVP_MD_CTX_free, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_up_ref, true) \
+    PER_FUNCTION_BLOCK(HMAC_CTX_free, true) \
+    PER_FUNCTION_BLOCK(HMAC_CTX_new, true) \
+    PER_FUNCTION_BLOCK(RSA_get0_crt_params, true) \
+    PER_FUNCTION_BLOCK(RSA_get0_factors, true) \
+    PER_FUNCTION_BLOCK(RSA_get0_key, true) \
+    PER_FUNCTION_BLOCK(RSA_flags, true) \
+    PER_FUNCTION_BLOCK(RSA_set0_crt_params, true) \
+    PER_FUNCTION_BLOCK(RSA_set0_factors, true) \
+    PER_FUNCTION_BLOCK(RSA_set0_key, true) \
+    PER_FUNCTION_BLOCK(OpenSSL_version_num, true) \
+    PER_FUNCTION_BLOCK(SSL_CIPHER_get_bits, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_options, true) \
+    PER_FUNCTION_BLOCK(SSL_get_state, true) \
+    PER_FUNCTION_BLOCK(SSL_session_reused, true) \
+    PER_FUNCTION_BLOCK(TLS_method, true) \
+    PER_FUNCTION_BLOCK(X509_up_ref, true) \
+    PER_FUNCTION_BLOCK(X509_get_issuer_name, true) \
+    PER_FUNCTION_BLOCK(X509_get_subject_name, true) \
+    PER_FUNCTION_BLOCK(X509_get_version, true) \
+    PER_FUNCTION_BLOCK(X509_get_X509_PUBKEY, true) \
+    PER_FUNCTION_BLOCK(X509_get0_notAfter, true) \
+    PER_FUNCTION_BLOCK(X509_get0_notBefore, true) \
+    PER_FUNCTION_BLOCK(X509_get0_pubkey_bitstr, true) \
+    PER_FUNCTION_BLOCK(X509_get0_tbs_sigalg, true) \
+    PER_FUNCTION_BLOCK(X509_CRL_get0_nextUpdate, true) \
+    PER_FUNCTION_BLOCK(X509_NAME_get0_der, true) \
+    PER_FUNCTION_BLOCK(X509_PUBKEY_get0_param, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_get0_cert, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_get0_untrusted, true) \
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define FOR_ALL_OPENSSL_FUNCTIONS \
+    FOR_ALL_OPENSSL_FUNCTIONS_ALL_VERISONS \
+    FOR_ALL_OPENSSL_FUNCTIONS_1_0
+#define FOR_ALL_OPENSSL_FUNCTIONS_STACK
+#else
+#define FOR_ALL_OPENSSL_FUNCTIONS \
+    FOR_ALL_OPENSSL_FUNCTIONS_ALL_VERISONS \
+    FOR_ALL_OPENSSL_FUNCTIONS_1_1
+#define FOR_ALL_OPENSSL_FUNCTIONS_STACK \
+    PER_FUNCTION_BLOCK(OPENSSL_sk_free, true) \
+    PER_FUNCTION_BLOCK(OPENSSL_sk_new_null, true) \
+    PER_FUNCTION_BLOCK(OPENSSL_sk_num, true) \
+    PER_FUNCTION_BLOCK(OPENSSL_sk_pop_free, true) \
+    PER_FUNCTION_BLOCK(OPENSSL_sk_push, true) \
+    PER_FUNCTION_BLOCK(OPENSSL_sk_value, true)
+#endif
+
 // Declare pointers to all the used OpenSSL functions
 #define PER_FUNCTION_BLOCK(fn, isRequired) extern __typeof(fn)* fn##_ptr;
 FOR_ALL_OPENSSL_FUNCTIONS
@@ -448,9 +541,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define BN_free BN_free_ptr
 #define BN_new BN_new_ptr
 #define BN_num_bits BN_num_bits_ptr
-#define CRYPTO_add_lock CRYPTO_add_lock_ptr
-#define CRYPTO_num_locks CRYPTO_num_locks_ptr
-#define CRYPTO_set_locking_callback CRYPTO_set_locking_callback_ptr
 #define d2i_ASN1_BIT_STRING d2i_ASN1_BIT_STRING_ptr
 #define d2i_ASN1_OCTET_STRING d2i_ASN1_OCTET_STRING_ptr
 #define d2i_BASIC_CONSTRAINTS d2i_BASIC_CONSTRAINTS_ptr
@@ -468,7 +558,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define DSA_generate_key DSA_generate_key_ptr
 #define DSA_generate_parameters_ex DSA_generate_parameters_ex_ptr
 #define DSA_new DSA_new_ptr
-#define DSA_OpenSSL DSA_OpenSSL_ptr
 #define DSA_sign DSA_sign_ptr
 #define DSA_size DSA_size_ptr
 #define DSA_up_ref DSA_up_ref_ptr
@@ -513,7 +602,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define ERR_clear_error ERR_clear_error_ptr
 #define ERR_error_string_n ERR_error_string_n_ptr
 #define ERR_get_error ERR_get_error_ptr
-#define ERR_load_crypto_strings ERR_load_crypto_strings_ptr
 #define ERR_peek_error ERR_peek_error_ptr
 #define ERR_peek_last_error ERR_peek_last_error_ptr
 #define ERR_put_error ERR_put_error_ptr
@@ -524,9 +612,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_aes_192_ecb EVP_aes_192_ecb_ptr
 #define EVP_aes_256_cbc EVP_aes_256_cbc_ptr
 #define EVP_aes_256_ecb EVP_aes_256_ecb_ptr
-#define EVP_CIPHER_CTX_cleanup EVP_CIPHER_CTX_cleanup_ptr
 #define EVP_CIPHER_CTX_ctrl EVP_CIPHER_CTX_ctrl_ptr
-#define EVP_CIPHER_CTX_init EVP_CIPHER_CTX_init_ptr
 #define EVP_CIPHER_CTX_set_key_length EVP_CIPHER_CTX_set_key_length_ptr
 #define EVP_CIPHER_CTX_set_padding EVP_CIPHER_CTX_set_padding_ptr
 #define EVP_CipherFinal_ex EVP_CipherFinal_ex_ptr
@@ -541,8 +627,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_DigestUpdate EVP_DigestUpdate_ptr
 #define EVP_get_digestbyname EVP_get_digestbyname_ptr
 #define EVP_md5 EVP_md5_ptr
-#define EVP_MD_CTX_create EVP_MD_CTX_create_ptr
-#define EVP_MD_CTX_destroy EVP_MD_CTX_destroy_ptr
 #define EVP_MD_size EVP_MD_size_ptr
 #define EVP_PKEY_CTX_free EVP_PKEY_CTX_free_ptr
 #define EVP_PKEY_CTX_new EVP_PKEY_CTX_new_ptr
@@ -565,8 +649,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_sha512 EVP_sha512_ptr
 #define EXTENDED_KEY_USAGE_free EXTENDED_KEY_USAGE_free_ptr
 #define GENERAL_NAMES_free GENERAL_NAMES_free_ptr
-#define HMAC_CTX_cleanup HMAC_CTX_cleanup_ptr
-#define HMAC_CTX_init HMAC_CTX_init_ptr
 #define HMAC_Final HMAC_Final_ptr
 #define HMAC_Init_ex HMAC_Init_ex_ptr
 #define HMAC_Update HMAC_Update_ptr
@@ -585,9 +667,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define OBJ_sn2nid OBJ_sn2nid_ptr
 #define OBJ_txt2nid OBJ_txt2nid_ptr
 #define OBJ_txt2obj OBJ_txt2obj_ptr
-#define OPENSSL_add_all_algorithms_conf OPENSSL_add_all_algorithms_conf_ptr
 #define OPENSSL_cleanse OPENSSL_cleanse_ptr
-#define OpenSSL_version_num OpenSSL_version_num_ptr
 #define PEM_read_bio_PKCS7 PEM_read_bio_PKCS7_ptr
 #define PEM_read_bio_X509_AUX PEM_read_bio_X509_AUX_ptr
 #define PEM_read_bio_X509_CRL PEM_read_bio_X509_CRL_ptr
@@ -614,12 +694,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define RSA_size RSA_size_ptr
 #define RSA_up_ref RSA_up_ref_ptr
 #define RSA_verify RSA_verify_ptr
-#define sk_free sk_free_ptr
-#define sk_new_null sk_new_null_ptr
-#define sk_num sk_num_ptr
-#define sk_pop_free sk_pop_free_ptr
-#define sk_push sk_push_ptr
-#define sk_value sk_value_ptr
 #define SSL_CIPHER_description SSL_CIPHER_description_ptr
 #define SSL_ctrl SSL_ctrl_ptr
 #define SSL_set_quiet_shutdown SSL_set_quiet_shutdown_ptr
@@ -648,8 +722,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_get_SSL_CTX SSL_get_SSL_CTX_ptr
 #define SSL_get_version SSL_get_version_ptr
 #define SSL_get0_alpn_selected SSL_get0_alpn_selected_ptr
-#define SSL_library_init SSL_library_init_ptr
-#define SSL_load_error_strings SSL_load_error_strings_ptr
 #define SSL_new SSL_new_ptr
 #define SSL_read SSL_read_ptr
 #define SSL_renegotiate_pending SSL_renegotiate_pending_ptr
@@ -657,13 +729,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_set_bio SSL_set_bio_ptr
 #define SSL_set_connect_state SSL_set_connect_state_ptr
 #define SSL_shutdown SSL_shutdown_ptr
-#define SSL_state SSL_state_ptr
-#define SSLeay SSLeay_ptr
-#define SSLv23_method SSLv23_method_ptr
 #define SSL_write SSL_write_ptr
-#define TLSv1_1_method TLSv1_1_method_ptr
-#define TLSv1_2_method TLSv1_2_method_ptr
-#define TLSv1_method TLSv1_method_ptr
 #define X509_check_issued X509_check_issued_ptr
 #define X509_check_purpose X509_check_purpose_ptr
 #define X509_CRL_free X509_CRL_free_ptr
@@ -716,6 +782,74 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EC_GROUP_set_curve_GF2m EC_GROUP_set_curve_GF2m_ptr
 #define EC_POINT_get_affine_coordinates_GF2m EC_POINT_get_affine_coordinates_GF2m_ptr
 #define EC_POINT_set_affine_coordinates_GF2m EC_POINT_set_affine_coordinates_GF2m_ptr
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define CRYPTO_add_lock CRYPTO_add_lock_ptr
+#define CRYPTO_num_locks CRYPTO_num_locks_ptr
+#define CRYPTO_set_locking_callback CRYPTO_set_locking_callback_ptr
+#define DSA_OpenSSL DSA_OpenSSL_ptr
+#define ERR_load_crypto_strings ERR_load_crypto_strings_ptr
+#define EVP_CIPHER_CTX_cleanup EVP_CIPHER_CTX_cleanup_ptr
+#define EVP_CIPHER_CTX_init EVP_CIPHER_CTX_init_ptr
+#define EVP_MD_CTX_create EVP_MD_CTX_create_ptr
+#define EVP_MD_CTX_destroy EVP_MD_CTX_destroy_ptr
+#define HMAC_CTX_cleanup HMAC_CTX_cleanup_ptr
+#define HMAC_CTX_init HMAC_CTX_init_ptr
+#define OPENSSL_add_all_algorithms_conf OPENSSL_add_all_algorithms_conf_ptr
+#define sk_free sk_free_ptr
+#define sk_new_null sk_new_null_ptr
+#define sk_num sk_num_ptr
+#define sk_pop_free sk_pop_free_ptr
+#define sk_push sk_push_ptr
+#define sk_value sk_value_ptr
+#define SSL_library_init SSL_library_init_ptr
+#define SSL_load_error_strings SSL_load_error_strings_ptr
+#define SSL_state SSL_state_ptr
+#define SSLeay SSLeay_ptr
+#define SSLv23_method SSLv23_method_ptr
+#define TLSv1_1_method TLSv1_1_method_ptr
+#define TLSv1_2_method TLSv1_2_method_ptr
+#define TLSv1_method TLSv1_method_ptr
+#else
+#define DSA_get0_key DSA_get0_key_ptr
+#define DSA_get0_pqg DSA_get0_pqg_ptr
+#define DSA_set0_key DSA_set0_key_ptr
+#define DSA_set0_pqg DSA_set0_pqg_ptr
+#define EVP_CIPHER_CTX_free EVP_CIPHER_CTX_free_ptr
+#define EVP_CIPHER_CTX_new EVP_CIPHER_CTX_new_ptr
+#define EVP_MD_CTX_new EVP_MD_CTX_new_ptr
+#define EVP_MD_CTX_free EVP_MD_CTX_free_ptr
+#define EVP_PKEY_up_ref EVP_PKEY_up_ref_ptr
+#define HMAC_CTX_free HMAC_CTX_free_ptr
+#define HMAC_CTX_new HMAC_CTX_new_ptr
+#define RSA_get0_crt_params RSA_get0_crt_params_ptr
+#define RSA_get0_factors RSA_get0_factors_ptr
+#define RSA_get0_key RSA_get0_key_ptr
+#define RSA_flags RSA_flags_ptr
+#define RSA_set0_crt_params RSA_set0_crt_params_ptr
+#define RSA_set0_factors RSA_set0_factors_ptr
+#define RSA_set0_key RSA_set0_key_ptr
+#define OpenSSL_version_num OpenSSL_version_num_ptr
+#define SSL_CIPHER_get_bits SSL_CIPHER_get_bits_ptr
+#define SSL_CTX_set_options SSL_CTX_set_options_ptr
+#define SSL_get_state SSL_get_state_ptr
+#define SSL_session_reused SSL_session_reused_ptr
+#define TLS_method TLS_method_ptr
+#define X509_up_ref X509_up_ref_ptr
+#define X509_get_issuer_name X509_get_issuer_name_ptr
+#define X509_get_subject_name X509_get_subject_name_ptr
+#define X509_get_version X509_get_version_ptr
+#define X509_get_X509_PUBKEY X509_get_X509_PUBKEY_ptr
+#define X509_get0_notAfter X509_get0_notAfter_ptr
+#define X509_get0_notBefore X509_get0_notBefore_ptr
+#define X509_get0_pubkey_bitstr X509_get0_pubkey_bitstr_ptr
+#define X509_get0_tbs_sigalg X509_get0_tbs_sigalg_ptr
+#define X509_CRL_get0_nextUpdate X509_CRL_get0_nextUpdate_ptr
+#define X509_NAME_get0_der X509_NAME_get0_der_ptr
+#define X509_PUBKEY_get0_param X509_PUBKEY_get0_param_ptr
+#define X509_STORE_CTX_get0_cert X509_STORE_CTX_get0_cert_ptr
+#define X509_STORE_CTX_get0_untrusted X509_STORE_CTX_get0_untrusted_ptr
+#endif
 
 #else // FEATURE_DISTRO_AGNOSTIC_SSL
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -127,6 +127,8 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(ASN1_OCTET_STRING_set, true) \
     PER_FUNCTION_BLOCK(ASN1_STRING_free, true) \
     PER_FUNCTION_BLOCK(ASN1_STRING_print_ex, true) \
+    PER_FUNCTION_BLOCK(ASN1_STRING_set, true) \
+    PER_FUNCTION_BLOCK(ASN1_STRING_type_new, true) \
     PER_FUNCTION_BLOCK(BASIC_CONSTRAINTS_free, true) \
     PER_FUNCTION_BLOCK(BIO_ctrl, true) \
     PER_FUNCTION_BLOCK(BIO_ctrl_pending, true) \
@@ -283,6 +285,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(OBJ_txt2obj, true) \
     PER_FUNCTION_BLOCK(OPENSSL_add_all_algorithms_conf, true) \
     PER_FUNCTION_BLOCK(OPENSSL_cleanse, true) \
+    PER_FUNCTION_BLOCK(OpenSSL_version_num, false) \
     PER_FUNCTION_BLOCK(PEM_read_bio_PKCS7, true) \
     PER_FUNCTION_BLOCK(PEM_read_bio_X509_AUX, true) \
     PER_FUNCTION_BLOCK(PEM_read_bio_X509_CRL, true) \
@@ -353,7 +356,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(SSL_set_connect_state, true) \
     PER_FUNCTION_BLOCK(SSL_shutdown, true) \
     PER_FUNCTION_BLOCK(SSL_state, true) \
-    PER_FUNCTION_BLOCK(SSLeay_version, true) \
+    PER_FUNCTION_BLOCK(SSLeay, false) \
     PER_FUNCTION_BLOCK(SSLv23_method, true) \
     PER_FUNCTION_BLOCK(SSL_write, true) \
     PER_FUNCTION_BLOCK(TLSv1_1_method, true) \
@@ -427,6 +430,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define ASN1_OCTET_STRING_set ASN1_OCTET_STRING_set_ptr
 #define ASN1_STRING_free ASN1_STRING_free_ptr
 #define ASN1_STRING_print_ex ASN1_STRING_print_ex_ptr
+#define ASN1_STRING_set ASN1_STRING_set_ptr
+#define ASN1_STRING_type_new ASN1_STRING_type_new_ptr
 #define BASIC_CONSTRAINTS_free BASIC_CONSTRAINTS_free_ptr
 #define BIO_ctrl BIO_ctrl_ptr
 #define BIO_ctrl_pending BIO_ctrl_pending_ptr
@@ -448,7 +453,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define CRYPTO_set_locking_callback CRYPTO_set_locking_callback_ptr
 #define d2i_ASN1_BIT_STRING d2i_ASN1_BIT_STRING_ptr
 #define d2i_ASN1_OCTET_STRING d2i_ASN1_OCTET_STRING_ptr
-#define d2i_ASN1_type_bytes d2i_ASN1_type_bytes_ptr
 #define d2i_BASIC_CONSTRAINTS d2i_BASIC_CONSTRAINTS_ptr
 #define d2i_EXTENDED_KEY_USAGE d2i_EXTENDED_KEY_USAGE_ptr
 #define d2i_PKCS12 d2i_PKCS12_ptr
@@ -583,6 +587,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define OBJ_txt2obj OBJ_txt2obj_ptr
 #define OPENSSL_add_all_algorithms_conf OPENSSL_add_all_algorithms_conf_ptr
 #define OPENSSL_cleanse OPENSSL_cleanse_ptr
+#define OpenSSL_version_num OpenSSL_version_num_ptr
 #define PEM_read_bio_PKCS7 PEM_read_bio_PKCS7_ptr
 #define PEM_read_bio_X509_AUX PEM_read_bio_X509_AUX_ptr
 #define PEM_read_bio_X509_CRL PEM_read_bio_X509_CRL_ptr
@@ -653,7 +658,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_set_connect_state SSL_set_connect_state_ptr
 #define SSL_shutdown SSL_shutdown_ptr
 #define SSL_state SSL_state_ptr
-#define SSLeay_version SSLeay_version_ptr
+#define SSLeay SSLeay_ptr
 #define SSLv23_method SSLv23_method_ptr
 #define SSL_write SSL_write_ptr
 #define TLSv1_1_method TLSv1_1_method_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1_print.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1_print.c
@@ -32,15 +32,11 @@ ASN1_STRING* CryptoNative_DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, A
         return NULL;
     }
 
-#ifdef OPENSSL_IS_BORINGSSL
-    #pragma unused(buf)
-    #pragma unused(len)
-    #pragma unused(type)
-    assert(false);
-    return NULL;
-#else
-    return d2i_ASN1_type_bytes(NULL, &buf, len, (int32_t)type);
-#endif
+    ASN1_STRING* string = ASN1_STRING_type_new((int32_t)type);
+    if (string)
+        ASN1_STRING_set(string, buf, len);
+    
+    return string;
 }
 
 int32_t CryptoNative_Asn1StringPrintEx(BIO* out, ASN1_STRING* str, Asn1StringPrintFlags flags)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1_print.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1_print.c
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_asn1_print.h"
+#include "pal_utilities.h"
 
 c_static_assert(PAL_B_ASN1_NUMERICSTRING == B_ASN1_NUMERICSTRING);
 c_static_assert(PAL_B_ASN1_PRINTABLESTRING == B_ASN1_PRINTABLESTRING);
@@ -31,7 +32,15 @@ ASN1_STRING* CryptoNative_DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, A
         return NULL;
     }
 
+#ifdef OPENSSL_IS_BORINGSSL
+    #pragma unused(buf)
+    #pragma unused(len)
+    #pragma unused(type)
+    assert(false);
+    return NULL;
+#else
     return d2i_ASN1_type_bytes(NULL, &buf, len, (int32_t)type);
+#endif
 }
 
 int32_t CryptoNative_Asn1StringPrintEx(BIO* out, ASN1_STRING* str, Asn1StringPrintFlags flags)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1_print.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1_print.h
@@ -39,7 +39,7 @@ typedef enum
 } Asn1StringPrintFlags;
 
 /*
-Shims the d2i_ASN1_type_bytes method and makes it easier to invoke from managed code.
+Shims the ASN1_STRING_type_new and ASN1_STRING_type_set methods and makes it easier to invoke from managed code.
 */
 DLLEXPORT ASN1_STRING* CryptoNative_DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.c
@@ -66,11 +66,19 @@ int32_t CryptoNative_DsaSign(
         return 0;
     }
 
+#ifdef OPENSSL_IS_BORINGSSL
+    if (dsa->priv_key == NULL)
+#else
     // DSA_OpenSSL() returns a shared pointer, no need to free/cache.
     if (dsa->meth == DSA_OpenSSL() && dsa->priv_key == NULL)
+#endif
     {
         *outSignatureLength = 0;
+#ifndef OPENSSL_IS_BORINGSSL
         ERR_PUT_error(ERR_LIB_DSA, DSA_F_DSA_DO_SIGN, DSA_R_MISSING_PARAMETERS, __FILE__, __LINE__);
+#else
+        OPENSSL_PUT_ERROR(DSA, DSA_R_MISSING_PARAMETERS);
+#endif
         return 0;
     }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.c
@@ -11,8 +11,8 @@ static ECCurveType GroupToCurveType(EC_GROUP* group)
     switch (EC_GROUP_get_curve_name(group)) {
         case NID_secp384r1:
         case NID_secp224r1:
-            return PrimeMontgomery;
         case NID_secp521r1:
+            return PrimeMontgomery;
         case NID_X9_62_prime256v1:
         default:
             return PrimeShortWeierstrass;

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_err.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_err.c
@@ -39,10 +39,18 @@ uint64_t CryptoNative_ErrPeekLastError()
 
 const char* CryptoNative_ErrReasonErrorString(uint64_t error)
 {
+#ifdef OPENSSL_IS_BORINGSSL
+    return ERR_reason_error_string((uint32_t)error);
+#else
     return ERR_reason_error_string((unsigned long)error);
+#endif
 }
 
 void CryptoNative_ErrErrorStringN(uint64_t e, char* buf, int32_t len)
 {
+#ifdef OPENSSL_IS_BORINGSSL
+    ERR_error_string_n((uint32_t)e, buf, Int32ToSizeT(len));
+#else
     ERR_error_string_n((unsigned long)e, buf, Int32ToSizeT(len));
+#endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_err.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_err.c
@@ -39,18 +39,10 @@ uint64_t CryptoNative_ErrPeekLastError()
 
 const char* CryptoNative_ErrReasonErrorString(uint64_t error)
 {
-#ifdef OPENSSL_IS_BORINGSSL
-    return ERR_reason_error_string((uint32_t)error);
-#else
     return ERR_reason_error_string((unsigned long)error);
-#endif
 }
 
 void CryptoNative_ErrErrorStringN(uint64_t e, char* buf, int32_t len)
 {
-#ifdef OPENSSL_IS_BORINGSSL
-    ERR_error_string_n((uint32_t)e, buf, Int32ToSizeT(len));
-#else
     ERR_error_string_n((unsigned long)e, buf, Int32ToSizeT(len));
-#endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -18,7 +18,11 @@ CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char
 EVP_CIPHER_CTX*
 CryptoNative_EvpCipherCreate2(const EVP_CIPHER* type, uint8_t* key, int32_t keyLength, int32_t effectiveKeyLength, unsigned char* iv, int32_t enc)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX* ctx = (EVP_CIPHER_CTX*)malloc(sizeof(EVP_CIPHER_CTX));
+#else
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+#endif
     if (ctx == NULL)
     {
         // Allocation failed

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -182,9 +182,5 @@ const EVP_CIPHER* CryptoNative_EvpRC2Ecb()
 
 const EVP_CIPHER* CryptoNative_EvpRC2Cbc()
 {
-#ifdef OPENSSL_NO_RC2
-    return NULL;
-#else
     return EVP_rc2_cbc();
-#endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -29,7 +29,9 @@ CryptoNative_EvpCipherCreate2(const EVP_CIPHER* type, uint8_t* key, int32_t keyL
         return NULL;
     }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_init(ctx);
+#endif
 
     // Perform partial initialization so we can set the key lengths
     int ret = EVP_CipherInit_ex(ctx, type, NULL, NULL, NULL, 0);
@@ -76,8 +78,12 @@ void CryptoNative_EvpCipherDestroy(EVP_CIPHER_CTX* ctx)
 {
     if (ctx != NULL)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         EVP_CIPHER_CTX_cleanup(ctx);
         free(ctx);
+#else
+        EVP_CIPHER_CTX_free(ctx);
+#endif
     }
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -173,10 +173,18 @@ const EVP_CIPHER* CryptoNative_EvpDes3Cbc()
 
 const EVP_CIPHER* CryptoNative_EvpRC2Ecb()
 {
+#ifdef OPENSSL_NO_RC2
+    return NULL;
+#else
     return EVP_rc2_ecb();
+#endif
 }
 
 const EVP_CIPHER* CryptoNative_EvpRC2Cbc()
 {
+#ifdef OPENSSL_NO_RC2
+    return NULL;
+#else
     return EVP_rc2_cbc();
+#endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey.c
@@ -24,11 +24,11 @@ int32_t CryptoNative_UpRefEvpPkey(EVP_PKEY* pkey)
         return 0;
     }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    return CRYPTO_add(&pkey->references, 1, CRYPTO_LOCK_EVP_PKEY);
+#else
     if (EVP_PKEY_up_ref(pkey))
         return 42;
     return 0;
-#else
-    return CRYPTO_add(&pkey->references, 1, CRYPTO_LOCK_EVP_PKEY);
 #endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey.c
@@ -24,5 +24,9 @@ int32_t CryptoNative_UpRefEvpPkey(EVP_PKEY* pkey)
         return 0;
     }
 
+#ifdef OPENSSL_IS_BORINGSSL
+    return EVP_PKEY_up_ref(pkey);
+#else
     return CRYPTO_add(&pkey->references, 1, CRYPTO_LOCK_EVP_PKEY);
+#endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey.c
@@ -25,7 +25,9 @@ int32_t CryptoNative_UpRefEvpPkey(EVP_PKEY* pkey)
     }
 
 #ifdef OPENSSL_IS_BORINGSSL
-    return EVP_PKEY_up_ref(pkey);
+    if (EVP_PKEY_up_ref(pkey))
+        return 42;
+    return 0;
 #else
     return CRYPTO_add(&pkey->references, 1, CRYPTO_LOCK_EVP_PKEY);
 #endif

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.c
@@ -14,7 +14,11 @@ HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_
     assert(keyLen >= 0);
     assert(md != NULL);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX* ctx = (HMAC_CTX*)malloc(sizeof(HMAC_CTX));
+#else
+    HMAC_CTX* ctx = HMAC_CTX_new();
+#endif
     if (ctx == NULL)
     {
         // Allocation failed
@@ -27,7 +31,9 @@ HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_
     if (keyLen == 0)
         key = &_;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX_init(ctx);
+#endif
     int ret = HMAC_Init_ex(ctx, key, keyLen, md, NULL);
 
     if (!ret)
@@ -43,8 +49,12 @@ void CryptoNative_HmacDestroy(HMAC_CTX* ctx)
 {
     if (ctx != NULL)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         HMAC_CTX_cleanup(ctx);
         free(ctx);
+#else
+        HMAC_CTX_free(ctx);
+#endif
     }
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
@@ -12,8 +12,10 @@
 //   * Managed code remains resilient to changes in size of HMAC_CTX across platforms
 
 // Forward declarations - shim API must not depend on knowing layout of these types.
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 typedef struct hmac_ctx_st HMAC_CTX;
 typedef struct env_md_st EVP_MD;
+#endif
 
 /**
  * Creates and initializes an HMAC_CTX with the given key and EVP_MD.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
@@ -12,6 +12,7 @@
 //   * Managed code remains resilient to changes in size of HMAC_CTX across platforms
 
 // Forward declarations - shim API must not depend on knowing layout of these types.
+// OpenSSL 1.1+ already uses opaque structures.
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 typedef struct hmac_ctx_st HMAC_CTX;
 typedef struct env_md_st EVP_MD;

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs12.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs12.c
@@ -54,6 +54,7 @@ int32_t CryptoNative_Pkcs12Parse(PKCS12* p12, const char* pass, EVP_PKEY** pkey,
         ERR_clear_error();
 
 #ifdef OPENSSL_IS_BORINGSSL
+        // BoringSSL returns the CA certificates in reverse order.
         if (ca != NULL)
         {
             X509Stack *new_ca = sk_X509_new_null();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs12.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs12.c
@@ -30,7 +30,7 @@ void CryptoNative_Pkcs12Destroy(PKCS12* p12)
 PKCS12* CryptoNative_Pkcs12Create(char* pass, EVP_PKEY* pkey, X509* cert, X509Stack* ca)
 {
     return PKCS12_create(
-        pass, NULL, pkey, cert, ca, NID_undef, NID_undef, PKCS12_DEFAULT_ITER, PKCS12_DEFAULT_ITER, 0);
+        pass, NULL, pkey, cert, ca, NID_undef, NID_undef, 0, 0, 0);
 }
 
 int32_t CryptoNative_GetPkcs12DerSize(PKCS12* p12)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.c
@@ -26,6 +26,10 @@ PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp)
 
 PKCS7* CryptoNative_Pkcs7CreateSigned()
 {
+#ifdef OPENSSL_IS_BORINGSSL
+    assert(false);
+    return NULL;
+#else
     PKCS7* pkcs7 = PKCS7_new();
 
     if (pkcs7 == NULL)
@@ -40,6 +44,7 @@ PKCS7* CryptoNative_Pkcs7CreateSigned()
     }
 
     return pkcs7;
+#endif
 }
 
 void CryptoNative_Pkcs7Destroy(PKCS7* p7)
@@ -72,12 +77,18 @@ int32_t CryptoNative_GetPkcs7Certificates(PKCS7* p7, X509Stack** certs)
 
 int32_t CryptoNative_Pkcs7AddCertificate(PKCS7* p7, X509* x509)
 {
+#ifdef OPENSSL_IS_BORINGSSL
+    #pragma unused(p7)
+    #pragma unused(x509)
+    return 0;
+#else
     if (p7 == NULL || x509 == NULL)
     {
         return 0;
     }
 
     return PKCS7_add_certificate(p7, x509);
+#endif
 }
 
 int32_t CryptoNative_GetPkcs7DerSize(PKCS7* p7)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.c
@@ -27,7 +27,7 @@ PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp)
 PKCS7* CryptoNative_Pkcs7CreateSigned()
 {
 #ifdef OPENSSL_IS_BORINGSSL
-    assert(false);
+    // assert(false);
     return NULL;
 #else
     PKCS7* pkcs7 = PKCS7_new();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.c
@@ -53,6 +53,7 @@ static int HasNoPrivateKey(RSA* rsa)
     if (rsa == NULL)
         return 1;
 
+#ifndef OPENSSL_IS_BORINGSSL
     // Shared pointer, don't free.
     const RSA_METHOD* meth = RSA_get_method(rsa);
 
@@ -60,6 +61,7 @@ static int HasNoPrivateKey(RSA* rsa)
     // That doesn't mean it's actually present, but we can't tell.
     if (meth->flags & RSA_FLAG_EXT_PKEY)
         return 0;
+#endif
 
     // In the event that there's a middle-ground where we report failure when success is expected,
     // one could do something like check if the RSA_METHOD intercepts all private key operations:
@@ -93,7 +95,11 @@ CryptoNative_RsaPrivateDecrypt(int32_t flen, const uint8_t* from, uint8_t* to, R
 {
     if (HasNoPrivateKey(rsa))
     {
-        ERR_PUT_error(ERR_LIB_RSA, RSA_F_RSA_PRIVATE_DECRYPT, RSA_R_VALUE_MISSING, __FILE__, __LINE__);
+#ifdef OPENSSL_IS_BORINGSSL
+        OPENSSL_PUT_ERROR(RSA, RSA_R_VALUE_MISSING);
+#else
+        ERR_put_error(ERR_LIB_RSA, RSA_F_RSA_PRIVATE_DECRYPT, RSA_R_VALUE_MISSING, __FILE__, __LINE__);
+#endif
         return -1;
     }
 
@@ -105,7 +111,11 @@ int32_t CryptoNative_RsaSignPrimitive(int32_t flen, const uint8_t* from, uint8_t
 {
     if (HasNoPrivateKey(rsa))
     {
-        ERR_PUT_error(ERR_LIB_RSA, RSA_F_RSA_PRIVATE_ENCRYPT, RSA_R_VALUE_MISSING, __FILE__, __LINE__);
+#ifdef OPENSSL_IS_BORINGSSL
+        OPENSSL_PUT_ERROR(RSA, RSA_R_VALUE_MISSING);
+#else
+        ERR_put_error(ERR_LIB_RSA, RSA_F_RSA_PRIVATE_ENCRYPT, RSA_R_VALUE_MISSING, __FILE__, __LINE__);
+#endif
         return -1;
     }
 
@@ -140,7 +150,11 @@ CryptoNative_RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigr
 
     if (HasNoPrivateKey(rsa))
     {
-        ERR_PUT_error(ERR_LIB_RSA, RSA_F_RSA_SIGN, RSA_R_VALUE_MISSING, __FILE__, __LINE__);
+#ifdef OPENSSL_IS_BORINGSSL
+        OPENSSL_PUT_ERROR(RSA, RSA_R_VALUE_MISSING);
+#else
+        ERR_put_error(ERR_LIB_RSA, RSA_F_RSA_SIGN, RSA_R_VALUE_MISSING, __FILE__, __LINE__);
+#endif
         return 0;
     }
 
@@ -151,7 +165,11 @@ CryptoNative_RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigr
     // we have to check that the digest size matches what we expect.
     if (digest != NULL && mlen != EVP_MD_size(digest))
     {
-        ERR_PUT_error(ERR_LIB_RSA, RSA_F_RSA_SIGN, RSA_R_INVALID_MESSAGE_LENGTH, __FILE__, __LINE__);
+#ifdef OPENSSL_IS_BORINGSSL
+        OPENSSL_PUT_ERROR(RSA, RSA_R_INVALID_MESSAGE_LENGTH);
+#else
+        ERR_put_error(ERR_LIB_RSA, RSA_F_RSA_SIGN, RSA_R_INVALID_MESSAGE_LENGTH, __FILE__, __LINE__);
+#endif
         return 0;
     }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -54,6 +54,9 @@ static long TrySetECDHNamedCurve(SSL_CTX* ctx)
 {
 	long result = 0;
 #ifdef SSL_CTX_set_ecdh_auto
+#ifdef OPENSSL_IS_BORINGSSL
+	#pragma unused(ctx)
+#endif
 	result = SSL_CTX_set_ecdh_auto(ctx, 1);
 #else
 	EC_KEY *ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
@@ -75,7 +78,7 @@ void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
         return;
     }
 
-    long protocolOptions = 0;
+    uint32_t protocolOptions = 0;
 
     if ((protocols & PAL_SSL_SSL2) != PAL_SSL_SSL2)
     {
@@ -396,7 +399,7 @@ int32_t CryptoNative_GetSslConnectionInfo(SSL* ssl,
         goto err;
     }
 
-    *dataKeySize = cipher->alg_bits;
+    SSL_CIPHER_get_bits(cipher, dataKeySize);
     if (GetSslConnectionInfoFromDescription(cipher, dataCipherAlg, keyExchangeAlg, dataHashAlg, hashKeySize))
     {
         return 1;
@@ -513,6 +516,12 @@ CryptoNative_SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallba
 // below string is corresponding to "AllowNoEncryption"
 #define SSL_TXT_Separator ":"
 #define SSL_TXT_Exclusion "!"
+#ifndef SSL_TXT_aNULL
+#define SSL_TXT_aNULL "aNULL"
+#endif
+#ifndef SSL_TXT_eNULL
+#define SSL_TXT_eNULL "eNULL"
+#endif
 #define SSL_TXT_AllIncludingNull SSL_TXT_ALL SSL_TXT_Separator SSL_TXT_eNULL
 #define SSL_TXT_NotAnon SSL_TXT_Separator SSL_TXT_Exclusion SSL_TXT_aNULL
 
@@ -612,6 +621,6 @@ void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const uint8_t** protocol, uint32
 
 int32_t CryptoNative_SslSetTlsExtHostName(SSL* ssl, uint8_t* name)
 {
-    return (int32_t)SSL_set_tlsext_host_name(ssl, name);
+    return (int32_t)SSL_set_tlsext_host_name(ssl, (const char *)name);
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -54,7 +54,7 @@ static long TrySetECDHNamedCurve(SSL_CTX* ctx)
 {
 	long result = 0;
 #ifdef SSL_CTX_set_ecdh_auto
-#ifdef OPENSSL_IS_BORINGSSL
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	#pragma unused(ctx)
 #endif
 	result = SSL_CTX_set_ecdh_auto(ctx, 1);
@@ -456,7 +456,11 @@ int32_t CryptoNative_SslDoHandshake(SSL* ssl)
 
 int32_t CryptoNative_IsSslStateOK(SSL* ssl)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     return SSL_state(ssl) == SSL_ST_OK;
+#else
+    return SSL_get_state(ssl) == TLS_ST_OK;
+#endif
 }
 
 X509* CryptoNative_SslGetPeerCertificate(SSL* ssl)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -20,8 +20,10 @@ int32_t CryptoNative_EnsureOpenSslInitialized(void);
 void CryptoNative_EnsureLibSslInitialized()
 {
     CryptoNative_EnsureOpenSslInitialized();
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     SSL_library_init();
     SSL_load_error_strings();
+#endif
 }
 
 const SSL_METHOD* CryptoNative_SslV2_3Method()

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -303,7 +303,11 @@ X509* CryptoNative_X509UpRef(X509* x509)
 {
     if (x509 != NULL)
     {
+#ifdef OPENSSL_IS_BORINGSSL
+        X509_up_ref(x509);
+#else
         CRYPTO_add(&x509->references, 1, CRYPTO_LOCK_X509);
+#endif
     }
 
     return x509;

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -231,12 +231,20 @@ X509Stack* CryptoNative_X509StoreCtxGetChain(X509_STORE_CTX* ctx)
 
 X509Stack* CryptoNative_X509StoreCtxGetSharedUntrusted(X509_STORE_CTX* ctx)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     return ctx ? ctx->untrusted : NULL;
+#else    
+    return ctx ? X509_STORE_CTX_get0_untrusted(ctx) : NULL;
+#endif
 }
 
 X509* CryptoNative_X509StoreCtxGetTargetCert(X509_STORE_CTX* ctx)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     return ctx ? ctx->cert : NULL;
+#else    
+    return ctx ? X509_STORE_CTX_get0_cert(ctx) : NULL;
+#endif
 }
 
 X509VerifyStatusCode CryptoNative_X509StoreCtxGetError(X509_STORE_CTX* ctx)
@@ -303,10 +311,10 @@ X509* CryptoNative_X509UpRef(X509* x509)
 {
     if (x509 != NULL)
     {
-#ifdef OPENSSL_IS_BORINGSSL
-        X509_up_ref(x509);
-#else
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         CRYPTO_add(&x509->references, 1, CRYPTO_LOCK_X509);
+#else
+        X509_up_ref(x509);
 #endif
     }
 


### PR DESCRIPTION
- FEATURE_DISTRO_AGNOSTIC_SSL works only for the same OpenSSL version, ie. when compiled against OpenSSL 1.0.x it will work on systems with 1.0.x, but not with 1.1.x, and vice-versa.
- BoringSSL support is compilable against the latest GIT, but `CryptoNative_Pkcs7CreateSigned`/`CryptoNative_Pkcs7AddCertificate` is not implemented yet and couple of ECC tests fail (probably due to missing APIs on BoringSSL side).