### PR TITLE
Fix HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP setup

### DIFF
--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -471,7 +471,7 @@ check_c_source_runs(
         // NOTE: PROT_EXEC and MAP_PRIVATE don't work well with shm_open
         //       on at least the current version of Mac OS X
 
-        if (mmap(nullptr, 1, PROT_EXEC, MAP_PRIVATE, fd, 0) == MAP_FAILED)
+        if (mmap(NULL, 1, PROT_EXEC, MAP_PRIVATE, fd, 0) == MAP_FAILED)
             return -1;
 
         return 0;


### PR DESCRIPTION
Because of build break, HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMA is not determined correctly
```
Performing Test HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP - Failed

Performing C SOURCE FILE Test HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP failed with the following output:
Change Dir: /opt/code/bin/obj/Linux.x64.Release/native/CMakeFiles/CMakeTmp

Run Build Command:"/usr/bin/make" "cmTC_7b088/fast"
/usr/bin/make -f CMakeFiles/cmTC_7b088.dir/build.make CMakeFiles/cmTC_7b088.dir/build
make[1]: Entering directory '/opt/code/bin/obj/Linux.x64.Release/native/CMakeFiles/CMakeTmp'
Building C object CMakeFiles/cmTC_7b088.dir/src.c.o
/usr/bin/clang-3.9    -std=gnu99 -D_GNU_SOURCE -DHAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP -Werror   -o CMakeFiles/cmTC_7b088.dir/src.c.o   -c /opt/code/bin/obj/Linux.x64.Release/native/CMakeFiles/CMakeTmp/src.c
/opt/code/bin/obj/Linux.x64.Release/native/CMakeFiles/CMakeTmp/src.c:17:18: error: use of undeclared identifier 'nullptr'
        if (mmap(nullptr, 1, PROT_EXEC, MAP_PRIVATE, fd, 0) == MAP_FAILED)
                 ^
1 error generated.
CMakeFiles/cmTC_7b088.dir/build.make:65: recipe for target 'CMakeFiles/cmTC_7b088.dir/src.c.o' failed
make[1]: *** [CMakeFiles/cmTC_7b088.dir/src.c.o] Error 1
make[1]: Leaving directory '/opt/code/bin/obj/Linux.x64.Release/native/CMakeFiles/CMakeTmp'
Makefile:126: recipe for target 'cmTC_7b088/fast' failed
make: *** [cmTC_7b088/fast] Error 2

Return value: 1
Source file was:

    #include <sys/mman.h>
    #include <fcntl.h>
    #include <unistd.h>

    int main()
    {
        int fd = shm_open("/corefx_configure_shm_open", O_CREAT | O_RDWR, 0777);
        if (fd == -1)
            return -1;

        shm_unlink("/corefx_configure_shm_open");

        // NOTE: PROT_EXEC and MAP_PRIVATE don't work well with shm_open
        //       on at least the current version of Mac OS X

        if (mmap(nullptr, 1, PROT_EXEC, MAP_PRIVATE, fd, 0) == MAP_FAILED)
            return -1;

        return 0;
    }
```