### PR TITLE
Removing Fedora 26 and adding 28 as appropriate.

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -487,7 +487,7 @@
       "allowOverride": true
     },
     "PB_TargetQueue": {
-      "value": "Centos.73.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Debian.9.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+opensuse.423.amd64+SLES.12.Amd64+Fedora.26.Amd64+Fedora.27.Amd64"
+      "value": "Centos.73.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Debian.9.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+opensuse.423.amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64"
     },
     "PB_VsoAccountName": {
       "value": "dn-bot"

--- a/buildpipeline/README.md
+++ b/buildpipeline/README.md
@@ -1,5 +1,5 @@
-These are the checked in build definitions used by BuildPipeline.
+These are the checked-in build definitions used by BuildPipeline.
 
 You may edit build steps, variables, and other artifacts of the definition directly to modify the BuildPipeline builds.
 
-If you want to make major changes to these definitions such as adding / deleting build steps, or other major rewrites, chcosta has tools to assist with those changes and can provide guidance.  It is important that we know what kinds of changes are being made to the build definitions so that we can invest in improviing those experiences.
+If you want to make major changes to these definitions such as adding / deleting build steps or other major rewrites, chcosta has tools to assist with those changes and can provide guidance.  It is important that we know what kinds of changes are being made to the build definitions so that we can invest in improving those experiences.

--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -54,10 +54,10 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      'Ubuntu.1604.Amd64.Open',
                                      'Ubuntu.1804.Amd64.Open',
                                      'OpenSuse.423.Amd64.Open',
-                                     'Fedora.26.Amd64.Open',]
+                                     'Fedora.27.Amd64.Open',]
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.9.Amd64.Open',
-                                      'Fedora.27.Amd64.Open',
+                                      'Fedora.28.Amd64.Open',
                                       'SLES.12.Amd64.Open',]
             }
 

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -23,7 +23,7 @@
             "PB_BuildArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -stripSymbols -- /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_BuildTestsArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Centos.73.Amd64+Centos.74.Amd64+RedHat.73.Amd64+RedHat.74.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1710.Amd64+Ubuntu.1804.Amd64+OpenSuse.423.Amd64+SLES.12.Amd64+Fedora.26.Amd64+Fedora.27.Amd64",
+            "PB_TargetQueue": "Centos.73.Amd64+Centos.74.Amd64+RedHat.73.Amd64+RedHat.74.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1710.Amd64+Ubuntu.1804.Amd64+OpenSuse.423.Amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {


### PR DESCRIPTION
Replace Fedora 26 (EOL) with Fedora 28 in CI
https://github.com/dotnet/core-eng/issues/3992

Test Infrastructure only change to make the /release/2.1 CI green again