### PR TITLE
[release/2.1] SetLastAccessTimeUtc and SetLastModifiedTimeUtc corrected  to set Milliseconds

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.UTimensat.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.UTimensat.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        internal struct UTimBuf
+        internal struct TimeSpec
         {
-            internal long AcTime;
-            internal long ModTime;
+            internal long TvSec;
+            internal long TvNsec;
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns 0 on success; otherwise, returns -1 
         /// </returns>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTime", SetLastError = true)]
-        internal static extern int UTime(string path, ref UTimBuf time);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTimensat", SetLastError = true)]
+        internal static extern int UTimensat(string path, ref TimeSpec times);
     }
 }

--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -73,6 +73,7 @@
 #cmakedefine01 HAVE_CRT_EXTERNS_H
 #cmakedefine01 HAVE_GETDOMAINNAME
 #cmakedefine01 HAVE_UNAME
+#cmakedefine01 HAVE_UTIMENSAT
 #cmakedefine01 HAVE_FUTIMES
 #cmakedefine01 HAVE_FUTIMENS
 #cmakedefine01 HAVE_MKSTEMPS

--- a/src/Native/Unix/System.Native/pal_time.cpp
+++ b/src/Native/Unix/System.Native/pal_time.cpp
@@ -9,6 +9,8 @@
 #include <assert.h>
 #include <utime.h>
 #include <time.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include <sys/time.h>
 #if HAVE_MACH_ABSOLUTE_TIME
 #include <mach/mach_time.h>
@@ -20,21 +22,27 @@ enum
     SecondsToNanoSeconds = 1000000000 // 10^9
 };
 
-static void ConvertUTimBuf(const UTimBuf& pal, utimbuf& native)
+extern "C" int32_t SystemNative_UTimensat(const char* path, TimeSpec* times)
 {
-    native.actime = static_cast<time_t>(pal.AcTime);
-    native.modtime = static_cast<time_t>(pal.ModTime);
-}
-
-extern "C" int32_t SystemNative_UTime(const char* path, UTimBuf* times)
-{
-    assert(times != nullptr);
-
-    utimbuf temp;
-    ConvertUTimBuf(*times, temp);
-
     int32_t result;
-    while (CheckInterrupted(result = utime(path, &temp)));
+#if HAVE_UTIMENSAT
+    struct timespec origTimes[2];
+    origTimes[0].tv_sec = (time_t)times[0].tv_sec;
+    origTimes[0].tv_nsec = (long)times[0].tv_nsec;
+
+    origTimes[1].tv_sec = (time_t)times[1].tv_sec;
+    origTimes[1].tv_nsec = (long)times[1].tv_nsec;    
+    while (CheckInterrupted(result = utimensat(AT_FDCWD, path, origTimes, 0)));
+#else
+    struct timeval origTimes[2];
+    origTimes[0].tv_sec = (long)times[0].tv_sec;
+    origTimes[0].tv_usec = (int)times[0].tv_nsec / 1000;
+    
+    origTimes[1].tv_sec = (long)times[1].tv_sec;
+    origTimes[1].tv_usec = (int)times[1].tv_nsec / 1000;
+    while (CheckInterrupted(result = utimes(path, origTimes)));
+#endif
+
     return result;
 }
 

--- a/src/Native/Unix/System.Native/pal_time.h
+++ b/src/Native/Unix/System.Native/pal_time.h
@@ -6,18 +6,18 @@
 
 #include "pal_types.h"
 
