### PR TITLE
Add even more integer parsing tests

### DIFF
--- a/src/System.Runtime/tests/System/Int32Tests.cs
+++ b/src/System.Runtime/tests/System/Int32Tests.cs
@@ -193,7 +193,7 @@ namespace System.Tests
             yield return new object[] { "00000000000000000000000000000000000000000000000002147483647", NumberStyles.None, null, 2147483647 };
             yield return new object[] { "123\0\0", NumberStyles.None, null, 123 };
 
-            // All lengths
+            // All lengths decimal
             foreach (bool neg in new[] { false, true })
             {
                 string s = neg ? "-" : "";
@@ -206,12 +206,24 @@ namespace System.Tests
                 }
             }
 
+            // All lengths hexadecimal
+            {
+                string s = "";
+                int result = 0;
+                for (int i = 1; i <= 8; i++)
+                {
+                    result = (result * 16) + (i % 16);
+                    s += (i % 16).ToString("X");
+                    yield return new object[] { s, NumberStyles.HexNumber, null, result };
+                }
+            }
+
             // HexNumber
             yield return new object[] { "123", NumberStyles.HexNumber, null, 0x123 };
             yield return new object[] { "abc", NumberStyles.HexNumber, null, 0xabc };
             yield return new object[] { "ABC", NumberStyles.HexNumber, null, 0xabc };
             yield return new object[] { "12", NumberStyles.HexNumber, null, 0x12 };
-            yield return new object[] { "80000000", NumberStyles.HexNumber, null, -2147483648 };
+            yield return new object[] { "80000000", NumberStyles.HexNumber, null, int.MinValue };
             yield return new object[] { "FFFFFFFF", NumberStyles.HexNumber, null, -1 };
 
             // Currency
@@ -327,39 +339,39 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse(string value, NumberStyles style, IFormatProvider provider, int expected)
+        public static void Parse_Valid(string value, NumberStyles style, IFormatProvider provider, int expected)
         {
-            bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             int result;
-            if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None)
+
+            // Default style and provider
+            if (style == NumberStyles.Integer && provider == null)
             {
-                // Use Parse(string) or Parse(string, IFormatProvider)
-                if (isDefaultProvider)
-                {
-                    Assert.True(int.TryParse(value, out result));
-                    Assert.Equal(expected, result);
+                Assert.True(int.TryParse(value, out result));
+                Assert.Equal(expected, result);
+                Assert.Equal(expected, int.Parse(value));
+            }
 
-                    Assert.Equal(expected, int.Parse(value));
-                }
+            // Default provider
+            if (provider == null)
+            {
+                Assert.Equal(expected, int.Parse(value, style));
 
+                // Substitute default NumberFormatInfo
+                Assert.True(int.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.Equal(expected, result);
+                Assert.Equal(expected, int.Parse(value, style, new NumberFormatInfo()));
+            }
+
+            // Default style
+            if (style == NumberStyles.Integer)
+            {
                 Assert.Equal(expected, int.Parse(value, provider));
             }
-            
-            // Use Parse(string, NumberStyles, IFormatProvider)
+
+            // Full overloads
             Assert.True(int.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-
             Assert.Equal(expected, int.Parse(value, style, provider));
-
-            if (isDefaultProvider)
-            {
-                // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.True(int.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
-                Assert.Equal(expected, result);
-                
-                Assert.Equal(expected, int.Parse(value, style));
-                Assert.Equal(expected, int.Parse(value, style, NumberFormatInfo.CurrentInfo));
-            }
         }
 
         public static IEnumerable<object[]> Parse_Invalid_TestData()
@@ -376,8 +388,8 @@ namespace System.Tests
             // Leading or trailing chars for which char.IsWhiteSpace is true but that's not valid for leading/trailing whitespace
             foreach (string c in new[] { "\x0085", "\x00A0", "\x1680", "\x2000", "\x2001", "\x2002", "\x2003", "\x2004", "\x2005", "\x2006", "\x2007", "\x2008", "\x2009", "\x200A", "\x2028", "\x2029", "\x202F", "\x205F", "\x3000" })
             {
-               yield return new object[] { c + "123", NumberStyles.Integer, null, typeof(FormatException) };
-               yield return new object[] { "123" + c, NumberStyles.Integer, null, typeof(FormatException) };
+                yield return new object[] { c + "123", NumberStyles.Integer, null, typeof(FormatException) };
+                yield return new object[] { "123" + c, NumberStyles.Integer, null, typeof(FormatException) };
             }
 
             // String contains garbage
@@ -390,9 +402,6 @@ namespace System.Tests
                 yield return new object[] { "123g", style, null, typeof(FormatException) };
                 yield return new object[] { "g123", style, null, typeof(FormatException) };
                 yield return new object[] { "214748364g", style, null, typeof(FormatException) };
-                yield return new object[] { "1000000000g", style, null, typeof(FormatException) };
-                yield return new object[] { "1000000000 g", style, null, typeof(FormatException) };
-                yield return new object[] { "1000000000  g", style, null, typeof(FormatException) };
             }
 
             // String has leading zeros
