### PR TITLE
Update Common.Tests.sln file for new SDK project changes.

### DIFF
--- a/src/Common/Common.Tests.sln
+++ b/src/Common/Common.Tests.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Tests", "tests\Common.Tests.csproj", "{C72FD34C-539A-4447-9796-62A229571199}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Tests", "tests\Common.Tests.csproj", "{C72FD34C-539A-4447-9796-62A229571199}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5E554AE7-CBC2-4C34-9FEA-1A6250CE5D3F}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fix the issue reported here: https://github.com/dotnet/corefx/issues/30188#issuecomment-406310371

Our buildtools UpdateVSConfigurations task didn't find this `.sln` file.