### PR TITLE
System.Security: Fix implementation of WriteKeyParameterInteger.

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
@@ -122,10 +122,12 @@ namespace Internal.Cryptography
                         break;
                     }
 
-                    if (newStart != 0)
+                    if (integer[newStart] != 0)
                     {
                         break;
                     }
+
+                    newStart++;
                 }
 
                 if (newStart == integer.Length)


### PR DESCRIPTION
Noticed this while finishing up my code sharing PR for [RSA/DSA/Ecc]SecurityTransforms.cs and [RSA/DSA/ECDsa].cs. Should be easy to review alone :-)

/cc @bartonjs 