### PR TITLE
[2.1]  Fix ReadAsync not returning when cancellation token fires during FlushAsync

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -304,6 +304,19 @@ namespace System.IO.Pipelines
                 // AttachToken before completing reader awaiter in case cancellationToken is already completed
                 cancellationTokenRegistration = _writerAwaitable.AttachToken(cancellationToken, s_signalWriterAwaitable, this);
 
+                // If the writer is completed (which it will be most of the time) then return a completed ValueTask
+                if (_writerAwaitable.IsCompleted)
+                {
+                    var flushResult = new FlushResult();
+                    GetFlushResult(ref flushResult);
+                    result = new ValueTask<FlushResult>(flushResult);
+                }
+                else
+                {
+                    // Otherwise it's async
+                    result = new ValueTask<FlushResult>(_writer, token: 0);
+                }
+
                 // Complete reader only if new data was pushed into the pipe
                 if (!wasEmpty)
                 {
@@ -317,19 +330,6 @@ namespace System.IO.Pipelines
                 // I couldn't find a way for flush to induce backpressure deadlock
                 // if it always adds new data to pipe and wakes up the reader but assert anyway
                 Debug.Assert(_writerAwaitable.IsCompleted || _readerAwaitable.IsCompleted);
-
-                // If the writer is completed (which it will be most of the time) the return a completed ValueTask
-                if (_writerAwaitable.IsCompleted)
-                {
-                    var flushResult = new FlushResult();
-                    GetFlushResult(ref flushResult);
-                    result = new ValueTask<FlushResult>(flushResult);
-                }
-                else
-                {
-                    // Otherwise it's async
-                    result = new ValueTask<FlushResult>(_writer, token: 0);
-                }
             }
 
             cancellationTokenRegistration.Dispose();

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -401,7 +401,7 @@ namespace System.IO.Pipelines.Tests
                 }
             });
 
-            Assert.True(Task.WaitAll(new [] { writer, reader, canceller }, TimeSpan.FromSeconds(30)), "Reader was not completed in reasonable time");
+            Assert.True(Task.WaitAll(new [] { writer, reader, canceller }, TimeSpan.FromMinutes(5)), "Reader was not completed in 5 minutes");
             Assert.True(cancellations > 0);
         }
     }

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -373,18 +373,19 @@ namespace System.IO.Pipelines.Tests
                     var readTask = Pipe.Reader.ReadAsync();
 
                     // Signal writer to initiate a flush
-                    if (!readTask.IsCompleted)
+                    if (!readTask.IsCompleted || readTask.Result.IsCompleted)
                     {
                         resetEvent.Set();
                     }
 
                     var result = await readTask;
-                    resetEvent.Reset();
 
                     if (result.Buffer.IsEmpty)
                     {
                         return;
                     }
+
+                    resetEvent.Reset();
 
                     Pipe.Reader.AdvanceTo(result.Buffer.End);
                 }
@@ -394,6 +395,7 @@ namespace System.IO.Pipelines.Tests
             {
                 while (!writer.IsCompleted)
                 {
+                    resetEvent.WaitOne();
                     cancellationTokenSource.Cancel();
                 }
             });

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -325,6 +325,81 @@ namespace System.IO.Pipelines.Tests
             Assert.True(task.IsCompleted);
             Assert.True(task.Result.IsCompleted);
         }
+
+        [Fact]
+        public void ReadAsyncCompletesIfFlushAsyncCanceledMidFlush()
+        {
+            // This test tries to get pipe into a state where ReadAsync is being awaited
+            // and FlushAsync is cancelled while the method is running
+            Pipe = new Pipe();
+            var resetEvent = new ManualResetEvent(false);
+
+            var cancellationTokenSource = new CancellationTokenSource();
+            var writer = Task.Run(async () =>
+            {
+                var cancellations = 0;
+                while (cancellations < 20)
+                {
+                    try
+                    {
+                        // We want reader to be awaiting
+                        resetEvent.WaitOne();
+                        Pipe.Writer.WriteEmpty(1);
+
+                        // We want the token to be cancelled during FlushAsync call
+                        // check it it's already cancelled and try a new one
+                        if (cancellationTokenSource.Token.IsCancellationRequested)
+                        {
+                            cancellationTokenSource = new CancellationTokenSource();
+                            continue;
+                        }
+
+                        await Pipe.Writer.FlushAsync(cancellationTokenSource.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        cancellations ++;
+                    }
+                }
+
+                Pipe.Writer.Complete();
+                return;
+            });
+
+            var reader = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    var readTask = Pipe.Reader.ReadAsync();
+
+                    // Signal writer to initiate a flush
+                    if (!readTask.IsCompleted)
+                    {
+                        resetEvent.Set();
+                    }
+
+                    var result = await readTask;
+                    resetEvent.Reset();
+
+                    if (result.Buffer.IsEmpty)
+                    {
+                        return;
+                    }
+
+                    Pipe.Reader.AdvanceTo(result.Buffer.End);
+                }
+            });
+
+            var canceller = Task.Run(() =>
+            {
+                while (!writer.IsCompleted)
+                {
+                    cancellationTokenSource.Cancel();
+                }
+            });
+
+            Assert.True(Task.WaitAll(new [] { writer, reader, canceller }, TimeSpan.FromSeconds(30)), "Reader was not completed in reasonable time");
+        }
     }
 
     public static class TestWriterExtensions


### PR DESCRIPTION
Fixes: #31201

Ports:

Main Fix
https://github.com/dotnet/corefx/pull/31212

Making test less flaky:
https://github.com/dotnet/corefx/pull/31745
https://github.com/dotnet/corefx/pull/31653
https://github.com/dotnet/corefx/pull/31365