### PR TITLE
Disable a regex test that is failing with minopts

### DIFF
--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -790,6 +790,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework needs fix for #26484")]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/18912")]
         public void Match_ExcessPrefix()
         {
             RemoteInvoke(() =>


### PR DESCRIPTION
See https://github.com/dotnet/coreclr/issues/18912. It looks like corefx test runs are being triggered from PRs in coreclr, disabling because this would always fail once tiered compilation is enabled by default.