### PR TITLE
Fixing Pkcs9SigningTime behavior on the X.509 Time range [1950;2049)

### DIFF
--- a/src/Common/src/System/Security/Cryptography/AsnWriter.cs
+++ b/src/Common/src/System/Security/Cryptography/AsnWriter.cs
@@ -1182,6 +1182,16 @@ namespace System.Security.Cryptography.Asn1
             WriteUtcTimeCore(tag.AsPrimitive(), value);
         }
 
+        public void WriteUtcTime(DateTimeOffset value, int minLegalYear)
+        {
+            // ensure that value is bounded within a century
+            if (minLegalYear <= value.Year && value.Year < minLegalYear + 100)
+            {
+                WriteUtcTime(value);
+            } else
+                throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
         // T-REC-X.680-201508 sec 47
         // T-REC-X.690-201508 sec 11.8
         private void WriteUtcTimeCore(Asn1Tag tag, DateTimeOffset value)

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
@@ -81,6 +81,7 @@ namespace Internal.Cryptography.Pal.AnyOS
 
         public override byte[] EncodeUtcTime(DateTime utcTime)
         {
+            const int minLegalYear = 1950;
             // Write using DER to support the most readers.
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
             {
@@ -90,11 +91,11 @@ namespace Internal.Cryptography.Pal.AnyOS
                 // Unknown => Local (adjust) => UTC (adjust "back", add Z marker; matches Windows)
                 if (utcTime.Kind == DateTimeKind.Unspecified)
                 {
-                    writer.WriteUtcTime(utcTime.ToLocalTime());
+                    writer.WriteUtcTime(utcTime.ToLocalTime(), minLegalYear);
                 }
                 else
                 {
-                    writer.WriteUtcTime(utcTime);
+                    writer.WriteUtcTime(utcTime, minLegalYear);
                 }
 
                 return writer.Encode();

--- a/src/System.Security.Cryptography.Pkcs/tests/Pkcs9AttributeTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/Pkcs9AttributeTests.cs
@@ -27,6 +27,42 @@ namespace System.Security.Cryptography.Pkcs.Tests
             Assert.Throws<ArgumentNullException>(() => ign = new Pkcs9AttributeObject(a));
         }
 
+        [Fact]
+        public static void TestDateBefore1950()
+        {
+            DateTime dt = new DateTime(1949, 12, 31, 11, 59, 59);
+            try
+            {
+                var st = new Pkcs9SigningTime(dt);
+            } catch (Exception ex)
+            {
+                if (ex is ArgumentOutOfRangeException || ex is CryptographicException)
+                {
+                    // test passes
+                }
+                else
+                    throw;
+            }
+        }
+
+        [Fact]
+        public static void TestDateAfter1949()
+        {
+            DateTime dt = new DateTime(2050, 01, 01, 00, 00, 00);
+            try
+            {
+                var st = new Pkcs9SigningTime(dt);
+            }
+            catch (Exception ex)
+            {
+                if (ex is ArgumentOutOfRangeException || ex is CryptographicException)
+                {
+                    // test passes
+                }
+                else
+                    throw;
+            }
+        }
 
         [Fact]
         public static void Pkcs9AttributeAsnEncodedDataCtorNullOidValue()


### PR DESCRIPTION
Adds AsnWriter.WriteUtcTime overload to align the behavior of Pkcs9SigningTime type on the X.509 Time range [1950;2049).
Fixes #30578 