### PR TITLE
System.Security: Change exception behavior of AsnWriter.WriteCharacterString

### DIFF
--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
@@ -483,7 +483,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
-                Assert.Throws<EncoderFallbackException>(() => WriteString(writer, input));
+                Assert.Throws<CryptographicException>(() => WriteString(writer, input));
             }
         }
 
@@ -491,7 +491,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
-                Assert.Throws<EncoderFallbackException>(() => WriteSpan(writer, input.AsSpan()));
+                Assert.Throws<CryptographicException>(() => WriteSpan(writer, input.AsSpan()));
             }
         }
     }


### PR DESCRIPTION
… to wrap EncoderFallbackException in CryptographicException. The counterpart AsnReader.GetCharacterString (and other related methods) wraps DecoderFallbackException in the same manner.

/cc @bartonjs 