### PR TITLE
[System.Security.Cryptography.Pkcs]: Rename internal `Helpers` class into `PkcsHelpers`.

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
@@ -80,7 +80,7 @@ namespace Internal.Cryptography.Pal.AnyOS
             {
                 List<AttributeAsn> attrList = CmsSigner.BuildAttributes(unprotectedAttributes);
 
-                envelopedData.UnprotectedAttributes = Helpers.NormalizeSet(attrList.ToArray());
+                envelopedData.UnprotectedAttributes = PkcsHelpers.NormalizeSet(attrList.ToArray());
             }
 
             if (originatorCerts != null && originatorCerts.Count > 0)
@@ -145,7 +145,7 @@ namespace Internal.Cryptography.Pal.AnyOS
                 envelopedData.Version = 2;
             }
 
-            return Helpers.EncodeContentInfo(envelopedData, Oids.Pkcs7Enveloped);
+            return PkcsHelpers.EncodeContentInfo(envelopedData, Oids.Pkcs7Enveloped);
         }
 
         private byte[] EncryptContent(

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
@@ -17,13 +17,13 @@ namespace Internal.Cryptography.Pal.AnyOS
 
         public override void AddCertsFromStoreForDecryption(X509Certificate2Collection certs)
         {
-            certs.AddRange(Helpers.GetStoreCertificates(StoreName.My, StoreLocation.CurrentUser, openExistingOnly: false));
+            certs.AddRange(PkcsHelpers.GetStoreCertificates(StoreName.My, StoreLocation.CurrentUser, openExistingOnly: false));
 
             try
             {
                 // This store exists on macOS, but not Linux
                 certs.AddRange(
-                    Helpers.GetStoreCertificates(StoreName.My, StoreLocation.LocalMachine, openExistingOnly: false));
+                    PkcsHelpers.GetStoreCertificates(StoreName.My, StoreLocation.LocalMachine, openExistingOnly: false));
             }
             catch (CryptographicException)
             {

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decrypt.cs
@@ -200,8 +200,8 @@ namespace Internal.Cryptography.Pal.Windows
                             case CMsgKeyAgreeOriginatorChoice.CMSG_KEY_AGREE_ORIGINATOR_CERT:
                                 {
                                     X509Certificate2Collection candidateCerts = new X509Certificate2Collection();
-                                    candidateCerts.AddRange(Helpers.GetStoreCertificates(StoreName.AddressBook, StoreLocation.CurrentUser, openExistingOnly: true));
-                                    candidateCerts.AddRange(Helpers.GetStoreCertificates(StoreName.AddressBook, StoreLocation.LocalMachine, openExistingOnly: true));
+                                    candidateCerts.AddRange(PkcsHelpers.GetStoreCertificates(StoreName.AddressBook, StoreLocation.CurrentUser, openExistingOnly: true));
+                                    candidateCerts.AddRange(PkcsHelpers.GetStoreCertificates(StoreName.AddressBook, StoreLocation.LocalMachine, openExistingOnly: true));
                                     candidateCerts.AddRange(originatorCerts);
                                     candidateCerts.AddRange(extraStore);
                                     SubjectIdentifier originatorId = pKeyAgreeRecipientInfo->OriginatorCertId.ToSubjectIdentifier();

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
@@ -467,7 +467,7 @@ namespace Internal.Cryptography.Pal.Windows
             for (int i = 0; i < pCryptAttribute->cValue; i++)
             {
                 byte[] encodedAttribute = pCryptAttribute->rgValue[i].ToByteArray();
-                AsnEncodedData attributeObject = Helpers.CreateBestPkcs9AttributeObjectAvailable(oid, encodedAttribute);
+                AsnEncodedData attributeObject = PkcsHelpers.CreateBestPkcs9AttributeObjectAvailable(oid, encodedAttribute);
                 attributeCollection.Add(attributeObject);
             }
 

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
@@ -143,8 +143,8 @@ namespace Internal.Cryptography.Pal.Windows
 
         public sealed override void AddCertsFromStoreForDecryption(X509Certificate2Collection certs)
         {
-            certs.AddRange(Helpers.GetStoreCertificates(StoreName.My, StoreLocation.CurrentUser, openExistingOnly: true));
-            certs.AddRange(Helpers.GetStoreCertificates(StoreName.My, StoreLocation.LocalMachine, openExistingOnly: true));
+            certs.AddRange(PkcsHelpers.GetStoreCertificates(StoreName.My, StoreLocation.CurrentUser, openExistingOnly: true));
+            certs.AddRange(PkcsHelpers.GetStoreCertificates(StoreName.My, StoreLocation.LocalMachine, openExistingOnly: true));
         }
 
         public sealed override Exception CreateRecipientsNotFoundException()

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -17,7 +17,7 @@ using X509IssuerSerial = System.Security.Cryptography.Xml.X509IssuerSerial;
 
 namespace Internal.Cryptography
 {
-    internal static partial class Helpers
+    internal static partial class PkcsHelpers
     {
 #if !netcoreapp
         // Compatibility API.

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -51,7 +51,7 @@
     <Compile Include="Internal\Cryptography\KeyAgreeRecipientInfoPal.cs" />
     <Compile Include="Internal\Cryptography\KeyLengths.cs" />
     <Compile Include="Internal\Cryptography\KeyTransRecipientInfoPal.cs" />
-    <Compile Include="Internal\Cryptography\Helpers.cs" />
+    <Compile Include="Internal\Cryptography\PkcsHelpers.cs" />
     <Compile Include="Internal\Cryptography\PkcsPal.cs" />
     <Compile Include="Internal\Cryptography\RecipientInfoPal.cs" />
     <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -121,7 +121,7 @@ namespace System.Security.Cryptography.Pkcs
             bool silent,
             out X509Certificate2Collection chainCerts)
         {
-            HashAlgorithmName hashAlgorithmName = Helpers.GetDigestAlgorithm(DigestAlgorithm);
+            HashAlgorithmName hashAlgorithmName = PkcsHelpers.GetDigestAlgorithm(DigestAlgorithm);
             IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName);
 
             hasher.AppendData(data.Span);
@@ -170,7 +170,7 @@ namespace System.Security.Cryptography.Pkcs
 
                 // Use the serializer/deserializer to DER-normalize the attribute order.
                 SignedAttributesSet signedAttrsSet = new SignedAttributesSet();
-                signedAttrsSet.SignedAttributes = Helpers.NormalizeSet(
+                signedAttrsSet.SignedAttributes = PkcsHelpers.NormalizeSet(
                     signedAttrs.ToArray(),
                     normalized =>
                     {
@@ -224,7 +224,7 @@ namespace System.Security.Cryptography.Pkcs
             {
                 List<AttributeAsn> attrs = BuildAttributes(UnsignedAttributes);
 
-                newSignerInfo.UnsignedAttributes = Helpers.NormalizeSet(attrs.ToArray());
+                newSignerInfo.UnsignedAttributes = PkcsHelpers.NormalizeSet(attrs.ToArray());
             }
 
             bool signed = CmsSignature.Sign(

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12Builder.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12Builder.cs
@@ -253,7 +253,7 @@ namespace System.Security.Cryptography.Pkcs
                         {
                             writer.PushSequence();
                             {
-                                writer.WriteObjectIdentifier(Helpers.GetOidFromHashAlgorithm(hashAlgorithm));
+                                writer.WriteObjectIdentifier(PkcsHelpers.GetOidFromHashAlgorithm(hashAlgorithm));
                                 writer.PopSequence();
                             }
 

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12CertBag.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12CertBag.cs
@@ -84,7 +84,7 @@ namespace System.Security.Cryptography.Pkcs
                 throw new InvalidOperationException(SR.Cryptography_Pkcs12_CertBagNotX509);
             }
 
-            return new X509Certificate2(Helpers.DecodeOctetString(_decoded.CertValue).ToArray());
+            return new X509Certificate2(PkcsHelpers.DecodeOctetString(_decoded.CertValue).ToArray());
         }
 
         private static byte[] EncodeBagValue(Oid certificateType, ReadOnlyMemory<byte> encodedCertificate)

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12Info.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12Info.cs
@@ -130,7 +130,7 @@ namespace System.Security.Cryptography.Pkcs
 
             if (pfx.AuthSafe.ContentType == Oids.Pkcs7Data)
             {
-                authSafeBytes = Helpers.DecodeOctetString(pfx.AuthSafe.Content);
+                authSafeBytes = PkcsHelpers.DecodeOctetString(pfx.AuthSafe.Content);
 
                 if (pfx.MacData.HasValue)
                 {

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12SafeContents.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12SafeContents.cs
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Pkcs
                     break;
                 case Oids.Pkcs7Data:
                     ConfidentialityMode = Pkcs12ConfidentialityMode.None;
-                    _bags = ReadBags(Helpers.DecodeOctetString(contentInfoAsn.Content));
+                    _bags = ReadBags(PkcsHelpers.DecodeOctetString(contentInfoAsn.Content));
                     break;
                 default:
                     throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
@@ -249,7 +249,7 @@ namespace System.Security.Cryptography.Pkcs
 
             if (Attributes.Count > 0)
             {
-                info.Attributes = Helpers.NormalizeSet(CmsSigner.BuildAttributes(Attributes).ToArray());
+                info.Attributes = PkcsHelpers.NormalizeSet(CmsSigner.BuildAttributes(Attributes).ToArray());
             }
 
             // Write in BER in case any of the provided fields was BER.

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Rfc3161TimestampRequest.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Rfc3161TimestampRequest.cs
@@ -206,7 +206,7 @@ namespace System.Security.Cryptography.Pkcs
             bool requestSignerCertificates = false,
             X509ExtensionCollection extensions = null)
         {
-            string oidStr = Helpers.GetOidFromHashAlgorithm(hashAlgorithm);
+            string oidStr = PkcsHelpers.GetOidFromHashAlgorithm(hashAlgorithm);
             
             return CreateFromHash(
                 hash,

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Rfc3161TimestampToken.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Rfc3161TimestampToken.cs
@@ -109,7 +109,7 @@ namespace System.Security.Cryptography.Pkcs
                 return false;
             }
 
-            bool ret = VerifyHash(hash, Helpers.GetOidFromHashAlgorithm(hashAlgorithm));
+            bool ret = VerifyHash(hash, PkcsHelpers.GetOidFromHashAlgorithm(hashAlgorithm));
 
             if (ret)
             {
@@ -179,7 +179,7 @@ namespace System.Security.Cryptography.Pkcs
         private bool VerifyData(ReadOnlySpan<byte> data)
         {
             Oid hashAlgorithmId = TokenInfo.HashAlgorithmId;
-            HashAlgorithmName hashAlgorithmName = Helpers.GetDigestAlgorithm(hashAlgorithmId);
+            HashAlgorithmName hashAlgorithmName = PkcsHelpers.GetDigestAlgorithm(hashAlgorithmId);
 
             using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName))
             {
@@ -511,7 +511,7 @@ namespace System.Security.Cryptography.Pkcs
 
                 try
                 {
-                    alg = Helpers.GetDigestAlgorithm(certId2.HashAlgorithm.Algorithm);
+                    alg = PkcsHelpers.GetDigestAlgorithm(certId2.HashAlgorithm.Algorithm);
 
                     if (signerCert.TryGetCertHash(alg, thumbprint, out int written))
                     {

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -104,7 +104,7 @@ namespace System.Security.Cryptography.Pkcs
                 throw new InvalidOperationException(SR.Cryptography_Cms_MessageNotSigned);
             }
 
-            return Helpers.EncodeContentInfo(_signedData, Oids.Pkcs7Signed);
+            return PkcsHelpers.EncodeContentInfo(_signedData, Oids.Pkcs7Signed);
         }
 
         public void Decode(byte[] encodedMessage)
@@ -310,7 +310,7 @@ namespace System.Security.Cryptography.Pkcs
             }
 
             AlgorithmIdentifierAsn signerAlgorithm = _signedData.SignerInfos[index].DigestAlgorithm;
-            Helpers.RemoveAt(ref _signedData.SignerInfos, index);
+            PkcsHelpers.RemoveAt(ref _signedData.SignerInfos, index);
 
             ConsiderDigestRemoval(signerAlgorithm);
             UpdateMetadata();
@@ -443,7 +443,7 @@ namespace System.Security.Cryptography.Pkcs
 
                 if (candidate.Equals(ref alg))
                 {
-                    Helpers.RemoveAt(ref _signedData.DigestAlgorithms, i);
+                    PkcsHelpers.RemoveAt(ref _signedData.DigestAlgorithms, i);
                     break;
                 }
             }
@@ -609,7 +609,7 @@ namespace System.Security.Cryptography.Pkcs
                 {
                     if (cert.Certificate.Value.Span.SequenceEqual(rawData))
                     {
-                        Helpers.RemoveAt(ref _signedData.CertificateSet, idx);
+                        PkcsHelpers.RemoveAt(ref _signedData.CertificateSet, idx);
                         Reencode();
                         return;
                     }

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
@@ -218,7 +218,7 @@ namespace System.Security.Cryptography.Pkcs
 
             if (isOnlyValue)
             {
-                Helpers.RemoveAt(ref mySigner.UnsignedAttributes, outerIndex);
+                PkcsHelpers.RemoveAt(ref mySigner.UnsignedAttributes, outerIndex);
             }
             else
             {
@@ -416,7 +416,7 @@ namespace System.Security.Cryptography.Pkcs
                 }
                 else
                 {
-                    Helpers.RemoveAt(ref myData.UnsignedAttributes, removeAttrIdx);
+                    PkcsHelpers.RemoveAt(ref myData.UnsignedAttributes, removeAttrIdx);
                 }
             }
             else
@@ -786,7 +786,7 @@ namespace System.Security.Cryptography.Pkcs
 
         private HashAlgorithmName GetDigestAlgorithm()
         {
-            return Helpers.GetDigestAlgorithm(DigestAlgorithm.Value);
+            return PkcsHelpers.GetDigestAlgorithm(DigestAlgorithm.Value);
         }
 
         internal static CryptographicAttributeObjectCollection MakeAttributeCollection(AttributeAsn[] attributes)
@@ -820,7 +820,7 @@ namespace System.Security.Cryptography.Pkcs
             while (collReader.HasData)
             {
                 byte[] attrBytes = collReader.GetEncodedValue().ToArray();
-                valueColl.Add(Helpers.CreateBestPkcs9AttributeObjectAvailable(type, attrBytes));
+                valueColl.Add(PkcsHelpers.CreateBestPkcs9AttributeObjectAvailable(type, attrBytes));
             }
 
             return new CryptographicAttributeObject(type, valueColl);

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
@@ -109,7 +109,7 @@ namespace System.Security.Cryptography.Pkcs
                         string issuer = issuerSerial.IssuerName;
                         byte[] certSerialNumber = certificate.GetSerialNumber();
 
-                        return Helpers.AreByteArraysEqual(certSerialNumber, serialNumber) && certificate.Issuer == issuer;
+                        return PkcsHelpers.AreByteArraysEqual(certSerialNumber, serialNumber) && certificate.Issuer == issuer;
                     }
 
                 case SubjectIdentifierType.SubjectKeyIdentifier:
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.Pkcs
                         byte[] ski = skiString.ToSkiBytes();
                         byte[] candidateSki = PkcsPal.Instance.GetSubjectKeyIdentifier(certificate);
 
-                        return Helpers.AreByteArraysEqual(ski, candidateSki);
+                        return PkcsHelpers.AreByteArraysEqual(ski, candidateSki);
                     }
 
                 default:


### PR DESCRIPTION
There are a variety of different parial `Internal.Cryptography.Helper` class parts split across
multiple assemblies.  This is causing problems for Mono because you cannot "combine" different
parts of partial class across assembly boundaries.

In Mono, the `System.Security.Cryptography.Pkcs` namespace lives in `System.Security.dll`,
but we are already using different parts of that internal class in our `mscorlib.dll`, which is
now causing conflicts.