### PR TITLE
Cleanup and add more Marshal.StringTo tests

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -85,8 +85,13 @@
     <Compile Include="System\Runtime\InteropServices\Marshal\SecureStringToGlobalAllocUnicodeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\SetComObjectDataTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\SizeOfTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\StringToCoTaskMemUTF8Tests.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\StringToBSTRTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\StringToCoTaskMemAnsiTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\StringToCoTaskMemAutoTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\StringToCoTaskMemUniTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\StringToCoTaskMemUTF8Tests.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\StringToHGlobalAnsiTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\StringToHGlobalUniTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\StringToHGlobalAutoTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\OffsetOfTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\PrelinkTests.cs" />

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToBSTRTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToBSTRTests.cs
@@ -24,14 +24,15 @@ namespace System.Runtime.InteropServices.Tests
         {
             using (SecureString secureString = ToSecureString(data))
             {
-                IntPtr bstr = Marshal.SecureStringToBSTR(secureString);
+                IntPtr ptr = Marshal.SecureStringToBSTR(secureString);
                 try
                 {
-                    Assert.Equal(data, Marshal.PtrToStringBSTR(bstr));
+                    Assert.NotEqual(IntPtr.Zero, ptr);
+                    Assert.Equal(data, Marshal.PtrToStringBSTR(ptr));
                 }
                 finally
                 {
-                    Marshal.ZeroFreeBSTR(bstr);
+                    Marshal.ZeroFreeBSTR(ptr);
                 }
             }
         }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToCoTaskMemAnsiTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToCoTaskMemAnsiTests.cs
@@ -48,7 +48,6 @@ namespace System.Runtime.InteropServices.Tests
                         Assert.Equal(expectedParameterlessString, Marshal.PtrToStringAnsi(ptr));
                         Assert.Equal(expectedFullString, Marshal.PtrToStringAnsi(ptr, s.Length));
                     }
-				
                 }
                 finally
                 {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToCoTaskMemAnsiTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToCoTaskMemAnsiTests.cs
@@ -21,23 +21,32 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData("\uD800\uDC00")]
         [InlineData("\0")]
         [InlineData("abc\0def")]
