### PR TITLE
Fix optional tooling restore

### DIFF
--- a/external/test-runtime/optional.csproj
+++ b/external/test-runtime/optional.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
+    <!-- $(RestoreSources) is set in the root Directory.Build.props and will override any sources specified
+         in the generated NuGet.config file. Blank it out here so the NuGet.config sources are used.
+     -->
+    <RestoreSources></RestoreSources>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMergePackageVersion)" />


### PR DESCRIPTION
With the SDK-style project change, all properties from the root Directory.Build.props are being imported into optional.csproj. The RestoreSources property overwrites any sources specified in the NuGet.config, which means the restore fails to find the packages.

The fix is to blank out RestoreSources so the NuGet.config sources are used.

Fix #30906