### PR TITLE
System.Security: Add T61String support to AsnReader.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1V2.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1V2.cs
@@ -817,7 +817,10 @@ namespace System.Security.Cryptography.Asn1
 
         public override int GetMaxCharCount(int byteCount)
         {
-            return s_utf8Encoding.GetMaxCharCount(byteCount);
+            // Latin-1 is single byte encoding, so byteCount == charCount
+            // UTF-8 is multi-byte encoding, so byteCount <= charCount
+            // We want to return the maximum of those two, which happens to be byteCount.
+            return byteCount;
         }
     }
 

--- a/src/Common/src/System/Security/Cryptography/Asn1V2.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1V2.cs
@@ -818,7 +818,7 @@ namespace System.Security.Cryptography.Asn1
         public override int GetMaxCharCount(int byteCount)
         {
             // Latin-1 is single byte encoding, so byteCount == charCount
-            // UTF-8 is multi-byte encoding, so byteCount <= charCount
+            // UTF-8 is multi-byte encoding, so byteCount >= charCount
             // We want to return the maximum of those two, which happens to be byteCount.
             return byteCount;
         }

--- a/src/Common/src/System/Security/Cryptography/Asn1V2.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1V2.cs
@@ -352,6 +352,7 @@ namespace System.Security.Cryptography.Asn1
         private static readonly Text.Encoding s_ia5Encoding = new IA5Encoding();
         private static readonly Text.Encoding s_visibleStringEncoding = new VisibleStringEncoding();
         private static readonly Text.Encoding s_printableStringEncoding = new PrintableStringEncoding();
+        private static readonly Text.Encoding s_t61Encoding = new T61Encoding();
 
         internal static Text.Encoding GetEncoding(UniversalTagNumber encodingType)
         {
@@ -367,6 +368,8 @@ namespace System.Security.Cryptography.Asn1
                     return s_visibleStringEncoding;
                 case UniversalTagNumber.BMPString:
                     return s_bmpEncoding;
+                case UniversalTagNumber.T61String:
+                    return s_t61Encoding;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(encodingType), encodingType, null);
             }
@@ -701,6 +704,120 @@ namespace System.Security.Cryptography.Asn1
         public override int GetMaxCharCount(int byteCount)
         {
             return byteCount / 2;
+        }
+    }
+
+    /// <summary>
+    /// Compatibility encoding for T61Strings. Interprets the characters as UTF-8 or
+    /// ISO-8859-1 as a fallback.
+    /// <summary>
+    internal class T61Encoding : Text.Encoding
+    {
+        private static readonly Text.Encoding s_utf8Encoding = new UTF8Encoding(false, throwOnInvalidBytes: true);
+        private static readonly Text.Encoding s_latin1Encoding = System.Text.Encoding.GetEncoding("iso-8859-1");
+
+        public override int GetByteCount(char[] chars, int index, int count)
+        {
+            return s_utf8Encoding.GetByteCount(chars, index, count);
+        }
+
+        public override unsafe int GetByteCount(char* chars, int count)
+        {
+            return s_utf8Encoding.GetByteCount(chars, count);
+        }
+
+        public override int GetByteCount(string s)
+        {
+            return s_utf8Encoding.GetByteCount(s);
+        }
+
+#if netcoreapp || uap
+        public override int GetByteCount(ReadOnlySpan<char> chars)
+        {
+            return s_utf8Encoding.GetByteCount(chars);
+        }
+#endif
+
+        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        {
+            return s_utf8Encoding.GetBytes(chars, charIndex, charCount, bytes, byteIndex);
+        }
+
+        public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
+        {
+            return s_utf8Encoding.GetBytes(chars, charCount, bytes, byteCount);
+        }
+
+        public override int GetCharCount(byte[] bytes, int index, int count)
+        {
+            try
+            {
+                return s_utf8Encoding.GetCharCount(bytes, index, count);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetCharCount(bytes, index, count);
+            }
+        }
+
+        public override unsafe int GetCharCount(byte* bytes, int count)
+        {
+            try
+            {
+                return s_utf8Encoding.GetCharCount(bytes, count);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetCharCount(bytes, count);
+            }
+        }
+
+#if netcoreapp || uap
+        public override int GetCharCount(ReadOnlySpan<byte> bytes)
+        {
+            try
+            {
+                return s_utf8Encoding.GetCharCount(bytes);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetCharCount(bytes);
+            }
+        }
+#endif
+
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+        {
+            try
+            {
+                return s_utf8Encoding.GetChars(bytes, byteIndex, byteCount, chars, charIndex);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetChars(bytes, byteIndex, byteCount, chars, charIndex);
+            }
+        }
+
+        public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
+        {
+            try
+            {
+                return s_utf8Encoding.GetChars(bytes, byteCount, chars, charCount);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetChars(bytes, byteCount, chars, charCount);
+            }
+        }
+
+        public override int GetMaxByteCount(int charCount)
+        {
+            return s_utf8Encoding.GetMaxByteCount(charCount);
+        }
+
+        public override int GetMaxCharCount(int byteCount)
+        {
+            return s_utf8Encoding.GetMaxCharCount(byteCount);
         }
     }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadT61String.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadT61String.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.Asn1;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests.Asn1
