### PR TITLE
Move BackendSupportsAlpn check to CoreFx.Private.TestUtilities

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -41,7 +41,7 @@ namespace System
     public static partial class PlatformDetection
     {
         public static bool IsReflectionEmitSupported;
-        public static bool BackendSupportsAlpn { get { throw null; } }
+        public static bool SupportsAlpn { get { throw null; } }
         public static bool ClientWebSocketPartialMessagesSupported { get { throw null; } }
         public static bool HasWindowsShell { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -41,6 +41,7 @@ namespace System
     public static partial class PlatformDetection
     {
         public static bool IsReflectionEmitSupported;
+        public static bool BackendSupportsAlpn { get { throw null; } }
         public static bool ClientWebSocketPartialMessagesSupported { get { throw null; } }
         public static bool HasWindowsShell { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -43,7 +43,6 @@ namespace System
         public static bool IsRedHatFamily7 => false;
         public static bool IsNotRedHatFamily6 => true;
 
-        // Windows 10 Anniversary release a.k.a Windows 10 Version 1607 added support to native WinHTTP for HTTP/2 protocol support.
         public static bool IsWindows10Version1607OrGreater => 
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater => 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -43,6 +43,7 @@ namespace System
         public static bool IsRedHatFamily7 => false;
         public static bool IsNotRedHatFamily6 => true;
 
+        // Windows 10 Anniversary release a.k.a Windows 10 Version 1607 added support to native WinHTTP for HTTP/2 protocol support.
         public static bool IsWindows10Version1607OrGreater => 
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater => 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -47,7 +47,7 @@ namespace System
         // Windows - Schannel supports alpn from win8.1/2012 R2 and higher.
         // Linux - OpenSsl supports alpn from openssl 1.0.2 and higher.
         // OSX - SecureTransport doesn't expose alpn APIs. #30492
-        public static bool BackendSupportsAlpn => (IsWindows && !IsWindows7) ||
+        public static bool SupportsAlpn => (IsWindows && !IsWindows7) ||
             (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
             (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -44,6 +44,13 @@ namespace System
 
         public static bool IsNotNetNative => !IsNetNative;
 
+        // Windows - Schannel supports alpn from win8.1/2012 R2 and higher.
+        // Linux - OpenSsl supports alpn from openssl 1.0.2 and higher.
+        // OSX - SecureTransport doesn't expose alpn APIs. #30492
+        public static bool BackendSupportsAlpn => (IsWindows && !IsWindows7) ||
+            (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+            (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
+
         // Officially, .Net Native only supports processes running in an AppContainer. However, the majority of tests still work fine
         // in a normal Win32 process and we often do so as running in an AppContainer imposes a substantial tax in debuggability
         // and investigatability. This predicate is used in ConditionalFacts to disable the specific tests that really need to be

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -22,12 +22,7 @@ namespace System.Net.Security.Tests
 
     public class SslStreamAlpnTests
     {
-        // Windows - Schannel supports alpn from win8 and higher.
-        // Linux - OpenSsl supports alpn from openssl 1.0.2 and higher.
-        // OSX - SecureTransport doesn't expose alpn APIs.
-        private static bool BackendSupportsAlpn => (PlatformDetection.IsWindows && !PlatformDetection.IsWindows7) ||
-            (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-            (PlatformDetection.OpenSslVersion.Major >= 1 && (PlatformDetection.OpenSslVersion.Minor >= 1 || PlatformDetection.OpenSslVersion.Build >= 2)));
+        private static bool BackendSupportsAlpn => PlatformDetection.BackendSupportsAlpn;
 
         private async Task DoHandshakeWithOptions(SslStream clientSslStream, SslStream serverSslStream, SslClientAuthenticationOptions clientOptions, SslServerAuthenticationOptions serverOptions)
         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -22,7 +22,7 @@ namespace System.Net.Security.Tests
 
     public class SslStreamAlpnTests
     {
-        private static bool BackendSupportsAlpn => PlatformDetection.BackendSupportsAlpn;
+        private static bool BackendSupportsAlpn => PlatformDetection.SupportsAlpn;
 
         private async Task DoHandshakeWithOptions(SslStream clientSslStream, SslStream serverSslStream, SslClientAuthenticationOptions clientOptions, SslServerAuthenticationOptions serverOptions)
         {


### PR DESCRIPTION
As SocketsHttpHandler now supports HTTP/2, we will need to enable a bunch of HTTP/2 tests, which target different OS and different platform handlers.

[Some old version of Schannel/OpenSSL doesn't support ALPN](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation), thus HTTP/2 won't work on certain OS.

Move BackendSupportsAlpn check to CoreFx.Private.TestUtilities so that all HTTP/2 tests can use this property.