### PR TITLE
[System.Diagnostics] Change resource ProcessStartIdentityNotSupported name and content to give more information to developers about current support of this fields.

### DIFF
--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -243,8 +243,11 @@
   <data name="ProcessorAffinityNotSupported" xml:space="preserve">
     <value>Processor affinity for processes or threads is not supported on this platform.</value>
   </data>
-  <data name="ProcessStartFeaturesNotSupported" xml:space="preserve">
-    <value>{0} field(s) is not supported by "run as another user" feature on this platform.</value>
+  <data name="ProcessStartWithPasswordAndDomainNotSupported" xml:space="preserve">
+    <value>Starting process as another user with specified password and domain is not supported on this platform.</value>
+  </data>
+  <data name="ProcessStartSingleFeatureNotSupported" xml:space="preserve">
+    <value>The {0} property is not supported on this platform.</value>
   </data>
   <data name="RUsageFailure" xml:space="preserve">
     <value>Failed to set or retrieve rusage information. See the error code for OS-specific error information.</value>

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -243,8 +243,8 @@
   <data name="ProcessorAffinityNotSupported" xml:space="preserve">
     <value>Processor affinity for processes or threads is not supported on this platform.</value>
   </data>
-  <data name="ProcessStartIdentityNotSupported" xml:space="preserve">
-    <value>Starting a process with a different identity is not supported on this platform.</value>
+  <data name="ProcessStartIdentityPartiallySupported" xml:space="preserve">
+    <value>Setting Domain, LoadUserProfile, PasswordInClearText and Password is not supported on this platform.</value>
   </data>
   <data name="RUsageFailure" xml:space="preserve">
     <value>Failed to set or retrieve rusage information. See the error code for OS-specific error information.</value>

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -244,7 +244,7 @@
     <value>Processor affinity for processes or threads is not supported on this platform.</value>
   </data>
   <data name="ProcessStartWithPasswordAndDomainNotSupported" xml:space="preserve">
-    <value>Starting process as another user with specified password and domain is not supported on this platform.</value>
+    <value>Starting a process as another user with specified password and domain is not supported on this platform.</value>
   </data>
   <data name="ProcessStartSingleFeatureNotSupported" xml:space="preserve">
     <value>The {0} property is not supported on this platform.</value>

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -243,8 +243,8 @@
   <data name="ProcessorAffinityNotSupported" xml:space="preserve">
     <value>Processor affinity for processes or threads is not supported on this platform.</value>
   </data>
-  <data name="ProcessStartIdentityPartiallySupported" xml:space="preserve">
-    <value>Setting Domain, LoadUserProfile, PasswordInClearText and Password is not supported on this platform.</value>
+  <data name="ProcessStartFeaturesNotSupported" xml:space="preserve">
+    <value>{0} field(s) is not supported by "run as another user" feature on this platform.</value>
   </data>
   <data name="RUsageFailure" xml:space="preserve">
     <value>Failed to set or retrieve rusage information. See the error code for OS-specific error information.</value>

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -244,7 +244,7 @@
     <value>Processor affinity for processes or threads is not supported on this platform.</value>
   </data>
   <data name="ProcessStartWithPasswordAndDomainNotSupported" xml:space="preserve">
-    <value>Starting a process as another user with specified password and domain is not supported on this platform.</value>
+    <value>Starting a process as another user with a specified password and domain is not supported on this platform.</value>
   </data>
   <data name="ProcessStartSingleFeatureNotSupported" xml:space="preserve">
     <value>The {0} property is not supported on this platform.</value>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -44,13 +44,13 @@ namespace System.Diagnostics
         [CLSCompliant(false)]
         public static Process Start(string fileName, string userName, SecureString password, string domain)
         {
-            throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported);
+            throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported);
         }
 
         [CLSCompliant(false)]
         public static Process Start(string fileName, string arguments, string userName, SecureString password, string domain)
         {
-            throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported);
+            throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported);
         }
 
         /// <summary>Stops the associated process immediately.</summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -44,13 +44,13 @@ namespace System.Diagnostics
         [CLSCompliant(false)]
         public static Process Start(string fileName, string userName, SecureString password, string domain)
         {
-            throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and Domain"));
+            throw new PlatformNotSupportedException(SR.ProcessStartWithPasswordAndDomainNotSupported);
         }
 
         [CLSCompliant(false)]
         public static Process Start(string fileName, string arguments, string userName, SecureString password, string domain)
         {
-            throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and Domain"));
+            throw new PlatformNotSupportedException(SR.ProcessStartWithPasswordAndDomainNotSupported);
         }
 
         /// <summary>Stops the associated process immediately.</summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -44,13 +44,13 @@ namespace System.Diagnostics
         [CLSCompliant(false)]
         public static Process Start(string fileName, string userName, SecureString password, string domain)
         {
-            throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported);
+            throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and Domain"));
         }
 
         [CLSCompliant(false)]
         public static Process Start(string fileName, string arguments, string userName, SecureString password, string domain)
         {
-            throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported);
+            throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and Domain"));
         }
 
         /// <summary>Stops the associated process immediately.</summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
