### PR TITLE
adjust DataOffset so SocketAddress.ToString() works same way as Windows 

### DIFF
--- a/src/Common/src/System/Net/SocketAddress.cs
+++ b/src/Common/src/System/Net/SocketAddress.cs
@@ -30,6 +30,7 @@ namespace System.Net.Internals
 
         private const int MinSize = 2;
         private const int MaxSize = 32; // IrDA requires 32 bytes
+        private const int DataOffset = 2;
         private bool _changed = true;
         private int _hash;
 
@@ -230,9 +231,9 @@ namespace System.Net.Internals
         {
             var sb = new StringBuilder().Append(Family.ToString()).Append(':').Append(Size).Append(":{");
 
-            for (int i = SocketAddressPal.DataOffset; i < Size; i++)
+            for (int i = DataOffset; i < Size; i++)
             {
-                if (i > SocketAddressPal.DataOffset)
+                if (i > DataOffset)
                 {
                     sb.Append(',');
                 }

--- a/src/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -12,7 +12,7 @@ namespace System.Net
 {
     internal static class SocketAddressPal
     {
-        public const int DataOffset = 0;
+        public const int DataOffset = 2;
 
         public static readonly int IPv6AddressSize = GetIPv6AddressSize();
         public static readonly int IPv4AddressSize = GetIPv4AddressSize();

--- a/src/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -12,8 +12,6 @@ namespace System.Net
 {
     internal static class SocketAddressPal
     {
-        public const int DataOffset = 2;
-
         public static readonly int IPv6AddressSize = GetIPv6AddressSize();
         public static readonly int IPv4AddressSize = GetIPv4AddressSize();
 

--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -10,7 +10,6 @@ namespace System.Net
     {
         public const int IPv6AddressSize = 28;
         public const int IPv4AddressSize = 16;
-        public const int DataOffset = 2;
 
         public static unsafe AddressFamily GetAddressFamily(byte[] buffer)
         {

--- a/src/System.Net.Primitives/tests/PalTests/SocketAddressPalTest.cs
+++ b/src/System.Net.Primitives/tests/PalTests/SocketAddressPalTest.cs
@@ -188,5 +188,15 @@ namespace System.Net.Primitives.PalTests
             Assert.Equal(scope, actualScope);
             Assert.Equal(port, SocketAddressPal.GetPort(buffer));
         }
+
+        // This is platform specific test. So far Windows, Linux and OSX use same layout.
+        [Fact]
+        public void Address_to_string()
+        {
+            IPEndPoint ipLocalEndPoint = new IPEndPoint(IPAddress.Loopback, Convert.ToInt32("cafe", 16));
+            SocketAddress socketAddress = ipLocalEndPoint.Serialize();
+
+            Assert.Equal("InterNetwork:16:{202,254,127,0,0,1,0,0,0,0,0,0,0,0}", socketAddress.ToString());
+        }
     }
 }

--- a/src/System.Net.Primitives/tests/PalTests/SocketAddressPalTest.cs
+++ b/src/System.Net.Primitives/tests/PalTests/SocketAddressPalTest.cs
@@ -189,9 +189,8 @@ namespace System.Net.Primitives.PalTests
             Assert.Equal(port, SocketAddressPal.GetPort(buffer));
         }
 
-        // This is platform specific test. So far Windows, Linux and OSX use same layout.
         [Fact]
-        public void SocketAddress_To_String()
+        public void ToString_ValidSocketAddress_ExpectedFormat()
         {
             IPEndPoint ipLocalEndPoint = new IPEndPoint(IPAddress.Loopback, Convert.ToInt32("cafe", 16));
             SocketAddress socketAddress = ipLocalEndPoint.Serialize();

--- a/src/System.Net.Primitives/tests/PalTests/SocketAddressPalTest.cs
+++ b/src/System.Net.Primitives/tests/PalTests/SocketAddressPalTest.cs
@@ -191,7 +191,7 @@ namespace System.Net.Primitives.PalTests
 
         // This is platform specific test. So far Windows, Linux and OSX use same layout.
         [Fact]
-        public void Address_to_string()
+        public void SocketAddress_To_String()
         {
             IPEndPoint ipLocalEndPoint = new IPEndPoint(IPAddress.Loopback, Convert.ToInt32("cafe", 16));
             SocketAddress socketAddress = ipLocalEndPoint.Serialize();


### PR DESCRIPTION
I tested this change on osx 10.13, Linux, Windows and Linux-arm.

