### PR TITLE
Speed up System.Drawing.Color factory and HSB/HSL methods

### DIFF
--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.sln
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.sln
@@ -7,6 +7,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Drawing.Primitives.T
 		{8F472B93-574C-4AEC-9D28-6C2360A55BBF} = {8F472B93-574C-4AEC-9D28-6C2360A55BBF}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Drawing.Primitives.Performance.Tests", "tests\Performance\System.Drawing.Primitives.Performance.Tests.csproj", "{1BD5C9BF-D7F2-4249-AA31-43B1850A5DB3}"
+	ProjectSection(ProjectDependencies) = postProject
+		{8F472B93-574C-4AEC-9D28-6C2360A55BBF} = {8F472B93-574C-4AEC-9D28-6C2360A55BBF}
+	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Drawing.Primitives", "src\System.Drawing.Primitives.csproj", "{8F472B93-574C-4AEC-9D28-6C2360A55BBF}"
 	ProjectSection(ProjectDependencies) = postProject
 		{10F74537-6423-48F5-A7F3-4DE94E42AF8F} = {10F74537-6423-48F5-A7F3-4DE94E42AF8F}
@@ -30,6 +35,10 @@ Global
 		{CF54638C-A382-4A78-9AD6-2304CEEFEB01}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{CF54638C-A382-4A78-9AD6-2304CEEFEB01}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{CF54638C-A382-4A78-9AD6-2304CEEFEB01}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{1BD5C9BF-D7F2-4249-AA31-43B1850A5DB3}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{1BD5C9BF-D7F2-4249-AA31-43B1850A5DB3}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{1BD5C9BF-D7F2-4249-AA31-43B1850A5DB3}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{1BD5C9BF-D7F2-4249-AA31-43B1850A5DB3}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{8F472B93-574C-4AEC-9D28-6C2360A55BBF}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{8F472B93-574C-4AEC-9D28-6C2360A55BBF}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{8F472B93-574C-4AEC-9D28-6C2360A55BBF}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
