### PR TITLE
ProtectedDataTests: mark tests as windows-specific

### DIFF
--- a/src/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
+++ b/src/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
     public static class ProtectedDataTests
     {
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void RoundTrip()
         {
             RoundTrip(null);
@@ -38,6 +39,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
         [InlineData(DataProtectionScope.CurrentUser, true)]
         [InlineData(DataProtectionScope.LocalMachine, false)]
         [InlineData(DataProtectionScope.LocalMachine, true)]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void ProtectEmptyData(DataProtectionScope scope, bool useEntropy)
         {
             // Use new byte[0] instead of Array.Empty<byte> to prove the implementation
@@ -52,6 +54,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NullEntropyEquivalence()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.
@@ -63,6 +66,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NullEntropyEquivalence2()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.
@@ -74,6 +78,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void WrongEntropy()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.

--- a/src/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
+++ b/src/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
@@ -12,10 +12,10 @@ using Xunit;
 
 namespace System.Security.Cryptography.ProtectedDataTests
 {
+    [PlatformSpecific(TestPlatforms.Windows)]
     public static class ProtectedDataTests
     {
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public static void RoundTrip()
         {
             RoundTrip(null);
@@ -39,7 +39,6 @@ namespace System.Security.Cryptography.ProtectedDataTests
         [InlineData(DataProtectionScope.CurrentUser, true)]
         [InlineData(DataProtectionScope.LocalMachine, false)]
         [InlineData(DataProtectionScope.LocalMachine, true)]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public static void ProtectEmptyData(DataProtectionScope scope, bool useEntropy)
         {
             // Use new byte[0] instead of Array.Empty<byte> to prove the implementation
@@ -54,7 +53,6 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NullEntropyEquivalence()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.
@@ -66,7 +64,6 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NullEntropyEquivalence2()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.
@@ -78,7 +75,6 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public static void WrongEntropy()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.


### PR DESCRIPTION
Since [ProtectedData](https://github.com/dotnet/corefx/blob/master/src/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs) doesn't have (and seems [won't have](https://github.com/dotnet/corefx/issues/22510)) non-Windows support decorating related xunit tests with `[PlatformSpecific(TestPlatforms.Windows)]` would help Mono to correctly rely on CoreFX stuff and tests.