### PR TITLE
Fixed getmntinfo() call on FreeBSD

### DIFF
--- a/src/Native/Unix/System.Native/pal_mount.c
+++ b/src/Native/Unix/System.Native/pal_mount.c
@@ -33,7 +33,13 @@ static int32_t GetMountInfo(MountPointFound onFound)
 #else
     struct statvfs* mounts = NULL;
 #endif
+    #if defined(__FreeBSD__)
+    // second argument of getmntinfo is mode, which, in FreeBSD, can either be MNT_WAIT (1) or MNT_NOWAIT (2)
+    // check getmntinfo(3) and getfsstat(2) for more info
+    int count = getmntinfo(&mounts, 1);
+    #elif
     int count = getmntinfo(&mounts, 0);
+    #endif
     for (int32_t i = 0; i < count; i++)
     {
         onFound(mounts[i].f_mntonname);

--- a/src/Native/Unix/System.Native/pal_mount.c
+++ b/src/Native/Unix/System.Native/pal_mount.c
@@ -33,13 +33,13 @@ static int32_t GetMountInfo(MountPointFound onFound)
 #else
     struct statvfs* mounts = NULL;
 #endif
-    #if defined(__FreeBSD__)
+#if defined(__FreeBSD__)
     // second argument of getmntinfo is mode, which, in FreeBSD, can either be MNT_WAIT (1) or MNT_NOWAIT (2)
     // check getmntinfo(3) and getfsstat(2) for more info
     int count = getmntinfo(&mounts, MNT_WAIT);
-    #elif
+#elif
     int count = getmntinfo(&mounts, 0);
-    #endif
+#endif
     for (int32_t i = 0; i < count; i++)
     {
         onFound(mounts[i].f_mntonname);

--- a/src/Native/Unix/System.Native/pal_mount.c
+++ b/src/Native/Unix/System.Native/pal_mount.c
@@ -33,13 +33,7 @@ static int32_t GetMountInfo(MountPointFound onFound)
 #else
     struct statvfs* mounts = NULL;
 #endif
-#if defined(__FreeBSD__)
-    // second argument of getmntinfo is mode, which, in FreeBSD, can either be MNT_WAIT (1) or MNT_NOWAIT (2)
-    // check getmntinfo(3) and getfsstat(2) for more info
     int count = getmntinfo(&mounts, MNT_WAIT);
-#elif
-    int count = getmntinfo(&mounts, 0);
-#endif
     for (int32_t i = 0; i < count; i++)
     {
         onFound(mounts[i].f_mntonname);

--- a/src/Native/Unix/System.Native/pal_mount.c
+++ b/src/Native/Unix/System.Native/pal_mount.c
@@ -36,7 +36,7 @@ static int32_t GetMountInfo(MountPointFound onFound)
     #if defined(__FreeBSD__)
     // second argument of getmntinfo is mode, which, in FreeBSD, can either be MNT_WAIT (1) or MNT_NOWAIT (2)
     // check getmntinfo(3) and getfsstat(2) for more info
-    int count = getmntinfo(&mounts, 1);
+    int count = getmntinfo(&mounts, MNT_WAIT);
     #elif
     int count = getmntinfo(&mounts, 0);
     #endif


### PR DESCRIPTION
This change was necessary because the original way the `getmntinfo()` function was being called did not complete successfully on FreeBSD. According to documentation, the second parameter `int mode` only accepts `MNT_WAIT` (1) or `MNT_NOWAIT` (2) as valid inputs and, as 0 was being passed in, the function returned zero mount points and set an `errno` of `EINVAL`.

References: [getmntinfo(3)](https://www.freebsd.org/cgi/man.cgi?query=getmntinfo) and [getfsstat(2)](https://www.freebsd.org/cgi/man.cgi?query=getfsstat&sektion=2&apropos=0&manpath=FreeBSD+11.2-RELEASE+and+Ports)

Related [coreclr/#18067](https://github.com/dotnet/coreclr/issues/18067)