### PR TITLE
OpenSSL: Relax the error checking code to cater for different versions.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -367,8 +367,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
             else // Any Unix
             {
-                Assert.Equal(0x0D07803A, ex.HResult);
-                Assert.Equal("error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error", ex.Message);
+                // OpenSSL encodes the function name into the error code. However, the function name differs
+                // between versions (OpenSSL 1.0, OpenSSL 1.1 and BoringSSL) and it's subject to change in
+                // the future, so don't test for the exact match and mask out the function code away. The 
+                // component number (high 8 bits) and error code  (low 12 bits) should remain the same.
+                Assert.Equal(0x0D00003A, ex.HResult & 0xFF000FFF);
             }
         }
 


### PR DESCRIPTION
Extracted from #30807.

- OpenSSL: ex.HResult == 0x0D07803A
- BoringSSL: ex.HResult == 0x0D00003A
- OpenSSL 1.0: ex.Message == "error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error"
- OpenSSL 1.1: ex.Message == "error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error"

BoringSSL dropped the function codes altogether. OpenSSL maintains the numbers so far, but changed the names, so the strings no longer match up in 1.1+. There's an [open proposal](https://github.com/openssl/openssl/issues/1415) to drop the function codes in OpenSSL in future versions.