@@ -44,6 +53,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CF54638C-A382-4A78-9AD6-2304CEEFEB01} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{1BD5C9BF-D7F2-4249-AA31-43B1850A5DB3} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{8F472B93-574C-4AEC-9D28-6C2360A55BBF} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{10F74537-6423-48F5-A7F3-4DE94E42AF8F} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -475,139 +475,66 @@ namespace System.Drawing
 
         public float GetBrightness()
         {
-            float r = R / 255.0f;
-            float g = G / 255.0f;
-            float b = B / 255.0f;
+            uint value = (uint)Value;
+            int r = (int)((value >> ARGBRedShift  ) & 0xff);
+            int g = (int)((value >> ARGBGreenShift) & 0xff);
+            int b = (int)((value >> ARGBBlueShift ) & 0xff);
 
-            float max, min;
+            int min = Math.Min(Math.Min(r, g), b);
+            int max = Math.Max(Math.Max(r, g), b);
 
-            max = r; min = r;
-
-            if (g > max)
-            {
-                max = g;
-            }
-            else if (g < min)
-            {
-                min = g;
-            }
-
-            if (b > max)
-            {
-                max = b;
-            }
-            else if (b < min)
-            {
-                min = b;
-            }
-
-            return (max + min) / 2;
+            return (max + min) / (byte.MaxValue * 2f);
         }
 
 
         public float GetHue()
         {
-            if (R == G && G == B)
-                return 0; // 0 makes as good an UNDEFINED value as any
+            uint value = (uint)Value;
+            int r = (int)((value >> ARGBRedShift  ) & 0xff);
+            int g = (int)((value >> ARGBGreenShift) & 0xff);
+            int b = (int)((value >> ARGBBlueShift ) & 0xff);
 
-            float r = R / 255.0f;
-            float g = G / 255.0f;
-            float b = B / 255.0f;
+            if (r == g && g == b)
+                return 0f;
 
-            float max, min;
-            float delta;
+            int min = Math.Min(Math.Min(r, g), b);
+            int max = Math.Max(Math.Max(r, g), b);
+
+            float delta = max - min;
             float hue;
 
-            max = r; min = r;
-
-            if (g > max)
-            {
-                max = g;
-            }
-            else if (g < min)
-            {
-                min = g;
-            }
-
-            if (b > max)
-            {
-                max = b;
-            }
-            else if (b < min)
-            {
-                min = b;
-            }
-
-            delta = max - min;
-
             if (r == max)
-            {
                 hue = (g - b) / delta;
-            }
             else if (g == max)
-            {
-                hue = 2 + (b - r) / delta;
-            }
+                hue = (b - r) / delta + 2f;
             else
-            {
-                Debug.Assert(b == max);
-                hue = 4 + (r - g) / delta;
-            }
-            hue *= 60;
+                hue = (r - g) / delta + 4f;
 
-            if (hue < 0.0f)
-            {
-                hue += 360.0f;
-            }
+            hue *= 60f;
+            if (hue < 0f)
+                hue += 360f;
+
             return hue;
         }
 
         public float GetSaturation()
         {
-            float r = R / 255.0f;
-            float g = G / 255.0f;
-            float b = B / 255.0f;
+            uint value = (uint)Value;
+            int r = (int)((value >> ARGBRedShift  ) & 0xff);
+            int g = (int)((value >> ARGBGreenShift) & 0xff);
+            int b = (int)((value >> ARGBBlueShift ) & 0xff);
 
-            float s = 0;
+            if (r == g && g == b)
+                return 0f;
 
-            float max = r;
-            float min = r;
+            int min = Math.Min(Math.Min(r, g), b);
+            int max = Math.Max(Math.Max(r, g), b);
 
-            if (g > max)
-            {
-                max = g;
-            }
-            else if (g < min)
-            {
-                min = g;
-            }
+            int div = max + min;
+            if (div > byte.MaxValue)
+                div = byte.MaxValue * 2 - max - min;
 
-            if (b > max)
-            {
-                max = b;
-            }
-            else if (b < min)
-            {
-                min = b;
-            }
-
-            // if max == min, then there is no color and
-            // the saturation is zero.
-            //
-            if (max != min)
-            {
-                float l = (max + min) / 2;
-
-                if (l <= .5)
-                {
-                    s = (max - min) / (max + min);
-                }
-                else
-                {
-                    s = (max - min) / (2 - max - min);
-                }
-            }
-            return s;
+            return (max - min) / (float)div;
         }
 
         public int ToArgb() => unchecked((int)Value);

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -322,6 +322,9 @@ namespace System.Drawing
         private const int ARGBGreenShift = 8;
         private const int ARGBBlueShift = 0;
         private const uint ARGBAlphaMask = 0xFFu << ARGBAlphaShift;
+        private const uint ARGBRedMask = 0xFFu << ARGBRedShift;
+        private const uint ARGBGreenMask = 0xFFu << ARGBGreenShift;
+        private const uint ARGBBlueMask = 0xFFu << ARGBBlueShift;
 
         // user supplied name of color. Will not be filled in if
         // we map to a "knowncolor"
@@ -357,13 +360,13 @@ namespace System.Drawing
             this.knownColor = unchecked((short)knownColor);
         }
 
-        public byte R => (byte)((Value >> ARGBRedShift) & 0xFF);
+        public byte R => (byte)(((uint)Value & ARGBRedMask) >> ARGBRedShift);
 
-        public byte G => (byte)((Value >> ARGBGreenShift) & 0xFF);
+        public byte G => (byte)(((uint)Value & ARGBGreenMask) >> ARGBGreenShift);
 
-        public byte B => (byte)((Value >> ARGBBlueShift) & 0xFF);
+        public byte B => (byte)(((uint)Value & ARGBBlueMask) >> ARGBBlueShift);
 
