### PR TITLE
Update concurrent socket disposal test to accomodate UAP

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -866,7 +867,11 @@ namespace System.Net.Sockets.Tests
                     Exception error = await Record.ExceptionAsync(() => send);
                     if (error != null)
                     {
-                        Assert.True(error is ObjectDisposedException || error is SocketException, error.ToString());
+                        Assert.True(
+                            error is ObjectDisposedException ||
+                            error is SocketException ||
+                            (error is SEHException && PlatformDetection.IsUap),
+                            error.ToString());
                     }
                 }
             }
@@ -901,7 +906,11 @@ namespace System.Net.Sockets.Tests
                     Exception error = await Record.ExceptionAsync(() => send);
                     if (error != null)
                     {
-                        Assert.True(error is ObjectDisposedException || error is SocketException, error.ToString());
+                        Assert.True(
+                            error is ObjectDisposedException ||
+                            error is SocketException ||
+                            (error is SEHException && PlatformDetection.IsUap),
+                            error.ToString());
                     }
                 }
             }


### PR DESCRIPTION
Apparently if a socket is disposed of while it's in use, we can get an SEHException back from the P/Invoke, presumably due to the OS code trying to throw an SEH exception out of the call.  Just update the test to accomodate this when IsUap is true.

Fixes https://github.com/dotnet/corefx/issues/29886
cc: @davidsh