### PR TITLE
OpenSSL: Parse the version number from the SSLeay numerical value

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
     {
         private static Version s_opensslVersion;
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SSLEayVersion")]
-        private static extern string OpenSslVersionDescription();
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslVersionNumber")]
+        private static extern uint OpenSslVersionNumber();
 
         internal static Version OpenSslVersion
         {
@@ -20,13 +20,8 @@ internal static partial class Interop
             {
                 if (s_opensslVersion == null)
                 {
-                    const string OpenSSL = "OpenSSL ";
-
-                    // Skip OpenSSL part, and get the version string of format x.y.z
-                    if (!Version.TryParse(OpenSslVersionDescription().AsSpan(OpenSSL.Length, 5).ToString(), out s_opensslVersion))
-                    {
-                        s_opensslVersion = new Version(0, 0, 0);
-                    }
+                    uint versionNumber = OpenSslVersionNumber();
+                    s_opensslVersion = new Version((int)(versionNumber >> 28), (int)((versionNumber >> 20) & 0xff), (int)((versionNumber >> 12) & 0xff));
                 }
 
                 return s_opensslVersion;

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -6,7 +6,6 @@
 #include "pal_utilities.h"
 #include "pal_safecrt.h"
 #include "openssl.h"
-#include "opensslshim.h"
 
 #include <assert.h>
 #include <limits.h>
@@ -1400,15 +1399,14 @@ done:
 
 /*
 Function:
-SSLEayVersion
+SSLeay (OpenSSL_version_num for OpenSSL 1.1+)
 
 Gets the version of openssl library.
 
 Return values:
-Textual description of the version on success.
-"not available" string on failure.
+Version number as MNNFFRBB (major minor fix final beta/patch)
 */
-char* CryptoNative_SSLEayVersion()
+uint32_t CryptoNative_OpenSslVersionNumber()
 {
-    return strdup(SSLeay_version(SSLEAY_VERSION));
+    return (uint32_t)SSLeay();
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
@@ -6,8 +6,7 @@
 #pragma once
 
 #include "pal_compiler.h"
-#include <openssl/x509.h>
-#include <openssl/x509v3.h>
+#include "opensslshim.h"
 
 DLLEXPORT int32_t CryptoNative_GetX509Thumbprint(X509* x509, uint8_t* pBuf, int32_t cBuf);
 
@@ -67,4 +66,4 @@ DLLEXPORT int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, con
 
 DLLEXPORT int32_t CryptoNative_EnsureOpenSslInitialized(void);
 
-DLLEXPORT char* CryptoNative_SSLEayVersion(void);
+DLLEXPORT uint32_t CryptoNative_OpenSslVersionNumber(void);

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -305,7 +305,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(SSL_set_connect_state, true) \
     PER_FUNCTION_BLOCK(SSL_shutdown, true) \
     PER_FUNCTION_BLOCK(SSL_state, true) \
-    PER_FUNCTION_BLOCK(SSLeay_version, true) \
+    PER_FUNCTION_BLOCK(SSLeay, true) \
     PER_FUNCTION_BLOCK(SSLv23_method, true) \
     PER_FUNCTION_BLOCK(SSL_write, true) \
     PER_FUNCTION_BLOCK(TLSv1_1_method, true) \
@@ -605,7 +605,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_set_connect_state SSL_set_connect_state_ptr
 #define SSL_shutdown SSL_shutdown_ptr
 #define SSL_state SSL_state_ptr
-#define SSLeay_version SSLeay_version_ptr
+#define SSLeay SSLeay_ptr
 #define SSLv23_method SSLv23_method_ptr
 #define SSL_write SSL_write_ptr
 #define TLSv1_1_method TLSv1_1_method_ptr


### PR DESCRIPTION
Rationale: The SSLeay/OpenSSL_version_num numerical value is well-defined unlike the string returned by SSLeay_version. The previous code worked fine for LibreSSL and OpenSSL. The new one also works for BoringSSL where the string representation of version is different.

Extracted from PR #30807.