### PR TITLE
Update RD.XML for TypeConverterAttribute

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/Resources/System.ComponentModel.TypeConverter.rd.xml
+++ b/src/System.ComponentModel.TypeConverter/src/Resources/System.ComponentModel.TypeConverter.rd.xml
@@ -13,6 +13,9 @@
         </Type>
         <Type Name="TypeConverterAttribute">
           <AttributeImplies Activate="Required Public" />
+          
+          <!-- AttributeCollection.GetDefaultAttribute will end up reflecting on the Default field -->
+          <Field Name="Default" Dynamic="Required" />
         </Type>
       </Namespace>
     </Assembly>


### PR DESCRIPTION
`GetDefaultAttribute` will look for a field named `Default` on things and there are code paths through which this is reachable with the `TypeConverterAttribute`.

https://github.com/dotnet/corefx/blob/b996738f877d17b0fe426c75b01f0a8ecdc21e07/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs#L267-L269