### PR TITLE
Proper fix for compilation issue caused by deprecated API in Mojave

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -25,9 +25,6 @@ set(NATIVECRYPTO_SOURCES
     pal_x509chain.c
 )
 
-# Temporary workaround for dotnet/corefx issue #30599
-add_compile_options(-Wno-deprecated-declarations)
-
 add_library(System.Security.Cryptography.Native.Apple
     SHARED
     ${NATIVECRYPTO_SOURCES}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.c
@@ -61,7 +61,7 @@ AppleCryptoNative_X509GetPublicKey(SecCertificateRef cert, SecKeyRef* pPublicKey
         *pOSStatusOut = noErr;
 
     if (cert == NULL || pPublicKeyOut == NULL || pOSStatusOut == NULL)
-        return kErrorBadInput;
+        return kErrorUnknownState;
 
     pthread_once (&once, InitCertificateCopy);
     // SecCertificateCopyPublicKey was deprecated in 10.14, so use SecCertificateCopyKey on the systems that have it (10.14+),
@@ -70,10 +70,13 @@ AppleCryptoNative_X509GetPublicKey(SecCertificateRef cert, SecKeyRef* pPublicKey
     {
         *pPublicKeyOut = (*secCertificateCopyKey)(cert);
     }
+    else if (secCertificateCopyPublicKey != NULL)
+    {
+        *pOSStatusOut = (*secCertificateCopyPublicKey)(cert, pPublicKeyOut);
+    }
     else
     {
-        assert(secCertificateCopyPublicKey != NULL);
-        *pOSStatusOut = (*secCertificateCopyPublicKey)(cert, pPublicKeyOut);
+        return kErrorBadInput;
     }
     return (*pOSStatusOut == noErr);
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.h
@@ -42,7 +42,7 @@ Returns 1 on success, 0 on failure, any other value on invalid state.
 
 Output:
 pPublicKeyOut: Receives a CFRetain()ed SecKeyRef for the public key
-pOSStatusOut: Receives the result of SecCertificateCopyPublicKey
+pOSStatusOut: Receives the result of SecCertificateCopyKey or SecCertificateCopyPublicKey, depending on the OS version.
 */
 DLLEXPORT int32_t
 AppleCryptoNative_X509GetPublicKey(SecCertificateRef cert, SecKeyRef* pPublicKeyOut, int32_t* pOSStatusOut);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/X509Pal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/X509Pal.cs
@@ -33,6 +33,11 @@ namespace Internal.Cryptography.Pal
                         case Oids.RsaRsa:
                             return new RSAImplementation.RSASecurityTransforms(key);
                         case Oids.DsaDsa:
+                            if (key.IsInvalid) 
+                            {
+                                // SecCertificateCopyKey returns null for DSA, so fall back to manually building it.
+                                return DecodeDsaPublicKey(encodedKeyValue, encodedParameters);
+                            } 
                             return new DSAImplementation.DSASecurityTransforms(key);
                         case Oids.Ecc:
                             return new ECDsaImplementation.ECDsaSecurityTransforms(key);


### PR DESCRIPTION
Proper fix for compilation issue caused by deprecated API in macOS Mojave by

using dlsym to call available API rather than suppressing deprecation warnings.

Fixes: #30599

cc: @janvorli, @bartonjs, @danmosemsft 