### PR TITLE
Allow RtlGetVersion to be called in uapaot scenario

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -235,7 +235,7 @@ namespace System
             out int pdwReturnedProductType
         );
 
-        [DllImport("ntdll.dll")]
+        [DllImport("ntdll.dll", ExactSpelling=true)]
         private static extern int RtlGetVersion(out RTL_OSVERSIONINFOEX lpVersionInformation);
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
After we turn useDefaultPInvoke to false, all pinvoke that is not in the known list for UWP will be translated into a throw. That is not what we want for RtlGetVersion. Using ExactSpelling=true will change the behavior and allow the API to be called.