### PR TITLE
Add support for RC4 cipher in EnvelopedCms through native cryptography primitives.

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Symmetric.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Symmetric.cs
@@ -15,6 +15,7 @@ internal static partial class Interop
             AES = 0,
             DES = 1,
             TripleDES = 2,
+            RC4 = 4,
             RC2 = 5,
         }
 
@@ -34,6 +35,7 @@ internal static partial class Interop
         {
             ECB = 1,
             CBC = 2,
+            RC4 = 9,
         }
 
         internal enum PAL_SymmetricOptions

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
@@ -81,5 +81,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpRC2Ecb")]
         internal static extern IntPtr EvpRC2Ecb();
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpRC4")]
+        internal static extern IntPtr EvpRC4();
     }
 }

--- a/src/Common/src/Interop/Windows/BCrypt/Cng.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Cng.cs
@@ -61,6 +61,7 @@ namespace Internal.NativeCrypto
         public const string BCRYPT_AES_ALGORITHM = "AES";
         public const string BCRYPT_DES_ALGORITHM = "DES";
         public const string BCRYPT_RC2_ALGORITHM = "RC2";
+        public const string BCRYPT_RC4_ALGORITHM = "RC4";
 
         public const string BCRYPT_CHAIN_MODE_CBC = "ChainingModeCBC";
         public const string BCRYPT_CHAIN_MODE_ECB = "ChainingModeECB";

--- a/src/Common/src/Interop/Windows/BCrypt/RC4BCryptModes.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/RC4BCryptModes.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+using Internal.NativeCrypto;
+
+namespace Internal.Cryptography
+{
+    internal static class RC4BCryptModes
+    {
+        internal static SafeAlgorithmHandle GetHandle(int effectiveKeyLength)
+        {
+            SafeAlgorithmHandle hAlg = Cng.BCryptOpenAlgorithmProvider(Cng.BCRYPT_RC4_ALGORITHM, null, Cng.OpenAlgorithmProviderFlags.NONE);
+
+            if (effectiveKeyLength != 0)
+            {
+                Cng.SetEffectiveKeyLength(hAlg, effectiveKeyLength);
+            }
+
+            return hAlg;
+        }
+    }
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.c
@@ -55,8 +55,8 @@ int32_t AppleCryptoNative_CryptorCreate(PAL_SymmetricOperation operation,
     // Ensure we aren't passing through things we don't understand
     assert(operation == PAL_OperationEncrypt || operation == PAL_OperationDecrypt);
     assert(algorithm == PAL_AlgorithmAES || algorithm == PAL_AlgorithmDES || algorithm == PAL_Algorithm3DES ||
-           algorithm == PAL_AlgorithmRC2);
-    assert(chainingMode == PAL_ChainingModeECB || chainingMode == PAL_ChainingModeCBC);
+           algorithm == PAL_AlgorithmRC4 || algorithm == PAL_AlgorithmRC2);
+    assert(chainingMode == PAL_ChainingModeECB || chainingMode == PAL_ChainingModeCBC || chainingMode == PAL_ChainingModeRC4);
     assert(paddingMode == PAL_PaddingModeNone || paddingMode == PAL_PaddingModePkcs7);
     assert(options == 0);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.h
@@ -22,6 +22,7 @@ enum
     PAL_AlgorithmAES = 0,
     PAL_AlgorithmDES = 1,
     PAL_Algorithm3DES = 2,
+    PAL_AlgorithmRC4 = 4,
     PAL_AlgorithmRC2 = 5,
 };
 typedef uint32_t PAL_SymmetricAlgorithm;
@@ -30,6 +31,7 @@ enum
 {
     PAL_ChainingModeECB = 1,
     PAL_ChainingModeCBC = 2,
+    PAL_ChainingModeRC4 = 9,
 };
 typedef uint32_t PAL_ChainingMode;
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -207,6 +207,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(EVP_PKEY_set1_RSA, true) \
     PER_FUNCTION_BLOCK(EVP_rc2_cbc, true) \
     PER_FUNCTION_BLOCK(EVP_rc2_ecb, true) \
+    PER_FUNCTION_BLOCK(EVP_rc4, true) \
     PER_FUNCTION_BLOCK(EVP_sha1, true) \
     PER_FUNCTION_BLOCK(EVP_sha256, true) \
     PER_FUNCTION_BLOCK(EVP_sha384, true) \
@@ -504,6 +505,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_PKEY_set1_RSA EVP_PKEY_set1_RSA_ptr
 #define EVP_rc2_cbc EVP_rc2_cbc_ptr
 #define EVP_rc2_ecb EVP_rc2_ecb_ptr
