### PR TITLE
[1.1] Update runtime IDs for new RHEL/OL/Fedora releases

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -233,6 +233,20 @@
             "#import": [ "rhel.7.4", "rhel.7.3-x64" ]
         },
 
+        "rhel.7.5": {
+            "#import": [ "rhel.7.4" ]
+        },
+        "rhel.7.5-x64": {
+            "#import": [ "rhel.7.5", "rhel.7.4-x64" ]
+        },
+
+        "rhel.7.6": {
+            "#import": [ "rhel.7.5" ]
+        },
+        "rhel.7.6-x64": {
+            "#import": [ "rhel.7.6", "rhel.7.5-x64" ]
+        },
+
         "ol": {
             "#import": [ "rhel" ]
         },
@@ -280,6 +294,20 @@
         },
         "ol.7.4-x64": {
             "#import": [ "ol.7.4", "ol.7.3-x64", "rhel.7.4-x64" ]
+        },
+
+        "ol.7.5": {
+            "#import": [ "ol.7.4", "rhel.7.5" ]
+        },
+        "ol.7.5-x64": {
+            "#import": [ "ol.7.5", "ol.7.4-x64", "rhel.7.5-x64" ]
+        },
+
+        "ol.7.6": {
+            "#import": [ "ol.7.5", "rhel.7.6" ]
+        },
+        "ol.7.6-x64": {
+            "#import": [ "ol.7.6", "ol.7.5-x64", "rhel.7.6-x64" ]
         },
 
         "centos": {
@@ -498,6 +526,13 @@
         },
         "fedora.28-x64": {
             "#import": [ "fedora.28", "fedora-x64" ]
+        },
+
+        "fedora.29": {
+            "#import": [ "fedora" ]
+        },
+        "fedora.29-x64": {
+            "#import": [ "fedora.29", "fedora-x64" ]
         },
 
         "opensuse": {


### PR DESCRIPTION
CentOS does not include a minor version in runtime id.

This is a port of #31170 (`626a46893b`) to release/1.1.