### PR TITLE
Optimize some Matrix4x4 operations with SSE

### DIFF
--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -62,6 +62,7 @@
     <Compile Include="System\Numerics\Vector3_Intrinsics.cs" />
     <Compile Include="System\Numerics\Vector4.cs" />
     <Compile Include="System\Numerics\Vector4_Intrinsics.cs" />
+    <Compile Include="System\Numerics\VectorMath.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsTargetingNetFx)' == 'true'">
     <Reference Include="mscorlib" />

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -4,10 +4,10 @@
     <RootNamespace>System.Numerics</RootNamespace>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <IsTargetingNetFx Condition="'$(TargetGroup)'=='netfx' OR '$(TargetGroup)'=='net46'">true</IsTargetingNetFx>
     <IsTargetingNetCoreApp Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap' OR '$(TargetGroup)'=='uapaot'">true</IsTargetingNetCoreApp>
     <IsPartialFacadeAssembly Condition="'$(IsTargetingNetFx)'=='true' OR '$(IsTargetingNetCoreApp)'=='true'">true</IsPartialFacadeAssembly>
+    <DefineConstants Condition="'$(TargetsNetCoreApp)'=='true'">$(DefineConstants);HAS_INTRINSICS</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
     <Configurations>net46-Debug;net46-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -7,7 +7,8 @@
     <IsTargetingNetFx Condition="'$(TargetGroup)'=='netfx' OR '$(TargetGroup)'=='net46'">true</IsTargetingNetFx>
     <IsTargetingNetCoreApp Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap' OR '$(TargetGroup)'=='uapaot'">true</IsTargetingNetCoreApp>
     <IsPartialFacadeAssembly Condition="'$(IsTargetingNetFx)'=='true' OR '$(IsTargetingNetCoreApp)'=='true'">true</IsPartialFacadeAssembly>
-    <DefineConstants Condition="'$(TargetsNetCoreApp)'=='true'">$(DefineConstants);HAS_INTRINSICS</DefineConstants>
+	<HasIntrinsics Condition="'$(TargetsNetCoreApp)'=='true'">true</HasIntrinsics>
+    <DefineConstants Condition="'$(HasIntrinsics)'=='true'">$(DefineConstants);HAS_INTRINSICS</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
     <Configurations>net46-Debug;net46-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
@@ -62,6 +63,8 @@
     <Compile Include="System\Numerics\Vector3_Intrinsics.cs" />
     <Compile Include="System\Numerics\Vector4.cs" />
     <Compile Include="System\Numerics\Vector4_Intrinsics.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(HasIntrinsics)' == 'true'">
     <Compile Include="System\Numerics\VectorMath.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsTargetingNetFx)' == 'true'">

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -7,7 +7,7 @@
     <IsTargetingNetFx Condition="'$(TargetGroup)'=='netfx' OR '$(TargetGroup)'=='net46'">true</IsTargetingNetFx>
     <IsTargetingNetCoreApp Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap' OR '$(TargetGroup)'=='uapaot'">true</IsTargetingNetCoreApp>
     <IsPartialFacadeAssembly Condition="'$(IsTargetingNetFx)'=='true' OR '$(IsTargetingNetCoreApp)'=='true'">true</IsPartialFacadeAssembly>
-	<HasIntrinsics Condition="'$(TargetsNetCoreApp)'=='true'">true</HasIntrinsics>
+    <HasIntrinsics Condition="'$(TargetsNetCoreApp)'=='true'">true</HasIntrinsics>
     <DefineConstants Condition="'$(HasIntrinsics)'=='true'">$(DefineConstants);HAS_INTRINSICS</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
     <Configurations>net46-Debug;net46-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>System.Numerics</RootNamespace>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <IsTargetingNetFx Condition="'$(TargetGroup)'=='netfx' OR '$(TargetGroup)'=='net46'">true</IsTargetingNetFx>
     <IsTargetingNetCoreApp Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap' OR '$(TargetGroup)'=='uapaot'">true</IsTargetingNetCoreApp>
     <IsPartialFacadeAssembly Condition="'$(IsTargetingNetFx)'=='true' OR '$(IsTargetingNetCoreApp)'=='true'">true</IsPartialFacadeAssembly>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -4,7 +4,7 @@
 
 using System.Globalization;
 using System.Runtime.InteropServices;
-#if netcoreapp
+#if HAS_INTRINSICS
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -1763,7 +1763,7 @@ namespace System.Numerics
         /// <returns>The transposed matrix.</returns>
         public static unsafe Matrix4x4 Transpose(Matrix4x4 matrix)
         {
-#if netcoreapp
+#if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
                 var row1 = Sse.LoadVector128(&matrix.M11);
@@ -1806,7 +1806,7 @@ namespace System.Numerics
             return result;
         }
 
-#if netcoreapp
+#if HAS_INTRINSICS
         private static Vector128<float> Lerp(Vector128<float> a, Vector128<float> b, Vector128<float> t) => 
             Sse.Add(a, Sse.Multiply(Sse.Subtract(b, a), t));
 #endif
