### PR TITLE
A probably faster ConcurrentStack<T>

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -609,6 +609,10 @@ namespace System.Collections.Concurrent
                     next = next._next;
                 }
 
+                // fast spin till _next is set
+                while (next._next == null)
+                { }
+
                 // Try to swap the new head.  If we succeed, break out of the loop.
                 if (Interlocked.CompareExchange(ref _head, next._next, head) == head)
                 {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -44,7 +44,7 @@ namespace System.Collections.Concurrent
         private class Node
         {
             internal readonly T _value; // Value of the node.
-            internal Node _next; // Next pointer.
+            internal volatile Node _next; // Next pointer.
 
             /// <summary>
             /// Constructs a new node with the specified value and no next node.
@@ -57,6 +57,8 @@ namespace System.Collections.Concurrent
             }
         }
 
+        private static readonly Node Guard = new Node(default(T));
+
         private volatile Node _head; // The stack is a singly linked list, and only remembers the head.
         private const int BACKOFF_MAX_YIELDS = 8; // Arbitrary number to cap backoff.
 
@@ -66,6 +68,7 @@ namespace System.Collections.Concurrent
         /// </summary>
         public ConcurrentStack()
         {
+            _head = Guard;
         }
 
         /// <summary>
@@ -82,6 +85,8 @@ namespace System.Collections.Concurrent
             {
                 throw new ArgumentNullException(nameof(collection));
             }
+
+            _head = Guard;
             InitializeFromCollection(collection);
         }
 
@@ -92,7 +97,7 @@ namespace System.Collections.Concurrent
         private void InitializeFromCollection(IEnumerable<T> collection)
         {
             // We just copy the contents of the collection to our stack.
-            Node lastNode = null;
+            Node lastNode = _head;
             foreach (T element in collection)
             {
                 Node newNode = new Node(element);
@@ -121,7 +126,7 @@ namespace System.Collections.Concurrent
             // the function returning (i.e. if another thread concurrently adds to the stack). It does
             // guarantee, however, that, if another thread does not mutate the stack, a subsequent call
             // to TryPop will return true -- i.e. it will also read the stack as non-empty.
-            get { return _head == null; }
+            get { return ReferenceEquals(_head, Guard); }
         }
 
         /// <summary>
@@ -148,8 +153,14 @@ namespace System.Collections.Concurrent
                 // they are being dequeued. If we ever changed this (e.g. to pool nodes somehow),
                 // we'd need to revisit this implementation.
 
-                for (Node curr = _head; curr != null; curr = curr._next)
+                for (Node curr = _head; ReferenceEquals(curr, Guard) == false;)
                 {
+                    // spin till _next is set
+                    while (curr._next == null)
+                    {}
+
+                    curr = curr._next;
+
                     count++; //we don't handle overflow, to be consistent with existing generic collection types in CLR
                 }
 
@@ -196,7 +207,7 @@ namespace System.Collections.Concurrent
             // operation for this: anybody who is mutating the head by pushing or popping
             // will need to use an atomic operation to guarantee they serialize and don't
             // overwrite our setting of the head to null.
-            _head = null;
+            _head = Guard;
         }
 
         /// <summary>
@@ -283,19 +294,12 @@ namespace System.Collections.Concurrent
         public void Push(T item)
         {
             // Pushes a node onto the front of the stack thread-safely. Internally, this simply
-            // swaps the current head pointer using a (thread safe) CAS operation to accomplish
-            // lock freedom. If the CAS fails, we add some back off to statistically decrease
-            // contention at the head, and then go back around and retry.
+            // swaps the current head pointer using a (thread safe) EXCH operation to accomplish
+            // lock freedom. Then it assings _next.
 
             Node newNode = new Node(item);
-            newNode._next = _head;
-            if (Interlocked.CompareExchange(ref _head, newNode, newNode._next) == newNode._next)
-            {
-                return;
-            }
-
-            // If we failed, go to the slow path and loop around until we succeed.
-            PushCore(newNode, newNode);
+            Node head = Interlocked.Exchange(ref _head, newNode);
+            newNode._next = head;
         }
 
         /// <summary>
@@ -352,7 +356,7 @@ namespace System.Collections.Concurrent
 
 
             Node head, tail;
-            head = tail = new Node(items[startIndex]);
+            head = tail =  new Node(items[startIndex]);
             for (int i = startIndex + 1; i < startIndex + count; i++)
             {
                 Node node = new Node(items[i]);
@@ -360,41 +364,8 @@ namespace System.Collections.Concurrent
                 head = node;
             }
 
