### PR TITLE
Mitigate exception ambiguity in Marshal test

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/BindToMonikerTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/BindToMonikerTests.cs
@@ -15,21 +15,14 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Throws<PlatformNotSupportedException>(() => Marshal.BindToMoniker(null));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNative), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNative))]
         [PlatformSpecific(TestPlatforms.Windows)]
         [InlineData(null)]
         [InlineData("")]
-        public void BindToMoniker_NullOrEmptyMonikerName_ThrowsAnyException(string monikerName)
+        [InlineData("invalidName")]
+        public void BindToMoniker_InvalidArgument_ThrowsAnyException(string monikerName)
         {
             Assert.ThrowsAny<Exception>(() => Marshal.BindToMoniker(monikerName));
-        }
-
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNative))]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("name")]
-        public void BindToMoniker_InvalidMonikerName_ThrowsCOMException(string monikerName)
-        {
-            Assert.Throws<COMException>(() => Marshal.BindToMoniker(monikerName));
         }
     }
 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionForHRTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionForHRTests.cs
@@ -46,7 +46,7 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Null(Marshal.GetExceptionForHR(errorCode, IntPtr.Zero));
         }
 
-        private void ClearCurrentIErrorInfo()
+        private static void ClearCurrentIErrorInfo()
         {
             // Ensure that if the thread's current IErrorInfo
             // is set during a run that it is thrown away prior

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionForHRTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionForHRTests.cs
@@ -11,9 +11,9 @@ namespace System.Runtime.InteropServices.Tests
         [Theory]
         [InlineData(unchecked((int)0x80020006))]
         [InlineData(unchecked((int)0x80020101))]
-        [ActiveIssue(30866)]
         public void GetExceptionForHR_EqualsErrorCode(int err)
         {
+            ClearCurrentIErrorInfo();
             Exception ex = Marshal.GetExceptionForHR(err);
             Assert.Equal(err, ex.HResult);
         }
@@ -22,7 +22,9 @@ namespace System.Runtime.InteropServices.Tests
         public void GetExceptionForHR_ThrowExceptionForHR_ThrowsSameException()
         {
             const int ErrorCode = unchecked((int)0x80131D0B);
-            COMException getHRException = Marshal.GetExceptionForHR(ErrorCode) as COMException;
+
+            ClearCurrentIErrorInfo();
+            var getHRException = (COMException)Marshal.GetExceptionForHR(ErrorCode);
             Assert.Equal(ErrorCode, getHRException.HResult);
             try
             {
@@ -42,6 +44,14 @@ namespace System.Runtime.InteropServices.Tests
         {
             Assert.Null(Marshal.GetExceptionForHR(errorCode));
             Assert.Null(Marshal.GetExceptionForHR(errorCode, IntPtr.Zero));
+        }
+
+        private void ClearCurrentIErrorInfo()
+        {
+            // Ensure that if the thread's current IErrorInfo
+            // is set during a run that it is thrown away prior
+            // to interpreting the HRESULT.
+            Marshal.GetExceptionForHR(unchecked((int)0x80040001));
         }
     }
 }


### PR DESCRIPTION
Address issue 30866
Remove the special case of expecting a `COMException` when the argument
is non-empty or `null` for `Marshal.BindToMoniker()` tests.