-        public byte A => (byte)((Value >> ARGBAlphaShift) & 0xFF);
+        public byte A => (byte)(((uint)Value & ARGBAlphaMask) >> ARGBAlphaShift);
 
         public bool IsKnownColor => (state & StateKnownColorValid) != 0;
 
@@ -477,10 +480,10 @@ namespace System.Drawing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void GetRgbValues(out int r, out int g, out int b)
         {
-            int value = unchecked((int)Value);
-            r = value >> ARGBRedShift & 0xFF;
-            g = value >> ARGBGreenShift & 0xFF;
-            b = value >> ARGBBlueShift & 0xFF;
+            uint value = (uint)Value;
+            r = (int)(value & ARGBRedMask) >> ARGBRedShift;
+            g = (int)(value & ARGBGreenMask) >> ARGBGreenShift;
+            b = (int)(value & ARGBBlueMask) >> ARGBBlueShift;
         }
 
         public float GetBrightness()

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -364,13 +364,13 @@ namespace System.Drawing
 
         public byte A => (byte)((Value >> ARGBAlphaShift) & 0xFF);
 
-        public bool IsKnownColor => ((state & StateKnownColorValid) != 0);
+        public bool IsKnownColor => (state & StateKnownColorValid) != 0;
 
         public bool IsEmpty => state == 0;
 
         public bool IsNamedColor => ((state & StateNameValid) != 0) || IsKnownColor;
 
-        public bool IsSystemColor => IsKnownColor && ((((KnownColor) knownColor) <= KnownColor.WindowText) || (((KnownColor) knownColor) > KnownColor.YellowGreen));
+        public bool IsSystemColor => IsKnownColor && (((KnownColor)knownColor <= KnownColor.WindowText) || ((KnownColor)knownColor > KnownColor.YellowGreen));
 
         // Not localized because it's only used for the DebuggerDisplayAttribute, and the values are
         // programmatic items.
@@ -464,11 +464,9 @@ namespace System.Drawing
         public static Color FromName(string name)
         {
             // try to get a known color first
-            Color color;
-            if (ColorTable.TryGetNamedColor(name, out color))
-            {
+            if (ColorTable.TryGetNamedColor(name, out Color color))
                 return color;
-            }
+
             // otherwise treat it as a named color
             return new Color(NotDefinedValue, StateNameValid, name, (KnownColor)0);
         }
@@ -543,7 +541,7 @@ namespace System.Drawing
 
         public override string ToString()
         {
-            if ((state & StateNameValid) != 0 || (state & StateKnownColorValid) != 0)
+            if (IsNamedColor)
             {
                 return nameof(Color) + " [" + Name + "]";
             }
@@ -565,7 +563,7 @@ namespace System.Drawing
 
         public static bool operator !=(Color left, Color right) => !(left == right);
 
-        public override bool Equals(object obj) => obj is Color && Equals((Color)obj);
+        public override bool Equals(object obj) => obj is Color other && Equals(other);
 
         public bool Equals(Color other) => this == other;
 

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -421,20 +421,14 @@ namespace System.Drawing
             }
         }
 
-        private static void ThrowOutOfByteRange(int value, string name) =>
-            throw new ArgumentException(SR.Format(SR.InvalidEx2BoundArgument, name, value, byte.MinValue, byte.MaxValue));
-
         private static void CheckByte(int value, string name)
         {
+            void ThrowOutOfByteRange(int v, string n) =>
+                throw new ArgumentException(SR.Format(SR.InvalidEx2BoundArgument, n, v, byte.MinValue, byte.MaxValue));
+
             if (unchecked((uint)value) > byte.MaxValue)
                 ThrowOutOfByteRange(value, name);
         }
-
-        private static uint MakeArgb(byte alpha, byte red, byte green, byte blue) =>
-            unchecked((uint)(red << ARGBRedShift |
-                green << ARGBGreenShift |
-                blue << ARGBBlueShift |
-                alpha << ARGBAlphaShift));
 
         private static Color FromArgb(uint argb) => new Color(argb, StateARGBValueValid, null, (KnownColor)0);
 
