### PR TITLE
Annotate reflection fallback for S.P.DataContractSerialization

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -27,6 +27,9 @@
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\CompilerServices\RemovableFeatureAttribute.cs">
+      <Link>System\Runtime\CompilerServices\RemovableFeatureAttribute</Link>
+    </Compile>
     <Compile Include="$(RuntimeSerializationSources)\Attributes.cs" />
     <Compile Include="$(RuntimeSerializationSources)\CodeGenerator.cs" />
     <Compile Include="$(RuntimeSerializationSources)\ClassDataContract.cs" />
@@ -144,6 +147,7 @@
     <Compile Include="System\Runtime\Serialization\IExtensibleDataObject.cs" />
     <Compile Include="System\Runtime\Serialization\Json\ReflectionJsonFormatReader.cs" />
     <Compile Include="System\Runtime\Serialization\Json\ReflectionJsonFormatWriter.cs" />
+    <Compile Include="System\Runtime\Serialization\ReflectionFeature.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionReader.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionClassWriter.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionXmlFormatReader.cs" />

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.Serialization
     using System.IO;
     using System.Globalization;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Xml;
     using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, DataContract>;
@@ -243,6 +244,14 @@ namespace System.Runtime.Serialization
         }
 
 #if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private XmlFormatClassWriterDelegate CreateXmlFormatWriterDelegate()
+        {
+            return new XmlFormatWriterGenerator().GenerateClassWriter(this);
+        }
+
+#if uapaot
         private XmlFormatClassWriterDelegate _xmlFormatWriterDelegate;
         public XmlFormatClassWriterDelegate XmlFormatWriterDelegate
 #else
@@ -264,7 +273,7 @@ namespace System.Runtime.Serialization
                     {
                         if (_helper.XmlFormatWriterDelegate == null)
                         {
-                            XmlFormatClassWriterDelegate tempDelegate = new XmlFormatWriterGenerator().GenerateClassWriter(this);
+                            XmlFormatClassWriterDelegate tempDelegate = CreateXmlFormatWriterDelegate();
                             Interlocked.MemoryBarrier();
                             _helper.XmlFormatWriterDelegate = tempDelegate;
                         }
@@ -278,6 +287,14 @@ namespace System.Runtime.Serialization
                 _xmlFormatWriterDelegate = value;
 #endif
             }
+        }
+
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private XmlFormatClassReaderDelegate CreateXmlFormatReaderDelegate()
+        {
+            return new XmlFormatReaderGenerator().GenerateClassReader(this);
         }
 
 #if uapaot
@@ -302,7 +319,7 @@ namespace System.Runtime.Serialization
                     {
                         if (_helper.XmlFormatReaderDelegate == null)
                         {
-                            XmlFormatClassReaderDelegate tempDelegate = new XmlFormatReaderGenerator().GenerateClassReader(this);
+                            XmlFormatClassReaderDelegate tempDelegate = CreateXmlFormatReaderDelegate();
                             Interlocked.MemoryBarrier();
                             _helper.XmlFormatReaderDelegate = tempDelegate;
                         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -10,6 +10,7 @@ namespace System.Runtime.Serialization
     using System.Collections;
     using System.Collections.Generic;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Xml;
     using System.Linq;
@@ -337,6 +338,14 @@ namespace System.Runtime.Serialization
         }
 
 #if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private XmlFormatCollectionWriterDelegate CreateXmlFormatWriterDelegate()
+        {
+            return new XmlFormatWriterGenerator().GenerateCollectionWriter(this);
+        }
+
+#if uapaot
         private XmlFormatCollectionWriterDelegate _xmlFormatWriterDelegate;
         public XmlFormatCollectionWriterDelegate XmlFormatWriterDelegate
 #else
@@ -358,7 +367,7 @@ namespace System.Runtime.Serialization
                     {
                         if (_helper.XmlFormatWriterDelegate == null)
                         {
-                            XmlFormatCollectionWriterDelegate tempDelegate = new XmlFormatWriterGenerator().GenerateCollectionWriter(this);
+                            XmlFormatCollectionWriterDelegate tempDelegate = CreateXmlFormatWriterDelegate();
                             Interlocked.MemoryBarrier();
                             _helper.XmlFormatWriterDelegate = tempDelegate;
                         }
@@ -372,6 +381,14 @@ namespace System.Runtime.Serialization
                 _xmlFormatWriterDelegate = value;
 #endif
             }
+        }
+
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private XmlFormatCollectionReaderDelegate CreateXmlFormatReaderDelegate()
+        {
+            return new XmlFormatReaderGenerator().GenerateCollectionReader(this);
         }
 
 #if uapaot
