### PR TITLE
System.Transactions, enable strict and fix struct-null comparisons

### DIFF
--- a/src/System.Transactions.Local/src/System.Transactions.Local.csproj
+++ b/src/System.Transactions.Local/src/System.Transactions.Local.csproj
@@ -4,11 +4,6 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
-    <!-- 
-    There are many instances of comparing an instance of a struct with null. Until these are all fixed,
-    disable the diagnostic.
-    -->
-    <Features>strict</Features>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup>

--- a/src/System.Transactions.Local/src/System.Transactions.Local.csproj
+++ b/src/System.Transactions.Local/src/System.Transactions.Local.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{E97557E3-7DB1-4828-ACA5-44D8C68B6698}</ProjectGuid>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
@@ -8,7 +8,7 @@
     There are many instances of comparing an instance of a struct with null. Until these are all fixed,
     disable the diagnostic.
     -->
-    <Features>$(Features.Replace('strict', '')</Features>
+    <Features>strict</Features>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup>

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionState.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionState.cs
@@ -85,7 +85,7 @@ namespace System.Transactions
             LazyInitializer.EnsureInitialized(ref s_transactionStateAborted, ref s_classSyncObject, () => new TransactionStateAborted());
 
         protected static TransactionStateCommitted TransactionStateCommitted =>
-            LazyInitializer.EnsureInitialized(ref s_transactionStateCommitted, ref s_classSyncObject, () =>  new TransactionStateCommitted());
+            LazyInitializer.EnsureInitialized(ref s_transactionStateCommitted, ref s_classSyncObject, () => new TransactionStateCommitted());
 
         protected static TransactionStateInDoubt TransactionStateInDoubt =>
             LazyInitializer.EnsureInitialized(ref s_transactionStateInDoubt, ref s_classSyncObject, () => new TransactionStateInDoubt());
@@ -301,10 +301,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), e.ToString());
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, e.ToString());
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, e.ToString());
             }
 
             throw new InvalidOperationException();
@@ -316,10 +313,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -331,10 +325,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -346,10 +337,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -361,10 +349,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -376,10 +361,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -391,10 +373,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -406,10 +385,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -421,10 +397,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -452,10 +425,7 @@ namespace System.Transactions
             TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
-                if (tx != null && tx.TransactionTraceId != null && tx.TransactionTraceId.TransactionIdentifier != null)
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx.TransactionTraceId.TransactionIdentifier.ToString(), string.Empty);
-                else
-                    etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, string.Empty, string.Empty);
+                etwLog.TransactionExceptionTrace(TransactionExceptionType.InvalidOperationException, tx?.TransactionTraceId.TransactionIdentifier ?? string.Empty, string.Empty);
             }
 
             throw new InvalidOperationException();
