### PR TITLE
Add retry policy to ProfileOptimization test

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Runtime/ProfileOptimization.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/Runtime/ProfileOptimization.netcoreapp.cs
@@ -19,8 +19,7 @@ namespace System.Runtime.Tests
         public void ProfileOptimization_CheckFileExists()
         {
             string tmpProfileFilePath = GetTestFileName();
-            string directoryName = Path.GetDirectoryName(tmpProfileFilePath);
-            string tmpTestFileName = Path.Combine(directoryName, Path.GetRandomFileName());
+            string tmpTestFileName = Path.Combine(Path.GetDirectoryName(tmpProfileFilePath), Path.GetRandomFileName());
 
             _output.WriteLine($"We'll test write permission on path '{tmpTestFileName}'");
 


### PR DESCRIPTION
fixes https://github.com/dotnet/corefx/issues/31792

~~Added retry policy. We retry n times for max \~20 seconds before report test fail.~~

/cc @danmosemsft @brianrob @Sunny-pu