### PR TITLE
Remove ExactSpelling = true in DllImport

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NonNetFx.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.NonNetFx.cs
@@ -17,10 +17,10 @@ namespace System
         public static bool IsNetfx472OrNewer => false;
 
 
-        [DllImport("libc", ExactSpelling = true, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libc", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr gnu_get_libc_release();
 
-        [DllImport("libc", ExactSpelling = true, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libc", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr gnu_get_libc_version();
 
         /// <summary>


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/31006 and https://github.com/dotnet/corefx/issues/30423

For UAPAOT scenario, if [DllImport]  is specified with ExactSpelling = true, mcg won't generate a throw only method for that PInvoke method. Thus during runtime, it will fail to launch.

There is another change to pass -usedefaultpinvoke false for ilc parameters.