### PR TITLE
[2.1] Port "Do not expand stacktraces when completion exception is rethrown multiple times"

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeCompletion.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeCompletion.cs
@@ -28,10 +28,13 @@ namespace System.IO.Pipelines
 
         public PipeCompletionCallbacks TryComplete(Exception exception = null)
         {
-            _isCompleted = true;
-            if (exception != null)
+            if (!_isCompleted)
             {
-                _exceptionInfo = ExceptionDispatchInfo.Capture(exception);
+                _isCompleted = true;
+                if (exception != null)
+                {
+                    _exceptionInfo = ExceptionDispatchInfo.Capture(exception);
+                }
             }
             return GetCallbacks();
         }

--- a/src/System.IO.Pipelines/tests/FlushAsyncCompletionTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCompletionTests.cs
@@ -33,5 +33,33 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(true, task2.IsFaulted);
             Assert.Equal("Concurrent reads or writes are not supported.", task2.Exception.InnerExceptions[0].Message);
         }
+
+        [Fact]
+        public async Task CompletingWithExceptionDoesNotAffectState()
+        {
+            Pipe.Writer.Complete();
+            Pipe.Writer.Complete(new Exception());
+
+            var result = await Pipe.Reader.ReadAsync();
+            Assert.True(result.IsCompleted);
+        }
+
+        [Fact]
+        public async Task CompletingWithExceptionDoesNotAffectFailedState()
+        {
+            Pipe.Writer.Complete(new InvalidOperationException());
+            Pipe.Writer.Complete(new Exception());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await Pipe.Reader.ReadAsync());
+        }
+
+        [Fact]
+        public async Task CompletingWithoutExceptionDoesNotAffectState()
+        {
+            Pipe.Writer.Complete(new InvalidOperationException());
+            Pipe.Writer.Complete();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await Pipe.Reader.ReadAsync());
+        }
     }
 }

--- a/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -238,6 +239,8 @@ namespace System.IO.Pipelines.Tests
             invalidOperationException = await Assert.ThrowsAsync<InvalidOperationException>(async () => await _pipe.Writer.FlushAsync());
             Assert.Equal("Reader exception", invalidOperationException.Message);
             Assert.Contains("ThrowTestException", invalidOperationException.StackTrace);
+
+            Assert.Single(Regex.Matches(invalidOperationException.StackTrace, "Pipe.GetFlushResult"));
         }
 
         [Fact]
@@ -304,6 +307,8 @@ namespace System.IO.Pipelines.Tests
             invalidOperationException = await Assert.ThrowsAsync<InvalidOperationException>(async () => await _pipe.Reader.ReadAsync());
             Assert.Equal("Writer exception", invalidOperationException.Message);
             Assert.Contains("ThrowTestException", invalidOperationException.StackTrace);
+
+            Assert.Single(Regex.Matches(invalidOperationException.StackTrace, "Pipe.GetReadResult"));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #31388 

2.1 template

#### Description

Multiple calls to ReadAsync on the faulted pipe would produce exceptions with ever-increasing stacktraces.

#### Customer Impact 
Customers would see exceptions with suspiciously long stacktraces: 

https://github.com/aspnet/KestrelHttpServer/issues/2745
https://github.com/aspnet/SignalR/issues/2672

#### Regression?
No

#### Risk
Only the way we use ExceptionDispatchInfo inside pipe changes. No other logical changes.
