### PR TITLE
Add SocketsHttpHandler AppContext and Env variables for HTTP/2 opt-in

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -28,6 +28,5 @@ namespace System.Net.Http
         public static readonly TimeSpan DefaultPooledConnectionIdleTimeout = TimeSpan.FromMinutes(2);
         public static readonly TimeSpan DefaultExpect100ContinueTimeout = TimeSpan.FromSeconds(1);
         public static readonly TimeSpan DefaultConnectTimeout = Timeout.InfiniteTimeSpan;
-        public static readonly Version DefaultMaxHttpVersion = HttpVersion.Version11;
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -10,6 +10,9 @@ namespace System.Net.Http
     /// <summary>Provides a state bag of settings for configuring HTTP connections.</summary>
     internal sealed class HttpConnectionSettings
     {
+        private const string Http2SupportEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT";
+        private const string Http2SupportAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.Http2Support";
+        
         internal DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
 
         internal bool _useCookies = HttpHandlerDefaults.DefaultUseCookies;
@@ -35,11 +38,16 @@ namespace System.Net.Http
         internal TimeSpan _expect100ContinueTimeout = HttpHandlerDefaults.DefaultExpect100ContinueTimeout;
         internal TimeSpan _connectTimeout = HttpHandlerDefaults.DefaultConnectTimeout;
 
-        internal Version _maxHttpVersion = HttpHandlerDefaults.DefaultMaxHttpVersion;
+        internal Version _maxHttpVersion;
 
         internal SslClientAuthenticationOptions _sslOptions;
 
         internal IDictionary<string, object> _properties;
+
+        public HttpConnectionSettings()
+        {
+            _maxHttpVersion = AllowHttp2 ? HttpVersion.Version20 : HttpVersion.Version11;
+        }
 
         public HttpConnectionSettings Clone()
         {
@@ -73,6 +81,29 @@ namespace System.Net.Http
                 _useCookies = _useCookies,
                 _useProxy = _useProxy,
             };
+        }
+
+        private static bool AllowHttp2
+        {
+            get
+            {
+                // First check for the AppContext switch, giving it priority over the environment variable.
+                if (AppContext.TryGetSwitch(Http2SupportAppCtxSettingName, out bool allowHttp2))
+                {
+                    return allowHttp2;
+                }
+
+                // AppContext switch wasn't used. Check the environment variable.
+                string envVar = Environment.GetEnvironmentVariable(Http2SupportEnvironmentVariableSettingName);
+                if (envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1")))
+                {
+                    // Allow HTTP/2.0 protocol.
+                    return true;
+                }
+
+                // Default to a maximum of HTTP/1.1.
+                return false;
+            }
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -270,22 +270,6 @@ namespace System.Net.Http
             }
         }
 
-        // Internal for now, until API is approved (#30527)
-        internal Version MaxHttpVersion
-        {
-            get => _settings._maxHttpVersion;
-            set
-            {
-                if (value != HttpVersion.Version11 && value != HttpVersion.Version20)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value));
-                }
-
-                CheckDisposedOrStarted();
-                _settings._maxHttpVersion = value;
-            }
-        }
-
         public IDictionary<string, object> Properties =>
             _settings._properties ?? (_settings._properties = new Dictionary<string, object>());
 


### PR DESCRIPTION
The conclusion from the API review meetings was that we are not adding any
new public APIs to control MaxHttpVersion. This PR adds AppContext and
environment variable controls for opting into HTTP/2.0 support for SocketsHttpHandler.

The default for now is that max version is HTTP/1.1 unless these switches are
used. We will re-evaluate changing the default as we get closer to shipping to
determine if HTTP/2.0 support should be on by default.

Fixes #31424