### PR TITLE
Use CertCloseStore from Common Interop in X509Certificates

### DIFF
--- a/src/Common/src/Interop/Windows/Crypt32/Interop.CertCloseStore.cs
+++ b/src/Common/src/Interop/Windows/Crypt32/Interop.CertCloseStore.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Crypt32
     {
-        [DllImport(Interop.Libraries.Crypt32, SetLastError = true)]
+        [DllImport(Interop.Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool CertCloseStore(IntPtr hCertStore, uint dwFlags);
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -312,9 +312,6 @@ internal static partial class Interop
         private static extern bool CertVerifyCertificateChainPolicy(IntPtr pszPolicyOID, SafeX509ChainHandle pChainContext, [In] ref CERT_CHAIN_POLICY_PARA pPolicyPara, [In, Out] ref CERT_CHAIN_POLICY_STATUS pPolicyStatus);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern bool CertCloseStore(IntPtr hCertStore, int dwFlags);
-
-        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CryptMsgClose(IntPtr hCryptMsg);
         
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
@@ -203,7 +203,7 @@ namespace Internal.Cryptography.Pal.Native
     {
         protected sealed override bool ReleaseHandle()
         {
-            bool success = Interop.crypt32.CertCloseStore(handle, 0);
+            bool success = Interop.Crypt32.CertCloseStore(handle, 0);
             return success;
         }
     }

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -108,6 +108,9 @@
     <Compile Include="Internal\Cryptography\Pal.Windows\X509Pal.PublicKey.cs" />
     <Compile Include="Internal\Cryptography\Pal.Windows\X509Pal.X500DistinguishedName.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafePasswordHandle.Windows.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertCloseStore.cs">
+      <Link>Common\Interop\Windows\Crypt32\Interop.CertCloseStore.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs</Link>
     </Compile>


### PR DESCRIPTION
Very beginning of progress for #30513

Consolidated them by:
- Adding `CharSet.Unicode` to common version
- Using `uint` for `dwFlags` from common version instead of `int` from X509 version