### PR TITLE
Temporarily disable thread test that fails with tiering

### DIFF
--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -183,6 +183,7 @@ namespace System.Threading.Threads.Tests
 
         [Fact]
         [ActiveIssue(20766,TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/19225", TargetFrameworkMonikers.Netcoreapp)]
         [PlatformSpecific(TestPlatforms.Windows)]
         public static void ApartmentState_NoAttributePresent_DefaultState_Windows()
         {


### PR DESCRIPTION
See https://github.com/dotnet/coreclr/issues/19225. This would fail in every CoreFX CI job in CoreCLR and CoreFX repos after tiering is enabled by default.