### PR TITLE
fix Race condition with SocketHelperSyncForceNonBlocking.AcceptAsync

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -101,13 +101,14 @@ namespace System.Net.Sockets.Tests
             // back and force on every Accept, which causes pending sync Accepts to return EWOULDBLOCK.
             // For now, just skip the test for SyncForceNonBlocking.
             // TODO: Issue #22885
-            if (typeof(T) == typeof(SocketHelperSyncForceNonBlocking))
-                return;
+            //if (typeof(T) == typeof(SocketHelperSyncForceNonBlocking))
+            //    return;
 
             using (Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                listener.Listen(numberAccepts);
+                //listener.Listen(numberAccepts);
+                Listen(listener, numberAccepts);
 
                 var clients = new Socket[numberAccepts];
                 var clientConnects = new Task[numberAccepts];
@@ -264,7 +265,8 @@ namespace System.Net.Sockets.Tests
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 int port = listener.BindToAnonymousPort(IPAddress.Loopback);
-                listener.Listen(1);
+                //listener.Listen(1);
+                Listen(listener, 1);
 
                 Task<Socket> acceptTask = AcceptAsync(listener, server);
                 client.Connect(IPAddress.Loopback, port);

--- a/src/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -40,17 +40,10 @@ namespace System.Net.Sockets.Tests
         [InlineData(5)]
         public async Task Accept_ConcurrentAcceptsBeforeConnects_Success(int numberAccepts)
         {
-            // The SyncForceNonBlocking implementation currently toggles the listener's Blocking setting
-            // back and force on every Accept, which causes pending sync Accepts to return EWOULDBLOCK.
-            // For now, just skip the test for SyncForceNonBlocking.
-            // TODO: Issue #22885
-            if (typeof(T) == typeof(SocketHelperSyncForceNonBlocking))
-                return;
-
             using (Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                listener.Listen(numberAccepts);
+                Listen(listener, numberAccepts);
 
                 var clients = new Socket[numberAccepts];
                 var servers = new Task<Socket>[numberAccepts];
@@ -97,17 +90,9 @@ namespace System.Net.Sockets.Tests
         [InlineData(5)]
         public async Task Accept_ConcurrentAcceptsAfterConnects_Success(int numberAccepts)
         {
-            // The SyncForceNonBlocking implementation currently toggles the listener's Blocking setting
-            // back and force on every Accept, which causes pending sync Accepts to return EWOULDBLOCK.
-            // For now, just skip the test for SyncForceNonBlocking.
-            // TODO: Issue #22885
-            //if (typeof(T) == typeof(SocketHelperSyncForceNonBlocking))
-            //    return;
-
             using (Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                //listener.Listen(numberAccepts);
                 Listen(listener, numberAccepts);
 
                 var clients = new Socket[numberAccepts];
@@ -265,8 +250,7 @@ namespace System.Net.Sockets.Tests
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 int port = listener.BindToAnonymousPort(IPAddress.Loopback);
-                //listener.Listen(1);
-                Listen(listener, 1);
+                listener.Listen(1);
 
                 Task<Socket> acceptTask = AcceptAsync(listener, server);
                 client.Connect(IPAddress.Loopback, port);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
@@ -31,6 +31,7 @@ namespace System.Net.Sockets.Tests
         public virtual bool ConnectAfterDisconnectResultsInInvalidOperationException => false;
         public virtual bool SupportsMultiConnect => true;
         public virtual bool SupportsAcceptIntoExistingSocket => true;
+        public virtual void Listen(Socket s, int backlog)  { s.Listen(backlog); }
     }
 
     public class SocketHelperArraySync : SocketHelperBase
@@ -72,9 +73,14 @@ namespace System.Net.Sockets.Tests
     public sealed class SocketHelperSyncForceNonBlocking : SocketHelperArraySync
     {
         public override Task<Socket> AcceptAsync(Socket s) =>
-            Task.Run(() => { s.ForceNonBlocking(true); Socket accepted = s.Accept(); accepted.ForceNonBlocking(true); return accepted; });
+            Task.Run(() => { Socket accepted = s.Accept(); accepted.ForceNonBlocking(true); return accepted; });
         public override Task ConnectAsync(Socket s, EndPoint endPoint) =>
             Task.Run(() => { s.ForceNonBlocking(true); s.Connect(endPoint); });
+        public override void Listen(Socket s, int backlog)
+        {
+            s.Listen(backlog);
+            s.ForceNonBlocking(true);
+        }
     }
 
     public sealed class SocketHelperApm : SocketHelperBase
@@ -262,6 +268,7 @@ namespace System.Net.Sockets.Tests
         public bool ConnectAfterDisconnectResultsInInvalidOperationException => _socketHelper.ConnectAfterDisconnectResultsInInvalidOperationException;
         public bool SupportsMultiConnect => _socketHelper.SupportsMultiConnect;
         public bool SupportsAcceptIntoExistingSocket => _socketHelper.SupportsAcceptIntoExistingSocket;
+        public void Listen(Socket s, int backlog) => _socketHelper.Listen(s, backlog);
     }
 
     //


### PR DESCRIPTION
fixes #22885

move forcing of non-blocking to new helper function instead of doing it in Accept()

I did 100+ full test runs with outerloop and I accept tests did not failed. 



