### PR TITLE
Prerequisites for enabling tiering by default in 2.2

### DIFF
--- a/src/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
+++ b/src/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -63,13 +64,10 @@ namespace System.Diagnostics.Tests
         {
             StackFrame stackFrame = CallMethod(1);
             MethodInfo expectedMethod = typeof(StackFrameTests).GetMethod(nameof(SkipFrames_CallMethod_ReturnsExpected));
-#if DEBUG
             Assert.Equal(expectedMethod, stackFrame.GetMethod());
-#else
-            Assert.NotEqual(expectedMethod, stackFrame.GetMethod());
-#endif
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public StackFrame CallMethod(int skipFrames) => new StackFrame(skipFrames);
 
         [Theory]
@@ -113,16 +111,12 @@ namespace System.Diagnostics.Tests
 
         public static IEnumerable<object[]> ToString_TestData()
         {
-#if DEBUG
             yield return new object[] { new StackFrame(), "MoveNext at offset {offset} in file:line:column {fileName}:{lineNumber}:{column}" + Environment.NewLine };
             yield return new object[] { new StackFrame("FileName", 1, 2), "MoveNext at offset {offset} in file:line:column FileName:1:2" + Environment.NewLine };
             yield return new object[] { new StackFrame(int.MaxValue), "<null>" + Environment.NewLine };
             yield return new object[] { GenericMethod<string>(), "GenericMethod<T> at offset {offset} in file:line:column {fileName}:{lineNumber}:{column}" + Environment.NewLine };
             yield return new object[] { GenericMethod<string, int>(), "GenericMethod<T,U> at offset {offset} in file:line:column {fileName}:{lineNumber}:{column}" + Environment.NewLine };
             yield return new object[] { new ClassWithConstructor().StackFrame, ".ctor at offset {offset} in file:line:column {fileName}:{lineNumber}:{column}" + Environment.NewLine };
-#else
-            yield break;
-#endif
         }
 
         [Theory]
@@ -136,12 +130,17 @@ namespace System.Diagnostics.Tests
             Assert.Equal(expectedToString, stackFrame.ToString());
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static StackFrame GenericMethod<T>() => new StackFrame();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static StackFrame GenericMethod<T, U>() => new StackFrame();
 
         private class ClassWithConstructor
         {
             public StackFrame StackFrame { get; }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public ClassWithConstructor() => StackFrame = new StackFrame();
         }
 
@@ -164,15 +163,9 @@ namespace System.Diagnostics.Tests
             {
                 Assert.Equal(StackFrame.OFFSET_UNKNOWN, stackFrame.GetILOffset());
             }
-#if !DEBUG
-            else if ((!PlatformDetection.IsFullFramework && isFileConstructor) || (PlatformDetection.IsFullFramework && !isFileConstructor && !isCurrentFrame && skipFrames == 0))
-            {
-                Assert.Equal(0, stackFrame.GetILOffset());
-            }
-#endif
             else
             {
-                Assert.True(stackFrame.GetILOffset() > 0, $"Expected GetILOffset() {stackFrame.GetILOffset()} for {stackFrame} to be greater than zero.");
+                Assert.True(stackFrame.GetILOffset() >= 0, $"Expected GetILOffset() {stackFrame.GetILOffset()} for {stackFrame} to be greater or equal to zero.");
             }
 
             // GetMethod returns null for unknown frames.

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -765,6 +765,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework needs fix for #26484")]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/18912", TargetFrameworkMonikers.Netcoreapp)]
         public void Match_ExcessPrefix()
         {
             RemoteInvoke(() =>

--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -191,20 +191,6 @@ namespace System.Threading.Threads.Tests
             }).Dispose();
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
-        [ActiveIssue(20766,TargetFrameworkMonikers.UapAot)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void ApartmentState_NoAttributePresent_STA_Windows_Core()
-        {
-            DummyClass.RemoteInvoke(() =>
-            {
-                Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-                Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
-                Assert.Throws<InvalidOperationException>(() => Thread.CurrentThread.SetApartmentState(ApartmentState.MTA));
-            }).Dispose();
-        }
-
         // The Thread Apartment State is set to MTA if attribute is not specified on main function
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]


### PR DESCRIPTION
- StackFrame tests fail after enabling tiering because they are dependent on JIT optimizations. Ported fixes to tests.
- Removed an invalid ApartmentState test that fails after enabling tiering, and coreclr prerequisites for enabling tiering would include a fix to the ApartmentState issue that caused this test to pass incorrectly without tiering
- Disabled a regex test that also fails in master coreclr's corefx CI jobs with minopts and tiering
- See individual commit descriptions for more info