### PR TITLE
Exposing DynamicMethod.DefineParameter API and adding test

### DIFF
--- a/src/System.Reflection.Emit.Lightweight/ref/System.Reflection.Emit.Lightweight.cs
+++ b/src/System.Reflection.Emit.Lightweight/ref/System.Reflection.Emit.Lightweight.cs
@@ -21,6 +21,7 @@ namespace System.Reflection.Emit
         public override System.Reflection.MethodAttributes Attributes { get { throw null; } }
         public override System.Reflection.CallingConventions CallingConvention { get { throw null; } }
         public override System.Type DeclaringType { get { throw null; } }
+        public ParameterBuilder DefineParameter(int position, System.Reflection.ParameterAttributes attributes, System.String parameterName) { throw null; }
         public bool InitLocals { get { throw null; } set { } }
         public override System.RuntimeMethodHandle MethodHandle { get { throw null; } }
         public override string Name { get { throw null; } }

--- a/src/System.Reflection.Emit.Lightweight/tests/DynamicMethodDefineParameter.cs
+++ b/src/System.Reflection.Emit.Lightweight/tests/DynamicMethodDefineParameter.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.Reflection.Emit.Tests
+{
+    public class DynamicMethodDefineParameter
+    {
+        [Fact]
+        public void DefineParameter_SetsParameterName()
+        {
+            Type[] mathArgs = { typeof(double), typeof(double) };
+
+            var powerOf = new DynamicMethod("PowerOf",
+                typeof(double),
+                mathArgs,
+                typeof(double).Module);
+
+            ILGenerator il = powerOf.GetILGenerator(256);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, typeof(Math).GetMethod("Pow"));
+            il.Emit(OpCodes.Ret);
+
+            var paramNames = new string[] { "param1", "param2" };
+            for (int i = 0; i < paramNames.Length; i++)
+            {
+                powerOf.DefineParameter(i+1, ParameterAttributes.In, paramNames[i]);
+            }
+            
+            object[] invokeArgs = { 2, 5 };
+            object objRet = powerOf.Invoke(null, BindingFlags.ExactBinding, null, invokeArgs, new CultureInfo("en-us"));
+
+            ParameterInfo[] parameters = powerOf.GetParameters();
+
+            Assert.Equal(paramNames.Length, parameters.Length);
+            Assert.Equal("param1", parameters[0].Name);
+            Assert.Equal("param2", parameters[1].Name);
+        }
+    }
+}

--- a/src/System.Reflection.Emit.Lightweight/tests/DynamicMethodDefineParameter.cs
+++ b/src/System.Reflection.Emit.Lightweight/tests/DynamicMethodDefineParameter.cs
@@ -10,7 +10,7 @@ namespace System.Reflection.Emit.Tests
     public class DynamicMethodDefineParameter
     {
         [Fact]
-        public void DefineParameter_SetsParameterName()
+        public void DefineParameter_SetsParameterCorrectly()
         {
             Type[] mathArgs = { typeof(double), typeof(double) };
 
@@ -24,21 +24,25 @@ namespace System.Reflection.Emit.Tests
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Call, typeof(Math).GetMethod("Pow"));
             il.Emit(OpCodes.Ret);
-
-            var paramNames = new string[] { "param1", "param2" };
-            for (int i = 0; i < paramNames.Length; i++)
-            {
-                powerOf.DefineParameter(i+1, ParameterAttributes.In, paramNames[i]);
-            }
+            
+            powerOf.DefineParameter(1, ParameterAttributes.In, "base");
+            powerOf.DefineParameter(2, ParameterAttributes.Out, "exponent");
             
             object[] invokeArgs = { 2, 5 };
             object objRet = powerOf.Invoke(null, BindingFlags.ExactBinding, null, invokeArgs, new CultureInfo("en-us"));
 
             ParameterInfo[] parameters = powerOf.GetParameters();
 
-            Assert.Equal(paramNames.Length, parameters.Length);
-            Assert.Equal("param1", parameters[0].Name);
-            Assert.Equal("param2", parameters[1].Name);
+            Assert.Equal(32.0, objRet);
+
+            Assert.Equal("base", parameters[0].Name);
+            Assert.Equal("exponent", parameters[1].Name);
+
+            Assert.Equal(typeof(double), parameters[0].ParameterType);
+            Assert.Equal(typeof(double), parameters[1].ParameterType);
+
+            Assert.Equal(ParameterAttributes.In, parameters[0].Attributes);
+            Assert.Equal(ParameterAttributes.Out, parameters[1].Attributes);
         }
     }
 }

--- a/src/System.Reflection.Emit.Lightweight/tests/System.Reflection.Emit.Lightweight.Tests.csproj
+++ b/src/System.Reflection.Emit.Lightweight/tests/System.Reflection.Emit.Lightweight.Tests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <Compile Include="DynamicMethodCreateDelegate.cs" />
     <Compile Include="DynamicMethodCtor.cs" />
+    <Compile Include="DynamicMethodDefineParameter.cs" />
     <Compile Include="DynamicMethodGetBaseDefinition.cs" />
     <Compile Include="DynamicMethodGetILGenerator.cs" />
     <Compile Include="DynamicMethodInitLocals.cs" />

--- a/src/shims/ApiCompatBaseline.netcoreapp.netfx461.ignore.txt
+++ b/src/shims/ApiCompatBaseline.netcoreapp.netfx461.ignore.txt
@@ -127,7 +127,6 @@ MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.ReturnType.
 MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.SetMethodBody(System.Byte[], System.Int32, System.Byte[], System.Collections.Generic.IEnumerable<System.Reflection.Emit.ExceptionHandler>, System.Collections.Generic.IEnumerable<System.Int32>)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.SetSymCustomAttribute(System.String, System.Byte[])' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.Signature.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Reflection.Emit.DynamicMethod.DefineParameter(System.Int32, System.Reflection.ParameterAttributes, System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Reflection.Emit.DynamicMethod.GetDynamicILInfo()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Reflection.Emit.EnumBuilder.CreateType()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Reflection.Emit.EnumBuilder.TypeToken.get()' does not exist in the implementation but it does exist in the contract.


### PR DESCRIPTION
`DynamicMethod.DefineParameter` was already implemented but not exposed.
This PR:
- Exposes `DefineParameter`
- Adds test to exercise the code. It asserts the parameter name, attribute and type

Fixes #29715 

cc: @AtsushiKan @jkotas @danmosemsft 