@@ -447,14 +441,22 @@ namespace System.Drawing
             CheckByte(green, nameof(green));
             CheckByte(blue, nameof(blue));
 
-            return FromArgb(unchecked(MakeArgb((byte)alpha, (byte)red, (byte)green, (byte)blue)));
+            return FromArgb(
+                (uint)alpha << ARGBAlphaShift |
+                (uint)red << ARGBRedShift |
+                (uint)green << ARGBGreenShift |
+                (uint)blue << ARGBBlueShift
+            );
         }
 
         public static Color FromArgb(int alpha, Color baseColor)
         {
             CheckByte(alpha, nameof(alpha));
 
-            return FromArgb(unchecked((uint)alpha << ARGBAlphaShift | ((uint)baseColor.Value & ~ARGBAlphaMask)));
+            return FromArgb(
+                (uint)alpha << ARGBAlphaShift |
+                (uint)baseColor.Value & ~ARGBAlphaMask
+            );
         }
 
         public static Color FromArgb(int red, int green, int blue) => FromArgb(byte.MaxValue, red, green, blue);
@@ -476,9 +478,9 @@ namespace System.Drawing
         private void GetRgbValues(out int r, out int g, out int b)
         {
             int value = unchecked((int)Value);
-            r = (value >> ARGBRedShift) & 0xFF;
-            g = (value >> ARGBGreenShift) & 0xFF;
-            b = (value >> ARGBBlueShift) & 0xFF;
+            r = value >> ARGBRedShift & 0xFF;
+            g = value >> ARGBGreenShift & 0xFF;
+            b = value >> ARGBBlueShift & 0xFF;
         }
 
         public float GetBrightness()

--- a/src/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.cs
@@ -429,6 +429,8 @@ namespace System.Drawing.Primitives.Tests
         [InlineData(51, 255, 51, 1f)]
         [InlineData(51, 51, 255, 1f)]
         [InlineData(51, 51, 51, 0f)]
+        [InlineData(204, 51, 51, 0.6f)]
+        [InlineData(221, 221, 204, 0.2f)]
         public void GetSaturation(int r, int g, int b, float expected)
         {
             Assert.Equal(expected, Color.FromArgb(r, g, b).GetSaturation());

--- a/src/System.Drawing.Primitives/tests/Performance/Configurations.props
+++ b/src/System.Drawing.Primitives/tests/Performance/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netcoreapp;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Drawing.Primitives/tests/Performance/Perf_Color.cs
+++ b/src/System.Drawing.Primitives/tests/Performance/Perf_Color.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Xunit.Performance;
+
+namespace System.Drawing.Tests
+{
+    public class Perf_Color : RemoteExecutorTestBase
+    {
+        public static readonly Color[] AllKnownColors;
+
+        static Perf_Color()
+        {
+            AllKnownColors = typeof(Color)
+                .GetProperties(BindingFlags.Static | BindingFlags.Public)
+                .Where(p => p.PropertyType == typeof(Color))
+                .Select(p => (Color)p.GetValue(null))
+                .ToArray();
+        }
+
+        [Benchmark(InnerIterationCount = 10_000_000)]
+        public void FromArgb_Channels()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        int val = i & 0xFF;
+                        Color.FromArgb(byte.MaxValue, val, byte.MinValue, val);
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = 10_000_000)]
+        public void FromArgb_AlphaColor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                var baseColor = Color.DarkSalmon;
+
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        Color.FromArgb(i & 0xFF, baseColor);
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = 100_000)]
+        public void GetBrightness()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                var colors = AllKnownColors;
+
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        for (int j = 0; j < colors.Length; j++)
+                        {
+                            colors[j].GetBrightness();
+                        }
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = 100_000)]
+        public void GetHue()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                var colors = AllKnownColors;
+
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        for (int j = 0; j < colors.Length; j++)
+                        {
+                            colors[j].GetHue();
+                        }
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = 100_000)]
+        public void GetSaturation()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                var colors = AllKnownColors;
+
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        for (int j = 0; j < colors.Length; j++)
+                        {
+                            colors[j].GetSaturation();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Primitives/tests/Performance/System.Drawing.Primitives.Performance.Tests.csproj
+++ b/src/System.Drawing.Primitives/tests/Performance/System.Drawing.Primitives.Performance.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
+    <ProjectGuid>{1BD5C9BF-D7F2-4249-AA31-43B1850A5DB3}</ProjectGuid>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Perf_Color.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CommonPath)\..\perf\PerfRunner\PerfRunner.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>PerfRunner</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
As evidenced by https://github.com/dotnet/corefx/issues/31820, some apps make a huge number of calls to the `Color` methods.  This change optimizes the `Color` factory and HSB/HSL methods to make those apps somewhat less slow.

