### PR TITLE
Handle NT auth with Connection: close on initial challenge

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,11 +13,11 @@ namespace System.Net.Http
 {
     internal partial class AuthenticationHelper
     {
-        private static Task<HttpResponseMessage> InnerSendAsync(HttpRequestMessage request, bool isProxyAuth, HttpConnection connection, CancellationToken cancellationToken)
+        private static Task<HttpResponseMessage> InnerSendAsync(HttpRequestMessage request, bool isProxyAuth, HttpConnectionPool pool, HttpConnection connection, CancellationToken cancellationToken)
         {
             return isProxyAuth ?
                 connection.SendAsyncCore(request, cancellationToken) :
-                connection.SendWithNtProxyAuthAsync(request, cancellationToken);
+                pool.SendWithNtProxyAuthAsync(connection, request, cancellationToken);
         }
 
         private static bool ProxySupportsConnectionAuth(HttpResponseMessage response)
@@ -37,9 +38,9 @@ namespace System.Net.Http
             return false;
         }
 
-        private static async Task<HttpResponseMessage> SendWithNtAuthAsync(HttpRequestMessage request, Uri authUri, ICredentials credentials, bool isProxyAuth, HttpConnection connection, CancellationToken cancellationToken)
+        private static async Task<HttpResponseMessage> SendWithNtAuthAsync(HttpRequestMessage request, Uri authUri, ICredentials credentials, bool isProxyAuth, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)
         {
-            HttpResponseMessage response = await InnerSendAsync(request, isProxyAuth, connection, cancellationToken).ConfigureAwait(false);
+            HttpResponseMessage response = await InnerSendAsync(request, isProxyAuth, connectionPool, connection, cancellationToken).ConfigureAwait(false);
             if (!isProxyAuth && connection.Kind == HttpConnectionKind.Proxy && !ProxySupportsConnectionAuth(response))
             {
                 // Proxy didn't indicate that it supports connection-based auth, so we can't proceed.
@@ -55,36 +56,65 @@ namespace System.Net.Http
                 if (challenge.AuthenticationType == AuthenticationType.Negotiate || 
                     challenge.AuthenticationType == AuthenticationType.Ntlm)
                 {
-                    string challengeData = challenge.ChallengeData;
-
-                    string spn = "HTTP/" + authUri.IdnHost;
-                    ChannelBinding channelBinding = connection.TransportContext?.GetChannelBinding(ChannelBindingKind.Endpoint);
-                    NTAuthentication authContext = new NTAuthentication(isServer:false, challenge.SchemeName, challenge.Credential, spn, ContextFlagsPal.Connection, channelBinding);
+                    bool isNewConnection = false;
                     try
                     {
-                        while (true)
+                        if (response.Headers.ConnectionClose.GetValueOrDefault())
                         {
-                            string challengeResponse = authContext.GetOutgoingBlob(challengeData);
-                            if (challengeResponse == null)
+                            // Server is closing the connection and asking us to authenticate on a new connection.
+                            (connection, response) = await connectionPool.CreateHttp11ConnectionAsync(request, cancellationToken).ConfigureAwait(false);
+                            if (response != null)
                             {
-                                // Response indicated denial even after login, so stop processing and return current response.
-                                break;
+                                return response;
                             }
 
+                            connectionPool.IncrementConnectionCount();
+                            connection.Acquire();
+                            isNewConnection = true;
+                        }
+                        else
+                        {
                             await connection.DrainResponseAsync(response).ConfigureAwait(false);
+                        }
 
-                            SetRequestAuthenticationHeaderValue(request, new AuthenticationHeaderValue(challenge.SchemeName, challengeResponse), isProxyAuth);
+                        string challengeData = challenge.ChallengeData;
 
-                            response = await InnerSendAsync(request, isProxyAuth, connection, cancellationToken).ConfigureAwait(false);
-                            if (authContext.IsCompleted || !TryGetRepeatedChallenge(response, challenge.SchemeName, isProxyAuth, out challengeData))
+                        string spn = "HTTP/" + authUri.IdnHost;
+                        ChannelBinding channelBinding = connection.TransportContext?.GetChannelBinding(ChannelBindingKind.Endpoint);
+                        NTAuthentication authContext = new NTAuthentication(isServer:false, challenge.SchemeName, challenge.Credential, spn, ContextFlagsPal.Connection, channelBinding);
+                        try
+                        {
+                            while (true)
                             {
-                                break;
+                                string challengeResponse = authContext.GetOutgoingBlob(challengeData);
+                                if (challengeResponse == null)
+                                {
+                                    // Response indicated denial even after login, so stop processing and return current response.
+                                    break;
+                                }
+
+                                SetRequestAuthenticationHeaderValue(request, new AuthenticationHeaderValue(challenge.SchemeName, challengeResponse), isProxyAuth);
+
+                                response = await InnerSendAsync(request, isProxyAuth, connectionPool, connection, cancellationToken).ConfigureAwait(false);
+                                if (authContext.IsCompleted || !TryGetRepeatedChallenge(response, challenge.SchemeName, isProxyAuth, out challengeData))
+                                {
+                                    break;
+                                }
+
+                                await connection.DrainResponseAsync(response).ConfigureAwait(false);
                             }
+                        }
+                        finally
+                        {
+                            authContext.CloseContext();
                         }
                     }
                     finally
                     {
-                        authContext.CloseContext();
+                        if (isNewConnection)
+                        {
+                            connection.Release();
+                        }
                     }
                 }
             }
@@ -92,14 +122,14 @@ namespace System.Net.Http
             return response;
         }
 
-        public static Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpRequestMessage request, Uri proxyUri, ICredentials proxyCredentials, HttpConnection connection, CancellationToken cancellationToken)
+        public static Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpRequestMessage request, Uri proxyUri, ICredentials proxyCredentials, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)
         {
-            return SendWithNtAuthAsync(request, proxyUri, proxyCredentials, isProxyAuth:true, connection, cancellationToken);
+            return SendWithNtAuthAsync(request, proxyUri, proxyCredentials, isProxyAuth:true, connection, connectionPool, cancellationToken);
         }
 
