### PR TITLE
improve port parsing to be more resilient against trailing characters

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -227,7 +227,17 @@ namespace System.Net.Http
             else
             {
                 host = value.Substring(0, separatorIndex);
-                if (!ushort.TryParse(value.AsSpan(separatorIndex + 1), out port))
+                int endIndex = separatorIndex + 1;
+                // Strip any trailing characters after port num,ber.
+                while (endIndex < value.Length)
+                {
+                    if (!char.IsDigit(value[endIndex]))
+                    {
+                        break;
+                    }
+                    endIndex += 1;
+                }
+                if (!ushort.TryParse(value.AsSpan(separatorIndex + 1, endIndex - separatorIndex - 1), out port))
                 {
                     return null;
                 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -228,7 +228,7 @@ namespace System.Net.Http
             {
                 host = value.Substring(0, separatorIndex);
                 int endIndex = separatorIndex + 1;
-                // Strip any trailing characters after port num,ber.
+                // Strip any trailing characters after port number.
                 while (endIndex < value.Length)
                 {
                     if (!char.IsDigit(value[endIndex]))
@@ -237,6 +237,7 @@ namespace System.Net.Http
                     }
                     endIndex += 1;
                 }
+
                 if (!ushort.TryParse(value.AsSpan(separatorIndex + 1, endIndex - separatorIndex - 1), out port))
                 {
                     return null;

--- a/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -112,6 +112,8 @@ namespace System.Net.Http.Tests
         [InlineData("domain\\foo:bar@1.1.1.1", "1.1.1.1", "80", "foo", "bar")]
         [InlineData("domain%5Cfoo:bar@1.1.1.1", "1.1.1.1", "80", "foo", "bar")]
         [InlineData("HTTP://ABC.COM/", "abc.com", "80", null, null)]
+        [InlineData("http://10.30.62.64:7890/", "10.30.62.64", "7890", null, null)]
+        [InlineData("http://1.2.3.4:8888/foo", "1.2.3.4", "8888", null, null)]
         public void HttpProxy_Uri_Parsing(string _input, string _host, string _port, string _user , string _password)
         {
             RemoteInvoke((input, host, port, user, password) =>


### PR DESCRIPTION
Primarily covers 'http://10.30.62.64:7890/' accepted by curl.