@@ -1820,7 +1820,7 @@ namespace System.Numerics
         /// <returns>The interpolated matrix.</returns>
         public static unsafe Matrix4x4 Lerp(Matrix4x4 matrix1, Matrix4x4 matrix2, float amount)
         {
-#if netcoreapp
+#if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
                 var amountVec = Sse.SetAllVector128(amount);
@@ -1906,7 +1906,7 @@ namespace System.Numerics
         /// <returns>The negated matrix.</returns>
         public static unsafe Matrix4x4 operator -(Matrix4x4 value)
         {
-#if netcoreapp
+#if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
                 var zero = Sse.SetZeroVector128();
@@ -1948,7 +1948,7 @@ namespace System.Numerics
         /// <returns>The resulting matrix.</returns>
         public static unsafe Matrix4x4 operator +(Matrix4x4 value1, Matrix4x4 value2)
         {
-#if netcoreapp
+#if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
                 Sse.Store(&value1.M11, Sse.Add(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
@@ -1988,7 +1988,7 @@ namespace System.Numerics
         /// <returns>The result of the subtraction.</returns>
         public static unsafe Matrix4x4 operator -(Matrix4x4 value1, Matrix4x4 value2)
         {
-#if netcoreapp
+#if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
                 Sse.Store(&value1.M11, Sse.Subtract(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
@@ -2028,7 +2028,7 @@ namespace System.Numerics
         /// <returns>The result of the multiplication.</returns>
         public static unsafe Matrix4x4 operator *(Matrix4x4 value1, Matrix4x4 value2)
         {
-#if netcoreapp
+#if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
                 Sse.Store(&value1.M11,
@@ -2094,7 +2094,7 @@ namespace System.Numerics
         /// <returns>The scaled matrix.</returns>
         public static unsafe Matrix4x4 operator *(Matrix4x4 value1, float value2)
         {
-#if netcoreapp
+#if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
                 var value2Vec = Sse.SetAllVector128(value2);
@@ -2134,7 +2134,7 @@ namespace System.Numerics
         /// <returns>True if the given matrices are equal; False otherwise.</returns>
         public static unsafe bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
         {
-#if netcoreapp
+#if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
                 return

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2163,21 +2163,10 @@ namespace System.Numerics
         /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
         public static unsafe bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
         {
-            if (Sse.IsSupported)
-            {
-                return
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) == 0 ||
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) == 0 ||
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0 ||
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0;
-            }
-            else 
-            {
-                return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
-                        value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
-                        value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||
-                        value1.M41 != value2.M41 || value1.M42 != value2.M42 || value1.M43 != value2.M43 || value1.M44 != value2.M44);
-            }
+            return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
+                    value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
+                    value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||
+                    value1.M41 != value2.M41 || value1.M42 != value2.M42 || value1.M43 != value2.M43 || value1.M44 != value2.M44);
         }
 
         /// <summary>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -5,7 +5,6 @@
 using System.Globalization;
 using System.Runtime.InteropServices;
 #if HAS_INTRINSICS
-using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -1806,11 +1805,6 @@ namespace System.Numerics
             return result;
         }
 
-#if HAS_INTRINSICS
-        private static Vector128<float> Lerp(Vector128<float> a, Vector128<float> b, Vector128<float> t) => 
-            Sse.Add(a, Sse.Multiply(Sse.Subtract(b, a), t));
-#endif
-
         /// <summary>
         /// Linearly interpolates between the corresponding values of two matrices.
         /// </summary>
@@ -1824,10 +1818,10 @@ namespace System.Numerics
             if (Sse.IsSupported)
             {
                 var amountVec = Sse.SetAllVector128(amount);
-                Sse.Store(&matrix1.M11, Lerp(Sse.LoadVector128(&matrix1.M11), Sse.LoadVector128(&matrix2.M11), amountVec));
-                Sse.Store(&matrix1.M21, Lerp(Sse.LoadVector128(&matrix1.M21), Sse.LoadVector128(&matrix2.M21), amountVec));
-                Sse.Store(&matrix1.M31, Lerp(Sse.LoadVector128(&matrix1.M31), Sse.LoadVector128(&matrix2.M31), amountVec));
-                Sse.Store(&matrix1.M41, Lerp(Sse.LoadVector128(&matrix1.M41), Sse.LoadVector128(&matrix2.M41), amountVec));
+                Sse.Store(&matrix1.M11, VectorMath.Lerp(Sse.LoadVector128(&matrix1.M11), Sse.LoadVector128(&matrix2.M11), amountVec));
+                Sse.Store(&matrix1.M21, VectorMath.Lerp(Sse.LoadVector128(&matrix1.M21), Sse.LoadVector128(&matrix2.M21), amountVec));
+                Sse.Store(&matrix1.M31, VectorMath.Lerp(Sse.LoadVector128(&matrix1.M31), Sse.LoadVector128(&matrix2.M31), amountVec));
+                Sse.Store(&matrix1.M41, VectorMath.Lerp(Sse.LoadVector128(&matrix1.M41), Sse.LoadVector128(&matrix2.M41), amountVec));
                 return matrix1;
             }
 #endif
@@ -2138,10 +2132,10 @@ namespace System.Numerics
             if (Sse.IsSupported)
             {
                 return
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) == 0 &&
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) == 0 &&
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0 &&
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0;
+                    VectorMath.Equal(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11)) &&
+                    VectorMath.Equal(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21)) &&
+                    VectorMath.Equal(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31)) &&
+                    VectorMath.Equal(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41));
             }
 #endif
             return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2196,15 +2196,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
-        public override bool Equals(object obj)
-        {
-            if (obj is Matrix4x4 m)
-            {
-                return this == m;
-            }
-
-            return false;
-        }
+        public override bool Equals(object obj) => (obj is Matrix4x4 other) && (this == other);
 
         /// <summary>
         /// Returns a String representing this matrix instance.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1758,28 +1758,45 @@ namespace System.Numerics
         /// </summary>
         /// <param name="matrix">The source matrix.</param>
         /// <returns>The transposed matrix.</returns>
-        public static Matrix4x4 Transpose(Matrix4x4 matrix)
+        public static unsafe Matrix4x4 Transpose(Matrix4x4 matrix)
         {
-            Matrix4x4 result;
+            if (Sse.IsSupported)
+            {
+                Matrix4x4 result = default;
+                var t0 = Sse.Shuffle(Sse.LoadVector128(&matrix.M11), Sse.LoadVector128(&matrix.M21), 0x44);
+                var t1 = Sse.Shuffle(Sse.LoadVector128(&matrix.M31), Sse.LoadVector128(&matrix.M41), 0x44);
+                var t2 = Sse.Shuffle(Sse.LoadVector128(&matrix.M11), Sse.LoadVector128(&matrix.M21), 0xEE);
+                var t3 = Sse.Shuffle(Sse.LoadVector128(&matrix.M31), Sse.LoadVector128(&matrix.M41), 0xEE);
 
-            result.M11 = matrix.M11;
-            result.M12 = matrix.M21;
-            result.M13 = matrix.M31;
-            result.M14 = matrix.M41;
-            result.M21 = matrix.M12;
-            result.M22 = matrix.M22;
-            result.M23 = matrix.M32;
-            result.M24 = matrix.M42;
-            result.M31 = matrix.M13;
-            result.M32 = matrix.M23;
-            result.M33 = matrix.M33;
-            result.M34 = matrix.M43;
-            result.M41 = matrix.M14;
-            result.M42 = matrix.M24;
-            result.M43 = matrix.M34;
-            result.M44 = matrix.M44;
+                Sse.Store(&result.M11, Sse.Shuffle(t0, t1, 0x88));
+                Sse.Store(&result.M21, Sse.Shuffle(t0, t1, 0xDD));
+                Sse.Store(&result.M31, Sse.Shuffle(t2, t3, 0x88));
+                Sse.Store(&result.M41, Sse.Shuffle(t2, t3, 0xDD));
+                return result;
+            }
+            else
+            {
+                Matrix4x4 result;
 
-            return result;
+                result.M11 = matrix.M11;
+                result.M12 = matrix.M21;
+                result.M13 = matrix.M31;
+                result.M14 = matrix.M41;
+                result.M21 = matrix.M12;
+                result.M22 = matrix.M22;
+                result.M23 = matrix.M32;
+                result.M24 = matrix.M42;
+                result.M31 = matrix.M13;
+                result.M32 = matrix.M23;
+                result.M33 = matrix.M33;
+                result.M34 = matrix.M43;
+                result.M41 = matrix.M14;
+                result.M42 = matrix.M24;
+                result.M43 = matrix.M34;
+                result.M44 = matrix.M44;
+
+                return result;
+            }
         }
 
         /// <summary>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2280,10 +2280,10 @@ namespace System.Numerics
             if (Sse.IsSupported)
             {
                 return
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) != 0 &&
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) != 0 &&
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) != 0 &&
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) != 0;
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) == 0 &&
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) == 0 &&
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0 &&
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0;
             }
             else
             {
@@ -2305,10 +2305,10 @@ namespace System.Numerics
             if (Sse.IsSupported)
             {
                 return
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) == 0 ||
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) == 0 ||
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0 ||
-                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0;
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) == 0 ||
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) == 0 ||
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0 ||
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0;
             }
             else 
             {

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -4,8 +4,10 @@
 
 using System.Globalization;
 using System.Runtime.InteropServices;
+#if netcoreapp
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace System.Numerics
 {
@@ -1804,8 +1806,10 @@ namespace System.Numerics
             return result;
         }
 
+#if netcoreapp
         private static Vector128<float> Lerp(Vector128<float> a, Vector128<float> b, Vector128<float> t) => 
             Sse.Add(a, Sse.Multiply(Sse.Subtract(b, a), t));
+#endif
 
         /// <summary>
         /// Linearly interpolates between the corresponding values of two matrices.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1761,6 +1761,7 @@ namespace System.Numerics
         /// <returns>The transposed matrix.</returns>
         public static unsafe Matrix4x4 Transpose(Matrix4x4 matrix)
         {
+#if netcoreapp
             if (Sse.IsSupported)
             {
                 var row1 = Sse.LoadVector128(&matrix.M11);
@@ -1780,31 +1781,29 @@ namespace System.Numerics
 
                 return matrix;
             }
-            else
-            {
-                Matrix4x4 result;
+#endif
+            Matrix4x4 result;
 
-                result.M11 = matrix.M11;
-                result.M12 = matrix.M21;
-                result.M13 = matrix.M31;
-                result.M14 = matrix.M41;
-                result.M21 = matrix.M12;
-                result.M22 = matrix.M22;
-                result.M23 = matrix.M32;
-                result.M24 = matrix.M42;
-                result.M31 = matrix.M13;
-                result.M32 = matrix.M23;
-                result.M33 = matrix.M33;
-                result.M34 = matrix.M43;
-                result.M41 = matrix.M14;
-                result.M42 = matrix.M24;
-                result.M43 = matrix.M34;
-                result.M44 = matrix.M44;
+            result.M11 = matrix.M11;
+            result.M12 = matrix.M21;
+            result.M13 = matrix.M31;
+            result.M14 = matrix.M41;
+            result.M21 = matrix.M12;
+            result.M22 = matrix.M22;
+            result.M23 = matrix.M32;
+            result.M24 = matrix.M42;
+            result.M31 = matrix.M13;
+            result.M32 = matrix.M23;
+            result.M33 = matrix.M33;
+            result.M34 = matrix.M43;
+            result.M41 = matrix.M14;
+            result.M42 = matrix.M24;
+            result.M43 = matrix.M34;
+            result.M44 = matrix.M44;
 
-                return result;
-            }
+            return result;
         }
-        
+
         private static Vector128<float> Lerp(Vector128<float> a, Vector128<float> b, Vector128<float> t) => 
             Sse.Add(a, Sse.Multiply(Sse.Subtract(b, a), t));
 
@@ -1817,6 +1816,7 @@ namespace System.Numerics
         /// <returns>The interpolated matrix.</returns>
         public static unsafe Matrix4x4 Lerp(Matrix4x4 matrix1, Matrix4x4 matrix2, float amount)
         {
+#if netcoreapp
             if (Sse.IsSupported)
             {
                 var amountVec = Sse.SetAllVector128(amount);
@@ -1826,36 +1826,34 @@ namespace System.Numerics
                 Sse.Store(&matrix1.M41, Lerp(Sse.LoadVector128(&matrix1.M41), Sse.LoadVector128(&matrix2.M41), amountVec));
                 return matrix1;
             }
-            else
-            {
-                Matrix4x4 result;
+#endif
+            Matrix4x4 result;
 
-                // First row
-                result.M11 = matrix1.M11 + (matrix2.M11 - matrix1.M11) * amount;
-                result.M12 = matrix1.M12 + (matrix2.M12 - matrix1.M12) * amount;
-                result.M13 = matrix1.M13 + (matrix2.M13 - matrix1.M13) * amount;
-                result.M14 = matrix1.M14 + (matrix2.M14 - matrix1.M14) * amount;
+            // First row
+            result.M11 = matrix1.M11 + (matrix2.M11 - matrix1.M11) * amount;
+            result.M12 = matrix1.M12 + (matrix2.M12 - matrix1.M12) * amount;
+            result.M13 = matrix1.M13 + (matrix2.M13 - matrix1.M13) * amount;
+            result.M14 = matrix1.M14 + (matrix2.M14 - matrix1.M14) * amount;
 
-                // Second row
-                result.M21 = matrix1.M21 + (matrix2.M21 - matrix1.M21) * amount;
-                result.M22 = matrix1.M22 + (matrix2.M22 - matrix1.M22) * amount;
-                result.M23 = matrix1.M23 + (matrix2.M23 - matrix1.M23) * amount;
-                result.M24 = matrix1.M24 + (matrix2.M24 - matrix1.M24) * amount;
+            // Second row
+            result.M21 = matrix1.M21 + (matrix2.M21 - matrix1.M21) * amount;
+            result.M22 = matrix1.M22 + (matrix2.M22 - matrix1.M22) * amount;
+            result.M23 = matrix1.M23 + (matrix2.M23 - matrix1.M23) * amount;
+            result.M24 = matrix1.M24 + (matrix2.M24 - matrix1.M24) * amount;
 
-                // Third row
-                result.M31 = matrix1.M31 + (matrix2.M31 - matrix1.M31) * amount;
-                result.M32 = matrix1.M32 + (matrix2.M32 - matrix1.M32) * amount;
-                result.M33 = matrix1.M33 + (matrix2.M33 - matrix1.M33) * amount;
-                result.M34 = matrix1.M34 + (matrix2.M34 - matrix1.M34) * amount;
+            // Third row
+            result.M31 = matrix1.M31 + (matrix2.M31 - matrix1.M31) * amount;
+            result.M32 = matrix1.M32 + (matrix2.M32 - matrix1.M32) * amount;
+            result.M33 = matrix1.M33 + (matrix2.M33 - matrix1.M33) * amount;
+            result.M34 = matrix1.M34 + (matrix2.M34 - matrix1.M34) * amount;
 
-                // Fourth row
-                result.M41 = matrix1.M41 + (matrix2.M41 - matrix1.M41) * amount;
-                result.M42 = matrix1.M42 + (matrix2.M42 - matrix1.M42) * amount;
-                result.M43 = matrix1.M43 + (matrix2.M43 - matrix1.M43) * amount;
-                result.M44 = matrix1.M44 + (matrix2.M44 - matrix1.M44) * amount;
+            // Fourth row
+            result.M41 = matrix1.M41 + (matrix2.M41 - matrix1.M41) * amount;
+            result.M42 = matrix1.M42 + (matrix2.M42 - matrix1.M42) * amount;
+            result.M43 = matrix1.M43 + (matrix2.M43 - matrix1.M43) * amount;
+            result.M44 = matrix1.M44 + (matrix2.M44 - matrix1.M44) * amount;
 
-                return result;
-            }
+            return result;
         }
 
         /// <summary>
@@ -1904,6 +1902,7 @@ namespace System.Numerics
         /// <returns>The negated matrix.</returns>
         public static unsafe Matrix4x4 operator -(Matrix4x4 value)
         {
+#if netcoreapp
             if (Sse.IsSupported)
             {
                 var zero = Sse.SetZeroVector128();
@@ -1914,29 +1913,27 @@ namespace System.Numerics
 
                 return value;
             }
-            else
-            {
-                Matrix4x4 m;
+#endif
+            Matrix4x4 m;
 
-                m.M11 = -value.M11;
-                m.M12 = -value.M12;
-                m.M13 = -value.M13;
-                m.M14 = -value.M14;
-                m.M21 = -value.M21;
-                m.M22 = -value.M22;
-                m.M23 = -value.M23;
-                m.M24 = -value.M24;
-                m.M31 = -value.M31;
-                m.M32 = -value.M32;
-                m.M33 = -value.M33;
-                m.M34 = -value.M34;
-                m.M41 = -value.M41;
-                m.M42 = -value.M42;
-                m.M43 = -value.M43;
-                m.M44 = -value.M44;
+            m.M11 = -value.M11;
+            m.M12 = -value.M12;
+            m.M13 = -value.M13;
+            m.M14 = -value.M14;
+            m.M21 = -value.M21;
+            m.M22 = -value.M22;
+            m.M23 = -value.M23;
+            m.M24 = -value.M24;
+            m.M31 = -value.M31;
+            m.M32 = -value.M32;
+            m.M33 = -value.M33;
+            m.M34 = -value.M34;
+            m.M41 = -value.M41;
+            m.M42 = -value.M42;
+            m.M43 = -value.M43;
+            m.M44 = -value.M44;
 
-                return m;
-            }
+            return m;
         }
 
         /// <summary>
@@ -1947,6 +1944,7 @@ namespace System.Numerics
         /// <returns>The resulting matrix.</returns>
         public static unsafe Matrix4x4 operator +(Matrix4x4 value1, Matrix4x4 value2)
         {
+#if netcoreapp
             if (Sse.IsSupported)
             {
                 Sse.Store(&value1.M11, Sse.Add(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
@@ -1955,29 +1953,27 @@ namespace System.Numerics
                 Sse.Store(&value1.M41, Sse.Add(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value1.M41)));
                 return value1;
             }
-            else
-            {
-                Matrix4x4 m;
+#endif
+            Matrix4x4 m;
 
-                m.M11 = value1.M11 + value2.M11;
-                m.M12 = value1.M12 + value2.M12;
-                m.M13 = value1.M13 + value2.M13;
-                m.M14 = value1.M14 + value2.M14;
-                m.M21 = value1.M21 + value2.M21;
-                m.M22 = value1.M22 + value2.M22;
-                m.M23 = value1.M23 + value2.M23;
-                m.M24 = value1.M24 + value2.M24;
-                m.M31 = value1.M31 + value2.M31;
-                m.M32 = value1.M32 + value2.M32;
-                m.M33 = value1.M33 + value2.M33;
-                m.M34 = value1.M34 + value2.M34;
-                m.M41 = value1.M41 + value2.M41;
-                m.M42 = value1.M42 + value2.M42;
-                m.M43 = value1.M43 + value2.M43;
-                m.M44 = value1.M44 + value2.M44;
+            m.M11 = value1.M11 + value2.M11;
+            m.M12 = value1.M12 + value2.M12;
+            m.M13 = value1.M13 + value2.M13;
+            m.M14 = value1.M14 + value2.M14;
+            m.M21 = value1.M21 + value2.M21;
+            m.M22 = value1.M22 + value2.M22;
+            m.M23 = value1.M23 + value2.M23;
+            m.M24 = value1.M24 + value2.M24;
+            m.M31 = value1.M31 + value2.M31;
+            m.M32 = value1.M32 + value2.M32;
+            m.M33 = value1.M33 + value2.M33;
+            m.M34 = value1.M34 + value2.M34;
+            m.M41 = value1.M41 + value2.M41;
+            m.M42 = value1.M42 + value2.M42;
+            m.M43 = value1.M43 + value2.M43;
+            m.M44 = value1.M44 + value2.M44;
 
-                return m;
-            }
+            return m;
         }
 
         /// <summary>
@@ -1988,6 +1984,7 @@ namespace System.Numerics
         /// <returns>The result of the subtraction.</returns>
         public static unsafe Matrix4x4 operator -(Matrix4x4 value1, Matrix4x4 value2)
         {
+#if netcoreapp
             if (Sse.IsSupported)
             {
                 Sse.Store(&value1.M11, Sse.Subtract(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
@@ -1996,29 +1993,27 @@ namespace System.Numerics
                 Sse.Store(&value1.M41, Sse.Subtract(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value1.M41)));
                 return value1;
             }
-            else
-            {
-                Matrix4x4 m;
+#endif
+            Matrix4x4 m;
 
-                m.M11 = value1.M11 - value2.M11;
-                m.M12 = value1.M12 - value2.M12;
-                m.M13 = value1.M13 - value2.M13;
-                m.M14 = value1.M14 - value2.M14;
-                m.M21 = value1.M21 - value2.M21;
-                m.M22 = value1.M22 - value2.M22;
-                m.M23 = value1.M23 - value2.M23;
-                m.M24 = value1.M24 - value2.M24;
-                m.M31 = value1.M31 - value2.M31;
-                m.M32 = value1.M32 - value2.M32;
-                m.M33 = value1.M33 - value2.M33;
-                m.M34 = value1.M34 - value2.M34;
-                m.M41 = value1.M41 - value2.M41;
-                m.M42 = value1.M42 - value2.M42;
-                m.M43 = value1.M43 - value2.M43;
-                m.M44 = value1.M44 - value2.M44;
+            m.M11 = value1.M11 - value2.M11;
+            m.M12 = value1.M12 - value2.M12;
+            m.M13 = value1.M13 - value2.M13;
+            m.M14 = value1.M14 - value2.M14;
+            m.M21 = value1.M21 - value2.M21;
+            m.M22 = value1.M22 - value2.M22;
+            m.M23 = value1.M23 - value2.M23;
+            m.M24 = value1.M24 - value2.M24;
+            m.M31 = value1.M31 - value2.M31;
+            m.M32 = value1.M32 - value2.M32;
+            m.M33 = value1.M33 - value2.M33;
+            m.M34 = value1.M34 - value2.M34;
+            m.M41 = value1.M41 - value2.M41;
+            m.M42 = value1.M42 - value2.M42;
+            m.M43 = value1.M43 - value2.M43;
+            m.M44 = value1.M44 - value2.M44;
 
-                return m;
-            }
+            return m;
         }
 
         /// <summary>
@@ -2029,6 +2024,7 @@ namespace System.Numerics
         /// <returns>The result of the multiplication.</returns>
         public static unsafe Matrix4x4 operator *(Matrix4x4 value1, Matrix4x4 value2)
         {
+#if netcoreapp
             if (Sse.IsSupported)
             {
                 Sse.Store(&value1.M11,
@@ -2056,36 +2052,34 @@ namespace System.Numerics
                                     Sse.Multiply(Sse.SetAllVector128(value1.M44), Sse.LoadVector128(&value2.M41)))));
                 return value1;
             }
-            else
-            {
-                Matrix4x4 m;
+#endif
+            Matrix4x4 m;
 
-                // First row
-                m.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21 + value1.M13 * value2.M31 + value1.M14 * value2.M41;
-                m.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22 + value1.M13 * value2.M32 + value1.M14 * value2.M42;
-                m.M13 = value1.M11 * value2.M13 + value1.M12 * value2.M23 + value1.M13 * value2.M33 + value1.M14 * value2.M43;
-                m.M14 = value1.M11 * value2.M14 + value1.M12 * value2.M24 + value1.M13 * value2.M34 + value1.M14 * value2.M44;
+            // First row
+            m.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21 + value1.M13 * value2.M31 + value1.M14 * value2.M41;
+            m.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22 + value1.M13 * value2.M32 + value1.M14 * value2.M42;
+            m.M13 = value1.M11 * value2.M13 + value1.M12 * value2.M23 + value1.M13 * value2.M33 + value1.M14 * value2.M43;
+            m.M14 = value1.M11 * value2.M14 + value1.M12 * value2.M24 + value1.M13 * value2.M34 + value1.M14 * value2.M44;
 
-                // Second row
-                m.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21 + value1.M23 * value2.M31 + value1.M24 * value2.M41;
-                m.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22 + value1.M23 * value2.M32 + value1.M24 * value2.M42;
-                m.M23 = value1.M21 * value2.M13 + value1.M22 * value2.M23 + value1.M23 * value2.M33 + value1.M24 * value2.M43;
-                m.M24 = value1.M21 * value2.M14 + value1.M22 * value2.M24 + value1.M23 * value2.M34 + value1.M24 * value2.M44;
+            // Second row
+            m.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21 + value1.M23 * value2.M31 + value1.M24 * value2.M41;
+            m.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22 + value1.M23 * value2.M32 + value1.M24 * value2.M42;
+            m.M23 = value1.M21 * value2.M13 + value1.M22 * value2.M23 + value1.M23 * value2.M33 + value1.M24 * value2.M43;
+            m.M24 = value1.M21 * value2.M14 + value1.M22 * value2.M24 + value1.M23 * value2.M34 + value1.M24 * value2.M44;
 
-                // Third row
-                m.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value1.M33 * value2.M31 + value1.M34 * value2.M41;
-                m.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value1.M33 * value2.M32 + value1.M34 * value2.M42;
-                m.M33 = value1.M31 * value2.M13 + value1.M32 * value2.M23 + value1.M33 * value2.M33 + value1.M34 * value2.M43;
-                m.M34 = value1.M31 * value2.M14 + value1.M32 * value2.M24 + value1.M33 * value2.M34 + value1.M34 * value2.M44;
+            // Third row
+            m.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value1.M33 * value2.M31 + value1.M34 * value2.M41;
+            m.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value1.M33 * value2.M32 + value1.M34 * value2.M42;
+            m.M33 = value1.M31 * value2.M13 + value1.M32 * value2.M23 + value1.M33 * value2.M33 + value1.M34 * value2.M43;
+            m.M34 = value1.M31 * value2.M14 + value1.M32 * value2.M24 + value1.M33 * value2.M34 + value1.M34 * value2.M44;
 
-                // Fourth row
-                m.M41 = value1.M41 * value2.M11 + value1.M42 * value2.M21 + value1.M43 * value2.M31 + value1.M44 * value2.M41;
-                m.M42 = value1.M41 * value2.M12 + value1.M42 * value2.M22 + value1.M43 * value2.M32 + value1.M44 * value2.M42;
-                m.M43 = value1.M41 * value2.M13 + value1.M42 * value2.M23 + value1.M43 * value2.M33 + value1.M44 * value2.M43;
-                m.M44 = value1.M41 * value2.M14 + value1.M42 * value2.M24 + value1.M43 * value2.M34 + value1.M44 * value2.M44;
+            // Fourth row
+            m.M41 = value1.M41 * value2.M11 + value1.M42 * value2.M21 + value1.M43 * value2.M31 + value1.M44 * value2.M41;
+            m.M42 = value1.M41 * value2.M12 + value1.M42 * value2.M22 + value1.M43 * value2.M32 + value1.M44 * value2.M42;
+            m.M43 = value1.M41 * value2.M13 + value1.M42 * value2.M23 + value1.M43 * value2.M33 + value1.M44 * value2.M43;
+            m.M44 = value1.M41 * value2.M14 + value1.M42 * value2.M24 + value1.M43 * value2.M34 + value1.M44 * value2.M44;
 
-                return m;
-            }
+            return m;
         }
 
         /// <summary>
@@ -2096,7 +2090,7 @@ namespace System.Numerics
         /// <returns>The scaled matrix.</returns>
         public static unsafe Matrix4x4 operator *(Matrix4x4 value1, float value2)
         {
-
+#if netcoreapp
             if (Sse.IsSupported)
             {
                 var value2Vec = Sse.SetAllVector128(value2);
@@ -2106,28 +2100,26 @@ namespace System.Numerics
                 Sse.Store(&value1.M41, Sse.Multiply(Sse.LoadVector128(&value1.M41), value2Vec));
                 return value1;
             }
-            else
-            {
-                Matrix4x4 m;
+#endif
+            Matrix4x4 m;
 
-                m.M11 = value1.M11 * value2;
-                m.M12 = value1.M12 * value2;
-                m.M13 = value1.M13 * value2;
-                m.M14 = value1.M14 * value2;
-                m.M21 = value1.M21 * value2;
-                m.M22 = value1.M22 * value2;
-                m.M23 = value1.M23 * value2;
-                m.M24 = value1.M24 * value2;
-                m.M31 = value1.M31 * value2;
-                m.M32 = value1.M32 * value2;
-                m.M33 = value1.M33 * value2;
-                m.M34 = value1.M34 * value2;
-                m.M41 = value1.M41 * value2;
-                m.M42 = value1.M42 * value2;
-                m.M43 = value1.M43 * value2;
-                m.M44 = value1.M44 * value2;
-                return m;
-            }
+            m.M11 = value1.M11 * value2;
+            m.M12 = value1.M12 * value2;
+            m.M13 = value1.M13 * value2;
+            m.M14 = value1.M14 * value2;
+            m.M21 = value1.M21 * value2;
+            m.M22 = value1.M22 * value2;
+            m.M23 = value1.M23 * value2;
+            m.M24 = value1.M24 * value2;
+            m.M31 = value1.M31 * value2;
+            m.M32 = value1.M32 * value2;
+            m.M33 = value1.M33 * value2;
+            m.M34 = value1.M34 * value2;
+            m.M41 = value1.M41 * value2;
+            m.M42 = value1.M42 * value2;
+            m.M43 = value1.M43 * value2;
+            m.M44 = value1.M44 * value2;
+            return m;
         }
 
         /// <summary>
@@ -2138,6 +2130,7 @@ namespace System.Numerics
         /// <returns>True if the given matrices are equal; False otherwise.</returns>
         public static unsafe bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
         {
+#if netcoreapp
             if (Sse.IsSupported)
             {
                 return
@@ -2146,13 +2139,11 @@ namespace System.Numerics
                     Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0 &&
                     Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0;
             }
-            else
-            {
-                return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.
-                        value1.M12 == value2.M12 && value1.M13 == value2.M13 && value1.M14 == value2.M14 && value1.M21 == value2.M21 && 
-                        value1.M23 == value2.M23 && value1.M24 == value2.M24 && value1.M31 == value2.M31 && value1.M32 == value2.M32 && 
-                        value1.M34 == value2.M34 && value1.M41 == value2.M41 && value1.M42 == value2.M42 && value1.M43 == value2.M43);
-            }
+#endif
+            return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.
+                    value1.M12 == value2.M12 && value1.M13 == value2.M13 && value1.M14 == value2.M14 && value1.M21 == value2.M21 && 
+                    value1.M23 == value2.M23 && value1.M24 == value2.M24 && value1.M31 == value2.M31 && value1.M32 == value2.M32 && 
+                    value1.M34 == value2.M34 && value1.M41 == value2.M41 && value1.M42 == value2.M42 && value1.M43 == value2.M43);
         }
 
         /// <summary>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1850,36 +1850,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The source matrix.</param>
         /// <returns>The negated matrix.</returns>
