### PR TITLE
Add more logging for authentication failure

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -739,7 +739,7 @@ namespace System.Net.Security
             {
                 if (token.Failed)
                 {
-                    NetEventSource.Info(this, $"Authentication failed. Status: {status.ToString()}, Exception message: {token.GetException().Message}");
+                    NetEventSource.Error(this, $"Authentication failed. Status: {status.ToString()}, Exception message: {token.GetException().Message}");
                 }
 
                 NetEventSource.Exit(this, token);

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -876,11 +876,12 @@ namespace System.Net.Security
 
             byte[] alpnResult = SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
             _negotiatedApplicationProtocol = alpnResult == null ? default : new SslApplicationProtocol(alpnResult, false);
-
+#if TRACE_VERBOSE
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Exit(this);
             }
+#endif
             return status;
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -764,9 +764,8 @@ namespace System.Net.Security
         --*/
         private SecurityStatusPal GenerateToken(byte[] input, int offset, int count, ref byte[] output)
         {
-#if TRACE_VERBOSE
             if (NetEventSource.IsEnabled) NetEventSource.Enter(this, $"_refreshCredentialNeeded = {_refreshCredentialNeeded}");
-#endif
+
             if (offset < 0 || offset > (input == null ? 0 : input.Length))
             {
                 NetEventSource.Fail(this, "Argument 'offset' out of range.");
@@ -876,12 +875,12 @@ namespace System.Net.Security
 
             byte[] alpnResult = SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
             _negotiatedApplicationProtocol = alpnResult == null ? default : new SslApplicationProtocol(alpnResult, false);
-#if TRACE_VERBOSE
+
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Exit(this);
             }
-#endif
+
             return status;
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -734,8 +734,16 @@ namespace System.Net.Security
             }
 
             ProtocolToken token = new ProtocolToken(nextmsg, status);
+
             if (NetEventSource.IsEnabled)
+            {
+                if (token.Failed)
+                {
+                    NetEventSource.Info(this, $"Authentication failed. Status: {status.ToString()}, Exception message: {token.GetException().Message}");
+                }
+
                 NetEventSource.Exit(this, token);
+            }
             return token;
         }
 
@@ -869,6 +877,10 @@ namespace System.Net.Security
             byte[] alpnResult = SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
             _negotiatedApplicationProtocol = alpnResult == null ? default : new SslApplicationProtocol(alpnResult, false);
 
+            if (NetEventSource.IsEnabled)
+            {
+                NetEventSource.Exit(this);
+            }
             return status;
         }
 


### PR DESCRIPTION
During TLS/SSL authentication, security related failures may occur, and we are lack of logging about why the handshake/authentication fails.

This PR added tracing in such scenario, and included details for the failure. Also added a missing `NetEventSource.Exit` for `GenerateToken()`.

Wrote some tests and used PerfView to examine the tracing manually.

<img width="1274" alt="capture1" src="https://user-images.githubusercontent.com/8537784/43019237-2492d000-8c11-11e8-91b7-cf0e3e8487fc.PNG">
