### PR TITLE
Disable GetNativeVariantForObject() API tests when targeting UAP

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "GetNativeVariantForObject() not supported on UWP")]
     public class GetNativeVariantForObjectTests
     {
         internal struct Variant


### PR DESCRIPTION
@stephentoub or @luqunl is this the apporpriate way to disable these test for UWP?

See #30936 