### PR TITLE
Disable PostRewindableStreamContentMultipleTimes test on NETFX

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -41,6 +41,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(30057, TargetFrameworkMonikers.Uap)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework disposes request content after send")]
         [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostRewindableStreamContentMultipleTimes_StreamContentFullySent(Uri serverUri)


### PR DESCRIPTION
PR #19082 changed .NET Core behavior to no longer dispose request content after send. However, the original behavior remains in .NET Framework. So, the test should be skipped on NETFX.

Closes #30987