### PR TITLE
Add CompareInfo and Span.IndexOf with string comparison benchmark tests

### DIFF
--- a/src/System.Globalization/tests/Performance/Perf.CompareInfo.cs
+++ b/src/System.Globalization/tests/Performance/Perf.CompareInfo.cs
@@ -4,21 +4,46 @@
 
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Collections.Generic;
 
 namespace System.Globalization.Tests
 {
     public class Perf_CompareInfo
     {
-        [Benchmark]
-        [InlineData("string1", "string2", CompareOptions.None)]
-        [InlineData("StrIng", "string", CompareOptions.IgnoreCase)]
-        [InlineData("StrIng", "string", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("\u3060", "\u305F", CompareOptions.None)]
-        [InlineData("ABCDE", "c", CompareOptions.None)]
-        [InlineData("$", "&", CompareOptions.IgnoreSymbols)]
-        public void Compare(string string1, string string2, CompareOptions options)
+        private static string GenerateInputString(char source, int count, char replaceChar, int replacePos)
         {
-            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            char[] str = new char[count];
+            for (int i = 0; i < count; i++)
+            {
+                str[i] = replaceChar;
+            }
+            str[replacePos] = replaceChar;
+
+            return new string(str);
+        }
+
+        public static IEnumerable<object[]> s_compareTestData = new List<object[]>
+        {
+            new object[] { "", "string1", "string2", CompareOptions.None },
+            new object[] { "tr-TR", "StrIng", "string", CompareOptions.IgnoreCase },
+            new object[] { "en-US", "StrIng", "string", CompareOptions.OrdinalIgnoreCase },
+            new object[] { "", "\u3060", "\u305F", CompareOptions.None },
+            new object[] { "ja-JP", "ABCDE", "c", CompareOptions.None },
+            new object[] { "es-ES", "$", "&", CompareOptions.IgnoreSymbols },
+            new object[] { "", GenerateInputString('A', 10, '5', 5), GenerateInputString('A', 10, '5', 6), CompareOptions.Ordinal },
+            new object[] { "", GenerateInputString('A', 100, 'X', 70), GenerateInputString('A', 100, 'X', 70), CompareOptions.OrdinalIgnoreCase },
+            new object[] { "ja-JP", GenerateInputString('A', 100, 'X', 70), GenerateInputString('A', 100, 'x', 70), CompareOptions.OrdinalIgnoreCase },
+            new object[] { "en-US", GenerateInputString('A', 1000, 'X', 500), GenerateInputString('A', 1000, 'X', 500), CompareOptions.None },
+            new object[] { "en-US", GenerateInputString('\u3060', 1000, 'x', 500), GenerateInputString('\u3060', 1000, 'x', 10), CompareOptions.None },
+            new object[] { "es-ES", GenerateInputString('\u3060', 100, '\u3059', 50), GenerateInputString('\u3060', 100, '\u3059', 50), CompareOptions.Ordinal },
+            new object[] { "tr-TR", GenerateInputString('\u3060', 5000, '\u3059', 2501), GenerateInputString('\u3060', 5000, '\u3059', 2500), CompareOptions.Ordinal }
+        };
+
+        [Benchmark]
+        [MemberData(nameof(s_compareTestData))]
+        public void Compare(string culture, string string1, string string2, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.GetCultureInfo(culture).CompareInfo;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
@@ -26,17 +51,32 @@ namespace System.Globalization.Tests
                 }
         }
 
-        [Benchmark]
-        [InlineData("foo", "", CompareOptions.None)]
-        [InlineData("foobardzsdzs", "rddzs", CompareOptions.Ordinal)]
-        [InlineData("Hello", "L", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.IgnoreCase)]
-        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace)]
-        [InlineData("More Test's", "Tests", CompareOptions.IgnoreSymbols)]
-        public void IndexOf(string source, string value, CompareOptions options)
+        public static IEnumerable<object[]> s_indexTestData = new List<object[]>
         {
-            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            new object[] { "", "string1", "string2", CompareOptions.None },
+            new object[] { "", "foobardzsdzs", "rddzs", CompareOptions.IgnoreCase },
+            new object[] { "en-US", "StrIng", "string", CompareOptions.OrdinalIgnoreCase },
+            new object[] { "", "\u3060", "\u305F", CompareOptions.None },
+            new object[] { "ja-JP", "ABCDE", "c", CompareOptions.None },
+            new object[] { "", "$", "&", CompareOptions.IgnoreSymbols },
+            new object[] { "", "More Test's", "Tests", CompareOptions.IgnoreSymbols },
+            new object[] { "es-ES", "TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace },
+            new object[] { "en-US", "Hello WorldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylongHello WorldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylongHello Worldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylong!xyz", "~", CompareOptions.Ordinal },
+            new object[] { "en-US", "Hello WorldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylongHello WorldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylongHello Worldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylong!xyz", "w", CompareOptions.OrdinalIgnoreCase },
+            new object[] { "es-ES", "Hello Worldbbbbbbbbbbbbbbcbbbbbbbbbbbbbbbbbbba!", "y", CompareOptions.Ordinal },
+            new object[] { "", GenerateInputString('A', 10, '5', 5), "5", CompareOptions.Ordinal },
+            new object[] { "", GenerateInputString('A', 100, 'X', 70), "x", CompareOptions.OrdinalIgnoreCase },
+            new object[] { "ja-JP", GenerateInputString('A', 100, 'X', 70), "x", CompareOptions.OrdinalIgnoreCase },
+            new object[] { "en-US", GenerateInputString('A', 1000, 'X', 500), "X", CompareOptions.None },
+            new object[] { "en-US", GenerateInputString('\u3060', 1000, 'x', 500), "x", CompareOptions.None },
+            new object[] { "es-ES", GenerateInputString('\u3060', 100, '\u3059', 50), "\u3059", CompareOptions.Ordinal }
+        };
+
+        [Benchmark]
+        [MemberData(nameof(s_indexTestData))]
+        public void IndexOf(string culture, string source, string value, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.GetCultureInfo(culture).CompareInfo;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
@@ -45,16 +85,10 @@ namespace System.Globalization.Tests
         }
 
         [Benchmark]
-        [InlineData("foo", "", CompareOptions.None)]
-        [InlineData("foobardzsdzs", "rddzs", CompareOptions.Ordinal)]
-        [InlineData("Hello", "L", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.IgnoreCase)]
-        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace)]
-        [InlineData("More Test's", "Tests", CompareOptions.IgnoreSymbols)]
-        public void LastIndexOf(string source, string value, CompareOptions options)
+        [MemberData(nameof(s_indexTestData))]
+        public void LastIndexOf(string culture, string source, string value, CompareOptions options)
         {
-            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            CompareInfo compareInfo = CultureInfo.GetCultureInfo(culture).CompareInfo;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
@@ -62,17 +96,30 @@ namespace System.Globalization.Tests
                 }
         }
 
