### PR TITLE
Filter binplace and harvest package depproj's to only direct reference

### DIFF
--- a/external/binplacePackages/binplacePackages.depproj
+++ b/external/binplacePackages/binplacePackages.depproj
@@ -33,8 +33,11 @@
     <!-- runtime dependency: System.Data.SqlClient uap10.0.16299 -->
     <!-- runtime dependency: System.Diagnostics.PerformanceCounters netcoreapp2.0,net461 -->
     <PackageReference Include="System.Memory" Condition="'$(TargetGroup)' == 'netcoreapp2.0' OR '$(TargetGroup)' == 'uap10.0.16299' OR '$(TargetsNetfx)' == 'true' OR ('$(TargetsNetStandard)' == 'true' AND '$(NETStandardVersion)' &gt;= 1.1)">
-  	  <Version>4.5.1</Version>
+      <Version>4.5.1</Version>
     </PackageReference>
+
+    <!-- Only include the assets from the direct packages we reference in the output -->
+    <PackageToInclude Include="@(PackageReference)" />
   </ItemGroup>
 
   <Target Name="AddHarvestedLibraries" BeforeTargets="CoreCompile"


### PR DESCRIPTION
We don't need to copy out the full closure of all packages for
these project so only copy the packages that are directly referenced.

cc @ViktorHofer @ericstj 

Fixes https://github.com/dotnet/corefx/issues/31156