@@ -2115,7 +2085,8 @@ namespace System.Transactions
             {
                 if (tx._innerException == null)
                 {
-                    tx._innerException = new TimeoutException(SR.TraceTransactionTimeout); ;
+                    tx._innerException = new TimeoutException(SR.TraceTransactionTimeout);
+                    ;
                 }
                 tx.PromotedTransaction.Rollback();
 
@@ -4547,7 +4518,7 @@ namespace System.Transactions
                     {
                         // The PSPE has returned an invalid promoted transaction.
                         throw TransactionException.CreateInvalidOperationException(
-                                TraceSourceType.TraceSourceLtm,             
+                                TraceSourceType.TraceSourceLtm,
                                 SR.PromotedReturnedInvalidValue,
                                 e,
                                 tx.DistributedTxId

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
@@ -203,7 +203,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                if (transaction != null && transaction.TransactionTraceId != null)
+                if (transaction != null && transaction.TransactionTraceId.TransactionIdentifier != null)
                     TransactionCreated(transaction.TransactionTraceId.TransactionIdentifier, type);
                 else
                     TransactionCreated(string.Empty, type);
@@ -229,7 +229,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                if (transaction != null && transaction.TransactionTraceId != null)
+                if (transaction != null && transaction.TransactionTraceId.TransactionIdentifier != null)
                     TransactionCloneCreate(transaction.TransactionTraceId.TransactionIdentifier, type);
                 else
                     TransactionCloneCreate(string.Empty, type);
@@ -255,7 +255,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                if (transaction != null && transaction.TransactionTraceId != null)
+                if (transaction != null && transaction.TransactionTraceId.TransactionIdentifier != null)
                     TransactionSerialized(transaction.TransactionTraceId.TransactionIdentifier, type);
                 else
                     TransactionSerialized(string.Empty, type);
@@ -352,7 +352,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (transaction != null && transaction.TransactionTraceId != null)
+                if (transaction != null && transaction.TransactionTraceId.TransactionIdentifier != null)
                     TransactionRollback(transaction.TransactionTraceId.TransactionIdentifier, type);
                 else
                     TransactionRollback(string.Empty, type);
@@ -378,7 +378,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                if (transaction != null && transaction.TransactionTraceId != null)
+                if (transaction != null && transaction.TransactionTraceId.TransactionIdentifier != null)
                     TransactionDependentCloneComplete(transaction.TransactionTraceId.TransactionIdentifier, type);
                 else
                     TransactionDependentCloneComplete(string.Empty, type);
@@ -404,7 +404,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Verbose, ALL_KEYWORDS))
             {
-                if (transaction != null && transaction.TransactionTraceId != null)
+                if (transaction != null && transaction.TransactionTraceId.TransactionIdentifier != null)
                     TransactionCommit(transaction.TransactionTraceId.TransactionIdentifier, type);
                 else
                     TransactionCommit(string.Empty, type);
@@ -430,7 +430,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Verbose, ALL_KEYWORDS))
             {
-                if (enlistment != null && enlistment.EnlistmentTraceId != null)
+                if (enlistment != null && enlistment.EnlistmentTraceId.EnlistmentIdentifier != 0)
                     EnlistmentStatus(enlistment.EnlistmentTraceId.EnlistmentIdentifier, notificationCall.ToString());
                 else
                     EnlistmentStatus(0, notificationCall.ToString());
@@ -455,7 +455,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Verbose, ALL_KEYWORDS))
             {
-                if (enlistment != null && enlistment.EnlistmentTraceId != null)
+                if (enlistment != null && enlistment.EnlistmentTraceId.EnlistmentIdentifier != 0)
                     EnlistmentDone(enlistment.EnlistmentTraceId.EnlistmentIdentifier);
                 else
                     EnlistmentDone(0);
@@ -480,7 +480,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Verbose, ALL_KEYWORDS))
             {
-                if (enlistment != null && enlistment.EnlistmentTraceId != null)
+                if (enlistment != null && enlistment.EnlistmentTraceId.EnlistmentIdentifier != 0)
                     EnlistmentPrepared(enlistment.EnlistmentTraceId.EnlistmentIdentifier);
                 else
                     EnlistmentPrepared(0);
@@ -505,7 +505,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (enlistment != null && enlistment.EnlistmentTraceId != null)
+                if (enlistment != null && enlistment.EnlistmentTraceId.EnlistmentIdentifier != 0)
                     EnlistmentForceRollback(enlistment.EnlistmentTraceId.EnlistmentIdentifier);
                 else
                     EnlistmentForceRollback(0);
@@ -530,7 +530,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (enlistment != null && enlistment.EnlistmentTraceId != null)
+                if (enlistment != null && enlistment.EnlistmentTraceId.EnlistmentIdentifier != 0)
                     EnlistmentAborted(enlistment.EnlistmentTraceId.EnlistmentIdentifier);
                 else
                     EnlistmentAborted(0);
@@ -556,7 +556,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Verbose, ALL_KEYWORDS))
             {
-                if (enlistment != null && enlistment.EnlistmentTraceId != null)
+                if (enlistment != null && enlistment.EnlistmentTraceId.EnlistmentIdentifier != 0)
                     EnlistmentCommitted(enlistment.EnlistmentTraceId.EnlistmentIdentifier);
                 else
                     EnlistmentCommitted(0);
@@ -581,7 +581,7 @@ namespace System.Transactions
 
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (enlistment != null && enlistment.EnlistmentTraceId != null)
+                if (enlistment != null && enlistment.EnlistmentTraceId.EnlistmentIdentifier != 0)
                     EnlistmentInDoubt(enlistment.EnlistmentTraceId.EnlistmentIdentifier);
                 else
                     EnlistmentInDoubt(0);
@@ -845,10 +845,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionScopeCreated(transactionID.TransactionIdentifier.ToString(), transactionScopeResult);
-                else
-                    TransactionScopeCreated(string.Empty, transactionScopeResult);
+                TransactionScopeCreated(transactionID.TransactionIdentifier??string.Empty, transactionScopeResult);
             }
         }
 
