### PR TITLE
Ensure Windows specific DNS resolution errors throw the correct exception

### DIFF
--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -120,10 +120,10 @@ namespace System.Net
             {
                 return WebExceptionStatus.UnknownError;
             }
-
             WebExceptionStatus status;
             switch (socketEx.SocketErrorCode)
             {
+                case SocketError.NoData:
                 case SocketError.HostNotFound:
                     status = WebExceptionStatus.NameResolutionFailure;
                     break;

--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -120,6 +120,7 @@ namespace System.Net
             {
                 return WebExceptionStatus.UnknownError;
             }
+
             WebExceptionStatus status;
             switch (socketEx.SocketErrorCode)
             {


### PR DESCRIPTION
This fix ensures that the Windows specific error code [WSA_NODATA](https://docs.microsoft.com/en-us/windows/desktop/winsock/windows-sockets-error-codes-2#WSANO_DATA) is correctly recognized as a DNS resolution error. This issue has been causing a recurring failure on Windows 7 CI machines.

Fixes: #31147