-        [Benchmark]
-        [InlineData("foo", "", CompareOptions.None)]
-        [InlineData("foobardzsdzs", "rddzs", CompareOptions.Ordinal)]
-        [InlineData("Hello", "L", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.IgnoreCase)]
-        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace)]
-        [InlineData("More Test's", "Tests", CompareOptions.IgnoreSymbols)]
-        public void IsPrefix(string source, string prefix, CompareOptions options)
+        public static IEnumerable<object[]> s_prefixTestData = new List<object[]>
         {
-            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            new object[] { "", "string1", "str", CompareOptions.None },
+            new object[] { "", "foobardzsdzs", "FooBarDZ", CompareOptions.IgnoreCase },
+            new object[] { "en-US", "StrIng", "str", CompareOptions.OrdinalIgnoreCase },
+            new object[] { "", "\u3060", "\u305F", CompareOptions.None },
+            new object[] { "ja-JP", "ABCDE", "cd", CompareOptions.None },
+            new object[] { "", "$", "&", CompareOptions.IgnoreSymbols },
+            new object[] { "", "More's Test's", "More", CompareOptions.IgnoreSymbols },
+            new object[] { "es-ES", "TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace },
+            new object[] { "es-ES", "Hello Worldbbbbbbbbbbbbbbcbbbbbbbbbbbbbbbbbbba!", "Hello World", CompareOptions.Ordinal },
+            new object[] { "", GenerateInputString('A', 10, '5', 5), "AAAAA", CompareOptions.Ordinal },
+            new object[] { "", GenerateInputString('A', 100, 'X', 70), new string('a', 30), CompareOptions.OrdinalIgnoreCase },
+            new object[] { "ja-JP", GenerateInputString('A', 100, 'X', 70), new string('a', 70), CompareOptions.OrdinalIgnoreCase },
+            new object[] { "en-US", GenerateInputString('A', 1000, 'X', 500), new string('A', 500), CompareOptions.None },
+            new object[] { "en-US", GenerateInputString('\u3060', 1000, 'x', 500), new string('\u3060', 30), CompareOptions.None },
+            new object[] { "es-ES", GenerateInputString('\u3060', 100, '\u3059', 50), "\u3060text", CompareOptions.Ordinal }
+        };
+
+        [Benchmark]
+        [MemberData(nameof(s_prefixTestData))]
+        public void IsPrefix(string culture, string source, string prefix, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.GetCultureInfo(culture).CompareInfo;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
@@ -80,17 +127,29 @@ namespace System.Globalization.Tests
                 }
         }
 
