### PR TITLE
Increate ReadAsyncCompletesIfFlushAsyncCanceledMidFlush timeout to 5 minutes

### DIFF
--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -401,7 +401,7 @@ namespace System.IO.Pipelines.Tests
                 }
             });
 
-            Assert.True(Task.WaitAll(new [] { writer, reader, canceller }, TimeSpan.FromSeconds(30)), "Reader was not completed in reasonable time");
+            Assert.True(Task.WaitAll(new [] { writer, reader, canceller }, TimeSpan.FromMinutes(5)), "Reader was not completed in 5 minutes");
             Assert.True(cancellations > 0);
         }
     }


### PR DESCRIPTION
To allow it to pass on slower JIT Stress runs.
See https://github.com/dotnet/coreclr/issues/19295