### PR TITLE
Keep test path under max path when test method names are long

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -84,7 +85,37 @@ namespace System.IO
         /// <param name="index">An optional index value to use as a suffix on the file name.  Typically a loop index.</param>
         /// <param name="memberName">The member name of the function calling this method.</param>
         /// <param name="lineNumber">The line number of the function calling this method.</param>
-        protected string GetTestFileName(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0) =>
+        protected string GetTestFileName(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            string testFileName = GenerateTestFileName(index, memberName, lineNumber);
+            string testFilePath = Path.Combine(TestDirectory, testFileName);
+
+            int excessLength = testFilePath.Length - 255;
+
+            if (excessLength > 0)
+            {
+                // The path will be too long for Windows -- can we
+                // trim memberName to fix it?
+                if (excessLength < memberName.Length + "...".Length)
+                {
+                    // Take a chunk out of the middle as perhaps it's the least interesting part of the name
+                    memberName = memberName.Substring(0, memberName.Length / 2 - excessLength / 2) + "..." + memberName.Substring(memberName.Length / 2 + excessLength / 2);
+
+                    testFileName = GenerateTestFileName(index, memberName, lineNumber);
+                    testFilePath = Path.Combine(TestDirectory, testFileName);
+                }
+                else
+                {
+                    throw new IOException($"Test method name '{memberName}' is too long to make a reasonable test directory path; use a shorter name");
+                }
+            }
+
+            Debug.Assert(testFilePath.Length <= 255 + "...".Length);
+
+            return testFileName;
+        }
+
+        private string GenerateTestFileName(int? index, string memberName, int lineNumber) =>
             string.Format(
                 index.HasValue ? "{0}_{1}_{2}_{3}" : "{0}_{1}_{3}",
                 memberName ?? "TestBase",

--- a/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
@@ -14,6 +14,8 @@ namespace System.IO
     {
         private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
 
+        private string fallbackGuid = Guid.NewGuid().ToString("N");
+
         protected static bool IsProcessElevated => s_isElevated.Value;
 
         /// <summary>Initialize the test class base.  This creates the associated test directory.</summary>
@@ -90,7 +92,9 @@ namespace System.IO
             string testFileName = GenerateTestFileName(index, memberName, lineNumber);
             string testFilePath = Path.Combine(TestDirectory, testFileName);
 
-            int excessLength = testFilePath.Length - 255;
+            const int maxLength = 260 - 5; // Windows MAX_PATH minus a bit
+
+            int excessLength = testFilePath.Length - maxLength;
 
             if (excessLength > 0)
             {
@@ -106,11 +110,11 @@ namespace System.IO
                 }
                 else
                 {
-                    throw new IOException($"Test method name '{memberName}' is too long to make a reasonable test directory path; use a shorter name");
+                    return fallbackGuid;
                 }
             }
 
-            Debug.Assert(testFilePath.Length <= 255 + "...".Length);
+            Debug.Assert(testFilePath.Length <= maxLength + "...".Length);
 
             return testFileName;
         }

--- a/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
@@ -14,7 +14,7 @@ namespace System.IO
     {
         private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
 
-        private string fallbackGuid = Guid.NewGuid().ToString("N");
+        private string fallbackGuid = Guid.NewGuid().ToString("N").Substring(0, 10);
 
         protected static bool IsProcessElevated => s_isElevated.Value;
 


### PR DESCRIPTION
Fix issues like
```
System.IO.IOException : CreateFile or CreateFile2 failed (error code 3): The system cannot find the path specified.
    File name: C:\\Users\\DotNetTestRunner\\AppData\\Local\\Packages\\5cd54353-3ed7-4a6e-a72f-db349f28867c_v52bfwc2c21ha\\AC\\Temp\\ThreadPoolBoundHandleTests_g0a4ac0p.f1g\\AllocateNativeOverlapped_PreAllocated_ReusedReturnedNativeOverlapped_OffsetLowAndOffsetHighSetToZero_206_2f4f5efa
    File path: C:\\Users\\DotNetTestRunner\\AppData\\Local\\Packages\\5cd54353-3ed7-4a6e-a72f-db349f28867c_v52bfwc2c21ha\\AC\\Temp\\ThreadPoolBoundHandleTests_g0a4ac0p.f1g\\AllocateNativeOverlapped_PreAllocated_ReusedReturnedNativeOverlapped_OffsetLowAndOffsetHighSetToZero_206_2f4f5efa
    Successfully wrote to the file.
Stack Trace :
   at HandleFactory.CreateHandle(Boolean async, String fileName) in E:\A\_work\4\s\corefx\src\System.Threading.Overlapped\tests\HandleFactory.cs:line 83
   at ThreadPoolBoundHandleTests.AllocateNativeOverlapped_PreAllocated_ReusedReturnedNativeOverlapped_OffsetLowAndOffsetHighSetToZero() in E:\A\_work\4\s\corefx\src\System.Threading.Overlapped\tests\ThreadPoolBoundHandle_AllocateNativeOverlappedTests.cs:line 206
```