@@ -480,7 +489,7 @@ namespace System.Tests
 
             // AllowDecimalPoint
             NumberFormatInfo decimalFormat = new NumberFormatInfo() { NumberDecimalSeparator = "." };
-            yield return new object[] { (67.9).ToString(), NumberStyles.AllowDecimalPoint, null, typeof(OverflowException) };
+            yield return new object[] { "67.9", NumberStyles.AllowDecimalPoint, null, typeof(OverflowException) };
 
             // Parsing integers doesn't allow NaN, PositiveInfinity or NegativeInfinity
             NumberFormatInfo doubleFormat = new NumberFormatInfo()
@@ -507,56 +516,109 @@ namespace System.Tests
             yield return new object[] { "123", NumberStyles.AllowLeadingSign, new NumberFormatInfo() { PositiveSign = "123" }, typeof(FormatException) };
             yield return new object[] { "123", NumberStyles.AllowLeadingSign, new NumberFormatInfo() { NegativeSign = "123" }, typeof(FormatException) };
 
-            // Not in range of Int32
-            foreach (string s in new[] { "2147483648", "10000000000", "-2147483649", "9223372036854775808", "-9223372036854775809" })
+            // Decimals not in range of Int32
+            foreach (string s in new[]
+            {
+                "2147483648", // int.MaxValue + 1
+                "2147483650", // 10s digit incremented above int.MaxValue
+                "10000000000", // extra digit after int.MaxValue
+
+                "4294967296", // uint.MaxValue + 1
+                "4294967300", // 100s digit incremented above uint.MaxValue
+
+                "9223372036854775808", // long.MaxValue + 1
+                "9223372036854775810", // 10s digit incremented above long.MaxValue
+                "10000000000000000000", // extra digit after long.MaxValue
+
+                "18446744073709551616", // ulong.MaxValue + 1
+                "18446744073709551620", // 10s digit incremented above ulong.MaxValue
+                "100000000000000000000", // extra digit after ulong.MaxValue
+
+                "-2147483649", // int.MinValue - 1
+                "-2147483650", // 10s digit decremented below int.MinValue
+                "-10000000000", // extra digit after int.MinValue
+
+                "-9223372036854775809", // long.MinValue - 1
+                "-9223372036854775810", // 10s digit decremented below long.MinValue
+                "-10000000000000000000", // extra digit after long.MinValue
+
+                "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000", // really big
+                "-100000000000000000000000000000000000000000000000000000000000000000000000000000000000000" // really small
+            })
             {
                 foreach (NumberStyles styles in new[] { NumberStyles.Any, NumberStyles.Integer })
                 {
                     yield return new object[] { s, styles, null, typeof(OverflowException) };
+                    yield return new object[] { s + "   ", styles, null, typeof(OverflowException) };
+                    yield return new object[] { s + "   " + "\0\0\0", styles, null, typeof(OverflowException) };
+
+                    yield return new object[] { s + "g", styles, null, typeof(FormatException) };
+                    yield return new object[] { s + "\0g", styles, null, typeof(FormatException) };
+                    yield return new object[] { s + " g", styles, null, typeof(FormatException) };
                 }
             }
