### PR TITLE
Fix Sync targets to not actually cause a build to occur as well

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -29,9 +29,15 @@
   <Import Project="$(ToolsDir)clean.targets" />
 
   <PropertyGroup>
-    <TraversalBuildDependsOn>
+    <PrebuildSetupTargets>
       GenerateConfigurationProperties;
-      CreateOrUpdateCurrentVersionFile;
+      CreateOrUpdateCurrentVersionFile
+    </PrebuildSetupTargets>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TraversalBuildDependsOn>
+      $(PrebuildSetupTargets);
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>
   </PropertyGroup>
@@ -42,7 +48,7 @@
     <GenerateConfigurationProps Properties="@(Property)" PropertyValues="@(PropertyValue)" PropsFolder="$(BuildConfigurationFolder)" />
   </Target>
 
-  <Target Name="Sync" DependsOnTargets="$(TraversalBuildDependsOn)">
+  <Target Name="Sync" DependsOnTargets="$(PrebuildSetupTargets)">
     <ItemGroup>
       <ExternalProject Include="external\dir.proj" />
     </ItemGroup>


### PR DESCRIPTION
The TraversalBuildDependsOn gets other things added to it like
BuildAllProjects which we don't want for the Sync target so
factoring out the common pre-steps and sharing just those
with sync and build.

Fixes an issue where Sync is failing because it is trying to build prematurely. This manifiests itself in different ways but generally looks something like:
```
error : Error when creating nuget packed package from /mnt/j/workspace/dotnet_corefx/release_2.1/linux-TGroup_netcoreapp+CGroup_Release+AGroup_arm64+TestOuter_false_prtest/bin/packages/Debug/specs/runtime.linux-arm64.Microsoft.Private.CoreFx.NETCoreApp.nuspec. System.IO.DirectoryNotFoundException: Could not find a part of the path '/mnt/j/workspace/dotnet_corefx/release_2.1/linux-TGroup_netcoreapp+CGroup_Release+AGroup_arm64+TestOuter_false_prtest/bin/Linux.arm64.Debug/native 
```

cc @danmosemsft 
