### PR TITLE
Fixing remaining projects with netsandard configurations that won't build succesfully

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/tests/Configurations.props
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Configurations.props
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard;
       netfx;
       uap;
       netcoreapp;

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{0D1E2954-A5C7-4B8C-932A-31EB4A96A737}</ProjectGuid>
     <DefineConstants>$(DefineConstants);XMLSERIALIZERGENERATORTESTS</DefineConstants>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup>
     <SkipTestsOnPlatform Condition="'$(TargetGroup)' == 'uap' OR '$(ArchGroup)' == 'arm' OR '$(ArchGroup)' == 'arm64' OR '$(ArchGroup)' == 'armel' OR '$(TargetGroup)' == 'netfx'">true</SkipTestsOnPlatform>

--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{A824F4CD-935B-4496-A1B2-C3664936DA7B}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
@@ -128,25 +128,25 @@
     <Compile Include="System\Runtime\InteropServices\AutomationProxyAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ImportedFromTypeLibAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ManagedToNativeComInteropStubAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GenerateGuidForTypeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GenerateProgIdForTypeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetComObjectDataTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetDelegateForFunctionPointerTests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetExceptionPointersTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetFunctionPointerForDelegateTests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetHINSTANCETests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetIDispatchForObjectTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetTypedObjectForIUnknownTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\ByteTests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int16Tests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int32Tests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int64Tests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\IntPtrTests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\SetComObjectDataTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibFuncAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibImportClassAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibTypeAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibVarAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibVersionAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetHINSTANCETests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\ByteTests.nonnetstandard.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GenerateGuidForTypeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GenerateProgIdForTypeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetComObjectDataTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetIDispatchForObjectTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetTypedObjectForIUnknownTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetExceptionPointersTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\SetComObjectDataTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetDelegateForFunctionPointerTests.nonnetstandard.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetFunctionPointerForDelegateTests.nonnetstandard.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int16Tests.nonnetstandard.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int32Tests.nonnetstandard.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int64Tests.nonnetstandard.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\IntPtrTests.nonnetstandard.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -60,24 +60,17 @@
     <Compile Include="System\Runtime\InteropServices\Marshal\FreeBSTRTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\FreeCoTaskMemTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\FreeHGlobalTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GenerateGuidForTypeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GenerateGuidForTypeTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GenerateProgIdForTypeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GenerateProgIdForTypeTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetComObjectDataTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetComObjectDataTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetDelegateForFunctionPointerTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetExceptionCodeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetExceptionForHRTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetExceptionPointersTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetFunctionPointerForDelegateTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetHINSTANCETests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetHRForExceptionTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetIDispatchForObjectTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetNativeVariantForObjectTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetObjectForNativeVariantTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetObjectsForNativeVariantsTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\GetTypedObjectForIUnknownTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\IsComObjectTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\IsComObjectTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\Marshal\PtrToStructureTests.cs" />
@@ -92,7 +85,6 @@
     <Compile Include="System\Runtime\InteropServices\Marshal\SecureStringToCoTaskMemUnicodeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\SecureStringToGlobalAllocAnsiTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\SecureStringToGlobalAllocUnicodeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\Marshal\SetComObjectDataTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\SetComObjectDataTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\Marshal\SizeOfTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\StringToBSTRTests.cs" />
@@ -141,5 +133,20 @@
     <Compile Include="System\Runtime\InteropServices\TypeLibTypeAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibVarAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibVersionAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetHINSTANCETests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\ByteTests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GenerateGuidForTypeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GenerateProgIdForTypeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetComObjectDataTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetIDispatchForObjectTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetTypedObjectForIUnknownTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetExceptionPointersTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\SetComObjectDataTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetDelegateForFunctionPointerTests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\GetFunctionPointerForDelegateTests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int16Tests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int32Tests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\Int64Tests.nonnetstandard.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\ReadWrite\IntPtrTests.nonnetstandard.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetDelegateForFunctionPointerTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetDelegateForFunctionPointerTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-    public class GetDelegateForFunctionPointerTests