+
+            // Hexadecimals not in range of Int32
+            foreach (string s in new[]
+            {
+                "100000000", // uint.MaxValue + 1
+                "FFFFFFFF0", // extra digit after uint.MaxValue
+
+                "10000000000000000", // ulong.MaxValue + 1
+                "FFFFFFFFFFFFFFFF0", // extra digit after ulong.MaxValue
+
+                "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000" // really big
+            })
+            {
+                yield return new object[] { s, NumberStyles.HexNumber, null, typeof(OverflowException) };
+                yield return new object[] { s + "   ", NumberStyles.HexNumber, null, typeof(OverflowException) };
+                yield return new object[] { s + "   " + "\0\0", NumberStyles.HexNumber, null, typeof(OverflowException) };
+
+                yield return new object[] { s + "g", NumberStyles.HexNumber, null, typeof(FormatException) };
+                yield return new object[] { s + "\0g", NumberStyles.HexNumber, null, typeof(FormatException) };
+                yield return new object[] { s + " g", NumberStyles.HexNumber, null, typeof(FormatException) };
+            }
+
             yield return new object[] { "2147483649-", NumberStyles.AllowTrailingSign, null, typeof(OverflowException) };
             yield return new object[] { "(2147483649)", NumberStyles.AllowParentheses, null, typeof(OverflowException) };
             yield return new object[] { "2E10", NumberStyles.AllowExponent, null, typeof(OverflowException) };
-            yield return new object[] { "800000000", NumberStyles.AllowHexSpecifier, null, typeof(OverflowException) };
-            yield return new object[] { "8000000000000000", NumberStyles.AllowHexSpecifier, null, typeof(OverflowException) };
         }
 
         [Theory]
         [MemberData(nameof(Parse_Invalid_TestData))]
         public static void Parse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
         {
-            bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             int result;
-            if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None && (style & NumberStyles.AllowLeadingWhite) == (style & NumberStyles.AllowTrailingWhite))
+
+            // Default style and provider
+            if (style == NumberStyles.Integer && provider == null)
             {
-                // Use Parse(string) or Parse(string, IFormatProvider)
-                if (isDefaultProvider)
-                {
-                    Assert.False(int.TryParse(value, out result));
-                    Assert.Equal(default(int), result);
+                Assert.False(int.TryParse(value, out result));
+                Assert.Equal(default, result);
+                Assert.Throws(exceptionType, () => int.Parse(value));
+            }
 
-                    Assert.Throws(exceptionType, () => int.Parse(value));
-                }
+            // Default provider
+            if (provider == null)
+            {
+                Assert.Throws(exceptionType, () => int.Parse(value, style));
 
+                // Substitute default NumberFormatInfo
+                Assert.False(int.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.Equal(default, result);
+                Assert.Throws(exceptionType, () => int.Parse(value, style, new NumberFormatInfo()));
+            }
+
+            // Default style
+            if (style == NumberStyles.Integer)
+            {
                 Assert.Throws(exceptionType, () => int.Parse(value, provider));
             }
 
-            // Use Parse(string, NumberStyles, IFormatProvider)
+            // Full overloads
             Assert.False(int.TryParse(value, style, provider, out result));
-            Assert.Equal(default(int), result);
-
+            Assert.Equal(default, result);
             Assert.Throws(exceptionType, () => int.Parse(value, style, provider));
-
-            if (isDefaultProvider)
-            {
-                // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.False(int.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
-                Assert.Equal(default(int), result);
-
-                Assert.Throws(exceptionType, () => int.Parse(value, style));
-                Assert.Throws(exceptionType, () => int.Parse(value, style, NumberFormatInfo.CurrentInfo));
-            }
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/Int32Tests.cs
+++ b/src/System.Runtime/tests/System/Int32Tests.cs
@@ -489,7 +489,7 @@ namespace System.Tests
 
             // AllowDecimalPoint
             NumberFormatInfo decimalFormat = new NumberFormatInfo() { NumberDecimalSeparator = "." };
-            yield return new object[] { "67.9", NumberStyles.AllowDecimalPoint, null, typeof(OverflowException) };
+            yield return new object[] { "67.9", NumberStyles.AllowDecimalPoint, decimalFormat, typeof(OverflowException) };
 
             // Parsing integers doesn't allow NaN, PositiveInfinity or NegativeInfinity
             NumberFormatInfo doubleFormat = new NumberFormatInfo()

--- a/src/System.Runtime/tests/System/Int64Tests.cs
+++ b/src/System.Runtime/tests/System/Int64Tests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Numerics;
 using Xunit;
 
 namespace System.Tests
@@ -178,85 +179,91 @@ namespace System.Tests
                 yield return new object[] { objs[0], objs[1], objs[2], unsigned ? (long)(uint)(int)objs[3] : (long)(int)objs[3] };
             }
 
