### PR TITLE
[Release/2.2 Port] Expose EventWrittenEventArgs.OSThreadId and EventWrittenEventArgs.TimeStamp in System.Diagnostics.Tracing contract

### DIFF
--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -294,6 +294,8 @@ namespace System.Diagnostics.Tracing
         public System.Diagnostics.Tracing.EventTags Tags { get { throw null; } }
         public System.Diagnostics.Tracing.EventTask Task { get { throw null; } }
         public byte Version { get { throw null; } }
+        public long OSThreadId { get { throw null; } }
+        public DateTime TimeStamp { get { throw null; } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(64))]
     public sealed partial class NonEventAttribute : System.Attribute

--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -294,8 +294,10 @@ namespace System.Diagnostics.Tracing
         public System.Diagnostics.Tracing.EventTags Tags { get { throw null; } }
         public System.Diagnostics.Tracing.EventTask Task { get { throw null; } }
         public byte Version { get { throw null; } }
+#if FEATURE_EVENTLISTENERCONTEXT
         public long OSThreadId { get { throw null; } }
         public DateTime TimeStamp { get { throw null; } }
+#endif
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(64))]
     public sealed partial class NonEventAttribute : System.Attribute

--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{0D8C8BAE-E5A5-4E9F-B101-3D18BD81D261}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_ETLEVENTS</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_ETLEVENTS;FEATURE_EVENTLISTENERCONTEXT</DefineConstants>
     <!-- CS0067: unused event, reference assembly does not care -->
     <NoWarn>$(NoWarn);0067</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Port #31564 to release/2.2.