### PR TITLE
[Release/2.2] Handle Rename of m_provider to m_etwProvider in EventSource

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
@@ -50,6 +50,10 @@ namespace BasicEventSourceTests
             using (var es = new LifetimeTestEventSource())
             {
                 FieldInfo field = es.GetType().GetTypeInfo().BaseType.GetField("m_provider", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if(field == null)
+                {
+                    field = es.GetType().GetTypeInfo().BaseType.GetField("m_etwProvider", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                }
                 object provider = field.GetValue(es);
                 wrProvider.Target = provider;
                 wrEventSource.Target = es;


### PR DESCRIPTION
Fix EventSource test that does private reflection on a member in EventSource whose name is changing as part of dotnet/coreclr#18217.