-            // All lengths
+            // All lengths decimal
             foreach (bool neg in new[] { false, true })
             {
                 string s = neg ? "-" : "";
                 long result = 0;
                 for (int i = 1; i <= 19; i++)
                 {
-                    result = result * 10 + (i % 10);
+                    result = (result * 10) + (i % 10);
                     s += (i % 10).ToString();
-                    yield return new object[] { s, NumberStyles.Integer, null, neg ? result*-1 : result };
+                    yield return new object[] { s, NumberStyles.Integer, null, neg ? result * -1 : result };
+                }
+            }
+
+            // All lengths hexadecimal
+            {
+                string s = "";
+                long result = 0;
+                for (int i = 1; i <= 16; i++)
+                {
+                    result = (result * 16) + (i % 16);
+                    s += (i % 16).ToString("X");
+                    yield return new object[] { s, NumberStyles.HexNumber, null, result };
                 }
             }
 
             // And test boundary conditions for Int64
-            yield return new object[] { "-9223372036854775808", NumberStyles.Integer, null, -9223372036854775808 };
-            yield return new object[] { "9223372036854775807", NumberStyles.Integer, null, 9223372036854775807 };
-            yield return new object[] { "   -9223372036854775808   ", NumberStyles.Integer, null, -9223372036854775808 };
-            yield return new object[] { "   +9223372036854775807   ", NumberStyles.Integer, null, 9223372036854775807 };
+            yield return new object[] { "-9223372036854775808", NumberStyles.Integer, null, long.MinValue };
+            yield return new object[] { "9223372036854775807", NumberStyles.Integer, null, long.MaxValue };
+            yield return new object[] { "   -9223372036854775808   ", NumberStyles.Integer, null, long.MinValue };
+            yield return new object[] { "   +9223372036854775807   ", NumberStyles.Integer, null, long.MaxValue };
             yield return new object[] { "7FFFFFFFFFFFFFFF", NumberStyles.HexNumber, null, long.MaxValue };
             yield return new object[] { "8000000000000000", NumberStyles.HexNumber, null, long.MinValue };
