### PR TITLE
Add more logging for certificate exchange/validation

### DIFF
--- a/src/Common/src/System/Net/Security/CertificateHelper.cs
+++ b/src/Common/src/System/Net/Security/CertificateHelper.cs
@@ -38,15 +38,27 @@ namespace System.Net.Security
             {
                 if (!cert.HasPrivateKey)
                 {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        NetEventSource.Info(candidateCerts, $"Skipping current X509Certificate2 {cert.GetHashCode()} since it doesn't have private key.");
+                    }
                     continue;
                 }
                 
                 if (IsValidClientCertificate(cert))
                 {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        NetEventSource.Info(candidateCerts, $"Choosing X509Certificate2 {cert.GetHashCode()} as the Client Certificate.");
+                    }
                     return cert;
                 }
             }
 
+            if (NetEventSource.IsEnabled)
+            {
+                NetEventSource.Info(candidateCerts, "No eligible client certificate found.");
+            }
             return null;
         }
 
@@ -56,10 +68,18 @@ namespace System.Net.Security
             {
                 if ((extension is X509EnhancedKeyUsageExtension eku) && !IsValidForClientAuthenticationEKU(eku))
                 {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        NetEventSource.Info(cert, $"Current X509EnhancedKeyUsageExtension {eku.GetHashCode()} is not valid for Client Authentication.");
+                    }
                     return false;
                 }
                 else if ((extension is X509KeyUsageExtension ku) && !IsValidForDigitalSignatureUsage(ku))
                 {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        NetEventSource.Info(cert, $"Current X509KeyUsageExtension {ku.GetHashCode()} is not valid for Digital Signature.");
+                    }
                     return false;
                 }
             }

--- a/src/Common/src/System/Net/Security/CertificateHelper.cs
+++ b/src/Common/src/System/Net/Security/CertificateHelper.cs
@@ -40,7 +40,7 @@ namespace System.Net.Security
                 {
                     if (NetEventSource.IsEnabled)
                     {
-                        NetEventSource.Info(candidateCerts, $"Skipping current X509Certificate2 {cert.GetHashCode()} since it doesn't have private key.");
+                        NetEventSource.Info(candidateCerts, $"Skipping current X509Certificate2 {cert.GetHashCode()} since it doesn't have private key. Certificate Subject: {cert.Subject}, Thumbprint: {cert.Thumbprint}.");
                     }
                     continue;
                 }
@@ -49,7 +49,7 @@ namespace System.Net.Security
                 {
                     if (NetEventSource.IsEnabled)
                     {
-                        NetEventSource.Info(candidateCerts, $"Choosing X509Certificate2 {cert.GetHashCode()} as the Client Certificate.");
+                        NetEventSource.Info(candidateCerts, $"Choosing X509Certificate2 {cert.GetHashCode()} as the Client Certificate. Certificate Subject: {cert.Subject}, Thumbprint: {cert.Thumbprint}.");
                     }
                     return cert;
                 }
@@ -70,7 +70,7 @@ namespace System.Net.Security
                 {
                     if (NetEventSource.IsEnabled)
                     {
-                        NetEventSource.Info(cert, $"Current X509EnhancedKeyUsageExtension {eku.GetHashCode()} is not valid for Client Authentication.");
+                        NetEventSource.Info(cert, $"For Certificate {cert.GetHashCode()} - current X509EnhancedKeyUsageExtension {eku.GetHashCode()} is not valid for Client Authentication.");
                     }
                     return false;
                 }
@@ -78,7 +78,7 @@ namespace System.Net.Security
                 {
                     if (NetEventSource.IsEnabled)
                     {
-                        NetEventSource.Info(cert, $"Current X509KeyUsageExtension {ku.GetHashCode()} is not valid for Digital Signature.");
+                        NetEventSource.Info(cert, $"For Certificate {cert.GetHashCode()} - current X509KeyUsageExtension {ku.GetHashCode()} is not valid for Digital Signature.");
                     }
                     return false;
                 }

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -526,6 +526,10 @@ namespace System.Net.Security
                 {
                     NetEventSource.Log.FindingMatchingCerts(this);
                 }
+                else
+                {
+                    NetEventSource.Info(this, "No client certificate to choose from");
+                }
             }
 
             //
@@ -1005,7 +1009,7 @@ namespace System.Net.Security
                 if (remoteCertificateEx == null)
                 {
                     if (NetEventSource.IsEnabled)
-                        NetEventSource.Exit(this, "(no remote cert)", !_sslAuthenticationOptions.RemoteCertRequired);
+                        NetEventSource.Exit(this, $"No remote certificate received. RemoteCertRequired: {RemoteCertRequired}");
                     sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNotAvailable;
                 }
                 else

--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -42,6 +42,10 @@ namespace System.Net.Security
             EncryptionPolicy = sslServerAuthenticationOptions.EncryptionPolicy;
             IsServer = true;
             RemoteCertRequired = sslServerAuthenticationOptions.ClientCertificateRequired;
+            if (NetEventSource.IsEnabled)
+            {
+                NetEventSource.Info(this, $"Server RemoteCertRequired: {RemoteCertRequired}.");
+            }
             RemoteCertificateValidationCallback = sslServerAuthenticationOptions.RemoteCertificateValidationCallback;
             TargetHost = string.Empty;
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamEKUTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamEKUTest.cs
@@ -150,7 +150,7 @@ namespace System.Net.Security.Tests
 
                 var clientOptions = new HttpsTestClient.Options(new IPEndPoint(IPAddress.Loopback, server.Port));
                 clientOptions.ServerName = serverOptions.ServerCertificate.GetNameInfo(X509NameType.SimpleName, false);
-                clientOptions.ClientCertificate = Configuration.Certificates.GetSelfSignedClientCertificate(); ;
+                clientOptions.ClientCertificate = Configuration.Certificates.GetSelfSignedClientCertificate();
 
                 var client = new HttpsTestClient(clientOptions);
 


### PR DESCRIPTION
1. Added Logging when server request a client certificate.
2. Added logging when client is unable to find matching certificate.
3. Made a log entry in `VerifyRemoteCertificate()` more clear.
4. Corrected a typo.

Verified that we already logged why the certificate is rejected (in `LogCertificateValidation()`). Wrote some tests and used PerfView to examine the tracing manually.