``` ini

BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17134.228 (1803/April2018Update/Redstone4)
Intel Xeon CPU E3-1505M v6 3.00GHz, 1 CPU, 8 logical and 4 physical cores
Frequency=2929686 Hz, Resolution=341.3335 ns, Timer=TSC
.NET Core SDK=2.1.400
  [Host] : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  before : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  after  : .NET Core ? (CoreCLR 4.6.26816.0, CoreFX 4.6.26816.0), 64bit RyuJIT

Jit=RyuJit  Platform=X64  Toolchain=Default  

```
|            Method |    Job |       Mean |     Error |    StdDev | Scaled |
|------------------ |------- |-----------:|----------:|----------:|-------:|
| FromArgb(A,Color) | before | 3,413.7 ns | 26.012 ns | 24.332 ns |   1.00 |
| FromArgb(A,Color) |  after | 1,047.6 ns |  7.910 ns |  7.399 ns |   0.31 |
|                   |        |            |           |           |        |
| FromArgb(A,R,G,B) | before | 2,974.0 ns | 22.484 ns | 21.031 ns |   1.00 |
| FromArgb(A,R,G,B) |  after |   797.6 ns |  5.037 ns |  4.465 ns |   0.27 |
|                   |        |            |           |           |        |
|    FromArgb(ARGB) | before |   316.5 ns |  2.405 ns |  2.250 ns |   1.00 |
|    FromArgb(ARGB) |  after |   316.6 ns |  2.325 ns |  2.175 ns |   1.00 |
|                   |        |            |           |           |        |
|     GetBrightness | before | 3,011.9 ns | 26.623 ns | 20.786 ns |   1.00 |
|     GetBrightness |  after |   975.6 ns | 19.204 ns | 21.345 ns |   0.32 |
|                   |        |            |           |           |        |
|            GetHue | before | 5,585.2 ns | 23.481 ns | 20.815 ns |   1.00 |
|            GetHue |  after | 1,288.7 ns | 15.075 ns | 14.101 ns |   0.23 |
|                   |        |            |           |           |        |
|     GetSaturation | before | 2,794.9 ns | 28.432 ns | 25.205 ns |   1.00 |
|     GetSaturation |  after | 1,198.2 ns | 17.657 ns | 15.652 ns |   0.43 |

The HSB methods have slightly different behavior in that they keep the values in fixed-point for as long as possible.  The old logic converted to float immediately, which results in slightly lower precision.  For example, `Color.DarkOliveGreen.GetHue()` returns 81.99999 under the old implementation but returns the more correct value of 82 in the new.  `Color.FromArgb(255, 255, 18).GetBrightness() == Color.FromArgb(137, 137, 136).GetBrightness()` evaluates to false in the old implementation but is (correctly) true in the new.  No differences are greater than that caused by the increased precision.

Times are based on [this](https://gist.github.com/saucecontrol/e8911e8db288a1b74897ef976b2c8c33) benchmark code.