### PR TITLE
Update build.cmd script to use shared packages folder

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -2,7 +2,7 @@
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __init_tools_log="$__scriptpath/init-tools.log"
-__PACKAGES_DIR="$__scriptpath/packages"
+__PACKAGES_DIR="~/.nuget/packages"
 __TOOLRUNTIME_DIR="$__scriptpath/Tools"
 __DOTNET_PATH="$__TOOLRUNTIME_DIR/dotnetcli"
 __DOTNET_CMD="$__DOTNET_PATH/dotnet"


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/5444

This speeds up clean rebuilds of corefx, especially if the internet connection isn't as fast as in Redmond. Additionally we save disk space... See the linked issue for more details.

The build.sh update isn't done yet as I wanted to gather early feedback if that path is the right one to take. We need to evaluate the packages dir path as we need it in init-tools in buildtools as we copy some files from the packages into the tools dir.