### PR TITLE
Fix networking tests to work against NETFX

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
@@ -30,7 +30,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(-1)]
-        [ActiveIssue(28882, TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NETFX doesn't throw on invalid values")]
         public void Set_InvalidValues_Throws(int invalidValue)
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2729,7 +2729,6 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/28882", TargetFrameworkMonikers.NetFramework)]
         public async Task PostAsync_ThrowFromContentCopy_RequestFails(bool syncFailure)
         {
             await LoopbackServer.CreateServerAsync(async (server, uri) =>
@@ -2748,6 +2747,7 @@ namespace System.Net.Http.Functional.Tests
                         lengthFunc: () => 12345678,
                         positionGetFunc: () => 0,
                         canReadFunc: () => true,
+                        readFunc: (buffer, offset, count) => throw error,
                         readAsyncFunc: (buffer, offset, count, cancellationToken) => syncFailure ? throw error : Task.Delay(1).ContinueWith<int>(_ => throw error)));
 
                     if (PlatformDetection.IsUap)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -207,13 +207,21 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue(28882, TargetFrameworkMonikers.NetFramework)]
         public async Task GetContentAsync_NullResponseContent_ReturnsDefaultValue()
         {
             using (var client = new HttpClient(new CustomResponseHandler((r,c) => Task.FromResult(new HttpResponseMessage() { Content = null }))))
             {
                 Assert.Same(string.Empty, await client.GetStringAsync(CreateFakeUri()));
-                Assert.Same(Array.Empty<byte>(), await client.GetByteArrayAsync(CreateFakeUri()));
+
+                if (PlatformDetection.IsFullFramework)
+                {
+                    Assert.Equal(Array.Empty<byte>(), await client.GetByteArrayAsync(CreateFakeUri()));
+                }
+                else
+                {
+                    Assert.Same(Array.Empty<byte>(), await client.GetByteArrayAsync(CreateFakeUri()));
+                }
+
                 Assert.Same(Stream.Null, await client.GetStreamAsync(CreateFakeUri()));
             }
         }
@@ -343,7 +351,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue(28882, TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework disposes request content after send")]
         public async Task SendAsync_RequestContentNotDisposed()
         {
             var content = new ByteArrayContent(new byte[1]);

--- a/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
@@ -186,7 +186,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue(28882, TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NETFX has smaller size limits")]
         public async Task ReadAsStreamAsync_LargeContent_AllBytesRead()
         {
             var form = new MultipartFormDataContent();
@@ -303,34 +303,37 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue(28882, TargetFrameworkMonikers.NetFramework)]
         public async Task ReadAsStreamAsync_InvalidArgs_Throw()
         {
             var mc = new MultipartContent();
             using (Stream s = await mc.ReadAsStreamAsync())
             {
                 Assert.True(s.CanRead);
-                Assert.False(s.CanWrite);
+                Assert.Equal(PlatformDetection.IsFullFramework, s.CanWrite);
                 Assert.True(s.CanSeek);
 
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => s.Read(null, 0, 0));
+                AssertExtensions.Throws<ArgumentNullException>("buffer", null, () => s.Read(null, 0, 0));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => s.Read(new byte[1], -1, 0));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => s.Read(new byte[1], 0, -1));
-                AssertExtensions.Throws<ArgumentException>("buffer", () => s.Read(new byte[1], 1, 1));
+                AssertExtensions.Throws<ArgumentException>("buffer", null, () => s.Read(new byte[1], 1, 1));
 
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { s.ReadAsync(null, 0, 0); });
+                AssertExtensions.Throws<ArgumentNullException>("buffer", null, () => { s.ReadAsync(null, 0, 0); });
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { s.ReadAsync(new byte[1], -1, 0); });
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => { s.ReadAsync(new byte[1], 0, -1); });
-                AssertExtensions.Throws<ArgumentException>("buffer", () => { s.ReadAsync(new byte[1], 1, 1); });
+                AssertExtensions.Throws<ArgumentException>("buffer", null, () => { s.ReadAsync(new byte[1], 1, 1); });
 
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => s.Position = -1);
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => s.Seek(-1, SeekOrigin.Begin));
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("origin", () => s.Seek(0, (SeekOrigin)42));
 
-                Assert.Throws<NotSupportedException>(() => s.Write(new byte[1], 0, 0));
-                Assert.Throws<NotSupportedException>(() => s.Write(new Span<byte>(new byte[1], 0, 0)));
-                Assert.Throws<NotSupportedException>(() => { s.WriteAsync(new byte[1], 0, 0); });
-                Assert.Throws<NotSupportedException>(() => s.SetLength(1));
+                // NETFX is not throwing exceptions but probably should since the stream should be considered read-only.
+                if (!PlatformDetection.IsFullFramework)
+                {
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => s.Seek(-1, SeekOrigin.Begin));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("origin", () => s.Seek(0, (SeekOrigin)42));
+                    Assert.Throws<NotSupportedException>(() => s.Write(new byte[1], 0, 0));
+                    Assert.Throws<NotSupportedException>(() => s.Write(new Span<byte>(new byte[1], 0, 0)));
+                    Assert.Throws<NotSupportedException>(() => { s.WriteAsync(new byte[1], 0, 0); });
+                    Assert.Throws<NotSupportedException>(() => s.SetLength(1));
+                }
             }
         }
 
@@ -356,7 +359,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue(28882, TargetFrameworkMonikers.NetFramework)]
         public async Task ReadAsStreamAsync_CreateContentReadStreamAsyncThrows_ExceptionStoredInTask()
         {
             var mc = new MultipartContent();
@@ -415,7 +417,9 @@ namespace System.Net.Http.Functional.Tests
 
             protected override bool TryComputeLength(out long length)
             {
-                throw new NotImplementedException();
+                length = 0;
+
+                return false;
             }
 
             protected override Task<Stream> CreateContentReadStreamAsync()

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -787,7 +787,6 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
-        [ActiveIssue(28882, TargetFrameworkMonikers.NetFramework)]
         public async Task SendRecv_DisposeDuringPendingReceive_ThrowsSocketException()
         {
             if (UsesSync) return; // if sync, can't guarantee call will have been initiated by time of disposal

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
@@ -126,8 +126,6 @@ namespace System.Net.Sockets.Tests
 
     public class SocketHelperTask : SocketHelperBase
     {
-        public override bool DisposeDuringOperationResultsInDisposedException =>
-            PlatformDetection.IsFullFramework; // due to SocketTaskExtensions.netfx implementation wrapping APM rather than EAP
         public override Task<Socket> AcceptAsync(Socket s) =>
             s.AcceptAsync();
         public override Task<Socket> AcceptAsync(Socket s, Socket acceptSocket) =>


### PR DESCRIPTION
Several of these tests were disabled because they failed on NETFX. This PR adjusts the tests
to work properly on NETFX due to some differences in behavior from .NET Core.

Fixes #28882