-        public static Matrix4x4 Negate(Matrix4x4 value)
-        {
-            if (Sse.IsSupported)
-            {
-                return -value;
-            }
-            else
-            {
-                Matrix4x4 result;
-
-                result.M11 = -value.M11;
-                result.M12 = -value.M12;
-                result.M13 = -value.M13;
-                result.M14 = -value.M14;
-                result.M21 = -value.M21;
-                result.M22 = -value.M22;
-                result.M23 = -value.M23;
-                result.M24 = -value.M24;
-                result.M31 = -value.M31;
-                result.M32 = -value.M32;
-                result.M33 = -value.M33;
-                result.M34 = -value.M34;
-                result.M41 = -value.M41;
-                result.M42 = -value.M42;
-                result.M43 = -value.M43;
-                result.M44 = -value.M44;
-
-                return result;
-            }
-        }
+        public static Matrix4x4 Negate(Matrix4x4 value) => -value;
 
         /// <summary>
         /// Adds two matrices together.
@@ -1887,36 +1858,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The resulting matrix.</returns>
-        public static Matrix4x4 Add(Matrix4x4 value1, Matrix4x4 value2)
-        {
-            if (Sse.IsSupported)
-            {
-                return value1 + value2;
-            }
-            else
-            {
-                Matrix4x4 result;
-
-                result.M11 = value1.M11 + value2.M11;
-                result.M12 = value1.M12 + value2.M12;
-                result.M13 = value1.M13 + value2.M13;
-                result.M14 = value1.M14 + value2.M14;
-                result.M21 = value1.M21 + value2.M21;
-                result.M22 = value1.M22 + value2.M22;
-                result.M23 = value1.M23 + value2.M23;
-                result.M24 = value1.M24 + value2.M24;
-                result.M31 = value1.M31 + value2.M31;
-                result.M32 = value1.M32 + value2.M32;
-                result.M33 = value1.M33 + value2.M33;
-                result.M34 = value1.M34 + value2.M34;
-                result.M41 = value1.M41 + value2.M41;
-                result.M42 = value1.M42 + value2.M42;
-                result.M43 = value1.M43 + value2.M43;
-                result.M44 = value1.M44 + value2.M44;
-
-                return result;
-            }
-        }
+        public static Matrix4x4 Add(Matrix4x4 value1, Matrix4x4 value2) => value1 + value2;
 
         /// <summary>
         /// Subtracts the second matrix from the first.
