### PR TITLE
Allows include build number for packages blocked from going stable

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -93,6 +93,15 @@
     </BinPlaceConfiguration>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(BlockStable)' == 'true'">
+    <!--
+      If BlockStable is set to true then always include the label and build number in the package version.
+      This needs to be set before we import packaging.targets which comes in the Build.Common.targets.
+    -->
+    <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>
+    <IncludeBuildNumberInPackageVersion>true</IncludeBuildNumberInPackageVersion>
+  </PropertyGroup>
+
   <Import Project="$(ToolsDir)/Build.Common.targets" Condition="Exists('$(ToolsDir)/Build.Common.targets')" />
 
   <!-- permit a wrapping build system to contribute targets to this build -->


### PR DESCRIPTION
For any packages that we doin't want to ship and marked as
BlockStable we should always force include the label and
build number in the package name.

cc @mmitche @ericstj 

This changes (3) and (4) from the original commit https://github.com/dotnet/corefx/commit/4fcf6cfc6de83755ce4b540a50c9849e7eaf634a.

3. StabilizePackageVersions=true, PackageVersionStamp='label'
- Packages not marked BlockStable will have prelease label 'label'
  and no build number
- BlockStable packages will have a prelease label 'label' and build
  number

4. StabilizePackageVersions=true, PackageVersionStamp=''
- Packages not marked BlockStable will not have a prelease label
  or build number, and thus have a stable version.
- BlockStable packages will have the prelease label commited in the
  repo and build number
