### PR TITLE
Expose OSThreadId and TimeStamp on EventWrittenEventArgs

### DIFF
--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -286,6 +286,8 @@ namespace System.Diagnostics.Tracing
         public System.Diagnostics.Tracing.EventTags Tags { get { throw null; } }
         public System.Diagnostics.Tracing.EventTask Task { get { throw null; } }
         public byte Version { get { throw null; } }
+        public long OSThreadId { get { throw null; } }
+        public DateTime TimeStamp { get { throw null; } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(64))]
     public sealed partial class NonEventAttribute : System.Attribute


### PR DESCRIPTION
Expose two new public APIs:

 + ```System.Diagnostics.Tracing.EventWrittenEventArgs.OSThreadId```
 + ```System.Diagnostics.Tracing.EventWrittenEventArgs.TimeStamp```

Fixes #31401.