@@ -1924,36 +1866,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the subtraction.</returns>
-        public static Matrix4x4 Subtract(Matrix4x4 value1, Matrix4x4 value2)
-        {
-            if (Sse.IsSupported)
-            {
-                return value1 - value2;
-            }
-            else
-            {
-                Matrix4x4 result;
-
-                result.M11 = value1.M11 - value2.M11;
-                result.M12 = value1.M12 - value2.M12;
-                result.M13 = value1.M13 - value2.M13;
-                result.M14 = value1.M14 - value2.M14;
-                result.M21 = value1.M21 - value2.M21;
-                result.M22 = value1.M22 - value2.M22;
-                result.M23 = value1.M23 - value2.M23;
-                result.M24 = value1.M24 - value2.M24;
-                result.M31 = value1.M31 - value2.M31;
-                result.M32 = value1.M32 - value2.M32;
-                result.M33 = value1.M33 - value2.M33;
-                result.M34 = value1.M34 - value2.M34;
-                result.M41 = value1.M41 - value2.M41;
-                result.M42 = value1.M42 - value2.M42;
-                result.M43 = value1.M43 - value2.M43;
-                result.M44 = value1.M44 - value2.M44;
-
-                return result;
-            }
-        }
+        public static Matrix4x4 Subtract(Matrix4x4 value1, Matrix4x4 value2) => value1 - value2;
 
         /// <summary>
         /// Multiplies a matrix by another matrix.
@@ -1961,43 +1874,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the multiplication.</returns>
-        public static Matrix4x4 Multiply(Matrix4x4 value1, Matrix4x4 value2)
-        {
-            if (Sse.IsSupported)
-            {
-                return value1 * value2;
-            }
-            else
-            {
-                Matrix4x4 result;
-
-                // First row
-                result.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21 + value1.M13 * value2.M31 + value1.M14 * value2.M41;
-                result.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22 + value1.M13 * value2.M32 + value1.M14 * value2.M42;
-                result.M13 = value1.M11 * value2.M13 + value1.M12 * value2.M23 + value1.M13 * value2.M33 + value1.M14 * value2.M43;
-                result.M14 = value1.M11 * value2.M14 + value1.M12 * value2.M24 + value1.M13 * value2.M34 + value1.M14 * value2.M44;
-
-                // Second row
-                result.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21 + value1.M23 * value2.M31 + value1.M24 * value2.M41;
-                result.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22 + value1.M23 * value2.M32 + value1.M24 * value2.M42;
-                result.M23 = value1.M21 * value2.M13 + value1.M22 * value2.M23 + value1.M23 * value2.M33 + value1.M24 * value2.M43;
-                result.M24 = value1.M21 * value2.M14 + value1.M22 * value2.M24 + value1.M23 * value2.M34 + value1.M24 * value2.M44;
-
-                // Third row
-                result.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value1.M33 * value2.M31 + value1.M34 * value2.M41;
-                result.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value1.M33 * value2.M32 + value1.M34 * value2.M42;
-                result.M33 = value1.M31 * value2.M13 + value1.M32 * value2.M23 + value1.M33 * value2.M33 + value1.M34 * value2.M43;
-                result.M34 = value1.M31 * value2.M14 + value1.M32 * value2.M24 + value1.M33 * value2.M34 + value1.M34 * value2.M44;
-
-                // Fourth row
-                result.M41 = value1.M41 * value2.M11 + value1.M42 * value2.M21 + value1.M43 * value2.M31 + value1.M44 * value2.M41;
-                result.M42 = value1.M41 * value2.M12 + value1.M42 * value2.M22 + value1.M43 * value2.M32 + value1.M44 * value2.M42;
-                result.M43 = value1.M41 * value2.M13 + value1.M42 * value2.M23 + value1.M43 * value2.M33 + value1.M44 * value2.M43;
-                result.M44 = value1.M41 * value2.M14 + value1.M42 * value2.M24 + value1.M43 * value2.M34 + value1.M44 * value2.M44;
-
-                return result;
-            }
-        }
+        public static Matrix4x4 Multiply(Matrix4x4 value1, Matrix4x4 value2) => value1 * value2;
 
         /// <summary>
         /// Multiplies a matrix by a scalar value.
@@ -2005,36 +1882,7 @@ namespace System.Numerics
         /// <param name="value1">The source matrix.</param>
         /// <param name="value2">The scaling factor.</param>
         /// <returns>The scaled matrix.</returns>
-        public static Matrix4x4 Multiply(Matrix4x4 value1, float value2)
-        {
-            if (Sse.IsSupported)
-            {
-                return value1 * value2;
-            }
-            else
-            {
-                Matrix4x4 result;
-
-                result.M11 = value1.M11 * value2;
-                result.M12 = value1.M12 * value2;
-                result.M13 = value1.M13 * value2;
-                result.M14 = value1.M14 * value2;
-                result.M21 = value1.M21 * value2;
-                result.M22 = value1.M22 * value2;
-                result.M23 = value1.M23 * value2;
-                result.M24 = value1.M24 * value2;
-                result.M31 = value1.M31 * value2;
-                result.M32 = value1.M32 * value2;
-                result.M33 = value1.M33 * value2;
-                result.M34 = value1.M34 * value2;
-                result.M41 = value1.M41 * value2;
-                result.M42 = value1.M42 * value2;
-                result.M43 = value1.M43 * value2;
-                result.M44 = value1.M44 * value2;
-
-                return result;
-            }
-        }
+        public static Matrix4x4 Multiply(Matrix4x4 value1, float value2) => value1 * value2;
 
         /// <summary>
         /// Returns a new matrix with the negated elements of the given matrix.
@@ -2324,20 +2172,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="other">The matrix to compare this instance to.</param>
         /// <returns>True if the matrices are equal; False otherwise.</returns>
-        public bool Equals(Matrix4x4 other)
-        {
-            if (Sse.IsSupported)
-            {
-                return this == other;
-            }
-            else
-            {
-                return (M11 == other.M11 && M22 == other.M22 && M33 == other.M33 && M44 == other.M44 && // Check diagonal element first for early out.
-                        M12 == other.M12 && M13 == other.M13 && M14 == other.M14 && M21 == other.M21 && 
-                        M23 == other.M23 && M24 == other.M24 && M31 == other.M31 && M32 == other.M32 && 
-                        M34 == other.M34 && M41 == other.M41 && M42 == other.M42 && M43 == other.M43);
-            }
-        }
+        public bool Equals(Matrix4x4 other) => this == other;
 
         /// <summary>
         /// Returns a boolean indicating whether the given Object is equal to this matrix instance.
@@ -2346,9 +2181,9 @@ namespace System.Numerics
         /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Matrix4x4)
+            if (obj is Matrix4x4 m)
             {
-                return Equals((Matrix4x4)obj);
+                return this == m;
             }
 
             return false;

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2025,29 +2025,36 @@ namespace System.Numerics
 #if HAS_INTRINSICS
             if (Sse.IsSupported)
             {
+                var row = Sse.LoadVector128(&value1.M11);
                 Sse.Store(&value1.M11,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M11), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M12), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M13), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M14), Sse.LoadVector128(&value2.M41)))));
+                    Sse.Add(Sse.Add(Sse.Multiply(Sse.Shuffle(row, row, 0x00), Sse.LoadVector128(&value2.M11)),
+                                    Sse.Multiply(Sse.Shuffle(row, row, 0x55), Sse.LoadVector128(&value2.M21))),
+                            Sse.Add(Sse.Multiply(Sse.Shuffle(row, row, 0xAA), Sse.LoadVector128(&value2.M31)),
+                                    Sse.Multiply(Sse.Shuffle(row, row, 0xFF), Sse.LoadVector128(&value2.M41)))));
 
+                // 0x00 is _MM_SHUFFLE(0,0,0,0), 0x55 is _MM_SHUFFLE(1,1,1,1), etc.
+                // TODO: Replace with a method once it's added to the API.
+
+                row = Sse.LoadVector128(&value1.M21);
                 Sse.Store(&value1.M21,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M21), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M22), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M23), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M24), Sse.LoadVector128(&value2.M41)))));
+                    Sse.Add(Sse.Add(Sse.Multiply(Sse.Shuffle(row, row, 0x00), Sse.LoadVector128(&value2.M11)),
+                                    Sse.Multiply(Sse.Shuffle(row, row, 0x55), Sse.LoadVector128(&value2.M21))),
+                            Sse.Add(Sse.Multiply(Sse.Shuffle(row, row, 0xAA), Sse.LoadVector128(&value2.M31)),
+                                    Sse.Multiply(Sse.Shuffle(row, row, 0xFF), Sse.LoadVector128(&value2.M41)))));
 
+                row = Sse.LoadVector128(&value1.M31);
                 Sse.Store(&value1.M31, 
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M31), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M32), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M33), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M34), Sse.LoadVector128(&value2.M41)))));
+                    Sse.Add(Sse.Add(Sse.Multiply(Sse.Shuffle(row, row, 0x00), Sse.LoadVector128(&value2.M11)),
+                                    Sse.Multiply(Sse.Shuffle(row, row, 0x55), Sse.LoadVector128(&value2.M21))),
+                            Sse.Add(Sse.Multiply(Sse.Shuffle(row, row, 0xAA), Sse.LoadVector128(&value2.M31)),
+                                    Sse.Multiply(Sse.Shuffle(row, row, 0xFF), Sse.LoadVector128(&value2.M41)))));
 
+                row = Sse.LoadVector128(&value1.M41);
                 Sse.Store(&value1.M41,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M41), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M42), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M43), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M44), Sse.LoadVector128(&value2.M41)))));
