### PR TITLE
Improve GdiPlusStreamHelper to use Span stream apis and kill allocations and make it somehow faster

### DIFF
--- a/src/Common/tests/System/Drawing/Helpers.cs
+++ b/src/Common/tests/System/Drawing/Helpers.cs
@@ -46,6 +46,8 @@ namespace System.Drawing
             }
         }
 
+        public static bool IsNotUnix => PlatformDetection.IsWindows;
+
         public static bool IsWindowsRS3OrEarlier => !PlatformDetection.IsWindows10Version1803OrGreater;
 
         public static bool GetRecentGdiPlusIsAvailable2()

--- a/src/System.Drawing.Common/src/System/Drawing/GdiPlusStreamHelper.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiPlusStreamHelper.Unix.cs
@@ -41,164 +41,80 @@ namespace System.Drawing
 {
     internal sealed partial class GdiPlusStreamHelper
     {
-        public Stream stream;
+        private Stream _stream;
 
-        private StreamGetHeaderDelegate sghd = null;
-        private StreamGetBytesDelegate sgbd = null;
-        private StreamSeekDelegate skd = null;
-        private StreamPutBytesDelegate spbd = null;
-        private StreamCloseDelegate scd = null;
-        private StreamSizeDelegate ssd = null;
-        private byte[] start_buf;
-        private int start_buf_pos;
-        private int start_buf_len;
-        private byte[] managedBuf;
-        private const int default_bufsize = 4096;
-
-        public GdiPlusStreamHelper(Stream s, bool seekToOrigin)
+        public unsafe GdiPlusStreamHelper(Stream stream, bool seekToOrigin)
         {
-            managedBuf = new byte[default_bufsize];
-
-            stream = s;
-            if (stream != null && stream.CanSeek && seekToOrigin)
+            // Seeking required
+            if (!stream.CanSeek)
             {
-                stream.Seek(0, SeekOrigin.Begin);
+                var memoryStream = new MemoryStream();
+                stream.CopyTo(memoryStream);
+                _stream = memoryStream;
             }
+            else
+            {
+                _stream = stream;
+            }
+
+            if (seekToOrigin)
+            {
+                _stream.Seek(0, SeekOrigin.Begin);
+            }
+
+            CloseDelegate = new StreamCloseDelegate(StreamCloseImpl);
+            GetBytesDelegate = new StreamGetBytesDelegate(StreamGetBytesImpl);
+            GetHeaderDelegate = new StreamGetHeaderDelegate(StreamGetHeaderImpl);
+            PutBytesDelegate = new StreamPutBytesDelegate(StreamPutBytesImpl);
+            SeekDelegate = new StreamSeekDelegate(StreamSeekImpl);
+            SizeDelegate = new StreamSizeDelegate(StreamSizeImpl);
         }
 
-        public int StreamGetHeaderImpl(IntPtr buf, int bufsz)
+        public unsafe int StreamGetHeaderImpl(byte* buf, int bufsz)
         {
-            int bytesRead;
+            return StreamGetBytesImpl(buf, bufsz, peek: true);
+        }
 
-            start_buf = new byte[bufsz];
+        public unsafe int StreamGetBytesImpl(byte* buf, int bufsz, bool peek)
+        {
+            if ((buf == null && peek) || !_stream.CanRead)
+                return -1;
+
+            if (bufsz <= 0)
+                return 0;
+
+            int read = 0;
+            long originalPosition = 0;
+            if (peek)
+            {
+                originalPosition = _stream.Position;
+            }
 
             try
             {
-                bytesRead = stream.Read(start_buf, 0, bufsz);
+                // Stream Span API isn't available in 2.0
+#if netcoreapp20
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
+                read = _stream.Read(buffer, 0, bufsz);
+                Marshal.Copy(buffer, 0, (IntPtr)buf, read);
+                ArrayPool<byte>.Shared.Return(buffer);
+#else
+                Span<byte> buffer = new Span<byte>(buf, bufsz);
+                read = _stream.Read(buffer);
+#endif
             }
             catch (IOException)
             {
                 return -1;
             }
 
-            if (bytesRead > 0 && buf != IntPtr.Zero)
+            if (peek)
             {
-                Marshal.Copy(start_buf, 0, (IntPtr)(buf.ToInt64()), bytesRead);
+                // If we are peeking bytes, then go back to original position before peeking
+                _stream.Seek(originalPosition, SeekOrigin.Begin);
             }
 
-            start_buf_pos = 0;
-            start_buf_len = bytesRead;
-
-            return bytesRead;
-        }
-
-        public StreamGetHeaderDelegate GetHeaderDelegate
-        {
-            get
-            {
-                if (stream != null && stream.CanRead)
-                {
-                    if (sghd == null)
-                    {
-                        sghd = new StreamGetHeaderDelegate(StreamGetHeaderImpl);
-                    }
-                    return sghd;
-                }
-                return null;
-            }
-        }
-
-        public int StreamGetBytesImpl(IntPtr buf, int bufsz, bool peek)
-        {
-            if (buf == IntPtr.Zero && peek)
-            {
-                return -1;
-            }
-
-            if (bufsz > managedBuf.Length)
-                managedBuf = new byte[bufsz];
-            int bytesRead = 0;
-            long streamPosition = 0;
-
-            if (bufsz > 0)
-            {
-                if (stream.CanSeek)
-                {
-                    streamPosition = stream.Position;
-                }
-                if (start_buf_len > 0)
-                {
-                    if (start_buf_len > bufsz)
-                    {
-                        Array.Copy(start_buf, start_buf_pos, managedBuf, 0, bufsz);
-                        start_buf_pos += bufsz;
-                        start_buf_len -= bufsz;
-                        bytesRead = bufsz;
-                        bufsz = 0;
-                    }
-                    else
-                    {
-                        // this is easy
-                        Array.Copy(start_buf, start_buf_pos, managedBuf, 0, start_buf_len);
-                        bufsz -= start_buf_len;
-                        bytesRead = start_buf_len;
-                        start_buf_len = 0;
-                    }
-                }
-
-                if (bufsz > 0)
-                {
-                    try
-                    {
-                        bytesRead += stream.Read(managedBuf, bytesRead, bufsz);
-                    }
-                    catch (IOException)
-                    {
-                        return -1;
-                    }
-                }
-
-                if (bytesRead > 0 && buf != IntPtr.Zero)
-                {
-                    Marshal.Copy(managedBuf, 0, (IntPtr)(buf.ToInt64()), bytesRead);
-                }
-
-                if (!stream.CanSeek && (bufsz == 10) && peek)
-                {
-                    // Special 'hack' to support peeking of the type for gdi+ on non-seekable streams
-                }
-
-                if (peek)
-                {
-                    if (stream.CanSeek)
-                    {
-                        // If we are peeking bytes, then go back to original position before peeking
-                        stream.Seek(streamPosition, SeekOrigin.Begin);
-                    }
-                    else
-                    {
-                        throw new NotSupportedException();
-                    }
-                }
-            }
-
-            return bytesRead;
-        }
-
-        public StreamGetBytesDelegate GetBytesDelegate
-        {
-            get
-            {
-                if (stream != null && stream.CanRead)
-                {
-                    if (sgbd == null)
-                    {
-                        sgbd = new StreamGetBytesDelegate(StreamGetBytesImpl);
-                    }
-                    return sgbd;
-                }
-                return null;
-            }
+            return read;
         }
 
         public long StreamSeekImpl(int offset, int whence)
@@ -207,103 +123,37 @@ namespace System.Drawing
             if ((whence < 0) || (whence > 2))
                 return -1;
 
-            // Invalidate the start_buf if we're actually going to call a Seek method.
-            start_buf_pos += start_buf_len;
-            start_buf_len = 0;
-
-            SeekOrigin origin;
-
-            // Translate 'whence' into a SeekOrigin enum member.
-            switch (whence)
-            {
-                case 0:
-                    origin = SeekOrigin.Begin;
-                    break;
-                case 1:
-                    origin = SeekOrigin.Current;
-                    break;
-                case 2:
-                    origin = SeekOrigin.End;
-                    break;
-
-                // The following line is redundant but necessary to avoid a
-                // "Use of unassigned local variable" error without actually
-                // initializing 'origin' to a dummy value.
-                default:
-                    return -1;
-            }
-
-            // Do the actual seek operation and return its result.
-            return stream.Seek((long)offset, origin);
+            return _stream.Seek((long)offset, (SeekOrigin)whence);
         }
 
-        public StreamSeekDelegate SeekDelegate
+        public unsafe int StreamPutBytesImpl(byte* buf, int bufsz)
         {
-            get
-            {
-                if (stream != null && stream.CanSeek)
-                {
-                    if (skd == null)
-                    {
-                        skd = new StreamSeekDelegate(StreamSeekImpl);
-                    }
-                    return skd;
-                }
-                return null;
-            }
-        }
+            if (!_stream.CanWrite)
+                return -1;
 
-        public int StreamPutBytesImpl(IntPtr buf, int bufsz)
-        {
-            if (bufsz > managedBuf.Length)
-                managedBuf = new byte[bufsz];
-            Marshal.Copy(buf, managedBuf, 0, bufsz);
-            stream.Write(managedBuf, 0, bufsz);
+            // Stream Span API isn't available in 2.0
+#if netcoreapp20
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
+            Marshal.Copy((IntPtr)buf, buffer, 0, bufsz);
+            _stream.Write(buffer, 0, bufsz);
+            ArrayPool<byte>.Shared.Return(buffer);
+#else
+            Span<byte> buffer = new Span<byte>(buf, bufsz);
+            _stream.Write(buffer);
+#endif
             return bufsz;
-        }
-
-        public StreamPutBytesDelegate PutBytesDelegate
-        {
-            get
-            {
-                if (stream != null && stream.CanWrite)
-                {
-                    if (spbd == null)
-                    {
-                        spbd = new StreamPutBytesDelegate(StreamPutBytesImpl);
-                    }
-                    return spbd;
-                }
-                return null;
-            }
         }
 
         public void StreamCloseImpl()
         {
-            stream.Dispose();
-        }
-
-        public StreamCloseDelegate CloseDelegate
-        {
-            get
-            {
-                if (stream != null)
-                {
-                    if (scd == null)
-                    {
-                        scd = new StreamCloseDelegate(StreamCloseImpl);
-                    }
-                    return scd;
-                }
-                return null;
-            }
+            _stream.Dispose();
         }
 
         public long StreamSizeImpl()
         {
             try
             {
-                return stream.Length;
+                return _stream.Length;
             }
             catch
             {
@@ -311,20 +161,11 @@ namespace System.Drawing
             }
         }
 
-        public StreamSizeDelegate SizeDelegate
-        {
-            get
-            {
-                if (stream != null)
-                {
-                    if (ssd == null)
-                    {
-                        ssd = new StreamSizeDelegate(StreamSizeImpl);
-                    }
-                    return ssd;
-                }
-                return null;
-            }
-        }
+        public StreamCloseDelegate CloseDelegate { get; }
+        public StreamGetBytesDelegate GetBytesDelegate { get; }
+        public StreamGetHeaderDelegate GetHeaderDelegate { get; }
+        public StreamPutBytesDelegate PutBytesDelegate { get; }
+        public StreamSeekDelegate SeekDelegate { get; }
+        public StreamSizeDelegate SizeDelegate { get; }
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -1090,10 +1090,10 @@ namespace System.Drawing
     }
 
     // These are unix-only
