### PR TITLE
Using Utimes instead of utime hence setting millisecond attribute of last access and last modified time to non-zero

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.UTimensat.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.UTimensat.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        internal struct TimeVal
+        internal struct TimeSpec
         {
             internal long TvSec;
-            internal long TvUsec;
+            internal long TvNsec;
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns 0 on success; otherwise, returns -1 
         /// </returns>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTimes", SetLastError = true)]
-        internal static extern int UTimes(string path, TimeVal[] times);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTimensat", SetLastError = true)]
+        internal static extern int UTimensat(string path, TimeSpec[] times);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.UTimensat.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.UTimensat.cs
@@ -24,6 +24,6 @@ internal static partial class Interop
         /// Returns 0 on success; otherwise, returns -1 
         /// </returns>
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTimensat", SetLastError = true)]
-        internal static extern int UTimensat(string path, TimeSpec[] times);
+        internal static extern int UTimensat(string path, ref TimeSpec times);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.UTimes.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.UTimes.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        internal struct UTimBuf
+        internal struct TimeVal
         {
-            internal long AcTime;
-            internal long ModTime;
+            internal long TvSec;
+            internal long TvUsec;
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns 0 on success; otherwise, returns -1 
         /// </returns>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTime", SetLastError = true)]
-        internal static extern int UTime(string path, ref UTimBuf time);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTimes", SetLastError = true)]
+        internal static extern int UTimes(string path, TimeVal[] times);
     }
 }

--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -77,6 +77,7 @@
 #cmakedefine01 HAVE_CRT_EXTERNS_H
 #cmakedefine01 HAVE_GETDOMAINNAME
 #cmakedefine01 HAVE_UNAME
+#cmakedefine01 HAVE_UTIMENSAT
 #cmakedefine01 HAVE_FUTIMES
 #cmakedefine01 HAVE_FUTIMENS
 #cmakedefine01 HAVE_MKSTEMPS

--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -10,6 +10,7 @@
 #include <utime.h>
 #include <time.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <sys/time.h>
 #if HAVE_MACH_ABSOLUTE_TIME
 #include <mach/mach_time.h>
@@ -21,7 +22,7 @@ enum
     SecondsToNanoSeconds = 1000000000 // 10^9
 };
 
-int32_t SystemNative_UTimensat(const char* path, TimeSpec times[2])
+int32_t SystemNative_UTimensat(const char* path, TimeSpec* times)
 {
     struct timespec origTimes[2];
     origTimes[0].tv_sec = (time_t)times[0].tv_sec;
@@ -32,8 +33,7 @@ int32_t SystemNative_UTimensat(const char* path, TimeSpec times[2])
 
     int32_t result;
     
-    // utimensat ignores dirfd when path is absolute.
-    while (CheckInterrupted(result = utimensat(100, path, origTimes, 0)));
+    while (CheckInterrupted(result = utimensat(AT_FDCWD, path, origTimes, 0)));
     return result;
 }
 

--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -20,21 +20,17 @@ enum
     SecondsToNanoSeconds = 1000000000 // 10^9
 };
 
-static void ConvertUTimBuf(const UTimBuf* pal, struct utimbuf* native)
+int32_t SystemNative_UTimes(const char* path, TimeVal times[2])
 {
-    native->actime = (time_t)(pal->AcTime);
-    native->modtime = (time_t)(pal->ModTime);
-}
+    struct timeval origTimes[2];
+    origTimes[0].tv_sec = times[0].tv_sec;
+    origTimes[0].tv_usec = (int)times[0].tv_usec;
 
-int32_t SystemNative_UTime(const char* path, UTimBuf* times)
-{
-    assert(times != NULL);
-
-    struct utimbuf temp;
-    ConvertUTimBuf(times, &temp);
+    origTimes[1].tv_sec = times[1].tv_sec;
+    origTimes[1].tv_usec = (int)times[1].tv_usec;
 
     int32_t result;
-    while (CheckInterrupted(result = utime(path, &temp)));
+    while (CheckInterrupted(result = utimes(path, origTimes)));
     return result;
 }
 