@@ -16,20 +16,20 @@ namespace System.Diagnostics
 
         public string PasswordInClearText
         {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
+            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
+            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
         }
 
         public string Domain
         {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
+            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
+            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
         }
 
         public bool LoadUserProfile
         {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
+            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
+            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
         }
 
         public bool UseShellExecute { get; set; }
@@ -39,8 +39,8 @@ namespace System.Diagnostics
         [CLSCompliant(false)]
         public SecureString Password
         {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
+            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
+            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
@@ -16,20 +16,20 @@ namespace System.Diagnostics
 
         public string PasswordInClearText
         {
-            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and PasswordInClearText")); }
-            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and PasswordInClearText")); }
+            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(PasswordInClearText))); }
+            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(PasswordInClearText))); }
         }
 
         public string Domain
         {
-            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Domain")); }
-            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Domain")); }
+            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Domain))); }
+            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Domain))); }
         }
 
         public bool LoadUserProfile
         {
-            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "LoadUserProfile")); }
-            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "LoadUserProfile")); }
+            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(LoadUserProfile))); }
+            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(LoadUserProfile))); }
         }
 
         public bool UseShellExecute { get; set; }
@@ -39,8 +39,8 @@ namespace System.Diagnostics
         [CLSCompliant(false)]
         public SecureString Password
         {
-            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and PasswordInClearText")); }
-            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and PasswordInClearText")); }
+            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Password))); }
+            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Password))); }
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
@@ -16,20 +16,20 @@ namespace System.Diagnostics
 
         public string PasswordInClearText
         {
-            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(PasswordInClearText))); }
-            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(PasswordInClearText))); }
+            get { throw new PlatformNotSupportedException(SR.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(PasswordInClearText))); }
+            set { throw new PlatformNotSupportedException(SR.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(PasswordInClearText))); }
         }
 
         public string Domain
         {
-            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Domain))); }
-            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Domain))); }
+            get { throw new PlatformNotSupportedException(SR.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Domain))); }
+            set { throw new PlatformNotSupportedException(SR.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Domain))); }
         }
 
         public bool LoadUserProfile
         {
-            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(LoadUserProfile))); }
-            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(LoadUserProfile))); }
+            get { throw new PlatformNotSupportedException(SR.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(LoadUserProfile))); }
+            set { throw new PlatformNotSupportedException(SR.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(LoadUserProfile))); }
         }
 
         public bool UseShellExecute { get; set; }
@@ -39,8 +39,8 @@ namespace System.Diagnostics
         [CLSCompliant(false)]
         public SecureString Password
         {
-            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Password))); }
-            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Password))); }
+            get { throw new PlatformNotSupportedException(SR.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Password))); }
+            set { throw new PlatformNotSupportedException(SR.Format(SR.ProcessStartSingleFeatureNotSupported, nameof(Password))); }
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
@@ -16,20 +16,20 @@ namespace System.Diagnostics
 
         public string PasswordInClearText
         {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
+            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and PasswordInClearText")); }
+            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and PasswordInClearText")); }
         }
 
         public string Domain
         {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
+            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Domain")); }
+            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Domain")); }
         }
 
         public bool LoadUserProfile
         {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
+            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "LoadUserProfile")); }
+            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "LoadUserProfile")); }
         }
 
         public bool UseShellExecute { get; set; }
@@ -39,8 +39,8 @@ namespace System.Diagnostics
         [CLSCompliant(false)]
         public SecureString Password
         {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityPartiallySupported); }
+            get { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and PasswordInClearText")); }
+            set { throw new PlatformNotSupportedException(string.Format(SR.ProcessStartFeaturesNotSupported, "Password and PasswordInClearText")); }
         }
     }
 }


### PR DESCRIPTION
**Hello!** I'm new to .NET Core (recently moved my project from `.NET Framework` for it).

## Story
- I didn't know that **RunAs** is partially available on Linux, so I used all functionality of it in my code.
- I catched exception `System.PlatformNotSupportedException`: Starting a process with a different identity is not supported on this platform, googled it and saw solution of #30140 by @eerhardt.
- Nothing helped. Then, I saw `LoadUserProfile = false` in my code, deleted it, and... that was real solution!

## Reproduce
1. Use `System.Diagnostics.Process` functionality in code.
2. Set `LoadUserProfile` or other unsupported field in process `StartInfo`.
3. Build project and run it on Unix.
4. Get `System.PlatformNotSupportedException` exception.

## Improvement idea
Maybe we need to change exception message for `LoadUserProfile` and others on Unix, so other users can understand it more quckly than me?

## Fixes
This PR fixes #31735.

**P.S. Sorry for my bad English, it's not my main language...**