### PR TITLE
Add logging for SocketsHttpHandler SendAsync task cancelled

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -450,6 +450,8 @@ namespace System.Net.Http
                 }
                 else
                 {
+                    if (NetEventSource.IsEnabled) Trace("Request content is not null. Start sending it.");
+
                     // Send the body if there is one.  We prefer to serialize the sending of the content before
                     // we try to receive any response, but if ExpectContinue has been set, we allow the sending
                     // to run concurrently until we receive the final status line, at which point we wait for it.
@@ -558,6 +560,9 @@ namespace System.Net.Http
                     sendRequestContentTask = null;
                 }
 
+                // Now we are sure that the request was fully sent.
+                if (NetEventSource.IsEnabled) Trace("Request is fully sent.");
+
                 // Parse the response headers.
                 while (true)
                 {
@@ -626,7 +631,7 @@ namespace System.Net.Http
                 }
                 ((HttpConnectionResponseContent)response.Content).SetStream(responseStream);
 
-                if (NetEventSource.IsEnabled) Trace($"Received response: {response}");
+                if (NetEventSource.IsEnabled) Trace($"Response is received: {response}");
 
                 // Process Set-Cookie headers.
                 if (_pool.Settings._useCookies)
@@ -732,6 +737,8 @@ namespace System.Net.Http
 
             // Flush any content that might still be buffered.
             await FlushAsync().ConfigureAwait(false);
+
+            if (NetEventSource.IsEnabled) Trace("Finished sending request content.");
         }
 
         private async Task SendRequestContentWithExpect100ContinueAsync(

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -450,7 +450,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    if (NetEventSource.IsEnabled) Trace("Request content is not null. Start sending it.");
+                    if (NetEventSource.IsEnabled) Trace($"Request content is not null, start processing it. hasExpectContinueHeader = {hasExpectContinueHeader}");
 
                     // Send the body if there is one.  We prefer to serialize the sending of the content before
                     // we try to receive any response, but if ExpectContinue has been set, we allow the sending
@@ -631,7 +631,7 @@ namespace System.Net.Http
                 }
                 ((HttpConnectionResponseContent)response.Content).SetStream(responseStream);
 
-                if (NetEventSource.IsEnabled) Trace($"Response is received: {response}");
+                if (NetEventSource.IsEnabled) Trace($"Received response: {response}");
 
                 // Process Set-Cookie headers.
                 if (_pool.Settings._useCookies)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -218,6 +218,7 @@ namespace System.Net.Http
         {
             if (cancellationToken.IsCancellationRequested)
             {
+                if (NetEventSource.IsEnabled) Trace("Unable to complete getting HTTP/1.1 connection due to requested cancellation.");
                 return new ValueTask<(HttpConnectionBase, bool, HttpResponseMessage)>(Task.FromCanceled<(HttpConnectionBase, bool, HttpResponseMessage)>(cancellationToken));
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -210,15 +210,15 @@ namespace System.Net.Http
                 return GetHttp2ConnectionAsync(request, cancellationToken);
             }
 
-            return GetHttp11ConnectionAsync(request, cancellationToken);
+            return GetHttpConnectionAsync(request, cancellationToken);
         }
 
         private ValueTask<(HttpConnectionBase connection, bool isNewConnection, HttpResponseMessage failureResponse)> 
-            GetHttp11ConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            GetHttpConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                if (NetEventSource.IsEnabled) Trace("Unable to complete getting HTTP/1.1 connection due to requested cancellation.");
+                if (NetEventSource.IsEnabled) Trace("Unable to complete getting HTTP/1.x connection due to requested cancellation.");
                 return new ValueTask<(HttpConnectionBase, bool, HttpResponseMessage)>(Task.FromCanceled<(HttpConnectionBase, bool, HttpResponseMessage)>(cancellationToken));
             }
 
@@ -445,7 +445,7 @@ namespace System.Net.Http
             }
 
             // If we reach this point, it means we need to fall back to a (new or existing) HTTP/1.1 connection.
-            return await GetHttp11ConnectionAsync(request, cancellationToken);
+            return await GetHttpConnectionAsync(request, cancellationToken);
         }
 
         public async Task<HttpResponseMessage> SendWithRetryAsync(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken)


### PR DESCRIPTION
The added traces can help to answer whether a request was fully send, and a response was fully received if the SendAsync Task is cancelled.

Verified with PerfView using existing `HttpClientHandlerTest.Cancellation.cs` tests.