### PR TITLE
Remove unused local from List<T>.RemoveRange

### DIFF
--- a/src/Common/src/CoreLib/System/Collections/Generic/List.cs
+++ b/src/Common/src/CoreLib/System/Collections/Generic/List.cs
@@ -941,7 +941,6 @@ namespace System.Collections.Generic
 
             if (count > 0)
             {
-                int i = _size;
                 _size -= count;
                 if (index < _size)
                 {


### PR DESCRIPTION
`int i` appears to be unused so i removed it.