### PR TITLE
Add test to ensure FromBase64 bug doesn't regress.

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Convert.FromBase64.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.FromBase64.cs
@@ -208,6 +208,29 @@ namespace System.Tests
             VerifyInvalidInput("abcdab==abcd");
             VerifyInvalidInput("abcda===abcd");
             VerifyInvalidInput("abcd====abcd");
+
+            // Input must not contain extra trailing padding characters
+            VerifyInvalidInput("=");
+            VerifyInvalidInput("abc===");
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void ExtraPaddingCharacter()
+        {
+            VerifyInvalidInput("abcdxyz=" + "=");
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void ExtraPaddingCharacterOnNetFx()
+        {
+            // This should throw a FormatException because of the extra "=". But due to a bug in NetFx, this 
+            // gets "successfully" decoded as if it were "abcdyz==".
+
+            byte[] actual = Convert.FromBase64String("abcdxyz=" + "=");
+            byte[] expected = { 0x69, 0xb7, 0x1d, 0xcb };
+            Assert.Equal<byte>(expected, actual);
         }
 
         [Fact]


### PR DESCRIPTION
Convert.FromBase64() had a subtle bug where an illicit
second padding character at the end of the string caused
the decode to "succeed" by dropping the fifth to
last character.

We inadvertently fixed this bug while optimizing that
api in .NetCore 2.1. Adding test to document bug and
ensure we don't regress.

Details in https://github.com/dotnet/corefx/issues/30793