### PR TITLE
Fix TransformManyBlock's EnsureOrdered=false to not hold lock while iterating

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
@@ -492,7 +492,14 @@ namespace System.Threading.Tasks.Dataflow
         /// <param name="outputItems">The untrusted enumerable.</param>
         private void StoreOutputItemsNonReorderedWithIteration(IEnumerable<TOutput> outputItems)
         {
-            bool isSerial = _target.DataflowBlockOptions.MaxDegreeOfParallelism == 1;
+            // The _source we're adding to isn't thread-safe, so we need to determine
+            // whether we need to lock.  If the block is configured with a max degree
+            // of parallelism of 1, then only one transform can run at a time, and so
+            // we don't need to lock.  Similarly, if there's a reordering buffer, then
+            // it guarantees that we're invoked serially, and we don't need to lock.
+            bool isSerial =
+                _target.DataflowBlockOptions.MaxDegreeOfParallelism == 1 ||
+                _reorderingBuffer != null;
 
             // If we're bounding, we need to increment the bounded count
             // for each individual item as we enumerate it.
@@ -538,10 +545,12 @@ namespace System.Threading.Tasks.Dataflow
                 }
                 else
                 {
-                    lock (ParallelSourceLock)
+                    foreach (TOutput item in outputItems)
                     {
-                        foreach (TOutput item in outputItems)
+                        lock (ParallelSourceLock) // don't hold lock while enumerating
+                        {
                             _source.AddMessage(item);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When EnsureOrdered is set to false (the default is true) and the max degree of parallelism isn't 1 (meaning it allows for parallelism), TransformManyBlock doesn't employ a reordering buffer but needs to then ensure that the collection it writes the results of the transform to is accessed in a thread-safe manner, so it takes a lock.  Currently it takes the lock around the whole enumeration of the result.  While that avoids lots of locking/unlocking for cases where the enumerable produces all of its results very quickly, it causes problems when the enumerable may be slow to produce results, as it then ends up serializing the processing of all of the enumerables.  The fix is simply to take the lock if it's needed only while adding to the target collection, not while iterating the enumerable.

This change does have a small breaking change potential, in that it's possible someone could have set parallelism to > 1 and set EnsureOrdered to false, and then relied on the lock that was being taken exactly for its serialization, in order to make their delegate effectively thread-safe.  But a) EnsureOrdered is a relatively new feature and this setting isn't the default, b) if you've set parallelism to something other than 1, by design you're asking for your delegate to run concurrently with itself.  So the chances of actually breaking something with this bug fix are minimal.

cc: @tarekgh, @kouvel 