### PR TITLE
Make non-file URL support optional in XmlUrlResolver

### DIFF
--- a/src/Common/src/System/Runtime/CompilerServices/RemovableFeatureAttribute.cs
+++ b/src/Common/src/System/Runtime/CompilerServices/RemovableFeatureAttribute.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime.CompilerServices
+{
+    // Instructs IL linkers that the method body decorated with this attribute can be removed
+    // during publishing.
+    //
+    // By default, the body gets replaced by throwing code.
+    //
+    // UseNopBody can be set to suppress the throwing behavior, replacing the throw with
+    // a no-operation body.
+    [AttributeUsage(AttributeTargets.Method)]
+    internal class RemovableFeatureAttribute : Attribute
+    {
+        public bool UseNopBody;
+
+        public string FeatureSwitchName;
+
+        public RemovableFeatureAttribute(string featureSwitchName)
+        {
+            FeatureSwitchName = featureSwitchName;
+        }
+    }
+}

--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -740,6 +740,7 @@
     <Compile Include="$(CommonPath)\System\LocalAppContext.cs" />
     <Compile Include="System\Xml\Core\LocalAppContextSwitches.cs" />
     <Compile Include="$(CommonPath)\System\CSharpHelpers.cs" />
+    <Compile Include="$(CommonPath)\System\Runtime\CompilerServices\RemovableFeatureAttribute.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Compile Include="System\Xml\Xsl\Runtime\XmlCollation.Windows.cs" />

--- a/src/System.Private.Xml/src/System/Xml/XmlDownloadManagerAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlDownloadManagerAsync.cs
@@ -34,19 +34,7 @@ namespace System.Xml
         private async Task<Stream> GetNonFileStreamAsync(Uri uri, ICredentials credentials, IWebProxy proxy,
             RequestCachePolicy cachePolicy)
         {
-            WebRequest req = WebRequest.Create(uri);
-            if (credentials != null)
-            {
-                req.Credentials = credentials;
-            }
-            if (proxy != null)
-            {
-                req.Proxy = proxy;
-            }
-            if (cachePolicy != null)
-            {
-                req.CachePolicy = cachePolicy;
-            }
+            WebRequest req = CreateWebRequestOrThrowIfRemoved(uri, credentials, proxy, cachePolicy);
 
             using (WebResponse resp = await req.GetResponseAsync().ConfigureAwait(false))
             using (Stream respStream = resp.GetResponseStream())


### PR DESCRIPTION
This adds [removable feature annotation](dotnet/designs#42) to `XmlDownloadManager`.

If the user specifies that they would like to remove support for this at publish/native compilation time, the linker/compiler is going to replace the method body of `CreateWebRequestOrThrowIfRemoved` with a throwing method body. The exception message is going to inform the user that the feature has been removed because they opted into the removal.

Contributes to #30597. Saves 1.2 MB of the size of the Windows UWP People app. This is a size on disk regression that came with NetStandard 2.0 and blocks the Windows team in picking up the latest compiler/framework.