### PR TITLE
Add coverlet.msbuild package for coverage experiments

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -65,6 +65,9 @@
     <PackageReference Include="OpenCover">
       <Version>4.6.519</Version>
     </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <Version>2.1.1</Version>
+    </PackageReference>
     <PackageReference Include="ReportGenerator">
       <Version>3.0.1</Version>
     </PackageReference>


### PR DESCRIPTION
Adds a reference to the package required to use coverlet.msbuild in CoreFx repo required by https://github.com/dotnet/buildtools/pull/2101