### PR TITLE
Add CoreLib helper used by DefaultValueAttribute constructor

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/ILLinkTrim.xml
+++ b/src/System.ComponentModel.TypeConverter/src/ILLinkTrim.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="System.ComponentModel.TypeConverter">
+    <type fullname="System.ComponentModel.TypeDescriptor">
+      <!-- called through reflection by System.ComponentModel.DefaultValueAttribute -->
+      <method name="ConvertFromInvariantString" />
+    </type>
+  </assembly>
+</linker>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -808,6 +808,12 @@ namespace System.ComponentModel
             return GetDescriptor(type, nameof(type)).GetConverter();
         }
 
+        // This is called by System.ComponentModel.DefaultValueAttribute via reflection.
+        private static object ConvertFromInvariantString(Type type, string stringValue)
+        {
+            return GetConverter(type).ConvertFromInvariantString(stringValue);
+        }
+
         /// <summary>
         /// Gets the default event for the specified type of component.
         /// </summary>


### PR DESCRIPTION
contributes to https://github.com/dotnet/corefx/issues/30648

We need to expose a static method helper used by System.ComponentModel.DefaultValueAttribute  constructor by reflection to avoid to move too much code to CoreLib.

related to https://github.com/dotnet/coreclr/pull/19354 and https://github.com/dotnet/corefx/pull/31649

/cc @jkotas 