### PR TITLE
Fix pipe completion behavior

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeCompletion.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeCompletion.cs
@@ -28,10 +28,13 @@ namespace System.IO.Pipelines
 
         public PipeCompletionCallbacks TryComplete(Exception exception = null)
         {
-            _isCompleted = true;
-            if (exception != null)
+            if (!_isCompleted)
             {
-                _exceptionInfo = ExceptionDispatchInfo.Capture(exception);
+                _isCompleted = true;
+                if (exception != null)
+                {
+                    _exceptionInfo = ExceptionDispatchInfo.Capture(exception);
+                }
             }
             return GetCallbacks();
         }

--- a/src/System.IO.Pipelines/tests/FlushAsyncCompletionTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCompletionTests.cs
@@ -33,5 +33,33 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(true, task2.IsFaulted);
             Assert.Equal("Concurrent reads or writes are not supported.", task2.Exception.InnerExceptions[0].Message);
         }
+
+        [Fact]
+        public async Task CompletingWithExceptionDoesNotAffectState()
+        {
+            Pipe.Writer.Complete();
+            Pipe.Writer.Complete(new Exception());
+
+            var result = await Pipe.Reader.ReadAsync();
+            Assert.True(result.IsCompleted);
+        }
+
+        [Fact]
+        public async Task CompletingWithExceptionDoesNotAffectFailedState()
+        {
+            Pipe.Writer.Complete(new InvalidOperationException());
+            Pipe.Writer.Complete(new Exception());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await Pipe.Reader.ReadAsync());
+        }
+
+        [Fact]
+        public async Task CompletingWithoutExceptionDoesNotAffectState()
+        {
+            Pipe.Writer.Complete(new InvalidOperationException());
+            Pipe.Writer.Complete();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await Pipe.Reader.ReadAsync());
+        }
     }
 }


### PR DESCRIPTION
Correct behaviour is  "the first completion wins"
It was regressed in https://github.com/dotnet/corefx/pull/31375 fix for https://github.com/dotnet/corefx/issues/31388