@@ -871,11 +868,11 @@ namespace System.Transactions
             {
                 string currentId = string.Empty;
                 string newId = string.Empty;
-                if (currenttransactionID != null && currenttransactionID.TransactionIdentifier != null)
+                if (currenttransactionID.TransactionIdentifier != null)
                 {
                     currentId = currenttransactionID.TransactionIdentifier.ToString();
                 }
-                if (newtransactionID!= null && newtransactionID.TransactionIdentifier != null)
+                if (newtransactionID.TransactionIdentifier != null)
                 {
                     newId = newtransactionID.TransactionIdentifier.ToString();
                 }
@@ -899,10 +896,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionScopeNestedIncorrectly(transactionID.TransactionIdentifier.ToString());
-                else
-                    TransactionScopeNestedIncorrectly(string.Empty);
+                TransactionScopeNestedIncorrectly(transactionID.TransactionIdentifier??string.Empty);
             }
         }
 
@@ -922,10 +916,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionScopeDisposed(transactionID.TransactionIdentifier.ToString());
-                else
-                    TransactionScopeDisposed(string.Empty);
+                TransactionScopeDisposed(transactionID.TransactionIdentifier??string.Empty);
             }
         }
 
@@ -945,10 +936,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionScopeIncomplete(transactionID.TransactionIdentifier.ToString());
-                else
-                    TransactionScopeIncomplete(string.Empty);
+                TransactionScopeIncomplete(transactionID.TransactionIdentifier??string.Empty);
             }
         }
 
@@ -988,10 +976,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionScopeTimeout(transactionID.TransactionIdentifier.ToString());
-                else
-                    TransactionScopeTimeout(string.Empty);
+                TransactionScopeTimeout(transactionID.TransactionIdentifier??string.Empty);
             }
         }
 
@@ -1011,10 +996,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionTimeout(transactionID.TransactionIdentifier.ToString());
-                else
-                    TransactionTimeout(string.Empty);
+                TransactionTimeout(transactionID.TransactionIdentifier??string.Empty);
             }
         }
 
@@ -1036,7 +1018,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                if (enlistmentID != null)
+                if (enlistmentID.EnlistmentIdentifier != 0)
                     TransactionstateEnlist(enlistmentID.EnlistmentIdentifier.ToString(), enlistmentType.ToString(), enlistmentOption.ToString());
                 else
                     TransactionstateEnlist(string.Empty, enlistmentType.ToString(), enlistmentOption.ToString());
@@ -1059,10 +1041,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Verbose, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionCommitted(transactionID.TransactionIdentifier.ToString());
-                else
-                    TransactionCommitted(string.Empty);
+                TransactionCommitted(transactionID.TransactionIdentifier??string.Empty);
             }
         }
 
@@ -1082,10 +1061,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionInDoubt(transactionID.TransactionIdentifier.ToString());
-                else
-                    TransactionInDoubt(string.Empty);
+                TransactionInDoubt(transactionID.TransactionIdentifier??string.Empty);
             }
         }
 
@@ -1106,13 +1082,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                string id = string.Empty;
-                string distributedId = string.Empty;
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    id= transactionID.TransactionIdentifier.ToString();
-                if (distributedTxID != null && distributedTxID.TransactionIdentifier != null)
-                    distributedId = distributedTxID.TransactionIdentifier.ToString();
-                TransactionPromoted(id, distributedId);
+                TransactionPromoted(transactionID.TransactionIdentifier ?? string.Empty, distributedTxID.TransactionIdentifier ?? string.Empty);
             }
         }
 
@@ -1132,10 +1102,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                if (transactionID != null && transactionID.TransactionIdentifier != null)
-                    TransactionAborted(transactionID.TransactionIdentifier.ToString());
-                else
-                    TransactionAborted(string.Empty);
+                TransactionAborted(transactionID.TransactionIdentifier??string.Empty);
             }
           }
 

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
@@ -392,7 +392,7 @@ namespace System.Transactions
             WriteEvent(TRANSACTION_DEPENDENT_CLONE_COMPLETE_EVENTID, transactionIdentifier, type);
         }
         #endregion
