### PR TITLE
Coverage runs are being aborted: increase timeout

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -75,7 +75,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
         // Archive results.
         Utilities.addArchival(newJob, '**/coverage/*,msbuild.log')
         // Timeout. Code coverage runs take longer, so we set the timeout to be longer.
-        Utilities.setJobTimeout(newJob, 180)
+        Utilities.setJobTimeout(newJob, 720)
         // Set triggers
         if (isPR) {
             if (!isLocal) {


### PR DESCRIPTION
Last run for code coverage was aborted when generating the report due to timeout. Increasing the timeout 4 fold to get a few runs and access the appropriate value. (Related to #23588)