-            yield return new object[] { "FFFFFFFFFFFFFFFF", NumberStyles.HexNumber, null, -1 };
-            yield return new object[] { "   FFFFFFFFFFFFFFFF  ", NumberStyles.HexNumber, null, -1 };
+            yield return new object[] { "FFFFFFFFFFFFFFFF", NumberStyles.HexNumber, null, -1L };
+            yield return new object[] { "   FFFFFFFFFFFFFFFF  ", NumberStyles.HexNumber, null, -1L };
         }
 
         [Theory]
         [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse(string value, NumberStyles style, IFormatProvider provider, long expected)
+        public static void Parse_Valid(string value, NumberStyles style, IFormatProvider provider, long expected)
         {
             long result;
-            // If no style is specified, use the (String) or (String, IFormatProvider) overload
-            if (style == NumberStyles.Integer)
+
+            // Default style and provider
+            if (style == NumberStyles.Integer && provider == null)
             {
                 Assert.True(long.TryParse(value, out result));
                 Assert.Equal(expected, result);
-
                 Assert.Equal(expected, long.Parse(value));
-
-                // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-                if (provider != null)
-                {
-                    Assert.Equal(expected, long.Parse(value, provider));
-                }
             }
 
-            // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-            Assert.True(long.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
-            Assert.Equal(expected, result);
-
-            // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+            // Default provider
             if (provider == null)
             {
                 Assert.Equal(expected, long.Parse(value, style));
+
+                // Substitute default NumberFormatInfo
+                Assert.True(long.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.Equal(expected, result);
+                Assert.Equal(expected, long.Parse(value, style, new NumberFormatInfo()));
             }
-            Assert.Equal(expected, long.Parse(value, style, provider ?? new NumberFormatInfo()));
+
+            // Default style
+            if (style == NumberStyles.Integer)
+            {
+                Assert.Equal(expected, long.Parse(value, provider));
+            }
+
+            // Full overloads
+            Assert.True(long.TryParse(value, style, provider, out result));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected, long.Parse(value, style, provider));
         }
 
         public static IEnumerable<object[]> Parse_Invalid_TestData()
         {
-            // Reuse all Int32 test data, except for those that would be validating Int32 overflows,
-            // since many of those will succeed for Int64.
+            // Reuse all int test data, except for those that wouldn't overflow long.
             foreach (object[] objs in Int32Tests.Parse_Invalid_TestData())
             {
-                if ((Type)objs[3] == typeof(OverflowException)) continue;
+                if ((Type)objs[3] == typeof(OverflowException) &&
+                    (!BigInteger.TryParse((string)objs[0], out BigInteger bi) || (bi >= long.MinValue && bi <= long.MaxValue)))
+                {
+                    continue;
+                }
                 yield return objs;
             }
-
-            // Then also validate Int64 boundary conditions for overflows.
-            yield return new object[] { "10000000000000000", NumberStyles.HexNumber, null, typeof(OverflowException) };
-            yield return new object[] { "-9223372036854775809", NumberStyles.Integer, null, typeof(OverflowException) };
-            yield return new object[] { "9223372036854775808", NumberStyles.Integer, null, typeof(OverflowException) };
-            yield return new object[] { "9223372036854775817", NumberStyles.Integer, null, typeof(OverflowException) };
-            yield return new object[] { "10000000000000000000", NumberStyles.Integer, null, typeof(OverflowException) };
-            yield return new object[] { "-10000000000000000000", NumberStyles.Integer, null, typeof(OverflowException) };
-            yield return new object[] { "922337203685477580a", NumberStyles.Integer, null, typeof(FormatException) };
-            yield return new object[] { "922337203685477580 a", NumberStyles.Integer, null, typeof(FormatException) };
-            yield return new object[] { "100000000000000000a", NumberStyles.Integer, null, typeof(FormatException) };
-            yield return new object[] { "1000000000000000000a", NumberStyles.Integer, null, typeof(FormatException) };
-            yield return new object[] { "100000000000000000 a", NumberStyles.Integer, null, typeof(FormatException) };
-            yield return new object[] { "1000000000000000000 a", NumberStyles.Integer, null, typeof(FormatException) };
         }
 
         [Theory]
@@ -264,31 +271,36 @@ namespace System.Tests
         public static void Parse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
         {
             long result;
-            // If no style is specified, use the (String) or (String, IFormatProvider) overload
-            if (style == NumberStyles.Integer)
+
+            // Default style and provider
+            if (style == NumberStyles.Integer && provider == null)
             {
                 Assert.False(long.TryParse(value, out result));
-                Assert.Equal(default(long), result);
-
+                Assert.Equal(default, result);
                 Assert.Throws(exceptionType, () => long.Parse(value));
-
-                // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-                if (provider != null)
-                {
-                    Assert.Throws(exceptionType, () => long.Parse(value, provider));
-                }
             }
 
-            // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-            Assert.False(long.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
-            Assert.Equal(default(long), result);
-
-            // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+            // Default provider
             if (provider == null)
             {
                 Assert.Throws(exceptionType, () => long.Parse(value, style));
+
+                // Substitute default NumberFormatInfo
+                Assert.False(long.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.Equal(default, result);
+                Assert.Throws(exceptionType, () => long.Parse(value, style, new NumberFormatInfo()));
             }
-            Assert.Throws(exceptionType, () => long.Parse(value, style, provider ?? new NumberFormatInfo()));
+
+            // Default style
+            if (style == NumberStyles.Integer)
+            {
+                Assert.Throws(exceptionType, () => long.Parse(value, provider));
+            }
+
+            // Full overloads
+            Assert.False(long.TryParse(value, style, provider, out result));
+            Assert.Equal(default, result);
+            Assert.Throws(exceptionType, () => long.Parse(value, style, provider));
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/UInt64Tests.cs
+++ b/src/System.Runtime/tests/System/UInt64Tests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Numerics;
 using Xunit;
 
 namespace System.Tests
@@ -161,97 +162,94 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Parse_Valid_TestData()
         {
-            NumberStyles defaultStyle = NumberStyles.Integer;
-            NumberFormatInfo emptyFormat = new NumberFormatInfo();
+            // Reuse all Int64 test data that's relevant
+            foreach (object[] objs in Int64Tests.Parse_Valid_TestData())
+            {
+                if ((long)objs[3] < 0) continue;
+                yield return new object[] { objs[0], objs[1], objs[2], (ulong)(long)objs[3] };
+            }
 
-            NumberFormatInfo customFormat = new NumberFormatInfo();
-            customFormat.CurrencySymbol = "$";
+            // All lengths decimal
+            {
+                string s = "";
+                ulong result = 0;
+                for (int i = 1; i <= 20; i++)
+                {
+                    result = (result * 10) + (ulong)(i % 10);
+                    s += (i % 10).ToString();
+                    yield return new object[] { s, NumberStyles.Integer, null, result };
+                }
+            }
 
-            yield return new object[] { "0", defaultStyle, null, (ulong)0 };
-            yield return new object[] { "123", defaultStyle, null, (ulong)123 };
-            yield return new object[] { "+123", defaultStyle, null, (ulong)123 };
-            yield return new object[] { "  123  ", defaultStyle, null, (ulong)123 };
-            yield return new object[] { "18446744073709551615", defaultStyle, null, 18446744073709551615 };
+            // All lengths hexadecimal
+            {
+                string s = "";
+                ulong result = 0;
+                for (int i = 1; i <= 16; i++)
+                {
+                    result = (result * 16) + (ulong)(i % 16);
+                    s += (i % 16).ToString("X");
+                    yield return new object[] { s, NumberStyles.HexNumber, null, result };
+                }
+            }
 
-            yield return new object[] { "12", NumberStyles.HexNumber, null, (ulong)0x12 };
-            yield return new object[] { "1000", NumberStyles.AllowThousands, null, (ulong)1000 };
-
-            yield return new object[] { "123", defaultStyle, emptyFormat, (ulong)123 };
-
-            yield return new object[] { "123", NumberStyles.Any, emptyFormat, (ulong)123 };
-            yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (ulong)0x12 };
-            yield return new object[] { "abc", NumberStyles.HexNumber, emptyFormat, (ulong)0xabc };
-            yield return new object[] { "ABC", NumberStyles.HexNumber, null, (ulong)0xabc };
-            yield return new object[] { "$1,000", NumberStyles.Currency, customFormat, (ulong)1000 };
+            // And test boundary conditions for UInt64
+            yield return new object[] { "18446744073709551615", NumberStyles.Integer, null, ulong.MaxValue };
+            yield return new object[] { "+18446744073709551615", NumberStyles.Integer, null, ulong.MaxValue };
+            yield return new object[] { "    +18446744073709551615  ", NumberStyles.Integer, null, ulong.MaxValue };
+            yield return new object[] { "FFFFFFFFFFFFFFFF", NumberStyles.HexNumber, null, ulong.MaxValue };
+            yield return new object[] { "   FFFFFFFFFFFFFFFF   ", NumberStyles.HexNumber, null, ulong.MaxValue };
         }
 
         [Theory]
         [MemberData(nameof(Parse_Valid_TestData))]
-        public static void Parse(string value, NumberStyles style, IFormatProvider provider, ulong expected)
+        public static void Parse_Valid(string value, NumberStyles style, IFormatProvider provider, ulong expected)
         {
             ulong result;
-            // If no style is specified, use the (String) or (String, IFormatProvider) overload
-            if (style == NumberStyles.Integer)
+
+            // Default style and provider
+            if (style == NumberStyles.Integer && provider == null)
             {
                 Assert.True(ulong.TryParse(value, out result));
                 Assert.Equal(expected, result);
-
                 Assert.Equal(expected, ulong.Parse(value));
-
-                // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-                if (provider != null)
-                {
-                    Assert.Equal(expected, ulong.Parse(value, provider));
-                }
             }
 
-            // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-            Assert.True(ulong.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
-            Assert.Equal(expected, result);
-
-            // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+            // Default provider
             if (provider == null)
             {
                 Assert.Equal(expected, ulong.Parse(value, style));
+
+                // Substitute default NumberFormatInfo
+                Assert.True(ulong.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.Equal(expected, result);
+                Assert.Equal(expected, ulong.Parse(value, style, new NumberFormatInfo()));
             }
-            Assert.Equal(expected, ulong.Parse(value, style, provider ?? new NumberFormatInfo()));
+
+            // Default style
+            if (style == NumberStyles.Integer)
+            {
+                Assert.Equal(expected, ulong.Parse(value, provider));
+            }
+
+            // Full overloads
+            Assert.True(ulong.TryParse(value, style, provider, out result));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected, ulong.Parse(value, style, provider));
         }
 
         public static IEnumerable<object[]> Parse_Invalid_TestData()
         {
-            NumberStyles defaultStyle = NumberStyles.Integer;
-
-            NumberFormatInfo customFormat = new NumberFormatInfo();
-            customFormat.CurrencySymbol = "$";
-            customFormat.NumberDecimalSeparator = ".";
-
-            yield return new object[] { null, defaultStyle, null, typeof(ArgumentNullException) };
-            yield return new object[] { "", defaultStyle, null, typeof(FormatException) };
-            yield return new object[] { " \t \n \r ", defaultStyle, null, typeof(FormatException) };
-            yield return new object[] { "Garbage", defaultStyle, null, typeof(FormatException) };
-
-            yield return new object[] { "abc", defaultStyle, null, typeof(FormatException) }; // Hex value
-            yield return new object[] { "1E23", defaultStyle, null, typeof(FormatException) }; // Exponent
-            yield return new object[] { "(123)", defaultStyle, null, typeof(FormatException) }; // Parentheses
-            yield return new object[] { 100.ToString("C0"), defaultStyle, null, typeof(FormatException) }; // Currency
-            yield return new object[] { 1000.ToString("N0"), defaultStyle, null, typeof(FormatException) }; // Thousands
-            yield return new object[] { 678.90.ToString("F2"), defaultStyle, null, typeof(FormatException) }; // Decimal
-            yield return new object[] { "+-123", defaultStyle, null, typeof(FormatException) };
-            yield return new object[] { "-+123", defaultStyle, null, typeof(FormatException) };
-            yield return new object[] { "+abc", NumberStyles.HexNumber, null, typeof(FormatException) };
-            yield return new object[] { "-abc", NumberStyles.HexNumber, null, typeof(FormatException) };
-
-            yield return new object[] { "- 123", defaultStyle, null, typeof(FormatException) };
-            yield return new object[] { "+ 123", defaultStyle, null, typeof(FormatException) };
-
-            yield return new object[] { "abc", NumberStyles.None, null, typeof(FormatException) }; // Hex value
-            yield return new object[] { "  123  ", NumberStyles.None, null, typeof(FormatException) }; // Trailing and leading whitespace
-
-            yield return new object[] { "678.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
-
-            yield return new object[] { "-1", defaultStyle, null, typeof(OverflowException) }; // < min value
-            yield return new object[] { "18446744073709551616", defaultStyle, null, typeof(OverflowException) }; // > max value
-            yield return new object[] { "(123)", NumberStyles.AllowParentheses, null, typeof(OverflowException) }; // Parentheses = negative
+            // Reuse all uint test data, except for those that wouldn't overflow ulong.
+            foreach (object[] objs in UInt32Tests.Parse_Invalid_TestData())
+            {
+                if ((Type)objs[3] == typeof(OverflowException) &&
+                    (!BigInteger.TryParse((string)objs[0], out BigInteger bi) || bi <= ulong.MaxValue))
+                {
+                    continue;
+                }
+                yield return objs;
+            }
         }
 
         [Theory]
@@ -259,31 +257,36 @@ namespace System.Tests
         public static void Parse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
         {
             ulong result;
-            // If no style is specified, use the (String) or (String, IFormatProvider) overload
-            if (style == NumberStyles.Integer)
+
+            // Default style and provider
+            if (style == NumberStyles.Integer && provider == null)
             {
                 Assert.False(ulong.TryParse(value, out result));
-                Assert.Equal(default(ulong), result);
-
+                Assert.Equal(default, result);
                 Assert.Throws(exceptionType, () => ulong.Parse(value));
-
-                // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-                if (provider != null)
-                {
-                    Assert.Throws(exceptionType, () => ulong.Parse(value, provider));
-                }
             }
 
-            // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-            Assert.False(ulong.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
-            Assert.Equal(default(ulong), result);
-
-            // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+            // Default provider
             if (provider == null)
             {
                 Assert.Throws(exceptionType, () => ulong.Parse(value, style));
+
+                // Substitute default NumberFormatInfo
+                Assert.False(ulong.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.Equal(default, result);
+                Assert.Throws(exceptionType, () => ulong.Parse(value, style, new NumberFormatInfo()));
             }
-            Assert.Throws(exceptionType, () => ulong.Parse(value, style, provider ?? new NumberFormatInfo()));
+
+            // Default style
+            if (style == NumberStyles.Integer)
+            {
+                Assert.Throws(exceptionType, () => ulong.Parse(value, provider));
+            }
+
+            // Full overloads
+            Assert.False(ulong.TryParse(value, style, provider, out result));
+            Assert.Equal(default, result);
+            Assert.Throws(exceptionType, () => ulong.Parse(value, style, provider));
         }
 
         [Theory]


### PR DESCRIPTION
In particular to improve UInt32/UInt64 coverage and to reuse more Int32 tests for other types.

This includes some more tests that highlight a corner-case break (wrong exception type being thrown) introduced in https://github.com/dotnet/coreclr/pull/18897 and that's fixed in https://github.com/dotnet/coreclr/pull/18930, so this won't pass on coreclr until that change is consumed into corefx.