### PR TITLE
Ensure we generate version prop before sync parallel build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -42,7 +42,7 @@
     <GenerateConfigurationProps Properties="@(Property)" PropertyValues="@(PropertyValue)" PropsFolder="$(BuildConfigurationFolder)" />
   </Target>
 
-  <Target Name="Sync" DependsOnTargets="GenerateConfigurationProperties">
+  <Target Name="Sync" DependsOnTargets="$(TraversalBuildDependsOn)">
     <ItemGroup>
       <ExternalProject Include="external\dir.proj" />
     </ItemGroup>

--- a/build.proj
+++ b/build.proj
@@ -29,9 +29,15 @@
   <Import Project="$(ToolsDir)clean.targets" />
 
   <PropertyGroup>
-    <TraversalBuildDependsOn>
+    <PrebuildSetupTargets>
       GenerateConfigurationProperties;
-      CreateOrUpdateCurrentVersionFile;
+      CreateOrUpdateCurrentVersionFile
+    </PrebuildSetupTargets>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TraversalBuildDependsOn>
+      $(PrebuildSetupTargets);
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>
   </PropertyGroup>
@@ -42,7 +48,7 @@
     <GenerateConfigurationProps Properties="@(Property)" PropertyValues="@(PropertyValue)" PropsFolder="$(BuildConfigurationFolder)" />
   </Target>
 
-  <Target Name="Sync" DependsOnTargets="$(TraversalBuildDependsOn)">
+  <Target Name="Sync" DependsOnTargets="$(PrebuildSetupTargets)">
     <ItemGroup>
       <ExternalProject Include="external\dir.proj" />
     </ItemGroup>


### PR DESCRIPTION
We need to generate the buildversion props file before we start
a parallel build otherwise we race condition that can break
the build.

cc @mmitche Port change https://github.com/dotnet/corefx/pull/31097 to master. 