### PR TITLE
Adding the ability to build a NETStandard test suite

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -179,7 +179,7 @@
   <!-- set properties for each vertical -->
   <PropertyGroup>
     <BuildingNETCoreAppVertical Condition="'$(BuildingNETCoreAppVertical)' == '' AND ('$(_bc_TargetGroup)'=='netcoreapp' OR '$(_bc_TargetGroup)'=='netcoreappaot' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETCoreAppVertical>
-	<BuildingNETStandardVertical Condition="'$(BuildingNETStandardVertical)' == '' AND ('$(_bc_TargetGroup)'=='netstandard' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETStandardVertical>
+    <BuildingNETStandardVertical Condition="'$(BuildingNETStandardVertical)' == '' AND ('$(_bc_TargetGroup)'=='netstandard' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETStandardVertical>
     <BuildingNETFxVertical Condition="'$(BuildingNETFxVertical)' == '' AND ('$(_bc_TargetGroup)'=='netfx' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETFxVertical>
     <BuildingUAPVertical Condition="'$(BuildingUAPVertical)' == '' AND ('$(_bc_TargetGroup)'=='uap' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingUAPVertical>
     <BuildingUAPAOTVertical Condition="'$(BuildingUAPAOTVertical)' == '' AND ('$(_bc_TargetGroup)'=='uapaot' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingUAPAOTVertical>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -179,6 +179,7 @@
   <!-- set properties for each vertical -->
   <PropertyGroup>
     <BuildingNETCoreAppVertical Condition="'$(BuildingNETCoreAppVertical)' == '' AND ('$(_bc_TargetGroup)'=='netcoreapp' OR '$(_bc_TargetGroup)'=='netcoreappaot' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETCoreAppVertical>
+	<BuildingNETStandardVertical Condition="'$(BuildingNETStandardVertical)' == '' AND ('$(_bc_TargetGroup)'=='netstandard' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETStandardVertical>
     <BuildingNETFxVertical Condition="'$(BuildingNETFxVertical)' == '' AND ('$(_bc_TargetGroup)'=='netfx' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETFxVertical>
     <BuildingUAPVertical Condition="'$(BuildingUAPVertical)' == '' AND ('$(_bc_TargetGroup)'=='uap' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingUAPVertical>
     <BuildingUAPAOTVertical Condition="'$(BuildingUAPAOTVertical)' == '' AND ('$(_bc_TargetGroup)'=='uapaot' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingUAPAOTVertical>
@@ -304,6 +305,7 @@
     <UAPAOTPackageRuntimePath>$(BinDir)pkg\uapaot\lib</UAPAOTPackageRuntimePath>
     <NetFxPackageRefPath>$(BinDir)pkg\netfx\ref</NetFxPackageRefPath>
     <NetFxPackageRuntimePath>$(BinDir)pkg\netfx\lib</NetFxPackageRuntimePath>
+    <NETStandardTestSuiteOutputPath>$(BinDir)NetStandardTestSuite\</NETStandardTestSuiteOutputPath>
 
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
     <BinPlaceTestSharedFramework Condition="'$(_bc_TargetGroup)' == 'netcoreapp' AND '$(BuildTests)'!='false'">true</BinPlaceTestSharedFramework>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -84,6 +84,11 @@
       <RuntimePath>$(TestHostRootPath)</RuntimePath>
     </BinPlaceConfiguration>
 
+    <!-- binplace netstandard test suite -->
+    <BinPlaceConfiguration Condition="'$(BuildingNETStandardVertical)' == 'true' AND '$(IsTestProject)' == 'true'" Include="netstandard-$(_bc_OSGroup)">
+      <TestPath>$(NETStandardTestSuiteOutputPath)$(AssemblyName)/</TestPath>
+    </BinPlaceConfiguration>
+
     <!-- binplace targeting packs which may be different from BuildConfiguration -->
     <BinPlaceConfiguration Include="netstandard">
       <RefPath>$(RefRootPath)netstandard/</RefPath>