+                    Sse.Add(Sse.Add(Sse.Multiply(Sse.Shuffle(row, row, 0x00), Sse.LoadVector128(&value2.M11)),
+                                    Sse.Multiply(Sse.Shuffle(row, row, 0x55), Sse.LoadVector128(&value2.M21))),
+                            Sse.Add(Sse.Multiply(Sse.Shuffle(row, row, 0xAA), Sse.LoadVector128(&value2.M31)),
+                                    Sse.Multiply(Sse.Shuffle(row, row, 0xFF), Sse.LoadVector128(&value2.M41)))));
                 return value1;
             }
 #endif

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
@@ -1851,18 +1850,11 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The source matrix.</param>
         /// <returns>The negated matrix.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Negate(Matrix4x4 value)
         {
             if (Sse.IsSupported)
             {
-                var zero = Sse.SetZeroVector128();
-                Sse.Store(&value.M11, Sse.Subtract(zero, Sse.LoadVector128(&value.M11)));
-                Sse.Store(&value.M21, Sse.Subtract(zero, Sse.LoadVector128(&value.M21)));
-                Sse.Store(&value.M31, Sse.Subtract(zero, Sse.LoadVector128(&value.M31)));
-                Sse.Store(&value.M41, Sse.Subtract(zero, Sse.LoadVector128(&value.M41)));
-
-                return value;
+                return -value;
             }
             else
             {
@@ -1895,16 +1887,11 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The resulting matrix.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Add(Matrix4x4 value1, Matrix4x4 value2)
         {
             if (Sse.IsSupported)
             {
-                Sse.Store(&value1.M11, Sse.Add(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
-                Sse.Store(&value1.M21, Sse.Add(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value1.M21)));
-                Sse.Store(&value1.M31, Sse.Add(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value1.M31)));
-                Sse.Store(&value1.M41, Sse.Add(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value1.M41)));
-                return value1;
+                return value1 + value2;
             }
             else
             {
@@ -1937,16 +1924,11 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the subtraction.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Subtract(Matrix4x4 value1, Matrix4x4 value2)
         {
             if (Sse.IsSupported)
             {
-                Sse.Store(&value1.M11, Sse.Subtract(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
-                Sse.Store(&value1.M21, Sse.Subtract(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value1.M21)));
-                Sse.Store(&value1.M31, Sse.Subtract(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value1.M31)));
-                Sse.Store(&value1.M41, Sse.Subtract(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value1.M41)));
-                return value1;
+                return value1 - value2;
             }
             else
             {
@@ -1979,38 +1961,11 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the multiplication.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe Matrix4x4 Multiply(Matrix4x4 value1, Matrix4x4 value2)
+        public static Matrix4x4 Multiply(Matrix4x4 value1, Matrix4x4 value2)
         {
             if (Sse.IsSupported)
             {
-                Matrix4x4 m = default;
-
-                Sse.Store(&m.M11,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M11), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M12), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M13), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M14), Sse.LoadVector128(&value2.M41)))));
-
-                Sse.Store(&m.M21,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M21), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M22), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M23), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M24), Sse.LoadVector128(&value2.M41)))));
-
-                Sse.Store(&m.M31,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M31), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M32), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M33), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M34), Sse.LoadVector128(&value2.M41)))));
-
-                Sse.Store(&m.M41,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M41), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M42), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M43), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M44), Sse.LoadVector128(&value2.M41)))));
-
-                return m;
+                return value1 * value2;
             }
             else
             {
@@ -2050,17 +2005,11 @@ namespace System.Numerics
         /// <param name="value1">The source matrix.</param>
         /// <param name="value2">The scaling factor.</param>
         /// <returns>The scaled matrix.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Multiply(Matrix4x4 value1, float value2)
         {
             if (Sse.IsSupported)
             {
-                var all = Sse.SetAllVector128(value2);
-                Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), all));
-                Sse.Store(&value1.M21, Sse.Multiply(Sse.LoadVector128(&value1.M21), all));
-                Sse.Store(&value1.M31, Sse.Multiply(Sse.LoadVector128(&value1.M31), all));
-                Sse.Store(&value1.M41, Sse.Multiply(Sse.LoadVector128(&value1.M41), all));
-                return value1;
+                return value1 * value2;
             }
             else
             {
@@ -2092,7 +2041,42 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The source matrix.</param>
         /// <returns>The negated matrix.</returns>
-        public static Matrix4x4 operator -(Matrix4x4 value) => Negate(value);
+        public static unsafe Matrix4x4 operator -(Matrix4x4 value)
+        {
+            if (Sse.IsSupported)
+            {
+                var zero = Sse.SetZeroVector128();
+                Sse.Store(&value.M11, Sse.Subtract(zero, Sse.LoadVector128(&value.M11)));
+                Sse.Store(&value.M21, Sse.Subtract(zero, Sse.LoadVector128(&value.M21)));
+                Sse.Store(&value.M31, Sse.Subtract(zero, Sse.LoadVector128(&value.M31)));
+                Sse.Store(&value.M41, Sse.Subtract(zero, Sse.LoadVector128(&value.M41)));
+
+                return value;
+            }
+            else
+            {
+                Matrix4x4 m;
+
+                m.M11 = -value.M11;
+                m.M12 = -value.M12;
+                m.M13 = -value.M13;
+                m.M14 = -value.M14;
+                m.M21 = -value.M21;
+                m.M22 = -value.M22;
+                m.M23 = -value.M23;
+                m.M24 = -value.M24;
+                m.M31 = -value.M31;
+                m.M32 = -value.M32;
+                m.M33 = -value.M33;
+                m.M34 = -value.M34;
+                m.M41 = -value.M41;
+                m.M42 = -value.M42;
+                m.M43 = -value.M43;
+                m.M44 = -value.M44;
+
+                return m;
+            }
+        }
 
         /// <summary>
         /// Adds two matrices together.
@@ -2100,7 +2084,40 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The resulting matrix.</returns>
-        public static Matrix4x4 operator +(Matrix4x4 value1, Matrix4x4 value2) => Add(value1, value2);
+        public static unsafe Matrix4x4 operator +(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            if (Sse.IsSupported)
+            {
+                Sse.Store(&value1.M11, Sse.Add(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
+                Sse.Store(&value1.M21, Sse.Add(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value1.M21)));
+                Sse.Store(&value1.M31, Sse.Add(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value1.M31)));
+                Sse.Store(&value1.M41, Sse.Add(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value1.M41)));
+                return value1;
+            }
+            else
+            {
+                Matrix4x4 m;
+
+                m.M11 = value1.M11 + value2.M11;
+                m.M12 = value1.M12 + value2.M12;
+                m.M13 = value1.M13 + value2.M13;
+                m.M14 = value1.M14 + value2.M14;
+                m.M21 = value1.M21 + value2.M21;
+                m.M22 = value1.M22 + value2.M22;
+                m.M23 = value1.M23 + value2.M23;
+                m.M24 = value1.M24 + value2.M24;
+                m.M31 = value1.M31 + value2.M31;
+                m.M32 = value1.M32 + value2.M32;
+                m.M33 = value1.M33 + value2.M33;
+                m.M34 = value1.M34 + value2.M34;
+                m.M41 = value1.M41 + value2.M41;
+                m.M42 = value1.M42 + value2.M42;
+                m.M43 = value1.M43 + value2.M43;
+                m.M44 = value1.M44 + value2.M44;
+
+                return m;
+            }
+        }
 
         /// <summary>
         /// Subtracts the second matrix from the first.
@@ -2108,7 +2125,40 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the subtraction.</returns>
-        public static Matrix4x4 operator -(Matrix4x4 value1, Matrix4x4 value2) => Subtract(value1, value2);
+        public static unsafe Matrix4x4 operator -(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            if (Sse.IsSupported)
+            {
+                Sse.Store(&value1.M11, Sse.Subtract(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
+                Sse.Store(&value1.M21, Sse.Subtract(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value1.M21)));
+                Sse.Store(&value1.M31, Sse.Subtract(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value1.M31)));
+                Sse.Store(&value1.M41, Sse.Subtract(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value1.M41)));
+                return value1;
+            }
+            else
+            {
+                Matrix4x4 m;
+
+                m.M11 = value1.M11 - value2.M11;
+                m.M12 = value1.M12 - value2.M12;
+                m.M13 = value1.M13 - value2.M13;
+                m.M14 = value1.M14 - value2.M14;
+                m.M21 = value1.M21 - value2.M21;
+                m.M22 = value1.M22 - value2.M22;
+                m.M23 = value1.M23 - value2.M23;
+                m.M24 = value1.M24 - value2.M24;
+                m.M31 = value1.M31 - value2.M31;
+                m.M32 = value1.M32 - value2.M32;
+                m.M33 = value1.M33 - value2.M33;
+                m.M34 = value1.M34 - value2.M34;
+                m.M41 = value1.M41 - value2.M41;
+                m.M42 = value1.M42 - value2.M42;
+                m.M43 = value1.M43 - value2.M43;
+                m.M44 = value1.M44 - value2.M44;
+
+                return m;
+            }
+        }
 
         /// <summary>
         /// Multiplies a matrix by another matrix.
@@ -2116,7 +2166,69 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the multiplication.</returns>
-        public static Matrix4x4 operator *(Matrix4x4 value1, Matrix4x4 value2) => Multiply(value1, value2);
+        public static unsafe Matrix4x4 operator *(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            if (Sse.IsSupported)
+            {
+                Matrix4x4 m = default;
+
+                Sse.Store(&m.M11,
+                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M11), Sse.LoadVector128(&value2.M11)),
+                                    Sse.Multiply(Sse.SetAllVector128(value1.M12), Sse.LoadVector128(&value2.M21))),
+                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M13), Sse.LoadVector128(&value2.M31)),
+                                    Sse.Multiply(Sse.SetAllVector128(value1.M14), Sse.LoadVector128(&value2.M41)))));
+
+                Sse.Store(&m.M21,
+                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M21), Sse.LoadVector128(&value2.M11)),
+                                    Sse.Multiply(Sse.SetAllVector128(value1.M22), Sse.LoadVector128(&value2.M21))),
+                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M23), Sse.LoadVector128(&value2.M31)),
+                                    Sse.Multiply(Sse.SetAllVector128(value1.M24), Sse.LoadVector128(&value2.M41)))));
+
+                Sse.Store(&m.M31, 
+                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M31), Sse.LoadVector128(&value2.M11)),
+                                    Sse.Multiply(Sse.SetAllVector128(value1.M32), Sse.LoadVector128(&value2.M21))),
+                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M33), Sse.LoadVector128(&value2.M31)),
+                                    Sse.Multiply(Sse.SetAllVector128(value1.M34), Sse.LoadVector128(&value2.M41)))));
+
+                Sse.Store(&m.M41,
+                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M41), Sse.LoadVector128(&value2.M11)),
+                                    Sse.Multiply(Sse.SetAllVector128(value1.M42), Sse.LoadVector128(&value2.M21))),
+                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M43), Sse.LoadVector128(&value2.M31)),
+                                    Sse.Multiply(Sse.SetAllVector128(value1.M44), Sse.LoadVector128(&value2.M41)))));
+
+                return m;
+            }
+            else
+            {
+                Matrix4x4 m;
+
+                // First row
+                m.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21 + value1.M13 * value2.M31 + value1.M14 * value2.M41;
+                m.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22 + value1.M13 * value2.M32 + value1.M14 * value2.M42;
+                m.M13 = value1.M11 * value2.M13 + value1.M12 * value2.M23 + value1.M13 * value2.M33 + value1.M14 * value2.M43;
+                m.M14 = value1.M11 * value2.M14 + value1.M12 * value2.M24 + value1.M13 * value2.M34 + value1.M14 * value2.M44;
+
+                // Second row
+                m.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21 + value1.M23 * value2.M31 + value1.M24 * value2.M41;
+                m.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22 + value1.M23 * value2.M32 + value1.M24 * value2.M42;
+                m.M23 = value1.M21 * value2.M13 + value1.M22 * value2.M23 + value1.M23 * value2.M33 + value1.M24 * value2.M43;
+                m.M24 = value1.M21 * value2.M14 + value1.M22 * value2.M24 + value1.M23 * value2.M34 + value1.M24 * value2.M44;
+
+                // Third row
+                m.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value1.M33 * value2.M31 + value1.M34 * value2.M41;
+                m.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value1.M33 * value2.M32 + value1.M34 * value2.M42;
+                m.M33 = value1.M31 * value2.M13 + value1.M32 * value2.M23 + value1.M33 * value2.M33 + value1.M34 * value2.M43;
+                m.M34 = value1.M31 * value2.M14 + value1.M32 * value2.M24 + value1.M33 * value2.M34 + value1.M34 * value2.M44;
+
+                // Fourth row
+                m.M41 = value1.M41 * value2.M11 + value1.M42 * value2.M21 + value1.M43 * value2.M31 + value1.M44 * value2.M41;
+                m.M42 = value1.M41 * value2.M12 + value1.M42 * value2.M22 + value1.M43 * value2.M32 + value1.M44 * value2.M42;
+                m.M43 = value1.M41 * value2.M13 + value1.M42 * value2.M23 + value1.M43 * value2.M33 + value1.M44 * value2.M43;
+                m.M44 = value1.M41 * value2.M14 + value1.M42 * value2.M24 + value1.M43 * value2.M34 + value1.M44 * value2.M44;
+
+                return m;
+            }
+        }
 
         /// <summary>
         /// Multiplies a matrix by a scalar value.
@@ -2124,7 +2236,41 @@ namespace System.Numerics
         /// <param name="value1">The source matrix.</param>
         /// <param name="value2">The scaling factor.</param>
         /// <returns>The scaled matrix.</returns>
-        public static Matrix4x4 operator *(Matrix4x4 value1, float value2) => Multiply(value1, value2);
+        public static unsafe Matrix4x4 operator *(Matrix4x4 value1, float value2)
+        {
+
+            if (Sse.IsSupported)
+            {
+                var all = Sse.SetAllVector128(value2);
+                Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), all));
+                Sse.Store(&value1.M21, Sse.Multiply(Sse.LoadVector128(&value1.M21), all));
+                Sse.Store(&value1.M31, Sse.Multiply(Sse.LoadVector128(&value1.M31), all));
+                Sse.Store(&value1.M41, Sse.Multiply(Sse.LoadVector128(&value1.M41), all));
+                return value1;
+            }
+            else
+            {
+                Matrix4x4 m;
+
+                m.M11 = value1.M11 * value2;
+                m.M12 = value1.M12 * value2;
+                m.M13 = value1.M13 * value2;
+                m.M14 = value1.M14 * value2;
+                m.M21 = value1.M21 * value2;
+                m.M22 = value1.M22 * value2;
+                m.M23 = value1.M23 * value2;
+                m.M24 = value1.M24 * value2;
+                m.M31 = value1.M31 * value2;
+                m.M32 = value1.M32 * value2;
+                m.M33 = value1.M33 * value2;
+                m.M34 = value1.M34 * value2;
+                m.M41 = value1.M41 * value2;
+                m.M42 = value1.M42 * value2;
+                m.M43 = value1.M43 * value2;
+                m.M44 = value1.M44 * value2;
+                return m;
+            }
+        }
 
         /// <summary>
         /// Returns a boolean indicating whether the given two matrices are equal.