-    internal delegate int StreamGetHeaderDelegate(IntPtr buf, int bufsz);
-    internal delegate int StreamGetBytesDelegate(IntPtr buf, int bufsz, bool peek);
+    internal unsafe delegate int StreamGetHeaderDelegate(byte* buf, int bufsz);
+    internal unsafe delegate int StreamGetBytesDelegate(byte* buf, int bufsz, bool peek);
     internal delegate long StreamSeekDelegate(int offset, int whence);
-    internal delegate int StreamPutBytesDelegate(IntPtr buf, int bufsz);
+    internal unsafe delegate int StreamPutBytesDelegate(byte* buf, int bufsz);
     internal delegate void StreamCloseDelegate();
     internal delegate long StreamSizeDelegate();
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.Unix.cs
@@ -60,12 +60,15 @@ namespace System.Drawing.Imaging
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
 
-            int status;
             // With libgdiplus we use a custom API for this, because there's no easy way
             // to get the Stream down to libgdiplus. So, we wrap the stream with a set of delegates.
             GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
-            status = Gdip.GdipCreateMetafileFromDelegate_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
+            int status = Gdip.GdipCreateMetafileFromDelegate_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
                 sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate, sh.SizeDelegate, out nativeImage);
+
+            // Since we're just passing to native code the delegates inside the wrapper, we need to keep sh alive
+            // to avoid the object being collected and therefore the delegates would be collected as well.
+            GC.KeepAlive(sh);
             Gdip.CheckStatus(status);
         }
 
