### PR TITLE
add back parsing for simple configuration

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -70,7 +70,7 @@ namespace System.Net.Http
                 ParseProxyConfig(proxyHelper.Proxy, out _insecureProxyUri, out _secureProxyUri);
                 if (_insecureProxyUri == null && _secureProxyUri == null)
                 {
-                    // If advance parsing by protocol fails, fall-back to simplified parsing.
+                    // If advanced parsing by protocol fails, fall-back to simplified parsing.
                     _insecureProxyUri = _secureProxyUri = GetUriFromString(proxyHelper.Proxy);
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -66,10 +66,11 @@ namespace System.Net.Http
 
             if (proxyHelper.ManualSettingsOnly)
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Info(proxyHelper, $"ManualSettingsUsed, {proxyHelper.Proxy}");
                 ParseProxyConfig(proxyHelper.Proxy, out _insecureProxyUri, out _secureProxyUri);
                 if (_insecureProxyUri == null && _secureProxyUri == null)
                 {
-                    // If advanced parsing by protocol fails, fall-back to simplified string.
+                    // If advance parsing by protocol fails, fall-back to simplified parsing.
                     _insecureProxyUri = _secureProxyUri = GetUriFromString(proxyHelper.Proxy);
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -67,6 +67,11 @@ namespace System.Net.Http
             if (proxyHelper.ManualSettingsOnly)
             {
                 ParseProxyConfig(proxyHelper.Proxy, out _insecureProxyUri, out _secureProxyUri);
+                if (_insecureProxyUri == null && _secureProxyUri == null)
+                {
+                    // If advanced parsing by protocol fails, fall-back to simplified string.
+                    _insecureProxyUri = _secureProxyUri = GetUriFromString(proxyHelper.Proxy);
+                }
 
                 if (!string.IsNullOrWhiteSpace(proxyHelper.ProxyBypass))
                 {

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -65,11 +65,11 @@ namespace System.Net.Http.Tests
         }
 
         [Theory]
-        [InlineData("localhost:1234")]
-        [InlineData("123.123.123.123")]
-        public void HttpProxy_SystemProxy_Loaded(string rawProxyString)
+        [InlineData("localhost:1234", "http://localhost:1234/")]
+        [InlineData("123.123.123.123", "http://123.123.123.123/")]
+        public void HttpProxy_SystemProxy_Loaded(string rawProxyString, string expectedUri)
         {
-            RemoteInvoke((proxyString) =>
+            RemoteInvoke((proxyString, expectedString) =>
             {
                 IWebProxy p;
 
@@ -80,9 +80,11 @@ namespace System.Net.Http.Tests
 
                 Assert.True(HttpSystemProxy.TryCreate(out p));
                 Assert.NotNull(p);
+                Assert.Equal(expectedString, p.GetProxy(new Uri(fooHttp)).ToString());
+                Assert.Equal(expectedString, p.GetProxy(new Uri(fooHttps)).ToString());
 
                 return SuccessExitCode;
-            }, rawProxyString).Dispose();
+            }, rawProxyString, expectedUri).Dispose();
         }
 
         [Theory]

--- a/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpSystemProxyTest.cs
@@ -65,6 +65,27 @@ namespace System.Net.Http.Tests
         }
 
         [Theory]
+        [InlineData("localhost:1234")]
+        [InlineData("123.123.123.123")]
+        public void HttpProxy_SystemProxy_Loaded(string rawProxyString)
+        {
+            RemoteInvoke((proxyString) =>
+            {
+                IWebProxy p;
+
+                FakeRegistry.Reset();
+
+                FakeRegistry.WinInetProxySettings.Proxy = proxyString;
+                WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
+
+                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.NotNull(p);
+
+                return SuccessExitCode;
+            }, rawProxyString).Dispose();
+        }
+
+        [Theory]
         [InlineData("http://localhost/", true)]
         [InlineData("http://127.0.0.1/", true)]
         [InlineData("http://128.0.0.1/", false)]
@@ -144,7 +165,6 @@ namespace System.Net.Http.Tests
         [InlineData("http://;")]
         [InlineData("http=;")]
         [InlineData("  ;  ")]
-        [InlineData("proxy.contoso.com")]
         public void HttpProxy_InvalidSystemProxy_Null(string rawProxyString)
         {
             RemoteInvoke((proxyString) =>


### PR DESCRIPTION
it seems like this got broken by #28671.
Proxy setting can contain separate http and https, but it does not in simplifies case.  

In scenario from #31242 we simply get "localhost:3128" string without any protocol specification. 
Based on my testing, this would apply to both http & https.

fixes #31242