--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -24,16 +24,25 @@ enum
 
 int32_t SystemNative_UTimensat(const char* path, TimeSpec* times)
 {
+    int32_t result;
+#if HAVE_UTIMENSAT
     struct timespec origTimes[2];
     origTimes[0].tv_sec = (time_t)times[0].tv_sec;
     origTimes[0].tv_nsec = (long)times[0].tv_nsec;
 
     origTimes[1].tv_sec = (time_t)times[1].tv_sec;
-    origTimes[1].tv_nsec = (long)times[1].tv_nsec;
-
-    int32_t result;
-    
+    origTimes[1].tv_nsec = (long)times[1].tv_nsec;    
     while (CheckInterrupted(result = utimensat(AT_FDCWD, path, origTimes, 0)));
+#else
+    struct timeval origTimes[2];
+    origTimes[0].tv_sec = (long)times[0].tv_sec;
+    origTimes[0].tv_usec = (int)times[0].tv_nsec / 1000;
+    
+    origTimes[1].tv_sec = (long)times[1].tv_sec;
+    origTimes[1].tv_usec = (int)times[1].tv_nsec / 1000;
+    while (CheckInterrupted(result = utimes(path, origTimes)));
+#endif
+
     return result;
 }
 

--- a/src/Native/Unix/System.Native/pal_time.h
+++ b/src/Native/Unix/System.Native/pal_time.h
@@ -6,19 +6,20 @@
 
 #include "pal_compiler.h"
 #include "pal_types.h"
+#include <time.h>
 
