### PR TITLE
Socket SendTo to use ReadOnlySpan<byte> for buffer

### DIFF
--- a/src/System.Net.Sockets/ref/System.Net.Sockets.netcoreapp.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.netcoreapp.cs
@@ -23,6 +23,8 @@ namespace System.Net.Sockets
         public int Send(ReadOnlySpan<byte> buffer) { throw null; }
         public int Send(ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public int Send(ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { throw null; }
+        public int SendTo(ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
+        public int SendTo(ReadOnlySpan<byte> buffer, System.Net.EndPoint remoteEP) { throw null; }
     }
 
     public static partial class SocketTaskExtensions

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -956,6 +956,19 @@ namespace System.Net.Sockets
             return errorCode;
         }
 
+        public static SocketError SendTo(SafeCloseSocket handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, byte[] socketAddress, int socketAddressLen, out int bytesTransferred)
+        {
+            if (!handle.IsNonBlocking)
+            {
+                return handle.AsyncContext.SendTo(buffer, socketFlags, socketAddress, socketAddressLen, handle.SendTimeout, out bytesTransferred);
+            }
+
+            bytesTransferred = 0;
+            SocketError errorCode;
+            TryCompleteSendTo(handle, buffer, socketFlags, socketAddress, socketAddressLen, ref bytesTransferred, out errorCode);
+            return errorCode;
+        }
+
         public static SocketError Receive(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, ref SocketFlags socketFlags, out int bytesTransferred)
         {
             SocketError errorCode;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -236,7 +236,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                fixed (byte* bufferPtr = &MemoryMarshal.GetReference(buffer))
+                fixed (byte* bufferPtr = buffer)
                 {
                     bytesSent = Interop.Winsock.sendto(
                         handle.DangerousGetHandle(),


### PR DESCRIPTION
An attempt to add span overloads for SendTo method on Socket.

I am a bit bothered by the fact that I copied implementation from the array based SendTo. But I believe I cannot change the behavior of existing code, not sure how to proceed with it.

And another bit is that I am calling ToArray on the span when logging to NetEventSource. Should I add overloads for NetEventSource as well?