### PR TITLE
Test a couple of fixes for apartment state issues related to enabling tiered jitting

### DIFF
--- a/src/System.Threading.Thread/tests/DefaultApartmentStateMain/Configurations.props
+++ b/src/System.Threading.Thread/tests/DefaultApartmentStateMain/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Threading.Thread/tests/DefaultApartmentStateMain/DefaultApartmentStateMain.cs
+++ b/src/System.Threading.Thread/tests/DefaultApartmentStateMain/DefaultApartmentStateMain.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Threading;
 
-namespace MTAMain
+namespace DefaultApartmentStateMain
 {
-    internal static class MTAMain
+    internal static class DefaultApartmentStateMain
     {
         private const int Success = 0;
         private const int SuccessOnUnix = 2;
@@ -15,7 +15,6 @@ namespace MTAMain
 
         private static Thread s_mainThread;
 
-        [MTAThread]
         static int Main(string[] args)
         {
             string testName = args[0];

--- a/src/System.Threading.Thread/tests/DefaultApartmentStateMain/DefaultApartmentStateMain.csproj
+++ b/src/System.Threading.Thread/tests/DefaultApartmentStateMain/DefaultApartmentStateMain.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <ProjectGuid>{32432E07-5CA4-41F3-9855-22AB1F1E69B3}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="DefaultApartmentStateMain.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="DefaultApartmentStateMain.runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="DefaultApartmentStateMain.exe.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Thread/tests/DefaultApartmentStateMain/DefaultApartmentStateMain.exe.config
+++ b/src/System.Threading.Thread/tests/DefaultApartmentStateMain/DefaultApartmentStateMain.exe.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <developmentMode developerInstallation="true" />
+  </runtime>
+</configuration>

--- a/src/System.Threading.Thread/tests/DefaultApartmentStateMain/DefaultApartmentStateMain.runtimeconfig.json
+++ b/src/System.Threading.Thread/tests/DefaultApartmentStateMain/DefaultApartmentStateMain.runtimeconfig.json
@@ -1,0 +1,8 @@
+{
+	"runtimeOptions": {
+		"framework": {
+			"name": "Microsoft.NETCore.App",
+			"version": "9.9.9"
+		}
+	}
+}

--- a/src/System.Threading.Thread/tests/STAMain/STAMain.cs
+++ b/src/System.Threading.Thread/tests/STAMain/STAMain.cs
@@ -9,46 +9,54 @@ namespace STAMain
 {
     internal static class STAMain
     {
+        private const int Success = 0;
+        private const int SuccessOnUnix = 2;
+        private const int Failure = 1;
+
+        private static Thread s_mainThread;
+
         [STAThread]
         static int Main(string[] args)
         {
-            const int Success = 0;
-            const int SuccessOnUnix = 2;
-            const int Failure = 1;
+            string testName = args[0];
+            s_mainThread = Thread.CurrentThread;
 
-            string mode = args[0];
-            int retValue = Failure;
-            Thread curThread = Thread.CurrentThread;
-            
-            if (mode == "GetApartmentState")
+            switch (testName)
             {
-                if (curThread.GetApartmentState() == ApartmentState.STA)
-                {
-                    curThread.SetApartmentState(ApartmentState.STA);
-                    retValue = Success;
-                }
-                else
-                {
-                    retValue = SuccessOnUnix;
-                }
+                case "GetApartmentStateTest":
+                    return GetApartmentStateTest();
+                case "SetApartmentStateTest":
+                    return SetApartmentStateTest();
+                default:
+                    return Failure;
             }
-            else
-            {
-                try
-                {
-                    curThread.SetApartmentState(ApartmentState.MTA);
-                }
-                catch (InvalidOperationException)
-                {
-                    retValue = Success;
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    retValue = SuccessOnUnix;
-                }
-            }
+        }
 
-            return retValue;
+        private static int GetApartmentStateTest()
+        {
+            if (s_mainThread.GetApartmentState() == ApartmentState.STA)
+            {
+                s_mainThread.SetApartmentState(ApartmentState.STA);
+                return Success;
+            }
+            return SuccessOnUnix;
+        }
+
+        private static int SetApartmentStateTest()
+        {
+            try
+            {
+                s_mainThread.SetApartmentState(ApartmentState.MTA);
+            }
+            catch (InvalidOperationException)
+            {
+                return Success;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return SuccessOnUnix;
+            }
+            return Failure;
         }
     }
 }

--- a/src/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
+++ b/src/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
@@ -34,6 +34,9 @@
     <ProjectReference Include="MTAMain\MTAMain.csproj">
       <Name>MTAMain</Name>
     </ProjectReference>
+    <ProjectReference Include="DefaultApartmentStateMain\DefaultApartmentStateMain.csproj">
+      <Name>DefaultApartmentStateMain</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -153,23 +153,25 @@ namespace System.Threading.Threads.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
-        [InlineData("STAMain.exe", "GetApartmentState")] 
-        [InlineData("STAMain.exe", "SetApartmentState")]
-        [InlineData("MTAMain.exe", "GetApartmentState")]
-        [InlineData("MTAMain.exe", "SetApartmentState")]
+        [InlineData("STAMain.exe", "GetApartmentStateTest")]
+        [InlineData("STAMain.exe", "SetApartmentStateTest")]
+        [InlineData("MTAMain.exe", "GetApartmentStateTest")]
+        [InlineData("MTAMain.exe", "SetApartmentStateTest")]
+        [InlineData("DefaultApartmentStateMain.exe", "GetApartmentStateTest")]
+        [InlineData("DefaultApartmentStateMain.exe", "SetApartmentStateTest")]
         [ActiveIssue(20766, TargetFrameworkMonikers.Uap)]
-        public static void ApartmentState_AttributePresent(string AppName, string mode)
+        public static void ApartmentState_AttributePresent(string appName, string testName)
         {
             var psi = new ProcessStartInfo();
             if (PlatformDetection.IsFullFramework || PlatformDetection.IsNetNative)
             {
-                psi.FileName = AppName;
-                psi.Arguments = $"{mode}";
+                psi.FileName = appName;
+                psi.Arguments = $"{testName}";
             }
             else
             {
                 psi.FileName = DummyClass.HostRunnerTest;
-                psi.Arguments = $"{AppName} {mode}";
+                psi.Arguments = $"{appName} {testName}";
             }
             using (Process p = Process.Start(psi))
             {


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/19691

Port of #31682 to 2.2. Changes only affect tests.

Tests for dotnet/coreclr#19384 (for the portion of which is ported as part of enabling tiering)

Related to dotnet/coreclr#17822
Related to dotnet/coreclr#17787
Related to dotnet/coreclr#19225