### PR TITLE
Fix handle double-free in recently added WindowsIdentity test (#30731)

### DIFF
--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -129,12 +129,16 @@ public class WindowsIdentityTests
     {
         using (var mutex = new Mutex())
         {
-            Assert.Throws<ArgumentException>(() =>
+            SafeAccessTokenHandle handle = null;
+            try
             {
-                WindowsIdentity.RunImpersonated(
-                    new SafeAccessTokenHandle(mutex.SafeWaitHandle.DangerousGetHandle()),
-                    () => { });
-            });
+                handle = new SafeAccessTokenHandle(mutex.SafeWaitHandle.DangerousGetHandle());
+                Assert.Throws<ArgumentException>(() => WindowsIdentity.RunImpersonated(handle, () => { }));
+            }
+            finally
+            {
+                handle?.SetHandleAsInvalid();
+            }
         }
     }
 


### PR DESCRIPTION
- Port of https://github.com/dotnet/corefx/pull/30731 to release/2.1
- Changes are to test code only
- Test issue was introduced with https://github.com/dotnet/corefx/pull/30379