### PR TITLE
Pass BlobNamePrefix to publish.proj when republishing signed packages

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -198,7 +198,7 @@
       },
       "inputs": {
         "filename": "msbuild",
-        "arguments": "src\\publish.proj /p:CloudDropAccountName=$(PB_CloudDropAccountName) /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:ContainerName=$(PB_Label) /p:OverwriteOnPublish=true /p:RepublishSignedFinalPackages=true",
+        "arguments": "src\\publish.proj /p:CloudDropAccountName=$(PB_CloudDropAccountName) /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:ContainerName=$(PB_Label) /p:OverwriteOnPublish=true /p:RepublishSignedFinalPackages=true /p:BlobNamePrefix=$(PB_ConfigurationGroup)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "failOnStandardError": "false"
       }


### PR DESCRIPTION
We need to pass `BlobNamePrefix` to publish.proj when republishing signed packages, because of https://github.com/dotnet/buildtools/blob/release/2.0.0/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets#L15. Without this change, we've been publishing into the root folder in Azure blob storage, instead of overwriting the unsigned packages we were trying to overwrite.

CC @MattGal @weshaggard

@dagood PTAL