### PR TITLE
Revert uwp6.0 auto-update

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -9,28 +9,28 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</CoreFxCurrentRef>
+    <CoreFxCurrentRef>f318c7c69a6452ac966861f33a1251419fb47404</CoreFxCurrentRef>
     <CoreClrCurrentRef>3a037b925fac2dfab6ca2f587099b45bb8413f5f</CoreClrCurrentRef>
-    <CoreSetupCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</CoreSetupCurrentRef>
+    <CoreSetupCurrentRef>f318c7c69a6452ac966861f33a1251419fb47404</CoreSetupCurrentRef>
     <ExternalCurrentRef>1fe3c36279b702b526ca9441412d441f1b6a4821</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>8a65f50bd6ed692c34b154c89b7cbb29799976f8</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>8a65f50bd6ed692c34b154c89b7cbb29799976f8</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>97059fa979a3c8fb8b9fba127c526f15e48c9dde</SniCurrentRef>
-    <StandardCurrentRef>40697681be31dff83b6c3b75a6de0d3adbc790a7</StandardCurrentRef>
+    <StandardCurrentRef>8a65f50bd6ed692c34b154c89b7cbb29799976f8</StandardCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <PlatformPackageVersion>2.1.0-preview1-25631-01</PlatformPackageVersion>
-    <CoreFxExpectedPrerelease>preview1-25801-01</CoreFxExpectedPrerelease>
+    <CoreFxExpectedPrerelease>preview1-25631-01</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.1.0-b-uwp6-25707-02</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25627-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>rel-25728-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>rel-25728-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-rel-25728-00</ProjectNTfsTestILCPackageVersion>
-    <NETStandardPackageVersion>2.1.0-preview1-25729-01</NETStandardPackageVersion>
+    <ProjectNTfsExpectedPrerelease>rel-25701-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>rel-25701-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-rel-25701-00</ProjectNTfsTestILCPackageVersion>
+    <NETStandardPackageVersion>2.1.0-preview1-25631-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
-    <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-25706-01</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-25631-01</MicrosoftNETCoreAppPackageVersion>
     <!-- Use the SNI runtime package -->
     <SniPackageVersion>4.4.0</SniPackageVersion>
   </PropertyGroup>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,9 +3,9 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "TestILC.amd64ret": "1.0.0-rel-25728-00",
-        "TestILC.armret": "1.0.0-rel-25728-00",
-        "TestILC.x86ret": "1.0.0-rel-25728-00"
+        "TestILC.amd64ret": "1.0.0-rel-25701-00",
+        "TestILC.armret": "1.0.0-rel-25701-00",
+        "TestILC.x86ret": "1.0.0-rel-25701-00"
       }
     }
   }


### PR DESCRIPTION
Revert "Update CoreFx, CoreSetup, ProjectNTfs, ProjectNTfsTestILC, Standard to preview1-25801-01, stable, rel-25728-00, rel-25728-00, preview1-25729-01, respectively"

This reverts commit 684e85ee5064f3a40e10684686369187f626f622.

This will put uwp6.0 back into the exact state (minus pipebuild properties) that it was when it shipped.