-struct UTimBuf
+typedef struct TimeSpec
 {
-    int64_t AcTime;
-    int64_t ModTime;
-};
+    int64_t tv_sec; // seconds
+    int64_t tv_nsec; // nanoseconds
+} TimeSpec;
 
 /**
  * Sets the last access and last modified time of a file
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-extern "C" int32_t SystemNative_UTime(const char* path, UTimBuf* time);
+extern "C" int32_t SystemNative_UTimensat(const char* path, TimeSpec* times);
 
 /**
  * Gets the resolution of the timestamp, in counts per second.

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -393,6 +393,10 @@ check_function_exists(
     futimens
     HAVE_FUTIMENS)
 
+check_function_exists(
+    utimensat
+    HAVE_UTIMENSAT)
+
 set (PREVIOUS_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 set (CMAKE_REQUIRED_FLAGS "-Werror -Wsign-conversion")
 

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -290,8 +290,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RmDir.cs">
       <Link>Common\Interop\Unix\Interop.RmDir.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.UTime.cs">
-      <Link>Common\Interop\Unix\Interop.UTime.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.UTimensat.cs">
+      <Link>Common\Interop\Unix\Interop.UTimensat.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\System\IO\PathInternal.Unix.cs">
       <Link>Common\CoreLib\System\IO\PathInternal.Unix.cs</Link>

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -42,7 +42,8 @@ namespace System.IO.Tests
 
             Assert.All(TimeFunctions(requiresRoundtripping: true), (function) =>
             {
-                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, function.Kind);
+                // Checking that milliseconds are not dropped after setter.
+                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, isHFS ? 0 : 321, function.Kind);
                 function.Setter(item, dt);
                 DateTime result = function.Getter(item);
                 Assert.Equal(dt, result);

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -94,7 +94,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void SetLastWriteTimeMilliSec()
+        public void SetLastWriteTimeTicks()
         {
             string firstFile = GetTestFilePath();
             string secondFile = GetTestFilePath();
@@ -105,6 +105,21 @@ namespace System.IO.Tests
             File.SetLastAccessTimeUtc(secondFile, DateTime.UtcNow);
             long firstFileTicks = File.GetLastWriteTimeUtc(firstFile).Ticks;
             long secondFileTicks = File.GetLastWriteTimeUtc(secondFile).Ticks;
+            Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
+        }
+
+        [Fact]
+        public void SetLastAccessTimeTicks()
+        {
+            string firstFile = GetTestFilePath();
+            string secondFile = GetTestFilePath();
+
+            File.WriteAllText(firstFile, "");
+            File.WriteAllText(secondFile, "");
+
+            File.SetLastWriteTimeUtc(secondFile, DateTime.UtcNow);
+            long firstFileTicks = File.GetLastAccessTimeUtc(firstFile).Ticks;
+            long secondFileTicks = File.GetLastAccessTimeUtc(secondFile).Ticks;
             Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
         }
     }

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -92,5 +92,20 @@ namespace System.IO.Tests
                 });
             }
         }
+
+        [Fact]
+        public void SetLastWriteTimeMilliSec()
+        {
+            string firstFile = GetTestFilePath();
+            string secondFile = GetTestFilePath();
+
+            File.WriteAllText(firstFile, "");
+            File.WriteAllText(secondFile, "");
+
+            File.SetLastAccessTimeUtc(secondFile, DateTime.UtcNow);
+            long firstFileTicks = File.GetLastWriteTimeUtc(firstFile).Ticks;
+            long secondFileTicks = File.GetLastWriteTimeUtc(secondFile).Ticks;
+            Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
+        }
     }
 }

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -17,6 +17,24 @@ namespace System.IO.Tests
             return new FileInfo(path);
         }
 
+        public FileInfo GetNonZeroMilliSec()
+        {
+            FileInfo fileinfo = new FileInfo(GetTestFilePath());
+            for (int i = 0; i < 5; i++)
+            {
+                fileinfo.Create().Dispose();
+                if (fileinfo.LastWriteTime.Millisecond != 0)
+                    break;
+
+                // This case should only happen 1/1000 times, unless the OS/Filesystem does
+                // not support millisecond granularity.
+
+                // If it's 1/1000, or low granularity, this may help:
+                Thread.Sleep(1234);
+            }
+            return fileinfo;
+        }
+
         public override FileInfo GetMissingItem() => new FileInfo(GetTestFilePath());
 
         public override string GetItemPath(FileInfo item) => item.FullName;
@@ -64,6 +82,55 @@ namespace System.IO.Tests
                 ((testFile, time) => { testFile.LastWriteTimeUtc = time; }),
                 ((testFile) => testFile.LastWriteTimeUtc),
                 DateTimeKind.Utc);
+        }
+
+        [ConditionalFact(nameof(isNotHFS))]
+        public void CopyToMillisecondPresent()
+        {
+            FileInfo input = GetNonZeroMilliSec();
+            FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
+
+            Assert.Equal(0, output.LastWriteTime.Millisecond);
+            output.Directory.Create();
+            output = input.CopyTo(output.FullName, true);
+
+            Assert.NotEqual(0, input.LastWriteTime.Millisecond);
+            Assert.NotEqual(0, output.LastWriteTime.Millisecond);
+        }
+
+        [ConditionalFact(nameof(isHFS))]
+        public void MoveToMillisecondPresent_HFS()
+        {
+            FileInfo input = new FileInfo(GetTestFilePath());
+            input.Create().Dispose();
+
+            string dest = Path.Combine(input.DirectoryName, GetTestFileName());
+            input.MoveTo(dest);
+            FileInfo output = new FileInfo(dest);
+            Assert.Equal(0, output.LastWriteTime.Millisecond);
+        }
+
+        [ConditionalFact(nameof(isNotHFS))]
+        public void MoveToMillisecondPresent()
+        {
+            FileInfo input = GetNonZeroMilliSec();
+            string dest = Path.Combine(input.DirectoryName, GetTestFileName());
+
+            input.MoveTo(dest);
+            FileInfo output = new FileInfo(dest);
+            Assert.NotEqual(0, output.LastWriteTime.Millisecond);
+        }
+
+        [ConditionalFact(nameof(isHFS))]
+        public void CopyToMillisecondPresent_HFS()
+        {
+            FileInfo input = new FileInfo(GetTestFilePath());
+            input.Create().Dispose();
+            FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
+            output.Directory.Create();
+            output = input.CopyTo(output.FullName, true);
+            Assert.Equal(0, input.LastWriteTime.Millisecond);
+            Assert.Equal(0, output.LastWriteTime.Millisecond);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #31379
Related corefx PR  https://github.com/dotnet/corefx/pull/31522