@@ -396,7 +413,7 @@ namespace System.Runtime.Serialization
                     {
                         if (_helper.XmlFormatReaderDelegate == null)
                         {
-                            XmlFormatCollectionReaderDelegate tempDelegate = new XmlFormatReaderGenerator().GenerateCollectionReader(this);
+                            XmlFormatCollectionReaderDelegate tempDelegate = CreateXmlFormatReaderDelegate();
                             Interlocked.MemoryBarrier();
                             _helper.XmlFormatReaderDelegate = tempDelegate;
                         }
@@ -411,6 +428,15 @@ namespace System.Runtime.Serialization
 #endif
             }
         }
+
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private XmlFormatGetOnlyCollectionReaderDelegate CreateXmlFormatGetOnlyCollectionReaderDelegate()
+        {
+            return new XmlFormatReaderGenerator().GenerateGetOnlyCollectionReader(this);
+        }
+
 
 #if uapaot
         private XmlFormatGetOnlyCollectionReaderDelegate _xmlFormatGetOnlyCollectionReaderDelegate;
@@ -444,7 +470,7 @@ namespace System.Runtime.Serialization
                                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.GetOnlyCollectionMustHaveAddMethod, GetClrTypeFullName(UnderlyingType))));
                             }
 
-                            XmlFormatGetOnlyCollectionReaderDelegate tempDelegate = new XmlFormatReaderGenerator().GenerateGetOnlyCollectionReader(this);
+                            XmlFormatGetOnlyCollectionReaderDelegate tempDelegate = CreateXmlFormatGetOnlyCollectionReaderDelegate();
                             Interlocked.MemoryBarrier();
                             _helper.XmlFormatGetOnlyCollectionReaderDelegate = tempDelegate;
                         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.Serialization
         private ISerializationSurrogateProvider _serializationSurrogateProvider;
         private bool _serializeReadOnlyTypes;
 
-        private static SerializationOption _option = SerializationOption.ReflectionAsBackup;
+        private static SerializationOption _option = IsReflectionBackupAllowed() ? SerializationOption.ReflectionAsBackup : SerializationOption.CodeGenOnly;
         private static bool _optionAlreadySet;
         internal static SerializationOption Option
         {
@@ -48,6 +48,17 @@ namespace System.Runtime.Serialization
                 _optionAlreadySet = true;
                 _option = value;
             }
+        }
+
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name, UseNopBody = true)]
+#endif
+        private static bool IsReflectionBackupAllowed()
+        {
+            // The RemovableFeature annotation above is going to replace this with
+            // "return false" if reflection based serialization feature was removed
+            // at publishing time.
+            return true;
         }
 
         public DataContractSerializer(Type type)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Xml;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System.Runtime.Serialization.Json
 {
@@ -17,6 +18,14 @@ namespace System.Runtime.Serialization.Json
             : base(new JsonClassDataContractCriticalHelper(traditionalDataContract))
         {
             _helper = base.Helper as JsonClassDataContractCriticalHelper;
+        }
+
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private JsonFormatClassReaderDelegate CreateJsonFormatReaderDelegate()
+        {
+            return new ReflectionJsonClassReader(TraditionalClassDataContract).ReflectionReadClass;
         }
 
         internal JsonFormatClassReaderDelegate JsonFormatReaderDelegate
@@ -32,13 +41,13 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatClassReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = new ReflectionJsonClassReader(TraditionalClassDataContract).ReflectionReadClass;
+                                tempDelegate = CreateJsonFormatReaderDelegate();
                             }
 #if uapaot
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
                                 tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract)?.ClassReaderDelegate;
-                                tempDelegate = tempDelegate ?? new ReflectionJsonClassReader(TraditionalClassDataContract).ReflectionReadClass;
+                                tempDelegate = tempDelegate ?? CreateJsonFormatReaderDelegate();
 
                                 if (tempDelegate == null)
                                     throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalClassDataContract.UnderlyingType.ToString()));
@@ -62,6 +71,14 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private JsonFormatClassWriterDelegate CreateJsonFormatWriterDelegate()
+        {
+            return new ReflectionJsonFormatWriter().ReflectionWriteClass;
+        }
+
         internal JsonFormatClassWriterDelegate JsonFormatWriterDelegate
         {
             get
@@ -75,13 +92,13 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatClassWriterDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = new ReflectionJsonFormatWriter().ReflectionWriteClass;
+                                tempDelegate = CreateJsonFormatWriterDelegate();
                             }
 #if uapaot
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
                                 tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract)?.ClassWriterDelegate;
-                                tempDelegate = tempDelegate ?? new ReflectionJsonFormatWriter().ReflectionWriteClass;
+                                tempDelegate = tempDelegate ?? CreateJsonFormatWriterDelegate();
 
                                 if (tempDelegate == null)
                                     throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalClassDataContract.UnderlyingType.ToString()));

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Xml;
 
