### PR TITLE
[rel/2.1] Add tests for TimeZoneInfo to ensure offset is not outside of range

### DIFF
--- a/src/System.Runtime/tests/TimeZoneInfoTests.cs
+++ b/src/System.Runtime/tests/TimeZoneInfoTests.cs
@@ -274,6 +274,54 @@ namespace System.Tests
             Assert.Equal(serialized, deserializedTimeZone.ToSerializedString());
         }
 
+        [Fact]
+        public static void TimeZoneInfo_DoesNotCreateAdjustmentRulesWithOffsetOutsideOfRange()
+        {
+            // On some OSes with some time zones setting
+            // time zone may contain old adjustment rule which have offset higher than 14h
+            // Assert.DoesNotThrow
+            DateTimeOffset.FromFileTime(0);
+        }
+
+        [Fact]
+        public static void TimeZoneInfo_DoesConvertTimeForOldDatesOfTimeZonesWithExceedingMaxRange()
+        {
+            // On some OSes this time zone contains old adjustment rules which have offset higher than 14h
+            TimeZoneInfo tzi = TryGetSystemTimeZone("Asia/Manila");
+            if (tzi == null)
+            {
+                // Time zone could not be found
+                return;
+            }
+
+            // Assert.DoesNotThrow
+            TimeZoneInfo.ConvertTime(new DateTimeOffset(1800, 4, 4, 10, 10, 4, 2, TimeSpan.Zero), tzi);
+        }
+
+        [Fact]
+        public static void GetSystemTimeZones_AllTimeZonesHaveOffsetInValidRange()
+        {
+            foreach (TimeZoneInfo tzi in TimeZoneInfo.GetSystemTimeZones())
+            {
+                foreach (TimeZoneInfo.AdjustmentRule ar in tzi.GetAdjustmentRules())
+                {
+                    Assert.True(Math.Abs((tzi.GetUtcOffset(ar.DateStart)).TotalHours) <= 14.0);
+                }
+            }
+        }
+
+        private static TimeZoneInfo TryGetSystemTimeZone(string id)
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(id);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                return null;
+            }
+        }
+
         private static TimeZoneInfo CreateCustomLondonTimeZone()
         {
             TimeZoneInfo.TransitionTime start = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 1, 0, 0), 3, 5, DayOfWeek.Sunday);


### PR DESCRIPTION
Tests for https://github.com/dotnet/coreclr/pull/18874

cc: @danmosemsft I presume this doesn't require additional shiproom?

tests should fail (linux) as long as coreclr PR is not merged