### PR TITLE
OpenSSL: Replace pkcs7_[new/content_new/set_type/add_certificate] with single pkcs7_sign call.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
@@ -19,8 +19,8 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_D2IPkcs7Bio")]
         internal static extern SafePkcs7Handle D2IPkcs7Bio(SafeBioHandle bp);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7CreateSigned")]
-        internal static extern SafePkcs7Handle Pkcs7CreateSigned();
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7Sign")]
+        internal static extern SafePkcs7Handle Pkcs7Sign(SafeX509StackHandle certs);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7Destroy")]
         internal static extern void Pkcs7Destroy(IntPtr p7);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
@@ -19,8 +19,8 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_D2IPkcs7Bio")]
         internal static extern SafePkcs7Handle D2IPkcs7Bio(SafeBioHandle bp);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7Sign")]
-        internal static extern SafePkcs7Handle Pkcs7Sign(SafeX509StackHandle certs);
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7CreateCertificateCollection")]
+        internal static extern SafePkcs7Handle Pkcs7CreateCertificateCollection(SafeX509StackHandle certs);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7Destroy")]
         internal static extern void Pkcs7Destroy(IntPtr p7);

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -242,11 +242,8 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(PKCS12_create, true) \
     PER_FUNCTION_BLOCK(PKCS12_free, true) \
     PER_FUNCTION_BLOCK(PKCS12_parse, true) \
-    PER_FUNCTION_BLOCK(PKCS7_add_certificate, true) \
-    PER_FUNCTION_BLOCK(PKCS7_content_new, true) \
+    PER_FUNCTION_BLOCK(PKCS7_sign, true) \
     PER_FUNCTION_BLOCK(PKCS7_free, true) \
-    PER_FUNCTION_BLOCK(PKCS7_new, true) \
-    PER_FUNCTION_BLOCK(PKCS7_set_type, true) \
     PER_FUNCTION_BLOCK(RAND_bytes, true) \
     PER_FUNCTION_BLOCK(RAND_poll, true) \
     PER_FUNCTION_BLOCK(RSA_free, true) \
@@ -542,11 +539,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define PKCS12_create PKCS12_create_ptr
 #define PKCS12_free PKCS12_free_ptr
 #define PKCS12_parse PKCS12_parse_ptr
-#define PKCS7_add_certificate PKCS7_add_certificate_ptr
-#define PKCS7_content_new PKCS7_content_new_ptr
+#define PKCS7_sign PKCS7_sign_ptr
 #define PKCS7_free PKCS7_free_ptr
-#define PKCS7_new PKCS7_new_ptr
-#define PKCS7_set_type PKCS7_set_type_ptr
 #define RAND_bytes RAND_bytes_ptr
 #define RAND_poll RAND_poll_ptr
 #define RSA_free RSA_free_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.c
@@ -24,7 +24,7 @@ PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp)
     return d2i_PKCS7_bio(bp, NULL);
 }
 
-PKCS7* CryptoNative_Pkcs7Sign(X509Stack* certs)
+PKCS7* CryptoNative_Pkcs7CreateCertificateCollection(X509Stack* certs)
 {
     return PKCS7_sign(NULL, NULL, certs, NULL, PKCS7_PARTIAL);
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.c
@@ -24,22 +24,9 @@ PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp)
     return d2i_PKCS7_bio(bp, NULL);
 }
 
-PKCS7* CryptoNative_Pkcs7CreateSigned()
+PKCS7* CryptoNative_Pkcs7Sign(X509Stack* certs)
 {
-    PKCS7* pkcs7 = PKCS7_new();
-
-    if (pkcs7 == NULL)
-    {
-        return NULL;
-    }
-
-    if (!PKCS7_set_type(pkcs7, NID_pkcs7_signed) || !PKCS7_content_new(pkcs7, NID_pkcs7_data))
-    {
-        PKCS7_free(pkcs7);
-        return NULL;
-    }
-
-    return pkcs7;
+    return PKCS7_sign(NULL, NULL, certs, NULL, PKCS7_PARTIAL);
 }
 
 void CryptoNative_Pkcs7Destroy(PKCS7* p7)
@@ -68,16 +55,6 @@ int32_t CryptoNative_GetPkcs7Certificates(PKCS7* p7, X509Stack** certs)
     }
 
     return 0;
-}
-
-int32_t CryptoNative_Pkcs7AddCertificate(PKCS7* p7, X509* x509)
-{
-    if (p7 == NULL || x509 == NULL)
-    {
-        return 0;
-    }
-
-    return PKCS7_add_certificate(p7, x509);
 }
 
 int32_t CryptoNative_GetPkcs7DerSize(PKCS7* p7)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.h
