### PR TITLE
Do not expand stacktraces when completion exception is rethrown multiple times

### DIFF
--- a/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -238,6 +239,8 @@ namespace System.IO.Pipelines.Tests
             invalidOperationException = await Assert.ThrowsAsync<InvalidOperationException>(async () => await _pipe.Writer.FlushAsync());
             Assert.Equal("Reader exception", invalidOperationException.Message);
             Assert.Contains("ThrowTestException", invalidOperationException.StackTrace);
+
+            Assert.Single(Regex.Matches(invalidOperationException.StackTrace, "Pipe.GetFlushResult"));
         }
 
         [Fact]
@@ -304,6 +307,8 @@ namespace System.IO.Pipelines.Tests
             invalidOperationException = await Assert.ThrowsAsync<InvalidOperationException>(async () => await _pipe.Reader.ReadAsync());
             Assert.Equal("Writer exception", invalidOperationException.Message);
             Assert.Contains("ThrowTestException", invalidOperationException.StackTrace);
+
+            Assert.Single(Regex.Matches(invalidOperationException.StackTrace, "Pipe.GetReadResult"));
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/31388

Because of incorrect usage of ExceptionDispatchInfo exception stack trace is expanded every time it's rethrown https://github.com/dotnet/corefx/issues/31371