### PR TITLE
Improve performance for GetViewBetween and enumerating TreeSubSet

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -316,11 +316,12 @@ namespace System.Collections.Generic
                     root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive);
                     version = _underlying.version;
 
-                    if (updateCount) {
-                        count = 0;
-                        InOrderTreeWalk(n => { count++; return true; });
-                        countVersion = _underlying.version;
-                    }
+                }
+
+                if (updateCount && countVersion != _underlying.version) {
+                    count = 0;
+                    InOrderTreeWalk(n => { count++; return true; });
+                    countVersion = _underlying.version;
                 }
             }
 

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -17,6 +17,7 @@ namespace System.Collections.Generic
         {
             private SortedSet<T> _underlying;
             private T _min, _max;
+            private int versionCount;
             // these exist for unbounded collections
             // for instance, you could allow this subset to be defined for i > 10. The set will throw if
             // anything <= 10 is added, but there is no upper bound. These features Head(), Tail(), were punted
@@ -42,7 +43,7 @@ namespace System.Collections.Generic
                 root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive); // root is first element within range
                 count = 0;
                 version = -1;
-                VersionCheckImpl();
+                versionCount = -1;
             }
 
             internal override bool AddIfNotPresent(T item)
@@ -87,7 +88,7 @@ namespace System.Collections.Generic
 
             public override void Clear()
             {
-                if (count == 0)
+                if (Count == 0)
                 {
                     return;
                 }
@@ -310,9 +311,25 @@ namespace System.Collections.Generic
                 {
                     root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive);
                     version = _underlying.version;
+                }
+            }
+
+            internal override void VersionCheckCount()
+            {
+                VersionCheckImpl();
+
+                if (versionCount != _underlying.version)
+                {
                     count = 0;
                     InOrderTreeWalk(n => { count++; return true; });
+                    versionCount = _underlying.version;
                 }
+            }
+
+            internal override int TotalCount()
+            {
+                Debug.Assert(_underlying != null);
+                return _underlying.Count;
             }
 
             // This passes functionality down to the underlying tree, clipping edges if necessary

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -18,9 +18,9 @@ namespace System.Collections.Generic
             private SortedSet<T> _underlying;
             private T _min, _max;
             // keeps track of whether the count variable is up to date
-            // up to date -> countVersion = _underlying.version
-            // not up to date -> countVersion < _underlying.version
-            private int countVersion;
+            // up to date -> _countVersion = _underlying.version
+            // not up to date -> _countVersion < _underlying.version
+            private int _countVersion;
             // these exist for unbounded collections
             // for instance, you could allow this subset to be defined for i > 10. The set will throw if
             // anything <= 10 is added, but there is no upper bound. These features Head(), Tail(), were punted
@@ -46,7 +46,7 @@ namespace System.Collections.Generic
                 root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive); // root is first element within range
                 count = 0;
                 version = -1;
-                countVersion = -1;
+                _countVersion = -1;
             }
 
             internal override bool AddIfNotPresent(T item)
@@ -317,10 +317,11 @@ namespace System.Collections.Generic
                     version = _underlying.version;
                 }
 
-                if (updateCount && countVersion != _underlying.version) {
+                if (updateCount && _countVersion != _underlying.version)
+                {
                     count = 0;
                     InOrderTreeWalk(n => { count++; return true; });
-                    countVersion = _underlying.version;
+                    _countVersion = _underlying.version;
                 }
             }
 

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -315,7 +315,6 @@ namespace System.Collections.Generic
                 {
                     root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive);
                     version = _underlying.version;
-
                 }
 
                 if (updateCount && countVersion != _underlying.version) {

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -281,7 +281,7 @@ namespace System.Collections.Generic
         {
             get
             {
-                VersionCheckCount();
+                VersionCheckCount(true);
                 return count;
             }
         }
@@ -310,8 +310,8 @@ namespace System.Collections.Generic
         #region Subclass helpers
 
         // Virtual function for TreeSubSet, which may need to update its count.
-        internal virtual void VersionCheck() { }
-        internal virtual void VersionCheckCount() { }
+        internal virtual void VersionCheck(bool updateCount = false) { }
+        // Virtual function for TreeSubSet, which may need the count variable of the parent set.
         internal virtual int TotalCount() { return Count; }
 
         // Virtual function for TreeSubSet, which may need to do range checks.

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -281,7 +281,7 @@ namespace System.Collections.Generic
         {
             get
             {
-                VersionCheckCount(true);
+                VersionCheck(updateCount: true);
                 return count;
             }
         }

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -281,7 +281,7 @@ namespace System.Collections.Generic
         {
             get
             {
-                VersionCheck();
+                VersionCheckCount();
                 return count;
             }
         }
@@ -311,6 +311,8 @@ namespace System.Collections.Generic
 
         // Virtual function for TreeSubSet, which may need to update its count.
         internal virtual void VersionCheck() { }
+        internal virtual void VersionCheckCount() { }
+        internal virtual int TotalCount() { return Count; }
 
         // Virtual function for TreeSubSet, which may need to do range checks.
         internal virtual bool IsWithinRange(T item) => true;
@@ -895,7 +897,7 @@ namespace System.Collections.Generic
             if (treeSubset != null)
                 VersionCheck();
 
-            if (asSorted != null && treeSubset == null && count == 0)
+            if (asSorted != null && treeSubset == null && Count == 0)
             {
                 SortedSet<T> dummy = new SortedSet<T>(asSorted, comparer);
                 root = dummy.root;
@@ -1950,7 +1952,7 @@ namespace System.Collections.Generic
                 _version = set.version;
 
                 // 2 log(n + 1) is the maximum height.
-                _stack = new Stack<Node>(2 * (int)Log2(set.Count + 1));
+                _stack = new Stack<Node>(2 * (int)Log2(set.TotalCount() + 1));
                 _current = null;
                 _reverse = reverse;
 


### PR DESCRIPTION
Increases performance for SortedSet - GetViewBetween and enumerating TreeSubSet
This also, fixes #30821 
* VersionCheckImpl is not called within the constructor anymore
* count does not get updated by VersionCheckImpl anymore
* count is now updated within VersionCheckCount which is only called when retrieving Count property. 
   As a result **count** has been replaced with **Count** where necessary.
* For TreeSubSet the enumerator now uses the Count of the parent set (entire tree) when creating the 
  stack. This results in a larger stack size, however it eliminates the need to get the count of TreeSubSet,
  which drastically increases the performance.

The performance impacts can be seen below (benchmarkdotnet was used on release build of corefx).

> Size of Set: 5000000
> Original: original code base
> Optimized: changed code base for performance improvements

**SubSet of size 10000**
1. Got a SubSet of size 10000 (2495000 - 2505000) (**GetView**)
2. Enumerated through the SubSet (**EnumerateView**)

![image](https://user-images.githubusercontent.com/14911112/42348411-3117ace2-805e-11e8-8181-c822f3ed0137.png)

**SubSet of size 500000**
1. Got a SubSet of size 1000000 (2000000 - 3000000) (**GetView**)
2. Enumerated through the SubSet (**EnumerateView**)

![image](https://user-images.githubusercontent.com/14911112/42348339-f19c7e76-805d-11e8-8a00-4dbe6a078b8e.png)

> The reason enumerating through a view has similar runtimes, is because the **count** property in the 
   original code is updated when the view is gotten and since no changes occur to the set, count doesn't 
   need to be updated during the start of enumeration.