### PR TITLE
Added Tests and packaging for System.Windows.Extensions.

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -293,12 +293,6 @@
         "4.0.1.0": "4.6.0"
       }
     },
-    "System.Windows.Extensions": {
-      "InboxOn": {},
-      "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.6.0"
-      }
-    },
     "Microsoft.Windows.Compatibility": {
       "InboxOn": {}
     },
@@ -5304,6 +5298,12 @@
     "System.Windows.Controls.Ribbon": {
       "InboxOn": {
         "net45": "4.0.0.0"
+      }
+    },
+    "System.Windows.Extensions": {
+      "InboxOn": {},
+      "AssemblyVersionInPackageVersion": {
+        "4.0.0.0": "4.6.0"
       }
     },
     "System.Windows.Forms": {

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -2134,7 +2134,7 @@
   },
   {
     "Name": "System.Windows.Extensions",
-    "Description": "Provides the functionality to display the X509Certificate2",
+    "Description": "Provides miscellaneous Windows-specific types",
     "CommonTypes":[
       "System.Security.Cryptography.X509Certificates.X509Certificate2UI",
       "System.Security.Cryptography.X509Certificates.X509SelectionFlag"

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -2133,6 +2133,14 @@
     ]
   },
   {
+    "Name": "System.Windows.Extensions",
+    "Description": "Provides the functionality to display the X509Certificate2",
+    "CommonTypes":[
+      "System.Security.Cryptography.X509Certificates.X509Certificate2UI",
+      "System.Security.Cryptography.X509Certificates.X509SelectionFlag"
+    ]
+  },
+  {
     "Name": "System.Private.Xml",
     "Description": "Provides a fast, non-cached, forward-only way to read and write Extensible Markup Language (XML) data.",
     "CommonTypes": [

--- a/src/System.Windows.Extensions/Directory.Build.props
+++ b/src/System.Windows.Extensions/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\Directory.Build.props" />
-    <PropertyGroup>
+  <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>

--- a/src/System.Windows.Extensions/pkg/System.Windows.Extensions.pkgproj
+++ b/src/System.Windows.Extensions/pkg/System.Windows.Extensions.pkgproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Windows.Extensions.csproj">
+      <SupportedFramework>netcoreapp2.1</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Windows.Extensions.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
+</Project>

--- a/src/System.Windows.Extensions/tests/Configurations.props
+++ b/src/System.Windows.Extensions/tests/Configurations.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp;
-      netfx;
+      netcoreapp-Windows_NT;
+      netfx-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -5,5 +5,6 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="X509Certificate2UITests.cs" />
+    <Compile Include="X509Certificate2UIManualTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.Windows.Extensions/tests/X509Certificate2UIManualTests.cs
+++ b/src/System.Windows.Extensions/tests/X509Certificate2UIManualTests.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     {
         public static bool ManualTestsEnabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MANUAL_TESTS"));
 
+        // Take action as decsribed in the title of the dialog box window.
         [ConditionalTheory(nameof(ManualTestsEnabled))]
         [InlineData(0)]
         [InlineData(1)]
@@ -51,21 +52,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
     internal class EccTestData
     {
-        internal const string Secp256r1OidValue = "1.2.840.10045.3.1.7";
-        internal const string Secp256r1OidHexValue = "06082A8648CE3D030107";
         internal ECParameters KeyParameters { get; private set; }
-        internal string CurveOid { get; private set; }
-        internal string CurveEncodedOidHex { get; private set; }
-        internal string Name { get; private set; }
 
         internal static readonly EccTestData Secp256r1Data = new EccTestData
         {
-            Name = nameof(Secp256r1Data),
-            CurveOid = Secp256r1OidValue,
-            CurveEncodedOidHex = Secp256r1OidHexValue,
-
-            // Suite B Implementers Guide to FIPS 186-3,
-            // D.1 Example ECDSA Signature for P-256
             KeyParameters = new ECParameters
             {
                 Curve = ECCurve.NamedCurves.nistP256,

--- a/src/System.Windows.Extensions/tests/X509Certificate2UIManualTests.cs
+++ b/src/System.Windows.Extensions/tests/X509Certificate2UIManualTests.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{   
+    // Run these tests after setting the MANUAL_TESTS environment variable.
+    public class X509Certificate2UIManualTests
+    {
+        public static bool ManualTestsEnabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MANUAL_TESTS"));
+
+        [ConditionalTheory(nameof(ManualTestsEnabled))]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public static void SelectCertificateSingleSelectionTest(int count)
+        {
+            using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp256r1Data.KeyParameters))
+            {
+                CertificateRequest request = new CertificateRequest("CN=Test", ecdsa, HashAlgorithmName.SHA256);
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                using (X509Certificate2 cert = request.Create(request.SubjectName, X509SignatureGenerator.CreateForECDsa(ecdsa), now, now.AddMinutes(10), new byte[1]))
+                {
+                    X509Certificate2Collection collection = new X509Certificate2Collection() { cert, cert };
+                    X509Certificate2Collection actual = X509Certificate2UI.SelectFromCollection(
+                        collection, $"Choose {count} Certificate", string.Empty, count < 2 ? X509SelectionFlag.SingleSelection : X509SelectionFlag.MultiSelection, IntPtr.Zero);
+                    Assert.Equal(count, actual.Count);
+                }
+            }
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void DisplayCertificateTest()
+        {
+            using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp256r1Data.KeyParameters))
+            {
+                CertificateRequest request = new CertificateRequest("CN=Test", ecdsa, HashAlgorithmName.SHA256);
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                using (X509Certificate2 cert = request.Create(request.SubjectName, X509SignatureGenerator.CreateForECDsa(ecdsa), now, now.AddMinutes(10), new byte[1]))
+                {
+                    X509Certificate2UI.DisplayCertificate(cert);
+                }
+            }
+        }
+    }
+
+    internal class EccTestData
+    {
+        internal const string Secp256r1OidValue = "1.2.840.10045.3.1.7";
+        internal const string Secp256r1OidHexValue = "06082A8648CE3D030107";
+        internal ECParameters KeyParameters { get; private set; }
+        internal string CurveOid { get; private set; }
+        internal string CurveEncodedOidHex { get; private set; }
+        internal string Name { get; private set; }
+
+        internal static readonly EccTestData Secp256r1Data = new EccTestData
+        {
+            Name = nameof(Secp256r1Data),
+            CurveOid = Secp256r1OidValue,
+            CurveEncodedOidHex = Secp256r1OidHexValue,
+
+            // Suite B Implementers Guide to FIPS 186-3,
+            // D.1 Example ECDSA Signature for P-256
+            KeyParameters = new ECParameters
+            {
+                Curve = ECCurve.NamedCurves.nistP256,
+
+                Q = new ECPoint
+                {
+                    X = HexToByteArray("8101ECE47464A6EAD70CF69A6E2BD3D88691A3262D22CBA4F7635EAFF26680A8"),
+                    Y = HexToByteArray("D8A12BA61D599235F67D9CB4D58F1783D3CA43E78F0A5ABAA624079936C0C3A9"),
+                },
+
+                D = HexToByteArray("70A12C2DB16845ED56FF68CFC21A472B3F04D7D6851BF6349F2D7D5B3452B38A"),
+            },
+        };
+
+        private static byte[] HexToByteArray(string hexString)
+        {
+            byte[] bytes = new byte[hexString.Length / 2];
+
+            for (int i = 0; i < hexString.Length; i += 2)
+            {
+                string s = hexString.Substring(i, 2);
+                bytes[i / 2] = byte.Parse(s, NumberStyles.HexNumber, null);
+            }
+
+            return bytes;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/31203

- Packaging for System.Windows.Extensions.
- Implemenation was broken  due to handle definations. Copied the handle implementation from System.Security.X509Certificates namespace to fix it
- Manual UI tests are added with infra similar to how we do testing  for System.Console

