### PR TITLE
fix a test issue caused by new MSIT VPN adapter

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -108,6 +108,9 @@ namespace System.Net.Http.Functional.Tests
         public static IPAddress GetIPv6LinkLocalAddress() =>
             NetworkInterface
                 .GetAllNetworkInterfaces()
+                .Where(i => i.Description != "PANGP Virtual Ethernet Adapter")      // This is a VPN adapter, but is reported as a regular Ethernet interface with 
+                                                                                    // a valid link-local address, but the link-local address doesn't actually work.
+                                                                                    // So just manually filter it out.
                 .SelectMany(i => i.GetIPProperties().UnicastAddresses)
                 .Select(a => a.Address)
                 .Where(a => a.IsIPv6LinkLocal)


### PR DESCRIPTION
MSIT seems to have recently pushed updates that add a new VPN adapter called "PANGP Virtual Ethernet Adapter". This adapter claims to support a link-local IPv6 address, but it doesn't seem to actually work (connections time out).

Work around this by explicitly filtering out this adapter when looking for a link-local address.

@dotnet/ncl 