### PR TITLE
 Overwrite GatherItemsForPattern target in publish.proj

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -29,6 +29,8 @@
     <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
     <!-- The SignFiles target needs OutDir to be defined -->
     <OutDir>$(PackageDownloadDirectory)</OutDir>
+    <!-- If we're re-publishing signed final packages, we need to overwrite the correct location in Azure storage. -->
+    <!-- this means prepending the ConfigurationGroup (should be 'Release') to the blob path -->
     <BlobNamePrefix Condition="$(RepublishSignedFinalPackages)' == 'true'">$(ConfigurationGroup)/</BlobNamePrefix>
   </PropertyGroup>
 

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -15,20 +15,21 @@
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForPublishing>
-        <RelativeBlobPath>$(ConfigurationGroup)/$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>  
+        <RelativeBlobPath>$(BlobNamePrefix)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>  
       </ForPublishing>
     </ItemGroup>
     <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />
   </Target>
 
   <!-- Set up publish patterns for "final" package publish - that is, the pipeline packages we download & publish to myget during official builds -->
-   <PropertyGroup>
-     <PackageDownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)AzureTransfer\$(ConfigurationGroup)</PackageDownloadDirectory>
-     <FinalPublishPattern>$(PackageDownloadDirectory)\**\*.nupkg</FinalPublishPattern>
-     <FinalPublishPrivatePattern>$(PackageDownloadDirectory)\**\*Private*.nupkg</FinalPublishPrivatePattern>
-     <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
+  <PropertyGroup>
+    <PackageDownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)AzureTransfer\$(ConfigurationGroup)</PackageDownloadDirectory>
+    <FinalPublishPattern>$(PackageDownloadDirectory)\**\*.nupkg</FinalPublishPattern>
+    <FinalPublishPrivatePattern>$(PackageDownloadDirectory)\**\*Private*.nupkg</FinalPublishPrivatePattern>
+    <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
     <!-- The SignFiles target needs OutDir to be defined -->
     <OutDir>$(PackageDownloadDirectory)</OutDir>
+    <BlobNamePrefix Condition="$(RepublishSignedFinalPackages)' == 'true'">$(ConfigurationGroup)/</BlobNamePrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -6,6 +6,21 @@
   <Import Project="$(ToolsDir)PublishContent.targets" />
   <Import Project="$(ToolsDir)versioning.targets" />
 
+  <!-- gathers the items to be published -->
+  <Target Name="GatherItemsForPattern">
+    <Error Condition="'$(PublishPattern)' == ''" Text="Please specify a value for PublishPattern using standard msbuild 'include' syntax." />
+    <ItemGroup>
+      <ForPublishing Include="$(PublishPattern)" />
+    </ItemGroup>
+    <!-- add relative blob path metadata -->
+    <ItemGroup>
+      <ForPublishing>
+        <RelativeBlobPath>$(ConfigurationGroup)/$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>  
+      </ForPublishing>
+    </ItemGroup>
+    <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />
+  </Target>
+
   <!-- Set up publish patterns for "final" package publish - that is, the pipeline packages we download & publish to myget during official builds -->
    <PropertyGroup>
      <PackageDownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)AzureTransfer\$(ConfigurationGroup)</PackageDownloadDirectory>


### PR DESCRIPTION
During final publish, we attempt to download the packages that have just been built by the pipeline, sign those packages, and re-upload them to azure, overwriting what was already there. However, currently this target is set up incorrectly - it downloads the packages, signs them, then publishes everything out of the `AzureTransfer\Release` directory - this means that, whatever we download from a directory structure that looks like `Release\pkg\packages`, will get published back into `pkg\packages` - i.e., one level higher up the directory tree than it should be. This should fix that issue.

@chcosta @weshaggard @dagood @safern PTAL