### PR TITLE
Skip Linq test for UWP

### DIFF
--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -256,7 +256,7 @@ namespace System.Linq.Tests
             {
                 // The full .NET Framework uses unsigned arithmetic summing up collection counts.
                 // See https://github.com/dotnet/corefx/pull/11492.
-                if (PlatformDetection.IsFullFramework)
+                if (!PlatformDetection.IsNetCore)
                 {
                     testCode();
                 }


### PR DESCRIPTION
Fix #31088 as suggested there.