### PR TITLE
Reduce coverage run timeout

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -75,7 +75,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
         // Archive results.
         Utilities.addArchival(newJob, '**/coverage/*,msbuild.log')
         // Timeout. Code coverage runs take longer, so we set the timeout to be longer.
-        Utilities.setJobTimeout(newJob, 720)
+        Utilities.setJobTimeout(newJob, 300)
         // Set triggers
         if (isPR) {
             if (!isLocal) {


### PR DESCRIPTION
[Today's run](https://ci.dot.net/job/dotnet_corefx/job/master/job/code_coverage_windows/607/Code_Coverage_Report/) completed in 3h15 minutes, I will go for 5 hours for now. 

There are some tests that are definitely taking too long but for *a pair* that I checked they are that slow only in coverage runs, so it seems that there is some side-effect of the coverage run. For reference, here is a list of the ones taking more than 250 seconds:

| Test in Coverage | Duration (sec) |
| ---- | ---- |
| System.IO.Compression.Brotli.Tests | 256 |
| System.IO.Compression.Tests.* | 573 |
| System.Linq.Parallel.Tests | 990 |
| System.Buffers.Text.Tests | 646 |
| System.Net.Tests | 309 |
| System.Net.Http.Functional.Tests | 335 |
| System.Runtime.Serialization.Formatter.Tests | 484 |