@@ -2132,7 +2278,14 @@ namespace System.Numerics
         /// <param name="value1">The first matrix to compare.</param>
         /// <param name="value2">The second matrix to compare.</param>
         /// <returns>True if the given matrices are equal; False otherwise.</returns>
-        public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2) => value1.Equals(value2);
+        public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.
+                                                value1.M12 == value2.M12 && value1.M13 == value2.M13 && value1.M14 == value2.M14 &&
+                    value1.M21 == value2.M21 && value1.M23 == value2.M23 && value1.M24 == value2.M24 &&
+                    value1.M31 == value2.M31 && value1.M32 == value2.M32 && value1.M34 == value2.M34 &&
+                    value1.M41 == value2.M41 && value1.M42 == value2.M42 && value1.M43 == value2.M43);
+        }
 
         /// <summary>
         /// Returns a boolean indicating whether the given two matrices are not equal.
@@ -2140,14 +2293,19 @@ namespace System.Numerics
         /// <param name="value1">The first matrix to compare.</param>
         /// <param name="value2">The second matrix to compare.</param>
         /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
-        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2) => !value1.Equals(value2);
+        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
+                    value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
+                    value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||
+                    value1.M41 != value2.M41 || value1.M42 != value2.M42 || value1.M43 != value2.M43 || value1.M44 != value2.M44);
+        }
 
         /// <summary>
         /// Returns a boolean indicating whether this matrix instance is equal to the other given matrix.
         /// </summary>
         /// <param name="other">The matrix to compare this instance to.</param>
         /// <returns>True if the matrices are equal; False otherwise.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Matrix4x4 other)
         {
             return (M11 == other.M11 && M22 == other.M22 && M33 == other.M33 && M44 == other.M44 && // Check diagonal element first for early out.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
 namespace System.Numerics
@@ -10,6 +11,7 @@ namespace System.Numerics
     /// <summary>
     /// A structure encapsulating a 4x4 matrix.
     /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
     public struct Matrix4x4 : IEquatable<Matrix4x4>
     {
         #region Public Fields

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2050,8 +2050,8 @@ namespace System.Numerics
                 var all = Sse.SetAllVector128(value2);
                 Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), all));
                 Sse.Store(&value1.M21, Sse.Multiply(Sse.LoadVector128(&value1.M21), all));
+                Sse.Store(&value1.M31, Sse.Multiply(Sse.LoadVector128(&value1.M31), all));
                 Sse.Store(&value1.M41, Sse.Multiply(Sse.LoadVector128(&value1.M41), all));
-                Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), all));
                 return value1;
             }
             else
@@ -2287,8 +2287,8 @@ namespace System.Numerics
                 var all = Sse.SetAllVector128(value2);
                 Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), all));
                 Sse.Store(&value1.M21, Sse.Multiply(Sse.LoadVector128(&value1.M21), all));
+                Sse.Store(&value1.M31, Sse.Multiply(Sse.LoadVector128(&value1.M31), all));
                 Sse.Store(&value1.M41, Sse.Multiply(Sse.LoadVector128(&value1.M41), all));
-                Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), all));
                 return value1;
             }
             else

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2275,13 +2275,23 @@ namespace System.Numerics
         /// <param name="value1">The first matrix to compare.</param>
         /// <param name="value2">The second matrix to compare.</param>
         /// <returns>True if the given matrices are equal; False otherwise.</returns>
-        public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
+        public static unsafe bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
         {
-            return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.
-                                                value1.M12 == value2.M12 && value1.M13 == value2.M13 && value1.M14 == value2.M14 &&
-                    value1.M21 == value2.M21 && value1.M23 == value2.M23 && value1.M24 == value2.M24 &&
-                    value1.M31 == value2.M31 && value1.M32 == value2.M32 && value1.M34 == value2.M34 &&
-                    value1.M41 == value2.M41 && value1.M42 == value2.M42 && value1.M43 == value2.M43);
+            if (Sse.IsSupported)
+            {
+                return
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) == 0xF &&
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) == 0xF &&
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0xF &&
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0xF;
+            }
+            else
+            {
+                return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.
+                        value1.M12 == value2.M12 && value1.M13 == value2.M13 && value1.M14 == value2.M14 && value1.M21 == value2.M21 && 
+                        value1.M23 == value2.M23 && value1.M24 == value2.M24 && value1.M31 == value2.M31 && value1.M32 == value2.M32 && 
+                        value1.M34 == value2.M34 && value1.M41 == value2.M41 && value1.M42 == value2.M42 && value1.M43 == value2.M43);
+            }
         }
 
         /// <summary>
@@ -2290,12 +2300,23 @@ namespace System.Numerics
         /// <param name="value1">The first matrix to compare.</param>
         /// <param name="value2">The second matrix to compare.</param>
         /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
-        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
+        public static unsafe bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
         {
-            return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
-                    value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
-                    value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||
-                    value1.M41 != value2.M41 || value1.M42 != value2.M42 || value1.M43 != value2.M43 || value1.M44 != value2.M44);
+            if (Sse.IsSupported)
+            {
+                return
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) != 0xF ||
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) != 0xF ||
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) != 0xF ||
+                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) != 0xF;
+            }
+            else 
+            {
+                return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
+                        value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
+                        value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||
+                        value1.M41 != value2.M41 || value1.M42 != value2.M42 || value1.M43 != value2.M43 || value1.M44 != value2.M44);
+            }
         }
 
         /// <summary>
@@ -2305,11 +2326,18 @@ namespace System.Numerics
         /// <returns>True if the matrices are equal; False otherwise.</returns>
         public bool Equals(Matrix4x4 other)
         {
-            return (M11 == other.M11 && M22 == other.M22 && M33 == other.M33 && M44 == other.M44 && // Check diagonal element first for early out.
-                                        M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
-                    M21 == other.M21 && M23 == other.M23 && M24 == other.M24 &&
-                    M31 == other.M31 && M32 == other.M32 && M34 == other.M34 &&
-                    M41 == other.M41 && M42 == other.M42 && M43 == other.M43);
+            if (Sse.IsSupported)
+            {
+                return this == other;
+            }
+            else
+            {
+                return (M11 == other.M11 && M22 == other.M22 && M33 == other.M33 && M44 == other.M44 && // Check diagonal element first for early out.
+                                            M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
+                        M21 == other.M21 && M23 == other.M23 && M24 == other.M24 &&
+                        M31 == other.M31 && M32 == other.M32 && M34 == other.M34 &&
+                        M41 == other.M41 && M42 == other.M42 && M43 == other.M43);
+            }
         }
 
         /// <summary>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1762,17 +1762,22 @@ namespace System.Numerics
         {
             if (Sse.IsSupported)
             {
-                Matrix4x4 result = default;
-                var t0 = Sse.Shuffle(Sse.LoadVector128(&matrix.M11), Sse.LoadVector128(&matrix.M21), 0x44);
-                var t1 = Sse.Shuffle(Sse.LoadVector128(&matrix.M31), Sse.LoadVector128(&matrix.M41), 0x44);
-                var t2 = Sse.Shuffle(Sse.LoadVector128(&matrix.M11), Sse.LoadVector128(&matrix.M21), 0xEE);
-                var t3 = Sse.Shuffle(Sse.LoadVector128(&matrix.M31), Sse.LoadVector128(&matrix.M41), 0xEE);
+                var row1 = Sse.LoadVector128(&matrix.M11);
+                var row2 = Sse.LoadVector128(&matrix.M21);
+                var row3 = Sse.LoadVector128(&matrix.M31);
+                var row4 = Sse.LoadVector128(&matrix.M41);
 
-                Sse.Store(&result.M11, Sse.Shuffle(t0, t1, 0x88));
-                Sse.Store(&result.M21, Sse.Shuffle(t0, t1, 0xDD));
-                Sse.Store(&result.M31, Sse.Shuffle(t2, t3, 0x88));
-                Sse.Store(&result.M41, Sse.Shuffle(t2, t3, 0xDD));
-                return result;
+                var l12 = Sse.UnpackLow(row1, row2);
+                var l34 = Sse.UnpackLow(row3, row4);
+                var h12 = Sse.UnpackHigh(row1, row2);
+                var h34 = Sse.UnpackHigh(row3, row4);
+
+                Sse.Store(&matrix.M11, Sse.MoveLowToHigh(l12, l34));
+                Sse.Store(&matrix.M21, Sse.MoveHighToLow(l34, l12));
+                Sse.Store(&matrix.M31, Sse.MoveLowToHigh(h12, h34));
+                Sse.Store(&matrix.M41, Sse.MoveHighToLow(h34, h12));
+
+                return matrix;
             }
             else
             {

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2161,7 +2161,7 @@ namespace System.Numerics
         /// <param name="value1">The first matrix to compare.</param>
         /// <param name="value2">The second matrix to compare.</param>
         /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
-        public static unsafe bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
+        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
         {
             return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
                     value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2170,33 +2170,30 @@ namespace System.Numerics
         {
             if (Sse.IsSupported)
             {
-                Matrix4x4 m = default;
-
-                Sse.Store(&m.M11,
+                Sse.Store(&value1.M11,
                     Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M11), Sse.LoadVector128(&value2.M11)),
                                     Sse.Multiply(Sse.SetAllVector128(value1.M12), Sse.LoadVector128(&value2.M21))),
                             Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M13), Sse.LoadVector128(&value2.M31)),
                                     Sse.Multiply(Sse.SetAllVector128(value1.M14), Sse.LoadVector128(&value2.M41)))));
 
-                Sse.Store(&m.M21,
+                Sse.Store(&value1.M21,
                     Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M21), Sse.LoadVector128(&value2.M11)),
                                     Sse.Multiply(Sse.SetAllVector128(value1.M22), Sse.LoadVector128(&value2.M21))),
                             Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M23), Sse.LoadVector128(&value2.M31)),
                                     Sse.Multiply(Sse.SetAllVector128(value1.M24), Sse.LoadVector128(&value2.M41)))));
 
-                Sse.Store(&m.M31, 
+                Sse.Store(&value1.M31, 
                     Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M31), Sse.LoadVector128(&value2.M11)),
                                     Sse.Multiply(Sse.SetAllVector128(value1.M32), Sse.LoadVector128(&value2.M21))),
                             Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M33), Sse.LoadVector128(&value2.M31)),
                                     Sse.Multiply(Sse.SetAllVector128(value1.M34), Sse.LoadVector128(&value2.M41)))));
 
-                Sse.Store(&m.M41,
+                Sse.Store(&value1.M41,
                     Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M41), Sse.LoadVector128(&value2.M11)),
                                     Sse.Multiply(Sse.SetAllVector128(value1.M42), Sse.LoadVector128(&value2.M21))),
                             Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M43), Sse.LoadVector128(&value2.M31)),
                                     Sse.Multiply(Sse.SetAllVector128(value1.M44), Sse.LoadVector128(&value2.M41)))));
-
-                return m;
+                return value1;
             }
             else
             {
@@ -2241,11 +2238,11 @@ namespace System.Numerics
 
             if (Sse.IsSupported)
             {
-                var all = Sse.SetAllVector128(value2);
-                Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), all));
-                Sse.Store(&value1.M21, Sse.Multiply(Sse.LoadVector128(&value1.M21), all));
-                Sse.Store(&value1.M31, Sse.Multiply(Sse.LoadVector128(&value1.M31), all));
-                Sse.Store(&value1.M41, Sse.Multiply(Sse.LoadVector128(&value1.M41), all));
+                var value2Vec = Sse.SetAllVector128(value2);
+                Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), value2Vec));
+                Sse.Store(&value1.M21, Sse.Multiply(Sse.LoadVector128(&value1.M21), value2Vec));
+                Sse.Store(&value1.M31, Sse.Multiply(Sse.LoadVector128(&value1.M31), value2Vec));
+                Sse.Store(&value1.M41, Sse.Multiply(Sse.LoadVector128(&value1.M41), value2Vec));
                 return value1;
             }
             else

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2150,8 +2150,18 @@ namespace System.Numerics
         /// <param name="value1">The first matrix to compare.</param>
         /// <param name="value2">The second matrix to compare.</param>
         /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
