### PR TITLE
Disable tests that rely on GetComObjectData() and SetComObjectData() …

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComAwareEventInfoTests.Windows.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComAwareEventInfoTests.Windows.cs
@@ -15,6 +15,7 @@ namespace System.Runtime.InteropServices.Tests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "ComEventsHelper.Combine throws a PNSE in .NET Core")]
+        [ActiveIssue(31214)]
         public void AddEventHandler_DispIdAttribute_ThrowsPlatformNotSupportedException()
         {
             var attribute = new ComAwareEventInfo(typeof(DispAttributeInterface), nameof(DispAttributeInterface.Event));

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComEventsHelperTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComEventsHelperTests.cs
@@ -33,6 +33,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "ComEventsHelper.Combine is not supported in .NET Core.")]
+        [ActiveIssue(31214)]
         public void Combine_NonNullRcw_ThrowsPlatformNotSupportedException()
         {
             Assert.Throws<PlatformNotSupportedException>(() => ComEventsHelper.Combine(1, Guid.Empty, 1, null));
@@ -61,6 +62,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "ComEventsHelper.Combine is not supported in .NET Core.")]
+        [ActiveIssue(31214)]
         public void Remove_NonNullRcw_ThrowsPlatformNotSupportedException()
         {
             Assert.Throws<PlatformNotSupportedException>(() => ComEventsHelper.Remove(1, Guid.Empty, 1, null));

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetComObjectDataTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetComObjectDataTests.cs
@@ -24,6 +24,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Marshal.GetComObjectData is not implemented in .NET Core.")]
+        [ActiveIssue(31214)]
         public void GetComObjectData_NetCore_ThrowsPlatformNotSupportedException()
         {
             Assert.Throws<PlatformNotSupportedException>(() => Marshal.GetComObjectData(null, null));

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PrelinkTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PrelinkTests.cs
@@ -36,7 +36,7 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void Prelink_NonRuntimeMethod_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.Prelink(new NonRuntimeMethodInfo()));
+            AssertExtensions.Throws<ArgumentException>("m", () => Marshal.Prelink(new NonRuntimeMethodInfo()));
         }
         
         public class NonRuntimeMethodInfo : MethodInfo

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SetComObjectDataTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SetComObjectDataTests.cs
@@ -27,6 +27,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Marshal.SetComObjectData is not implemented in .NET Core.")]
+        [ActiveIssue(31214)]
         public void SetComObjectData_NetCore_ThrowsPlatformNotSupportedException()
         {
             Assert.Throws<PlatformNotSupportedException>(() => Marshal.SetComObjectData(null, null, null));


### PR DESCRIPTION
…semantics

Fix bug in Prelink_NonRuntimeMethod_ThrowsArgumentException test.

see #31188, #31153