-        public static Task<HttpResponseMessage> SendWithNtConnectionAuthAsync(HttpRequestMessage request, ICredentials credentials, HttpConnection connection, CancellationToken cancellationToken)
+        public static Task<HttpResponseMessage> SendWithNtConnectionAuthAsync(HttpRequestMessage request, ICredentials credentials, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)
         {
-            return SendWithNtAuthAsync(request, request.RequestUri, credentials, isProxyAuth:false, connection, cancellationToken);
+            return SendWithNtAuthAsync(request, request.RequestUri, credentials, isProxyAuth:false, connection, connectionPool, cancellationToken);
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -673,7 +673,7 @@ namespace System.Net.Http
 
         // Note that this is safe to be called concurrently by multiple threads.
 
-        public sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken)
+        public sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Http2Stream http2Stream = new Http2Stream(this);
             try

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -682,37 +682,9 @@ namespace System.Net.Http
             }
         }
 
-        public Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        public sealed override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (_pool.AnyProxyKind && _pool.ProxyCredentials != null)
-            {
-                return AuthenticationHelper.SendWithNtProxyAuthAsync(request, _pool.ProxyUri, _pool.ProxyCredentials, this, cancellationToken);
-            }
-
             return SendAsyncCore(request, cancellationToken);
-        }
-
-        private Task<HttpResponseMessage> SendAsyncInternal(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken)
-        {
-            if (doRequestAuth && _pool.Settings._credentials != null)
-            {
-                return AuthenticationHelper.SendWithNtConnectionAuthAsync(request, _pool.Settings._credentials, this, cancellationToken);
-            }
-
-            return SendWithNtProxyAuthAsync(request, cancellationToken);
-        }
-
-        public sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken)
-        {
-            Acquire();
-            try
-            {
-                return await SendAsyncInternal(request, doRequestAuth, cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                Release();
-            }
         }
 
         private HttpContentWriteStream CreateRequestContentStream(HttpRequestMessage request)
@@ -1470,7 +1442,7 @@ namespace System.Net.Http
             }
         }
 
-        private void Acquire()
+        internal void Acquire()
         {
             Debug.Assert(_currentRequest == null);
             Debug.Assert(!_inUse);
@@ -1478,7 +1450,7 @@ namespace System.Net.Http
             _inUse = true;
         }
 
-        private void Release()
+        internal void Release()
         {
             Debug.Assert(_inUse);
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -9,6 +9,6 @@ namespace System.Net.Http
 {
     internal abstract class HttpConnectionBase
     {
-        public abstract Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken);
+        public abstract Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Fixes #30327.

When we receive an initial NT auth challenge that has Connection: close set on the response, we need to proceed with authentication on a new connection.

@davidsh @dotnet/ncl 