-        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
+        public static unsafe bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
         {
+#if HAS_INTRINSICS
+            if (Sse.IsSupported)
+            {
+                return
+                    VectorMath.NotEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11)) ||
+                    VectorMath.NotEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21)) ||
+                    VectorMath.NotEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31)) ||
+                    VectorMath.NotEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41));
+            }
+#endif
             return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
                     value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
                     value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1851,6 +1851,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The source matrix.</param>
         /// <returns>The negated matrix.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Negate(Matrix4x4 value)
         {
             if (Sse.IsSupported)
@@ -1894,6 +1895,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The resulting matrix.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Add(Matrix4x4 value1, Matrix4x4 value2)
         {
             if (Sse.IsSupported)
@@ -1935,6 +1937,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the subtraction.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Subtract(Matrix4x4 value1, Matrix4x4 value2)
         {
             if (Sse.IsSupported)
@@ -1976,6 +1979,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the multiplication.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Multiply(Matrix4x4 value1, Matrix4x4 value2)
         {
             if (Sse.IsSupported)
@@ -2046,6 +2050,7 @@ namespace System.Numerics
         /// <param name="value1">The source matrix.</param>
         /// <param name="value2">The scaling factor.</param>
         /// <returns>The scaled matrix.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Matrix4x4 Multiply(Matrix4x4 value1, float value2)
         {
             if (Sse.IsSupported)
@@ -2142,6 +2147,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="other">The matrix to compare this instance to.</param>
         /// <returns>True if the matrices are equal; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Matrix4x4 other)
         {
             return (M11 == other.M11 && M22 == other.M22 && M33 == other.M33 && M44 == other.M44 && // Check diagonal element first for early out.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
@@ -2086,42 +2087,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The source matrix.</param>
         /// <returns>The negated matrix.</returns>
-        public static unsafe Matrix4x4 operator -(Matrix4x4 value)
-        {
-            if (Sse.IsSupported)
-            {
-                var zero = Sse.SetZeroVector128();
-                Sse.Store(&value.M11, Sse.Subtract(zero, Sse.LoadVector128(&value.M11)));
-                Sse.Store(&value.M21, Sse.Subtract(zero, Sse.LoadVector128(&value.M21)));
-                Sse.Store(&value.M31, Sse.Subtract(zero, Sse.LoadVector128(&value.M31)));
-                Sse.Store(&value.M41, Sse.Subtract(zero, Sse.LoadVector128(&value.M41)));
-
-                return value;
-            }
-            else
-            {
-                Matrix4x4 m;
-
-                m.M11 = -value.M11;
-                m.M12 = -value.M12;
-                m.M13 = -value.M13;
-                m.M14 = -value.M14;
-                m.M21 = -value.M21;
-                m.M22 = -value.M22;
-                m.M23 = -value.M23;
-                m.M24 = -value.M24;
-                m.M31 = -value.M31;
-                m.M32 = -value.M32;
-                m.M33 = -value.M33;
-                m.M34 = -value.M34;
-                m.M41 = -value.M41;
-                m.M42 = -value.M42;
-                m.M43 = -value.M43;
-                m.M44 = -value.M44;
-
-                return m;
-            }
-        }
+        public static Matrix4x4 operator -(Matrix4x4 value) => Negate(value);
 
         /// <summary>
         /// Adds two matrices together.
@@ -2129,40 +2095,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The resulting matrix.</returns>
-        public static unsafe Matrix4x4 operator +(Matrix4x4 value1, Matrix4x4 value2)
-        {
-            if (Sse.IsSupported)
-            {
-                Sse.Store(&value1.M11, Sse.Add(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
-                Sse.Store(&value1.M21, Sse.Add(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value1.M21)));
-                Sse.Store(&value1.M31, Sse.Add(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value1.M31)));
-                Sse.Store(&value1.M41, Sse.Add(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value1.M41)));
-                return value1;
-            }
-            else
-            {
-                Matrix4x4 m;
-
-                m.M11 = value1.M11 + value2.M11;
-                m.M12 = value1.M12 + value2.M12;
-                m.M13 = value1.M13 + value2.M13;
-                m.M14 = value1.M14 + value2.M14;
-                m.M21 = value1.M21 + value2.M21;
-                m.M22 = value1.M22 + value2.M22;
-                m.M23 = value1.M23 + value2.M23;
-                m.M24 = value1.M24 + value2.M24;
-                m.M31 = value1.M31 + value2.M31;
-                m.M32 = value1.M32 + value2.M32;
-                m.M33 = value1.M33 + value2.M33;
-                m.M34 = value1.M34 + value2.M34;
-                m.M41 = value1.M41 + value2.M41;
-                m.M42 = value1.M42 + value2.M42;
-                m.M43 = value1.M43 + value2.M43;
-                m.M44 = value1.M44 + value2.M44;
-
-                return m;
-            }
-        }
+        public static Matrix4x4 operator +(Matrix4x4 value1, Matrix4x4 value2) => Add(value1, value2);
 
         /// <summary>
         /// Subtracts the second matrix from the first.
@@ -2170,40 +2103,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the subtraction.</returns>
-        public static unsafe Matrix4x4 operator -(Matrix4x4 value1, Matrix4x4 value2)
-        {
-            if (Sse.IsSupported)
-            {
-                Sse.Store(&value1.M11, Sse.Subtract(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value1.M11)));
-                Sse.Store(&value1.M21, Sse.Subtract(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value1.M21)));
-                Sse.Store(&value1.M31, Sse.Subtract(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value1.M31)));
-                Sse.Store(&value1.M41, Sse.Subtract(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value1.M41)));
-                return value1;
-            }
-            else
-            {
-                Matrix4x4 m;
-
-                m.M11 = value1.M11 - value2.M11;
-                m.M12 = value1.M12 - value2.M12;
-                m.M13 = value1.M13 - value2.M13;
-                m.M14 = value1.M14 - value2.M14;
-                m.M21 = value1.M21 - value2.M21;
-                m.M22 = value1.M22 - value2.M22;
-                m.M23 = value1.M23 - value2.M23;
-                m.M24 = value1.M24 - value2.M24;
-                m.M31 = value1.M31 - value2.M31;
-                m.M32 = value1.M32 - value2.M32;
-                m.M33 = value1.M33 - value2.M33;
-                m.M34 = value1.M34 - value2.M34;
-                m.M41 = value1.M41 - value2.M41;
-                m.M42 = value1.M42 - value2.M42;
-                m.M43 = value1.M43 - value2.M43;
-                m.M44 = value1.M44 - value2.M44;
-
-                return m;
-            }
-        }
+        public static Matrix4x4 operator -(Matrix4x4 value1, Matrix4x4 value2) => Subtract(value1, value2);
 
         /// <summary>
         /// Multiplies a matrix by another matrix.
@@ -2211,69 +2111,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the multiplication.</returns>
-        public static unsafe Matrix4x4 operator *(Matrix4x4 value1, Matrix4x4 value2)
-        {
-            if (Sse.IsSupported)
-            {
-                Matrix4x4 m = default;
-
-                Sse.Store(&m.M11,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M11), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M12), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M13), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M14), Sse.LoadVector128(&value2.M41)))));
-
-                Sse.Store(&m.M21,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M21), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M22), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M23), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M24), Sse.LoadVector128(&value2.M41)))));
-
-                Sse.Store(&m.M31, 
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M31), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M32), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M33), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M34), Sse.LoadVector128(&value2.M41)))));
-
-                Sse.Store(&m.M41,
-                    Sse.Add(Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M41), Sse.LoadVector128(&value2.M11)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M42), Sse.LoadVector128(&value2.M21))),
-                            Sse.Add(Sse.Multiply(Sse.SetAllVector128(value1.M43), Sse.LoadVector128(&value2.M31)),
-                                    Sse.Multiply(Sse.SetAllVector128(value1.M44), Sse.LoadVector128(&value2.M41)))));
-
-                return m;
-            }
-            else
-            {
-                Matrix4x4 m;
-
-                // First row
-                m.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21 + value1.M13 * value2.M31 + value1.M14 * value2.M41;
-                m.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22 + value1.M13 * value2.M32 + value1.M14 * value2.M42;
-                m.M13 = value1.M11 * value2.M13 + value1.M12 * value2.M23 + value1.M13 * value2.M33 + value1.M14 * value2.M43;
-                m.M14 = value1.M11 * value2.M14 + value1.M12 * value2.M24 + value1.M13 * value2.M34 + value1.M14 * value2.M44;
-
-                // Second row
-                m.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21 + value1.M23 * value2.M31 + value1.M24 * value2.M41;
-                m.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22 + value1.M23 * value2.M32 + value1.M24 * value2.M42;
-                m.M23 = value1.M21 * value2.M13 + value1.M22 * value2.M23 + value1.M23 * value2.M33 + value1.M24 * value2.M43;
-                m.M24 = value1.M21 * value2.M14 + value1.M22 * value2.M24 + value1.M23 * value2.M34 + value1.M24 * value2.M44;
-
-                // Third row
-                m.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value1.M33 * value2.M31 + value1.M34 * value2.M41;
-                m.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value1.M33 * value2.M32 + value1.M34 * value2.M42;
-                m.M33 = value1.M31 * value2.M13 + value1.M32 * value2.M23 + value1.M33 * value2.M33 + value1.M34 * value2.M43;
-                m.M34 = value1.M31 * value2.M14 + value1.M32 * value2.M24 + value1.M33 * value2.M34 + value1.M34 * value2.M44;
-
-                // Fourth row
-                m.M41 = value1.M41 * value2.M11 + value1.M42 * value2.M21 + value1.M43 * value2.M31 + value1.M44 * value2.M41;
-                m.M42 = value1.M41 * value2.M12 + value1.M42 * value2.M22 + value1.M43 * value2.M32 + value1.M44 * value2.M42;
-                m.M43 = value1.M41 * value2.M13 + value1.M42 * value2.M23 + value1.M43 * value2.M33 + value1.M44 * value2.M43;
-                m.M44 = value1.M41 * value2.M14 + value1.M42 * value2.M24 + value1.M43 * value2.M34 + value1.M44 * value2.M44;
-
-                return m;
-            }
-        }
+        public static Matrix4x4 operator *(Matrix4x4 value1, Matrix4x4 value2) => Multiply(value1, value2);
 
         /// <summary>
         /// Multiplies a matrix by a scalar value.
@@ -2281,41 +2119,7 @@ namespace System.Numerics
         /// <param name="value1">The source matrix.</param>
         /// <param name="value2">The scaling factor.</param>
         /// <returns>The scaled matrix.</returns>
-        public static unsafe Matrix4x4 operator *(Matrix4x4 value1, float value2)
-        {
-
-            if (Sse.IsSupported)
-            {
-                var all = Sse.SetAllVector128(value2);
-                Sse.Store(&value1.M11, Sse.Multiply(Sse.LoadVector128(&value1.M11), all));
-                Sse.Store(&value1.M21, Sse.Multiply(Sse.LoadVector128(&value1.M21), all));
-                Sse.Store(&value1.M31, Sse.Multiply(Sse.LoadVector128(&value1.M31), all));
-                Sse.Store(&value1.M41, Sse.Multiply(Sse.LoadVector128(&value1.M41), all));
-                return value1;
-            }
-            else
-            {
-                Matrix4x4 m;
-
-                m.M11 = value1.M11 * value2;
-                m.M12 = value1.M12 * value2;
-                m.M13 = value1.M13 * value2;
-                m.M14 = value1.M14 * value2;
-                m.M21 = value1.M21 * value2;
-                m.M22 = value1.M22 * value2;
-                m.M23 = value1.M23 * value2;
-                m.M24 = value1.M24 * value2;
-                m.M31 = value1.M31 * value2;
-                m.M32 = value1.M32 * value2;
-                m.M33 = value1.M33 * value2;
-                m.M34 = value1.M34 * value2;
-                m.M41 = value1.M41 * value2;
-                m.M42 = value1.M42 * value2;
-                m.M43 = value1.M43 * value2;
-                m.M44 = value1.M44 * value2;
-                return m;
-            }
-        }
+        public static Matrix4x4 operator *(Matrix4x4 value1, float value2) => Multiply(value1, value2);
 
         /// <summary>
         /// Returns a boolean indicating whether the given two matrices are equal.
@@ -2323,14 +2127,7 @@ namespace System.Numerics
         /// <param name="value1">The first matrix to compare.</param>
         /// <param name="value2">The second matrix to compare.</param>
         /// <returns>True if the given matrices are equal; False otherwise.</returns>
-        public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
-        {
-            return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.
-                                                value1.M12 == value2.M12 && value1.M13 == value2.M13 && value1.M14 == value2.M14 &&
-                    value1.M21 == value2.M21 && value1.M23 == value2.M23 && value1.M24 == value2.M24 &&
-                    value1.M31 == value2.M31 && value1.M32 == value2.M32 && value1.M34 == value2.M34 &&
-                    value1.M41 == value2.M41 && value1.M42 == value2.M42 && value1.M43 == value2.M43);
-        }
+        public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2) => value1.Equals(value2);
 
         /// <summary>
         /// Returns a boolean indicating whether the given two matrices are not equal.
@@ -2338,13 +2135,7 @@ namespace System.Numerics
         /// <param name="value1">The first matrix to compare.</param>
         /// <param name="value2">The second matrix to compare.</param>
         /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
