### PR TITLE
Enable strict globally, fix comparison of IntPtr, Guid with null

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -241,6 +241,8 @@
   <!-- Language configuration -->
   <PropertyGroup>
     <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
+    <!-- Enables Strict mode for Roslyn compiler -->
+    <Features>strict</Features>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -3,6 +3,11 @@
     <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <!-- 
+    We wish to test operations that would result in
+    "Operator '-' cannot be applied to operands of type 'ushort' and 'EnumArithmeticTests.UInt16Enum'"
+    -->
+    <Features>$(Features.Replace('strict', '')</Features>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AccessTests.cs" />

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/AllHeaders/TDSTraceHeader.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/AllHeaders/TDSTraceHeader.cs
@@ -68,7 +68,7 @@ namespace Microsoft.SqlServer.TDS.AllHeaders
             byte[] guidBytes = new byte[16];
 
             // Check if activity ID is available
-            if (ActivityID != null)
+            if (ActivityID != Guid.Empty)
             {
                 guidBytes = ActivityID.ToByteArray();
             }

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/LoudListener.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/LoudListener.cs
@@ -27,7 +27,7 @@ namespace BasicEventSourceTests
             t_lastEvent = eventData;
 
             Debug.Write(string.Format("Event {0} ", eventData.EventId));
-            Debug.Write(string.Format(" (activity {0}{1}) ", eventData.ActivityId, eventData.RelatedActivityId != null ? "->" + eventData.RelatedActivityId : ""));
+            Debug.Write(string.Format(" (activity {0}{1}) ", eventData.ActivityId, eventData.RelatedActivityId != Guid.Empty ? "->" + eventData.RelatedActivityId : ""));
             Debug.WriteLine(string.Format(" ({0}).", eventData.Payload != null ? string.Join(", ", eventData.Payload) : ""));
         }
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
@@ -29,6 +29,7 @@ namespace System.IO.Pipelines
             _canceledState = CanceledState.NotCanceled;
             _completion = completed ? s_awaitableIsCompleted : s_awaitableIsNotCompleted;
             _completionState = null;
+            _cancellationToken = CancellationToken.None;
             _cancellationTokenRegistration = default;
             _synchronizationContext = null;
             _executionContext = null;

--- a/src/System.Management/src/System/Management/ManagementScope.cs
+++ b/src/System.Management/src/System/Management/ManagementScope.cs
@@ -382,7 +382,7 @@ namespace System.Management
         static bool LoadDelegate<TDelegate>(ref TDelegate delegate_f, IntPtr hModule, string procName) where TDelegate : class
         {
             IntPtr procAddr = Interop.Kernel32.GetProcAddress(hModule, procName);
-            return procAddr != null &&
+            return procAddr != IntPtr.Zero &&
                 (delegate_f = Marshal.GetDelegateForFunctionPointer<TDelegate>(procAddr)) != null;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.MultiAgent.cs
@@ -1229,7 +1229,6 @@ namespace System.Net.Http
                     asyncRead = easy._requestContentStream.ReadAsync(
                        new Memory<byte>(sts.Buffer, 0, Math.Min(sts.Buffer.Length, length)), easy._cancellationToken);
                 }
-                Debug.Assert(asyncRead != null, "Badly implemented stream returned a null task from ReadAsync");
 
                 // Even though it's "Async", it's possible this read could complete synchronously or extremely quickly.  
                 // Check to see if it did, in which case we can also satisfy the libcurl request synchronously in this callback.

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/StandardOleMarshalObject.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/StandardOleMarshalObject.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.InteropServices
                 {
                     if (HResults.S_OK == Interop.Ole32.CoGetStandardMarshal(ref riid, pUnknown, dwDestContext, IntPtr.Zero, mshlflags, out pStandardMarshal))
                     {
-                        Debug.Assert(pStandardMarshal != null, "Failed to get marshaler for interface '" + riid.ToString() + "', CoGetStandardMarshal returned S_OK");
+                        Debug.Assert(pStandardMarshal != IntPtr.Zero, "Failed to get marshaler for interface '" + riid.ToString() + "', CoGetStandardMarshal returned S_OK");
                         return pStandardMarshal;
                     }
                 }

--- a/src/System.Runtime/tests/System/HandleTests.cs
+++ b/src/System.Runtime/tests/System/HandleTests.cs
@@ -16,7 +16,7 @@ public static class HandleTests
         Type t = typeof(Derived);
         FieldInfo f = t.GetField(nameof(Base.MyField));
         RuntimeFieldHandle h = f.FieldHandle;
-        Assert.True(h.Value != null);
+        Assert.True(h.Value != IntPtr.Zero);
     }
 
     [Fact]

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
@@ -19,7 +19,6 @@ namespace System.Security.Cryptography
 
         private IncrementalHash(HashAlgorithmName name, HashProvider hash)
         {
-            Debug.Assert(name != null);
             Debug.Assert(!string.IsNullOrEmpty(name.Name));
             Debug.Assert(hash != null);
 
@@ -29,7 +28,6 @@ namespace System.Security.Cryptography
 
         private IncrementalHash(HashAlgorithmName name, HMACCommon hmac)
         {
-            Debug.Assert(name != null);
             Debug.Assert(!string.IsNullOrEmpty(name.Name));
             Debug.Assert(hmac != null);
 

--- a/src/System.Transactions.Local/src/System.Transactions.Local.csproj
+++ b/src/System.Transactions.Local/src/System.Transactions.Local.csproj
@@ -4,6 +4,11 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <!-- 
+    There are many instances of comparing an instance of a struct with null. Until these are all fixed,
+    disable the diagnostic.
+    -->
+    <Features>$(Features.Replace('strict', '')</Features>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup>


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/issues/31447 and https://github.com/dotnet/corefx/issues/31456

```c#
            IntPtr ptr = IntPtr.Zero;
            Console.WriteLine(ptr == null);   // false
            Console.WriteLine(ptr != null);    // true
```
IntPtr should never be compared with null.

I had a cursory look at other uses of GetProcAddress and they all seem to be comparing to IntPtr.Zero as they should, but a Roslyn analyzer would probably be necessary to be sure.