### PR TITLE
Partial cleanup of `Internal.Cryptography.Helpers`.

### DIFF
--- a/src/Common/src/Internal/Cryptography/Helpers.cs
+++ b/src/Common/src/Internal/Cryptography/Helpers.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Internal.Cryptography
 {
-    internal static class Helpers
+    internal static partial class Helpers
     {
         public static byte[] CloneByteArray(this byte[] src)
         {
@@ -21,4 +21,3 @@ namespace Internal.Cryptography
         }
     }
 }
-

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
@@ -10,18 +10,8 @@ using System.Security.Cryptography.Asn1;
 
 namespace Internal.Cryptography
 {
-    internal static class Helpers
+    internal static partial class Helpers
     {
-        public static byte[] CloneByteArray(this byte[] src)
-        {
-            if (src == null)
-            {
-                return null;
-            }
-
-            return (byte[])(src.Clone());
-        }
-
         public static KeySizes[] CloneKeySizesArray(this KeySizes[] src)
         {
             return (KeySizes[])(src.Clone());

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -98,6 +98,9 @@
     <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+      <Link>Internal\Cryptography\Helpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Internal\Cryptography\HashProvider.cs">
       <Link>Internal\Cryptography\HashProvider.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -14,18 +14,8 @@ using ErrorCode = Interop.NCrypt.ErrorCode;
 
 namespace Internal.Cryptography
 {
-    internal static class Helpers
+    internal static partial class Helpers
     {
-        public static byte[] CloneByteArray(this byte[] src)
-        {
-            if (src == null)
-            {
-                return null;
-            }
-
-            return (byte[])(src.Clone());
-        }
-
         public static bool UsesIv(this CipherMode cipherMode)
         {
             return cipherMode != CipherMode.ECB;

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -215,6 +215,9 @@
     <Compile Include="$(CommonPath)\Internal\Cryptography\HashProviderCng.cs">
       <Link>Internal\Cryptography\HashProviderCng.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+      <Link>Internal\Cryptography\Helpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/Helpers.cs
@@ -7,18 +7,8 @@ using System.Security.Cryptography;
 
 namespace Internal.Cryptography
 {
-    internal static class Helpers
+    internal static partial class Helpers
     {
-        public static byte[] CloneByteArray(this byte[] src)
-        {
-            if (src == null)
-            {
-                return null;
-            }
-
-            return (byte[])(src.Clone());
-        }
-
         public static KeySizes[] CloneKeySizesArray(this KeySizes[] src)
         {
             return (KeySizes[])(src.Clone());

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -53,6 +53,9 @@
     <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+      <Link>Internal\Cryptography\Helpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoTransform.cs">
       <Link>Internal\Cryptography\UniversalCryptoTransform.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Internal\Cryptography\AsnFormatter.cs" />
-    <Compile Include="Internal\Cryptography\Helpers.cs" />
     <Compile Include="Internal\Cryptography\OidLookup.cs" />
     <Compile Include="System\Security\Cryptography\AsnEncodedData.cs" />
     <Compile Include="System\Security\Cryptography\AsnEncodedDataCollection.cs" />
@@ -17,6 +16,9 @@
     <Compile Include="System\Security\Cryptography\OidCollection.cs" />
     <Compile Include="System\Security\Cryptography\OidEnumerator.cs" />
     <Compile Include="System\Security\Cryptography\OidGroup.cs" />
+    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+      <Link>Internal\Cryptography\Helpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="Internal\Cryptography\AsnFormatter.Windows.cs" />

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Helpers.cs
@@ -17,13 +17,8 @@ using X509IssuerSerial = System.Security.Cryptography.Xml.X509IssuerSerial;
 
 namespace Internal.Cryptography
 {
-    internal static class Helpers
+    internal static partial class Helpers
     {
-        public static byte[] CloneByteArray(this byte[] a)
-        {
-            return (byte[])(a.Clone());
-        }
-
 #if !netcoreapp
         // Compatibility API.
         internal static void AppendData(this IncrementalHash hasher, ReadOnlySpan<byte> data)

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -54,6 +54,9 @@
     <Compile Include="Internal\Cryptography\Helpers.cs" />
     <Compile Include="Internal\Cryptography\PkcsPal.cs" />
     <Compile Include="Internal\Cryptography\RecipientInfoPal.cs" />
+    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+      <Link>Internal\Cryptography\Helpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Internal types (platform: AnyOS) -->
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -9,18 +9,8 @@ using System.Globalization;
 
 namespace Internal.Cryptography
 {
-    internal static class Helpers
+    internal static partial class Helpers
     {
-        public static byte[] CloneByteArray(this byte[] src)
-        {
-            if (src == null)
-            {
-                return null;
-            }
-
-            return (byte[])(src.Clone());
-        }
-
         // Encode a byte array as an array of upper-case hex characters.
         public static char[] ToHexArrayUpper(this byte[] bytes)
         {


### PR DESCRIPTION
At the moment, each of the `System.Security.Cryptography.*` projects defines its own
`Internal.Cryptography.Helpers` and several of them contain identical helper methods
such as for instance `CloneByteArray()`.

This causes problems for Mono when we're trying to combine pieces from multiple of these
projects into our assemblies.

This is a partial cleanup, which adds a `partial` modifier to all these classes and
moves the `CloneByteArray()` into a new shared file.