-typedef struct TimeVal
+typedef struct TimeSpec
 {
-    long tv_sec; // seconds
-    long tv_usec; // microseconds
-} TimeVal;
+    time_t tv_sec; // seconds
+    long tv_nsec; // nanoseconds
+} TimeSpec;
 
 /**
  * Sets the last access and last modified time of a file
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-DLLEXPORT int32_t SystemNative_UTimes(const char* path, TimeVal times[2]);
+DLLEXPORT int32_t SystemNative_UTimensat(const char* path, TimeSpec times[2]);
 
 /**
  * Gets the resolution of the timestamp, in counts per second.

--- a/src/Native/Unix/System.Native/pal_time.h
+++ b/src/Native/Unix/System.Native/pal_time.h
@@ -6,12 +6,11 @@
 
 #include "pal_compiler.h"
 #include "pal_types.h"
-#include <time.h>
 
 typedef struct TimeSpec
 {
-    time_t tv_sec; // seconds
-    long tv_nsec; // nanoseconds
+    int64_t tv_sec; // seconds
+    int64_t tv_nsec; // nanoseconds
 } TimeSpec;
 
 /**

--- a/src/Native/Unix/System.Native/pal_time.h
+++ b/src/Native/Unix/System.Native/pal_time.h
@@ -7,18 +7,18 @@
 #include "pal_compiler.h"
 #include "pal_types.h"
 
-typedef struct UTimBuf
+typedef struct TimeVal
 {
-    int64_t AcTime;
-    int64_t ModTime;
-} UTimBuf;
+    long tv_sec; // seconds
+    long tv_usec; // microseconds
+} TimeVal;
 
 /**
  * Sets the last access and last modified time of a file
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-DLLEXPORT int32_t SystemNative_UTime(const char* path, UTimBuf* time);
+DLLEXPORT int32_t SystemNative_UTimes(const char* path, TimeVal times[2]);
 
 /**
  * Gets the resolution of the timestamp, in counts per second.

--- a/src/Native/Unix/System.Native/pal_time.h
+++ b/src/Native/Unix/System.Native/pal_time.h
@@ -19,7 +19,7 @@ typedef struct TimeSpec
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-DLLEXPORT int32_t SystemNative_UTimensat(const char* path, TimeSpec times[2]);
+DLLEXPORT int32_t SystemNative_UTimensat(const char* path, TimeSpec* times);
 
 /**
  * Gets the resolution of the timestamp, in counts per second.

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -403,6 +403,10 @@ check_function_exists(
     futimens
     HAVE_FUTIMENS)
 
+check_function_exists(
+    utimensat
+    HAVE_UTIMENSAT)
+
 set (PREVIOUS_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 set (CMAKE_REQUIRED_FLAGS "-Werror -Wsign-conversion")
 

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -280,8 +280,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RmDir.cs">
       <Link>Common\Interop\Unix\Interop.RmDir.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.UTimes.cs">
-      <Link>Common\Interop\Unix\Interop.UTimes.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.UTimensat.cs">
+      <Link>Common\Interop\Unix\Interop.UTimensat.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\System\IO\PathInternal.Unix.cs">
       <Link>Common\CoreLib\System\IO\PathInternal.Unix.cs</Link>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -280,8 +280,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RmDir.cs">
       <Link>Common\Interop\Unix\Interop.RmDir.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.UTime.cs">
-      <Link>Common\Interop\Unix\Interop.UTime.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.UTimes.cs">
+      <Link>Common\Interop\Unix\Interop.UTimes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\System\IO\PathInternal.Unix.cs">
       <Link>Common\CoreLib\System\IO\PathInternal.Unix.cs</Link>

--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -202,14 +202,14 @@ namespace System.IO
             _fileStatusInitialized = -1;
             EnsureStatInitialized(path);
 
-            // we use utimes() to set the accessTime and writeTime
+            // we use utimes()/utimensat() to set the accessTime and writeTime
             Span<Interop.Sys.TimeSpec> buf = stackalloc Interop.Sys.TimeSpec[2];
 
             // setting second part
             buf[0].TvSec = accessTime ?? _fileStatus.ATime;
             buf[1].TvSec = writeTime ?? _fileStatus.MTime;
 
-            // setting microsecond part
+            // setting nanosecond part
             buf[0].TvNsec = accessTime == null ? _fileStatus.ATimeNsec : 0;
             buf[1].TvNsec = writeTime == null ? _fileStatus.MTimeNsec : 0;
 

--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -201,7 +201,7 @@ namespace System.IO
             EnsureStatInitialized(path);
 
             // we use utimes() to set the accessTime and writeTime
-            Interop.Sys.TimeVal[] buf = new Interop.Sys.TimeVal[2];
+            var buf = new Interop.Sys.TimeSpec[2];
 
             // setting second part
             buf[0].TvSec = accessTime ?? _fileStatus.ATime;
@@ -209,11 +209,12 @@ namespace System.IO
 
             // setting microsecond part
             if (accessTime == null)
-                buf[0].TvUsec = _fileStatus.ATimeNsec / 1000;
+                buf[0].TvNsec = _fileStatus.ATimeNsec;
             if (writeTime == null)
-                buf[1].TvUsec = _fileStatus.MTimeNsec / 1000;
+                buf[1].TvNsec = _fileStatus.MTimeNsec;
 
-            Interop.CheckIo(Interop.Sys.UTimes(path, buf), path, InitiallyDirectory);
+            Interop.CheckIo(Interop.Sys.UTimensat(Path.GetFullPath(path), buf), path, InitiallyDirectory);      
+
             _fileStatusInitialized = -1;
         }
 

--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -203,7 +203,7 @@ namespace System.IO
             EnsureStatInitialized(path);
 
             // we use utimes() to set the accessTime and writeTime
-            Span<Interop.Sys.TimeSpec> buf = stackalloc Interop.Sys.TimeSpec[2];;
+            Span<Interop.Sys.TimeSpec> buf = stackalloc Interop.Sys.TimeSpec[2];
 
             // setting second part
             buf[0].TvSec = accessTime ?? _fileStatus.ATime;

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -77,7 +77,7 @@ namespace System.IO.Tests
         }
 
         [ConditionalFact(nameof(isNotHFS))] // OSX HFS driver format does not support millisec granularity
-        public void TimesIncludeMillisecondPart_Unix()
+        public void TimesIncludeMillisecondPart()
         {
             T item = GetExistingItem();
             Assert.All(TimeFunctions(), (function) =>
@@ -109,7 +109,7 @@ namespace System.IO.Tests
         }
 
         [ConditionalFact(nameof(isHFS))]
-        public void TimesIncludeMillisecondPart_OSX()
+        public void TimesIncludeMillisecondPart_HFS()
         {
             T item = GetExistingItem();
             // OSX HFS driver format does not support millisec granularity

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -103,8 +103,9 @@ namespace System.IO.Tests
             File.WriteAllText(secondFile, "");
 
             File.SetLastAccessTimeUtc(secondFile, DateTime.UtcNow);
-
-            Assert.True(File.GetLastWriteTimeUtc(firstFile).Ticks < File.GetLastWriteTimeUtc(secondFile).Ticks);
+            long firstFileTicks = File.GetLastWriteTimeUtc(firstFile).Ticks;
+            long secondFileTicks = File.GetLastWriteTimeUtc(secondFile).Ticks;
+            Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -92,5 +92,19 @@ namespace System.IO.Tests
                 });
             }
         }
+
+        [Fact]
+        public void SetLastWriteTimeMilliSec()
+        {
+            string firstFile = GetTestFilePath();
+            string secondFile = GetTestFilePath();
+
+            File.WriteAllText(firstFile, "");
+            File.WriteAllText(secondFile, "");
+
+            File.SetLastAccessTimeUtc(secondFile, DateTime.UtcNow);
+
+            Assert.True(File.GetLastWriteTimeUtc(firstFile).Ticks < File.GetLastWriteTimeUtc(secondFile).Ticks);
+        }
     }
 }


### PR DESCRIPTION
utimensat documentation http://man7.org/linux/man-pages/man2/utimensat.2.html
Fixes https://github.com/dotnet/corefx/issues/31379