### PR TITLE
Fix incorrect stable version in stable.packages.props

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/stable.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/stable.packages.props
@@ -1409,7 +1409,7 @@
       <Version>4.1.3</Version>
     </StablePackage>
     <StablePackage Include="System.Net.Http.WinHttpHandler">
-      <Version>4.0.4</Version>
+      <Version>4.0.3</Version>
     </StablePackage>
     <StablePackage Include="System.Net.Security">
       <Version>4.0.2</Version>


### PR DESCRIPTION
In https://github.com/dotnet/corefx/pull/23479, we went straight from version `4.0.2` to `4.0.4` for WinHttp, even though the latest package in myget is 4.0.3. We should move this down to 4.0.3 in this list, so that when we next produce this package, it will produce a non-stable version as expected.

@safern PTAL

CC @weshaggard 