### PR TITLE
Old Linux kernels might not support SO_REUSEPORT

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1730,6 +1730,7 @@ int32_t SystemNative_GetSockOpt(
             }
 
             socklen_t optLen = (socklen_t)*optionLen;
+#ifdef SO_REUSEPORT
             // On Unix, SO_REUSEPORT controls the ability to bind multiple sockets to the same address.
             int err = getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, optionValue, &optLen);
 
@@ -1749,7 +1750,9 @@ int32_t SystemNative_GetSockOpt(
                 value = value == 0 ? 1 : 0;
             }
             *(int32_t*)optionValue = value;
-
+#else
+            return Error_ENOTSUP;
+#endif
             return Error_SUCCESS;
         }
     }
@@ -1808,6 +1811,7 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
         // We make both SocketOptionName_SO_REUSEADDR and SocketOptionName_SO_EXCLUSIVEADDRUSE control SO_REUSEPORT.
         if (socketOptionName == SocketOptionName_SO_EXCLUSIVEADDRUSE || socketOptionName == SocketOptionName_SO_REUSEADDR)
         {
+#ifdef SO_REUSEPORT
             if (optionLen != sizeof(int32_t))
             {
                 return Error_EINVAL;
@@ -1830,6 +1834,9 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
 
             int err = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &value, (socklen_t)optionLen);
             return err == 0 ? Error_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+#else
+            return Error_ENOTSUP;
+#endif
         }
     }
 #ifdef IP_MTU_DISCOVER


### PR DESCRIPTION
`SO_REUSEPORT` was introduced in Linux Kernel 3.9, I can't find the minimal Kernel version .NET Core supports  but it might help those who try to compile it on <3.9 (like CentOS 6.8 which is still maintained and supported by mono or Ubuntu 13.x). 
PS: is it better to throw an error or do a no-op?

cc @nealef @marek-safar 