### PR TITLE
System.Security: Fix unbalanced reference count in X509Store.Remove on macOS.

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509Store.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509Store.cs
@@ -21,7 +21,7 @@ internal static partial class Interop
 
         [DllImport(Libraries.AppleCryptoNative)]
         private static extern int AppleCryptoNative_X509StoreRemoveCertificate(
-            SafeSecCertificateHandle cert,
+            SafeKeychainItemHandle cert,
             SafeKeychainHandle keychain,
             out int pOSStatus);
 
@@ -42,7 +42,7 @@ internal static partial class Interop
             }
         }
 
-        internal static void X509StoreRemoveCertificate(SafeSecCertificateHandle certHandle, SafeKeychainHandle keychain)
+        internal static void X509StoreRemoveCertificate(SafeKeychainItemHandle certHandle, SafeKeychainHandle keychain)
         {
             int osStatus;
             int ret = AppleCryptoNative_X509StoreRemoveCertificate(certHandle, keychain, out osStatus);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
@@ -387,5 +387,6 @@ AppleCryptoNative_X509StoreRemoveCertificate(CFTypeRef certOrIdentity, SecKeycha
     }
 
     *pOSStatus = DeleteInKeychain(cert, keychain);
+    CFRelease(cert);
     return *pOSStatus == noErr;
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
@@ -73,7 +73,8 @@ namespace Internal.Cryptography.Pal
 
                 AppleCertificatePal applePal = (AppleCertificatePal)cert;
 
-                Interop.AppleCrypto.X509StoreRemoveCertificate(applePal.CertificateHandle, _keychainHandle);
+                var handle = (SafeKeychainItemHandle)applePal.IdentityHandle ?? applePal.CertificateHandle;
+                Interop.AppleCrypto.X509StoreRemoveCertificate(handle, _keychainHandle);
             }
 
             public SafeHandle SafeHandle => _keychainHandle;


### PR DESCRIPTION
Fixes #31028.

/cc @bartonjs 