### PR TITLE
Add PipeStream.FlushAsync

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -374,6 +374,13 @@ namespace System.IO.Pipes
             }
         }
 
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            // Just throw exceptions -- we do no I/O in this method.
+            Flush();
+            return Task.CompletedTask;
+        }
+
         protected override void Dispose(bool disposing)
         {
             try


### PR DESCRIPTION
This saves GC pressure by avoiding a TaskFactory.StartNew call in the base FlushAsync implementation.

As PerfView shows below, 2K is allocated by the threadpool when the default `Stream.FlushAsync` implementation runs (or at least, sometimes when it runs). Besides adding GC pressure, this slows down IPC by requiring a thread pool scheduled task to execute (with nearly nothing inside) before completing the returned task. 

![image](https://user-images.githubusercontent.com/3548/43361515-82439284-928d-11e8-9f7c-7c378fd0ba80.png)
