### PR TITLE
Replace SecureStringMarshal calls with Marshal calls.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.Unix.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Win32.SafeHandles
 
         private IntPtr CreateHandle(SecureString password)
         {
-            return SecureStringMarshal.SecureStringToGlobalAllocAnsi(password);
+            return Marshal.SecureStringToGlobalAllocAnsi(password);
         }
 
         private void FreeHandle()

--- a/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.Windows.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.Windows.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Win32.SafeHandles
 
         private IntPtr CreateHandle(SecureString password)
         {
-            return SecureStringMarshal.SecureStringToGlobalAllocUnicode(password);
+            return Marshal.SecureStringToGlobalAllocUnicode(password);
         }
 
         private void FreeHandle()


### PR DESCRIPTION
Rationale: SecureStringMarshal is just forwarding the calls to Marshal. The original plan to drop the methods from Marshal class was abandoned. Mono needs to reference the type from mscorlib, where SecureStringMarshal is not available, and this would make things easier without affecting the functionality (https://github.com/mono/mono/issues/9416).