### PR TITLE
Another Case where millisecond Granularity was missed

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -204,27 +204,21 @@ namespace System.IO
             Span<Interop.Sys.TimeSpec> buf = stackalloc Interop.Sys.TimeSpec[2];
 
             long seconds = time.ToUnixTimeSeconds();
-            long nanoSeconds = (time.ToUnixTimeMilliseconds() - seconds * 1000) * 1_000_000;
+            long nanoseconds = (time.ToUnixTimeMilliseconds() - seconds * 1000) * 1_000_000;
 
             if (isAccessTime)
             {
-                // setting seconds and nanoseconds for LastAccessTime
                 buf[0].TvSec = seconds;
-                buf[0].TvNsec = nanoSeconds;
-
-                // setting seconds and nanoseconds for LastModifiedTime
+                buf[0].TvNsec = nanoseconds;
                 buf[1].TvSec = _fileStatus.MTime;
                 buf[1].TvNsec = _fileStatus.MTimeNsec;
             }
             else
             {
-                // setting seconds and nanoseconds for LastAccessTime
                 buf[0].TvSec = _fileStatus.ATime;
                 buf[0].TvNsec = _fileStatus.ATimeNsec;
-
-                // setting seconds and nanoseconds for LastModifiedTime
                 buf[1].TvSec = seconds;
-                buf[1].TvNsec = nanoSeconds;
+                buf[1].TvNsec = nanoseconds;
             }
 
             Interop.CheckIo(Interop.Sys.UTimensat(path, ref MemoryMarshal.GetReference(buf)), path, InitiallyDirectory);          

--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -177,7 +177,7 @@ namespace System.IO
             return UnixTimeToDateTimeOffset(_fileStatus.ATime, _fileStatus.ATimeNsec);
         }
 
-        internal void SetLastAccessTime(string path, DateTimeOffset time) => SetAccessWriteTimes(path, time, true);
+        internal void SetLastAccessTime(string path, DateTimeOffset time) => SetAccessWriteTimes(path, time,  isAccessTime: true);
 
         internal DateTimeOffset GetLastWriteTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
@@ -187,7 +187,7 @@ namespace System.IO
             return UnixTimeToDateTimeOffset(_fileStatus.MTime, _fileStatus.MTimeNsec);
         }
 
-        internal void SetLastWriteTime(string path, DateTimeOffset time) => SetAccessWriteTimes(path, time, false);
+        internal void SetLastWriteTime(string path, DateTimeOffset time) => SetAccessWriteTimes(path, time, isAccessTime: false);
         
         private DateTimeOffset UnixTimeToDateTimeOffset(long seconds, long nanoseconds)
         {

--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -178,7 +178,11 @@ namespace System.IO
         }
 
         internal void SetLastAccessTime(string path, DateTimeOffset time)
-            => SetAccessWriteTimes(path, time.ToUnixTimeMilliseconds() * 1000000, null);
+        {
+            long secs = time.ToUnixTimeSeconds();
+            long milli = time.ToUnixTimeMilliseconds() - secs * 1000;
+            SetAccessWriteTimes(path, secs, milli * 1000000, null , null);
+        }
 
         internal DateTimeOffset GetLastWriteTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
@@ -189,14 +193,18 @@ namespace System.IO
         }
 
         internal void SetLastWriteTime(string path, DateTimeOffset time)
-            => SetAccessWriteTimes(path, null, time.ToUnixTimeMilliseconds() * 1000000);
+        {
+            long secs = time.ToUnixTimeSeconds();
+            long milli = time.ToUnixTimeMilliseconds() - secs * 1000;
+            SetAccessWriteTimes(path, null, null, secs, milli * 1000000);
+        }
 
         private DateTimeOffset UnixTimeToDateTimeOffset(long seconds, long nanoseconds)
         {
             return DateTimeOffset.FromUnixTimeSeconds(seconds).AddTicks(nanoseconds / NanosecondsPerTick).ToLocalTime();
         }
 
