### PR TITLE
IO.Ports UAP: use GetCommPorts

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
         internal const string Advapi32 = "advapi32.dll";
         internal const string BCrypt = "BCrypt.dll";
         internal const string CoreComm_L1_1_1 = "api-ms-win-core-comm-l1-1-1.dll";
+        internal const string CoreComm_L1_1_2 = "api-ms-win-core-comm-l1-1-2.dll";
         internal const string Crypt32 = "crypt32.dll";
         internal const string CryptUI = "cryptui.dll";
         internal const string Error_L1 = "api-ms-win-core-winrt-error-l1-1-0.dll";

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetCommPorts.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetCommPorts.cs
@@ -19,7 +19,7 @@ internal partial class Interop
             Span<uint> portNumbers,
             out uint portNumbersFound)
         {
-            fixed (uint* portNumbersBuffer = &portNumbers[0])
+            fixed (uint* portNumbersBuffer = &MemoryMarshal.GetReference(portNumbers))
             {
                 return GetCommPorts(portNumbersBuffer, (uint)portNumbers.Length, out portNumbersFound);
             }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetCommPorts.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetCommPorts.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreComm_L1_1_2, SetLastError = true)]
+        unsafe private static extern int GetCommPorts(
+             uint* lpPortNumbers,
+             uint uPortNumbersCount,
+             out uint puPortNumbersFound);
+
+        unsafe internal static int GetCommPorts(
+            Span<uint> portNumbers,
+            out uint portNumbersFound)
+        {
+            fixed (uint* portNumbersBuffer = &portNumbers[0])
+            {
+                return GetCommPorts(portNumbersBuffer, (uint)portNumbers.Length, out portNumbersFound);
+            }
+        }
+    }
+}

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -132,6 +132,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.OpenCommPort.cs">
       <Link>Common\Interop\Windows\mincore\Interop.OpenCommPort.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetCommPorts.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.GetCommPorts.cs</Link>
+    </Compile>
     <Compile Include="System\IO\Ports\SerialPort.Uap.cs" />
     <Compile Include="System\IO\Ports\SerialStream.Uap.cs" />
   </ItemGroup>

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -154,6 +154,7 @@
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.Uap.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.Uap.cs
@@ -10,8 +10,39 @@ namespace System.IO.Ports
     {
         public static string[] GetPortNames()
         {
-            // See https://github.com/dotnet/corefx/issues/20588 for more information.
-            throw new PlatformNotSupportedException(System.SR.PlatformNotSupported_SerialPort_GetPortNames);
+            Span<uint> portNumbers = stackalloc uint[16];
+            uint portNumbersFound;
+            int error;
+
+            try
+            {
+                error = Interop.mincore.GetCommPorts(portNumbers, out portNumbersFound);
+            }
+            catch (Exception e) when (e is EntryPointNotFoundException || e is DllNotFoundException)
+            {
+                throw new PlatformNotSupportedException(System.SR.PlatformNotSupported_SerialPort_GetPortNames);
+            }
+
+            if (error == Interop.Errors.ERROR_MORE_DATA)
+            {
+                portNumbers = portNumbersFound <= 64 ?
+                    stackalloc uint[(int)portNumbersFound] :
+                    new uint[portNumbersFound];
+                error = Interop.mincore.GetCommPorts(portNumbers, out portNumbersFound);
+            }
+
+            if (error != Interop.Errors.ERROR_SUCCESS)
+            {
+                throw new Win32Exception(error);
+            }
+
+            var portNames = new string[portNumbersFound];
+            for (int i = 0; i < portNumbersFound; ++i)
+            {
+                portNames[i] = "COM" + portNumbers[i].ToString();
+            }
+
+            return portNames;
         }
     }
 }

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.Uap.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.Uap.cs
@@ -25,9 +25,7 @@ namespace System.IO.Ports
 
             if (error == Interop.Errors.ERROR_MORE_DATA)
             {
-                portNumbers = portNumbersFound <= 64 ?
-                    stackalloc uint[(int)portNumbersFound] :
-                    new uint[portNumbersFound];
+                portNumbers = new uint[portNumbersFound];
                 error = Interop.mincore.GetCommPorts(portNumbers, out portNumbersFound);
             }
 

