### PR TITLE
System.IO.Pipes: Add additional Create overloads for Mono

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
@@ -5,6 +5,7 @@
 using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using System.Security;
 
 namespace System.IO.Pipes
@@ -17,6 +18,12 @@ namespace System.IO.Pipes
         // Creates the anonymous pipe.
         private void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
         {
+            Create(direction, inheritability, bufferSize, null);
+        }
+
+        // Creates the anonymous pipe.
+        private void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity pipeSecurity)
+        {
             Debug.Assert(direction != PipeDirection.InOut, "Anonymous pipe direction shouldn't be InOut");
             Debug.Assert(bufferSize >= 0, "bufferSize is negative");
 
@@ -25,14 +32,26 @@ namespace System.IO.Pipes
             SafePipeHandle newServerHandle;
 
             // Create the two pipe handles that make up the anonymous pipe.
-            Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = PipeStream.GetSecAttrs(inheritability);
-            if (direction == PipeDirection.In)
+            var pinningHandle = new GCHandle();
+            try
             {
-                bSuccess = Interop.Kernel32.CreatePipe(out serverHandle, out _clientHandle, ref secAttrs, bufferSize);
+                Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = PipeStream.GetSecAttrs(inheritability, pipeSecurity, ref pinningHandle);
+
+                if (direction == PipeDirection.In)
+                {
+                    bSuccess = Interop.Kernel32.CreatePipe(out serverHandle, out _clientHandle, ref secAttrs, bufferSize);
+                }
+                else
+                {
+                    bSuccess = Interop.Kernel32.CreatePipe(out _clientHandle, out serverHandle, ref secAttrs, bufferSize);
+                }
             }
-            else
+            finally
             {
-                bSuccess = Interop.Kernel32.CreatePipe(out _clientHandle, out serverHandle, ref secAttrs, bufferSize);
+                if (pinningHandle.IsAllocated)
+                {
+                    pinningHandle.Free();
+                }
             }
 
             if (!bSuccess)

--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
@@ -21,7 +21,7 @@ namespace System.IO.Pipes
             Create(direction, inheritability, bufferSize, null);
         }
 
-        // Creates the anonymous pipe.
+        // Creates the anonymous pipe. This overload is used in Mono to implement public constructors.
         private void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity pipeSecurity)
         {
             Debug.Assert(direction != PipeDirection.InOut, "Anonymous pipe direction shouldn't be InOut");

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -24,6 +24,14 @@ namespace System.IO.Pipes
                 PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
                 HandleInheritability inheritability)
         {
+            Create(pipeName, direction, maxNumberOfServerInstances, transmissionMode, options, inBufferSize,
+                outBufferSize, null, inheritability, 0);
+        }
+
+        private void Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances,
+                PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
+                PipeSecurity pipeSecurity, HandleInheritability inheritability, PipeAccessRights additionalAccessRights)
+        {
             Debug.Assert(pipeName != null && pipeName.Length != 0, "fullPipeName is null or empty");
             Debug.Assert(direction >= PipeDirection.In && direction <= PipeDirection.InOut, "invalid pipe direction");
             Debug.Assert(inBufferSize >= 0, "inBufferSize is negative");
@@ -39,9 +47,7 @@ namespace System.IO.Pipes
                 throw new ArgumentOutOfRangeException(nameof(pipeName), SR.ArgumentOutOfRange_AnonymousReserved);
             }
 
-            PipeSecurity pipeSecurity = null;
-
-            if (IsCurrentUserOnly)
+            if (IsCurrentUserOnly && pipeSecurity == null)
             {
                 using (WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent())
                 {
@@ -64,7 +70,8 @@ namespace System.IO.Pipes
 
             int openMode = ((int)direction) |
                            (maxNumberOfServerInstances == 1 ? Interop.Kernel32.FileOperations.FILE_FLAG_FIRST_PIPE_INSTANCE : 0) |
-                           (int)options;
+                           (int)options |
+                           (int)additionalAccessRights;
 
             // We automatically set the ReadMode to match the TransmissionMode.
             int pipeModes = (int)transmissionMode << 2 | (int)transmissionMode << 1;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -28,6 +28,7 @@ namespace System.IO.Pipes
                 outBufferSize, null, inheritability, 0);
         }
 
+        // This overload is used in Mono to implement public constructors.
         private void Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances,
                 PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
                 PipeSecurity pipeSecurity, HandleInheritability inheritability, PipeAccessRights additionalAccessRights)
@@ -47,8 +48,10 @@ namespace System.IO.Pipes
                 throw new ArgumentOutOfRangeException(nameof(pipeName), SR.ArgumentOutOfRange_AnonymousReserved);
             }
 
-            if (IsCurrentUserOnly && pipeSecurity == null)
+            if (IsCurrentUserOnly)
             {
+                Debug.Assert(pipeSecurity == null);
+
                 using (WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent())
                 {
                     SecurityIdentifier identifier = currentIdentity.Owner;


### PR DESCRIPTION
Rationale: There are some missing constructor overloads in the pipe classes that deal with `PipeSecurity` (#30170).

`PipeSecurity` is inherited from `NativeObjectSecurity`, which throws `PlatformNotSupportedException` in `InternalSet` on anything but Windows. Since the implementation doesn't really seem cross-platform it is questionable whether the overloads would make sense on CoreFX.

However, Mono implements the NetFX API surface and thus it has to provide implementation for the constructors. It seems reasonable to limit such implementation to Windows and throw `PlatformNotSupportedException` on anything else. In order to provide the Windows implementation some code must be exposed in CoreFX that would be used in Mono to implement the remaining overloads.