+{
+    public sealed class ReadT61String : Asn1ReaderTests
+    {
+        public static IEnumerable<object[]> ValidEncodingData { get; } =
+            new object[][]
+            {
+                // https://github.com/dotnet/corefx/issues/27466
+                new object[]
+                {
+                    PublicEncodingRules.DER,
+                    "140E47726170654369747920696E632E",
+                    "GrapeCity inc.",
+                },
+                new object[]
+                {
+                    PublicEncodingRules.DER,
+                    "1411546F6F6C7320446576656C6F706D656E74",
+                    "Tools Development",
+                },
+                // Mono test case taken from old bug report
+                new object[]
+                {
+                    PublicEncodingRules.DER,
+                    "14244865646562792773204DF862656C68616E64656C202F2F204356523A3133343731393637",
+                    "Hedeby's M\u00f8belhandel // CVR:13471967",
+                },
+                new object[]
+                {
+                    PublicEncodingRules.DER,
+                    "14264865646562792773204DF862656C68616E64656C202D2053616C6773616664656C696E67656E",
+                    "Hedeby's M\u00f8belhandel - Salgsafdelingen",
+                },
+                // Valid UTF-8 string is interpreted as UTF-8
+                new object[]
+                {
+                    PublicEncodingRules.DER,
+                    "1402C2A2",
+                    "\u00a2",
+                },
+                // Invalid UTF-8 string with valid UTF-8 sequence is interpreted as ISO 8859-1
+                new object[]
+                {
+                    PublicEncodingRules.DER,
+                    "1403C2A2F8",
+                    "\u00c2\u00a2\u00f8",
+                },
+            };
+
+        [Theory]
+        [MemberData(nameof(ValidEncodingData))]
+        public static void GetT61String_Success(
+            PublicEncodingRules ruleSet,
+            string inputHex,
+            string expectedValue)
+        {
+            byte[] inputData = inputHex.HexToByteArray();
+            AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
+            string value = reader.GetCharacterString(UniversalTagNumber.T61String);
+
+            Assert.Equal(expectedValue, value);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidEncodingData))]
+        public static void TryCopyT61String(
+            PublicEncodingRules ruleSet,
+            string inputHex,
+            string expectedValue)
+        {
+            byte[] inputData = inputHex.HexToByteArray();
+            char[] output = new char[expectedValue.Length];
+
+            AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
+            bool copied;
+            int charsWritten;
+
+            if (output.Length > 0)
+            {
+                output[0] = 'a';
+
+                copied = reader.TryCopyCharacterString(
+                    UniversalTagNumber.T61String,
+                    output.AsSpan(0, expectedValue.Length - 1),
+                    out charsWritten);
+
+                Assert.False(copied, "reader.TryCopyT61String - too short");
+                Assert.Equal(0, charsWritten);
+                Assert.Equal('a', output[0]);
+            }
+
+            copied = reader.TryCopyCharacterString(
+                UniversalTagNumber.T61String,
+                output,
+                out charsWritten);
+
+            Assert.True(copied, "reader.TryCopyT61String");
+
+            string actualValue = new string(output, 0, charsWritten);
+            Assert.Equal(expectedValue, actualValue);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadT61String.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadT61String.cs
@@ -49,6 +49,13 @@ namespace System.Security.Cryptography.Tests.Asn1
                     "1402C2A2",
                     "\u00a2",
                 },
+                // Valid UTF-8 string is interpreted as UTF-8 (multi-segment)
+                new object[]
+                {
+                    PublicEncodingRules.BER,
+                    "34800401C20401A20000",
+                    "\u00a2",
+                },
                 // Invalid UTF-8 string with valid UTF-8 sequence is interpreted as ISO 8859-1
                 new object[]
                 {

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -23,6 +23,7 @@
     <Compile Include="Asn1\Reader\ReadOctetString.cs" />
     <Compile Include="Asn1\Reader\ReadSequence.cs" />
     <Compile Include="Asn1\Reader\ReadSetOf.cs" />
+    <Compile Include="Asn1\Reader\ReadT61String.cs" />
     <Compile Include="Asn1\Reader\ReadUtcTime.cs" />
     <Compile Include="Asn1\Reader\ReadUTF8String.cs" />
     <Compile Include="Asn1\Reader\ReaderStateTests.cs" />


### PR DESCRIPTION
I didn't realize that `DerSequenceReader` is basically deprecated in favor of `AsnReader`. T61String support was added to `DerSequenceReader`, so it should also be supported by the newer `AsnReader`.

/cc @bartonjs 