--- a/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
+++ b/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace System.IO.Ports.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/corefx/issues/20588", TargetFrameworkMonikers.Uap)] // fails in both Uap and UapAot
     public class GetPortNames : PortsTest
     {
         #region Test Cases

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -33,6 +33,7 @@ namespace Legacy.Support
 
         private static string[] GetCommPortsFromRegistry()
         {
+            // See https://msdn.microsoft.com/en-us/library/windows/hardware/ff546502.aspx for more information.
             using (RegistryKey serialKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM"))
             {
                 if (serialKey != null)

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using Microsoft.Win32;
 
 namespace Legacy.Support
 {
@@ -22,9 +23,36 @@ namespace Legacy.Support
         {
             if (PlatformDetection.IsUap)
             {
-                return new [] { "COM3", "COM4", "COM5", "COM6", "COM7" }; // we are waiting for a Win32 new QueryDosDevice API since the current doesn't work for Uap https://github.com/dotnet/corefx/issues/21156
+                // On UAP it is not possible to call QueryDosDevice, so use HARDWARE\DEVICEMAP\SERIALCOMM on the registry
+                // to get this information. The UAP code uses the GetCommPorts API to retrieve the same information.
+                return GetCommPortsFromRegistry();
             }
 
+            return GetCommPortsViaQueryDosDevice();
+        }
+
+        private static string[] GetCommPortsFromRegistry()
+        {
+            using (RegistryKey serialKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM"))
+            {
+                if (serialKey != null)
+                {
+                    string[] result = serialKey.GetValueNames();
+                    for (int i = 0; i < result.Length; i++)
+                    {
+                        // Replace the name in the array with its value.
+                        result[i] = (string)serialKey.GetValue(result[i]);
+                    }
+
+                    return result;
+                }
+            }
+
+            return Array.Empty<string>();
+        }
+
+        private static string[] GetCommPortsViaQueryDosDevice()
+        {
             List<string> ports = new List<string>();
             int returnSize = 0;
             int maxSize = 1000000;

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -323,16 +323,16 @@ namespace System.Tests
         [Fact]
         public void GetSystemDirectory()
         {
-            //if (PlatformDetection.IsWindowsNanoServer)
-            //{
-            //    // https://github.com/dotnet/corefx/issues/19110
-            //    // On Windows Nano, ShGetKnownFolderPath currently doesn't give
-            //    // the correct result for SystemDirectory.
-            //    // Assert that it's wrong, so that if it's fixed, we don't forget to
-            //    // enable this test for Nano.
-            //    Assert.NotEqual(Environment.GetFolderPath(Environment.SpecialFolder.System), Environment.SystemDirectory);
-            //    return;
-            //}
+            if (PlatformDetection.IsWindowsNanoServer)
+            {
+                // https://github.com/dotnet/corefx/issues/19110
+                // On Windows Nano, ShGetKnownFolderPath currently doesn't give
+                // the correct result for SystemDirectory.
+                // Assert that it's wrong, so that if it's fixed, we don't forget to
+                // enable this test for Nano.
+                Assert.NotEqual(Environment.GetFolderPath(Environment.SpecialFolder.System), Environment.SystemDirectory);
+                return;
+            }
 
             Assert.Equal(Environment.GetFolderPath(Environment.SpecialFolder.System), Environment.SystemDirectory);
         }

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -323,16 +323,16 @@ namespace System.Tests
         [Fact]
         public void GetSystemDirectory()
         {
-            if (PlatformDetection.IsWindowsNanoServer)
-            {
-                // https://github.com/dotnet/corefx/issues/19110
-                // On Windows Nano, ShGetKnownFolderPath currently doesn't give
-                // the correct result for SystemDirectory.
-                // Assert that it's wrong, so that if it's fixed, we don't forget to
-                // enable this test for Nano.
-                Assert.NotEqual(Environment.GetFolderPath(Environment.SpecialFolder.System), Environment.SystemDirectory);
-                return;
-            }
+            //if (PlatformDetection.IsWindowsNanoServer)
+            //{
+            //    // https://github.com/dotnet/corefx/issues/19110
+            //    // On Windows Nano, ShGetKnownFolderPath currently doesn't give
+            //    // the correct result for SystemDirectory.
+            //    // Assert that it's wrong, so that if it's fixed, we don't forget to
+            //    // enable this test for Nano.
+            //    Assert.NotEqual(Environment.GetFolderPath(Environment.SpecialFolder.System), Environment.SystemDirectory);
+            //    return;
+            //}
 
             Assert.Equal(Environment.GetFolderPath(Environment.SpecialFolder.System), Environment.SystemDirectory);
         }


### PR DESCRIPTION
Implements `SerialPort.GetPortNames` for UWP using `GetCommPorts` API. Fixes #20588, #23294.