-        private void SetAccessWriteTimes(string path, long? accessTime, long? writeTime)
+        private void SetAccessWriteTimes(string path, long? accessTime, long? accessTimeNano, long? writeTime, long? writeTimeNano)
         {
             // force a refresh so that we have an up-to-date times for values not being overwritten
             _fileStatusInitialized = -1;
@@ -206,12 +214,12 @@ namespace System.IO
             Span<Interop.Sys.TimeSpec> buf = stackalloc Interop.Sys.TimeSpec[2];
 
             // setting second part
-            buf[0].TvSec = accessTime == null ? _fileStatus.ATime : 0;
-            buf[1].TvSec = writeTime == null ? _fileStatus.MTime : 0;
+            buf[0].TvSec = accessTime ?? _fileStatus.ATime;
+            buf[1].TvSec = writeTime ?? _fileStatus.MTime;
 
             // setting nanosecond part
-            buf[0].TvNsec = accessTime ?? _fileStatus.ATimeNsec;
-            buf[1].TvNsec = writeTime ?? _fileStatus.MTimeNsec;
+            buf[0].TvNsec = accessTimeNano ?? _fileStatus.ATimeNsec;
+            buf[1].TvNsec = writeTimeNano ?? _fileStatus.MTimeNsec;
 
             Interop.CheckIo(Interop.Sys.UTimensat(path, ref MemoryMarshal.GetReference(buf)), path, InitiallyDirectory);          
 

--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -181,7 +181,7 @@ namespace System.IO
         {
             long secs = time.ToUnixTimeSeconds();
             long milli = time.ToUnixTimeMilliseconds() - secs * 1000;
-            SetAccessWriteTimes(path, secs, milli * 1000000, null , null);
+            SetAccessWriteTimes(path, secs, milli * 1_000_000, null , null);
         }
 
         internal DateTimeOffset GetLastWriteTime(ReadOnlySpan<char> path, bool continueOnError = false)
@@ -196,7 +196,7 @@ namespace System.IO
         {
             long secs = time.ToUnixTimeSeconds();
             long milli = time.ToUnixTimeMilliseconds() - secs * 1000;
-            SetAccessWriteTimes(path, null, null, secs, milli * 1000000);
+            SetAccessWriteTimes(path, null, null, secs, milli * 1_000_000);
         }
 
         private DateTimeOffset UnixTimeToDateTimeOffset(long seconds, long nanoseconds)

--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -178,7 +178,7 @@ namespace System.IO
         }
 
         internal void SetLastAccessTime(string path, DateTimeOffset time)
-            => SetAccessWriteTimes(path, time.ToUnixTimeSeconds(), null);
+            => SetAccessWriteTimes(path, time.ToUnixTimeMilliseconds() * 1000000, null);
 
         internal DateTimeOffset GetLastWriteTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
@@ -189,7 +189,7 @@ namespace System.IO
         }
 
         internal void SetLastWriteTime(string path, DateTimeOffset time)
-            => SetAccessWriteTimes(path, null, time.ToUnixTimeSeconds());
+            => SetAccessWriteTimes(path, null, time.ToUnixTimeMilliseconds() * 1000000);
 
         private DateTimeOffset UnixTimeToDateTimeOffset(long seconds, long nanoseconds)
         {
@@ -206,12 +206,12 @@ namespace System.IO
             Span<Interop.Sys.TimeSpec> buf = stackalloc Interop.Sys.TimeSpec[2];
 
             // setting second part
-            buf[0].TvSec = accessTime ?? _fileStatus.ATime;
-            buf[1].TvSec = writeTime ?? _fileStatus.MTime;
+            buf[0].TvSec = accessTime == null ? _fileStatus.ATime : 0;
+            buf[1].TvSec = writeTime == null ? _fileStatus.MTime : 0;
 
             // setting nanosecond part
-            buf[0].TvNsec = accessTime == null ? _fileStatus.ATimeNsec : 0;
-            buf[1].TvNsec = writeTime == null ? _fileStatus.MTimeNsec : 0;
+            buf[0].TvNsec = accessTime ?? _fileStatus.ATimeNsec;
+            buf[1].TvNsec = writeTime ?? _fileStatus.MTimeNsec;
 
             Interop.CheckIo(Interop.Sys.UTimensat(path, ref MemoryMarshal.GetReference(buf)), path, InitiallyDirectory);          
 

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -49,7 +49,7 @@ namespace System.IO.Tests
             Assert.All(TimeFunctions(requiresRoundtripping: true), (function) =>
             {
                 // Checking that milliseconds are not dropped after setter.
-                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, 321, function.Kind);
+                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, isHFS ? 0 : 321, function.Kind);
                 function.Setter(item, dt);
                 DateTime result = function.Getter(item);
                 Assert.Equal(dt, result);

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -48,7 +48,8 @@ namespace System.IO.Tests
 
             Assert.All(TimeFunctions(requiresRoundtripping: true), (function) =>
             {
-                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, 32, function.Kind);
+                // Checking that milliseconds are not dropped after setter.
+                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, 321, function.Kind);
                 function.Setter(item, dt);
                 DateTime result = function.Getter(item);
                 Assert.Equal(dt, result);

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -48,7 +48,7 @@ namespace System.IO.Tests
 
             Assert.All(TimeFunctions(requiresRoundtripping: true), (function) =>
             {
-                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, function.Kind);
+                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, 32, function.Kind);
                 function.Setter(item, dt);
                 DateTime result = function.Getter(item);
                 Assert.Equal(dt, result);

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -94,7 +94,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void SetLastWriteTimeMilliSec()
+        public void SetLastWriteTimeTicks()
         {
             string firstFile = GetTestFilePath();
             string secondFile = GetTestFilePath();
@@ -105,6 +105,21 @@ namespace System.IO.Tests
             File.SetLastAccessTimeUtc(secondFile, DateTime.UtcNow);
             long firstFileTicks = File.GetLastWriteTimeUtc(firstFile).Ticks;
             long secondFileTicks = File.GetLastWriteTimeUtc(secondFile).Ticks;
+            Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
+        }
+
+        [Fact]
+        public void SetLastAccessTimeTicks()
+        {
+            string firstFile = GetTestFilePath();
+            string secondFile = GetTestFilePath();
+
+            File.WriteAllText(firstFile, "");
+            File.WriteAllText(secondFile, "");
+
+            File.SetLastWriteTimeUtc(secondFile, DateTime.UtcNow);
+            long firstFileTicks = File.GetLastAccessTimeUtc(firstFile).Ticks;
+            long secondFileTicks = File.GetLastAccessTimeUtc(secondFile).Ticks;
             Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
         }
     }

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -18,6 +18,24 @@ namespace System.IO.Tests
             return new FileInfo(path);
         }
 