-        public void SecureStringToCoTaskMemAnsi_InvokePtrToStringAnsi_Roundtrips(string data)
+        public void SecureStringToCoTaskMemAnsi_InvokePtrToStringAnsi_Roundtrips(string s)
         {
-            string expectedFullString = new string(data.ToCharArray().Select(c => c > 0xFF ? '?' : c).ToArray());
+            string expectedFullString = new string(s.ToCharArray().Select(c => c > 0xFF ? '?' : c).ToArray());
             int nullIndex = expectedFullString.IndexOf('\0');
             string expectedParameterlessString = nullIndex == -1 ? expectedFullString : expectedFullString.Substring(0, nullIndex);
 
-            using (SecureString secureString = ToSecureString(data))
+            using (SecureString secureString = ToSecureString(s))
             {
                 IntPtr ptr = Marshal.SecureStringToCoTaskMemAnsi(secureString);
                 try
                 {
+                    Assert.NotEqual(IntPtr.Zero, ptr);
+
                     // Unix is incorrect with unicode chars.
-                    bool containsNonAnsiChars = data.Any(c => c > 0xFF);
+                    bool containsNonAnsiChars = s.Any(c => c > 0xFF);
                     if (!containsNonAnsiChars || PlatformDetection.IsWindows)
                     {
+                        // Make sure the native memory is correctly laid out.
+                        for (int i = 0; i < s.Length; i++)
+                        {
+                            Assert.Equal(expectedFullString[i], (char)Marshal.ReadByte(IntPtr.Add(ptr, i)));
+                        }
+
+                        // Make sure the native memory roundtrips.
                         Assert.Equal(expectedParameterlessString, Marshal.PtrToStringAnsi(ptr));
-                        Assert.Equal(expectedFullString, Marshal.PtrToStringAnsi(ptr, data.Length));
+                        Assert.Equal(expectedFullString, Marshal.PtrToStringAnsi(ptr, s.Length));
                     }
 				
                 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToCoTaskMemUnicodeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToCoTaskMemUnicodeTests.cs
@@ -20,18 +20,27 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData("\uD800\uDC00")]
         [InlineData("\0")]
         [InlineData("abc\0def")]
-        public void SecureStringToCoTaskMemUnicode_PtrToStringUni_Roundtrips(string data)
+        public void SecureStringToCoTaskMemUnicode_PtrToStringUni_Roundtrips(string s)
         {
-            int nullIndex = data.IndexOf('\0');
-            string expected = nullIndex == -1 ? data : data.Substring(0, nullIndex);
+            int nullIndex = s.IndexOf('\0');
+            string expected = nullIndex == -1 ? s : s.Substring(0, nullIndex);
 
-            using (SecureString secureString = ToSecureString(data))
+            using (SecureString secureString = ToSecureString(s))
             {
                 IntPtr ptr = Marshal.SecureStringToCoTaskMemUnicode(secureString);
                 try
                 {
+                    Assert.NotEqual(IntPtr.Zero, ptr);
+
+                    // Make sure the native memory is correctly laid out.
+                    for (int i = 0; i < s.Length; i++)
+                    {
+                        Assert.Equal(s[i], (char)Marshal.ReadInt16(IntPtr.Add(ptr, i << 1)));
+                    }
+
+                    // Make sure the native memory roundtrips.
                     Assert.Equal(expected, Marshal.PtrToStringUni(ptr));
-                    Assert.Equal(data, Marshal.PtrToStringUni(ptr, data.Length));
+                    Assert.Equal(s, Marshal.PtrToStringUni(ptr, s.Length));
                 }
                 finally
                 {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToGlobalAllocUnicodeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SecureStringToGlobalAllocUnicodeTests.cs
@@ -20,18 +20,27 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData("\uD800\uDC00")]
         [InlineData("\0")]
         [InlineData("abc\0def")]
-        public void SecureStringToGlobalAllocUnicode_InvokePtrToStringUni_Roundtrips(string data)
+        public void SecureStringToGlobalAllocUnicode_InvokePtrToStringUni_Roundtrips(string s)
         {
-            int nullIndex = data.IndexOf('\0');
-            string expected = nullIndex == -1 ? data : data.Substring(0, nullIndex);
+            int nullIndex = s.IndexOf('\0');
+            string expected = nullIndex == -1 ? s : s.Substring(0, nullIndex);
 
-            using (SecureString secureString = ToSecureString(data))
+            using (SecureString secureString = ToSecureString(s))
             {
                 IntPtr ptr = Marshal.SecureStringToGlobalAllocUnicode(secureString);
                 try
                 {
+                    Assert.NotEqual(IntPtr.Zero, ptr);
+
+                    // Make sure the native memory is correctly laid out.
+                    for (int i = 0; i < s.Length; i++)
+                    {
+                        Assert.Equal(s[i], (char)Marshal.ReadInt16(IntPtr.Add(ptr, i << 1)));
+                    }
+
+                    // Make sure the native memory roundtrips.
                     Assert.Equal(expected, Marshal.PtrToStringUni(ptr));
-                    Assert.Equal(data, Marshal.PtrToStringUni(ptr, data.Length));
+                    Assert.Equal(s, Marshal.PtrToStringUni(ptr, s.Length));
                 }
                 finally
                 {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringMarshalingTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringMarshalingTests.cs
@@ -26,15 +26,15 @@ namespace System.Runtime.InteropServices.Tests
         {
             foreach (String ts in TestStrings)
             {
-                IntPtr BStr = Marshal.StringToBSTR(ts);
+                IntPtr ptr = Marshal.StringToBSTR(ts);
                 try
                 {
-                    String str = Marshal.PtrToStringBSTR(BStr);
+                    String str = Marshal.PtrToStringBSTR(ptr);
                     Assert.Equal(ts, str);
                 }
                 finally
                 {
-                    Marshal.FreeBSTR(BStr);
+                    Marshal.FreeBSTR(ptr);
                 }
             }
         }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToBSTRTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToBSTRTests.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class StringToBSTRTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("pizza")]
+        [InlineData("pepperoni")]
+        [InlineData("password")]
+        [InlineData("P4ssw0rdAa1")]
+        [InlineData("\uD800")]
+        [InlineData("\uD800\uDC00")]
+        [InlineData("\u1234")]
+        [InlineData("\0")]
+        [InlineData("abc\0def")]
+        public void StringToBSTR_InvokePtrToStringBSTR_ReturnsExpected(string s)
+        {
+            IntPtr ptr = Marshal.StringToBSTR(s);
+            try
+            {
+                Assert.NotEqual(IntPtr.Zero, ptr);  
+                Assert.Equal(s, Marshal.PtrToStringBSTR(ptr));
+            }
+            finally
+            {
+                Marshal.ZeroFreeBSTR(ptr);
+            }
+        }
+
+        [Fact]
+        public void StringToBSTR_NullString_ReturnsZero()
+        {
+            Assert.Equal(IntPtr.Zero, Marshal.StringToBSTR(null));
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAnsiTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAnsiTests.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class StringToCoTaskMemAnsiTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("pizza")]
+        [InlineData("pepperoni")]
+        [InlineData("password")]
+        [InlineData("P4ssw0rdAa1")]
+        [InlineData("\u1234")]
+        [InlineData("\uD800")]
+        [InlineData("\uD800\uDC00")]
+        [InlineData("\0")]
+        [InlineData("abc\0def")]
+        public void StringToCoTaskMemAnsi_InvokePtrToStringAnsi_Roundtrips(string s)
+        {
+            string expectedFullString = new string(s.ToCharArray().Select(c => c > 0xFF ? '?' : c).ToArray());
+            int nullIndex = expectedFullString.IndexOf('\0');
+            string expectedParameterlessString = nullIndex == -1 ? expectedFullString : expectedFullString.Substring(0, nullIndex);
+    
+            IntPtr ptr = Marshal.StringToCoTaskMemAnsi(s);
+            try
+            {
+                Assert.NotEqual(IntPtr.Zero, ptr);
+
+                // Unix uses UTF8 for Ansi marshalling.
+                bool containsNonAnsiChars = s.Any(c => c > 0xFF);
+                if (!containsNonAnsiChars || PlatformDetection.IsWindows)
+                {
+                    // Make sure the native memory is correctly laid out.
+                    for (int i = 0; i < s.Length; i++)
+                    {
+                        Assert.Equal(expectedFullString[i], (char)Marshal.ReadByte(IntPtr.Add(ptr, i)));
+                    }
+
+                    // Make sure the native memory roundtrips.
+                    Assert.Equal(expectedParameterlessString, Marshal.PtrToStringAnsi(ptr));
+                    Assert.Equal(expectedFullString, Marshal.PtrToStringAnsi(ptr, s.Length));
+                }
+				
+            }
+            finally
+            {
+                Marshal.ZeroFreeCoTaskMemAnsi(ptr);
+            }
+        }
+
+        [Fact]
+        public void StringToCoTaskMemAnsi_NullString_ReturnsZero()
+        {
+            Assert.Equal(IntPtr.Zero, Marshal.StringToCoTaskMemAnsi(null));
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAnsiTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAnsiTests.cs
@@ -45,7 +45,6 @@ namespace System.Runtime.InteropServices.Tests
                     Assert.Equal(expectedParameterlessString, Marshal.PtrToStringAnsi(ptr));
                     Assert.Equal(expectedFullString, Marshal.PtrToStringAnsi(ptr, s.Length));
                 }
-				
             }
             finally
             {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAutoTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAutoTests.cs
@@ -14,14 +14,14 @@ namespace System.Runtime.InteropServices.Tests
         public void StringToCoTaskMemAuto_NonNullString_Roundtrips(string s)
         {
             IntPtr ptr = Marshal.StringToCoTaskMemAuto(s);
-
             try
             {
+                Assert.NotEqual(IntPtr.Zero, ptr);
+
                 // Make sure the native memory is correctly laid out.
                 for (int i = 0; i < s.Length; i++)
                 {
-                    char c = (char)Marshal.ReadInt16(IntPtr.Add(ptr, i << 1));
-                    Assert.Equal(s[i], c);
+                    Assert.Equal(s[i], (char)Marshal.ReadInt16(IntPtr.Add(ptr, i << 1)));
                 }
 
                 // Make sure the memory roundtrips.

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemUniTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemUniTests.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class StringToCoTaskMemUniTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("pizza")]
+        [InlineData("pepperoni")]
+        [InlineData("password")]
+        [InlineData("P4ssw0rdAa1")]
+        [InlineData("\u1234")]
+        [InlineData("\uD800")]
+        [InlineData("\uD800\uDC00")]
+        [InlineData("\0")]
+        [InlineData("abc\0def")]
+        public void StringToCoTaskMemUni_PtrToStringUni_Roundtrips(string s)
+        {
+            int nullIndex = s.IndexOf('\0');
+            string expected = nullIndex == -1 ? s : s.Substring(0, nullIndex);
+
+            IntPtr ptr = Marshal.StringToCoTaskMemUni(s);
+            try
+            {
+                Assert.NotEqual(IntPtr.Zero, ptr);
+
+                // Make sure the native memory is correctly laid out.
+                for (int i = 0; i < s.Length; i++)
+                {
+                    Assert.Equal(s[i], (char)Marshal.ReadInt16(IntPtr.Add(ptr, i << 1)));
+                }
+
+                // Make sure the native memory roundtrips.
+                Assert.Equal(expected, Marshal.PtrToStringUni(ptr));
+                Assert.Equal(s, Marshal.PtrToStringUni(ptr, s.Length));
+            }
+            finally
+            {
+                Marshal.ZeroFreeCoTaskMemUnicode(ptr);
+            }
+        }
+
+        [Fact]
+        public void StringToCoTaskMemUni_NullString_ReturnsZero()
+        {
+            Assert.Equal(IntPtr.Zero, Marshal.StringToCoTaskMemUni(null));
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToHGlobalAnsiTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToHGlobalAnsiTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class StringToHGlobalAnsiTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("pizza")]
+        [InlineData("pepperoni")]
+        [InlineData("password")]
+        [InlineData("P4ssw0rdAa1")]
+        [InlineData("\u1234")]
+        [InlineData("\uD800")]
+        [InlineData("\uD800\uDC00")]
+        [InlineData("\0")]
+        [InlineData("abc\0def")]
+        public void StringToHGlobalAnsi_InvokePtrToStringAnsi_Roundtrips(string s)
+        {
+            string expectedFullString = new string(s.ToCharArray().Select(c => c > 0xFF ? '?' : c).ToArray());
+            int nullIndex = expectedFullString.IndexOf('\0');
+            string expectedParameterlessString = nullIndex == -1 ? expectedFullString : expectedFullString.Substring(0, nullIndex);
+
+            IntPtr ptr = Marshal.StringToHGlobalAnsi(s);
+            try
+            {
+                Assert.NotEqual(IntPtr.Zero, ptr);
+
+                // Unix uses UTF8 for Ansi marshalling.
+                bool containsNonAnsiChars = s.Any(c => c > 0xFF);
+                if (!containsNonAnsiChars || PlatformDetection.IsWindows)
+                {
+                    // Make sure the native memory is correctly laid out.
+                    for (int i = 0; i < s.Length; i++)
+                    {
+                        Assert.Equal(expectedFullString[i], (char)Marshal.ReadByte(IntPtr.Add(ptr, i)));
+                    }
+
+                    // Make sure the native memory roundtrips.
+                    Assert.Equal(expectedParameterlessString, Marshal.PtrToStringAnsi(ptr));
+                    Assert.Equal(expectedFullString, Marshal.PtrToStringAnsi(ptr, s.Length));
+                }
+            }
+            finally
+            {
+                Marshal.ZeroFreeGlobalAllocAnsi(ptr);
+            }
+        }
+
+        [Fact]
+        public void StringToHGlobalAnsi_NullString_ReturnsZero()
+        {
+            Assert.Equal(IntPtr.Zero, Marshal.StringToHGlobalAnsi(null));
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToHGlobalUniTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToHGlobalUniTests.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class StringToHGlobalUniTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("pizza")]
+        [InlineData("pepperoni")]
+        [InlineData("password")]
+        [InlineData("P4ssw0rdAa1")]
+        [InlineData("\u1234")]
+        [InlineData("\uD800")]
+        [InlineData("\uD800\uDC00")]
+        [InlineData("\0")]
+        [InlineData("abc\0def")]
+        public void StringToHGlobalUni_InvokePtrToStringUni_Roundtrips(string s)
+        {
+            int nullIndex = s.IndexOf('\0');
+            string expected = nullIndex == -1 ? s : s.Substring(0, nullIndex);
+
+            IntPtr ptr = Marshal.StringToHGlobalUni(s);
+            try
+            {
+                Assert.NotEqual(IntPtr.Zero, ptr);
+
+                // Make sure the native memory is correctly laid out.
+                for (int i = 0; i < s.Length; i++)
+                {
+                    Assert.Equal(s[i], (char)Marshal.ReadInt16(IntPtr.Add(ptr, i << 1)));
+                }
+
+                // Make sure the native memory roundtrips.
+                Assert.Equal(expected, Marshal.PtrToStringUni(ptr));
+                Assert.Equal(s, Marshal.PtrToStringUni(ptr, s.Length));
+            }
+            finally
+            {
+                Marshal.ZeroFreeGlobalAllocUnicode(ptr);
+            }
+        }
+
+        [Fact]
+        public void StringToHGlobalUni_NullString_ReturnsZero()
+        {
+            Assert.Equal(IntPtr.Zero, Marshal.StringToHGlobalUni(null));
+        }
+    }
+}


### PR DESCRIPTION
Extracted from https://github.com/dotnet/corefx/pull/31057 to make reviewing PRs a bit easier

Basically adds more tests for argument validation, all the various overloads for `StringTo` as well as validating results on the byte level

/cc @AaronRobinsonMSFT