+#define EVP_rc4 EVP_rc4_ptr
 #define EVP_sha1 EVP_sha1_ptr
 #define EVP_sha256 EVP_sha256_ptr
 #define EVP_sha384 EVP_sha384_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -180,3 +180,8 @@ const EVP_CIPHER* CryptoNative_EvpRC2Cbc()
 {
     return EVP_rc2_cbc();
 }
+
+const EVP_CIPHER* CryptoNative_EvpRC4()
+{
+    return EVP_rc4();
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.h
@@ -162,3 +162,11 @@ EvpRC2Cbc
 Direct shim to EVP_des_rc2_cbc.
 */
 DLLEXPORT const EVP_CIPHER* CryptoNative_EvpRC2Cbc(void);
+
+/*
+Function:
+EvpRC4
+
+Direct shim to EVP_rc4.
+*/
+DLLEXPORT const EVP_CIPHER* CryptoNative_EvpRC4(void);

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
@@ -159,7 +159,7 @@ namespace Internal.Cryptography
                         ? Interop.AppleCrypto.PAL_SymmetricOperation.Encrypt
                         : Interop.AppleCrypto.PAL_SymmetricOperation.Decrypt,
                     algorithm,
-                    GetPalChainMode(cipherMode),
+                    GetPalChainMode(algorithm, cipherMode),
                     Interop.AppleCrypto.PAL_PaddingMode.None,
                     pbKey,
                     key.Length,
@@ -172,8 +172,13 @@ namespace Internal.Cryptography
             ProcessInteropError(ret, ccStatus);
         }
 
