### PR TITLE
Support deserializing empty TimeSpan

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/PrimitiveXmlSerializers.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/PrimitiveXmlSerializers.cs
@@ -634,6 +634,12 @@ namespace System.Xml.Serialization
             {
                 if (((object)Reader.LocalName == (object)_id19_TimeSpan && (object)Reader.NamespaceURI == (object)_id2_Item))
                 {
+                    if(Reader.IsEmptyElement)
+                    {
+                        Reader.Skip();
+                        o = default(TimeSpan);
+                    }
+                    else
                     {
                         o = System.Xml.XmlConvert.ToTimeSpan(Reader.ReadElementString());
                     }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -851,17 +851,10 @@ namespace System.Xml.Serialization
                 {
                     Reader.Skip();
                 }
-                else if(element.Mapping.TypeDesc.Type == typeof(TimeSpan))
-                {
-                    if(Reader.IsEmptyElement)
-                    {
-                        Reader.Skip();
-                        value = default(TimeSpan);
-                    }
-                    else
-                    {
-                        value = XmlConvert.ToTimeSpan(Reader.ReadElementString());
-                    }
+                else if(element.Mapping.TypeDesc.Type == typeof(TimeSpan) && Reader.IsEmptyElement)
+                {                   
+                    Reader.Skip();
+                    value = default(TimeSpan);                   
                 }
                 else
                 {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -851,6 +851,18 @@ namespace System.Xml.Serialization
                 {
                     Reader.Skip();
                 }
+                else if(element.Mapping.TypeDesc.Type == typeof(TimeSpan))
+                {
+                    if(Reader.IsEmptyElement)
+                    {
+                        Reader.Skip();
+                        value = default(TimeSpan);
+                    }
+                    else
+                    {
+                        value = XmlConvert.ToTimeSpan(Reader.ReadElementString());
+                    }
+                }
                 else
                 {
                     if (element.Mapping.TypeDesc == QnameTypeDesc)

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -4775,27 +4775,50 @@ namespace System.Xml.Serialization
                 }
                 Writer.Indent++;
 
-                WriteSourceBegin(source);
-                if (element.Mapping.TypeDesc == QnameTypeDesc)
-                    Writer.Write("ReadElementQualifiedName()");
+                if (element.Mapping.TypeDesc.Type == typeof(TimeSpan))
+                {
+                    Writer.WriteLine("if (Reader.IsEmptyElement) {");
+                    Writer.Indent++;
+                    Writer.WriteLine("Reader.Skip();");
+                    WriteSourceBegin(source);
+                    Writer.Write("default(System.TimeSpan)");
+                    WriteSourceEnd(source);
+                    Writer.WriteLine(";");
+                    Writer.Indent--;
+                    Writer.WriteLine("}");
+                    Writer.WriteLine("else {");
+                    Writer.Indent++;
+                    WriteSourceBegin(source);
+                    WritePrimitive(element.Mapping, "Reader.ReadElementString()");
+                    WriteSourceEnd(source);
+                    Writer.WriteLine(";");
+                    Writer.Indent--;
+                    Writer.WriteLine("}");
+                }
                 else
                 {
-                    string readFunc;
-                    switch (element.Mapping.TypeDesc.FormatterName)
+                    WriteSourceBegin(source);
+                    if (element.Mapping.TypeDesc == QnameTypeDesc)
+                        Writer.Write("ReadElementQualifiedName()");
+                    else
                     {
-                        case "ByteArrayBase64":
-                        case "ByteArrayHex":
-                            readFunc = "false";
-                            break;
-                        default:
-                            readFunc = "Reader.ReadElementString()";
-                            break;
+                        string readFunc;
+                        switch (element.Mapping.TypeDesc.FormatterName)
+                        {
+                            case "ByteArrayBase64":
+                            case "ByteArrayHex":
+                                readFunc = "false";
+                                break;
+                            default:
+                                readFunc = "Reader.ReadElementString()";
+                                break;
+                        }
+                        WritePrimitive(element.Mapping, readFunc);
                     }
-                    WritePrimitive(element.Mapping, readFunc);
-                }
 
-                WriteSourceEnd(source);
-                Writer.WriteLine(";");
+                    WriteSourceEnd(source);
+                    Writer.WriteLine(";");
+                }
                 Writer.Indent--;
                 Writer.WriteLine("}");
             }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -3046,34 +3046,78 @@ namespace System.Xml.Serialization
                 {
                 }
 
-                WriteSourceBegin(source);
-                if (element.Mapping.TypeDesc == QnameTypeDesc)
+                if (element.Mapping.TypeDesc.Type == typeof(TimeSpan))
                 {
-                    MethodInfo XmlSerializationReader_ReadElementQualifiedName = typeof(XmlSerializationReader).GetMethod(
-                           "ReadElementQualifiedName",
-                           CodeGenerator.InstanceBindingFlags,
-                           Array.Empty<Type>()
-                           );
+                    MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
+                       "get_Reader",
+                       CodeGenerator.InstanceBindingFlags,
+                       Array.Empty<Type>()
+                       );
+                    MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
+                        "get_IsEmptyElement",
+                        CodeGenerator.InstanceBindingFlags,
+                        Array.Empty<Type>()
+                        );
                     ilg.Ldarg(0);
-                    ilg.Call(XmlSerializationReader_ReadElementQualifiedName);
+                    ilg.Call(XmlSerializationReader_get_Reader);
+                    ilg.Call(XmlReader_get_IsEmptyElement);
+                    ilg.If();
+                    WriteSourceBegin(source);
+                    MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
+                        "Skip",
+                        CodeGenerator.InstanceBindingFlags,
+                        Array.Empty<Type>()
+                        );
+                    ilg.Ldarg(0);
+                    ilg.Call(XmlSerializationReader_get_Reader);
+                    ilg.Call(XmlReader_Skip);
+                    ConstructorInfo TimeSpan_ctor = typeof(TimeSpan).GetConstructor(
+                        CodeGenerator.InstanceBindingFlags,
+                        null,
+                        new Type[] { typeof(Int64) },
+                        null
+                        );
+                    ilg.Ldc(default(TimeSpan).Ticks);
+                    ilg.New(TimeSpan_ctor);
+                    WriteSourceEnd(source, element.Mapping.TypeDesc.Type);
+                    ilg.Else();
+                    WriteSourceBegin(source);
+                    WritePrimitive(element.Mapping, "Reader.ReadElementString()");
+                    WriteSourceEnd(source, element.Mapping.TypeDesc.Type);
+                    ilg.EndIf();
                 }
                 else
                 {
-                    string readFunc;
-                    switch (element.Mapping.TypeDesc.FormatterName)
+                    WriteSourceBegin(source);
+                    if (element.Mapping.TypeDesc == QnameTypeDesc)
                     {
-                        case "ByteArrayBase64":
-                        case "ByteArrayHex":
-                            readFunc = "false";
-                            break;
-                        default:
-                            readFunc = "Reader.ReadElementString()";
-                            break;
+                        MethodInfo XmlSerializationReader_ReadElementQualifiedName = typeof(XmlSerializationReader).GetMethod(
+                               "ReadElementQualifiedName",
+                               CodeGenerator.InstanceBindingFlags,
+                               Array.Empty<Type>()
+                               );
+                        ilg.Ldarg(0);
+                        ilg.Call(XmlSerializationReader_ReadElementQualifiedName);
                     }
-                    WritePrimitive(element.Mapping, readFunc);
+                    else
+                    {
+                        string readFunc;
+                        switch (element.Mapping.TypeDesc.FormatterName)
+                        {
+                            case "ByteArrayBase64":
+                            case "ByteArrayHex":
+                                readFunc = "false";
+                                break;
+                            default:
+                                readFunc = "Reader.ReadElementString()";
+                                break;
+                        }
+                        WritePrimitive(element.Mapping, readFunc);
+                    }
+
+                    WriteSourceEnd(source, element.Mapping.TypeDesc.Type);
                 }
 