@@ -18,6 +19,14 @@ namespace System.Runtime.Serialization.Json
             _helper = base.Helper as JsonCollectionDataContractCriticalHelper;
         }
 
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private JsonFormatCollectionReaderDelegate CreateJsonFormatReaderDelegate()
+        {
+            return new ReflectionJsonCollectionReader().ReflectionReadCollection;
+        }
+
         internal JsonFormatCollectionReaderDelegate JsonFormatReaderDelegate
         {
             get
@@ -31,13 +40,13 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatCollectionReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = new ReflectionJsonCollectionReader().ReflectionReadCollection;
+                                tempDelegate = CreateJsonFormatReaderDelegate();
                             }
 #if uapaot
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
                                 tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract)?.CollectionReaderDelegate;
-                                tempDelegate = tempDelegate ?? new ReflectionJsonCollectionReader().ReflectionReadCollection;
+                                tempDelegate = tempDelegate ?? CreateJsonFormatReaderDelegate();
 
                                 if (tempDelegate == null)
                                     throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalCollectionDataContract.UnderlyingType.ToString()));
@@ -61,6 +70,14 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private JsonFormatGetOnlyCollectionReaderDelegate CreateJsonFormatGetOnlyReaderDelegate()
+        {
+            return new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
+        }
+
         internal JsonFormatGetOnlyCollectionReaderDelegate JsonFormatGetOnlyReaderDelegate
         {
             get
@@ -80,13 +97,13 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatGetOnlyCollectionReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
+                                tempDelegate = CreateJsonFormatGetOnlyReaderDelegate();
                             }
 #if uapaot
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
                                 tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract)?.GetOnlyCollectionReaderDelegate;
-                                tempDelegate = tempDelegate ?? new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
+                                tempDelegate = tempDelegate ?? CreateJsonFormatGetOnlyReaderDelegate();
 
                                 if (tempDelegate == null)
                                     throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalCollectionDataContract.UnderlyingType.ToString()));
@@ -97,7 +114,7 @@ namespace System.Runtime.Serialization.Json
 #if uapaot
                                 tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).GetOnlyCollectionReaderDelegate;
 #else   
-                                tempDelegate = new JsonFormatReaderGenerator().GenerateGetOnlyCollectionReader(TraditionalCollectionDataContract);
+                                tempDelegate =  new JsonFormatReaderGenerator().GenerateGetOnlyCollectionReader(TraditionalCollectionDataContract);
 #endif
                             }
 
@@ -109,6 +126,15 @@ namespace System.Runtime.Serialization.Json
                 return _helper.JsonFormatGetOnlyReaderDelegate;
             }
         }
+
+#if uapaot
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+        private JsonFormatCollectionWriterDelegate CreateJsonFormatWriterDelegate()
+        {
+            return new ReflectionJsonFormatWriter().ReflectionWriteCollection;
+        }
+
 
         internal JsonFormatCollectionWriterDelegate JsonFormatWriterDelegate
         {
@@ -123,13 +149,13 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatCollectionWriterDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = new ReflectionJsonFormatWriter().ReflectionWriteCollection;
+                                tempDelegate = CreateJsonFormatWriterDelegate();
                             }
 #if uapaot
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
                                 tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract)?.CollectionWriterDelegate;