-            tail._next = _head;
-            if (Interlocked.CompareExchange(ref _head, head, tail._next) == tail._next)
-            {
-                return;
-            }
-
-            // If we failed, go to the slow path and loop around until we succeed.
-            PushCore(head, tail);
-        }
-
-
-        /// <summary>
-        /// Push one or many nodes into the stack, if head and tails are equal then push one node to the stack other wise push the list between head
-        /// and tail to the stack
-        /// </summary>
-        /// <param name="head">The head pointer to the new list</param>
-        /// <param name="tail">The tail pointer to the new list</param>
-        private void PushCore(Node head, Node tail)
-        {
-            SpinWait spin = new SpinWait();
-
-            // Keep trying to CAS the existing head with the new node until we succeed.
-            do
-            {
-                spin.SpinOnce();
-                // Reread the head and link our new node.
-                tail._next = _head;
-            }
-            while (Interlocked.CompareExchange(
-                ref _head, head, tail._next) != tail._next);
-
-            if (CDSCollectionETWBCLProvider.Log.IsEnabled())
-            {
-                CDSCollectionETWBCLProvider.Log.ConcurrentStack_FastPushFailed(spin.Count);
-            }
+            Node prevHead = Interlocked.Exchange(ref _head, head);
+            tail._next = prevHead;
         }
 
         /// <summary>
@@ -452,7 +423,7 @@ namespace System.Collections.Concurrent
             Node head = _head;
 
             // If the stack is empty, return false; else return the element and true.
-            if (head == null)
+            if (ReferenceEquals(head, Guard))
             {
                 result = default(T);
                 return false;
@@ -478,11 +449,16 @@ namespace System.Collections.Concurrent
         {
             Node head = _head;
             //stack is empty
-            if (head == null)
+            if (ReferenceEquals(head, Guard))
             {
                 result = default(T);
                 return false;
             }
+
+            // fast spin till _next is set
+            while (head._next == null)
+            {}
+
             if (Interlocked.CompareExchange(ref _head, head._next, head) == head)
             {
                 result = head._value;
@@ -612,7 +588,7 @@ namespace System.Collections.Concurrent
             {
                 head = _head;
                 // Is the stack empty?
-                if (head == null)
+                if (ReferenceEquals(head, Guard))
                 {
                     if (count == 1 && CDSCollectionETWBCLProvider.Log.IsEnabled())
                     {
@@ -624,8 +600,12 @@ namespace System.Collections.Concurrent
                 }
                 next = head;
                 int nodesCount = 1;
-                for (; nodesCount < count && next._next != null; nodesCount++)
+                for (; nodesCount < count && ReferenceEquals(next, Guard) == false; nodesCount++)
                 {
+                    // fast spin till _next is set
+                    while (next._next == null)
+                    { }
+
                     next = next._next;
                 }
 
@@ -729,9 +709,14 @@ namespace System.Collections.Concurrent
         {
             List<T> list = new List<T>();
 
-            while (curr != null)
+            while (ReferenceEquals(curr, Guard) == false)
             {
                 list.Add(curr._value);
+
+                // fast spin till _next is set
+                while (curr._next == null)
+                { }
+
                 curr = curr._next;
             }
 
@@ -764,8 +749,12 @@ namespace System.Collections.Concurrent
         private IEnumerator<T> GetEnumerator(Node head)
         {
             Node current = head;
-            while (current != null)
+            while (ReferenceEquals(current, Guard) == false)
             {
+                // fast spin till _next is set
+                while (current._next == null)
+                { }
+
                 yield return current._value;
                 current = current._next;
             }


### PR DESCRIPTION
This PR aims at speeding up  `ConcurrentStack<T>`. It's done by introducing a `Guard` node that allows fast Push operations that are based on `Interlocked.Exchange` instead of `Interlocked.CompareExchange`. This approach introduces additional check on `_next` as it's assigned after swapping with the new head.

### Implementation details
- head is exchanged via unconditional `Interlocked.Exchange` and then it has its `_next` assigned (in opposite to the previous implementation). It means that if `null` is read from `_next` field, the pusher didn't finish the push and a few spins are required to make `_next` visible.
- `_head` is never `null`. It's initially assigned to the `Guard` node. If it was null, then the algorithm could not differentiate between `_next` pointing to the null-head or `_next` being still written
- assigning `_next` is done always as the next operation to `Interlocked.Exchange`, falling into the `while(head._next == null) {}` shouldn't be that frequent