### PR TITLE
System.Security: Fix test failures on macOS Mojave.

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.c
@@ -84,6 +84,9 @@ uint64_t AppleCryptoNative_EccGetKeySizeInBits(SecKeyRef publicKey)
     // Word of caution: While seeking meaning in these numbers I ran across a snippet of code
     // which suggests that on iOS (vs macOS) they use a different set of reasoning and produce
     // different numbers (they used (8 + 2*thisValue) on iOS for "signature length").
+    //
+    // Starting with macOS Mojave and the new SecCertificateCopyKey API the values
+    // are the actual key size in bytes.
     switch (blockSize)
     {
         case 72:
@@ -91,6 +94,16 @@ uint64_t AppleCryptoNative_EccGetKeySizeInBits(SecKeyRef publicKey)
         case 104:
             return 384;
         case 141:
+            return 521;
+
+        case 28:
+            // Not fully supported as of macOS Mojave Developer Preview 4
+            return 0;
+        case 32:
+            return 256;
+        case 48:
+            return 384;
+        case 66:
             return 521;
     }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.c
@@ -97,7 +97,19 @@ uint64_t AppleCryptoNative_EccGetKeySizeInBits(SecKeyRef publicKey)
             return 521;
 
         case 28:
-            // Not fully supported as of macOS Mojave Developer Preview 4
+            // Not fully supported as of macOS Mojave Developer Preview 4 and could later
+            // result in internal library errors when consumed by other APIs:
+            //
+            // "Internal error #ffff9d28 at VerifyTransform_block_invoke /BuildRoot/Library/
+            // Caches/com.apple.xbs/Sources/Security/Security-58286.200.178/OSX/
+            // libsecurity_transform/lib/SecSignVerifyTransform.c:540" UserInfo={NSDescription=
+            // Internal error #ffff9d28 at VerifyTransform_block_invoke /BuildRoot/Library/
+            // Caches/com.apple.xbs/Sources/Security/Security-58286.200.178/OSX/
+            // libsecurity_transform/lib/SecSignVerifyTransform.c:540, Originating Transform
+            // =CoreFoundationObject}))
+            //
+            // Thus 0 is returned instead of 224 and the managed code treats it as
+            // unsupported key size.
             return 0;
         case 32:
             return 256;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificatePal.cs
@@ -381,6 +381,12 @@ namespace Internal.Cryptography.Pal
             SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
             SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
 
+            if (publicKey.IsInvalid)
+            {
+                // SecCertificateCopyKey returns null for DSA, so fall back to manually building it.
+                publicKey = Interop.AppleCrypto.ImportEphemeralKey(_certData.SubjectPublicKeyInfo, false);
+            }
+
             return new DSAImplementation.DSASecurityTransforms(publicKey, privateKey);
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificatePal.cs
@@ -368,6 +368,7 @@ namespace Internal.Cryptography.Pal
             Debug.Assert(!_identityHandle.IsInvalid);
             SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
             SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
+            Debug.Assert(!publicKey.IsInvalid);
 
             return new RSAImplementation.RSASecurityTransforms(publicKey, privateKey);
         }
@@ -398,6 +399,7 @@ namespace Internal.Cryptography.Pal
             Debug.Assert(!_identityHandle.IsInvalid);
             SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
             SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
+            Debug.Assert(!publicKey.IsInvalid);
 
             return new ECDsaImplementation.ECDsaSecurityTransforms(publicKey, privateKey);
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/X509Pal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/X509Pal.cs
@@ -23,7 +23,7 @@ namespace Internal.Cryptography.Pal
             public AsymmetricAlgorithm DecodePublicKey(Oid oid, byte[] encodedKeyValue, byte[] encodedParameters,
                 ICertificatePal certificatePal)
             {
-                const int errSecUnsupportedKeyFormat = -67734;
+                const int errSecInvalidKeyRef = -67712;
                 const int errSecUnsupportedKeySize = -67735;
                 AppleCertificatePal applePal = certificatePal as AppleCertificatePal;
 
@@ -49,7 +49,7 @@ namespace Internal.Cryptography.Pal
                             // algorithm in the test suite (as of macOS Mojave Developer Preview 4).
                             if (key.IsInvalid)
                             {
-                                throw Interop.AppleCrypto.CreateExceptionForOSStatus(errSecUnsupportedKeyFormat);
+                                throw Interop.AppleCrypto.CreateExceptionForOSStatus(errSecInvalidKeyRef);
                             }
                             // EccGetKeySizeInBits can fail for two reasons. First, the Apple implementation has changed
                             // and we receive values from API that were not previously handled. In that case the CoreFX


### PR DESCRIPTION
Fixes #31102. Feedback welcome.

/cc @bartonjs @maryamariyan 