### PR TITLE
System.Security: Fix byte order in X509Certificate serial number properties and methods.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificatePal.cs
@@ -238,9 +238,7 @@ namespace Internal.Cryptography.Pal
             get
             {
                 EnsureCertData();
-                byte[] serial = _certData.SerialNumber;
-                Array.Reverse(serial);
-                return serial;
+                return _certData.SerialNumber;
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -102,12 +102,7 @@ namespace Internal.Cryptography.Pal
             {
                 using (SafeSharedAsn1IntegerHandle serialNumber = Interop.Crypto.X509GetSerialNumber(_cert))
                 {
-                    byte[] serial = Interop.Crypto.GetAsn1IntegerBytes(serialNumber);
-
-                    // Windows returns this in BigInteger Little-Endian,
-                    // OpenSSL returns this in BigInteger Big-Endian.
-                    Array.Reverse(serial);
-                    return serial;
+                    return Interop.Crypto.GetAsn1IntegerBytes(serialNumber);
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -199,6 +199,7 @@ namespace Internal.Cryptography.Pal
                 {
                     CERT_CONTEXT* pCertContext = _certContext.CertContext;
                     byte[] serialNumber = pCertContext->pCertInfo->SerialNumber.ToByteArray();
+                    Array.Reverse(serialNumber);
                     GC.KeepAlive(this);
                     return serialNumber;
                 }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -442,14 +442,16 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual byte[] GetSerialNumber()
         {
             ThrowIfInvalid();
-
-            return GetRawSerialNumber().CloneByteArray();
+            byte[] serialNumber = GetRawSerialNumber().CloneByteArray();
+            // PAL always returns big-endian, GetSerialNumber returns little-endian
+            Array.Reverse(serialNumber);
+            return serialNumber;
         }
 
         public virtual string GetSerialNumberString()
         {
             ThrowIfInvalid();
-
+            // PAL always returns big-endian, GetSerialNumberString returns big-endian too
             return GetRawSerialNumber().ToHexStringUpper();
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -288,9 +288,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             get
             {
-                byte[] serialNumber = GetSerialNumber();
-                Array.Reverse(serialNumber);
-                return serialNumber.ToHexStringUpper();
+                return GetSerialNumberString();
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -37,17 +37,18 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(30543, TargetFrameworkMonikers.NetFramework)]
         public static void TestSerial()
         {
-            string expectedSerialHex = "B00000000100DD9F3BD08B0AAF11B000000033";
-            byte[] expectedSerial = expectedSerialHex.HexToByteArray();
+            string expectedSerialHex = "33000000B011AF0A8BD03B9FDD0001000000B0";
+            byte[] expectedSerial = "B00000000100DD9F3BD08B0AAF11B000000033".HexToByteArray();
 
             using (X509Certificate2 c = LoadCertificateFromFile())
             {
                 byte[] serial = c.GetSerialNumber();
                 Assert.Equal(expectedSerial, serial);
                 string serialHex = c.GetSerialNumberString();
+                Assert.Equal(expectedSerialHex, serialHex);
+                serialHex = c.SerialNumber;
                 Assert.Equal(expectedSerialHex, serialHex);
             }
         }


### PR DESCRIPTION
Fixes #30543. /cc @bartonjs