### PR TITLE
ctor overloads and tests added for windows identity

### DIFF
--- a/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
+++ b/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
@@ -318,11 +318,21 @@ namespace System.Security.Principal
         SystemOperator = 549,
         User = 545,
     }
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public enum WindowsAccountType
+    {
+        Normal = 0,
+        Guest = 1,
+        System = 2,
+        Anonymous = 3
+    }
     public partial class WindowsIdentity : System.Security.Claims.ClaimsIdentity, System.IDisposable, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
     {
         public new const string DefaultIssuer = "AD AUTHORITY";
         public WindowsIdentity(System.IntPtr userToken) { }
         public WindowsIdentity(System.IntPtr userToken, string type) { }
+        public WindowsIdentity(System.IntPtr userToken, string type, WindowsAccountType acctType){ }
+        public WindowsIdentity(System.IntPtr userToken, string type, WindowsAccountType acctType, bool isAuthenticated) { }
         public WindowsIdentity(string sUserPrincipalName) { }
         public WindowsIdentity(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected WindowsIdentity(System.Security.Principal.WindowsIdentity identity) { }

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -59,6 +59,7 @@ namespace System.Security.Principal
 
         public WindowsIdentity(IntPtr userToken, string type) : this(userToken, type, -1) { }
 
+        // The actual accType is ignored and always will be retrieved from the system.
         public WindowsIdentity(IntPtr userToken, string type, WindowsAccountType acctType) : this(userToken, type, -1) { }
 
         public WindowsIdentity(IntPtr userToken, string type, WindowsAccountType acctType, bool isAuthenticated)

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -30,15 +30,14 @@ public class WindowsIdentityTests
     [Fact]
     public static void ConstructorsAndProperties()
     {
-        // Retrieve the Windows account token for the current user.
-        DoTest((logonToken) =>
+        TestUsingAccessToken((logonToken) =>
         {
             // Construct a WindowsIdentity object using the input account token.
-            WindowsIdentity windowsIdentity = new WindowsIdentity(logonToken);
+            var windowsIdentity = new WindowsIdentity(logonToken);
             Assert.NotNull(windowsIdentity);
             CheckDispose(windowsIdentity);
 
-            WindowsIdentity windowsIdentity2 = new WindowsIdentity(logonToken, authenticationType);
+            var windowsIdentity2 = new WindowsIdentity(logonToken, authenticationType);
             Assert.NotNull(windowsIdentity2);
             Assert.True(windowsIdentity2.IsAuthenticated);
 
@@ -52,9 +51,9 @@ public class WindowsIdentityTests
     [InlineData(false)]
     public static void AuthenticationCtor(bool authentication)
     {
-        DoTest((logonToken) =>
+        TestUsingAccessToken((logonToken) =>
         {
-            WindowsIdentity windowsIdentity = new WindowsIdentity(logonToken, authenticationType, WindowsAccountType.Normal, isAuthenticated: authentication);
+            var windowsIdentity = new WindowsIdentity(logonToken, authenticationType, WindowsAccountType.Normal, isAuthenticated: authentication);
             Assert.NotNull(windowsIdentity);
             Assert.Equal(authentication, windowsIdentity.IsAuthenticated);
 
@@ -66,9 +65,9 @@ public class WindowsIdentityTests
     [Fact]
     public static void WindowsAccountTypeCtor()
     {
-        DoTest((logonToken) =>
+        TestUsingAccessToken((logonToken) =>
         {
-            WindowsIdentity windowsIdentity = new WindowsIdentity(logonToken, authenticationType, WindowsAccountType.Normal);
+            var windowsIdentity = new WindowsIdentity(logonToken, authenticationType, WindowsAccountType.Normal);
             Assert.NotNull(windowsIdentity);
             Assert.True(windowsIdentity.IsAuthenticated);
 
@@ -80,9 +79,9 @@ public class WindowsIdentityTests
     [Fact]
     public static void CloneAndProperties()
     {
-        DoTest((logonToken) =>
+        TestUsingAccessToken((logonToken) =>
         {
-            WindowsIdentity winId = new WindowsIdentity(logonToken);
+            var winId = new WindowsIdentity(logonToken);
 
             WindowsIdentity cloneWinId = winId.Clone() as WindowsIdentity;
             Assert.NotNull(cloneWinId);
@@ -221,15 +220,16 @@ public class WindowsIdentityTests
         }
     }
 
-    private static void DoTest(Action<IntPtr> test)
+    private static void TestUsingAccessToken(Action<IntPtr> ctorOrPropertyTest)
     {
+        // Retrieve the Windows account token for the current user.
         SafeAccessTokenHandle token = WindowsIdentity.GetCurrent().AccessToken;
         bool gotRef = false;
         try
         {
             token.DangerousAddRef(ref gotRef);
             IntPtr logonToken = token.DangerousGetHandle();
-            test(logonToken);
+            ctorOrPropertyTest(logonToken);
         }
         finally
         {

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -15,13 +15,12 @@ using Xunit;
 
 public class WindowsIdentityTests
 {
-    private static readonly string authenticationType = "WindowsAuthentication";
+    private const string authenticationType = "WindowsAuthentication";
 
     [Fact]
     public static void GetAnonymousUserTest()
     {
         WindowsIdentity windowsIdentity = WindowsIdentity.GetAnonymous();
-        Assert.NotNull(windowsIdentity);
         Assert.True(windowsIdentity.IsAnonymous);
         Assert.False(windowsIdentity.IsAuthenticated);
         CheckDispose(windowsIdentity, true);        
@@ -34,11 +33,9 @@ public class WindowsIdentityTests
         {
             // Construct a WindowsIdentity object using the input account token.
             var windowsIdentity = new WindowsIdentity(logonToken);
-            Assert.NotNull(windowsIdentity);
             CheckDispose(windowsIdentity);
 
             var windowsIdentity2 = new WindowsIdentity(logonToken, authenticationType);
-            Assert.NotNull(windowsIdentity2);
             Assert.True(windowsIdentity2.IsAuthenticated);
 
             Assert.Equal(authenticationType, windowsIdentity2.AuthenticationType);
@@ -54,7 +51,6 @@ public class WindowsIdentityTests
         TestUsingAccessToken((logonToken) =>
         {
             var windowsIdentity = new WindowsIdentity(logonToken, authenticationType, WindowsAccountType.Normal, isAuthenticated: authentication);
-            Assert.NotNull(windowsIdentity);
             Assert.Equal(authentication, windowsIdentity.IsAuthenticated);
 
             Assert.Equal(authenticationType, windowsIdentity.AuthenticationType);
@@ -68,7 +64,6 @@ public class WindowsIdentityTests
         TestUsingAccessToken((logonToken) =>
         {
             var windowsIdentity = new WindowsIdentity(logonToken, authenticationType, WindowsAccountType.Normal);
-            Assert.NotNull(windowsIdentity);
             Assert.True(windowsIdentity.IsAuthenticated);
 
             Assert.Equal(authenticationType, windowsIdentity.AuthenticationType);

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -15,6 +15,8 @@ using Xunit;
 
 public class WindowsIdentityTests
 {
+    private static string authenticationType = "WindowsAuthentication";
+
     [Fact]
     public static void GetAnonymousUserTest()
     {
@@ -41,7 +43,6 @@ public class WindowsIdentityTests
             Assert.NotNull(windowsIdentity);
             CheckDispose(windowsIdentity);
 
-            string authenticationType = "WindowsAuthentication";
             WindowsIdentity windowsIdentity2 = new WindowsIdentity(logonToken, authenticationType);
             Assert.NotNull(windowsIdentity2);
             Assert.True(windowsIdentity2.IsAuthenticated);
@@ -57,6 +58,56 @@ public class WindowsIdentityTests
     }
 
     [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public static void AuthenticationCtor(bool authentication)
+    {
+        SafeAccessTokenHandle token = WindowsIdentity.GetCurrent().AccessToken;
+        bool gotRef = false;
+        try
+        {
+            token.DangerousAddRef(ref gotRef);
+            IntPtr logonToken = token.DangerousGetHandle();
+
+            WindowsIdentity windowsIdentity = new WindowsIdentity(logonToken, authenticationType, WindowsAccountType.Normal, isAuthenticated: authentication);
+            Assert.NotNull(windowsIdentity);
+            Assert.Equal(authentication, windowsIdentity.IsAuthenticated);
+
+            Assert.Equal(authenticationType, windowsIdentity.AuthenticationType);
+            CheckDispose(windowsIdentity);
+        }
+        finally
+        {
+            if (gotRef)
+                token.DangerousRelease();
+        }
+    }
+
+    [Fact]
+    public static void WinndowsAccountTypeCtor()
+    {
+        SafeAccessTokenHandle token = WindowsIdentity.GetCurrent().AccessToken;
+        bool gotRef = false;
+        try
+        {
+            token.DangerousAddRef(ref gotRef);
+            IntPtr logonToken = token.DangerousGetHandle();
+
+            WindowsIdentity windowsIdentity2 = new WindowsIdentity(logonToken, authenticationType, WindowsAccountType.Normal);
+            Assert.NotNull(windowsIdentity2);
+            Assert.True(windowsIdentity2.IsAuthenticated);
+
+            Assert.Equal(authenticationType, windowsIdentity2.AuthenticationType);
+            CheckDispose(windowsIdentity2);
+        }
+        finally
+        {
+            if (gotRef)
+                token.DangerousRelease();
+        }
+    }
+
+    [Fact]
     public static void CloneAndProperties()
     {
         SafeAccessTokenHandle token = WindowsIdentity.GetCurrent().AccessToken;

--- a/src/shims/ApiCompatBaseline.netcoreapp.netfx461.ignore.txt
+++ b/src/shims/ApiCompatBaseline.netcoreapp.netfx461.ignore.txt
@@ -88,8 +88,6 @@ CannotMakeMemberNonVirtual : Member 'System.Security.Cryptography.SHA512Managed.
 
 // Can't build WindowsIdentities or WindowsPrincipals on non-Windows OSes. https://github.com/dotnet/corefx/issues/18073
 MembersMustExist : Member 'System.Security.Principal.IdentityReferenceCollection.IsReadOnly.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Principal.WindowsIdentity..ctor(System.IntPtr, System.String, System.Security.Principal.WindowsAccountType)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Principal.WindowsIdentity..ctor(System.IntPtr, System.String, System.Security.Principal.WindowsAccountType, System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.Principal.WindowsIdentity..ctor(System.Security.Principal.WindowsIdentity)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.Principal.WindowsIdentity..ctor(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.Principal.WindowsIdentity.DeviceClaims.get()' does not exist in the implementation but it does exist in the contract.

--- a/src/shims/ApiCompatBaseline.netcoreapp.netfx461.txt
+++ b/src/shims/ApiCompatBaseline.netcoreapp.netfx461.txt
@@ -26,7 +26,6 @@ TypesMustExist : Type 'System.Runtime.Serialization.Formatters.ISoapMessage' doe
 TypesMustExist : Type 'System.Runtime.Serialization.Formatters.ServerFault' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Serialization.Formatters.SoapFault' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Serialization.Formatters.SoapMessage' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Security.Principal.WindowsAccountType' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Principal.WindowsImpersonationContext' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly System:
 MembersMustExist : Member 'System.CodeDom.Compiler.CompilerParameters.Evidence.get()' does not exist in the implementation but it does exist in the contract.


### PR DESCRIPTION
Related to :- https://github.com/dotnet/corefx/issues/17164

# Already Present 
- System.Security.Principal.WindowsIdentity..ctor(System.Security.Principal.WindowsIdentity)
- System.Security.Principal.IdentityReferenceCollection.IsReadOnly.get()
- System.Security.Principal.WindowsIdentity.UserClaims.get()
- System.Security.Principal.WindowsPrincipal.DeviceClaims.get()
- System.Security.Principal.WindowsPrincipal.UserClaims.get()
- System.Security.Principal.WindowsIdentity.DeviceClaims.get()

# Related to Impersonation
- System.Security.Principal.WindowsIdentity.Impersonate()
- System.Security.Principal.WindowsIdentity.Impersonate(System.IntPtr)
- System.Security.Principal.WindowsIdentity..ctor(System.String, System.String)
- System.Security.Principal.WindowsImpersonationContext

# Added
- System.Security.Principal.WindowsIdentity..ctor(System.IntPtr, System.String, System.Security.Principal.WindowsAccountType)
- System.Security.Principal.WindowsIdentity..ctor(System.IntPtr, System.String, System.Security.Principal.WindowsAccountType, System.Boolean)
- System.Security.Principal.WindowsAccountType