+    public partial class GetDelegateForFunctionPointerTests
     {
         [Theory]
         [InlineData(typeof(NonGenericDelegate))]
@@ -24,29 +24,6 @@ namespace System.Runtime.InteropServices.Tests
             IntPtr ptr = Marshal.GetFunctionPointerForDelegate(d);
 
             Delegate functionDelegate = Marshal.GetDelegateForFunctionPointer(ptr, t);
-            GC.KeepAlive(d);
-            VerifyDelegate(functionDelegate, targetMethod);
-        }
-
-        [Fact]
-        public void GetDelegateForFunctionPointer_CollectibleType_ReturnsExpected()
-        {
-            MethodInfo targetMethod = typeof(GetDelegateForFunctionPointerTests).GetMethod(nameof(Method));
-            Delegate d = targetMethod.CreateDelegate(typeof(NonGenericDelegate));
-            IntPtr ptr = Marshal.GetFunctionPointerForDelegate(d);
-
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type", TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
-            ConstructorBuilder constructorBuilder = typeBuilder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new Type[] { typeof(object), typeof(IntPtr) });
-            constructorBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-
-            MethodBuilder methodBuilder = typeBuilder.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, targetMethod.ReturnType, targetMethod.GetParameters().Select(p => p.ParameterType).ToArray());
-            methodBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-
-            Type type = typeBuilder.CreateType();
-
-            Delegate functionDelegate = Marshal.GetDelegateForFunctionPointer(ptr, type);
             GC.KeepAlive(d);
             VerifyDelegate(functionDelegate, targetMethod);
         }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetDelegateForFunctionPointerTests.nonnetstandard.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetDelegateForFunctionPointerTests.nonnetstandard.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices.Tests.Common;
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public partial class GetDelegateForFunctionPointerTests
+    {
+        [Fact]
+        public void GetDelegateForFunctionPointer_CollectibleType_ReturnsExpected()
+        {
+            MethodInfo targetMethod = typeof(GetDelegateForFunctionPointerTests).GetMethod(nameof(Method));
+            Delegate d = targetMethod.CreateDelegate(typeof(NonGenericDelegate));
+            IntPtr ptr = Marshal.GetFunctionPointerForDelegate(d);
+
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type", TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
+            ConstructorBuilder constructorBuilder = typeBuilder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new Type[] { typeof(object), typeof(IntPtr) });
+            constructorBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+
+            MethodBuilder methodBuilder = typeBuilder.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, targetMethod.ReturnType, targetMethod.GetParameters().Select(p => p.ParameterType).ToArray());
+            methodBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+
+            Type type = typeBuilder.CreateType();
+
+            Delegate functionDelegate = Marshal.GetDelegateForFunctionPointer(ptr, type);
+            GC.KeepAlive(d);
+            VerifyDelegate(functionDelegate, targetMethod);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetFunctionPointerForDelegateTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetFunctionPointerForDelegateTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-    public class GetFunctionPointerForDelegateTests
+    public partial class GetFunctionPointerForDelegateTests
     {
         [Fact]
         public void GetFunctionPointerForDelegate_NormalDelegateNonGeneric_ReturnsExpected()
@@ -86,26 +86,6 @@ namespace System.Runtime.InteropServices.Tests
             MethodInfo targetMethod = typeof(GetFunctionPointerForDelegateTests).GetMethod(nameof(Method));
             Delegate d = targetMethod.CreateDelegate(typeof(GenericDelegate<string>));
             AssertExtensions.Throws<ArgumentException>("delegate", () => Marshal.GetFunctionPointerForDelegate(d));
-        }
-
-        [Fact]
-        public void GetFunctionPointerForDelegate_DelegateCollectible_ThrowsNotSupportedException()
-        {
-            MethodInfo targetMethod = typeof(GetFunctionPointerForDelegateTests).GetMethod(nameof(Method));
-
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type", TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
-            ConstructorBuilder constructorBuilder = typeBuilder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new Type[] { typeof(object), typeof(IntPtr) });
-            constructorBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-
-            MethodBuilder methodBuilder = typeBuilder.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, targetMethod.ReturnType, targetMethod.GetParameters().Select(p => p.ParameterType).ToArray());
-            methodBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-
-            Type type = typeBuilder.CreateType();
-
-            Delegate d = targetMethod.CreateDelegate(type);
-            Assert.Throws<NotSupportedException>(() => Marshal.GetFunctionPointerForDelegate(d));
         }
 
         public delegate void GenericDelegate<T>(T t);

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetFunctionPointerForDelegateTests.nonnetstandard.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetFunctionPointerForDelegateTests.nonnetstandard.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public partial class GetFunctionPointerForDelegateTests
+    {
+        [Fact]
+        public void GetFunctionPointerForDelegate_DelegateCollectible_ThrowsNotSupportedException()
+        {
+            MethodInfo targetMethod = typeof(GetFunctionPointerForDelegateTests).GetMethod(nameof(Method));
+
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type", TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
+            ConstructorBuilder constructorBuilder = typeBuilder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new Type[] { typeof(object), typeof(IntPtr) });
+            constructorBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+
+            MethodBuilder methodBuilder = typeBuilder.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, targetMethod.ReturnType, targetMethod.GetParameters().Select(p => p.ParameterType).ToArray());
+            methodBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+
+            Type type = typeBuilder.CreateType();
+
+            Delegate d = targetMethod.CreateDelegate(type);
+            Assert.Throws<NotSupportedException>(() => Marshal.GetFunctionPointerForDelegate(d));
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-    public class ByteTests
+    public partial class ByteTests
     {
         [Theory]
         [InlineData(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, byte.MaxValue })]
@@ -137,18 +137,6 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void ReadByte_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadByte(collectibleObject, 0));
-        }
-
-        [Fact]
         public void WriteByte_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteByte(IntPtr.Zero, 0));
@@ -160,18 +148,6 @@ namespace System.Runtime.InteropServices.Tests
         public void WriteByte_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteByte(null, 2, 0));
