### PR TITLE
Add Microsoft-Windows-DotNETRuntime to the list of framework EventSources

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -36,7 +36,8 @@ namespace BasicEventSourceTests
                     eventSource.Name != "System.Buffers.ArrayPoolEventSource" &&
                     eventSource.Name != "System.Threading.SynchronizationEventSource" &&
                     eventSource.Name != "System.Runtime.InteropServices.InteropEventProvider" &&
-                    eventSource.Name != "System.Reflection.Runtime.Tracing"
+                    eventSource.Name != "System.Reflection.Runtime.Tracing" &&
+                    eventSource.Name != "Microsoft-Windows-DotNETRuntime"
                     )
                 {
                     eventSourceNames += eventSource.Name + " ";


### PR DESCRIPTION
```System.Diagnostics.Tracing.Tests``` has knowledge of the list of framework EventSources, and attempt to make sure that there are no non-framework EventSources in existence at the beginning of each test.

https://github.com/dotnet/coreclr/pull/19393 adds a new framework ```EventSource``` that needs to be added to the list in ```System.Diagnostics.Tracing.Tests```.