### PR TITLE
Add Strings.Filter methods (#31181)

### DIFF
--- a/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
+++ b/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
@@ -14,6 +14,11 @@ namespace Microsoft.VisualBasic
         Method = 1,
         Set = 8,
     }
+    public enum CompareMethod
+    { 
+        Binary = 0,
+        Text = 1,
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=false, AllowMultiple=false)]
     public sealed partial class ComClassAttribute : System.Attribute
     {
@@ -41,6 +46,8 @@ namespace Microsoft.VisualBasic
         public const string vbNullString = null;
         public const string vbTab = "\t";
         public const string vbVerticalTab = "\v";
+        public const CompareMethod vbBinaryCompare = CompareMethod.Binary;
+        public const CompareMethod vbTextCompare = CompareMethod.Text;
     }
     public sealed partial class ControlChars
     {
@@ -101,6 +108,8 @@ namespace Microsoft.VisualBasic
         public static int AscW(string String) { throw null; }
         public static char Chr(int CharCode) { throw null; }
         public static char ChrW(int CharCode) { throw null; }
+        public static string[] Filter(object[] Source, string Match, bool Include = true, [Microsoft.VisualBasic.CompilerServices.OptionCompareAttribute] CompareMethod Compare = CompareMethod.Binary) { throw null; }
+        public static string[] Filter(string[] Source, string Match, bool Include = true, [Microsoft.VisualBasic.CompilerServices.OptionCompareAttribute] CompareMethod Compare = CompareMethod.Binary) { throw null; }
         public static string Left(string str, int Length) { throw null; }
         public static string LTrim(string str) { throw null; }
         public static string Mid(string str, int Start) { throw null; }

--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.vbproj
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.vbproj
@@ -41,6 +41,7 @@
     <Compile Include="Microsoft\VisualBasic\CompilerServices\Utils.LateBinder.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\Utils.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\Versioned.vb" />
+    <Compile Include="Microsoft\VisualBasic\Globals.vb" />
     <Compile Include="Microsoft\VisualBasic\Devices\NetworkAvailableEventArgs.vb" />
     <Compile Include="Microsoft\VisualBasic\ComClassAttribute.vb" />
     <Compile Include="Microsoft\VisualBasic\Constants.vb" />

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Constants.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Constants.vb
@@ -16,5 +16,9 @@ Namespace Global.Microsoft.VisualBasic
         Public Const vbVerticalTab As String = ChrW(11)
         Public Const vbNullChar As String = ChrW(0)
         Public Const vbNullString As String = Nothing
+
+        'vbCompareMethod enum values
+        Public Const vbBinaryCompare As CompareMethod = CompareMethod.Binary
+        Public Const vbTextCompare As CompareMethod = CompareMethod.Text
     End Module
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Globals.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/Globals.vb
@@ -1,0 +1,10 @@
+' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Namespace Global.Microsoft.VisualBasic
+    Public Enum CompareMethod
+        [Binary] = 0
+        [Text] = 1
+    End Enum
+End Namespace

--- a/src/Microsoft.VisualBasic/tests/StringsTests.cs
+++ b/src/Microsoft.VisualBasic/tests/StringsTests.cs
@@ -105,6 +105,82 @@ namespace Microsoft.VisualBasic.Tests
         }
 
         [Theory]