-                                tempDelegate = tempDelegate ?? new ReflectionJsonFormatWriter().ReflectionWriteCollection;
+                                tempDelegate = tempDelegate ?? CreateJsonFormatWriterDelegate();
 
                                 if (tempDelegate == null)
                                     throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalCollectionDataContract.UnderlyingType.ToString()));

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionFeature.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionFeature.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.Serialization
+{
+    class ReflectionBasedSerializationFeature
+    {
+        public const string Name = "System.Runtime.Serialization.ReflectionBasedSerialization";
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -14,6 +14,7 @@ namespace System.Runtime.Serialization
     using System.Xml.Schema;
     using System.Security;
     using System.Linq;
+    using System.Runtime.CompilerServices;
 
 #if uapaot
     public delegate IXmlSerializable CreateXmlSerializableDelegate();
@@ -379,6 +380,7 @@ namespace System.Runtime.Serialization
         }
 #endif
 
+        [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
         internal IXmlSerializable ReflectionCreateXmlSerializable(Type type)
         {
             if (type.IsValueType)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -11,6 +11,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Security;
+using System.Runtime.CompilerServices;
 
 namespace System.Runtime.Serialization
 {
@@ -68,16 +69,24 @@ namespace System.Runtime.Serialization
             private ArgBuilder _collectionContractArg;
 #endif
 
+#if uapaot
+            [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+            private XmlFormatClassReaderDelegate CreateReflectionXmlClassReader(ClassDataContract classContract)
+            {
+                return new ReflectionXmlClassReader(classContract).ReflectionReadClass;
+            }
+
             public XmlFormatClassReaderDelegate GenerateClassReader(ClassDataContract classContract)
             {
                 if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                 {
-                    return new ReflectionXmlClassReader(classContract).ReflectionReadClass;
+                    return CreateReflectionXmlClassReader(classContract);
                 }
 #if uapaot
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                 {
-                    return new ReflectionXmlClassReader(classContract).ReflectionReadClass;
+                    return CreateReflectionXmlClassReader(classContract);
                 }
 #endif
                 else
@@ -161,16 +170,24 @@ namespace System.Runtime.Serialization
                 }
             }
 
+#if uapaot
+            [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+            private XmlFormatCollectionReaderDelegate CreateReflectionXmlCollectionReader()
+            {
+                return new ReflectionXmlCollectionReader().ReflectionReadCollection;
+            }
+
             public XmlFormatCollectionReaderDelegate GenerateCollectionReader(CollectionDataContract collectionContract)
             {
                 if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                 {
-                    return new ReflectionXmlCollectionReader().ReflectionReadCollection;
+                    return CreateReflectionXmlCollectionReader();
                 }
 #if uapaot
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                 {
-                    return new ReflectionXmlCollectionReader().ReflectionReadCollection;
+                    return CreateReflectionXmlCollectionReader();
                 }
 #endif
                 else
@@ -187,16 +204,24 @@ namespace System.Runtime.Serialization
                 }
             }
 
+#if uapaot
+            [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+            private XmlFormatGetOnlyCollectionReaderDelegate CreateReflectionReadGetOnlyCollectionReader()
+            {
+                return new ReflectionXmlCollectionReader().ReflectionReadGetOnlyCollection;
+            }
+
             public XmlFormatGetOnlyCollectionReaderDelegate GenerateGetOnlyCollectionReader(CollectionDataContract collectionContract)
             {
                 if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                 {
-                    return new ReflectionXmlCollectionReader().ReflectionReadGetOnlyCollection;
+                    return CreateReflectionReadGetOnlyCollectionReader();
                 }
 #if uapaot
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                 {
-                    return new ReflectionXmlCollectionReader().ReflectionReadGetOnlyCollection;
+                    return CreateReflectionReadGetOnlyCollectionReader();
                 }
 #endif
                 else

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
@@ -11,7 +11,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Security;
-
+using System.Runtime.CompilerServices;
 
 namespace System.Runtime.Serialization
 {
@@ -64,16 +64,24 @@ namespace System.Runtime.Serialization
             private int _childElementIndex = 0;
 #endif
 
+#if uapaot
+            [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+            private XmlFormatClassWriterDelegate CreateReflectionXmlFormatClassWriterDelegate()
+            {
+                return new ReflectionXmlFormatWriter().ReflectionWriteClass;
+            }
+
             internal XmlFormatClassWriterDelegate GenerateClassWriter(ClassDataContract classContract)
             {
                 if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                 {
-                    return new ReflectionXmlFormatWriter().ReflectionWriteClass;
+                    return CreateReflectionXmlFormatClassWriterDelegate();
                 }
 #if uapaot
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                 {
-                    return new ReflectionXmlFormatWriter().ReflectionWriteClass;
+                    return CreateReflectionXmlFormatClassWriterDelegate();
                 }
 #endif
                 else
@@ -105,16 +113,24 @@ namespace System.Runtime.Serialization
                 }
             }
 
+#if uapaot
+            [RemovableFeature(ReflectionBasedSerializationFeature.Name)]
+#endif
+            private XmlFormatCollectionWriterDelegate CreateReflectionXmlFormatCollectionWriterDelegate()
+            {
+                return new ReflectionXmlFormatWriter().ReflectionWriteCollection;
+            }
+
             internal XmlFormatCollectionWriterDelegate GenerateCollectionWriter(CollectionDataContract collectionContract)
             {
                 if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                 {
-                    return new ReflectionXmlFormatWriter().ReflectionWriteCollection;
+                    return CreateReflectionXmlFormatCollectionWriterDelegate();
                 }
 #if uapaot
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                 {
-                    return new ReflectionXmlFormatWriter().ReflectionWriteCollection;
+                    return CreateReflectionXmlFormatCollectionWriterDelegate();
                 }
 #endif
                 else


### PR DESCRIPTION
This adds [removable feature annotation](dotnet/designs#42) to data
contract serialization.

If the user specifies that they would like to remove support for this
at publish/native compilation time, the linker/compiler is going to
replace the annotated method bodies with a throwing method body.
The exception message is going to inform the user that the feature
has been removed because they opted into the removal. The throwing
method body is significantly smaller than the transitive closure
of code reachable from the original method body.

Contributes to #30597. Turning this feature off in the UWP People app
saves 4% of size. This is a size on disk regression that came with
the new version of CoreFX and blocks the Windows team in picking up
the latest framework. There is a zero size growth goal.