### PR TITLE
Disable a Numerics.Vectors test that fails under minopts and tiering

### DIFF
--- a/src/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -884,6 +884,7 @@ namespace System.Numerics.Tests
 
         // A test for Equals (object)
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/19197", TargetFrameworkMonikers.Netcoreapp)]
         public void Vector3EqualsTest()
         {
             Vector3 a = new Vector3(1.0f, 2.0f, 3.0f);


### PR DESCRIPTION
See https://github.com/dotnet/coreclr/issues/19197. This test would always fail in the CI after tiering is enabled by default.

@dotnet/jit-contrib 