### PR TITLE
release/2.1: improve parsing for IE HTTP proxy setting

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -66,7 +66,13 @@ namespace System.Net.Http
 
             if (proxyHelper.ManualSettingsOnly)
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Info(proxyHelper, $"ManualSettingsUsed, {proxyHelper.Proxy}");
                 ParseProxyConfig(proxyHelper.Proxy, out _insecureProxyUri, out _secureProxyUri);
+                if (_insecureProxyUri == null && _secureProxyUri == null)
+                {
+                    // If advanced parsing by protocol fails, fall-back to simplified parsing.
+                    _insecureProxyUri = _secureProxyUri = GetUriFromString(proxyHelper.Proxy);
+                }
 
                 if (!string.IsNullOrWhiteSpace(proxyHelper.ProxyBypass))
                 {


### PR DESCRIPTION
This is back-port of #31314 to release/2.1

fixes #31242
