### PR TITLE
Fix looking up headers on HttpClient response

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -782,7 +782,7 @@ namespace System.Net.Http.Headers
             // If we don't have the header in the store yet, add it now.
             HeaderStoreItemInfo result = new HeaderStoreItemInfo();
 
-            AddHeaderToStore(descriptor, result);
+            AddHeaderToStore((descriptor.HeaderType & _treatAsCustomHeaderTypes) != 0 ? descriptor.AsCustomHeader() : descriptor, result);
 
             return result;
         }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -782,7 +782,10 @@ namespace System.Net.Http.Headers
             // If we don't have the header in the store yet, add it now.
             HeaderStoreItemInfo result = new HeaderStoreItemInfo();
 
-            AddHeaderToStore((descriptor.HeaderType & _treatAsCustomHeaderTypes) != 0 ? descriptor.AsCustomHeader() : descriptor, result);
+            // If the descriptor header type is in _treatAsCustomHeaderTypes, it must be converted to a custom header before calling this method
+            Debug.Assert((descriptor.HeaderType & _treatAsCustomHeaderTypes) == 0);
+
+            AddHeaderToStore(descriptor, result);
 
             return result;
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -928,7 +928,8 @@ namespace System.Net.Http
             }
             else
             {
-                response.Headers.TryAddWithoutValidation(descriptor, headerValue);
+                // Request headers returned on the response must be treated as custom headers
+                response.Headers.TryAddWithoutValidation(descriptor.HeaderType == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1531,6 +1531,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Headers.Add("Accept-Datetime", "Thu, 31 May 2007 20:35:00 GMT");
                     request.Headers.Add("Access-Control-Request-Method", "GET");
                     request.Headers.Add("Access-Control-Request-Headers", "GET");
+                    request.Headers.Add("Age", "12");
                     request.Headers.Authorization = new AuthenticationHeaderValue("Basic", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
                     request.Headers.CacheControl = new CacheControlHeaderValue() { NoCache = true };
                     request.Headers.Connection.Add("close");
@@ -1582,7 +1583,6 @@ namespace System.Net.Http.Functional.Tests
                     request.Headers.Add("X-Csrf-Token", "i8XNjC4b8KVok4uw5RftR38Wgp2BFwql");
                     request.Headers.Add("X-Request-ID", "f058ebd6-02f7-4d3f-942e-904344e8cde5");
                     request.Headers.Add("X-Request-ID", "f058ebd6-02f7-4d3f-942e-904344e8cde5");
-
                     (await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)).Dispose();
                 }
             }, async server =>
@@ -1605,6 +1605,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Contains("Accept-Datetime: Thu, 31 May 2007 20:35:00 GMT", headersSet);
                     Assert.Contains("Access-Control-Request-Method: GET", headersSet);
                     Assert.Contains("Access-Control-Request-Headers: GET", headersSet);
+                    Assert.Contains("Age: 12", headersSet);
                     Assert.Contains("Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==", headersSet);
                     Assert.Contains("Cache-Control: no-cache", headersSet);
                     Assert.Contains("Connection: close", headersSet, StringComparer.OrdinalIgnoreCase); // NetFxHandler uses "Close" vs "close"
@@ -1691,6 +1692,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Contains("text/example;charset=utf-8", resp.Headers.GetValues("Accept-Patch"));
                     Assert.Contains("bytes", resp.Headers.AcceptRanges);
                     Assert.Equal(TimeSpan.FromSeconds(12), resp.Headers.Age.GetValueOrDefault());
+                    Assert.Contains("Bearer 63123a47139a49829bcd8d03005ca9d7", resp.Headers.GetValues("Authorization"));
                     Assert.Contains("GET", resp.Content.Headers.Allow);
                     Assert.Contains("HEAD", resp.Content.Headers.Allow);
                     Assert.Contains("http/1.1=\"http2.example.com:8001\"; ma=7200", resp.Headers.GetValues("Alt-Svc"));
@@ -1751,6 +1753,7 @@ namespace System.Net.Http.Functional.Tests
                 $"Accept-Patch:{fold} text/example;charset=utf-8{newline}" +
                 $"Accept-Ranges:{fold} bytes{newline}" +
                 $"Age: {fold}12{newline}" +
+                $"Authorization: Bearer 63123a47139a49829bcd8d03005ca9d7{newline}" +
                 $"Allow: {fold}GET, HEAD{newline}" +
                 $"Alt-Svc:{fold} http/1.1=\"http2.example.com:8001\"; ma=7200{newline}" +
                 $"Cache-Control: {fold}max-age=3600{newline}" +

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1583,6 +1583,7 @@ namespace System.Net.Http.Functional.Tests
                     request.Headers.Add("X-Csrf-Token", "i8XNjC4b8KVok4uw5RftR38Wgp2BFwql");
                     request.Headers.Add("X-Request-ID", "f058ebd6-02f7-4d3f-942e-904344e8cde5");
                     request.Headers.Add("X-Request-ID", "f058ebd6-02f7-4d3f-942e-904344e8cde5");
+
                     (await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)).Dispose();
                 }
             }, async server =>

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpResponseHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpResponseHeadersTest.cs
@@ -609,13 +609,6 @@ namespace System.Net.Http.Tests
             Assert.Equal(2, headers.Pragma.Count);
         }
 
-        [Fact]
-        public void CustomHeaders_RequestHeadersAsCustomHeadersWithGetValues_Success()
-        {
-            headers.TryAddWithoutValidation(new HeaderDescriptor(KnownHeaders.Range), "bytes=200-1000");
-            Assert.Equal("bytes=200-1000", headers.GetValues("Range").First());
-        }
-
         #endregion
 
         [Fact]

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpResponseHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpResponseHeadersTest.cs
@@ -609,6 +609,13 @@ namespace System.Net.Http.Tests
             Assert.Equal(2, headers.Pragma.Count);
         }
 
+        [Fact]
+        public void CustomHeaders_RequestHeadersAsCustomHeadersWithGetValues_Success()
+        {
+            headers.TryAddWithoutValidation(new HeaderDescriptor(KnownHeaders.Range), "bytes=200-1000");
+            Assert.Equal("bytes=200-1000", headers.GetValues("Range").First());
+        }
+
         #endregion
 
         [Fact]


### PR DESCRIPTION
 Headers marked as `HttpHeaderType.Request` were not able to be via the `Headers.GetValues` method. When looking up a header, the `HeaderDescriptor` gets set to to `HttpHeaderType.Custom` in `GetHeaderDescriptor`, but the persisted header in `_headerStore` had `HeaderType` set to `HttpHeaderType.Request`, so lookups would fail. This change makes the insert logic consistent with the lookup logic.

Fixes #31143 

cc @davidsh 