-        private Interop.AppleCrypto.PAL_ChainingMode GetPalChainMode(CipherMode cipherMode)
+        private Interop.AppleCrypto.PAL_ChainingMode GetPalChainMode(
+            Interop.AppleCrypto.PAL_SymmetricAlgorithm algorithm,
+            CipherMode cipherMode)
         {
+            if (algorithm == Interop.AppleCrypto.PAL_SymmetricAlgorithm.RC4)
+                return Interop.AppleCrypto.PAL_ChainingMode.RC4;
+
             switch (cipherMode)
             {
                 case CipherMode.CBC:

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC4Implementation.OSX.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC4Implementation.OSX.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    partial class RC4Implementation
+    {
+        private static ICryptoTransform CreateTransformCore(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            byte[] key,
+            int effectiveKeyLength,
+            byte[] iv,
+            int blockSize,
+            bool encrypting)
+        {
+            BasicSymmetricCipher cipher = new AppleCCCryptor(
+                Interop.AppleCrypto.PAL_SymmetricAlgorithm.RC4,
+                cipherMode,
+                blockSize,
+                key,
+                iv,
+                encrypting);
+
+            return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC4Implementation.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC4Implementation.Unix.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    partial class RC4Implementation
+    {
+        private static ICryptoTransform CreateTransformCore(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            byte[] key,
+            int effectiveKeyLength,
+            byte[] iv,
+            int blockSize,
+            bool encrypting)
+        {
+            // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
+            IntPtr algorithm = Interop.Crypto.EvpRC4();
+            BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, key, effectiveKeyLength, iv, encrypting);
+            return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC4Implementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC4Implementation.Windows.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Diagnostics;
+using Internal.NativeCrypto;
+
+namespace Internal.Cryptography
+{
+    partial class RC4Implementation
+    {
+        private static ICryptoTransform CreateTransformCore(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            byte[] key,
+            int effectiveKeyLength,
+            byte[] iv,
+            int blockSize,
+            bool encrypting)
+        {
+            using (SafeAlgorithmHandle algorithm = RC4BCryptModes.GetHandle(effectiveKeyLength))
+            {
+                // The BasicSymmetricCipherBCrypt ctor will increase algorithm reference count and take ownership.
+                BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, true, iv, encrypting);
+                return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC4Implementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC4Implementation.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal sealed partial class RC4Implementation : SymmetricAlgorithm
+    {
+        private const int BitsPerByte = 8;
+
+        public RC4Implementation()
+        {
+            LegalBlockSizesValue = s_legalBlockSizes.CloneKeySizesArray();
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
+            KeySizeValue = 128;
+            BlockSizeValue = 64;
+            FeedbackSizeValue = BlockSizeValue;
+        }
+
+        public override ICryptoTransform CreateDecryptor()
+        {
+            return CreateTransform(Key, IV, encrypting: false);
+        }
+
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateTransform(rgbKey, rgbIV.CloneByteArray(), encrypting: false);
+        }
+
+        public override ICryptoTransform CreateEncryptor()
+        {
+            return CreateTransform(Key, IV, encrypting: true);
+        }
+
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateTransform(rgbKey, rgbIV.CloneByteArray(), encrypting: true);
+        }
+
+
+        public override byte[] IV
+        {
+            get { return Array.Empty<byte>(); }
+            set { throw new NotSupportedException(); }
+        }
+
+        public override void GenerateIV()
+        {
+            // Not used for stream ciphers
+        }
+
+        public sealed override void GenerateKey()
+        {
+            byte[] key = new byte[KeySize / BitsPerByte];
+            RandomNumberGenerator.Fill(key);
+            Key = key;
+        }
+
+        private ICryptoTransform CreateTransform(byte[] rgbKey, byte[] rgbIV, bool encrypting)
+        {
+            // note: rgbIV is guaranteed to be cloned before this method, so no need to clone it again
+
+            if (rgbKey == null)
+                throw new ArgumentNullException(nameof(rgbKey));
+
+            long keySize = rgbKey.Length * (long)BitsPerByte;
+            if (keySize > int.MaxValue || !((int)keySize).IsLegalSize(LegalKeySizes))
+                throw new ArgumentException(SR.Cryptography_InvalidKeySize, nameof(rgbKey));
+
+            if (rgbIV != null)
+            {
+                long ivSize = rgbIV.Length * (long)BitsPerByte;
+                if (ivSize != BlockSize)
+                    throw new ArgumentException(SR.Cryptography_InvalidIVSize, nameof(rgbIV));
+            }
+
+            int effectiveKeySize = KeySizeValue == 0 ? (int)keySize : KeySizeValue;
+            return CreateTransformCore(Mode, Padding, rgbKey, effectiveKeySize, rgbIV, BlockSize / BitsPerByte, encrypting);
+        }
+
+        private static readonly KeySizes[] s_legalBlockSizes =
+        {
+            new KeySizes(minSize: 64, maxSize: 64, skipSize: 0)
+        };
+
+        private static readonly KeySizes[] s_legalKeySizes =
+        {
+            new KeySizes(minSize: 40, maxSize: 2048, skipSize: 8)
+        };
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -22,6 +22,7 @@
     <Compile Include="Internal\Cryptography\HashAlgorithmNames.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.cs" />
     <Compile Include="Internal\Cryptography\RC2Implementation.cs" />
+    <Compile Include="Internal\Cryptography\RC4Implementation.cs" />
     <Compile Include="Internal\Cryptography\RijndaelImplementation.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.cs" />
     <Compile Include="System\Security\Cryptography\Aes.cs" />
@@ -195,6 +196,7 @@
     <Compile Include="Internal\Cryptography\HashProviderDispenser.Windows.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Windows.cs" />
     <Compile Include="Internal\Cryptography\RC2Implementation.Windows.cs" />
+    <Compile Include="Internal\Cryptography\RC4Implementation.Windows.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.Windows.cs" />
     <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipherBCrypt.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipherBCrypt.cs</Link>
@@ -264,6 +266,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\RC2BCryptModes.cs">
       <Link>Common\Interop\Windows\BCrypt\RC2BCryptModes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\RC4BCryptModes.cs">
+      <Link>Common\Interop\Windows\BCrypt\RC4BCryptModes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\TripleDesBCryptModes.cs">
       <Link>Common\Interop\Windows\BCrypt\TripleDesBCryptModes.cs</Link>
@@ -495,6 +500,7 @@
     <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\RC2Implementation.Unix.cs" />
+    <Compile Include="Internal\Cryptography\RC4Implementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.Unix.cs" />
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\ECDiffieHellman.Create.OpenSsl.cs" />
@@ -593,6 +599,7 @@
     <Compile Include="Internal\Cryptography\HashProviderDispenser.OSX.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.OSX.cs" />
     <Compile Include="Internal\Cryptography\RC2Implementation.OSX.cs" />
+    <Compile Include="Internal\Cryptography\RC4Implementation.OSX.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.OSX.cs" />
     <Compile Include="System\Security\Cryptography\ECDiffieHellman.Create.SecurityTransforms.cs" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -128,6 +128,8 @@ namespace System.Security.Cryptography
                 Type SHA384DefaultType = typeof(System.Security.Cryptography.SHA384Managed);
                 Type SHA512DefaultType = typeof(System.Security.Cryptography.SHA512Managed);
 
+                Type RC4ImplementationType = typeof(Internal.Cryptography.RC4Implementation);
+
                 string SHA1CryptoServiceProviderType = "System.Security.Cryptography.SHA1CryptoServiceProvider, " + AssemblyName_Csp;
                 string MD5CryptoServiceProviderType = "System.Security.Cryptography.MD5CryptoServiceProvider," + AssemblyName_Csp;
                 string RSACryptoServiceProviderType = "System.Security.Cryptography.RSACryptoServiceProvider, " + AssemblyName_Csp;
@@ -207,6 +209,8 @@ namespace System.Security.Cryptography
 
                 ht.Add("RC2", RC2CryptoServiceProviderType);
                 ht.Add("System.Security.Cryptography.RC2", RC2CryptoServiceProviderType);
+
+                ht.Add("RC4", RC4ImplementationType);
 
                 ht.Add("Rijndael", RijndaelManagedType);
                 ht.Add("System.Security.Cryptography.Rijndael", RijndaelManagedType);

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
@@ -168,6 +168,11 @@ namespace Internal.Cryptography.Pal.AnyOS
                     alg = RC2.Create();
 #pragma warning restore CA5351
                     break;
+                case Oids.Rc4:
+                    alg = CryptoConfig.CreateFromName("RC4") as SymmetricAlgorithm;
+                    if (alg == null)
+                        throw new CryptographicException(SR.Cryptography_Cms_UnknownAlgorithm, algorithmIdentifier.Value);
+                    break;
                 case Oids.DesCbc:
 #pragma warning disable CA5351
                     alg = DES.Create();

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/ContentEncryptionAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/ContentEncryptionAlgorithmTests.cs
@@ -12,9 +12,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 {
     public static partial class ContentEncryptionAlgorithmTests
     {
-        public static bool SupportsRc4 => PlatformDetection.IsWindows;
-        public static bool DoesNotSupportRc4 => !SupportsRc4;
-
         [Fact]
         public static void EncryptionAlgorithmRc2_InvalidKeyLength()
         {
@@ -112,7 +109,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(40, algorithm.KeyLength);
         }
 
-        [ConditionalFact(nameof(SupportsRc4))]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void DecodeAlgorithmRc4_40_RoundTrip()
         {
@@ -133,25 +129,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.NotNull(algorithm.Oid);
             Assert.Equal(Oids.Rc4, algorithm.Oid.Value);
             Assert.Equal(40, algorithm.KeyLength);
-        }
-
-
-        [ConditionalFact(nameof(DoesNotSupportRc4))]
-        [OuterLoop(/* Leaks key on disk if interrupted */)]
-        public static void DecodeAlgorithmRc4_40_PlatformNotSupported()
-        {
-            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3, 4 });
-            EnvelopedCms ecms = new EnvelopedCms(contentInfo, new AlgorithmIdentifier(new Oid(Oids.Rc4), 40));
-
-            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.GetCertificate())
-            {
-                CmsRecipient recipient = new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber, cert);
-
-                CryptographicException e =
-                    Assert.Throws<CryptographicException>(() => ecms.Encrypt(recipient));
-
-                Assert.Contains(Oids.Rc4, e.Message);
-            }
         }
 
         [Fact]
@@ -229,7 +206,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(192, algorithm.KeyLength);
         }
 
-        [ConditionalFact(nameof(SupportsRc4))]
         public static void DecodeAlgorithmRc4_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Rc4));

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.KeyPersistence.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.KeyPersistence.cs
@@ -80,12 +80,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         [OuterLoop("Leaks key on disk if interrupted")]
         public void Decrypt_Capi_Perphemeral(string algOid)
         {
-            // Explicit key API uses managed implementation which does not support RC4
-            if (algOid == Oids.Rc4 && (!ContentEncryptionAlgorithmTests.SupportsRc4 || _useExplicitPrivateKey))
-            {
-                return;
-            }
-
             byte[] content = { 1, 1, 2, 3, 5, 8, 13, 21 };
             ContentInfo contentInfo = new ContentInfo(content);
             TestSimpleDecrypt_RoundTrip(

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -13,8 +13,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 {
     public static partial class EdgeCasesTests
     {
-        public static bool SupportsRc4 { get; } = ContentEncryptionAlgorithmTests.SupportsRc4;
-
         public static bool SupportsCngCertificates { get; } = (!PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer);
 
         [ConditionalFact(nameof(SupportsCngCertificates))]
@@ -144,7 +142,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             ValidateZeroLengthContent(encodedMessage);
         }
 
-        [ConditionalFact(nameof(SupportsRc4))]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "RC4 isn't available via CNG, and CNG is the only library available to UWP")]
         public static void Rc4AndCngWrappersDontMixTest()


### PR DESCRIPTION
Tested only on macOS and Linux so far.

Rationale:
- NetFX and CoreFX on Windows already supports it, so it makes sense to have feature parity.
- While the cipher itself is deprecated for its cryptography weaknesses it saw some limited use in S/MIME context. The messages encrypted using RC4 may still be available in the wild or as part of message archives and it could be useful to be able to decrypt them.

That said, RC4 was never officially recommended cipher for S/MIME, so RC2, 3DES and AES are much more prevalent and the arguments above may not be enough to justify its inclusion.