@@ -30,12 +30,12 @@ Returns the new PKCS7 instance.
 DLLEXPORT PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp);
 
 /*
-Create a new PKCS7 instance and prepare it to be a signed PKCS7
-with a data payload and certificates.
+Create a new PKCS7 instance and prepare it to be a signed PKCS7 object
+with certificates only.
 
 Returns the new PKCS7 instance.
 */
-DLLEXPORT PKCS7* CryptoNative_Pkcs7Sign(X509Stack* certs);
+DLLEXPORT PKCS7* CryptoNative_Pkcs7CreateCertificateCollection(X509Stack* certs);
 
 /*
 Cleans up and deletes a PKCS7 instance.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.h
@@ -31,11 +31,11 @@ DLLEXPORT PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp);
 
 /*
 Create a new PKCS7 instance and prepare it to be a signed PKCS7
-with a data payload.
+with a data payload and certificates.
 
 Returns the new PKCS7 instance.
 */
-DLLEXPORT PKCS7* CryptoNative_Pkcs7CreateSigned(void);
+DLLEXPORT PKCS7* CryptoNative_Pkcs7Sign(X509Stack* certs);
 
 /*
 Cleans up and deletes a PKCS7 instance.
@@ -61,11 +61,6 @@ Return values:
 certificate contents of the structure.
 */
 DLLEXPORT int32_t CryptoNative_GetPkcs7Certificates(PKCS7* p7, X509Stack** certs);
-
-/*
-Shims the PKCS7_add_certificate function and makes it easier to invoke from managed code.
-*/
-DLLEXPORT int32_t CryptoNative_Pkcs7AddCertificate(PKCS7* p7, X509* x509);
 
 /*
 Returns the number of bytes it will take to convert

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ExportProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ExportProvider.cs
@@ -180,7 +180,7 @@ namespace Internal.Cryptography.Pal
                     GC.KeepAlive(cert); // ensure cert's safe handle isn't finalized while raw handle is in use
                 }
 
-                using (SafePkcs7Handle pkcs7 = Interop.Crypto.Pkcs7Sign(certs))
+                using (SafePkcs7Handle pkcs7 = Interop.Crypto.Pkcs7CreateCertificateCollection(certs))
                 {
                     Interop.Crypto.CheckValidOpenSslHandle(pkcs7);
                     return Interop.Crypto.OpenSslEncode(

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ExportProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ExportProvider.cs
@@ -172,29 +172,22 @@ namespace Internal.Cryptography.Pal
         {
             // Pack all of the certificates into a new PKCS7*, export it to a byte[],
             // then free the PKCS7*, since we don't need it any more.
-            using (SafePkcs7Handle pkcs7 = Interop.Crypto.Pkcs7CreateSigned())
+            using (SafeX509StackHandle certs = Interop.Crypto.NewX509Stack())
             {
-                Interop.Crypto.CheckValidOpenSslHandle(pkcs7);
-
                 foreach (X509Certificate2 cert in _certs)
                 {
-                    // Pkcs7AddCertificate => PKCS7_add_certificate increments the
-                    // reference count of the certificate, so passing just the Handle
-                    // value is sufficient.
-                    //
-                    // It gets decremented again when the SafePkcs7Handle is released.
-                    if (!Interop.Crypto.Pkcs7AddCertificate(pkcs7, cert.Handle))
-                    {
-                        throw Interop.Crypto.CreateOpenSslCryptographicException();
-                    }
-
+                    PushHandle(cert.Handle, certs);
                     GC.KeepAlive(cert); // ensure cert's safe handle isn't finalized while raw handle is in use
                 }
 
-                return Interop.Crypto.OpenSslEncode(
-                    handle => Interop.Crypto.GetPkcs7DerSize(handle),
-                    (handle, buf) => Interop.Crypto.EncodePkcs7(handle, buf),
-                    pkcs7);
+                using (SafePkcs7Handle pkcs7 = Interop.Crypto.Pkcs7Sign(certs))
+                {
+                    Interop.Crypto.CheckValidOpenSslHandle(pkcs7);
+                    return Interop.Crypto.OpenSslEncode(
+                        handle => Interop.Crypto.GetPkcs7DerSize(handle),
+                        (handle, buf) => Interop.Crypto.EncodePkcs7(handle, buf),
+                        pkcs7);
+                }
             }
         }
     }


### PR DESCRIPTION
Rationale: BoringSSL doesn't support the `pkcs7_[new/content_new/set_type/add_certificate]` calls, but it supports the `pkcs7_sign` call for exactly the same use case. This has been supported since OpenSSL 1.0.0 and it makes the code shorter.

Extracted from PR #30807.