-        
+
         #region Transaction Commit
         /// <summary>Trace an event when there is commit on that transaction.</summary>
         /// <param name="transaction">The transaction to commit.</param>
@@ -841,11 +841,11 @@ namespace System.Transactions
         /// <param name="transactionID">The transaction ID.</param>
         /// <param name="transactionScopeResult">The transaction scope result.</param>
         [NonEvent]
-        internal void TransactionScopeCreated(TransactionTraceIdentifier transactionID, TransactionScopeResult transactionScopeResult )
+        internal void TransactionScopeCreated(TransactionTraceIdentifier transactionID, TransactionScopeResult transactionScopeResult)
         {
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                TransactionScopeCreated(transactionID.TransactionIdentifier??string.Empty, transactionScopeResult);
+                TransactionScopeCreated(transactionID.TransactionIdentifier ?? string.Empty, transactionScopeResult);
             }
         }
 
@@ -896,7 +896,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                TransactionScopeNestedIncorrectly(transactionID.TransactionIdentifier??string.Empty);
+                TransactionScopeNestedIncorrectly(transactionID.TransactionIdentifier ?? string.Empty);
             }
         }
 
@@ -916,7 +916,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                TransactionScopeDisposed(transactionID.TransactionIdentifier??string.Empty);
+                TransactionScopeDisposed(transactionID.TransactionIdentifier ?? string.Empty);
             }
         }
 
@@ -936,7 +936,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                TransactionScopeIncomplete(transactionID.TransactionIdentifier??string.Empty);
+                TransactionScopeIncomplete(transactionID.TransactionIdentifier ?? string.Empty);
             }
         }
 
@@ -976,7 +976,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                TransactionScopeTimeout(transactionID.TransactionIdentifier??string.Empty);
+                TransactionScopeTimeout(transactionID.TransactionIdentifier ?? string.Empty);
             }
         }
 
@@ -996,7 +996,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                TransactionTimeout(transactionID.TransactionIdentifier??string.Empty);
+                TransactionTimeout(transactionID.TransactionIdentifier ?? string.Empty);
             }
         }
 
@@ -1041,7 +1041,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Verbose, ALL_KEYWORDS))
             {
-                TransactionCommitted(transactionID.TransactionIdentifier??string.Empty);
+                TransactionCommitted(transactionID.TransactionIdentifier ?? string.Empty);
             }
         }
 
@@ -1061,7 +1061,7 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                TransactionInDoubt(transactionID.TransactionIdentifier??string.Empty);
+                TransactionInDoubt(transactionID.TransactionIdentifier ?? string.Empty);
             }
         }
 
@@ -1102,9 +1102,9 @@ namespace System.Transactions
         {
             if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
             {
-                TransactionAborted(transactionID.TransactionIdentifier??string.Empty);
+                TransactionAborted(transactionID.TransactionIdentifier ?? string.Empty);
             }
-          }
+        }
 
         [Event(TRANSACTION_ABORTED_EVENTID, Keywords = Keywords.TraceLtm, Level = EventLevel.Warning, Task = Tasks.Transaction, Opcode = Opcodes.Aborted, Message = "Transaction aborted: transaction ID is {0}")]
         private void TransactionAborted(string transactionID)
@@ -1170,19 +1170,19 @@ namespace System.Transactions
         {
             Guid guid = Guid.Empty;
 
-            if (str.IndexOf('-')>=0)
+            if (str.IndexOf('-') >= 0)
             { // GUID with dash
-                if (str.Length>=36)
+                if (str.Length >= 36)
                 {
-                    string str_part1 = str.Substring(0,36);
+                    string str_part1 = str.Substring(0, 36);
                     Guid.TryParse(str_part1, out guid);
                 }
             }
             else
             {
-                if (str.Length>=32)
+                if (str.Length >= 32)
                 {
-                    string str_part1 = str.Substring(0,32);
+                    string str_part1 = str.Substring(0, 32);
                     Guid.TryParse(str_part1, out guid);
                 }
             }


### PR DESCRIPTION
Strict is enabled and all struct-null comparisons are fixed up to check the value that is going to be passed to the log correctly in each case.

Fixes https://github.com/dotnet/corefx/issues/31476