### PR TITLE
[release/uwp6.0] Clone DotNet-BuildPipeline, not CoreFX master

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -432,10 +432,10 @@
       "checkoutNestedSubmodules": "false",
       "labelSourcesFormat": "$(build.buildNumber)"
     },
-    "id": "58fa2458-e392-4373-ba2b-dd3ef0c2d7ce",
+    "id": "0a2b2664-c1be-429c-9b40-8a24dee27a4a",
     "type": "TfsGit",
-    "name": "DotNet-CoreFX-Trusted",
-    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-CoreFX-Trusted",
+    "name": "DotNet-BuildPipeline",
+    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline",
     "defaultBranch": "refs/heads/master",
     "clean": "false",
     "checkoutSubmodules": false


### PR DESCRIPTION
skip ci please
(The buildpipeline json files aren't touched by tests.)

This prevents interference from changes on latest CoreFX master commits.

Ideally, “SkipSyncSource” would be set to “true” to avoid cloning corefx master at:

https://github.com/dotnet/corefx/blob/5f64969892a2b5c068e67c1cc9391def07d5082e/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json#L430

However, any agents this leg has already run on are contaminated. If we set SkipSyncSource to true now, new builds won’t clear out the old sources. Telling the def to clean the directory is historically not likely to work reliably due to lingering processes. (And maybe additional issues I’m not thinking of.)

The Publish leg also clones DotNet-BuildPipeline, so this isn't a new dependency for the build.