### PR TITLE
Globalization coverage: use proper runtimeconfig.json

### DIFF
--- a/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/System.Globalization.CalendarsWithConfigSwitch.Tests.csproj
+++ b/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/System.Globalization.CalendarsWithConfigSwitch.Tests.csproj
@@ -14,7 +14,11 @@
     <SkipXunitRuntimeConfigCopying>true</SkipXunitRuntimeConfigCopying>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="xunit.console.netcore.runtimeconfig.json">
+    <Content Condition="'$(UsingCoverageDedicatedRuntime)'!='true'" Include="xunit.console.netcore.runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <!-- If using coverage dedicated runtime the proper runtimeconfig needs to be ussed -->
+    <Content Condition="'$(UsingCoverageDedicatedRuntime)'=='true'" Include="coverage/xunit.console.netcore.runtimeconfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/coverage/xunit.console.netcore.runtimeconfig.json
+++ b/src/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/coverage/xunit.console.netcore.runtimeconfig.json
@@ -1,0 +1,11 @@
+{
+  "runtimeOptions": {
+    "configProperties": {
+      "Switch.System.Globalization.EnforceJapaneseEraYearRanges": true
+    },
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+        "version": "10.10.10"
+	    }
+  }
+}

--- a/src/System.Globalization/tests/Invariant/Invariant.Tests.csproj
+++ b/src/System.Globalization/tests/Invariant/Invariant.Tests.csproj
@@ -12,7 +12,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvariantMode.cs" />
-    <Content Include="xunit.console.netcore.runtimeconfig.json">
+    <Content Condition="'$(UsingCoverageDedicatedRuntime)'!='true'" Include="xunit.console.netcore.runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <!-- If using coverage dedicated runtime the proper runtimeconfig needs to be ussed -->
+    <Content Condition="'$(UsingCoverageDedicatedRuntime)'=='true'" Include="coverage/xunit.console.netcore.runtimeconfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/System.Globalization/tests/Invariant/coverage/xunit.console.netcore.runtimeconfig.json
+++ b/src/System.Globalization/tests/Invariant/coverage/xunit.console.netcore.runtimeconfig.json
@@ -1,0 +1,11 @@
+{
+  "runtimeOptions": {
+    "configProperties": {
+      "System.Globalization.Invariant": true
+    },
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+        "version": "10.10.10"
+	    }
+  }
+}


### PR DESCRIPTION
Together with https://github.com/dotnet/buildtools/pull/2098 this change will make these tests work as expected in coverage runs. There is a bit of duplication for the runtimeconfig.json but is simple and localized enough that seems the best way to do it at this moment. Part of https://github.com/dotnet/corefx/issues/31041