-        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
-        {
-            return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
-                    value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
-                    value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||
-                    value1.M41 != value2.M41 || value1.M42 != value2.M42 || value1.M43 != value2.M43 || value1.M44 != value2.M44);
-        }
+        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2) => !value1.Equals(value2);
 
         /// <summary>
         /// Returns a boolean indicating whether this matrix instance is equal to the other given matrix.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1852,7 +1852,7 @@ namespace System.Numerics
         {
             if (Sse.IsSupported)
             {
-                var zero = Sse.SetAllVector128(0f);
+                var zero = Sse.SetZeroVector128();
                 Sse.Store(&value.M11, Sse.Subtract(zero, Sse.LoadVector128(&value.M11)));
                 Sse.Store(&value.M21, Sse.Subtract(zero, Sse.LoadVector128(&value.M21)));
                 Sse.Store(&value.M31, Sse.Subtract(zero, Sse.LoadVector128(&value.M31)));
@@ -2088,7 +2088,7 @@ namespace System.Numerics
         {
             if (Sse.IsSupported)
             {
-                var zero = Sse.SetAllVector128(0f);
+                var zero = Sse.SetZeroVector128();
                 Sse.Store(&value.M11, Sse.Subtract(zero, Sse.LoadVector128(&value.M11)));
                 Sse.Store(&value.M21, Sse.Subtract(zero, Sse.LoadVector128(&value.M21)));
                 Sse.Store(&value.M31, Sse.Subtract(zero, Sse.LoadVector128(&value.M31)));

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1850,7 +1850,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The source matrix.</param>
         /// <returns>The negated matrix.</returns>
-        public static unsafe Matrix4x4 Negate(Matrix4x4 value)
+        public static Matrix4x4 Negate(Matrix4x4 value)
         {
             if (Sse.IsSupported)
             {
@@ -1887,7 +1887,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The resulting matrix.</returns>
-        public static unsafe Matrix4x4 Add(Matrix4x4 value1, Matrix4x4 value2)
+        public static Matrix4x4 Add(Matrix4x4 value1, Matrix4x4 value2)
         {
             if (Sse.IsSupported)
             {
@@ -1924,7 +1924,7 @@ namespace System.Numerics
         /// <param name="value1">The first source matrix.</param>
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The result of the subtraction.</returns>
-        public static unsafe Matrix4x4 Subtract(Matrix4x4 value1, Matrix4x4 value2)
+        public static Matrix4x4 Subtract(Matrix4x4 value1, Matrix4x4 value2)
         {
             if (Sse.IsSupported)
             {
@@ -2005,7 +2005,7 @@ namespace System.Numerics
         /// <param name="value1">The source matrix.</param>
         /// <param name="value2">The scaling factor.</param>
         /// <returns>The scaled matrix.</returns>
-        public static unsafe Matrix4x4 Multiply(Matrix4x4 value1, float value2)
+        public static Matrix4x4 Multiply(Matrix4x4 value1, float value2)
         {
             if (Sse.IsSupported)
             {
@@ -2280,10 +2280,10 @@ namespace System.Numerics
             if (Sse.IsSupported)
             {
                 return
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) == 0xF &&
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) == 0xF &&
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0xF &&
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0xF;
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) != 0 &&
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) != 0 &&
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) != 0 &&
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) != 0;
             }
             else
             {
@@ -2305,10 +2305,10 @@ namespace System.Numerics
             if (Sse.IsSupported)
             {
                 return
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) != 0xF ||
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) != 0xF ||
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) != 0xF ||
-                    Sse.MoveMask(Sse.CompareEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) != 0xF;
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M11), Sse.LoadVector128(&value2.M11))) == 0 ||
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M21), Sse.LoadVector128(&value2.M21))) == 0 ||
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M31), Sse.LoadVector128(&value2.M31))) == 0 ||
+                    Sse.MoveMask(Sse.CompareNotEqual(Sse.LoadVector128(&value1.M41), Sse.LoadVector128(&value2.M41))) == 0;
             }
             else 
             {
@@ -2333,10 +2333,9 @@ namespace System.Numerics
             else
             {
                 return (M11 == other.M11 && M22 == other.M22 && M33 == other.M33 && M44 == other.M44 && // Check diagonal element first for early out.
-                                            M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
-                        M21 == other.M21 && M23 == other.M23 && M24 == other.M24 &&
-                        M31 == other.M31 && M32 == other.M32 && M34 == other.M34 &&
-                        M41 == other.M41 && M42 == other.M42 && M43 == other.M43);
+                        M12 == other.M12 && M13 == other.M13 && M14 == other.M14 && M21 == other.M21 && 
+                        M23 == other.M23 && M24 == other.M24 && M31 == other.M31 && M32 == other.M32 && 
+                        M34 == other.M34 && M41 == other.M41 && M42 == other.M42 && M43 == other.M43);
             }
         }
 

--- a/src/System.Numerics.Vectors/src/System/Numerics/VectorMath.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/VectorMath.cs
@@ -25,8 +25,19 @@ namespace System.Numerics
         {
             if (Sse.IsSupported)
             {
-                // do not use !Equal if vectors contain NaN
                 return Sse.MoveMask(Sse.CompareNotEqual(vector1, vector2)) == 0;
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+
+        public static bool NotEqual(Vector128<float> vector1, Vector128<float> vector2)
+        {
+            if (Sse.IsSupported)
+            {
+                return Sse.MoveMask(Sse.CompareNotEqual(vector1, vector2)) != 0;
             }
             else
             {

--- a/src/System.Numerics.Vectors/src/System/Numerics/VectorMath.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/VectorMath.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#if HAS_INTRINSICS
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace System.Numerics
+{
+    internal static class VectorMath
+    {
+        public static Vector128<float> Lerp(Vector128<float> a, Vector128<float> b, Vector128<float> t)
+        {
+            if (Sse.IsSupported)
+            {
+                return Sse.Add(a, Sse.Multiply(Sse.Subtract(b, a), t));
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+
+        public static bool Equal(Vector128<float> vector1, Vector128<float> vector2)
+        {
+            if (Sse.IsSupported)
+            {
+                // do not use !Equal if vectors contain NaN
+                return Sse.MoveMask(Sse.CompareNotEqual(vector1, vector2)) == 0;
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+    }
+}
+#endif

--- a/src/System.Numerics.Vectors/src/System/Numerics/VectorMath.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/VectorMath.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-#if HAS_INTRINSICS
 using System.Diagnostics;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -29,4 +28,3 @@ namespace System.Numerics
         }
     }
 }
-#endif

--- a/src/System.Numerics.Vectors/src/System/Numerics/VectorMath.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/VectorMath.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 #if HAS_INTRINSICS
+using System.Diagnostics;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
@@ -11,38 +12,20 @@ namespace System.Numerics
     {
         public static Vector128<float> Lerp(Vector128<float> a, Vector128<float> b, Vector128<float> t)
         {
-            if (Sse.IsSupported)
-            {
-                return Sse.Add(a, Sse.Multiply(Sse.Subtract(b, a), t));
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
-            }
+            Debug.Assert(Sse.IsSupported);
+            return Sse.Add(a, Sse.Multiply(Sse.Subtract(b, a), t));
         }
 
         public static bool Equal(Vector128<float> vector1, Vector128<float> vector2)
         {
-            if (Sse.IsSupported)
-            {
-                return Sse.MoveMask(Sse.CompareNotEqual(vector1, vector2)) == 0;
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
-            }
+            Debug.Assert(Sse.IsSupported);
+            return Sse.MoveMask(Sse.CompareNotEqual(vector1, vector2)) == 0;
         }
 
         public static bool NotEqual(Vector128<float> vector1, Vector128<float> vector2)
         {
-            if (Sse.IsSupported)
-            {
-                return Sse.MoveMask(Sse.CompareNotEqual(vector1, vector2)) != 0;
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
-            }
+            Debug.Assert(Sse.IsSupported);
+            return Sse.MoveMask(Sse.CompareNotEqual(vector1, vector2)) != 0;
         }
     }
 }


### PR DESCRIPTION
This PR optimizes some `Matrix4x4` operations with SSE (see https://github.com/dotnet/corefx/issues/31425). Some of the operations could also be optimized with AVX but for some reason on my PC it performs worse than SSE ([VZEROUPPER](https://github.com/dotnet/coreclr/issues/18575)? or maybe CPU decreases AVX frequency due to rapid benchmarking?).

Environment:
```ini
.NET Core: .NET Core SDK=3.0.100-alpha1-20180720-2

Windows 10:
   Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores

macOS 10.13:
   Intel Core i7-4980HQ CPU 2.80GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
```

## Matrix4x4.Add (Matrix4x4, Matrix4x4) and Subtract
`Matrix4x4 result = matrix1 + matrix2;`

Windows (Coffee Lake):

|  Method |      Mean | Scaled |
|-------- |----------:|-------:|
| Add_old | 13.353 ns |   1.00 |
| Add_new |  4.486 ns |   0.34 |

macOS (Haswell):

|  Method |      Mean | Scaled |
|-------- |----------:|-------:|
| Add_old | 15.347 ns |   1.00 |
| Add_new |  7.473 ns |   0.49 |


## Matrix4x4.Lerp (Matrix4x4, Matrix4x4, float)
`Matrix4x4 result = Matrix4x4.Lerp(matrix1, matrix2, amount);`

Windows (Coffee Lake):

|   Method |      Mean | Scaled |
|--------- |----------:|-------:|
| Lerp_old | 15.286 ns |   1.00 |
| Lerp_new |  5.365 ns |   0.35 |

macOS (Haswell):

|   Method |      Mean | Scaled |
|--------- |----------:|-------:|
| Lerp_old | 17.047 ns |   1.00 |
| Lerp_new |  7.657 ns |   0.45 |

## Matrix4x4.Multiply (Matrix4x4, Matrix4x4)
`Matrix4x4 result = matrix1 * matrix2;`

Windows (Coffee Lake):

|       Method |      Mean | Scaled |
|------------- |----------:|-------:|
| Multiply_old | 27.146 ns |   1.00 |
| Multiply_new |  7.461 ns |   0.27 |

macOS (Haswell):

|       Method |     Mean | Scaled |
|------------- |---------:|-------:|
| Multiply_old | 32.05 ns |   1.00 |
| Multiply_new | 11.24 ns |   0.35 |

## Matrix4x4.Multiply (Matrix4x4, float)
`Matrix4x4 result = matrix1 * scalar;`

Windows (Coffee Lake):

|               Method |      Mean | Scaled |
|--------------------- |----------:|-------:|
| MultiplyByScalar_old | 12.927 ns |   1.00 |
| MultiplyByScalar_new |  3.284 ns |   0.25 |

macOS (Haswell):

|               Method |      Mean | Scaled |
|--------------------- |----------:|-------:|
| MultiplyByScalar_old | 14.334 ns |   1.00 |
| MultiplyByScalar_new |  5.086 ns |   0.35 |

## Matrix4x4.Negate (Matrix4x4)
`Matrix4x4 result = -matrix1;`

Windows (Coffee Lake):

|     Method |      Mean | Scaled |
|----------- |----------:|-------:|
| Negate_old | 12.932 ns |   1.00 |
| Negate_new |  3.187 ns |   0.25 |

macOS (Haswell):

|     Method |      Mean | Scaled |
|----------- |----------:|-------:|
| Negate_old | 14.877 ns |   1.00 |
| Negate_new |  5.201 ns |   0.35 |

## Matrix4x4.Equals (Matrix4x4)
`bool result = matrix1 == matrix2;`

Windows (Coffee Lake):

|              Method |     Mean |
|-------------------- |---------:|
| Equals_NotEqual_old | 1.742 ns |
| Equals_NotEqual_new | 1.581 ns |
|    Equals_Equal_old | 7.081 ns |
|    Equals_Equal_new | 2.960 ns |

macOS (Haswell):

|              Method |     Mean |
|-------------------- |---------:|
| Equals_NotEqual_old | 3.172 ns |
| Equals_NotEqual_new | 3.022 ns |
|    Equals_Equal_old | 8.180 ns |
|    Equals_Equal_new | 4.618 ns |

## Matrix4x4.Transpose (Matrix4x4)
`Matrix4x4 result = Matrix4x4.Transpose(matrix1);`

Windows (Coffee Lake):

|        Method |      Mean | Scaled |
|-------------- |----------:|-------:|
| Transpose_old | 12.720 ns |   1.00 |
| Transpose_new |  3.156 ns |   0.25 |

macOS (Haswell):

|        Method |      Mean | Scaled |
|-------------- |----------:|-------:|
| Transpose_old | 14.297 ns |   1.00 |
| Transpose_new |  5.548 ns |   0.39 |

Benchmarks: https://gist.github.com/EgorBo/c80a25517245374c8dcdca2af4536ffe