+        [InlineData(new string[] { }, null, null)]
+        [InlineData(new string[] { }, "", null)]
+        public void Filter_WhenNoMatchArgument_ReturnsNull(string[] source, string match, string[] expected)
+        {
+            Assert.Equal(expected, Strings.Filter(source, match));
+        }
+
+        [Theory]
+        [InlineData(new string[] { }, "a", new string[] { }, new string[] { })]
+        public void NoElements(string[] source, string match, string[] includeExpected, string[] excludeExpected)
+        {
+            Assert.Equal(includeExpected, Strings.Filter(source, match, Include: true));
+            Assert.Equal(excludeExpected, Strings.Filter(source, match, Include: false));
+        }
+
+        [Theory]
+        [InlineData(new string[] { }, "a", new string[] { }, new string[] { })]
+        [InlineData(new string[] { "a" }, "a", new string[] { "a" }, new string[] { })]
+        [InlineData(new string[] { "ab" }, "a", new string[] { "ab" }, new string[] { })]
+        [InlineData(new string[] { "ba" }, "a", new string[] { "ba" }, new string[] { })]
+        [InlineData(new string[] { "bab" }, "a", new string[] { "bab" }, new string[] { })]
+        [InlineData(new string[] { "b" }, "a", new string[] { }, new string[] { "b" })]
+        [InlineData(new string[] { "a" }, "ab", new string[] { }, new string[] { "a" })]
+        [InlineData(new string[] { "ab" }, "ab", new string[] { "ab" }, new string[] { })]
+        public void Filter_SingleElement(string[] source, string match, string[] includeExpected, string[] excludeExpected)
+        {
+            Assert.Equal(includeExpected, Strings.Filter(source, match, Include: true));
+            Assert.Equal(excludeExpected, Strings.Filter(source, match, Include: false));
+        }
+
+        [Theory]
+        [InlineData(new string[] { "A" }, "a", new string[] { }, new string[] { "A" })]
+        public void Filter_SingleElement_BinaryCompare(string[] source, string match, string[] includeExpected, string[] excludeExpected)
+        {
+            Assert.Equal(includeExpected, Strings.Filter(source, match, Include: true, Compare: CompareMethod.Binary));
+            Assert.Equal(excludeExpected, Strings.Filter(source, match, Include: false, Compare: CompareMethod.Binary));
+        }
+
+        [Theory]
+        [InlineData(new string[] { "A" }, "a", new string[] { "A" }, new string[] { })]
+        public void Filter_SingleElement_TextCompare(string[] source, string match, string[] includeExpected, string[] excludeExpected)
+        {
+            Assert.Equal(includeExpected, Strings.Filter(source, match, Include: true, Compare: CompareMethod.Text));
+            Assert.Equal(excludeExpected, Strings.Filter(source, match, Include: false, Compare: CompareMethod.Text));
+        }
+
+        [Theory]
+        [InlineData(new string[] { "a", "a" }, "a", new string[] { "a", "a" }, new string[] { })]
+        [InlineData(new string[] { "a", "b" }, "a", new string[] { "a" }, new string[] { "b" })]
+        [InlineData(new string[] { "b", "a" }, "a", new string[] { "a" }, new string[] { "b" })]
+        [InlineData(new string[] { "b", "b" }, "a", new string[] { }, new string[] { "b", "b" })]
+        public void Filter_MultipleElements(string[] source, string match, string[] includeExpected, string[] excludeExpected)
+        {
+            Assert.Equal(includeExpected, Strings.Filter(source, match, Include: true));
+            Assert.Equal(excludeExpected, Strings.Filter(source, match, Include: false));
+        }
+
+        [Fact]
+        public void Filter_Objects_WhenObjectCannotBeConvertedToString_ThrowsArgumentOutOfRangeException()
+        {
+            var source = new object[] { typeof(object) };
+            var match = "a";
+
+            AssertExtensions.Throws<ArgumentException>("Source", null, () => Strings.Filter(source, match));
+        }
+
+        [Theory]
+        [InlineData(new object[] { 42 }, "42", new string[] { "42" }, new string[] { })]
+        [InlineData(new object[] { true }, "True", new string[] { "True" }, new string[] { })]
+        public void Objects(object[] source, string match, string[] includeExpected, string[] excludeExpected)
+        {
+            Assert.Equal(includeExpected, Strings.Filter(source, match, Include: true));
+            Assert.Equal(excludeExpected, Strings.Filter(source, match, Include: false));
+        }
+
+        [Theory]
         [InlineData("a", -1)]
         public void Left_Invalid(string str, int length)
         {


### PR DESCRIPTION
I ported `Strings.Filter`. Part of issue #31181.

Work is completed except for the test 'Filter_WhenSourceIsMultiDimensional_ThrowsArgumentException'. I don't know how to pass an array with a rank other than 1 into the method. I think it isn't possible at all. If so, should we skip the test or should we remove the test on `Source.Rank`?