### PR TITLE
Seal Appdomain to match NETFX

### DIFF
--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -8,7 +8,7 @@
 
 namespace System
 {
-    public partial class AppDomain : System.MarshalByRefObject
+    public sealed partial class AppDomain : System.MarshalByRefObject
     {
         private AppDomain() { }
         public static AppDomain CurrentDomain { get { throw null; } }

--- a/src/System.Runtime.Extensions/src/System/AppDomain.cs
+++ b/src/System.Runtime.Extensions/src/System/AppDomain.cs
@@ -14,7 +14,7 @@ using System.Threading;
 
 namespace System
 {
-    public partial class AppDomain : MarshalByRefObject
+    public sealed partial class AppDomain : MarshalByRefObject
     {
         private static readonly AppDomain s_domain = new AppDomain();
         private readonly object _forLock = new object();


### PR DESCRIPTION
Fix #31391

I assume we are OK with the theoretical breaking change from .NET Core 2.0/2.1 based on the assumption next to nobody has subclassed AppDomain.