### PR TITLE
Pkcs9SigningTime: normalize exception on windows file time < 1601

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
@@ -54,7 +54,16 @@ namespace Internal.Cryptography.Pal.Windows
 
         public sealed override byte[] EncodeUtcTime(DateTime utcTime)
         {
-            long ft = utcTime.ToFileTimeUtc();
+            long ft;
+            try 
+            {
+                ft = utcTime.ToFileTimeUtc();
+            }
+            catch (ArgumentException ex)
+            {
+                throw new CryptographicException(ex.Message, ex);
+            }
+
             unsafe
             {
                 return Interop.Crypt32.CryptEncodeObjectToByteArray(CryptDecodeObjectStructType.PKCS_UTC_TIME, &ft);

--- a/src/System.Security.Cryptography.Pkcs/tests/Pkcs9AttributeTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/Pkcs9AttributeTests.cs
@@ -28,6 +28,19 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        public static void InputDateTimeAsWindowsFileTimeBefore1601()
+        {
+            DateTime dt = new DateTime (1600, 12, 31, 11, 59, 59, DateTimeKind.Utc);
+            Assert.ThrowsAny<CryptographicException>(() => new Pkcs9SigningTime(dt));
+        }
+
+        [Fact]
+        public static void InputDateTimeAsWindowsFileTimeMinValue()
+        {
+            Assert.ThrowsAny<CryptographicException>(() => new Pkcs9SigningTime(DateTime.MinValue));
+        }
+
+        [Fact]
         public static void InputDateTimeAsX509TimeBefore1950_Utc()
         {
             DateTime dt = new DateTime(1949, 12, 31, 23, 59, 59, DateTimeKind.Utc);


### PR DESCRIPTION
Due to support Windows file time code like 
`var st = new Pkcs9SigningTime(new DateTime (1600, 12, 31, 11, 59, 59));` 
will throw `ArgumentOutOfRangeException`

and code like 
`var dt = new Pkcs9SigningTime(new DateTime (1605, 12, 31, 11, 59, 59));`
will throw CryptographicException

On non-Windows platforms it throws `CryptographicException` in both cases.

This change aligns Windows-part to use `CryptographicException`.