### PR TITLE
Disable System.Drawing.Tests.Graphics_DrawLinetests.DrawLines_Points

### DIFF
--- a/src/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
+++ b/src/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
@@ -7,6 +7,7 @@ namespace System.Drawing.Tests
 {
     public class Graphics_DrawLineTests : DrawingTest
     {
+        [ActiveIssue(30180, TestPlatforms.Linux)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void DrawLines_Points()
         {


### PR DESCRIPTION
cc: @danmosemsft @JeremyKuhne 

related to: #30180 