+        public FileInfo GetNonZeroMilliSec()
+        {
+            FileInfo fileinfo = new FileInfo(GetTestFilePath());
+            for (int i = 0; i < 5; i++)
+            {
+                fileinfo.Create().Dispose();
+                if (fileinfo.LastWriteTime.Millisecond != 0)
+                    break;
+
+                // This case should only happen 1/1000 times, unless the OS/Filesystem does
+                // not support millisecond granularity.
+
+                // If it's 1/1000, or low granularity, this may help:
+                Thread.Sleep(1234);
+            }
+            return fileinfo;
+        }
+
         public override FileInfo GetMissingItem() => new FileInfo(GetTestFilePath());
 
         public override string GetItemPath(FileInfo item) => item.FullName;
@@ -70,25 +88,37 @@ namespace System.IO.Tests
         [ConditionalFact(nameof(isNotHFS))]
         public void CopyToMillisecondPresent()
         {
-            FileInfo input = new FileInfo(GetTestFilePath());
-            for (int i = 0; i < 5; i++)
-            {
-                input.Create().Dispose();
-                if (input.LastWriteTime.Millisecond != 0)
-                    break;
-
-                // This case should only happen 1/1000 times, unless the OS/Filesystem does
-                // not support millisecond granularity.
-
-                // If it's 1/1000, or low granularity, this may help:
-                Thread.Sleep(1234);
-            }
-
+            FileInfo input = GetNonZeroMilliSec();
             FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
+
             Assert.Equal(0, output.LastWriteTime.Millisecond);
             output.Directory.Create();
             output = input.CopyTo(output.FullName, true);
+
             Assert.NotEqual(0, input.LastWriteTime.Millisecond);
+            Assert.NotEqual(0, output.LastWriteTime.Millisecond);
+        }
+
+        [ConditionalFact(nameof(isHFS))]
+        public void MoveToMillisecondPresent_HFS()
+        {
+            FileInfo input = new FileInfo(GetTestFilePath());
+            input.Create().Dispose();
+
+            string dest = Path.Combine(GetTestFilePath(), GetTestFileName());
+            input.MoveTo(dest);
+            FileInfo output = new FileInfo(dest);
+            Assert.Equal(0, output.LastWriteTime.Millisecond);
+        }
+
+        [ConditionalFact(nameof(isNotHFS))]
+        public void MoveToMillisecondPresent()
+        {
+            FileInfo input = GetNonZeroMilliSec();
+            string dest = Path.Combine(input.DirectoryName, GetTestFileName());
+
+            input.MoveTo(dest);
+            FileInfo output = new FileInfo(dest);
             Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -105,7 +105,7 @@ namespace System.IO.Tests
             FileInfo input = new FileInfo(GetTestFilePath());
             input.Create().Dispose();
 
-            string dest = Path.Combine(GetTestFilePath(), GetTestFileName());
+            string dest = Path.Combine(input.DirectoryName, GetTestFileName());
             input.MoveTo(dest);
             FileInfo output = new FileInfo(dest);
             Assert.Equal(0, output.LastWriteTime.Millisecond);


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/issues/31379

In the above mentioned issue, when we were setting lastAccessTime the attributes after seconds were getting dropped and  vice versa behaviour while setting lastWriteTime.
This was fixed by  https://github.com/dotnet/corefx/pull/31522 

Another case that was missed by https://github.com/dotnet/corefx/pull/31522 was setting  and getting LastWrite\AccessTime property. the tests existed for this case but in all such cases the value for millisecond was zero. we were still setting zero for this case. This PR corrects that.
The PR also modifies test for this case and add some more tests for more cases