### PR TITLE
Ignores LRM ('\u200E') when decoding hex string

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -36,9 +36,16 @@ namespace Internal.Cryptography
 
         // Decode a hex string-encoded byte array passed to various X509 crypto api.
         // The parsing rules are overly forgiving but for compat reasons, they cannot be tightened.
-        public static byte[] DecodeHexString(this string s)
+        public static byte[] DecodeHexString(this string hexString)
         {
             int whitespaceCount = 0;
+
+            ReadOnlySpan<char> s = hexString;
+
+            if (s.Length != 0 && s[0] == '\u200E')
+            {
+                s = s.Slice(1);
+            }
 
             for (int i = 0; i < s.Length; i++)
             {
@@ -52,7 +59,7 @@ namespace Internal.Cryptography
             bool byteInProgress = false;
             int index = 0;
 
-            for (int i = s.Length != 0 && s[0] == '\u200E' ? 1 : 0; i < s.Length; i++)
+            for (int i = 0; i < s.Length; i++)
             {
                 char c = s[i];
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -52,7 +52,7 @@ namespace Internal.Cryptography
             bool byteInProgress = false;
             int index = 0;
 
-            for (int i = 0; i < s.Length; i++)
+            for (int i = s.Length != 0 && s[0] == '\u200E' ? 1 : 0; i < s.Length; i++)
             {
                 char c = s[i];
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -730,6 +730,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("597 1A6 5A3 34D DA9 807 80F F84 1EB E87 F97 232 41F 2")]
         // Non-symmetric whitespace is allowed
         [InlineData("    5971A65   A334DDA980780FF84  1EBE87F97           23241F   2")]
+        // Should ignore Left-to-right mark \u200E
+        [InlineData("\u200E59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
         public static void TestBySubjectKeyIdentifier_ExtensionPresent(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -180,7 +180,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        public static void FindByThumbprintWithLrm()
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "31463 is not fixed in NetFX")]
+        public static void FindByThumbprint_WithLrm()
         {
             RunTest(
                 (msCer, pfxCer, col1) =>
@@ -682,6 +683,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "31463 is not fixed in NetFX")]
         public static void TestBySerialNumber_WithLRM()
         {
             // Hex string is also an allowed input format and case-blind
@@ -764,9 +766,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("597 1A6 5A3 34D DA9 807 80F F84 1EB E87 F97 232 41F 2")]
         // Non-symmetric whitespace is allowed
         [InlineData("    5971A65   A334DDA980780FF84  1EBE87F97           23241F   2")]
-        // Should ignore Left-to-right mark \u200E
-        [InlineData(_leftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
         public static void TestBySubjectKeyIdentifier_ExtensionPresent(string subjectKeyIdentifier)
+        {
+            RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
+        }
+
+        // Should ignore Left-to-right mark \u200E
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "31463 is not fixed in NetFX")]
+        [InlineData(_leftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
+        public static void TestBySubjectKeyIdentifier_ExtensionPresentWithLTM(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 {
     public static class FindTests
     {
-        private const string _leftToRightMark = "\u200E";
+        private const string LeftToRightMark = "\u200E";
 
         private static void RunTest(Action<X509Certificate2Collection> test)
         {
@@ -190,7 +190,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         pfxCer,
                         col1,
                         X509FindType.FindByThumbprint,
-                        _leftToRightMark + pfxCer.Thumbprint);
+                        LeftToRightMark + pfxCer.Thumbprint);
                 });
         }
 
@@ -689,7 +689,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // Hex string is also an allowed input format and case-blind
             RunSingleMatchTest_PfxCer(
                 X509FindType.FindBySerialNumber,
-                _leftToRightMark + "d5 b5 bc 1c 45 8a 55 88 45 bf f5 1c b4 df f3 1c");
+                LeftToRightMark + "d5 b5 bc 1c 45 8a 55 88 45 bf f5 1c b4 df f3 1c");
         }
 
         [Fact]
@@ -774,7 +774,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         // Should ignore Left-to-right mark \u200E
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "31463 is not fixed in NetFX")]
-        [InlineData(_leftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
+        [InlineData(LeftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
+        // Compat: Lone trailing nybbles are ignored
+        [InlineData(LeftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2 3")]
+        // Compat: Lone trailing nybbles are ignored, even if not hex
+        [InlineData(LeftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2 p")]
         public static void TestBySubjectKeyIdentifier_ExtensionPresentWithLTM(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);

--- a/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -14,6 +14,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 {
     public static class FindTests
     {
+        private const string _leftToRightMark = "\u200E";
+
         private static void RunTest(Action<X509Certificate2Collection> test)
         {
             RunTest((msCer, pfxCer, col1) => test(col1));
@@ -174,6 +176,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         col1,
                         X509FindType.FindByThumbprint,
                         pfxCer.Thumbprint);
+                });
+        }
+
+        [Fact]
+        public static void FindByThumbprintWithLrm()
+        {
+            RunTest(
+                (msCer, pfxCer, col1) =>
+                {
+                    EvaluateSingleMatch(
+                        pfxCer,
+                        col1,
+                        X509FindType.FindByThumbprint,
+                        _leftToRightMark + pfxCer.Thumbprint);
                 });
         }
 
@@ -657,6 +673,24 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void TestBySerialNumber_WithSpaces()
+        {
+            // Hex string is also an allowed input format and case-blind
+            RunSingleMatchTest_PfxCer(
+                X509FindType.FindBySerialNumber,
+                "d5 b5 bc 1c 45 8a 55 88 45 bf f5 1c b4 df f3 1c");
+        }
+
+        [Fact]
+        public static void TestBySerialNumber_WithLRM()
+        {
+            // Hex string is also an allowed input format and case-blind
+            RunSingleMatchTest_PfxCer(
+                X509FindType.FindBySerialNumber,
+                _leftToRightMark + "d5 b5 bc 1c 45 8a 55 88 45 bf f5 1c b4 df f3 1c");
+        }
+
+        [Fact]
         public static void TestBySerialNumber_NoMatch()
         {
             RunZeroMatchTest(
@@ -731,7 +765,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         // Non-symmetric whitespace is allowed
         [InlineData("    5971A65   A334DDA980780FF84  1EBE87F97           23241F   2")]
         // Should ignore Left-to-right mark \u200E
-        [InlineData("\u200E59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
+        [InlineData(_leftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2")]
         public static void TestBySubjectKeyIdentifier_ExtensionPresent(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);


### PR DESCRIPTION
Fixes #31463