### PR TITLE
Remove old Interop.Kernel32.GetVolumeInformation overload

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetVolumeInformation.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetVolumeInformation.cs
@@ -10,9 +10,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        internal static extern bool GetVolumeInformation(string drive, [Out]StringBuilder volumeName, int volumeNameBufLen, out int volSerialNumber, out int maxFileNameLen, out int fileSystemFlags, [Out]StringBuilder fileSystemName, int fileSystemNameBufLen);
-
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
         internal static unsafe extern bool GetVolumeInformation(string drive, char* volumeName, int volumeNameBufLen, int* volSerialNumber, int* maxFileNameLen, out int fileSystemFlags, char* fileSystemName, int fileSystemNameBufLen);
 
         internal const uint FILE_SUPPORTS_ENCRYPTION = 0x00020000;

--- a/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
+++ b/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>System.IO.FileSystem.DriveInfo</RootNamespace>
     <AssemblyName>System.IO.FileSystem.DriveInfo</AssemblyName>
@@ -35,6 +35,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetDiskFreeSpaceEx.cs">
       <Link>Common\Interop\Windows\Interop.GetDiskFreeSpaceEx.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.MaxLengths.cs">
+      <Link>Common\Interop\Windows\Interop.MaxLengths.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetVolumeLabel.cs">
       <Link>Common\Interop\Windows\Interop.SetVolumeLabel.cs</Link>
     </Compile>
@@ -52,6 +55,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\Interop.FormatMessage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\System\IO\DisableMediaInsertionPrompt.cs">
+      <Link>Common\System\IO\DisableMediaInsertionPrompt.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\System\IO\Win32Marshal.cs">
       <Link>Common\CoreLib\System\IO\Win32Marshal.cs</Link>

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
@@ -131,12 +131,7 @@ namespace System.IO
                 {
                     if (!Interop.Kernel32.GetVolumeInformation(Name, volumeName, Interop.Kernel32.MAX_PATH + 1, null, null, out int fileSystemFlags, null, 0))
                     {
-                        int errorCode = Marshal.GetLastWin32Error();
-                        // Win9x appears to return ERROR_INVALID_DATA when a
-                        // drive doesn't exist.
-                        if (errorCode == Interop.Errors.ERROR_INVALID_DATA)
-                            errorCode = Interop.Errors.ERROR_INVALID_DRIVE;
-                        throw Error.GetExceptionForWin32DriveError(errorCode, Name);
+                        throw Error.GetExceptionForWin32DriveError(Name);
                     }
                 }
 

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
@@ -25,32 +25,20 @@ namespace System.IO
             }
         }
 
-        public string DriveFormat
+        public unsafe string DriveFormat
         {
             get
             {
-                const int volNameLen = 50;
-                StringBuilder volumeName = new StringBuilder(volNameLen);
-                const int fileSystemNameLen = 50;
-                StringBuilder fileSystemName = new StringBuilder(fileSystemNameLen);
-                int serialNumber, maxFileNameLen, fileSystemFlags;
+                char* fileSystemName = stackalloc char[Interop.Kernel32.MAX_PATH + 1];
 
-                uint oldMode;
-                bool success = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
-                try
+                using (DisableMediaInsertionPrompt.Create())
                 {
-                    bool r = Interop.Kernel32.GetVolumeInformation(Name, volumeName, volNameLen, out serialNumber, out maxFileNameLen, out fileSystemFlags, fileSystemName, fileSystemNameLen);
-                    if (!r)
+                    if (!Interop.Kernel32.GetVolumeInformation(Name, null, 0, null, null, out int fileSystemFlags, fileSystemName, Interop.Kernel32.MAX_PATH + 1))
                     {
                         throw Error.GetExceptionForLastWin32DriveError(Name);
                     }
                 }
-                finally
-                {
-                    if (success)
-                        Interop.Kernel32.SetThreadErrorMode(oldMode, out oldMode);
-                }
-                return fileSystemName.ToString();
+                return new string(fileSystemName);
             }
         }
 
@@ -133,24 +121,15 @@ namespace System.IO
         }
 
         // Null is a valid volume label.
-        public string VolumeLabel
+        public unsafe string VolumeLabel
         {
             get
             {
-                // NTFS uses a limit of 32 characters for the volume label,
-                // as of Windows Server 2003.
-                const int volNameLen = 50;
-                StringBuilder volumeName = new StringBuilder(volNameLen);
-                const int fileSystemNameLen = 50;
-                StringBuilder fileSystemName = new StringBuilder(fileSystemNameLen);
-                int serialNumber, maxFileNameLen, fileSystemFlags;
+                char* volumeName = stackalloc char[Interop.Kernel32.MAX_PATH + 1];
 
-                uint oldMode;
-                bool success = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
-                try
+                using (DisableMediaInsertionPrompt.Create())
                 {
-                    bool r = Interop.Kernel32.GetVolumeInformation(Name, volumeName, volNameLen, out serialNumber, out maxFileNameLen, out fileSystemFlags, fileSystemName, fileSystemNameLen);
-                    if (!r)
+                    if (!Interop.Kernel32.GetVolumeInformation(Name, volumeName, Interop.Kernel32.MAX_PATH + 1, null, null, out int fileSystemFlags, null, 0))
                     {
                         int errorCode = Marshal.GetLastWin32Error();
                         // Win9x appears to return ERROR_INVALID_DATA when a
@@ -160,12 +139,8 @@ namespace System.IO
                         throw Error.GetExceptionForWin32DriveError(errorCode, Name);
                     }
                 }
-                finally
-                {
-                    if (success)
-                        Interop.Kernel32.SetThreadErrorMode(oldMode, out oldMode);
-                }
-                return volumeName.ToString();
+
+                return new string(volumeName);
             }
             set
             {

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
@@ -131,7 +131,7 @@ namespace System.IO
                 {
                     if (!Interop.Kernel32.GetVolumeInformation(Name, volumeName, Interop.Kernel32.MAX_PATH + 1, null, null, out int fileSystemFlags, null, 0))
                     {
-                        throw Error.GetExceptionForWin32DriveError(Name);
+                        throw Error.GetExceptionForLastWin32DriveError(Name);
                     }
                 }
 


### PR DESCRIPTION
closes https://github.com/dotnet/corefx/issues/31867

/cc @JeremyKuhne @pjanotti @krwq 