### PR TITLE
System.Security: Move X509ExtensionAsn to common classes; remove Certificate, TbsCerti…

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.cs
@@ -3,25 +3,22 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.Asn1;
 using System.Security.Cryptography.X509Certificates;
 using Internal.Cryptography;
 
-namespace System.Security.Cryptography.Pkcs.Asn1
+namespace System.Security.Cryptography.Asn1
 {
     [StructLayout(LayoutKind.Sequential)]
     internal struct X509ExtensionAsn
     {
         [ObjectIdentifier]
-        internal string ExtnId;
+        public string ExtnId;
 
-#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
         [DefaultValue(0x01, 0x01, 0x00)]
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
-        internal bool Critical;
+        public bool Critical;
 
         [OctetString]
-        internal ReadOnlyMemory<byte> ExtnValue;
+        public ReadOnlyMemory<byte> ExtnValue;
 
         public X509ExtensionAsn(X509Extension extension, bool copyValue=true)
         {

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Helpers.cs
@@ -418,12 +418,17 @@ namespace Internal.Cryptography
             //
             // https://msdn.microsoft.com/en-us/library/windows/desktop/aa376079%28v=vs.85%29.aspx
 
+            PublicKey key = certificate.PublicKey;
+            SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn();
+            spki.Algorithm = new AlgorithmIdentifierAsn { Algorithm = key.Oid, Parameters = key.EncodedParameters.RawData };
+            spki.SubjectPublicKey = key.EncodedKeyValue.RawData;
+
+            using (AsnWriter writer = AsnSerializer.Serialize(spki, AsnEncodingRules.DER))
 #pragma warning disable CA5350 // SHA-1 is required for compat.
             using (HashAlgorithm hash = SHA1.Create())
 #pragma warning restore CA5350 // Do not use insecure cryptographic algorithm SHA1.
             {
-                ReadOnlyMemory<byte> publicKeyInfoBytes = GetSubjectPublicKeyInfo(certificate);
-                return hash.ComputeHash(publicKeyInfoBytes.ToArray());
+                return hash.ComputeHash(writer.Encode());
             }
         }
 
@@ -450,12 +455,6 @@ namespace Internal.Cryptography
             }
         }
 
-        private static ReadOnlyMemory<byte> GetSubjectPublicKeyInfo(X509Certificate2 certificate)
-        {
-            var parsedCertificate = AsnSerializer.Deserialize<Certificate>(certificate.RawData, AsnEncodingRules.DER);
-            return parsedCertificate.TbsCertificate.SubjectPublicKeyInfo;
-        }
-
         public static ReadOnlyMemory<byte> DecodeOctetString(ReadOnlyMemory<byte> encodedOctetString)
         {
             AsnReader reader = new AsnReader(encodedOctetString, AsnEncodingRules.BER);
@@ -479,61 +478,6 @@ namespace Internal.Cryptography
 
             Debug.Fail("TryCopyOctetStringBytes failed with an over-allocated array");
             throw new CryptographicException();
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct Certificate
-        {
-            internal TbsCertificateLite TbsCertificate;
-            internal AlgorithmIdentifierAsn AlgorithmIdentifier;
-            [BitString]
-            internal ReadOnlyMemory<byte> SignatureValue;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct TbsCertificateLite
-        {
-            [ExpectedTag(0, ExplicitTag = true)]
-#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
-            [DefaultValue(0xA0, 0x03, 0x02, 0x01, 0x00)]
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
-            internal int Version;
-
-            [Integer]
-            internal ReadOnlyMemory<byte> SerialNumber;
-
-            internal AlgorithmIdentifierAsn AlgorithmIdentifier;
-
-            [AnyValue]
-            [ExpectedTag(TagClass.Universal, (int)UniversalTagNumber.SequenceOf)]
-            internal ReadOnlyMemory<byte> Issuer;
-
-            [AnyValue]
-            [ExpectedTag(TagClass.Universal, (int)UniversalTagNumber.Sequence)]
-            internal ReadOnlyMemory<byte> Validity;
-
-            [AnyValue]
-            [ExpectedTag(TagClass.Universal, (int)UniversalTagNumber.SequenceOf)]
-            internal ReadOnlyMemory<byte> Subject;
-
-            [AnyValue]
-            [ExpectedTag(TagClass.Universal, (int)UniversalTagNumber.Sequence)]
-            internal ReadOnlyMemory<byte> SubjectPublicKeyInfo;
-
-            [ExpectedTag(1)]
-            [OptionalValue]
-            [BitString]
-            internal ReadOnlyMemory<byte>? IssuerUniqueId;
-
-            [ExpectedTag(2)]
-            [OptionalValue]
-            [BitString]
-            internal ReadOnlyMemory<byte>? SubjectUniqueId;
-
-            [OptionalValue]
-            [AnyValue]
-            [ExpectedTag(3)]
-            internal ReadOnlyMemory<byte>? Extensions;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -273,6 +273,9 @@
     <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.cs">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\X509ExtensionAsn.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.cs</Link>
+    </Compile>
     <Compile Include="System\Security\Cryptography\Pkcs\Asn1\CertificateChoiceAsn.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Asn1\ContentInfoAsn.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Asn1\EncapsulatedContentInfoAsn.cs" />
@@ -288,7 +291,6 @@
     <Compile Include="System\Security\Cryptography\Pkcs\Asn1\SignerIdentifierAsn.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Asn1\SignerInfoAsn.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Asn1\SigningCertificateAsn.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Asn1\X509ExtensionAsn.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\CmsSignature.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\CmsSignature.ECDsa.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\CmsSignature.RSA.cs" />


### PR DESCRIPTION
…ficateLite classes in favor of calculating the SubjectPublicKeyInfoAsn from X509Certificate2 PublicKey data.