### PR TITLE
Port and test VB Collection

### DIFF
--- a/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
+++ b/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
@@ -16,6 +16,38 @@ namespace Microsoft.VisualBasic
         Method = 1,
         Set = 8,
     }
+    public sealed partial class Collection : System.Collections.ICollection, System.Collections.IList, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+    {
+        public Collection() { }
+        public int Count { get { throw null; } }
+        int System.Collections.ICollection.Count { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        bool System.Collections.IList.IsFixedSize { get { throw null; } }
+        bool System.Collections.IList.IsReadOnly { get { throw null; } }
+        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+        public object this[int Index] { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(2))]
+        public object this[object Index] { get { throw null; } }
+        public object this[string Key] { get { throw null; } }
+        public void Add(object Item, string Key = null, object Before = null, object After = null) { }
+        public void Clear() { }
+        public bool Contains(string Key) { throw null; }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        int System.Collections.IList.Add(object value) { throw null; }
+        void System.Collections.IList.Clear() { }
+        bool System.Collections.IList.Contains(object value) { throw null; }
+        int System.Collections.IList.IndexOf(object value) { throw null; }
+        void System.Collections.IList.Insert(int index, object value) { }
+        void System.Collections.IList.Remove(object value) { }
+        void System.Collections.IList.RemoveAt(int index) { }
+        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+        public void Remove(int Index) { }
+        public void Remove(string Key) { }
+    }
     public enum CompareMethod
     { 
         Binary = 0,

--- a/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
+++ b/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualBasic
         Method = 1,
         Set = 8,
     }
-    public sealed partial class Collection : System.Collections.ICollection, System.Collections.IList, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+    public sealed partial class Collection : System.Collections.ICollection, System.Collections.IList
     {
         public Collection() { }
         public int Count { get { throw null; } }
@@ -34,7 +34,6 @@ namespace Microsoft.VisualBasic
         public void Clear() { }
         public bool Contains(string Key) { throw null; }
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         int System.Collections.IList.Add(object value) { throw null; }
@@ -44,7 +43,6 @@ namespace Microsoft.VisualBasic
         void System.Collections.IList.Insert(int index, object value) { }
         void System.Collections.IList.Remove(object value) { }
         void System.Collections.IList.RemoveAt(int index) { }
-        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
         public void Remove(int Index) { }
         public void Remove(string Key) { }
     }

--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.vbproj
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.vbproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Microsoft\VisualBasic\CallType.vb" />
+    <Compile Include="Microsoft\VisualBasic\Collection.vb" />
     <Compile Include="Microsoft\VisualBasic\ApplicationServices\StartupEventArgs.vb" />
     <Compile Include="Microsoft\VisualBasic\ApplicationServices\StartupNextInstanceEventArgs.vb" />
     <Compile Include="Microsoft\VisualBasic\ApplicationServices\UnhandledExceptionEventArgs.vb" />
@@ -47,6 +48,7 @@
     <Compile Include="Microsoft\VisualBasic\ComClassAttribute.vb" />
     <Compile Include="Microsoft\VisualBasic\Constants.vb" />
     <Compile Include="Microsoft\VisualBasic\ControlChars.vb" />