@@ -262,13 +265,16 @@ namespace System.Drawing.Imaging
             if (stream == null)
                 throw new NullReferenceException(nameof(stream));
 
-            int status = Gdip.NotImplemented;
             // With libgdiplus we use a custom API for this, because there's no easy way
             // to get the Stream down to libgdiplus. So, we wrap the stream with a set of delegates.
             GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
-            status = Gdip.GdipRecordMetafileFromDelegateI_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
+            int status = Gdip.GdipRecordMetafileFromDelegateI_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
                 sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate, sh.SizeDelegate, referenceHdc,
                 type, ref frameRect, frameUnit, description, out nativeImage);
+
+            // Since we're just passing to native code the delegates inside the wrapper, we need to keep sh alive
+            // to avoid the object being collected and therefore the delegates would be collected as well.
+            GC.KeepAlive(sh);
             Gdip.CheckStatus(status);
         }
 
@@ -277,14 +283,17 @@ namespace System.Drawing.Imaging
         {
             if (stream == null)
                 throw new NullReferenceException(nameof(stream));
-
-            int status = Gdip.NotImplemented;
+            
             // With libgdiplus we use a custom API for this, because there's no easy way
             // to get the Stream down to libgdiplus. So, we wrap the stream with a set of delegates.
             GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
-            status = Gdip.GdipRecordMetafileFromDelegate_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
+            int status = Gdip.GdipRecordMetafileFromDelegate_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
                 sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate, sh.SizeDelegate, referenceHdc,
                 type, ref frameRect, frameUnit, description, out nativeImage);
