### PR TITLE
MilliSecond Granualrity added to Copy operation on unix

### DIFF
--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -1278,9 +1278,9 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
 #if HAVE_FUTIMES
         struct timeval origTimes[2];
         origTimes[0].tv_sec = sourceStat.st_atime;
-        origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat)/1000;
+        origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat) / 1000;
         origTimes[1].tv_sec = sourceStat.st_mtime;
-        origTimes[1].tv_usec = ST_MTIME_NSEC(&sourceStat)/1000;
+        origTimes[1].tv_usec = ST_MTIME_NSEC(&sourceStat) / 1000;
         while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
 #elif HAVE_FUTIMENS
         // futimes is not a POSIX function, and not available on Android,

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -1278,18 +1278,18 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
 #if HAVE_FUTIMES
         struct timeval origTimes[2];
         origTimes[0].tv_sec = sourceStat.st_atime;
-        origTimes[0].tv_usec = 0;
+        origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat)/1000;
         origTimes[1].tv_sec = sourceStat.st_mtime;
-        origTimes[1].tv_usec = 0;
+        origTimes[1].tv_usec = ST_MTIME_NSEC(&sourceStat)/1000;
         while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
 #elif HAVE_FUTIMENS
         // futimes is not a POSIX function, and not available on Android,
         // but futimens is
         struct timespec origTimes[2];
         origTimes[0].tv_sec = (time_t)sourceStat.st_atime;
-        origTimes[0].tv_nsec = 0;
+        origTimes[0].tv_nsec = ST_ATIME_NSEC(&sourceStat);
         origTimes[1].tv_sec = (time_t)sourceStat.st_mtime;
-        origTimes[1].tv_nsec = 0;
+        origTimes[1].tv_nsec = ST_MTIME_NSEC(&sourceStat);
         while ((ret = futimens(outFd, origTimes)) < 0 && errno == EINTR);
 #endif
     }

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -10,7 +10,7 @@ namespace System.IO.Tests
 {
     public abstract class BaseGetSetTimes<T> : FileSystemTest
     {
-        private const string HFS = "hfs";
+        protected const string HFS = "hfs";
         public delegate void SetTime(T item, DateTime time);
         public delegate DateTime GetTime(T item);
 

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -76,20 +76,15 @@ namespace System.IO.Tests
 	        FileInfo input = new FileInfo(Path.Combine(TestDirectory, fileName));
 	        FileInfo output = new FileInfo(Path.Combine(TestDirectory, GetTestFileName(), fileName));
 	        input.Create().Dispose();
-            Console.WriteLine($"Input: {input.LastWriteTime.Millisecond} ms, {input.LastWriteTime.Ticks} ticks");
-	        Console.WriteLine($"Output: {output.LastWriteTime.Millisecond} ms, {output.LastWriteTime.Ticks} ticks");
-	        if(!output.Exists || input.LastWriteTime > output.LastWriteTime) 
-            {
-		        if(!output.Directory.Exists)
-                {
-			        output.Directory.Create();
-			        Console.WriteLine("Directory Created");
-		        }
-            }
-            output = input.CopyTo(output.FullName, true);
-            Console.WriteLine($"Input: {input.LastWriteTime.Millisecond} ms, {input.LastWriteTime.Ticks} ticks");
-	        Console.WriteLine($"Output: {output.LastWriteTime.Millisecond} ms, {output.LastWriteTime.Ticks} ticks");
-		}
+            
+            Assert.NotEqual(0, input.LastWriteTime.Millisecond);
+	        Assert.Equal(0, output.LastWriteTime.Millisecond);
+            output.Directory.Create();
+			output = input.CopyTo(output.FullName, true);
+
+            Assert.NotEqual(0, input.LastWriteTime.Millisecond);
+	        Assert.NotEqual(0, output.LastWriteTime.Millisecond);
+        }
 
         [Fact]
         public void DeleteAfterEnumerate_TimesStillSet()

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -65,7 +65,7 @@ namespace System.IO.Tests
                 ((testFile) => testFile.LastWriteTimeUtc),
                 DateTimeKind.Utc);
             yield return TimeFunction.Create(
-                ((testFile, time) => { CopytoOperation(); }),
+                ((testFile, time) => CopytoOperation()),
                 ((testFile) => testFile.LastWriteTimeUtc),
                 DateTimeKind.Utc);         
         }

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -72,27 +72,50 @@ namespace System.IO.Tests
         {
             FileInfo input = new FileInfo(Path.Combine(TestDirectory, GetTestFileName()));
             input.Create().Dispose();
-            for (int i = 0; i < 5; i++)
+
+            string driveFormat = new DriveInfo(input.DirectoryName).DriveFormat;
+            if (!driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase))
             {
-                if (input.LastWriteTime.Millisecond != 0)
-                    break;
+                for (int i = 0; i < 5; i++)
+                {
+                    if (input.LastWriteTime.Millisecond != 0)
+                        break;
 
-                // This case should only happen 1/1000 times, unless the OS/Filesystem does
-                // not support millisecond granularity.
+                    // This case should only happen 1/1000 times, unless the OS/Filesystem does
+                    // not support millisecond granularity.
 
-                // If it's 1/1000, or low granularity, this may help:
-                Thread.Sleep(1234);
-                input = new FileInfo(Path.Combine(TestDirectory, GetTestFileName()));
-                input.Create().Dispose();
+                    // If it's 1/1000, or low granularity, this may help:
+                    Thread.Sleep(1234);
+                    input = new FileInfo(Path.Combine(TestDirectory, GetTestFileName()));
+                    input.Create().Dispose();
+                }
+
+                FileInfo output = new FileInfo(Path.Combine(TestDirectory, GetTestFileName(), input.Name));
+                Assert.Equal(0, output.LastWriteTime.Millisecond);
+                output.Directory.Create();
+                output = input.CopyTo(output.FullName, true);
+
+                Assert.NotEqual(0, input.LastWriteTime.Millisecond);
+                Assert.NotEqual(0, output.LastWriteTime.Millisecond);
             }
