### PR TITLE
Use IEqualityComparer<T> instead of IComparer<T> during HashSet serialization

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -398,7 +398,7 @@ namespace System.Collections.Generic
             }
 
             info.AddValue(VersionName, _version); // need to serialize version to avoid problems with serializing while enumerating
-            info.AddValue(ComparerName, _comparer, typeof(IComparer<T>));
+            info.AddValue(ComparerName, _comparer, typeof(IEqualityComparer<T>));
             info.AddValue(CapacityName, _buckets == null ? 0 : _buckets.Length);
 
             if (_buckets != null)

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using Xunit;
 
 namespace System.Collections.Tests

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -341,22 +341,5 @@ namespace System.Collections.Tests
             ISet<T> iset = (set as ISet<T>);
             Assert.NotNull(iset);
         }
-
-        [Fact]
-        public void GetObjectData_ComparerEqualsType_Success()
-        {
-            var hashSet = new HashSet<string>();
-            SerializationInfo testData = new SerializationInfo(typeof(HashSet<string>), new FormatterConverter());
-            hashSet.GetObjectData(testData, new StreamingContext(StreamingContextStates.Other));
-
-            foreach (SerializationEntry entry in testData)
-            {
-                if (entry.Name == "Comparer")
-                {
-                    Assert.IsAssignableFrom(entry.ObjectType, entry.Value);
-                    break;
-                }
-            }
-        }
     }
 }

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace System.Collections.Tests
@@ -339,6 +340,23 @@ namespace System.Collections.Tests
             HashSet<T> set = new HashSet<T>();
             ISet<T> iset = (set as ISet<T>);
             Assert.NotNull(iset);
+        }
+
+        [Fact]
+        public void GetObjectData_ComparerEqualsType_Success()
+        {
+            var hashSet = new HashSet<string>();
+            SerializationInfo testData = new SerializationInfo(typeof(HashSet<string>), new FormatterConverter());
+            hashSet.GetObjectData(testData, new StreamingContext(StreamingContextStates.Other));
+
+            foreach (SerializationEntry entry in testData)
+            {
+                if (entry.Name == "Comparer")
+                {
+                    Assert.IsAssignableFrom(entry.ObjectType, entry.Value);
+                    break;
+                }
+            }
         }
     }
 }

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -97,7 +97,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
             }
 
             // Check if the passed in value in a serialization entry is assignable by the passed in type.
-            if (!PlatformDetection.IsFullFramework && obj is ISerializable customSerializableObj)
+            if (obj is ISerializable customSerializableObj && HasObjectTypeIntegrity(customSerializableObj))
             {
                 CheckObjectTypeIntegrity(customSerializableObj);
             }
@@ -536,6 +536,13 @@ namespace System.Runtime.Serialization.Formatters.Tests
             Assert.True(objType.IsGenericType, $"Type `{objType.FullName}` must be generic.");
             Assert.Equal("System.Collections.Generic.ObjectEqualityComparer`1", objType.GetGenericTypeDefinition().FullName);
             Assert.Equal(obj.GetType().GetGenericArguments()[0], objType.GetGenericArguments()[0]);
+        }
+
+        private static bool HasObjectTypeIntegrity(ISerializable serializable)
+        {
+            return !PlatformDetection.IsFullFramework ||
+                !(serializable is NotFiniteNumberException ||
+                serializable.GetType().GetGenericTypeDefinition() == typeof(HashSet<>));
         }
 
         private static void CheckObjectTypeIntegrity(ISerializable serializable)

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -96,6 +96,12 @@ namespace System.Runtime.Serialization.Formatters.Tests
                     BinaryFormatterHelpers.ToBase64String(obj, FormatterAssemblyStyle.Full));
             }
 
+            // Check if the passed in value in a serialization entry is assignable by the passed in type.
+            if (!PlatformDetection.IsFullFramework && obj is ISerializable customSerializableObj)
+            {
+                CheckObjectTypeIntegrity(customSerializableObj);
+            }
+
             SanityCheckBlob(obj, blobs);
 
             // SqlException, ReflectionTypeLoadException and LicenseException aren't deserializable from Desktop --> Core.
@@ -530,6 +536,20 @@ namespace System.Runtime.Serialization.Formatters.Tests
             Assert.True(objType.IsGenericType, $"Type `{objType.FullName}` must be generic.");
             Assert.Equal("System.Collections.Generic.ObjectEqualityComparer`1", objType.GetGenericTypeDefinition().FullName);
             Assert.Equal(obj.GetType().GetGenericArguments()[0], objType.GetGenericArguments()[0]);
+        }
+
+        private static void CheckObjectTypeIntegrity(ISerializable serializable)
+        {
+            SerializationInfo testData = new SerializationInfo(serializable.GetType(), new FormatterConverter());
+            serializable.GetObjectData(testData, new StreamingContext(StreamingContextStates.Other));
+
+            foreach (SerializationEntry entry in testData)
+            {
+                if (entry.Value != null)
+                {
+                    Assert.IsAssignableFrom(entry.ObjectType, entry.Value);
+                }
+            }
         }
 
         private static void SanityCheckBlob(object obj, TypeSerializableValue[] blobs)

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -541,8 +541,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         private static bool HasObjectTypeIntegrity(ISerializable serializable)
         {
             return !PlatformDetection.IsFullFramework ||
-                !(serializable is NotFiniteNumberException ||
-                (serializable.GetType().IsGenericType && serializable.GetType().GetGenericTypeDefinition() == typeof(HashSet<>)));
+                !(serializable is NotFiniteNumberException);
         }
 
         private static void CheckObjectTypeIntegrity(ISerializable serializable)

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -542,7 +542,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         {
             return !PlatformDetection.IsFullFramework ||
                 !(serializable is NotFiniteNumberException ||
-                serializable.GetType().GetGenericTypeDefinition() == typeof(HashSet<>));
+                (serializable.GetType().IsGenericType && serializable.GetType().GetGenericTypeDefinition() == typeof(HashSet<>)));
         }
 
         private static void CheckObjectTypeIntegrity(ISerializable serializable)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/30891
Requires https://github.com/dotnet/coreclr/pull/18833