### PR TITLE
Get rid of DoubleHelper in Number.FormatAndParse.cs

### DIFF
--- a/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
+++ b/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
@@ -31,7 +31,13 @@ namespace System
                 return false;
             }
 
-            value = (d == 0.0) ? 0.0 : d;
+            if (d == 0.0)
+            {
+                // normalize -0.0 to 0.0
+                d = 0.0;
+            }
+
+            value = d;
             return true;
         }
 

--- a/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
+++ b/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
@@ -31,12 +31,7 @@ namespace System
                 return false;
             }
 
-            if (d == 0.0)
-            {
-                d = 0.0;
-            }
-
-            value = d;
+            value = (d == 0.0) ? 0.0 : d;
             return true;
         }
 

--- a/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
+++ b/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
@@ -25,22 +25,18 @@ namespace System
         internal static bool NumberBufferToDouble(ref NumberBuffer number, out double value)
         {
             double d = NumberToDouble(ref number);
-
-            uint e = DoubleHelper.Exponent(d);
-            ulong m = DoubleHelper.Mantissa(d);
-            if (e == 0x7FF)
+            if (!Double.IsFinite(d))
             {
                 value = default;
                 return false;
             }
 
-            if (e == 0 && m == 0)
+            if (d == 0.0)
             {
-                d = 0;
+                d = 0.0;
             }
 
             value = d;
-
             return true;
         }
 
@@ -511,24 +507,6 @@ namespace System
                 val |= 0x8000000000000000;
 
             return *(double*)&val;
-        }
-
-        private static class DoubleHelper
-        {
-            public static unsafe uint Exponent(double d)
-            {
-                return (*((uint*)&d + 1) >> 20) & 0x000007ff;
-            }
-
-            public static unsafe ulong Mantissa(double d)
-            {
-                return (*((uint*)&d)) | ((ulong)(*((uint*)&d + 1) & 0x000fffff) << 32);
-            }
-
-            public static unsafe bool Sign(double d)
-            {
-                return (*((uint*)&d + 1) >> 31) != 0;
-            }
         }
     }
 }


### PR DESCRIPTION
See https://github.com/dotnet/coreclr/pull/18853
(makes code smaller and BigEndian friendly)