-                WriteSourceEnd(source, element.Mapping.TypeDesc.Type);
                 if (doEndIf)
                     ilg.EndIf();
             }

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -687,6 +687,22 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
+    public static void Xml_DeserializeTypeWithEmptyTimeSpanProperty()
+    {
+        string xml = 
+            @"<?xml version=""1.0""?>
+            <TypeWithTimeSpanProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+            <TimeSpanProperty />
+            </TypeWithTimeSpanProperty>";
+        XmlSerializer ser = new XmlSerializer(typeof(TypeWithTimeSpanProperty));
+        StringReader reader = new StringReader(xml);
+        TypeWithTimeSpanProperty deserializedObj = (TypeWithTimeSpanProperty)ser.Deserialize(reader);
+
+        Assert.NotNull(deserializedObj);
+        Assert.Equal(default(TimeSpan), deserializedObj.TimeSpanProperty);
+    }
+
+    [Fact]
     public static void Xml_TypeWithByteProperty()
     {
         var obj = new TypeWithByteProperty() { ByteProperty = 123 };

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -705,6 +705,22 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
+    public static void Xml_DeserializeEmptyTimeSpanType()
+    {
+        string xml =
+    @"<?xml version=""1.0""?>
+     <TimeSpan />";
+        XmlSerializer serializer = new XmlSerializer(typeof(TimeSpan));
+
+        using (StringReader reader = new StringReader(xml))
+        {
+            TimeSpan deserializedObj = (TimeSpan)serializer.Deserialize(reader);
+            Assert.NotNull(deserializedObj);
+            Assert.Equal(default(TimeSpan), deserializedObj);
+        }
+    }
+
+    [Fact]
     public static void Xml_TypeWithByteProperty()
     {
         var obj = new TypeWithByteProperty() { ByteProperty = 123 };

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -694,12 +694,14 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
             <TypeWithTimeSpanProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
             <TimeSpanProperty />
             </TypeWithTimeSpanProperty>";
-        XmlSerializer ser = new XmlSerializer(typeof(TypeWithTimeSpanProperty));
-        StringReader reader = new StringReader(xml);
-        TypeWithTimeSpanProperty deserializedObj = (TypeWithTimeSpanProperty)ser.Deserialize(reader);
+        XmlSerializer serializer = new XmlSerializer(typeof(TypeWithTimeSpanProperty));
 
-        Assert.NotNull(deserializedObj);
-        Assert.Equal(default(TimeSpan), deserializedObj.TimeSpanProperty);
+        using (StringReader reader = new StringReader(xml))
+        {
+            TypeWithTimeSpanProperty deserializedObj = (TypeWithTimeSpanProperty)serializer.Deserialize(reader);
+            Assert.NotNull(deserializedObj);
+            Assert.Equal(default(TimeSpan), deserializedObj.TimeSpanProperty);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #31505 
Deserializing an empty TimeSpan will return 00:00:00 on full framework, but throw an exception on .NET core. This fix is to support it on .NET Core to keep the behavior consistent.

@huanwu @mconnew @Lxiamail 