+        }
 
+        [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
+        public void CopyToMillisecondPresent_HFS()
+        {
+            FileInfo input = new FileInfo(Path.Combine(TestDirectory, GetTestFileName()));
+            input.Create().Dispose();
             FileInfo output = new FileInfo(Path.Combine(TestDirectory, GetTestFileName(), input.Name));
-            Assert.Equal(0, output.LastWriteTime.Millisecond);
-            output.Directory.Create();
-            output = input.CopyTo(output.FullName, true);
 
-            Assert.NotEqual(0, input.LastWriteTime.Millisecond);
-            Assert.NotEqual(0, output.LastWriteTime.Millisecond);
+            string driveFormat = new DriveInfo(input.DirectoryName).DriveFormat;
+            if (driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase))
+            {             
+                output.Directory.Create();
+                output = input.CopyTo(output.FullName, true);
+                Assert.Equal(0, input.LastWriteTime.Millisecond);
+                Assert.Equal(0, output.LastWriteTime.Millisecond);
+            }
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -64,7 +64,32 @@ namespace System.IO.Tests
                 ((testFile, time) => { testFile.LastWriteTimeUtc = time; }),
                 ((testFile) => testFile.LastWriteTimeUtc),
                 DateTimeKind.Utc);
+            yield return TimeFunction.Create(
+                ((testFile, time) => { CopytoOperation(); }),
+                ((testFile) => testFile.LastWriteTimeUtc),
+                DateTimeKind.Utc);         
         }
+
+        private void CopytoOperation()
+        {
+            string fileName = GetTestFileName();
+	        FileInfo input = new FileInfo(Path.Combine(TestDirectory, fileName));
+	        FileInfo output = new FileInfo(Path.Combine(TestDirectory, GetTestFileName(), fileName));
+	        input.Create().Dispose();
+            Console.WriteLine($"Input: {input.LastWriteTime.Millisecond} ms, {input.LastWriteTime.Ticks} ticks");
+	        Console.WriteLine($"Output: {output.LastWriteTime.Millisecond} ms, {output.LastWriteTime.Ticks} ticks");
+	        if(!output.Exists || input.LastWriteTime > output.LastWriteTime) 
+            {
+		        if(!output.Directory.Exists)
+                {
+			        output.Directory.Create();
+			        Console.WriteLine("Directory Created");
+		        }
+            }
+            output = input.CopyTo(output.FullName, true);
+            Console.WriteLine($"Input: {input.LastWriteTime.Millisecond} ms, {input.LastWriteTime.Ticks} ticks");
+	        Console.WriteLine($"Output: {output.LastWriteTime.Millisecond} ms, {output.LastWriteTime.Ticks} ticks");
+		}
 
         [Fact]
         public void DeleteAfterEnumerate_TimesStillSet()

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -67,23 +67,23 @@ namespace System.IO.Tests
             yield return TimeFunction.Create(
                 ((testFile, time) => CopytoOperation()),
                 ((testFile) => testFile.LastWriteTimeUtc),
-                DateTimeKind.Utc);         
+                DateTimeKind.Utc);
         }
 
         private void CopytoOperation()
         {
             string fileName = GetTestFileName();
-	        FileInfo input = new FileInfo(Path.Combine(TestDirectory, fileName));
-	        FileInfo output = new FileInfo(Path.Combine(TestDirectory, GetTestFileName(), fileName));
-	        input.Create().Dispose();
-            
-            Assert.NotEqual(0, input.LastWriteTime.Millisecond);
-	        Assert.Equal(0, output.LastWriteTime.Millisecond);
-            output.Directory.Create();
-			output = input.CopyTo(output.FullName, true);
+            FileInfo input = new FileInfo(Path.Combine(TestDirectory, fileName));
+            FileInfo output = new FileInfo(Path.Combine(TestDirectory, GetTestFileName(), fileName));
+            input.Create().Dispose();
 
             Assert.NotEqual(0, input.LastWriteTime.Millisecond);
-	        Assert.NotEqual(0, output.LastWriteTime.Millisecond);
+            Assert.Equal(0, output.LastWriteTime.Millisecond);
+            output.Directory.Create();
+            output = input.CopyTo(output.FullName, true);
+
+            Assert.NotEqual(0, input.LastWriteTime.Millisecond);
+            Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/12403
without fix
```
Input: 187 ms, 636669266341879837 ticks
  Output: 0 ms, 504911232000000000 ticks
  Directory Created
  Input: 187 ms, 636669266341879837 ticks
  Output: 0 ms, 636669266340000000 ticks
```
with fix
```
  Input: 764 ms, 636669013077642750 ticks
  Output: 0 ms, 504910936800000000 ticks
  Directory Created
  Input: 764 ms, 636669013077642750 ticks
  Output: 764 ms, 636669013077642750 ticks
  Finished:    System.IO.FileSystem.Tests
```
The CI should fail on 4f23720 as fix is not there and pass on the recent commit