+
+            // Since we're just passing to native code the delegates inside the wrapper, we need to keep sh alive
+            // to avoid the object being collected and therefore the delegates would be collected as well.
+            GC.KeepAlive(sh);
             Gdip.CheckStatus(status);
         }
 
@@ -355,13 +364,16 @@ namespace System.Drawing.Imaging
             IntPtr header = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(MetafileHeader)));
             try
             {
-                int status;
                 // With libgdiplus we use a custom API for this, because there's no easy way
                 // to get the Stream down to libgdiplus. So, we wrap the stream with a set of delegates.
                 GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
-                status = Gdip.GdipGetMetafileHeaderFromDelegate_linux(sh.GetHeaderDelegate,
+                int status = Gdip.GdipGetMetafileHeaderFromDelegate_linux(sh.GetHeaderDelegate,
                     sh.GetBytesDelegate, sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate,
                     sh.SizeDelegate, header);
+
+                // Since we're just passing to native code the delegates inside the wrapper, we need to keep sh alive
+                // to avoid the object being collected and therefore the delegates would be collected as well.
+                GC.KeepAlive(sh);
                 Gdip.CheckStatus(status);
                 return new MetafileHeader(header);
             }

--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -1717,7 +1717,9 @@ namespace System.Drawing.Tests
             {
                 using (Bitmap bitmap = new Bitmap(new NonSeekableStream(stream)))
                 {
-                    // Should copy successfully
+                    Assert.Equal(100, bitmap.Height);
+                    Assert.Equal(100, bitmap.Width);
+                    Assert.Equal(ImageFormat.Png, bitmap.RawFormat);
                 }
             }
         }

