### PR TITLE
[release/uwp6.1] Port removals of unix configurations from CI/Official Builds

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -450,7 +450,7 @@
       "allowOverride": true
     },
     "PB_TargetQueue": {
-      "value": "Centos.73.Amd64+RedHat.72.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1704.Amd64+suse.422.amd64+SLES.12.Amd64+fedora.25.amd64+Fedora.26.Amd64"
+      "value": "Centos.73.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Debian.9.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+opensuse.423.amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64"
     },
     "PB_VsoAccountName": {
       "value": "dn-bot"

--- a/buildpipeline/README.md
+++ b/buildpipeline/README.md
@@ -1,5 +1,5 @@
-These are the checked in build definitions used by BuildPipeline.
+These are the checked-in build definitions used by BuildPipeline.
 
 You may edit build steps, variables, and other artifacts of the definition directly to modify the BuildPipeline builds.
 
-If you want to make major changes to these definitions such as adding / deleting build steps, or other major rewrites, chcosta has tools to assist with those changes and can provide guidance.  It is important that we know what kinds of changes are being made to the build definitions so that we can invest in improviing those experiences.
+If you want to make major changes to these definitions such as adding / deleting build steps or other major rewrites, chcosta has tools to assist with those changes and can provide guidance.  It is important that we know what kinds of changes are being made to the build definitions so that we can invest in improving those experiences.

--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -52,13 +52,13 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      'Debian.87.Amd64.Open',
                                      'Ubuntu.1404.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
-                                     'suse.422.amd64.Open',
-                                     'fedora.25.amd64.Open',]
+                                     'Ubuntu.1804.Amd64.Open',
+                                     'OpenSuse.423.Amd64.Open',
+                                     'Fedora.27.Amd64.Open',]
             if (params.TestOuter) {
-                targetHelixQueues += ['Debian.90.Amd64.Open',
-                                      'Fedora.26.Amd64.Open',
-                                      'SLES.12.Amd64.Open',
-                                      'Ubuntu.1704.Amd64.Open',]
+                targetHelixQueues += ['Debian.9.Amd64.Open',
+                                      'Fedora.28.Amd64.Open',
+                                      'SLES.12.Amd64.Open',]
             }
 
             sh "./Tools/msbuild.sh src/upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${params.CGroup} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=\$CloudDropAccessToken /p:CloudResultsAccessToken=\$OutputCloudResultsAccessToken /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=${targetHelixQueues.join('+')} /p:HelixLogFolder=${WORKSPACE}/${logFolder}/ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -21,7 +21,7 @@
             "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
-            "PB_TargetQueue": "Centos.73.Amd64+Centos.74.Amd64+RedHat.73.Amd64+RedHat.74.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1710.Amd64+Ubuntu.1804.Amd64+OpenSuse.423.Amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64",
+            "PB_TargetQueue": "Centos.73.Amd64+Centos.74.Amd64+RedHat.73.Amd64+RedHat.74.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+OpenSuse.423.Amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -17,11 +17,11 @@
       "Definitions": [{
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "rhel7_prereqs_2",
+            "PB_DockerTag": "centos-7-d485f41-20173404063424",
             "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
-            "PB_TargetQueue": "Centos.73.Amd64+RedHat.72.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1704.Amd64+suse.422.amd64+SLES.12.Amd64+fedora.25.amd64+Fedora.26.Amd64",
+            "PB_TargetQueue": "Centos.73.Amd64+Centos.74.Amd64+RedHat.73.Amd64+RedHat.74.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1710.Amd64+Ubuntu.1804.Amd64+OpenSuse.423.Amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {


### PR DESCRIPTION
- Port e4559a3ca8b32edd8f8c2c8b51ee484b2b29e01b "Removing Fedora 26 and adding 28 as appropriate. Fix a couple README.md typos."
- Port 945b7405486de3e7042779c0319115ac6380e3e0 "Remove Ubuntu 17.10 from CoreFX official runs"