### PR TITLE
Add FreeBSD terminfo location to well-known

### DIFF
--- a/src/System.Console/src/System/TermInfo.cs
+++ b/src/System.Console/src/System/TermInfo.cs
@@ -176,6 +176,7 @@ namespace System
                     "/etc/terminfo",
                     "/lib/terminfo",
                     "/usr/share/terminfo",
+                    "/usr/share/misc/terminfo"
                 };
 
             /// <summary>Read the database for the specified terminal.</summary>


### PR DESCRIPTION
According to [terminfo(5)](https://www.freebsd.org/cgi/man.cgi?query=terminfo&sektion=5) on FreeBSD, this should be the well-known location for the terminfo database on the platform. Consequently, this is where ncurses looks for terminfo on FreeBSD.