### PR TITLE
Move CryptMsgClose to Common Interop from Pkcs and X509

### DIFF
--- a/src/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgClose.cs
+++ b/src/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgClose.cs
@@ -3,11 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
-
-using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -151,7 +151,6 @@
     <Compile Include="Interop\Windows\Crypt32\Interop.CryptEncodeDecodeWrappers.cs" />
     <Compile Include="Interop\Windows\Crypt32\Interop.CryptEncodeObject.cs" />
     <Compile Include="Interop\Windows\Crypt32\Interop.CryptKeySpec.cs" />
-    <Compile Include="Interop\Windows\Crypt32\Interop.CryptMsgClose.cs" />
     <Compile Include="Interop\Windows\Crypt32\Interop.CryptMsgControl.cs" />
     <Compile Include="Interop\Windows\Crypt32\Interop.CryptMsgGetParam.cs" />
     <Compile Include="Interop\Windows\Crypt32\Interop.CryptMsgOpenToDecode.cs" />
@@ -172,6 +171,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgClose.cs">
+      <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgClose.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.DATA_BLOB.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.DATA_BLOB.cs</Link>

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -312,9 +312,6 @@ internal static partial class Interop
         private static extern bool CertVerifyCertificateChainPolicy(IntPtr pszPolicyOID, SafeX509ChainHandle pChainContext, [In] ref CERT_CHAIN_POLICY_PARA pPolicyPara, [In, Out] ref CERT_CHAIN_POLICY_STATUS pPolicyStatus);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern bool CryptMsgClose(IntPtr hCryptMsg);
-        
-        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern unsafe bool CryptImportPublicKeyInfoEx2(CertEncodingType dwCertEncodingType, CERT_PUBLIC_KEY_INFO* pInfo, int dwFlags, void* pvAuxInfo, out SafeBCryptKeyHandle phKey);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
@@ -215,7 +215,7 @@ namespace Internal.Cryptography.Pal.Native
     {
         protected sealed override bool ReleaseHandle()
         {
-            bool success = Interop.crypt32.CryptMsgClose(handle);
+            bool success = Interop.Crypt32.CryptMsgClose(handle);
             return success;
         }
     }

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -112,6 +112,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertCloseStore.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertCloseStore.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgClose.cs">
+      <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgClose.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs</Link>
     </Compile>


### PR DESCRIPTION
Work for #30513

- Move `Interop.CryptMsgClose.cs` from `Pkcs` to Common
- Reference the Common version in `Pkcs` and `X509Certificates`