-        [Benchmark]
-        [InlineData("foo", "", CompareOptions.None)]
-        [InlineData("foobardzsdzs", "rddzs", CompareOptions.Ordinal)]
-        [InlineData("Hello", "L", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.IgnoreCase)]
-        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.OrdinalIgnoreCase)]
-        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace)]
-        [InlineData("More Test's", "Tests", CompareOptions.IgnoreSymbols)]
-        public void IsSuffix(string source, string suffix, CompareOptions options)
+        public static IEnumerable<object[]> s_suffixTestData = new List<object[]>
         {
-            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            new object[] { "", "string1", "ing1", CompareOptions.None },
+            new object[] { "", "foobardzsdzs", "DZsDzS", CompareOptions.IgnoreCase },
+            new object[] { "en-US", "StrIng", "str", CompareOptions.OrdinalIgnoreCase },
+            new object[] { "", "\u3060", "\u305F", CompareOptions.IgnoreSymbols },
+            new object[] { "ja-JP", "ABCDE", "E", CompareOptions.None },
+            new object[] { "", "$", "&", CompareOptions.IgnoreSymbols },
+            new object[] { "", "More's Test's", "Test", CompareOptions.IgnoreSymbols },
+            new object[] { "es-ES", "TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace },
+            new object[] { "", GenerateInputString('A', 10, '5', 5), "5AAAA", CompareOptions.Ordinal },
+            new object[] { "", GenerateInputString('A', 100, 'X', 70), new string('a', 30), CompareOptions.OrdinalIgnoreCase },
+            new object[] { "ja-JP", GenerateInputString('A', 100, 'X', 70), "x" + new string('a', 29), CompareOptions.OrdinalIgnoreCase },
+            new object[] { "en-US", GenerateInputString('A', 1000, 'X', 100), new string('A', 900), CompareOptions.None },
+            new object[] { "en-US", GenerateInputString('\u3060', 1000, 'x', 500), new string('\u3060', 30), CompareOptions.None },
+            new object[] { "es-ES", GenerateInputString('\u3060', 100, '\u3059', 50), "\u3060text", CompareOptions.Ordinal }
+        };
+
+        [Benchmark]
+        [MemberData(nameof(s_suffixTestData))]
+        public void IsSuffix(string culture, string source, string suffix, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.GetCultureInfo(culture).CompareInfo;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                 {
@@ -101,10 +160,11 @@ namespace System.Globalization.Tests
         [Benchmark]
         [InlineData("foo")]
         [InlineData("Exhibit \u00C0")]
-        [InlineData("TestFooBA\u0300R")]
+        [InlineData("TestFooBA\u0300RnotsolongTELLme")]
         [InlineData("More Test's")]
         [InlineData("$")]
         [InlineData("\u3060")]
+        [InlineData("Hello WorldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylongHello WorldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylongHello Worldbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbareallyreallylong!xyz")]
         public void IsSortable(string text)
         {
             foreach (var iteration in Benchmark.Iterations)

--- a/src/System.Globalization/tests/Performance/Perf.CompareInfo.cs
+++ b/src/System.Globalization/tests/Performance/Perf.CompareInfo.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Globalization.Tests
+{
+    public class Perf_CompareInfo
+    {
+        [Benchmark]
+        [InlineData("string1", "string2", CompareOptions.None)]
+        [InlineData("StrIng", "string", CompareOptions.IgnoreCase)]
+        [InlineData("StrIng", "string", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("\u3060", "\u305F", CompareOptions.None)]
+        [InlineData("ABCDE", "c", CompareOptions.None)]
+        [InlineData("$", "&", CompareOptions.IgnoreSymbols)]
+        public void Compare(string string1, string string2, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                {
+                    compareInfo.Compare(string1, string2, options);
+                }
+        }
+
+        [Benchmark]
+        [InlineData("foo", "", CompareOptions.None)]
+        [InlineData("foobardzsdzs", "rddzs", CompareOptions.Ordinal)]
+        [InlineData("Hello", "L", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.IgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace)]
+        [InlineData("More Test's", "Tests", CompareOptions.IgnoreSymbols)]
+        public void IndexOf(string source, string value, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                {
+                    compareInfo.IndexOf(source, value, options);
+                }
+        }
+
+        [Benchmark]
+        [InlineData("foo", "", CompareOptions.None)]
+        [InlineData("foobardzsdzs", "rddzs", CompareOptions.Ordinal)]
+        [InlineData("Hello", "L", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.IgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace)]
+        [InlineData("More Test's", "Tests", CompareOptions.IgnoreSymbols)]
+        public void LastIndexOf(string source, string value, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                {
+                    compareInfo.LastIndexOf(source, value, options);
+                }
+        }
+
+        [Benchmark]
+        [InlineData("foo", "", CompareOptions.None)]
+        [InlineData("foobardzsdzs", "rddzs", CompareOptions.Ordinal)]
+        [InlineData("Hello", "L", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.IgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace)]
+        [InlineData("More Test's", "Tests", CompareOptions.IgnoreSymbols)]
+        public void IsPrefix(string source, string prefix, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                {
+                    compareInfo.IsPrefix(source, prefix, options);
+                }
+        }
+
+        [Benchmark]
+        [InlineData("foo", "", CompareOptions.None)]
+        [InlineData("foobardzsdzs", "rddzs", CompareOptions.Ordinal)]
+        [InlineData("Hello", "L", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.IgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", CompareOptions.OrdinalIgnoreCase)]
+        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace)]
+        [InlineData("More Test's", "Tests", CompareOptions.IgnoreSymbols)]
+        public void IsSuffix(string source, string suffix, CompareOptions options)
+        {
+            CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                {
+                    compareInfo.IsSuffix(source, suffix, options);
+                }
+        }
+
+        [Benchmark]
+        [InlineData("foo")]
+        [InlineData("Exhibit \u00C0")]
+        [InlineData("TestFooBA\u0300R")]
+        [InlineData("More Test's")]
+        [InlineData("$")]
+        [InlineData("\u3060")]
+        public void IsSortable(string text)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                {
+                    CompareInfo.IsSortable(text);
+                }
+        }
+    }
+}

--- a/src/System.Globalization/tests/Performance/System.Globalization.Performance.Tests.csproj
+++ b/src/System.Globalization/tests/Performance/System.Globalization.Performance.Tests.csproj
@@ -8,6 +8,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="Perf.CompareInfo.cs" />
     <Compile Include="Perf.CultureInfo.cs" />
     <Compile Include="Perf.DateTimeCultureInfo.cs" />
     <Compile Include="Perf.NumberCultureInfo.cs" />

--- a/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
@@ -163,5 +163,25 @@ namespace System.Memory.Tests
             }
             Assert.Equal(size / 2, index);
         }
+
+        [InlineData("foo", "", StringComparison.Ordinal)]
+        [InlineData("foobardzsdzs", "rddzs", StringComparison.Ordinal)]
+        [InlineData("Hello", "L", StringComparison.OrdinalIgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", StringComparison.CurrentCultureIgnoreCase)]
+        [InlineData("Exhibit \u00C0", "a\u0300", StringComparison.OrdinalIgnoreCase)]
+        [InlineData("TestFooBA\u0300R", "FooB\u00C0R", StringComparison.InvariantCultureIgnoreCase)]
+        [InlineData("More Test's", "Tests", StringComparison.InvariantCulture)]
+        [InlineData("very long input string that is hardly recognizable by a clever PC and therefore not usable", "PC", StringComparison.Ordinal)]
+        public void SpanIndexOfSpanComparison(string input, string value, StringComparison comparisonType)
+        {
+            ReadOnlySpan<char> inputSpan = input.AsSpan();
+            ReadOnlySpan<char> valueSpan = value.AsSpan();
+
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                {
+                    inputSpan.IndexOf(valueSpan, comparisonType);
+                }
+        }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/dotnet/coreclr/pull/18652#issuecomment-401839352

Simple benchmarks to have some measurements. We will add the respective Span ones as soon as implemented and also the LastIndexOf with the StringComparison overload.

I didn't set any inner iteration count as we are currently porting all our benchmarks to BenchmarkDotNet which determines the perfect iteration count by itself. Setting it manually makes porting harder as the measurements aren't comparable easily.