-        }
-
-        [Fact]
-        public void WriteByte_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteByte(collectibleObject, 0, 0));
         }
 
         public struct BlittableStruct

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.nonnetstandard.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.nonnetstandard.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public partial class ByteTests
+    {
+        [Fact]
+        public void ReadByte_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadByte(collectibleObject, 0));
+        }
+
+        [Fact]
+        public void WriteByte_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteByte(collectibleObject, 0, 0));
+        }
+    }
+}
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-    public class Int16Tests
+    public partial class Int16Tests
     {
         [Theory]
         [InlineData(new short[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, short.MaxValue })]
@@ -139,18 +139,6 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void ReadInt16_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt16(collectibleObject, 0));
-        }
-
-        [Fact]
         public void WriteInt16_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt16(IntPtr.Zero, 0));
@@ -162,18 +150,6 @@ namespace System.Runtime.InteropServices.Tests
         public void WriteInt16_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteInt16(null, 2, 0));
-        }
-
-        [Fact]
-        public void WriteInt16_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteInt16(collectibleObject, 0, 0));
         }
 
         public struct BlittableStruct

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.nonnetstandard.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.nonnetstandard.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public partial class Int16Tests
+    {
+        [Fact]
+        public void ReadInt16_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt16(collectibleObject, 0));
+        }
+
+        [Fact]
+        public void WriteInt16_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteInt16(collectibleObject, 0, 0));
+        }
+    }
+}
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-    public class Int32Tests
+    public partial class Int32Tests
     {
         [Theory]
         [InlineData(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, int.MaxValue })]
@@ -139,18 +139,6 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void ReadInt32_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt32(collectibleObject, 0));
-        }
-
-        [Fact]
         public void WriteInt32_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt32(IntPtr.Zero, 0));
@@ -162,18 +150,6 @@ namespace System.Runtime.InteropServices.Tests
         public void WriteInt32_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteInt32(null, 2, 0));
-        }
-
-        [Fact]
-        public void WriteInt32_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteInt32(collectibleObject, 0, 0));
         }
 
         public struct BlittableStruct

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.nonnetstandard.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.nonnetstandard.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public partial class Int32Tests
+    {
+        [Fact]
+        public void ReadInt32_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt32(collectibleObject, 0));
+        }
+
+        [Fact]
+        public void WriteInt32_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteInt32(collectibleObject, 0, 0));
+        }
+    }
+}
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-    public class Int64Tests
+    public partial class Int64Tests
     {
         [Theory]
         [InlineData(new long[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, long.MaxValue })]
@@ -151,18 +151,6 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void ReadInt64_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt64(collectibleObject, 0));
-        }
-
-        [Fact]
         public void WriteInt64_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt64(IntPtr.Zero, 0));
@@ -174,18 +162,6 @@ namespace System.Runtime.InteropServices.Tests
         public void WriteInt64_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteInt64(null, 2, 0));
-        }
-
-        [Fact]
-        public void WriteInt64_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteInt64(collectibleObject, 0, 0));
         }
 
         public struct BlittableStruct

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.nonnetstandard.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.nonnetstandard.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public partial class Int64Tests
+    {
+        [Fact]
+        public void ReadInt64_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt64(collectibleObject, 0));
+        }
+
+        [Fact]
+        public void WriteInt64_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteInt64(collectibleObject, 0, 0));
+        }
+    }
+}
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-    public class IntPtrTests
+    public partial class IntPtrTests
     {
         public static IEnumerable<object[]> ReadWrite_TestData()
         {
@@ -146,18 +146,6 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void ReadIntPtr_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadIntPtr(collectibleObject, 0));
-        }
-
-        [Fact]
         public void WriteIntPtr_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteIntPtr(IntPtr.Zero, (IntPtr)0));
@@ -169,18 +157,6 @@ namespace System.Runtime.InteropServices.Tests
         public void WriteIntPtr_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteIntPtr(null, 2, (IntPtr)0));
-        }
-
-        [Fact]
-        public void WriteIntPtr_NotReadable_ThrowsArgumentException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type collectibleType = typeBuilder.CreateType();
-            object collectibleObject = Activator.CreateInstance(collectibleType);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteIntPtr(collectibleObject, 0, IntPtr.Zero));
         }
 
         public struct BlittableStruct

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.nonnetstandard.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.nonnetstandard.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public partial class IntPtrTests
+    {
+        [Fact]
+        public void ReadIntPtr_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadIntPtr(collectibleObject, 0));
+        }
+
+        [Fact]
+        public void WriteIntPtr_NotReadable_ThrowsArgumentException()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
+            Type collectibleType = typeBuilder.CreateType();
+            object collectibleObject = Activator.CreateInstance(collectibleType);
+
+            AssertExtensions.Throws<ArgumentException>(null, () => Marshal.WriteIntPtr(collectibleObject, 0, IntPtr.Zero));
+        }
+    }
+}
+
+#pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
With these last set of changes, all of the test projects that have a netstandard configuration will build successfully, which means that after them I can start building the required infrastructure in order to produce the test suite (issue #30729).

cc: @danmosemsft 
@luqun since he is the owner of InteropServices.