### PR TITLE
Use nameof in ArgumentNullExceptions that throw the paramName

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/Mono/TestLabel.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/TestLabel.cs
@@ -57,7 +57,7 @@ namespace MonoTests.System.Configuration.Util
             if ((prefix == null) || (prefix.Equals(string.Empty)))
                 throw new ArgumentException("Cannot be null or empty.", "prefix");
             if (delimiter == null)
-                throw new ArgumentNullException("delimiter");
+                throw new ArgumentNullException(nameof(delimiter));
 
             scopes = new List<Scope>();
             scopes.Add(new Scope(prefix, style));

--- a/src/System.Data.Common/tests/System/Data/Common/DbDataReaderMock.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DbDataReaderMock.cs
@@ -43,7 +43,7 @@ namespace System.Data.Tests.Common
         {
             if (testData == null)
             {
-                throw new ArgumentNullException("testData");
+                throw new ArgumentNullException(nameof(testData));
             }
 
             _testDataTable = testData;

--- a/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/MultipleResultsTest/MultipleResultsTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/MultipleResultsTest/MultipleResultsTest.cs
@@ -307,7 +307,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             internal CarriageReturnLineFeedReplacer(TextWriter output)
             {
                 if (output == null)
-                    throw new ArgumentNullException("output");
+                    throw new ArgumentNullException(nameof(output));
 
                 _output = output;
             }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/ConnectionPoolWrapper.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/ConnectionPoolWrapper.cs
@@ -19,7 +19,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public ConnectionPoolWrapper(SqlConnection connection)
         {
             if (connection == null)
-                throw new ArgumentNullException("connection");
+                throw new ArgumentNullException(nameof(connection));
 
             _connectionPool = ConnectionHelper.GetConnectionPool(connection.GetInternalConnection());
             ConnectionString = connection.ConnectionString;
@@ -36,7 +36,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public ConnectionPoolWrapper(string connectionString)
         {
             if (connectionString == null)
-                throw new ArgumentNullException("connectionString");
+                throw new ArgumentNullException(nameof(connectionString));
 
             ConnectionString = connectionString;
             _connectionPool = ConnectionPoolHelper.ConnectionPoolFromString(connectionString);
@@ -104,7 +104,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public bool ContainsConnection(SqlConnection connection)
         {
             if (connection == null)
-                throw new ArgumentNullException("connection");
+                throw new ArgumentNullException(nameof(connection));
 
             return (_connectionPool == ConnectionHelper.GetConnectionPool(connection.GetInternalConnection()));
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/InternalConnectionWrapper.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/InternalConnectionWrapper.cs
@@ -26,7 +26,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public InternalConnectionWrapper(SqlConnection connection, bool supportKillByTSql = false)
         {
             if (connection == null)
-                throw new ArgumentNullException("connection");
+                throw new ArgumentNullException(nameof(connection));
 
             _internalConnection = connection.GetInternalConnection();
             ConnectionString = connection.ConnectionString;
@@ -55,7 +55,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public bool IsInternalConnectionOf(SqlConnection connection)
         {
             if (connection == null)
-                throw new ArgumentNullException("connection");
+                throw new ArgumentNullException(nameof(connection));
 
             return (_internalConnection == connection.GetInternalConnection());
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/ConnectionHelper.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/ConnectionHelper.cs
@@ -42,7 +42,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
         private static void VerifyObjectIsInternalConnection(object internalConnection)
         {
             if (internalConnection == null)
-                throw new ArgumentNullException("internalConnection");
+                throw new ArgumentNullException(nameof(internalConnection));
             if (!s_dbConnectionInternal.IsInstanceOfType(internalConnection))
                 throw new ArgumentException("Object provided was not a DbConnectionInternal", "internalConnection");
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/ConnectionPoolHelper.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/ConnectionPoolHelper.cs
@@ -78,7 +78,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
         public static object ConnectionPoolFromString(string connectionString)
         {
             if (connectionString == null)
-                throw new ArgumentNullException("connectionString");
+                throw new ArgumentNullException(nameof(connectionString));
 
             object pool = null;
             object factorySingleton = s_sqlConnectionFactorySingleton.GetValue(null);
@@ -126,7 +126,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
         private static void VerifyObjectIsPool(object pool)
         {
             if (pool == null)
-                throw new ArgumentNullException("pool");
+                throw new ArgumentNullException(nameof(pool));
             if (!s_dbConnectionPool.IsInstanceOfType(pool))
                 throw new ArgumentException("Object provided was not a DbConnectionPool", "pool");
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/TdsParserStateObjectHelper.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/TdsParserStateObjectHelper.cs
@@ -53,7 +53,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
         private static void VerifyObjectIsTdsParserStateObject(object stateObject)
         {
             if (stateObject == null)
-                throw new ArgumentNullException("stateObject");
+                throw new ArgumentNullException(nameof(stateObject));
             if (!s_tdsParserStateObjectManaged.IsInstanceOfType(stateObject))
                 throw new ArgumentException("Object provided was not a DbConnectionInternal", "internalConnection");
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -161,7 +161,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             internal CarriageReturnLineFeedReplacer(TextWriter output)
             {
                 if (output == null)
-                    throw new ArgumentNullException("output");
+                    throw new ArgumentNullException(nameof(output));
 
                 _output = output;
             }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/Randomizer.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/Randomizer.cs
@@ -460,7 +460,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         ==============================================================================*/
         public virtual void NextBytes(byte[] buffer)
         {
-            if (buffer == null) throw new ArgumentNullException("buffer");
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             for (int i = 0; i < buffer.Length; i++)
             {
                 buffer[i] = (byte)(InternalSample() % (byte.MaxValue + 1));

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomTableColumn.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomTableColumn.cs
@@ -31,7 +31,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         {
             if (typeInfo == null)
             {
-                throw new ArgumentNullException("typeInfo");
+                throw new ArgumentNullException(nameof(typeInfo));
             }
 
             if ((options & SqlRandomColumnOptions.ColumnSet) != 0)

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomTypeInfo.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomTypeInfo.cs
@@ -71,7 +71,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         protected void ValidateColumnInfo(SqlRandomTableColumn columnInfo)
         {
             if (columnInfo == null)
-                throw new ArgumentNullException("columnInfo");
+                throw new ArgumentNullException(nameof(columnInfo));
 
             if (Type != columnInfo.Type)
                 throw new ArgumentException("Type mismatch");

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomizer.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomizer.cs
@@ -139,7 +139,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public void Shuffle<T>(T[] values, int? valuesToSet = null)
         {
             if (values == null)
-                throw new ArgumentNullException("values");
+                throw new ArgumentNullException(nameof(values));
 
             int count = values.Length;
             int selectValues = count;
@@ -270,7 +270,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public void FillByteArray(byte[] result)
         {
             if (result == null)
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
 
             if (result.Length == 0)
                 return;
@@ -290,7 +290,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public void FillAnsiCharArray(char[] result)
         {
             if (result == null)
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
 
             if (result.Length == 0)
                 return;
@@ -310,7 +310,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public void FillUcs2CharArray(char[] result)
         {
             if (result == null)
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
 
             if (result.Length == 0)
                 return;

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/PlaceholderStream.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/PlaceholderStream.cs
@@ -87,7 +87,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             if (innerStream == null)
             {
                 // We can't proceed without underlying stream
-                throw new ArgumentNullException("innerStream", "Underlying stream is required");
+                throw new ArgumentNullException(nameof(innerStream), "Underlying stream is required");
             }
 
             // Save transport stream

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/AutoTDSStream.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/AutoTDSStream.cs
@@ -91,7 +91,7 @@ namespace Microsoft.SqlServer.TDS
             if (innerTDSStream == null)
             {
                 // We can't proceed without underlying stream
-                throw new ArgumentNullException("innerTDSStream", "Underlying TDS stream is required");
+                throw new ArgumentNullException(nameof(innerTDSStream), "Underlying TDS stream is required");
             }
 
             // Save transport stream

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/FeatureExtAck/TDSFeatureExtAckFederatedAuthenticationOption.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/FeatureExtAck/TDSFeatureExtAckFederatedAuthenticationOption.cs
@@ -44,7 +44,7 @@ namespace Microsoft.SqlServer.TDS.FeatureExtAck
             // Nonce and/or Signature can be null depending on the FedAuthLibrary used
             if (clientNonce == null && signature != null)
             {
-                throw new ArgumentNullException("signature");
+                throw new ArgumentNullException(nameof(signature));
             }
             else if (clientNonce != null && clientNonce.Length != s_nonceDataLength)
             {

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/TDSStream.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/TDSStream.cs
@@ -141,7 +141,7 @@ namespace Microsoft.SqlServer.TDS
             if (innerStream == null)
             {
                 // We can't proceed without underlying stream
-                throw new ArgumentNullException("innerStream", "Underlying stream is required");
+                throw new ArgumentNullException(nameof(innerStream), "Underlying stream is required");
             }
 
             // Save transport stream

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4069,7 +4069,7 @@ namespace System.Net.Sockets
             }
             if (e.RemoteEndPoint == null)
             {
-                throw new ArgumentNullException("RemoteEndPoint");
+                throw new ArgumentNullException(nameof(e.RemoteEndPoint));
             }
             if (!CanTryAddressFamily(e.RemoteEndPoint.AddressFamily))
             {
@@ -4122,7 +4122,7 @@ namespace System.Net.Sockets
             }
             if (e.RemoteEndPoint == null)
             {
-                throw new ArgumentNullException("RemoteEndPoint");
+                throw new ArgumentNullException(nameof(e.RemoteEndPoint));
             }
             if (!CanTryAddressFamily(e.RemoteEndPoint.AddressFamily))
             {

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -416,7 +416,7 @@ namespace System
 
             uriString = serializationInfo.GetString("RelativeUri");  // Do not rename (binary serialization)
             if ((object)uriString == null)
-                throw new ArgumentNullException("uriString");
+                throw new ArgumentNullException(nameof(uriString));
 
             CreateThis(uriString, false, UriKind.Relative);
         }

--- a/src/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
+++ b/src/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
@@ -23,7 +23,7 @@ namespace System.Reflection.Context
         
         protected CustomReflectionContext(ReflectionContext source)
         {
-            SourceContext = source ?? throw new ArgumentNullException("source");
+            SourceContext = source ?? throw new ArgumentNullException(nameof(source));
             _projector = new ReflectionContextProjector(this);
         }
 
@@ -31,7 +31,7 @@ namespace System.Reflection.Context
         {
             if (assembly == null)
             {
-                throw new ArgumentNullException("assembly");
+                throw new ArgumentNullException(nameof(assembly));
             }
 
             return _projector.ProjectAssemblyIfNeeded(assembly);
@@ -41,7 +41,7 @@ namespace System.Reflection.Context
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             return _projector.ProjectTypeIfNeeded(type);

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/CanonicalEncoder.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/CanonicalEncoder.cs
@@ -406,7 +406,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
         {
             if (buffer == null)
             {
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
             }
 
             if (count < 0 || count > buffer.Length)

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/CanonicalWriter.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/CanonicalWriter.cs
@@ -112,7 +112,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
                 ThrowIfNotInStartState();
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
                 _encoder = value;
             }
@@ -465,7 +465,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
 
             OnPossibleEndOfBase64Content();
@@ -529,7 +529,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
         {
             if (text == null)
             {
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             if (_state == WriteState.Element)
@@ -639,7 +639,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
         {
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (_state == WriteState.Attribute)
@@ -659,7 +659,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
         {
             if (localName == null || localName.Length == 0)
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (ns == null)
@@ -774,7 +774,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
 
             if (localName == null)
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (prefix == null)
@@ -886,7 +886,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
 
             if (localName == null || localName.Length == 0)
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             OnPossibleEndOfBase64Content();
@@ -930,7 +930,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
 
             WriteStringCore(s);
@@ -944,7 +944,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
 
             WriteStringCore(s.Value);

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/SimpleXmlNodeList.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/SimpleXmlNodeList.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
         {
             if (node == null)
             {
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
             }
             _list.Add(node);
         }

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -3836,7 +3836,7 @@ public class ImplementDictionary : IDictionary
     public bool IsFixedSize { get { return false; } }
     public void Remove(object key)
     {
-        if (key == null) throw new ArgumentNullException("key");
+        if (key == null) throw new ArgumentNullException(nameof(key));
         int index;
         if (TryGetIndexOfKey(key, out index))
         {
@@ -4143,7 +4143,7 @@ public class MyArgumentException : Exception, ISerializable
     {
         if (info == null)
         {
-            throw new ArgumentNullException("info");
+            throw new ArgumentNullException(nameof(info));
         }
 
         base.GetObjectData(info, context);

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
@@ -117,7 +117,7 @@ namespace System.Threading
         public override void Post(SendOrPostCallback d, object state)
         {
             if (d == null)
-                throw new ArgumentNullException("d");
+                throw new ArgumentNullException(nameof(d));
             Contract.EndContractBlock();
 
             var ignored = _dispatcher.RunAsync(CoreDispatcherPriority.Normal, new Invoker(d, state).Invoke);
@@ -140,7 +140,7 @@ namespace System.Threading
         public override void Post(SendOrPostCallback d, object state)
         {
             if (d == null)
-                throw new ArgumentNullException("d");
+                throw new ArgumentNullException(nameof(d));
             Contract.EndContractBlock();
 
             // We explicitly choose to ignore the return value here. This enqueue operation might fail if the 


### PR DESCRIPTION
This follows the similar PR #30228, which didn't seem to catch these instances. This PR focuses only on simple `ArgumentNullException`s that use a parameter name directly. (I can make other PRs for other instances in the future)

I don't know if this goes against the rather [strict anti coding style changes described in the contribution guide](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md#coding-style-changes), but I feel like the usage of `nameof` is a little more useful than strictly coding style, and I think @stephentoub [welcomed people to experiment on this](https://github.com/dotnet/corefx/pull/30228#issuecomment-395956876). This is my first PR in this repository, please let me know if anything seems off.