### PR TITLE
Always run end.sh/ps1 step

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -321,6 +321,7 @@
       "continueOnError": true,
       "displayName": "run end.sh",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "alwaysRun": true,
       "task": {
         "id": "10f1f9a1-74b0-47ab-87bf-e3c9c68e8b0d",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -320,6 +320,7 @@
       "enabled": true,
       "continueOnError": true,
       "displayName": "run end.sh",
+      "condition": "always()",
       "timeoutInMinutes": 0,
       "alwaysRun": true,
       "task": {

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -273,6 +273,7 @@
       "continueOnError": true,
       "displayName": "run end.sh",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "alwaysRun": true,
       "task": {
         "id": "10f1f9a1-74b0-47ab-87bf-e3c9c68e8b0d",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
@@ -297,6 +297,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -348,6 +348,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",

--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -149,6 +149,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -298,6 +298,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",

--- a/buildpipeline/DotNet-Trusted-Tests-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Tests-Publish.json
@@ -144,6 +144,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",


### PR DESCRIPTION
This cleanup step should run regardless of any tasks failing beforehand.

See dotnet/core-eng#3860