### PR TITLE
Disable 2 test classes for UAP

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -574,7 +574,7 @@ namespace System.Net.Http.Functional.Tests
                             new UriBuilder(uri) { Scheme = "https" }.ToString()), default));
                     sw.Stop();
 
-                    Assert.InRange(sw.ElapsedMilliseconds, 500, 30_000);
+                    Assert.InRange(sw.ElapsedMilliseconds, 500, 60_000);
                     releaseServer.SetResult(true);
                 }
             }, server => releaseServer.Task); // doesn't establish SSL connection

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Marshalling between VARIANT and Object is not supported in AppX")]
     public class GetObjectForNativeVariantTests
     {
         [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectsForNativeVariantsTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectsForNativeVariantsTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Marshalling between VARIANT and Object is not supported in AppX")]
     public class GetObjectsForNativeVariantsTests
     {
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
CoreCLR throws for these tests here when in appx
https://github.com/dotnet/coreclr/search?l=C%2B%2B&q=IDS_EE_BADMARSHAL_TYPE_VARIANTASOBJECT

causing
https://mc.dot.net/#/product/netcore/30/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fuwp~2F/build/20180730.01/workItem/System.Runtime.InteropServices.Tests

Also increased an Http test timeout where I saw a failure because it was 37 sec instead of 0-30 sec.