### PR TITLE
support for correct Tools on Linux/ARM

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -102,6 +102,12 @@ if [ ! -e "$__DOTNET_PATH" ]; then
                         __PKG_RID=rhel.6
                     fi
                 fi
+                OSArch=$(uname -m)
+                if [ $OSArch == 'armv7l' ];then
+                    __PKG_ARCH=arm
+                elif [ $OSArch == 'aarch64' ]; then
+                    __PKG_ARCH=arm64
+                fi
 
                 ;;
 


### PR DESCRIPTION
I did not find any command line override. This change allows to get correct tools on arm system.
This is beginning of changes to support build on arm and match coreclr. 

Build speed may vary depending on the system. But it is nice to build and run tests quickly in same workflow as x86.  