### PR TITLE
Disable packaging source files in runtime package

### DIFF
--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -71,12 +71,12 @@
 
     <ItemGroup>
       <!-- Include refs -->
-      <File Include="@(RefFile)">
+      <File Include="@(RefFile)" Condition="'%(RefFile.IsSourceCodeFile)' != 'true'">
         <TargetPath Condition="'%(RefFile.TargetPath)' == ''">$(RefFileTargetPath)%(RefFile.SubFolder)</TargetPath>
       </File>
 
       <!-- Include lib -->
-      <File Include="@(LibFile)">
+      <File Include="@(LibFile)"  Condition="'%(LibFile.IsSourceCodeFile)' != 'true'">
         <TargetPath Condition="'%(LibFile.TargetPath)' == '' ">$(LibFileTargetPath)%(LibFile.SubFolder)</TargetPath>
       </File>
 


### PR DESCRIPTION
This disables packaging of source files in `Microsoft.Private.CoreFx.NETCoreApp`, as well as in the corresponding runtime packages. @MattGal @weshaggard @dagood PTAL

Should this also be ported to the release branches?

For https://github.com/dotnet/corefx/issues/19781 and https://github.com/dotnet/core-setup/issues/4328