### PR TITLE
Remove ref assembly output workaround.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -320,15 +320,6 @@
     <IncludeDllSafeSearchPathAttribute Condition="'$(TargetGroup)' == 'netstandard1.0'">false</IncludeDllSafeSearchPathAttribute>
   </PropertyGroup>
 
-  <!-- Set up default paths for reference assemblies -->
-  <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
-    <!-- Create a common root output directory for all reference assemblies -->
-    <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$(BaseOutputPath)ref/</ReferenceAssemblyOutputPath>
-    <TargetOutputRelPath Condition="'$(IsCompatAssembly)'=='true'">$(TargetOutputRelPath)Compat/</TargetOutputRelPath>
-    <OutputPath>$(ReferenceAssemblyOutputPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</OutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)ref/$(AssemblyName)/$(TargetOutputRelPath)</IntermediateOutputPath>
-  </PropertyGroup>
-
   <!-- Properties related to multi-file mode for ILC tests -->
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <!-- Only enable multi-file for Release-x64 and Debug-x86 for now -->


### PR DESCRIPTION
This workaround was necessary until https://github.com/dotnet/buildtools/pull/2091 was merged. Now it can be removed.

See the discussion here: https://github.com/dotnet/corefx/pull/29831#discussion_r200525701