--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -53,6 +53,7 @@ simpleNode('windows.10.amd64.clientrs4.devex.open') {
             bat ".\\build-tests.cmd ${framework} -buildArch=${params.AGroup} -${params.CGroup}${additionalArgs} -- /p:RuntimeOS=win10 /p:ArchiveTests=${archiveTests} /p:EnableDumpling=true"
         }
         else {
+            bat ".\\build-tests.cmd -framework:netstandard -buildArch=${params.AGroup} -${params.CGroup} -SkipTests"
             bat ".\\build-tests.cmd ${framework} -${params.CGroup}${additionalArgs}"
         }
     }

--- a/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace System.IO.Pipelines.Tests
 {
-    public class PipelineReaderWriterFacts : IDisposable
+    public partial class PipelineReaderWriterFacts : IDisposable
     {
         public PipelineReaderWriterFacts()
         {
@@ -150,42 +150,6 @@ namespace System.IO.Pipelines.Tests
             ReadOnlySequence<byte> buffer = result.Buffer;
 
             _pipe.Reader.Complete();
-        }
-
-        [Fact]
-        public async Task ResetAfterCompleteReaderAndWriterWithoutAdvancingClearsEverything()
-        {
-            _pipe.Writer.WriteEmpty(4094);
-            _pipe.Writer.WriteEmpty(4094);
-            await _pipe.Writer.FlushAsync();
-            ReadResult result = await _pipe.Reader.ReadAsync();
-            ReadOnlySequence<byte> buffer = result.Buffer;
-
-            SequenceMarshal.TryGetReadOnlySequenceSegment(
-                buffer,
-                out ReadOnlySequenceSegment<byte> start,
-                out int startIndex,
-                out ReadOnlySequenceSegment<byte> end,
-                out int endIndex);
-
-            var startSegment = (BufferSegment)start;
-            var endSegment = (BufferSegment)end;
-            Assert.NotNull(startSegment.MemoryOwner);
-            Assert.NotNull(endSegment.MemoryOwner);
-
-            _pipe.Reader.Complete();
-
-            // Nothing cleaned up
-            Assert.NotNull(startSegment.MemoryOwner);
-            Assert.NotNull(endSegment.MemoryOwner);
-
-            _pipe.Writer.Complete();
-
-            // Should be cleaned up now
-            Assert.Null(startSegment.MemoryOwner);
-            Assert.Null(endSegment.MemoryOwner);
-
-            _pipe.Reset();
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.nonnetstandard.cs
+++ b/src/System.IO.Pipelines/tests/PipeReaderWriterFacts.nonnetstandard.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipelines.Tests
+{
+    public partial class PipelineReaderWriterFacts : IDisposable
+    {
+        [Fact]
+        public async Task ResetAfterCompleteReaderAndWriterWithoutAdvancingClearsEverything()
+        {
+           _pipe.Writer.WriteEmpty(4094);
+           _pipe.Writer.WriteEmpty(4094);
+           await _pipe.Writer.FlushAsync();
+           ReadResult result = await _pipe.Reader.ReadAsync();
+           ReadOnlySequence<byte> buffer = result.Buffer;
+
+           SequenceMarshal.TryGetReadOnlySequenceSegment(
+               buffer,
+               out ReadOnlySequenceSegment<byte> start,
+               out int startIndex,
+               out ReadOnlySequenceSegment<byte> end,
+               out int endIndex);
+
+           var startSegment = (BufferSegment)start;
+           var endSegment = (BufferSegment)end;
+           Assert.NotNull(startSegment.MemoryOwner);
+           Assert.NotNull(endSegment.MemoryOwner);
+
+           _pipe.Reader.Complete();
+
+           // Nothing cleaned up
+           Assert.NotNull(startSegment.MemoryOwner);
+           Assert.NotNull(endSegment.MemoryOwner);
+
+           _pipe.Writer.Complete();
+
+           // Should be cleaned up now
+           Assert.Null(startSegment.MemoryOwner);
+           Assert.Null(endSegment.MemoryOwner);
+
+           _pipe.Reset();
+        }
+    }
+}

--- a/src/System.IO.Pipelines/tests/PipeResetTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeResetTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.IO.Pipelines.Tests
 {
-    public class PipeResetTests : IDisposable
+    public partial class PipeResetTests : IDisposable
     {
         public PipeResetTests()
         {
@@ -26,21 +26,6 @@ namespace System.IO.Pipelines.Tests
         private readonly TestMemoryPool _pool;
 
         private readonly Pipe _pipe;
-
-        [Fact]
-        public async Task LengthIsReseted()
-        {
-            var source = new byte[] { 1, 2, 3 };
-
-            await _pipe.Writer.WriteAsync(source);
-
-            _pipe.Reader.Complete();
-            _pipe.Writer.Complete();
-
-            _pipe.Reset();
-
-            Assert.Equal(0, _pipe.Length);
-        }
 
         [Fact]
         public async Task ReadsAndWritesAfterReset()

--- a/src/System.IO.Pipelines/tests/PipeResetTests.nonnetstandard.cs
+++ b/src/System.IO.Pipelines/tests/PipeResetTests.nonnetstandard.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipelines.Tests
+{
+    public partial class PipeResetTests : IDisposable
+    {
+        [Fact]
+        public async Task LengthIsReseted()
+        {
+           var source = new byte[] { 1, 2, 3 };
+
+           await _pipe.Writer.WriteAsync(source);
+
+           _pipe.Reader.Complete();
+           _pipe.Writer.Complete();
+
+           _pipe.Reset();
+
+           Assert.Equal(0, _pipe.Length);
+        }
+    }
+}

--- a/src/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
+++ b/src/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
     <!-- Some internal types are needed, so we reference the implementation assembly, rather than the reference assembly. -->
     <TargetingPackExclusions Include="System.IO.Pipelines" />
     <ReferenceFromRuntime Include="System.IO.Pipelines" />
@@ -15,7 +15,6 @@
     <Compile Include="FlushAsyncCompletionTests.cs" />
     <Compile Include="FlushResultTests.cs" />
     <Compile Include="PipeCompletionCallbacksTests.cs" />
-    <Compile Include="PipeLengthTests.cs" />
     <Compile Include="PipeOptionsTests.cs" />
     <Compile Include="PipeReaderWriterFacts.cs" />
     <Compile Include="PipePoolTests.cs" />
@@ -27,5 +26,10 @@
     <Compile Include="ReadResultTests.cs" />
     <Compile Include="SchedulerFacts.cs" />
     <Compile Include="TestMemoryPool.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
+    <Compile Include="PipeLengthTests.cs" />
+    <Compile Include="PipeReaderWriterFacts.nonnetstandard.cs" />
+    <Compile Include="PipeResetTests.nonnetstandard.cs" />
   </ItemGroup>
 </Project>

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -25,6 +25,13 @@
   <Import Project="$(ToolsDir)tests.targets" Condition="Exists('$(ToolsDir)tests.targets')" />
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
 
+  <Target Name="BinPlaceXUnitRuntimeForNetstandardSuite" Condition="'$(TargetGroup)' == 'netstandard'" BeforeTargets="BuildAllProjects">
+    <!-- Ensure that we binplace all of the xunit assemblies on the netstandard runtime path in order to be able to build netstandard test suite -->
+    <MSBuild Projects="$(MSBuildThisFileDirectory)../external/test-runtime/XUnit.Runtime.depproj"
+             Properties="TargetGroup=$(TargetGroup)"
+             ContinueOnError="ErrorAndStop" />
+  </Target>
+
   <PropertyGroup>
     <_ProjectPattern Condition="'$(Performance)' != 'true'">.Tests</_ProjectPattern>
     <_ProjectPattern Condition="'$(Performance)' == 'true'">.Performance.Tests</_ProjectPattern>


### PR DESCRIPTION
Fixing no. 1 item of issue #30729

With the changes on this PR we will now be able to produce a Netstandard Test suite that we can share to other frameworks that support NETStandard so that they are consistent with the expected behavior.

cc: @weshaggard @danmosemsft @ericstj 

I'll add one more commit to this PR to add a CI that will build the netstandard test suite so that we ensure that netstandard test configurations won't get broken.