### PR TITLE
[release/2.1] Add support and tests for HTTP 308 Permanent Redirect (#30398)

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
@@ -653,11 +653,12 @@ namespace System.Diagnostics
         {
             if (request.AllowAutoRedirect)
             {
-                if (statusCode == HttpStatusCode.Ambiguous       ||  // 300
-                    statusCode == HttpStatusCode.Moved           ||  // 301
-                    statusCode == HttpStatusCode.Redirect        ||  // 302
-                    statusCode == HttpStatusCode.RedirectMethod  ||  // 303
-                    statusCode == HttpStatusCode.RedirectKeepVerb)   // 307
+                if (statusCode == HttpStatusCode.Ambiguous        ||  // 300
+                    statusCode == HttpStatusCode.Moved            ||  // 301
+                    statusCode == HttpStatusCode.Redirect         ||  // 302
+                    statusCode == HttpStatusCode.RedirectMethod   ||  // 303
+                    statusCode == HttpStatusCode.RedirectKeepVerb ||  // 307
+                    (int)statusCode == 308) // 308 Permanent Redirect is not in netfx yet, and so has to be specified this way.
                 {
                     return s_autoRedirectsAccessor(request) >= request.MaximumAutomaticRedirections;
                 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -81,6 +81,7 @@ namespace System.Net.Http
                 case HttpStatusCode.SeeOther:
                 case HttpStatusCode.TemporaryRedirect:
                 case HttpStatusCode.MultipleChoices:
+                case HttpStatusCode.PermanentRedirect:
                     break;
 
                 default:

--- a/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
@@ -116,7 +116,8 @@ namespace System.Net.Http
                     response.StatusCode != HttpStatusCode.MovedPermanently &&
                     response.StatusCode != HttpStatusCode.Redirect &&
                     response.StatusCode != HttpStatusCode.RedirectMethod &&
-                    response.StatusCode != HttpStatusCode.RedirectKeepVerb)
+                    response.StatusCode != HttpStatusCode.RedirectKeepVerb &&
+                    response.StatusCode != HttpStatusCode.PermanentRedirect)
                 {
                     break;
                 }
@@ -151,10 +152,11 @@ namespace System.Net.Http
                 }
 
                 // Follow HTTP RFC 7231 rules. In general, 3xx responses
-                // except for 307 will keep verb except POST becomes GET.
-                // 307 responses have all verbs stay the same.
+                // except for 307 and 308 will keep verb except POST becomes GET.
+                // 307 and 308 responses have all verbs stay the same.
                 // https://tools.ietf.org/html/rfc7231#section-6.4
                 if (response.StatusCode != HttpStatusCode.RedirectKeepVerb &&
+                    response.StatusCode != HttpStatusCode.PermanentRedirect &&
                     requestHttpMethod == HttpMethod.Post)
                 {
                     requestHttpMethod = HttpMethod.Get;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -62,7 +62,8 @@ namespace System.Net.Http.Functional.Tests
             new object[] { 301 },
             new object[] { 302 },
             new object[] { 303 },
-            new object[] { 307 }
+            new object[] { 307 },
+            new object[] { 308 }
         };
 
         public static readonly object[][] RedirectStatusCodesOldMethodsNewMethods = {
@@ -85,6 +86,10 @@ namespace System.Net.Http.Functional.Tests
             new object[] { 307, "GET", "GET" },
             new object[] { 307, "POST", "POST" },
             new object[] { 307, "HEAD", "HEAD" },
+
+            new object[] { 308, "GET", "GET" },
+            new object[] { 308, "POST", "POST" },
+            new object[] { 308, "HEAD", "HEAD" },
         };
 
         // Standard HTTP methods defined in RFC7231: http://tools.ietf.org/html/rfc7231#section-4.3
@@ -245,6 +250,12 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task DefaultHeaders_SetCredentials_ClearedOnRedirect(int statusCode)
         {
+            if (statusCode == 308 && (PlatformDetection.IsFullFramework || IsWinHttpHandler && PlatformDetection.WindowsVersion < 10))
+            {
+                // 308 redirects are not supported on old versions of WinHttp, or on .NET Framework.
+                return;
+            }
+
             HttpClientHandler handler = CreateHttpClientHandler();
             using (var client = new HttpClient(handler))
             {
@@ -721,6 +732,12 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_AllowAutoRedirectFalse_RedirectFromHttpToHttp_StatusCodeRedirect(int statusCode)
         {
+            if (statusCode == 308 && (PlatformDetection.IsFullFramework || IsWinHttpHandler && PlatformDetection.WindowsVersion < 10))
+            {
+                // 308 redirects are not supported on old versions of WinHttp, or on .NET Framework.
+                return;
+            }
+
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.AllowAutoRedirect = false;
             using (var client = new HttpClient(handler))
@@ -748,6 +765,12 @@ namespace System.Net.Http.Functional.Tests
                 // Known behavior: curl does not change method to "GET"
                 // https://github.com/dotnet/corefx/issues/26434
                 newMethod = "POST";
+            }
+
+            if (statusCode == 308 && (PlatformDetection.IsFullFramework || IsWinHttpHandler && PlatformDetection.WindowsVersion < 10))
+            {
+                // 308 redirects are not supported on old versions of WinHttp, or on .NET Framework.
+                return;
             }
 
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -868,6 +891,12 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttp_StatusCodeOK(int statusCode)
         {
+            if (statusCode == 308 && (PlatformDetection.IsFullFramework || IsWinHttpHandler && PlatformDetection.WindowsVersion < 10))
+            {
+                // 308 redirects are not supported on old versions of WinHttp, or on .NET Framework.
+                return;
+            }
+
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.AllowAutoRedirect = true;
             using (var client = new HttpClient(handler))
@@ -1225,6 +1254,12 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK(int statusCode)
         {
+            if (statusCode == 308 && (PlatformDetection.IsFullFramework || IsWinHttpHandler && PlatformDetection.WindowsVersion < 10))
+            {
+                // 308 redirects are not supported on old versions of WinHttp, or on .NET Framework.
+                return;
+            }
+
             Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: Username, password: Password);
             Uri redirectUri = Configuration.Http.RedirectUriForCreds(
                 secure: false,


### PR DESCRIPTION
The HttpStatusCode enum was only recently updated to include HTTP status code 308, via PR #26727. With the platform handlers we support whatever cURL and WinHttp support, so 308 works even though the status code did not exist in the enum until recently. However in SocketsHttpHandler we only support the redirects that were in the enum when that code was written, which at the time did not include 308.

This PR adds support for 308 redirects to SocketsHttpHandler, and enables 308 redirects in our tests.

This is an exact port of PR #30398.

Fixes: #30389