--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -2102,6 +2102,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(CoordinateSpace.Device)]
         [InlineData(CoordinateSpace.World)]
@@ -2120,6 +2121,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(CoordinateSpace.Device)]
         [InlineData(CoordinateSpace.World)]

--- a/src/System.Drawing.Common/tests/Performance/Perf_Graphics_Transforms.cs
+++ b/src/System.Drawing.Common/tests/Performance/Perf_Graphics_Transforms.cs
@@ -12,7 +12,7 @@ namespace System.Drawing.Tests
     public class Perf_Graphics_Transforms : RemoteExecutorTestBase
     {
         [Benchmark(InnerIterationCount = 10000)]
-        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetGdiplusIsAvailable))]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetGdiplusIsAvailable), nameof(Helpers.IsNotUnix))] // Graphics.TransformPoints is not implemented in libgdiplus yet. See dotnet/corefx 20884
         public void TransformPoints()
         {
             Point[] points =

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -3181,7 +3181,8 @@ namespace MonoTests.System.Drawing
                 Assert.Equal(-12156236, bmp.GetPixel(1, 9).ToArgb());
             }
         }
-
+        
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void TransformPoints()
         {


### PR DESCRIPTION
# Speed Perf
### Old implementation
System.Drawing.Common.Performance.Tests.dll                            | Metric   | Unit | Iterations |  Average | STDEV.S |      Min |      Max
  :---------------------------------------------------------------------- |:-------- |:----:|:----------:| --------:| -------:| --------:| --------:
   System.Drawing.Tests.Perf_Image_Load.Bitmap_FromStream                 | Duration | msec |     9      | 1184.877 |  61.607 | 1104.953 | 1267.921
   System.Drawing.Tests.Perf_Image_Load.Image_FromStream                  | Duration | msec |     11     |  940.115 | 227.919 |  679.585 | 1269.089
   System.Drawing.Tests.Perf_Image_Load.Image_FromStream_NoValidation_Gif | Duration | msec |     23     |  452.558 |  20.079 |  431.718 |  503.783


### New implementation
System.Drawing.Common.Performance.Tests.dll                            | Metric   | Unit | Iterations |  Average | STDEV.S |      Min |      Max
  :---------------------------------------------------------------------- |:-------- |:----:|:----------:| --------:| -------:| --------:| --------:
   System.Drawing.Tests.Perf_Image_Load.Bitmap_FromStream                 | Duration | msec |     9      | 1147.698 |  64.877 | 1072.184 | 1237.095
   System.Drawing.Tests.Perf_Image_Load.Image_FromStream                  | Duration | msec |     13     |  809.292 | 202.312 |  636.097 | 1091.778
   System.Drawing.Tests.Perf_Image_Load.Image_FromStream_NoValidation_Gif | Duration | msec |     23     |  443.872 |  12.655 |  434.314 |  495.118

# Memory Perf
### Old implementation
|Test       | Unit  | Iterations | Average     | Min    | Max    
|:-----------------  |:------- |:----------:|:-----------:|-------:| -------:|
Bitmap_FromStream  | bytes |   100   |  210748.64 | 210624 | 223088
Image_FromStream  | bytes |   100   |  210749.68 | 210624 | 223192
Gif_FromStream  | bytes |   100   |  4691.28 | 4648 | 8976

### New implementation
|Test       | Unit  | Iterations | Average     | Min    | Max    
|:-----------------  |:------- |:----------:|:-----------:|-------:| -------:|
Bitmap_FromStream  | bytes |   100   |  1612.64 | 1488 | 13952
Image_FromStream  | bytes |   100   |  1613.68 | 1488 | 14056
Gif_FromStream  | bytes |   100   |  539.28 | 496 | 4824
