### PR TITLE
Fix RD.XML for System.Private.Xml

### DIFF
--- a/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
+++ b/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
@@ -15,7 +15,6 @@
         </Type>
         <Type Name="ReflectionXmlSerializationReaderHelper" Dynamic="Required All" />
       </Namespace>
-      <Namespace Name="System.Xml.Schema" Dynamic="Public" />
     </Assembly>
     <Namespace Name="System.Collections">
       <Type Name="IEnumerable" Dynamic="Required All" />

--- a/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/Resources/System.Xml.XmlSerializer.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/Resources/System.Xml.XmlSerializer.ReflectionOnly.Tests.rd.xml
@@ -7,6 +7,7 @@
           <Property Name="Mode" Dynamic="Required" />
         </Type>
       </Namespace>
+      <Namespace Name="System.Xml.Schema" Dynamic="Public" />
     </Assembly>
   </Library>
 </Directives>


### PR DESCRIPTION
This corrects the size on disk disaster caused by #19912. After that pull request, all of the schema validation stuff would always be included for any app that depends on System.Private.Xml because during initial analysis we consider a lot of things in S.P.Xml necessary as a precaution for SG generating references to it. The RD.XML in S.P.Xml then roots things forever.

I spent some time getting a repro of the original failure and convinced myself this is not a scenario that would require RD.XML in the S.P.Xml assembly.

Here's the facts:
* This test uses a test hook to explicitly disable pregenerated serialization code for `XmlSchema`. (https://github.com/dotnet/corefx/blob/1afc5360013bedc4099875c836342f493b083e5f/src/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs#L175 that is on stack at the time of failure is an analysis slam dunk, so we do have pregenerated code, we just don't use it because of the hook)
* The test is then testing the reflection fallback path to serialize XmlSchema. This doesn't work. Reflection fallback path won't in general work for _any framework provided type_ because there's no RD.XML to root it. Reflection fallback really only works for user types because of our default RD.XML that roots all user types (we also use that for the CoreFX tests, which is why the other reflection fallback tests don't hit issues).