### PR TITLE
System.Security: Fix X509Certificate.GetName/GetIssuerName to match NetFX

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -462,13 +462,15 @@ namespace System.Security.Cryptography.X509Certificates
         [Obsolete("This method has been deprecated.  Please use the Subject property instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
         public virtual string GetName()
         {
-            return Subject;
+            ThrowIfInvalid();
+            return Pal.SubjectName.Decode(X500DistinguishedNameFlags.None);
         }
 
         [Obsolete("This method has been deprecated.  Please use the Issuer property instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
         public virtual string GetIssuerName()
         {
-            return Issuer;
+            ThrowIfInvalid();
+            return Pal.IssuerName.Decode(X500DistinguishedNameFlags.None);
         }
 
         public override string ToString()

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -26,11 +26,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static void X509CertTest()
         {
             string certSubject = @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com";
+            string certSubjectObsolete = @"E=pkit@microsoft.com, C=US, S=WA, L=Redmond, O=Microsoft, OU=ITG, CN=Microsoft Corporate Root Authority";
 
             using (X509Certificate cert = new X509Certificate(Path.Combine("TestData", "microsoft.cer")))
             {
                 Assert.Equal(certSubject, cert.Subject);
                 Assert.Equal(certSubject, cert.Issuer);
+#pragma warning disable CS0618 // Type or member is obsolete
+                Assert.Equal(certSubjectObsolete, cert.GetName());
+                Assert.Equal(certSubjectObsolete, cert.GetIssuerName());
+#pragma warning restore CS0618
 
                 int snlen = cert.GetSerialNumber().Length;
                 Assert.Equal(16, snlen);

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -212,7 +212,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Fact]
         [ActiveIssue(2910, TestPlatforms.AnyUnix)]
-        [ActiveIssue(30544, TargetFrameworkMonikers.NetFramework)]
         public static void TestLoadSignedFile()
         {
             // X509Certificate2 can also extract the certificate from a signed file.
@@ -228,7 +227,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     "CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     issuer);
 #pragma warning disable 0618
-                Assert.Equal(c.Issuer, c.GetIssuerName());
+                Assert.Equal(
+                    "C=US, S=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Code Signing PCA",
+                    c.GetIssuerName());
 #pragma warning restore 0618
 
                 string subject = c.Subject;
@@ -236,7 +237,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     subject);
 #pragma warning disable 0618
-                Assert.Equal(subject, c.GetName());
+                Assert.Equal(
+                    "C=US, S=Washington, L=Redmond, O=Microsoft Corporation, OU=MOPR, CN=Microsoft Corporation",
+                    c.GetName());
 #pragma warning restore 0618
 
                 string expectedThumbprintHash = "67B1757863E3EFF760EA9EBB02849AF07D3A8080";


### PR DESCRIPTION
Fixes #30544.