+    <Compile Include="Microsoft\VisualBasic\Helpers\ForEachEnum.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\DoubleType.vb" />
     <Compile Include="Microsoft\VisualBasic\DateAndTime.vb" />
     <Compile Include="Microsoft\VisualBasic\HideModuleNameAttribute.vb" />

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Collection.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Collection.vb
@@ -1,0 +1,935 @@
+' Copyright (c) Microsoft Corporation.  All rights reserved.
+
+Imports System
+Imports System.Collections
+#If TELESTO Then
+Imports System.Collections.Generic
+#End If
+Imports System.Globalization
+Imports System.Diagnostics
+#If Not TELESTO Then
+Imports System.Runtime.Serialization
+#End If
+Imports System.Security
+Imports System.Security.Permissions
+
+Imports Microsoft.VisualBasic.CompilerServices
+Imports Microsoft.VisualBasic.CompilerServices.ExceptionUtils
+Imports Microsoft.VisualBasic.CompilerServices.Utils
+
+Namespace Microsoft.VisualBasic
+
+#If TELESTO Then
+    ' Types in Telesto aren't serializable <Serializable()> _
+    ' Debugger display stuff not supported. <DebuggerTypeProxy(GetType(Collection.CollectionDebugView))> _
+    <DebuggerDisplay("Count = {Count}")> _
+    Public NotInheritable Class Collection : Implements IEnumerable, ICollection, IList 'Telesto doesn't support ISerializable, IDeserializationCallback
+#Else
+    <Serializable()> _
+    <DebuggerTypeProxy(GetType(Collection.CollectionDebugView))> _
+    <DebuggerDisplay("Count = {Count}")> _
+    Public NotInheritable Class Collection : Implements ICollection, IList, ISerializable, IDeserializationCallback
+#End If
+
+        '= PUBLIC =============================================================
+
+        '''**************************************************************************
+        ''' ;New
+        ''' <summary>
+        ''' Ctor.
+        ''' </summary>
+        ''' <remarks></remarks>
+        Public Sub New()
+            MyBase.New()
+            Initialize(GetCultureInfo)
+        End Sub
+
+        '*****************************************************************************
+        'These methods are 1 based
+        '*****************************************************************************
+
+        '''**************************************************************************
+        ''' ;Add
+        ''' <summary>
+        ''' Add an item to the collection
+        ''' </summary>
+        ''' <param name="Item"></param>
+        ''' <param name="Key"></param>
+        ''' <param name="Before"></param>
+        ''' <param name="After"></param>
+        ''' <remarks></remarks>
+        Public Sub Add(ByVal Item As Object, Optional ByVal Key As String = Nothing, Optional ByVal Before As Object = Nothing, Optional ByVal After As Object = Nothing)
+
+            'Before and After are mutually exclusive
+            If (Not Before Is Nothing) AndAlso (Not After Is Nothing) Then
+                Throw New ArgumentException(GetResourceString(ResID.Collection_BeforeAfterExclusive))
+            End If
+
+            'Create a new node
+            Dim NewNode As Node = New Node(Key, Item)
+
+            'If a key was specified, add the new node to the hashtable of keys.  If this is 
+            '  a duplicate key, we'll get an argument exception.  This prevents us from
+            '  having to do a hashtable look-up to verify the key is unique.
+            'However, we then have to be careful to remove the node from the hashtable if we fail to add the item to the
+            '  list because the Before or After keys were bad.
+            If Key IsNot Nothing Then
+                Try
+                    m_KeyedNodesHash.Add(Key, NewNode)
+                Catch ex As ArgumentException
+                    Debug.Assert(m_KeyedNodesHash.ContainsKey(Key), "We got an argumentexception from a hashtable add, but it wasn't a duplicate key.  Please file a bug.  What other kind of argument exception could we get here?")
+                    '... Duplicate key.  Throw our own exception and our own message.
+                    Throw VbMakeException(New ArgumentException(GetResourceString(ResID.Collection_DuplicateKey)), vbErrors.DuplicateKey)
+                End Try
+            End If
+
+            Try
+                'Add the item to list and also (if a key was specified) to the hashtable 
+                If (Before Is Nothing) AndAlso (After Is Nothing) Then  'Neither Before nor After have  been specified
+                    'Add the value to the linked list
+                    m_ItemsList.Add(NewNode)
+                ElseIf Before IsNot Nothing Then
+                    'Before has been specified
+                    Debug.Assert(Before IsNot Nothing, "Huh?")
+                    Dim BeforeString As String = TryCast(Before, String)
+
+                    If BeforeString IsNot Nothing Then
+                        Dim BeforeNode As Node = Nothing
+                        If Not m_KeyedNodesHash.TryGetValue(BeforeString, BeforeNode) Then
+                            Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Before"))
+                        End If
+                        Debug.Assert(BeforeNode IsNot Nothing)
+
+                        m_ItemsList.InsertBefore(NewNode, BeforeNode)
+                    Else
+                        m_ItemsList.Insert(CInt(Before) - 1, NewNode) 'Convert from 1 based to 0 based.
+                    End If
+                Else
+                    'After has been specified
+                    Debug.Assert(After IsNot Nothing, "Huh?")
+                    Dim AfterString As String = TryCast(After, String)
+
+                    If AfterString IsNot Nothing Then
+                        Dim AfterNode As Node = Nothing
+                        If Not m_KeyedNodesHash.TryGetValue(AfterString, AfterNode) Then
+                            Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "After"))
+                        End If
+                        Debug.Assert(AfterNode IsNot Nothing)
+                        m_ItemsList.InsertAfter(NewNode, AfterNode)
+                    Else
+                        m_ItemsList.Insert(CInt(After), NewNode)  'Conversion from 1 based to 0 based offsets need to add 1.
+                    End If
+                End If
+            Catch ex As OutOfMemoryException
+                Throw
+            Catch ex As Threading.ThreadAbortException
+                Throw
+            Catch ex As StackOverflowException
+                Throw
+            Catch ex As Exception
+                'We couldn't add the item to the list because the Before or After key was not found.  We need to back out the
+                '  insert that we did into the hash table.
+                If Key IsNot Nothing Then
+                    m_KeyedNodesHash.Remove(Key)
+                End If
+
+                Throw
+            End Try
+
+            'Adjust the ForEach iterators
+            AdjustEnumeratorsOnNodeInserted(NewNode)
+        End Sub
+
+        '''**************************************************************************
+        ''' ;Clear 
+        ''' <summary>
+        ''' Clears all items in the collection
+        ''' </summary>
+        ''' <remarks></remarks>
+        Public Sub Clear()
+            m_KeyedNodesHash.Clear()
+            m_ItemsList.Clear()
+
+            'Notify the enumerators
+            Dim i As Integer = m_Iterators.Count - 1
+            While i >= 0
+                Dim Ref As WeakReference = DirectCast(m_Iterators(i), WeakReference)
+                If Ref.IsAlive Then
+                    Dim Enumerator As ForEachEnum = CType(Ref.Target, ForEachEnum)
+                    If Not Enumerator Is Nothing Then
+                        Enumerator.AdjustOnListCleared()
+                    End If
+                Else
+                    m_Iterators.RemoveAt(i)
+                End If
+                i -= 1
+            End While
+        End Sub
+
+        '''**************************************************************************
+        ''' ;Contains 
+        ''' <summary>
+        ''' Returns true iff the given key is in the collection
+        ''' </summary>
+        ''' <param name="Key"></param>
+        ''' <returns>True - the given key is in the collection.  False otherwise.</returns>
+        ''' <remarks></remarks>
+
+        Public Function Contains(ByVal Key As String) As Boolean
+            If Key Is Nothing Then
+                Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Key"))
+            End If
+            Return m_KeyedNodesHash.ContainsKey(Key)
+        End Function
+
+        Public Overloads Sub Remove(ByVal Key As String)
+            Dim Node As Node = Nothing
+            If m_KeyedNodesHash.TryGetValue(Key, Node) Then
+                Debug.Assert(Node IsNot Nothing)
+
+                'Adjust the ForEach iterators
+                AdjustEnumeratorsOnNodeRemoved(Node) 'Must be done before the prev/next pointers are removed
+
+                'Remove the item from the list and hash table (we know it has a key)
+                Debug.Assert(Node.m_Key IsNot Nothing, "How can that be?  We just found it by its key.")
+                m_KeyedNodesHash.Remove(Key)
+                m_ItemsList.RemoveNode(Node)
+
+                'Remove prev/next pointers because the iterators will be thrown off if this isn't done.  Also it's easier for debugging.
+                Node.m_Prev = Nothing
+                Node.m_Next = Nothing
+            Else
+                Debug.Assert(Node Is Nothing)
+                Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Key"))
+            End If
+        End Sub
+
+        Public Overloads Sub Remove(ByVal Index As Integer)
+            IndexCheck(Index)
+            Dim Node As Node = m_ItemsList.RemoveAt(Index - 1) '0 based
+            Debug.Assert(Node IsNot Nothing, "Should have thrown exception rather than return Nothing")
+
+            AdjustEnumeratorsOnNodeRemoved(Node) 'Must be done before the prev/next pointers are removed
+
+            'Remove from the hash table if it has a key
+            If Node.m_Key IsNot Nothing Then
+                m_KeyedNodesHash.Remove(Node.m_Key)
+            End If
+
+            'Remove prev/next pointers because the iterators will be thrown off if this isn't done.  Also it's easier for debugging.
+            Node.m_Prev = Nothing
+            Node.m_Next = Nothing
+        End Sub
+
+        Default Public Overloads ReadOnly Property Item(ByVal Index As Integer) As Object
+            'This method uses 1 based arrays.
+            Get
+                IndexCheck(Index)
+                Dim Node As Node = m_ItemsList.Item(Index - 1)
+                Debug.Assert(Node IsNot Nothing, "Should have thrown rather than returning Nothing")
+                Return Node.m_Value
+            End Get
+        End Property
+
+        Default Public Overloads ReadOnly Property Item(ByVal Key As String) As Object
+            Get
+                If Key Is Nothing Then
+                    'Backwards compat with Everett - throw IndexOutOfRange if Key = Nothing
+                    Throw New IndexOutOfRangeException(GetResourceString(ResID.Argument_CollectionIndex))
+                End If
+
+                Dim Node As Node = Nothing
+                If Not m_KeyedNodesHash.TryGetValue(Key, Node) Then
+                    Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Index"))
+                End If
+                Debug.Assert(Node IsNot Nothing)
+
+                Return Node.m_Value
+            End Get
+        End Property
+
+#If TELESTO Then
+        'FIXME: <System.ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Advanced)> 
+        Default Public Overloads ReadOnly Property Item(ByVal Index As Object) As Object
+#Else
+        <System.ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Advanced)> _
+        Default Public Overloads ReadOnly Property Item(ByVal Index As Object) As Object
+#End If
+            Get
+                If (TypeOf Index Is String) OrElse (TypeOf Index Is Char) OrElse (TypeOf Index Is Char()) Then
+                    ' Index is string and is being treated as key
+                    Dim Key As String = CStr(Index)
+                    Return Me.Item(Key)
+                Else
+                    ' Index is being treated as numeric expression
+                    Dim IndexValue As Integer
+                    Try
+                        IndexValue = CInt(Index)
+                    Catch ex As StackOverflowException
+                        Throw ex
+                    Catch ex As OutOfMemoryException
+                        Throw ex
+                    Catch ex As System.Threading.ThreadAbortException
+                        Throw ex
+                    Catch
+                        Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Index"))
+                    End Try
+
+                    Return Me.Item(IndexValue)
+                End If
+            End Get
+        End Property
+
+        Public ReadOnly Property Count() As Integer
+            Get
+                Return m_ItemsList.Count
+            End Get
+        End Property
+
+        Public Function GetEnumerator() As IEnumerator
+
+            ' Remove Dead Iterators if any from Iterator list m_Iterators
+            Dim oldWeakref As WeakReference
+            Dim i As Integer = m_Iterators.Count - 1
+
+            While (i >= 0)
+                oldWeakref = CType(m_Iterators(i), WeakReference)
+                If Not oldWeakref.IsAlive Then
+                    m_Iterators.RemoveAt(i)
+                End If
+                i -= 1
+            End While
+
+            ' Create A New Iterator, add to Iterator List and return
+            Dim enumerator As ForEachEnum = New ForEachEnum(Me)
+            Dim weakref As WeakReference = New WeakReference(enumerator)
+            enumerator.WeakRef = weakref
+            m_Iterators.Add(weakref)
+            Return enumerator
+        End Function
+
+        '= FRIEND =============================================================
+
+        Friend Sub RemoveIterator(ByVal weakref As WeakReference)
+            m_Iterators.Remove(weakref)
+        End Sub
+
+        Friend Sub AddIterator(ByVal weakref As WeakReference)
+            m_Iterators.Add(weakref)
+        End Sub
+
+        'Returns the first node in the linked list
+        Friend Function GetFirstListNode() As Node
+            Return m_ItemsList.GetFirstListNode()
+        End Function
+
+        '***************************************************************
+        '
+        ' Nested class: Node
+        '
+        '***************************************************************
+        Friend NotInheritable Class Node
+            'Constructor.  Key or Value may be Nothing
+            Friend Sub New(ByVal Key As String, ByVal Value As Object)
+                m_Value = Value
+                m_Key = Key
+            End Sub
+
+            Friend m_Value As Object 'The value.
+            Friend m_Key As String   'The key.  If Nothing, the collection item has no user-specified key.
+            Friend m_Next As Node    'Doubly-linked list pointer to the next node
+            Friend m_Prev As Node    'Doubly-linked list pointer to the previous node
+
+#If 0 Then 'For debugging purposes
+            Public Overrides Function ToString() As String
+                Dim s As New System.Text.StringBuilder
+
+                s.Append("Node (")
+                If m_Key Is Nothing Then
+                    s.Append("no key")
+                Else
+                    s.Append("key=""" & m_Key & """")
+                End If
+                s.Append("): ")
+                Try
+                    s.Append(m_Value.ToString())
+                Catch ex As OutOfMemoryException
+                    Throw
+                Catch ex As Threading.ThreadAbortException
+                    Throw
+                Catch ex As StackOverflowException
+                    Throw
+                Catch ex As Exception
+                    s.Append(ex.Message)
+                End Try
+
+                Return s.ToString()
+            End Function
+#End If
+        End Class 'Node
+
+        '''******************************************************************************
+        ''' ;CollectionDebugView
+        ''' <summary>
+        ''' Debugger proxy for the Collection class.  Provides a view of the collection 
+        ''' that just displays the collection contents. 
+        ''' </summary>
+        ''' <remarks></remarks>
+        Friend NotInheritable Class CollectionDebugView
+            Public Sub New(ByVal RealClass As Collection)
+                m_InstanceBeingWatched = RealClass
+            End Sub
+
+            'Returns an array with all items in the collection.  
+            <DebuggerBrowsable(DebuggerBrowsableState.RootHidden)> _
+            Public ReadOnly Property Items() As Object()
+                Get
+                    Dim Count As Integer = m_InstanceBeingWatched.Count
+                    If Count = 0 Then
+                        Return Nothing
+                    End If
+
+                    Dim Results(Count) As Object
+                    Results(0) = GetResourceString(ResID.EmptyPlaceHolderMessage)
+
+                    For Index As Integer = 1 To Count
+                        Dim NewNode As Node = m_InstanceBeingWatched.InternalItemsList.Item(Index - 1)
+                        Results(Index) = New KeyValuePair(NewNode.m_Key, NewNode.m_Value)
+                    Next Index
+                    Return Results
+                End Get
+            End Property
+
+            <DebuggerBrowsable(DebuggerBrowsableState.Never)> Private m_InstanceBeingWatched As Collection
+        End Class
+
+        '= PRIVATE =============================================================
+
+        '''******************************************************************************
+        ''' ;Initialize
+        ''' <summary>
+        ''' Initialize all internal structures to set up an empty collection.
+        ''' </summary>
+        ''' <param name="CultureInfo">the culture info to use for key comparisons for the lifetime of this collection.</param>
+        ''' <param name="StartingHashCapacity"></param>
+        ''' <remarks></remarks>
+        Private Sub Initialize(ByVal CultureInfo As CultureInfo, Optional ByVal StartingHashCapacity As Integer = 0)
+            Debug.Assert(CultureInfo IsNot Nothing)
+
+            If StartingHashCapacity > 0 Then
+                m_KeyedNodesHash = New Generic.Dictionary(Of String, Node)(StartingHashCapacity, StringComparer.Create(CultureInfo, ignoreCase:=True))
+            Else
+                m_KeyedNodesHash = New Generic.Dictionary(Of String, Node)(StringComparer.Create(CultureInfo, ignoreCase:=True))
+            End If
+            m_ItemsList = New FastList()
+#If TELESTO Then
+            m_Iterators = New List(Of Object) 
+#Else
+            m_Iterators = New ArrayList 
+#End IF
+
+
+#If Not TELESTO Then
+            m_CultureInfo = CultureInfo
+#End If
+        End Sub
+
+        '***************************************************************
+        '
+        ' Nested class: FastList
+        '
+        '***************************************************************
+        Private NotInheritable Class FastList
+
+            '= FRIEND  =============================================================
+
+            Friend Sub New()
+                MyBase.New()
+            End Sub
+
+            Friend Sub Add(ByVal Node As Node)
+                If m_StartOfList Is Nothing Then
+                    m_StartOfList = Node
+                Else
+                    m_EndOfList.m_Next = Node
+                    Node.m_Prev = m_EndOfList
+                End If
+                m_EndOfList = Node
+                m_Count += 1
+            End Sub
+
+            'Searches for a given value in the list.  Returns its node's index or -1 if not found.
+            Friend Function IndexOfValue(ByVal Value As Object) As Integer
+                Dim CurrentNode As Node = m_StartOfList
+                Dim Index As Integer = 0
+
+                While Not CurrentNode Is Nothing
+                    If DataIsEqual(CurrentNode.m_Value, Value) Then
+                        Return Index
+                    End If
+                    CurrentNode = CurrentNode.m_Next
+                    Index += 1
+                End While
+                Return -1
+            End Function
+
+            Friend Sub RemoveNode(ByVal NodeToBeDeleted As Node)
+                Debug.Assert(Not (NodeToBeDeleted Is Nothing), "How can we remove a non-existent node ?")
+                DeleteNode(NodeToBeDeleted, NodeToBeDeleted.m_Prev)
+            End Sub
+
+            'Removes the node at the given index.
+            '  Returns the node that was removed
+            Friend Function RemoveAt(ByVal Index As Integer) As Node
+                Dim CurrentNode As Node = m_StartOfList
+                Dim CurrentIndex As Integer = 0
+                Dim PrevNode As Node = Nothing
+
+                While CurrentIndex < Index AndAlso (Not (CurrentNode Is Nothing))
+                    PrevNode = CurrentNode
+                    CurrentNode = CurrentNode.m_Next
+                    CurrentIndex += 1
+                End While
+
+                If (CurrentNode Is Nothing) Then
+                    Throw New ArgumentOutOfRangeException("Index")
+                End If
+
+                DeleteNode(CurrentNode, PrevNode)
+                Return CurrentNode
+            End Function
+
+            Friend Function Count() As Integer
+                Return m_Count
+            End Function
+
+            Friend Sub Clear()
+                m_StartOfList = Nothing
+                m_EndOfList = Nothing
+                m_Count = 0
+            End Sub
+
+            'Retrieves the node at the given index (0-based)
+            Friend ReadOnly Property Item(ByVal Index As Integer) As Node
+                Get
+                    Dim N As Node = GetNodeAtIndex(Index)
+                    If (N Is Nothing) Then
+                        Throw New ArgumentOutOfRangeException("Index")
+                    End If
+                    Return N
+                End Get
+            End Property
+
+            Friend Sub Insert(ByVal Index As Integer, ByVal Node As Node)
+                Dim PrevNode As Node = Nothing
+
+                ' (Index > m_Count) is here for a reason. We allow insertion immediately beyond the end of the
+                ' list i.e. if there are 0 to m_Count -1 elements, we allow insertion into the
+                ' m_Count index
+                If (Index < 0) OrElse (Index > m_Count) Then
+                    Throw New ArgumentOutOfRangeException("Index")
+                End If
+
+                Dim NodeAtIndex As Node = GetNodeAtIndex(Index, PrevNode) 'Note: PrevNode passed ByRef
+                Insert(Node, PrevNode, NodeAtIndex)
+            End Sub
+
+            'Inserts a node into the list.
+            '  The item is inserted before NodeToInsertBefore (may not be Nothing).
+            Friend Sub InsertBefore(ByVal Node As Node, ByVal NodeToInsertBefore As Node)
+                Debug.Assert(NodeToInsertBefore IsNot Nothing, "FastList.InsertBefore: NodeToInsertBefore may not be nothing")
+                Insert(Node, NodeToInsertBefore.m_Prev, NodeToInsertBefore)
+            End Sub
+
+
+            'Inserts a node into the list.
+            '  The item is inserted after NodeToInsertAfter (may not be Nothing).
+            Friend Sub InsertAfter(ByVal Node As Node, ByVal NodeToInsertAfter As Node)
+                Debug.Assert(NodeToInsertAfter IsNot Nothing, "FastList.InsertAfter: NodeToInsertAfter may not be nothing")
+                Insert(Node, NodeToInsertAfter, NodeToInsertAfter.m_Next)
+            End Sub
+
+            'Returns the first node in the list
+            Friend Function GetFirstListNode() As Node
+                Return m_StartOfList
+            End Function
+
+            '= PRIVATE =============================================================
+
+            Private Function DataIsEqual(ByVal obj1 As Object, ByVal obj2 As Object) As Boolean
+                If obj1 Is obj2 Then
+                    Return True
+                End If
+
+                If obj1.GetType() Is obj2.GetType() Then
+                    Return Object.Equals(obj1, obj2)
+                Else
+                    Return False
+                End If
+            End Function
+
+            Private Function GetNodeAtIndex(ByVal Index As Integer, Optional ByRef PrevNode As Node = Nothing) As Node
+                Dim CurrentNode As Node = m_StartOfList
+                Dim CurrentIndex As Integer = 0
+                PrevNode = Nothing
+
+                While CurrentIndex < Index AndAlso (Not (CurrentNode Is Nothing))
+                    PrevNode = CurrentNode
+                    CurrentNode = CurrentNode.m_Next
+                    CurrentIndex += 1
+                End While
+
+                Return CurrentNode
+            End Function
+
+            'Inserts the given node into the list between the two given nodes (may be Nothing at the beginning/end of the list)
+            Private Sub Insert(ByVal Node As Node, ByVal PrevNode As Node, ByVal CurrentNode As Node)
+                Node.m_Next = CurrentNode
+
+                If Not CurrentNode Is Nothing Then
+                    CurrentNode.m_Prev = Node
+                End If
+
+                If PrevNode Is Nothing Then
+                    m_StartOfList = Node
+                Else
+                    PrevNode.m_Next = Node
+                    Node.m_Prev = PrevNode
+                End If
+
+                If Node.m_Next Is Nothing Then
+                    m_EndOfList = Node
+                End If
+
+                m_Count += 1
+            End Sub
+
+            Private Sub DeleteNode(ByVal NodeToBeDeleted As Node, ByVal PrevNode As Node)
+                Debug.Assert(Not (NodeToBeDeleted Is Nothing), "How can we delete a non-existent node ?")
+
+                If PrevNode Is Nothing Then ' are we are deleting the first node ?
+
+                    Debug.Assert(NodeToBeDeleted Is m_StartOfList, "How can any node besides the first node not have a previous node ?")
+
+                    m_StartOfList = m_StartOfList.m_Next
+
+                    If m_StartOfList Is Nothing Then
+                        m_EndOfList = Nothing
+                    Else
+                        m_StartOfList.m_Prev = Nothing
+                    End If
+                Else
+                    PrevNode.m_Next = NodeToBeDeleted.m_Next
+                    If PrevNode.m_Next Is Nothing Then
+                        m_EndOfList = PrevNode
+                    Else
+                        PrevNode.m_Next.m_Prev = PrevNode
+                    End If
+                End If
+                m_Count -= 1
+            End Sub
+
+            Private m_StartOfList As Node
+            Private m_EndOfList As Node
+            Private m_Count As Integer = 0
+        End Class 'FastList
+
+        'NOTE:  This structure exists so that the debugger windows can show the items in a collection.  See the Items property.
+        Private Structure KeyValuePair
+            Friend Sub New(ByVal NewKey As Object, ByVal NewValue As Object)
+                m_Key = NewKey
+                m_Value = NewValue
+            End Sub
+            Private m_Key As Object
+            Private m_Value As Object
+            Public ReadOnly Property Key() As Object
+                Get
+                    Return m_Key
+                End Get
+            End Property
+            Public ReadOnly Property Value() As Object
+                Get
+                    Return m_Value
+                End Get
+            End Property
+        End Structure
+
+        Private Sub AdjustEnumeratorsOnNodeInserted(ByVal NewNode As Node)
+            AdjustEnumeratorsHelper(NewNode, ForEachEnum.AdjustIndexType.Insert)
+        End Sub
+
+        Private Sub AdjustEnumeratorsOnNodeRemoved(ByVal RemovedNode As Node)
+            AdjustEnumeratorsHelper(RemovedNode, ForEachEnum.AdjustIndexType.Remove)
+        End Sub
+
+        Private Sub AdjustEnumeratorsHelper(ByVal NewOrRemovedNode As Node, ByVal Type As ForEachEnum.AdjustIndexType)
+            Debug.Assert(NewOrRemovedNode IsNot Nothing, "AdjustIndexes: Node shouldn't be Nothing")
+            Dim weakref As WeakReference
+            Dim i As Integer = m_Iterators.Count - 1
+
+            While (i >= 0)
+                weakref = CType(m_Iterators(i), WeakReference)
+                If weakref.IsAlive Then
+                    Dim enumerator As ForEachEnum = CType(weakref.Target, ForEachEnum)
+                    If Not enumerator Is Nothing Then
+                        enumerator.Adjust(NewOrRemovedNode, Type)  '1 based
+                    End If
+                Else
+                    m_Iterators.RemoveAt(i)
+                End If
+
+                i -= 1
+            End While
+        End Sub
+
+        Private Sub IndexCheck(ByVal Index As Integer)
+            If (Index < 1 OrElse Index > m_ItemsList.Count) Then
+                Throw New IndexOutOfRangeException(GetResourceString(ResID.Argument_CollectionIndex))
+            End If
+        End Sub
+
+        Private Function InternalItemsList() As FastList
+            Return m_ItemsList
+        End Function
+
+
+#Region "Serialization implementation"
+#If Not TELESTO Then
+        Private Const SERIALIZATIONKEY_KEYS As String = "Keys"
+        Private Const SERIALIZATIONKEY_KEYSCOUNT As String = "KeysCount" 'Number of items with a user-defined key (not same as keys array length)
+        Private Const SERIALIZATIONKEY_VALUES As String = "Values"
+        Private Const SERIALIZATIONKEY_CULTUREINFO As String = "CultureInfo"
+
+        'DeSerialization constructor
+        Private Sub New(ByVal info As SerializationInfo, ByVal context As StreamingContext)
+            m_DeserializationInfo = info
+        End Sub
+
+        <SecurityCritical()> _
+        Private Sub GetObjectData(ByVal info As SerializationInfo, ByVal context As StreamingContext) Implements ISerializable.GetObjectData
+            Dim Keys(Me.Count - 1) As String
+            Dim Values(Me.Count - 1) As Object
+
+            Dim Node As Node = GetFirstListNode()
+            Dim Index As Integer
+            Dim ElementsWithKey As Integer = 0
+            While Node IsNot Nothing
+                If Node.m_Key IsNot Nothing Then
+                    ElementsWithKey += 1
+                End If
+
+                Keys(Index) = Node.m_Key
+                Values(Index) = Node.m_Value
+
+                Index += 1
+                Node = Node.m_Next
+            End While
+            Debug.Assert(Index = Me.Count)
+            Debug.Assert(ElementsWithKey <= Me.Count)
+
+            info.AddValue(SERIALIZATIONKEY_KEYS, Keys, GetType(String()))
+            info.AddValue(SERIALIZATIONKEY_KEYSCOUNT, ElementsWithKey, GetType(Int32))
+            info.AddValue(SERIALIZATIONKEY_VALUES, Values, GetType(Object()))
+            info.AddValue(SERIALIZATIONKEY_CULTUREINFO, m_CultureInfo)
+        End Sub
+
+        Private Sub OnDeserialization(ByVal sender As Object) Implements IDeserializationCallback.OnDeserialization
+            Try
+                'Initialization using the saved culture info
+                Dim CultureInfo As CultureInfo = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_CULTUREINFO, GetType(CultureInfo)), CultureInfo)
+                If CultureInfo Is Nothing Then
+                    Throw New SerializationException(GetResourceString(ResID.Serialization_MissingCultureInfo))
+                End If
+
+                'Validate the keys and values arrays
+                Dim Keys() As String = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_KEYS, GetType(String())), String())
+                Dim Values() As Object = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_VALUES, GetType(Object())), Object())
+
+                If Keys Is Nothing Then
+                    Throw New SerializationException(GetResourceString(ResID.Serialization_MissingKeys))
+                End If
+
+                If Values Is Nothing Then
+                    Throw New SerializationException(GetResourceString(ResID.Serialization_MissingValues))
+                End If
+
+                If Keys.Length <> Values.Length Then
+                    Throw New SerializationException(GetResourceString(ResID.Serialization_KeyValueDifferentSizes))
+                End If
+
+                'Get the number of elements that have an associated key (the Keys array contains an item for all elements, and if that
+                '  item doesn't have a key, that element in the array is Nothing, so Keys.Length isn't the same)
+                Dim ElementsWithKey As Integer = m_DeserializationInfo.GetInt32(SERIALIZATIONKEY_KEYSCOUNT)
+
+                'It's okay if ElementsWithKey isn't in the deserialization info - we'll just assume a value of zero, which causes
+                '  us to not give a starting hash table capacity
+                If ElementsWithKey < 0 OrElse ElementsWithKey > Keys.Length Then
+                    Debug.Assert(ElementsWithKey >= 0, "Bad deserialization data?  ElementsWithKey is bad.  Ignoring and recovering because it's only an optimization anyway.")
+                    ElementsWithKey = 0
+                End If
+
+                Initialize(CultureInfo, ElementsWithKey) 'Giving the hash table the appropriate starting capacity should speed up hash insertions since it doesn't have to resize
+
+                'Add all elements to the collection.  We always insert to the end, which is fast and preserves our original order.
+                For Index As Integer = 0 To Keys.Length - 1
+                    Me.Add(Values(Index), Keys(Index)) 'If Keys(Index) is Nothing, the value will be added without a key
+                Next
+                Debug.Assert(Me.Count = Keys.Length)
+                m_DeserializationInfo = Nothing
+            Finally
+                If m_DeserializationInfo IsNot Nothing Then 'something bad happened - reset the collection to a pristine state so they don't access who knows what is left over in the collection
+                    m_DeserializationInfo = Nothing
+                    Me.Initialize(GetCultureInfo)
+                End If
+            End Try
+        End Sub
+#End If 'not TELESTO
+#End Region
+
+#Region "Interface Implementation"
+
+        '*****************************************************************************
+        'These methods are 0 based.
+        '*****************************************************************************
+        Private Function ICollectionGetEnumerator() As IEnumerator Implements ICollection.GetEnumerator
+            Return GetEnumerator()
+        End Function
+
+        Private ReadOnly Property ICollectionCount() As Integer Implements ICollection.Count
+            Get
+                Return m_ItemsList.Count
+            End Get
+        End Property
+
+        Private ReadOnly Property ICollectionIsSynchronized() As Boolean Implements ICollection.IsSynchronized
+            Get
+                Return False
+            End Get
+        End Property
+
+        Private ReadOnly Property ICollectionSyncRoot() As Object Implements ICollection.SyncRoot
+            Get
+                Return Me
+            End Get
+        End Property
+
+        Private ReadOnly Property IListIsFixedSize() As Boolean Implements IList.IsFixedSize
+            Get
+                Return False
+            End Get
+        End Property
+
+        Private ReadOnly Property IListIsReadOnly() As Boolean Implements IList.IsReadOnly
+            Get
+                Return False
+            End Get
+        End Property
+
+        Private Sub ICollectionCopyTo(ByVal [array] As System.Array, ByVal index As Integer) Implements ICollection.CopyTo
+            '*** BEGIN ARG CHECKS
+            If [array] Is Nothing Then
+                Throw New ArgumentNullException(GetResourceString(ResID.Argument_InvalidNullValue1, "array"))
+            End If
+
+            If [array].Rank <> 1 Then
+                Throw New ArgumentException(GetResourceString(ResID.Argument_RankEQOne1, "array"))
+            End If
+
+            If (index < 0) OrElse ([array].Length - index < Count) Then
+                Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "index"))
+            End If
+            '*** END ARG CHECKS
+
+            Dim i As Integer
+            Dim objArray As Object() = TryCast(array, Object())
+
+            If objArray IsNot Nothing Then
+                For i = 1 To Count
+                    objArray(index + i - 1) = Me.Item(i)
+                Next i
+            Else
+                For i = 1 To Count
+                    [array].SetValue(Me.Item(i), index + i - 1)
+                Next i
+            End If
+        End Sub
+
+        Private Function IListAdd(ByVal value As Object) As Integer Implements IList.Add
+            Add(value, Nothing)
+            Return m_ItemsList.Count - 1 'IList is 0 based.  Return a 0-based index.  If m_ItemsList.Count is zero, we threw during Add() so no need to gate the Count = 0 case.
+        End Function
+
+
+        'CONSIDER: why not delegate to Collection.Add?  Same for the others...
+        Private Sub IListInsert(ByVal index As Integer, ByVal value As Object) Implements IList.Insert
+            Dim NewNode As New Node(Nothing, value)
+            m_ItemsList.Insert(index, NewNode) 'FastList is 0-indexed just like IList, so no transformation of "index" needed
+            'No key, so no need to add to the hash table.
+            'Adjust the ForEach iterators
+            AdjustEnumeratorsOnNodeInserted(NewNode)
+        End Sub
+
+        Private Sub IListRemoveAt(ByVal index As Integer) Implements IList.RemoveAt
+            Dim Node As Node = m_ItemsList.RemoveAt(index)    '0 based
+            Debug.Assert(Node IsNot Nothing, "Should have thrown exception rather than return Nothing")
+
+            AdjustEnumeratorsOnNodeRemoved(Node) 'Adjust the ForEach iterators
+            If Node.m_Key IsNot Nothing Then
+                m_KeyedNodesHash.Remove(Node.m_Key)
+            End If
+
+            Node.m_Prev = Nothing
+            Node.m_Next = Nothing
+        End Sub
+
+        Private Sub IListRemove(ByVal value As Object) Implements IList.Remove
+            Dim index As Integer
+            index = IListIndexOf(value)
+            If index <> -1 Then
+                IListRemoveAt(index)
+            End If
+            'No exception thrown if not found
+        End Sub
+
+        Private Sub IListClear() Implements IList.Clear
+            Clear()
+        End Sub
+
+        Private Property IListItem(ByVal index As Integer) As Object Implements IList.Item
+            Get
+                Dim Node As Node
+
+                Node = m_ItemsList.Item(index)
+                Return Node.m_Value
+            End Get
+
+            Set(ByVal value As Object)
+                Dim Node As Node = m_ItemsList.Item(index)
+                Node.m_Value = value
+            End Set
+        End Property
+
+        Private Function IListContains(ByVal value As Object) As Boolean Implements IList.Contains
+            Return (IListIndexOf(value) <> -1)
+        End Function
+
+        Private Function IListIndexOf(ByVal value As Object) As Integer Implements IList.IndexOf
+            Return m_ItemsList.IndexOfValue(value)
+        End Function
+
+#End Region
+
+#If Not TELESTO Then
+        Private m_DeserializationInfo As SerializationInfo
+        Private m_CultureInfo As CultureInfo 'The CultureInfo used for key comparisons
+#End If
+        Private m_KeyedNodesHash As Generic.Dictionary(Of String, Node) 'Hashtable mapping key (string) -> Node, contains only items added to the collection with a key
+        Private m_ItemsList As FastList 'Doubly-linked list of Node containing all items in the collection
+#If TELESTO Then
+        Private m_Iterators As List(Of Object) 'List of iterators currently iterating this collection
+#Else
+        Private m_Iterators As ArrayList 'List of iterators currently iterating this collection        
+#End IF
+    End Class 'Collection
+End Namespace
+

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Collection.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Collection.vb
@@ -1,55 +1,40 @@
-' Copyright (c) Microsoft Corporation.  All rights reserved.
+' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
 
 Imports System
 Imports System.Collections
-#If TELESTO Then
 Imports System.Collections.Generic
-#End If
 Imports System.Globalization
 Imports System.Diagnostics
-#If Not TELESTO Then
 Imports System.Runtime.Serialization
-#End If
 Imports System.Security
 Imports System.Security.Permissions
-
 Imports Microsoft.VisualBasic.CompilerServices
 Imports Microsoft.VisualBasic.CompilerServices.ExceptionUtils
 Imports Microsoft.VisualBasic.CompilerServices.Utils
 
 Namespace Microsoft.VisualBasic
 
-#If TELESTO Then
-    ' Types in Telesto aren't serializable <Serializable()> _
-    ' Debugger display stuff not supported. <DebuggerTypeProxy(GetType(Collection.CollectionDebugView))> _
-    <DebuggerDisplay("Count = {Count}")> _
-    Public NotInheritable Class Collection : Implements IEnumerable, ICollection, IList 'Telesto doesn't support ISerializable, IDeserializationCallback
-#Else
-    <Serializable()> _
-    <DebuggerTypeProxy(GetType(Collection.CollectionDebugView))> _
-    <DebuggerDisplay("Count = {Count}")> _
+    <Serializable()>
+    <DebuggerTypeProxy(GetType(Collection.CollectionDebugView))>
+    <DebuggerDisplay("Count = {Count}")>
     Public NotInheritable Class Collection : Implements ICollection, IList, ISerializable, IDeserializationCallback
-#End If
+        Private m_DeserializationInfo As SerializationInfo
+        Private m_CultureInfo As CultureInfo 'The CultureInfo used for key comparisons
+        Private m_KeyedNodesHash As Generic.Dictionary(Of String, Node) 'Hashtable mapping key (string) -> Node, contains only items added to the collection with a key
+        Private m_ItemsList As FastList 'Doubly-linked list of Node containing all items in the collection
+        Private m_Iterators As List(Of Object) 'List of iterators currently iterating this collection
 
-        '= PUBLIC =============================================================
-
-        '''**************************************************************************
-        ''' ;New
-        ''' <summary>
-        ''' Ctor.
-        ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
             MyBase.New()
-            Initialize(GetCultureInfo)
+            Initialize(GetCultureInfo())
         End Sub
 
         '*****************************************************************************
         'These methods are 1 based
         '*****************************************************************************
 
-        '''**************************************************************************
-        ''' ;Add
         ''' <summary>
         ''' Add an item to the collection
         ''' </summary>
@@ -57,16 +42,15 @@ Namespace Microsoft.VisualBasic
         ''' <param name="Key"></param>
         ''' <param name="Before"></param>
         ''' <param name="After"></param>
-        ''' <remarks></remarks>
         Public Sub Add(ByVal Item As Object, Optional ByVal Key As String = Nothing, Optional ByVal Before As Object = Nothing, Optional ByVal After As Object = Nothing)
 
             'Before and After are mutually exclusive
-            If (Not Before Is Nothing) AndAlso (Not After Is Nothing) Then
-                Throw New ArgumentException(GetResourceString(ResID.Collection_BeforeAfterExclusive))
+            If (Before IsNot Nothing) AndAlso (After IsNot Nothing) Then
+                Throw New ArgumentException(SR.Collection_BeforeAfterExclusive)
             End If
 
             'Create a new node
-            Dim NewNode As Node = New Node(Key, Item)
+            Dim newNode As Node = New Node(Key, Item)
 
             'If a key was specified, add the new node to the hashtable of keys.  If this is 
             '  a duplicate key, we'll get an argument exception.  This prevents us from
@@ -75,49 +59,48 @@ Namespace Microsoft.VisualBasic
             '  list because the Before or After keys were bad.
             If Key IsNot Nothing Then
                 Try
-                    m_KeyedNodesHash.Add(Key, NewNode)
+                    m_KeyedNodesHash.Add(Key, newNode)
                 Catch ex As ArgumentException
-                    Debug.Assert(m_KeyedNodesHash.ContainsKey(Key), "We got an argumentexception from a hashtable add, but it wasn't a duplicate key.  Please file a bug.  What other kind of argument exception could we get here?")
-                    '... Duplicate key.  Throw our own exception and our own message.
-                    Throw VbMakeException(New ArgumentException(GetResourceString(ResID.Collection_DuplicateKey)), vbErrors.DuplicateKey)
+                    Debug.Assert(m_KeyedNodesHash.ContainsKey(Key), "We got an argumentexception from a hashtable add, but it wasn't a duplicate key.")
+                    ' Duplicate key.  Throw our own exception and our own message.
+                    Throw VbMakeException(New ArgumentException(SR.Collection_DuplicateKey), vbErrors.DuplicateKey)
                 End Try
             End If
 
             Try
                 'Add the item to list and also (if a key was specified) to the hashtable 
-                If (Before Is Nothing) AndAlso (After Is Nothing) Then  'Neither Before nor After have  been specified
+                If (Before Is Nothing) AndAlso (After Is Nothing) Then  'Neither Before nor After have been specified
                     'Add the value to the linked list
-                    m_ItemsList.Add(NewNode)
+                    m_ItemsList.Add(newNode)
                 ElseIf Before IsNot Nothing Then
                     'Before has been specified
-                    Debug.Assert(Before IsNot Nothing, "Huh?")
-                    Dim BeforeString As String = TryCast(Before, String)
+                    Dim beforeString As String = TryCast(Before, String)
 
-                    If BeforeString IsNot Nothing Then
+                    If beforeString IsNot Nothing Then
                         Dim BeforeNode As Node = Nothing
-                        If Not m_KeyedNodesHash.TryGetValue(BeforeString, BeforeNode) Then
-                            Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Before"))
+                        If Not m_KeyedNodesHash.TryGetValue(beforeString, BeforeNode) Then
+                            Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, NameOf(Before)), NameOf(Before))
                         End If
                         Debug.Assert(BeforeNode IsNot Nothing)
 
-                        m_ItemsList.InsertBefore(NewNode, BeforeNode)
+                        m_ItemsList.InsertBefore(newNode, BeforeNode)
                     Else
-                        m_ItemsList.Insert(CInt(Before) - 1, NewNode) 'Convert from 1 based to 0 based.
+                        m_ItemsList.Insert(CInt(Before) - 1, newNode) 'Convert from 1 based to 0 based.
                     End If
                 Else
                     'After has been specified
-                    Debug.Assert(After IsNot Nothing, "Huh?")
-                    Dim AfterString As String = TryCast(After, String)
+                    Dim afterString As String = TryCast(After, String)
 
-                    If AfterString IsNot Nothing Then
+                    If afterString IsNot Nothing Then
                         Dim AfterNode As Node = Nothing
-                        If Not m_KeyedNodesHash.TryGetValue(AfterString, AfterNode) Then
-                            Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "After"))
+                        If Not m_KeyedNodesHash.TryGetValue(afterString, AfterNode) Then
+                            Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, NameOf(After)), NameOf(After))
                         End If
                         Debug.Assert(AfterNode IsNot Nothing)
-                        m_ItemsList.InsertAfter(NewNode, AfterNode)
+
+                        m_ItemsList.InsertAfter(newNode, AfterNode)
                     Else
-                        m_ItemsList.Insert(CInt(After), NewNode)  'Conversion from 1 based to 0 based offsets need to add 1.
+                        m_ItemsList.Insert(CInt(After), newNode)  'Conversion from 1 based to 0 based offsets need to add 1.
                     End If
                 End If
             Catch ex As OutOfMemoryException
@@ -137,15 +120,12 @@ Namespace Microsoft.VisualBasic
             End Try
 
             'Adjust the ForEach iterators
-            AdjustEnumeratorsOnNodeInserted(NewNode)
+            AdjustEnumeratorsOnNodeInserted(newNode)
         End Sub
 
-        '''**************************************************************************
-        ''' ;Clear 
         ''' <summary>
         ''' Clears all items in the collection
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub Clear()
             m_KeyedNodesHash.Clear()
             m_ItemsList.Clear()
@@ -153,11 +133,11 @@ Namespace Microsoft.VisualBasic
             'Notify the enumerators
             Dim i As Integer = m_Iterators.Count - 1
             While i >= 0
-                Dim Ref As WeakReference = DirectCast(m_Iterators(i), WeakReference)
-                If Ref.IsAlive Then
-                    Dim Enumerator As ForEachEnum = CType(Ref.Target, ForEachEnum)
-                    If Not Enumerator Is Nothing Then
-                        Enumerator.AdjustOnListCleared()
+                Dim ref As WeakReference = DirectCast(m_Iterators(i), WeakReference)
+                If ref.IsAlive Then
+                    Dim enumerator As ForEachEnum = CType(ref.Target, ForEachEnum)
+                    If Not enumerator Is Nothing Then
+                        enumerator.AdjustOnListCleared()
                     End If
                 Else
                     m_Iterators.RemoveAt(i)
@@ -166,105 +146,96 @@ Namespace Microsoft.VisualBasic
             End While
         End Sub
 
-        '''**************************************************************************
-        ''' ;Contains 
         ''' <summary>
-        ''' Returns true iff the given key is in the collection
+        ''' Returns true if the given key is in the collection
         ''' </summary>
         ''' <param name="Key"></param>
         ''' <returns>True - the given key is in the collection.  False otherwise.</returns>
-        ''' <remarks></remarks>
-
         Public Function Contains(ByVal Key As String) As Boolean
             If Key Is Nothing Then
-                Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Key"))
+                Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, NameOf(Key)), NameOf(Key))
             End If
             Return m_KeyedNodesHash.ContainsKey(Key)
         End Function
 
         Public Overloads Sub Remove(ByVal Key As String)
-            Dim Node As Node = Nothing
-            If m_KeyedNodesHash.TryGetValue(Key, Node) Then
-                Debug.Assert(Node IsNot Nothing)
+            Dim node As Node = Nothing
+            If m_KeyedNodesHash.TryGetValue(Key, node) Then
+                Debug.Assert(node IsNot Nothing)
 
                 'Adjust the ForEach iterators
-                AdjustEnumeratorsOnNodeRemoved(Node) 'Must be done before the prev/next pointers are removed
+                AdjustEnumeratorsOnNodeRemoved(node) 'Must be done before the prev/next pointers are removed
 
                 'Remove the item from the list and hash table (we know it has a key)
-                Debug.Assert(Node.m_Key IsNot Nothing, "How can that be?  We just found it by its key.")
+                Debug.Assert(node.m_Key IsNot Nothing, "How can that be?  We just found it by its key.")
                 m_KeyedNodesHash.Remove(Key)
-                m_ItemsList.RemoveNode(Node)
+                m_ItemsList.RemoveNode(node)
 
                 'Remove prev/next pointers because the iterators will be thrown off if this isn't done.  Also it's easier for debugging.
-                Node.m_Prev = Nothing
-                Node.m_Next = Nothing
+                node.m_Prev = Nothing
+                node.m_Next = Nothing
             Else
-                Debug.Assert(Node Is Nothing)
-                Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Key"))
+                Debug.Assert(node Is Nothing)
+                Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, NameOf(Key)), NameOf(Key))
             End If
         End Sub
 
         Public Overloads Sub Remove(ByVal Index As Integer)
             IndexCheck(Index)
-            Dim Node As Node = m_ItemsList.RemoveAt(Index - 1) '0 based
-            Debug.Assert(Node IsNot Nothing, "Should have thrown exception rather than return Nothing")
+            Dim node As Node = m_ItemsList.RemoveAt(Index - 1) '0 based
+            Debug.Assert(node IsNot Nothing, "Should have thrown exception rather than return Nothing")
 
-            AdjustEnumeratorsOnNodeRemoved(Node) 'Must be done before the prev/next pointers are removed
+            AdjustEnumeratorsOnNodeRemoved(node) 'Must be done before the prev/next pointers are removed
 
             'Remove from the hash table if it has a key
-            If Node.m_Key IsNot Nothing Then
-                m_KeyedNodesHash.Remove(Node.m_Key)
+            If node.m_Key IsNot Nothing Then
+                m_KeyedNodesHash.Remove(node.m_Key)
             End If
 
             'Remove prev/next pointers because the iterators will be thrown off if this isn't done.  Also it's easier for debugging.
-            Node.m_Prev = Nothing
-            Node.m_Next = Nothing
+            node.m_Prev = Nothing
+            node.m_Next = Nothing
         End Sub
 
         Default Public Overloads ReadOnly Property Item(ByVal Index As Integer) As Object
             'This method uses 1 based arrays.
             Get
                 IndexCheck(Index)
-                Dim Node As Node = m_ItemsList.Item(Index - 1)
-                Debug.Assert(Node IsNot Nothing, "Should have thrown rather than returning Nothing")
-                Return Node.m_Value
+                Dim node As Node = m_ItemsList.Item(Index - 1)
+                Debug.Assert(node IsNot Nothing, "Should have thrown rather than returning Nothing")
+                Return node.m_Value
             End Get
         End Property
 
         Default Public Overloads ReadOnly Property Item(ByVal Key As String) As Object
             Get
                 If Key Is Nothing Then
-                    'Backwards compat with Everett - throw IndexOutOfRange if Key = Nothing
-                    Throw New IndexOutOfRangeException(GetResourceString(ResID.Argument_CollectionIndex))
+                    'Backwards compat - throw IndexOutOfRange if Key = Nothing
+                    Throw New IndexOutOfRangeException(SR.Argument_CollectionIndex)
                 End If
 
-                Dim Node As Node = Nothing
-                If Not m_KeyedNodesHash.TryGetValue(Key, Node) Then
-                    Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Index"))
+                Dim node As Node = Nothing
+                If Not m_KeyedNodesHash.TryGetValue(Key, node) Then
+                    Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Index"), NameOf(Key))
                 End If
-                Debug.Assert(Node IsNot Nothing)
+                Debug.Assert(node IsNot Nothing)
 
-                Return Node.m_Value
+                Return node.m_Value
             End Get
         End Property
 
-#If TELESTO Then
-        'FIXME: <System.ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Advanced)> 
+        <System.ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Advanced)>
         Default Public Overloads ReadOnly Property Item(ByVal Index As Object) As Object
-#Else
-        <System.ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Advanced)> _
-        Default Public Overloads ReadOnly Property Item(ByVal Index As Object) As Object
-#End If
             Get
                 If (TypeOf Index Is String) OrElse (TypeOf Index Is Char) OrElse (TypeOf Index Is Char()) Then
                     ' Index is string and is being treated as key
-                    Dim Key As String = CStr(Index)
-                    Return Me.Item(Key)
+                    Dim key As String = CStr(Index)
+                    Return Me.Item(key)
                 Else
                     ' Index is being treated as numeric expression
-                    Dim IndexValue As Integer
+                    Dim indexValue As Integer
                     Try
-                        IndexValue = CInt(Index)
+                        indexValue = CInt(Index)
                     Catch ex As StackOverflowException
                         Throw ex
                     Catch ex As OutOfMemoryException
@@ -272,10 +243,10 @@ Namespace Microsoft.VisualBasic
                     Catch ex As System.Threading.ThreadAbortException
                         Throw ex
                     Catch
-                        Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "Index"))
+                        Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, NameOf(Index)), NameOf(Index))
                     End Try
 
-                    Return Me.Item(IndexValue)
+                    Return Me.Item(indexValue)
                 End If
             End Get
         End Property
@@ -308,8 +279,6 @@ Namespace Microsoft.VisualBasic
             Return enumerator
         End Function
 
-        '= FRIEND =============================================================
-
         Friend Sub RemoveIterator(ByVal weakref As WeakReference)
             m_Iterators.Remove(weakref)
         End Sub
@@ -323,11 +292,6 @@ Namespace Microsoft.VisualBasic
             Return m_ItemsList.GetFirstListNode()
         End Function
 
-        '***************************************************************
-        '
-        ' Nested class: Node
-        '
-        '***************************************************************
         Friend NotInheritable Class Node
             'Constructor.  Key or Value may be Nothing
             Friend Sub New(ByVal Key As String, ByVal Value As Object)
@@ -339,80 +303,46 @@ Namespace Microsoft.VisualBasic
             Friend m_Key As String   'The key.  If Nothing, the collection item has no user-specified key.
             Friend m_Next As Node    'Doubly-linked list pointer to the next node
             Friend m_Prev As Node    'Doubly-linked list pointer to the previous node
-
-#If 0 Then 'For debugging purposes
-            Public Overrides Function ToString() As String
-                Dim s As New System.Text.StringBuilder
-
-                s.Append("Node (")
-                If m_Key Is Nothing Then
-                    s.Append("no key")
-                Else
-                    s.Append("key=""" & m_Key & """")
-                End If
-                s.Append("): ")
-                Try
-                    s.Append(m_Value.ToString())
-                Catch ex As OutOfMemoryException
-                    Throw
-                Catch ex As Threading.ThreadAbortException
-                    Throw
-                Catch ex As StackOverflowException
-                    Throw
-                Catch ex As Exception
-                    s.Append(ex.Message)
-                End Try
-
-                Return s.ToString()
-            End Function
-#End If
         End Class 'Node
 
-        '''******************************************************************************
-        ''' ;CollectionDebugView
         ''' <summary>
         ''' Debugger proxy for the Collection class.  Provides a view of the collection 
         ''' that just displays the collection contents. 
         ''' </summary>
-        ''' <remarks></remarks>
         Friend NotInheritable Class CollectionDebugView
+            <DebuggerBrowsable(DebuggerBrowsableState.Never)>
+            Private m_InstanceBeingWatched As Collection
+
             Public Sub New(ByVal RealClass As Collection)
                 m_InstanceBeingWatched = RealClass
             End Sub
 
             'Returns an array with all items in the collection.  
-            <DebuggerBrowsable(DebuggerBrowsableState.RootHidden)> _
+            <DebuggerBrowsable(DebuggerBrowsableState.RootHidden)>
             Public ReadOnly Property Items() As Object()
                 Get
-                    Dim Count As Integer = m_InstanceBeingWatched.Count
-                    If Count = 0 Then
+                    Dim count As Integer = m_InstanceBeingWatched.Count
+                    If count = 0 Then
                         Return Nothing
                     End If
 
-                    Dim Results(Count) As Object
-                    Results(0) = GetResourceString(ResID.EmptyPlaceHolderMessage)
+                    Dim results(count) As Object
+                    results(0) = SR.EmptyPlaceHolderMessage
 
-                    For Index As Integer = 1 To Count
-                        Dim NewNode As Node = m_InstanceBeingWatched.InternalItemsList.Item(Index - 1)
-                        Results(Index) = New KeyValuePair(NewNode.m_Key, NewNode.m_Value)
+                    For Index As Integer = 1 To count
+                        Dim newNode As Node = m_InstanceBeingWatched.InternalItemsList.Item(Index - 1)
+                        results(Index) = New KeyValuePair(newNode.m_Key, newNode.m_Value)
                     Next Index
-                    Return Results
+                    Return results
                 End Get
             End Property
-
-            <DebuggerBrowsable(DebuggerBrowsableState.Never)> Private m_InstanceBeingWatched As Collection
         End Class
 
-        '= PRIVATE =============================================================
-
-        '''******************************************************************************
-        ''' ;Initialize
         ''' <summary>
         ''' Initialize all internal structures to set up an empty collection.
         ''' </summary>
         ''' <param name="CultureInfo">the culture info to use for key comparisons for the lifetime of this collection.</param>
         ''' <param name="StartingHashCapacity"></param>
-        ''' <remarks></remarks>
         Private Sub Initialize(ByVal CultureInfo As CultureInfo, Optional ByVal StartingHashCapacity As Integer = 0)
             Debug.Assert(CultureInfo IsNot Nothing)
 
@@ -422,26 +352,14 @@ Namespace Microsoft.VisualBasic
                 m_KeyedNodesHash = New Generic.Dictionary(Of String, Node)(StringComparer.Create(CultureInfo, ignoreCase:=True))
             End If
             m_ItemsList = New FastList()
-#If TELESTO Then
-            m_Iterators = New List(Of Object) 
-#Else
-            m_Iterators = New ArrayList 
-#End IF
-
-
-#If Not TELESTO Then
+            m_Iterators = New List(Of Object)
             m_CultureInfo = CultureInfo
-#End If
         End Sub
 
-        '***************************************************************
-        '
-        ' Nested class: FastList
-        '
-        '***************************************************************
         Private NotInheritable Class FastList
-
-            '= FRIEND  =============================================================
+            Private m_StartOfList As Node
+            Private m_EndOfList As Node
+            Private m_Count As Integer
 
             Friend Sub New()
                 MyBase.New()
@@ -460,43 +378,43 @@ Namespace Microsoft.VisualBasic
 
             'Searches for a given value in the list.  Returns its node's index or -1 if not found.
             Friend Function IndexOfValue(ByVal Value As Object) As Integer
-                Dim CurrentNode As Node = m_StartOfList
-                Dim Index As Integer = 0
+                Dim currentNode As Node = m_StartOfList
+                Dim index As Integer = 0
 
-                While Not CurrentNode Is Nothing
-                    If DataIsEqual(CurrentNode.m_Value, Value) Then
-                        Return Index
+                While Not currentNode Is Nothing
+                    If DataIsEqual(currentNode.m_Value, Value) Then
+                        Return index
                     End If
-                    CurrentNode = CurrentNode.m_Next
-                    Index += 1
+                    currentNode = currentNode.m_Next
+                    index += 1
                 End While
                 Return -1
             End Function
 
             Friend Sub RemoveNode(ByVal NodeToBeDeleted As Node)
-                Debug.Assert(Not (NodeToBeDeleted Is Nothing), "How can we remove a non-existent node ?")
+                Debug.Assert(NodeToBeDeleted IsNot Nothing, "How can we remove a non-existent node ?")
                 DeleteNode(NodeToBeDeleted, NodeToBeDeleted.m_Prev)
             End Sub
 
             'Removes the node at the given index.
             '  Returns the node that was removed
             Friend Function RemoveAt(ByVal Index As Integer) As Node
-                Dim CurrentNode As Node = m_StartOfList
-                Dim CurrentIndex As Integer = 0
-                Dim PrevNode As Node = Nothing
+                Dim currentNode As Node = m_StartOfList
+                Dim currentIndex As Integer = 0
+                Dim prevNode As Node = Nothing
 
-                While CurrentIndex < Index AndAlso (Not (CurrentNode Is Nothing))
-                    PrevNode = CurrentNode
-                    CurrentNode = CurrentNode.m_Next
-                    CurrentIndex += 1
+                While currentIndex < Index AndAlso (currentNode IsNot Nothing)
+                    prevNode = currentNode
+                    currentNode = currentNode.m_Next
+                    currentIndex += 1
                 End While
 
-                If (CurrentNode Is Nothing) Then
-                    Throw New ArgumentOutOfRangeException("Index")
+                If (currentNode Is Nothing) Then
+                    Throw New ArgumentOutOfRangeException(NameOf(Index))
                 End If
 
-                DeleteNode(CurrentNode, PrevNode)
-                Return CurrentNode
+                DeleteNode(currentNode, prevNode)
+                Return currentNode
             End Function
 
             Friend Function Count() As Integer
@@ -512,26 +430,26 @@ Namespace Microsoft.VisualBasic
             'Retrieves the node at the given index (0-based)
             Friend ReadOnly Property Item(ByVal Index As Integer) As Node
                 Get
-                    Dim N As Node = GetNodeAtIndex(Index)
-                    If (N Is Nothing) Then
-                        Throw New ArgumentOutOfRangeException("Index")
+                    Dim node As Node = GetNodeAtIndex(Index)
+                    If (node Is Nothing) Then
+                        Throw New ArgumentOutOfRangeException(NameOf(Index))
                     End If
-                    Return N
+                    Return node
                 End Get
             End Property
 
             Friend Sub Insert(ByVal Index As Integer, ByVal Node As Node)
-                Dim PrevNode As Node = Nothing
+                Dim prevNode As Node = Nothing
 
                 ' (Index > m_Count) is here for a reason. We allow insertion immediately beyond the end of the
                 ' list i.e. if there are 0 to m_Count -1 elements, we allow insertion into the
                 ' m_Count index
                 If (Index < 0) OrElse (Index > m_Count) Then
-                    Throw New ArgumentOutOfRangeException("Index")
+                    Throw New ArgumentOutOfRangeException(NameOf(Index))
                 End If
 
-                Dim NodeAtIndex As Node = GetNodeAtIndex(Index, PrevNode) 'Note: PrevNode passed ByRef
-                Insert(Node, PrevNode, NodeAtIndex)
+                Dim nodeAtIndex As Node = GetNodeAtIndex(Index, prevNode) 'Note: PrevNode passed ByRef
+                Insert(Node, prevNode, nodeAtIndex)
             End Sub
 
             'Inserts a node into the list.
@@ -554,8 +472,6 @@ Namespace Microsoft.VisualBasic
                 Return m_StartOfList
             End Function
 
-            '= PRIVATE =============================================================
-
             Private Function DataIsEqual(ByVal obj1 As Object, ByVal obj2 As Object) As Boolean
                 If obj1 Is obj2 Then
                     Return True
@@ -569,17 +485,17 @@ Namespace Microsoft.VisualBasic
             End Function
 
             Private Function GetNodeAtIndex(ByVal Index As Integer, Optional ByRef PrevNode As Node = Nothing) As Node
-                Dim CurrentNode As Node = m_StartOfList
-                Dim CurrentIndex As Integer = 0
+                Dim currentNode As Node = m_StartOfList
+                Dim currentIndex As Integer = 0
                 PrevNode = Nothing
 
-                While CurrentIndex < Index AndAlso (Not (CurrentNode Is Nothing))
-                    PrevNode = CurrentNode
-                    CurrentNode = CurrentNode.m_Next
-                    CurrentIndex += 1
+                While currentIndex < Index AndAlso (currentNode IsNot Nothing)
+                    PrevNode = currentNode
+                    currentNode = currentNode.m_Next
+                    currentIndex += 1
                 End While
 
-                Return CurrentNode
+                Return currentNode
             End Function
 
             'Inserts the given node into the list between the two given nodes (may be Nothing at the beginning/end of the list)
@@ -605,7 +521,7 @@ Namespace Microsoft.VisualBasic
             End Sub
 
             Private Sub DeleteNode(ByVal NodeToBeDeleted As Node, ByVal PrevNode As Node)
-                Debug.Assert(Not (NodeToBeDeleted Is Nothing), "How can we delete a non-existent node ?")
+                Debug.Assert(NodeToBeDeleted IsNot Nothing, "How can we delete a non-existent node ?")
 
                 If PrevNode Is Nothing Then ' are we are deleting the first node ?
 
@@ -628,25 +544,24 @@ Namespace Microsoft.VisualBasic
                 End If
                 m_Count -= 1
             End Sub
-
-            Private m_StartOfList As Node
-            Private m_EndOfList As Node
-            Private m_Count As Integer = 0
         End Class 'FastList
 
         'NOTE:  This structure exists so that the debugger windows can show the items in a collection.  See the Items property.
         Private Structure KeyValuePair
+            Private m_Key As Object
+            Private m_Value As Object
+
             Friend Sub New(ByVal NewKey As Object, ByVal NewValue As Object)
                 m_Key = NewKey
                 m_Value = NewValue
             End Sub
-            Private m_Key As Object
-            Private m_Value As Object
+
             Public ReadOnly Property Key() As Object
                 Get
                     Return m_Key
                 End Get
             End Property
+
             Public ReadOnly Property Value() As Object
                 Get
                     Return m_Value
@@ -684,7 +599,7 @@ Namespace Microsoft.VisualBasic
 
         Private Sub IndexCheck(ByVal Index As Integer)
             If (Index < 1 OrElse Index > m_ItemsList.Count) Then
-                Throw New IndexOutOfRangeException(GetResourceString(ResID.Argument_CollectionIndex))
+                Throw New IndexOutOfRangeException(SR.Argument_CollectionIndex)
             End If
         End Sub
 
@@ -694,7 +609,6 @@ Namespace Microsoft.VisualBasic
 
 
 #Region "Serialization implementation"
-#If Not TELESTO Then
         Private Const SERIALIZATIONKEY_KEYS As String = "Keys"
         Private Const SERIALIZATIONKEY_KEYSCOUNT As String = "KeysCount" 'Number of items with a user-defined key (not same as keys array length)
         Private Const SERIALIZATIONKEY_VALUES As String = "Values"
@@ -705,85 +619,84 @@ Namespace Microsoft.VisualBasic
             m_DeserializationInfo = info
         End Sub
 
-        <SecurityCritical()> _
+        <SecurityCritical()>
         Private Sub GetObjectData(ByVal info As SerializationInfo, ByVal context As StreamingContext) Implements ISerializable.GetObjectData
-            Dim Keys(Me.Count - 1) As String
-            Dim Values(Me.Count - 1) As Object
+            Dim keys(Me.Count - 1) As String
+            Dim values(Me.Count - 1) As Object
+            Dim node As Node = GetFirstListNode()
+            Dim index As Integer
+            Dim elementsWithKey As Integer = 0
 
-            Dim Node As Node = GetFirstListNode()
-            Dim Index As Integer
-            Dim ElementsWithKey As Integer = 0
-            While Node IsNot Nothing
-                If Node.m_Key IsNot Nothing Then
-                    ElementsWithKey += 1
+            While node IsNot Nothing
+                If node.m_Key IsNot Nothing Then
+                    elementsWithKey += 1
                 End If
 
-                Keys(Index) = Node.m_Key
-                Values(Index) = Node.m_Value
+                keys(index) = node.m_Key
+                values(index) = node.m_Value
 
-                Index += 1
-                Node = Node.m_Next
+                index += 1
+                node = node.m_Next
             End While
-            Debug.Assert(Index = Me.Count)
-            Debug.Assert(ElementsWithKey <= Me.Count)
+            Debug.Assert(index = Me.Count)
+            Debug.Assert(elementsWithKey <= Me.Count)
 
-            info.AddValue(SERIALIZATIONKEY_KEYS, Keys, GetType(String()))
-            info.AddValue(SERIALIZATIONKEY_KEYSCOUNT, ElementsWithKey, GetType(Int32))
-            info.AddValue(SERIALIZATIONKEY_VALUES, Values, GetType(Object()))
+            info.AddValue(SERIALIZATIONKEY_KEYS, keys, GetType(String()))
+            info.AddValue(SERIALIZATIONKEY_KEYSCOUNT, elementsWithKey, GetType(Int32))
+            info.AddValue(SERIALIZATIONKEY_VALUES, values, GetType(Object()))
             info.AddValue(SERIALIZATIONKEY_CULTUREINFO, m_CultureInfo)
         End Sub
 
         Private Sub OnDeserialization(ByVal sender As Object) Implements IDeserializationCallback.OnDeserialization
             Try
                 'Initialization using the saved culture info
-                Dim CultureInfo As CultureInfo = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_CULTUREINFO, GetType(CultureInfo)), CultureInfo)
-                If CultureInfo Is Nothing Then
-                    Throw New SerializationException(GetResourceString(ResID.Serialization_MissingCultureInfo))
+                Dim cultureInfo As CultureInfo = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_CULTUREINFO, GetType(CultureInfo)), CultureInfo)
+                If cultureInfo Is Nothing Then
+                    Throw New SerializationException(SR.Serialization_MissingCultureInfo)
                 End If
 
                 'Validate the keys and values arrays
-                Dim Keys() As String = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_KEYS, GetType(String())), String())
-                Dim Values() As Object = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_VALUES, GetType(Object())), Object())
+                Dim keys() As String = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_KEYS, GetType(String())), String())
+                Dim values() As Object = DirectCast(m_DeserializationInfo.GetValue(SERIALIZATIONKEY_VALUES, GetType(Object())), Object())
 
-                If Keys Is Nothing Then
-                    Throw New SerializationException(GetResourceString(ResID.Serialization_MissingKeys))
+                If keys Is Nothing Then
+                    Throw New SerializationException(SR.Serialization_MissingKeys)
                 End If
 
-                If Values Is Nothing Then
-                    Throw New SerializationException(GetResourceString(ResID.Serialization_MissingValues))
+                If values Is Nothing Then
+                    Throw New SerializationException(SR.Serialization_MissingValues)
                 End If
 
-                If Keys.Length <> Values.Length Then
-                    Throw New SerializationException(GetResourceString(ResID.Serialization_KeyValueDifferentSizes))
+                If keys.Length <> values.Length Then
+                    Throw New SerializationException(SR.Serialization_KeyValueDifferentSizes)
                 End If
 
                 'Get the number of elements that have an associated key (the Keys array contains an item for all elements, and if that
                 '  item doesn't have a key, that element in the array is Nothing, so Keys.Length isn't the same)
-                Dim ElementsWithKey As Integer = m_DeserializationInfo.GetInt32(SERIALIZATIONKEY_KEYSCOUNT)
+                Dim elementsWithKey As Integer = m_DeserializationInfo.GetInt32(SERIALIZATIONKEY_KEYSCOUNT)
 
                 'It's okay if ElementsWithKey isn't in the deserialization info - we'll just assume a value of zero, which causes
                 '  us to not give a starting hash table capacity
-                If ElementsWithKey < 0 OrElse ElementsWithKey > Keys.Length Then
-                    Debug.Assert(ElementsWithKey >= 0, "Bad deserialization data?  ElementsWithKey is bad.  Ignoring and recovering because it's only an optimization anyway.")
-                    ElementsWithKey = 0
+                If elementsWithKey < 0 OrElse elementsWithKey > keys.Length Then
+                    Debug.Assert(elementsWithKey >= 0, "Bad deserialization data?  ElementsWithKey is bad.  Ignoring and recovering because it's only an optimization anyway.")
+                    elementsWithKey = 0
                 End If
 
-                Initialize(CultureInfo, ElementsWithKey) 'Giving the hash table the appropriate starting capacity should speed up hash insertions since it doesn't have to resize
+                Initialize(cultureInfo, elementsWithKey) 'Giving the hash table the appropriate starting capacity should speed up hash insertions since it doesn't have to resize
 
                 'Add all elements to the collection.  We always insert to the end, which is fast and preserves our original order.
-                For Index As Integer = 0 To Keys.Length - 1
-                    Me.Add(Values(Index), Keys(Index)) 'If Keys(Index) is Nothing, the value will be added without a key
+                For Index As Integer = 0 To keys.Length - 1
+                    Me.Add(values(Index), keys(Index)) 'If Keys(Index) is Nothing, the value will be added without a key
                 Next
-                Debug.Assert(Me.Count = Keys.Length)
+                Debug.Assert(Me.Count = keys.Length)
                 m_DeserializationInfo = Nothing
             Finally
                 If m_DeserializationInfo IsNot Nothing Then 'something bad happened - reset the collection to a pristine state so they don't access who knows what is left over in the collection
                     m_DeserializationInfo = Nothing
-                    Me.Initialize(GetCultureInfo)
+                    Me.Initialize(GetCultureInfo())
                 End If
             End Try
         End Sub
-#End If 'not TELESTO
 #End Region
 
 #Region "Interface Implementation"
@@ -826,19 +739,17 @@ Namespace Microsoft.VisualBasic
         End Property
 
         Private Sub ICollectionCopyTo(ByVal [array] As System.Array, ByVal index As Integer) Implements ICollection.CopyTo
-            '*** BEGIN ARG CHECKS
             If [array] Is Nothing Then
-                Throw New ArgumentNullException(GetResourceString(ResID.Argument_InvalidNullValue1, "array"))
+                Throw New ArgumentNullException(NameOf(array), SR.Format(SR.Argument_InvalidNullValue1, NameOf(array)))
             End If
 
             If [array].Rank <> 1 Then
-                Throw New ArgumentException(GetResourceString(ResID.Argument_RankEQOne1, "array"))
+                Throw New ArgumentException(SR.Format(SR.Argument_RankEQOne1, NameOf(array)), NameOf(array))
             End If
 
             If (index < 0) OrElse ([array].Length - index < Count) Then
-                Throw New ArgumentException(GetResourceString(ResID.Argument_InvalidValue1, "index"))
+                Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, NameOf(index)), NameOf(index))
             End If
-            '*** END ARG CHECKS
 
             Dim i As Integer
             Dim objArray As Object() = TryCast(array, Object())
@@ -859,27 +770,25 @@ Namespace Microsoft.VisualBasic
             Return m_ItemsList.Count - 1 'IList is 0 based.  Return a 0-based index.  If m_ItemsList.Count is zero, we threw during Add() so no need to gate the Count = 0 case.
         End Function
 
-
-        'CONSIDER: why not delegate to Collection.Add?  Same for the others...
         Private Sub IListInsert(ByVal index As Integer, ByVal value As Object) Implements IList.Insert
-            Dim NewNode As New Node(Nothing, value)
-            m_ItemsList.Insert(index, NewNode) 'FastList is 0-indexed just like IList, so no transformation of "index" needed
+            Dim newNode As New Node(Nothing, value)
+            m_ItemsList.Insert(index, newNode) 'FastList is 0-indexed just like IList, so no transformation of "index" needed
             'No key, so no need to add to the hash table.
             'Adjust the ForEach iterators
-            AdjustEnumeratorsOnNodeInserted(NewNode)
+            AdjustEnumeratorsOnNodeInserted(newNode)
         End Sub
 
         Private Sub IListRemoveAt(ByVal index As Integer) Implements IList.RemoveAt
-            Dim Node As Node = m_ItemsList.RemoveAt(index)    '0 based
-            Debug.Assert(Node IsNot Nothing, "Should have thrown exception rather than return Nothing")
+            Dim node As Node = m_ItemsList.RemoveAt(index)    '0 based
+            Debug.Assert(node IsNot Nothing, "Should have thrown exception rather than return Nothing")
 
-            AdjustEnumeratorsOnNodeRemoved(Node) 'Adjust the ForEach iterators
-            If Node.m_Key IsNot Nothing Then
-                m_KeyedNodesHash.Remove(Node.m_Key)
+            AdjustEnumeratorsOnNodeRemoved(node) 'Adjust the ForEach iterators
+            If node.m_Key IsNot Nothing Then
+                m_KeyedNodesHash.Remove(node.m_Key)
             End If
 
-            Node.m_Prev = Nothing
-            Node.m_Next = Nothing
+            node.m_Prev = Nothing
+            node.m_Next = Nothing
         End Sub
 
         Private Sub IListRemove(ByVal value As Object) Implements IList.Remove
@@ -897,15 +806,15 @@ Namespace Microsoft.VisualBasic
 
         Private Property IListItem(ByVal index As Integer) As Object Implements IList.Item
             Get
-                Dim Node As Node
+                Dim node As Node
 
-                Node = m_ItemsList.Item(index)
-                Return Node.m_Value
+                node = m_ItemsList.Item(index)
+                Return node.m_Value
             End Get
 
             Set(ByVal value As Object)
-                Dim Node As Node = m_ItemsList.Item(index)
-                Node.m_Value = value
+                Dim node As Node = m_ItemsList.Item(index)
+                node.m_Value = value
             End Set
         End Property
 
@@ -918,18 +827,6 @@ Namespace Microsoft.VisualBasic
         End Function
 
 #End Region
-
-#If Not TELESTO Then
-        Private m_DeserializationInfo As SerializationInfo
-        Private m_CultureInfo As CultureInfo 'The CultureInfo used for key comparisons
-#End If
-        Private m_KeyedNodesHash As Generic.Dictionary(Of String, Node) 'Hashtable mapping key (string) -> Node, contains only items added to the collection with a key
-        Private m_ItemsList As FastList 'Doubly-linked list of Node containing all items in the collection
-#If TELESTO Then
-        Private m_Iterators As List(Of Object) 'List of iterators currently iterating this collection
-#Else
-        Private m_Iterators As ArrayList 'List of iterators currently iterating this collection        
-#End IF
     End Class 'Collection
 End Namespace
 

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Helpers/ForEachEnum.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Helpers/ForEachEnum.vb
@@ -1,0 +1,184 @@
+' Copyright (c) Microsoft Corporation.  All rights reserved.
+
+Imports System
+Imports System.Collections
+Imports System.Diagnostics
+Imports Microsoft.VisualBasic.CompilerServices
+
+Namespace Microsoft.VisualBasic
+
+    'This is in the helpers directory but not in the compilerservices namespace
+
+    'The ForEachEnum class is publicly exposed through Collection.GetEnumerator().
+#If TELESTO Then
+    Friend NotInheritable Class ForEachEnum 'FIXME: <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)> 
+#Else
+    <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)> _
+    Friend NotInheritable Class ForEachEnum
+#End If
+
+        Implements IEnumerator
+        Implements IDisposable
+
+        'No Finalize - this is intentional because we do not want to invoke RemoveIterator in finalize
+        '              because of threading and synchronization issues involved which would then cause
+        '              perf degrade.
+
+        Private mDisposed As Boolean = False
+        Private Sub Dispose() Implements IDisposable.Dispose
+            If Not mDisposed Then
+                mCollectionObject.RemoveIterator(WeakRef)
+                mDisposed = True
+            End If
+            mCurrent = Nothing
+            mNext = Nothing
+        End Sub
+
+        'The collection this enumerator is enumerating over
+        Private mCollectionObject As Microsoft.VisualBasic.Collection
+
+        'The current element being iterated.  Note: this element may no longer be in the list,
+        '  (if it was deleted), so do *not* assume that its previous and next pointers are valid.
+        Private mCurrent As Collection.Node
+
+        'The next item to enumerate.  This is always updated on MoveNext and is used to determine where
+        '  the enumeration goes next (not mCurrent).
+        Private mNext As Collection.Node
+
+        'A flag indicating that we are ready to start enumerating but have not done so yet (allows us
+        '  to delay fixing mNext until the next MoveNext).
+        Private mAtBeginning As Boolean
+
+        Friend WeakRef As WeakReference
+
+        Public Sub New(ByVal coll As Microsoft.VisualBasic.Collection)
+            MyBase.New()
+            mCollectionObject = coll
+
+            Reset()
+        End Sub
+
+        Public Function MoveNext() As Boolean Implements IEnumerator.MoveNext
+            If mDisposed Then
+                Return False
+            End If
+
+            If mAtBeginning Then
+                'We haven't started iterating yet.  Start at the beginning.
+
+                mAtBeginning = False
+                mNext = mCollectionObject.GetFirstListNode()
+            End If
+
+            Debug.Assert(Not mAtBeginning)
+            If mNext Is Nothing Then
+                Dispose()
+                Return False
+            End If
+
+            mCurrent = mNext
+            If mCurrent IsNot Nothing Then
+                mNext = mCurrent.m_Next
+                Return True
+            Else
+                Debug.Assert(mNext Is Nothing)
+                Dispose()
+                Return False
+            End If
+        End Function
+
+        Public Sub Reset() Implements IEnumerator.Reset
+            If mDisposed Then
+                mCollectionObject.AddIterator(WeakRef)
+                mDisposed = False
+            End If
+
+            mCurrent = Nothing
+            mNext = Nothing
+            mAtBeginning = True
+        End Sub
+
+        Public ReadOnly Property Current() As Object Implements IEnumerator.Current
+            Get
+                If mCurrent Is Nothing Then
+                    Return Nothing
+                Else
+                    Return mCurrent.m_Value
+                End If
+            End Get
+        End Property
+
+        Friend Enum AdjustIndexType
+            Insert
+            Remove
+        End Enum
+
+        'REVIEW VSW#395751 : This a public function on a friend class.  Does it need to be public?  How can the customer call this function today?  Latebinding/Reflection...
+
+        'Adjusts the enumerator to account for newly-inserted or removed items in/from the collection.
+        '  For insertion, this call must be made *after* the insertion has taken place.  For deletion, 
+        '  this call must have been made before the next/prev pointers in the deleted node have been
+        '  invalidated (they must still be pointing to the values before the deletion).
+        Public Sub Adjust(ByVal Node As Collection.Node, ByVal Type As AdjustIndexType)
+            
+            If Node Is Nothing Then
+#If TELESTO Then
+                Debug.Assert(False, "Node shouldn't be nothing")
+#Else
+                Debug.Fail("Node shouldn't be nothing")        
+#End If
+                Exit Sub 'defensive
+            End If
+
+            If mDisposed Then
+                'Nothing to do
+                Exit Sub
+            End If
+
+            Select Case Type
+                Case AdjustIndexType.Insert
+                    Debug.Assert(Node IsNot mCurrent, "If we just inserted Node, then it couldn't be the current node because it's not in the list yet")
+
+                    'mCurrent may not necessarily be still in the list, so we have to be wary of using mCurrent.m_Next.  However, if
+                    '  there is a current node, and its next is pointing to Node, then mCurrent must still be in the list (since Node wasn't
+                    '  in the list before).  So in this case we'll go ahead and set our mNext to the newly-inserted node.
+                    'It would seem to make sense also to set mNext to the new node if mNext is Nothing (i.e., we're at the end of the list), but
+                    '  this would be a difference in RTM/Everett behavior that doesn't seem warranted.
+                    If mCurrent IsNot Nothing AndAlso Node Is mCurrent.m_Next Then
+                        'The new node was inserted right after our current node.
+                        '  Iterate through it next.
+                        mNext = Node
+                    End If
+
+                    'Note that the case of inserting at the beginning before we've
+                    '  iterated through any nodes will be handled in MoveNext with the
+                    '  mAtBeginning flag.
+
+                Case AdjustIndexType.Remove
+                    If Node Is mCurrent Then
+                        'Current node was removed.  No need to do anything, because we want GetCurrent() to continue to
+                        '  return this same node's data until the next MoveNext().
+                    ElseIf Node Is mNext Then
+                        'The next node was removed.  Make our next node to iterate through
+                        '  be the one after that instead
+                        mNext = mNext.m_Next
+                    End If
+                Case Else
+#If TELESTO Then
+                    Debug.Assert(False, "Unexpected adjustment type in enumerator") ' Silverlight CLR does not have Debug.Fail.
+#Else
+                    Debug.Fail("Unexpected adjustment type in enumerator")
+#End If
+            End Select
+        End Sub
+
+        'Should be called if the list this is enumerating is cleared.  It will set the
+        '  enumerator past the end of the list (nothing more to enumerate).
+        Friend Sub AdjustOnListCleared()
+            mNext = Nothing
+        End Sub
+
+    End Class
+
+End Namespace
+

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Helpers/ForEachEnum.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Helpers/ForEachEnum.vb
@@ -1,4 +1,6 @@
-' Copyright (c) Microsoft Corporation.  All rights reserved.
+' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
 
 Imports System
 Imports System.Collections
@@ -10,13 +12,8 @@ Namespace Microsoft.VisualBasic
     'This is in the helpers directory but not in the compilerservices namespace
 
     'The ForEachEnum class is publicly exposed through Collection.GetEnumerator().
-#If TELESTO Then
-    Friend NotInheritable Class ForEachEnum 'FIXME: <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)> 
-#Else
-    <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)> _
+    <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>
     Friend NotInheritable Class ForEachEnum
-#End If
-
         Implements IEnumerator
         Implements IDisposable
 
@@ -25,14 +22,6 @@ Namespace Microsoft.VisualBasic
         '              perf degrade.
 
         Private mDisposed As Boolean = False
-        Private Sub Dispose() Implements IDisposable.Dispose
-            If Not mDisposed Then
-                mCollectionObject.RemoveIterator(WeakRef)
-                mDisposed = True
-            End If
-            mCurrent = Nothing
-            mNext = Nothing
-        End Sub
 
         'The collection this enumerator is enumerating over
         Private mCollectionObject As Microsoft.VisualBasic.Collection
@@ -50,6 +39,15 @@ Namespace Microsoft.VisualBasic
         Private mAtBeginning As Boolean
 
         Friend WeakRef As WeakReference
+
+        Private Sub Dispose() Implements IDisposable.Dispose
+            If Not mDisposed Then
+                mCollectionObject.RemoveIterator(WeakRef)
+                mDisposed = True
+            End If
+            mCurrent = Nothing
+            mNext = Nothing
+        End Sub
 
         Public Sub New(ByVal coll As Microsoft.VisualBasic.Collection)
             MyBase.New()
@@ -113,20 +111,14 @@ Namespace Microsoft.VisualBasic
             Remove
         End Enum
 
-        'REVIEW VSW#395751 : This a public function on a friend class.  Does it need to be public?  How can the customer call this function today?  Latebinding/Reflection...
-
         'Adjusts the enumerator to account for newly-inserted or removed items in/from the collection.
         '  For insertion, this call must be made *after* the insertion has taken place.  For deletion, 
         '  this call must have been made before the next/prev pointers in the deleted node have been
         '  invalidated (they must still be pointing to the values before the deletion).
         Public Sub Adjust(ByVal Node As Collection.Node, ByVal Type As AdjustIndexType)
-            
+
             If Node Is Nothing Then
-#If TELESTO Then
-                Debug.Assert(False, "Node shouldn't be nothing")
-#Else
-                Debug.Fail("Node shouldn't be nothing")        
-#End If
+                Debug.Fail("Node shouldn't be nothing")
                 Exit Sub 'defensive
             End If
 
@@ -164,11 +156,7 @@ Namespace Microsoft.VisualBasic
                         mNext = mNext.m_Next
                     End If
                 Case Else
-#If TELESTO Then
-                    Debug.Assert(False, "Unexpected adjustment type in enumerator") ' Silverlight CLR does not have Debug.Fail.
-#Else
                     Debug.Fail("Unexpected adjustment type in enumerator")
-#End If
             End Select
         End Sub
 
@@ -181,4 +169,3 @@ Namespace Microsoft.VisualBasic
     End Class
 
 End Namespace
-

--- a/src/Microsoft.VisualBasic/tests/CollectionsTests.cs
+++ b/src/Microsoft.VisualBasic/tests/CollectionsTests.cs
@@ -1,0 +1,455 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace Microsoft.VisualBasic.Tests
+{
+    public static class CollectionsTests
+    {
+        [Fact]
+        public static void Ctor_Empty()
+        {
+            var coll = new Collection();
+
+            Assert.Equal(0, coll.Count);
+        }
+
+        private static Foo CreateValue(int i) => new Foo(i, i.ToString());
+
+        private static Collection CreateCollection(int count)
+        {
+            var coll = new Collection();
+            for (int i = 0; i < 10; i++)
+            {
+                coll.Add(CreateValue(i));
+            }
+            return coll;
+        }
+
+        private static Collection CreateKeyedCollection(int count)
+        {
+            var coll = new Collection();
+            for (int i = 0; i < 10; i++)
+            {
+                coll.Add(CreateValue(i), Key: "Key" + i.ToString());
+            }
+            return coll;
+        }
+
+        [Fact]
+        public static void Add()
+        {
+            IList coll = new Collection();
+            for (int i = 0; i < 10; i++)
+            {
+                Foo value = CreateValue(i);
+                coll.Add(value);
+                Assert.True(coll.Contains(value));
+            }
+            Assert.Equal(10, coll.Count);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                Foo value = CreateValue(i);
+                Assert.Equal(value, coll[i]);
+            }
+        }
+
+        [Fact]
+        public static void Add_RelativeIndex()
+        {
+            var coll = new Collection();
+            var item1 = CreateValue(1);
+            var item2 = CreateValue(2);
+            var item3 = CreateValue(3);
+
+            coll.Add(item1);
+            coll.Add(item2, Before: 1);
+            coll.Add(item3, After: 1);
+
+            Assert.Equal(item2, coll[1]);
+            Assert.Equal(item3, coll[2]);
+            Assert.Equal(item1, coll[3]);
+        }
+
+        [Fact]
+        public static void Add_RelativeKey()
+        {
+            var coll = new Collection();
+            var item1 = CreateValue(1);
+            var item2 = CreateValue(2);
+            var item3 = CreateValue(3);
+
+            coll.Add(item1, "Key1");
+            coll.Add(item2, Key: "Key2", Before: "Key1");
+            coll.Add(item3, After: "Key2");
+
+            Assert.Equal(item2, coll[1]);
+            Assert.Equal(item3, coll[2]);
+            Assert.Equal(item1, coll[3]);
+        }
+
+        [Fact]
+        public static void Add_Relative_Invalid()
+        {
+            var coll = new Collection();
+            var item1 = CreateValue(1);
+
+            Assert.Throws<ArgumentException>(() => coll.Add(item1, Before: 1, After: 1)); // Before and after specified
+            Assert.Throws<InvalidCastException>(() => coll.Add(item1, Before: new object())); // Before not in a string or int
+            Assert.Throws<InvalidCastException>(() => coll.Add(item1, After: new object())); // After not in a string or int
+            Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll.Add(item1, Before: 5)); // Before not in range
+            Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll.Add(item1, After: 5)); // After not in range
+            Assert.Throws<ArgumentException>("Before", () => coll.Add(item1, Before: "Key5")); // Before not found
+            Assert.Throws<ArgumentException>("After", () => coll.Add(item1, After: "Key5")); // After not found
+        }
+
+        [Fact]
+        public static void Remove()
+        {
+            IList coll = CreateCollection(10);
+            for (int i = 0; i < 10; i++)
+            {
+                Foo value = CreateValue(i);
+                coll.Remove(value);
+                Assert.False(coll.Contains(value));
+            }
+            Assert.Equal(0, coll.Count);
+
+            coll.Remove(new Foo()); // No throw for non-existent object
+        }
+
+        [Fact]
+        public static void Insert()
+        {
+            IList coll = new Collection();
+            for (int i = 0; i < 10; i++)
+            {
+                Foo value = CreateValue(i);
+                coll.Insert(i, value);
+                Assert.True(coll.Contains(value));
+            }
+            Assert.Equal(10, coll.Count);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                var expected = CreateValue(i);
+                Assert.Equal(expected, coll[i]);
+            }
+        }
+
+        [Fact]
+        public static void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException()
+        {
+            IList coll = CreateCollection(10);
+            Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll.Insert(-1, new Foo())); // Index < 0
+            Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll.Insert(coll.Count + 1, new Foo())); // Index > coll.Count
+
+            Assert.Equal(10, coll.Count);
+        }
+
+        [Fact]
+        public static void RemoveAt()
+        {
+            IList coll = CreateCollection(10);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                coll.RemoveAt(0);
+                Assert.False(coll.Contains(CreateValue(i)));
+            }
+        }
+
+        [Fact]
+        public static void RemoveAt_InvalidIndex_ThrowsArgumentOutOfRangeException()
+        {
+            IList coll = CreateCollection(10);
+
+            var firstItem = coll[0];
+            coll.RemoveAt(-10);    // Indexing bug when accessing through the IList interface on non-empty collection
+            Assert.False(coll.Contains(firstItem));
+            Assert.Equal(9, coll.Count);
+
+            coll = new Collection();
+
+            Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll.RemoveAt(-1)); // Index < 0
+        }
+
+        [Fact]
+        public static void Remove_Key()
+        {
+            var coll = CreateKeyedCollection(10);
+
+            Assert.True(coll.Contains("Key3"));
+            coll.Remove("Key3");
+            Assert.False(coll.Contains("Key3"));
+        }
+
+        [Fact]
+        public static void Remove_InvalidKey_ThrowsArgumentException()
+        {
+            var coll = CreateKeyedCollection(10);
+
+            Assert.Throws<ArgumentException>("Key", () => coll.Remove("Key10"));
+        }
+
+        [Fact]
+        public static void Remove_Index()
+        {
+            Collection coll = CreateCollection(10);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                coll.Remove(1);
+                Assert.False(((IList)coll).Contains(CreateValue(i)));
+            }
+        }
+
+        [Fact]
+        public static void Remove_InvalidIndex_ThrowsArgumentException()
+        {
+            var coll = CreateCollection(10);
+
+            Assert.Throws<IndexOutOfRangeException>(() => coll.Remove(20));
+        }
+
+        [Fact]
+        public static void Clear()
+        {
+            Collection coll = CreateCollection(10);
+            coll.Clear();
+            Assert.Equal(0, coll.Count);
+        }
+
+        [Fact]
+        public static void IndexOf()
+        {
+            IList coll = CreateCollection(10);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                int ndx = coll.IndexOf(CreateValue(i));
+                Assert.Equal(i, ndx);
+            }
+        }
+
+        [Fact]
+        public static void Contains()
+        {
+            IList coll = CreateCollection(10);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                Assert.True(coll.Contains(CreateValue(i)));
+            }
+            Assert.False(coll.Contains(new Foo()));
+        }
+
+        [Fact]
+        public static void Contains_ByKey()
+        {
+            var coll = CreateKeyedCollection(10);
+
+            Assert.True(coll.Contains("Key3"));
+            Assert.False(coll.Contains("Key10"));
+        }
+
+        [Fact]
+        public static void Item_Get()
+        {
+            Collection coll = CreateCollection(10);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                Assert.Equal(CreateValue(i), coll[i + 1]);
+            }
+
+            Assert.Equal(CreateValue(5), coll[(object)6]);
+        }
+
+        [Fact]
+        public static void Item_Get_InvalidIndex_ThrowsIndexOutOfRangeException()
+        {
+            Collection coll = CreateCollection(10);
+
+            Assert.Equal(((IList)coll)[-10], coll[1]);    // Indexing bug when accessing through the IList interface on non-empty collection
+
+            Assert.Throws<IndexOutOfRangeException>(() => coll[0]); // Index <= 0
+            Assert.Throws<IndexOutOfRangeException>(() => coll[coll.Count + 1]); // Index < 0
+            Assert.Throws<ArgumentException>(() => coll[(object)Guid.Empty]); // Neither string nor int
+        }
+
+        [Fact]
+        public static void Item_GetByKey()
+        {
+            Collection coll = CreateKeyedCollection(10);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                Assert.Equal(CreateValue(i), coll["Key" + i.ToString()]);
+            }
+
+            Assert.Equal(CreateValue(5), coll[(object)"Key5"]);
+            Assert.Equal(CreateValue(5), coll[(object)new char[] { 'K', 'e', 'y', '5' }]);
+
+            coll.Add(CreateValue(11), "X");
+            Assert.Equal(CreateValue(11), coll[(object)'X']);
+        }
+
+        [Fact]
+        public static void Item_GetByKey_InvalidIndex_ThrowsIndexOutOfRangeException()
+        {
+            Collection coll = CreateKeyedCollection(10);
+
+            Assert.Throws<ArgumentException>("Key", () => coll["Key20"]);
+            Assert.Throws<IndexOutOfRangeException>(() => coll[(string)null]);
+            Assert.Throws<IndexOutOfRangeException>(() => coll[(object)null]);
+        }
+
+        [Fact]
+        public static void Item_Set()
+        {
+            IList coll = CreateCollection(10);
+            for (int i = 0; i < coll.Count; i++)
+            {
+                var value = CreateValue(coll.Count - i);
+                coll[i] = value;
+                Assert.Equal(value, coll[i]);
+            }
+        }
+
+        [Fact]
+        public static void Item_Set_Invalid()
+        {
+            IList coll = new Collection();
+
+            Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll[-1] = new Foo()); // Index < 0
+            Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll[coll.Count + 1] = new Foo()); // Index >= InnerList.Count
+        }
+
+        [Fact]
+        public static void CopyTo()
+        {
+            Collection coll = CreateCollection(10);
+
+            // Basic
+            var fooArr = new Foo[10];
+            ((ICollection)coll).CopyTo(fooArr, 0);
+
+            Assert.Equal(coll.Count, fooArr.Length);
+            for (int i = 0; i < fooArr.Length; i++)
+            {
+                Assert.Equal(coll[i + 1], fooArr.GetValue(i));
+            }
+
+            // With index
+            fooArr = new Foo[coll.Count * 2];
+            ((ICollection)coll).CopyTo(fooArr, coll.Count);
+
+            for (int i = coll.Count; i < fooArr.Length; i++)
+            {
+                Assert.Equal(coll[i - coll.Count + 1], fooArr.GetValue(i));
+            }
+        }
+
+        [Fact]
+        public static void CopyTo_Invalid()
+        {
+            ICollection coll = CreateCollection(10);
+            var fooArr = new Foo[10];
+            // Index < 0
+            Assert.Throws<ArgumentException>("index", () => coll.CopyTo(fooArr, -1));
+            // Index + fooArray.Length > coll.Count
+            Assert.Throws<ArgumentException>("index", () => coll.CopyTo(fooArr, 5));
+        }
+
+        [Fact]
+        public static void GetEnumerator()
+        {
+            Collection coll = CreateCollection(10);
+            IEnumerator enumerator = coll.GetEnumerator();
+            Assert.NotNull(enumerator);
+
+            int count = 0;
+            while (enumerator.MoveNext())
+            {
+                Assert.Equal(coll[count + 1], enumerator.Current);
+                count++;
+            }
+
+            Assert.Equal(coll.Count, count);
+        }
+
+        [Fact]
+        public static void GetEnumerator_PrePost()
+        {
+            Collection coll = CreateCollection(10);
+            IEnumerator enumerator = coll.GetEnumerator();
+
+            // Index <= 0
+            Assert.Equal(null, enumerator.Current);
+
+            // Index >= dictionary.Count
+            while (enumerator.MoveNext())
+                ;
+            Assert.Equal(null, enumerator.Current);
+            Assert.False(enumerator.MoveNext());
+
+            // Current throws after resetting
+            enumerator.Reset();
+            Assert.True(enumerator.MoveNext());
+
+            enumerator.Reset();
+            Assert.Equal(null, enumerator.Current);
+        }
+
+        [Fact]
+        public static void SyncRoot()
+        {
+            ICollection coll = new Collection();
+            Assert.Equal(coll.SyncRoot, coll);
+        }
+
+        [Fact]
+        public static void IListProperties()
+        {
+            IList coll = CreateCollection(10);
+            Assert.False(coll.IsFixedSize);
+            Assert.False(coll.IsReadOnly);
+            Assert.False(coll.IsSynchronized);
+        }
+
+        [ActiveIssue("CultureInfo is not serializable")]
+        [Fact]
+        public static void SerializeDeserialize()
+        {
+            Collection expected = CreateKeyedCollection(10);
+
+            IEnumerable actual = BinaryFormatterHelpers.Clone(expected);
+            Assert.Equal(expected, actual);
+        }
+
+        private class Foo
+        {
+            public Foo()
+            {
+            }
+
+            public Foo(int intValue, string stringValue)
+            {
+                IntValue = intValue;
+                StringValue = stringValue;
+            }
+
+            public int IntValue { get; set; }
+            public string StringValue { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                Foo foo = obj as Foo;
+                if (foo == null)
+                    return false;
+                return foo.IntValue == IntValue && foo.StringValue == StringValue;
+            }
+
+            public override int GetHashCode() => IntValue;
+        }
+    }
+}

--- a/src/Microsoft.VisualBasic/tests/CollectionsTests.cs
+++ b/src/Microsoft.VisualBasic/tests/CollectionsTests.cs
@@ -104,8 +104,8 @@ namespace Microsoft.VisualBasic.Tests
             Assert.Throws<InvalidCastException>(() => coll.Add(item1, After: new object())); // After not in a string or int
             Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll.Add(item1, Before: 5)); // Before not in range
             Assert.Throws<ArgumentOutOfRangeException>("Index", () => coll.Add(item1, After: 5)); // After not in range
-            Assert.Throws<ArgumentException>("Before", () => coll.Add(item1, Before: "Key5")); // Before not found
-            Assert.Throws<ArgumentException>("After", () => coll.Add(item1, After: "Key5")); // After not found
+            Assert.Throws<ArgumentException>(() => coll.Add(item1, Before: "Key5")); // Before not found
+            Assert.Throws<ArgumentException>(() => coll.Add(item1, After: "Key5")); // After not found
         }
 
         [Fact]
@@ -192,7 +192,7 @@ namespace Microsoft.VisualBasic.Tests
         {
             var coll = CreateKeyedCollection(10);
 
-            Assert.Throws<ArgumentException>("Key", () => coll.Remove("Key10"));
+            Assert.Throws<ArgumentException>(() => coll.Remove("Key10"));
         }
 
         [Fact]
@@ -298,7 +298,7 @@ namespace Microsoft.VisualBasic.Tests
         {
             Collection coll = CreateKeyedCollection(10);
 
-            Assert.Throws<ArgumentException>("Key", () => coll["Key20"]);
+            Assert.Throws<ArgumentException>(() => coll["Key20"]);
             Assert.Throws<IndexOutOfRangeException>(() => coll[(string)null]);
             Assert.Throws<IndexOutOfRangeException>(() => coll[(object)null]);
         }
@@ -355,9 +355,9 @@ namespace Microsoft.VisualBasic.Tests
             ICollection coll = CreateCollection(10);
             var fooArr = new Foo[10];
             // Index < 0
-            Assert.Throws<ArgumentException>("index", () => coll.CopyTo(fooArr, -1));
+            Assert.Throws<ArgumentException>(() => coll.CopyTo(fooArr, -1));
             // Index + fooArray.Length > coll.Count
-            Assert.Throws<ArgumentException>("index", () => coll.CopyTo(fooArr, 5));
+            Assert.Throws<ArgumentException>(() => coll.CopyTo(fooArr, 5));
         }
 
         [Fact]

--- a/src/Microsoft.VisualBasic/tests/CollectionsTests.cs
+++ b/src/Microsoft.VisualBasic/tests/CollectionsTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections;
-using System.Runtime.Serialization.Formatters.Tests;
 using Xunit;
 
 namespace Microsoft.VisualBasic.Tests
@@ -414,16 +413,6 @@ namespace Microsoft.VisualBasic.Tests
             Assert.False(coll.IsFixedSize);
             Assert.False(coll.IsReadOnly);
             Assert.False(coll.IsSynchronized);
-        }
-
-        [ActiveIssue("CultureInfo is not serializable")]
-        [Fact]
-        public static void SerializeDeserialize()
-        {
-            Collection expected = CreateKeyedCollection(10);
-
-            IEnumerable actual = BinaryFormatterHelpers.Clone(expected);
-            Assert.Equal(expected, actual);
         }
 
         private class Foo

--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
@@ -4,6 +4,7 @@
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CollectionsTests.cs" />
     <Compile Include="CompilerServices\BooleanTypeTests.cs" />
     <Compile Include="CompilerServices\DoubleTypeTests.cs" />
     <Compile Include="CompilerServices\DecimalTypeTests.cs" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/31181
Related bug logged https://github.com/dotnet/corefx/issues/31239

Serialize/Deserialize is non-functional because CultureInfo is not marked as serializable. Should I remove that object from the list and differ from full framework or is there another approach?

/t:GenerateReferenceSource didn't work very well for the interface methods. It took the method names (eg IListRemove) instead of the defining the interface. Maybe some missing VB logic? Please confirm I got this right.

Choose the TELESTO version of m_Iterators to avoid ArrayList use. Already using generic dictionary in this class.