### PR TITLE
Re-enable Test_BadEventSource_MismatchedIds_WithEtwListener.

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.Etw.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.Etw.cs
@@ -17,7 +17,6 @@ namespace BasicEventSourceTests
         /// <summary>
         /// Test the 
         /// </summary>
-        [ActiveIssue(30876)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/corefx/issues/29754
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Depends on inspecting IL at runtime.")]
         public void Test_BadEventSource_MismatchedIds_WithEtwListener()


### PR DESCRIPTION
Fixes #30876.

Dependent upon https://github.com/dotnet/coreclr/pull/18835.