### PR TITLE
client side ALPN for OSX

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -37,7 +37,7 @@ internal static partial class Interop
         private static readonly IntPtr[] s_cfAlpnHttp211Protocol = new IntPtr[] { s_cfHttp2Str.DangerousGetHandle(), s_cfHttp11Str.DangerousGetHandle() };
 
         private static readonly SafeCreateHandle s_cfAlpnHttp11Protocols = CoreFoundation.CFArrayCreate(s_cfAlpnHttp11Protocol, (UIntPtr)1);
-        private static readonly SafeCreateHandle s_cfAlpnHttp2Protocols = CoreFoundation.CFArrayCreate(s_cfAlpnHttp2Protocol , (UIntPtr)1);
+        private static readonly SafeCreateHandle s_cfAlpnHttp2Protocols = CoreFoundation.CFArrayCreate(s_cfAlpnHttp2Protocol, (UIntPtr)1);
         private static readonly SafeCreateHandle s_cfAlpnHttp211Protocols = CoreFoundation.CFArrayCreate(s_cfAlpnHttp211Protocol , (UIntPtr)2);
 
         internal enum PAL_TlsHandshakeState
@@ -591,10 +591,10 @@ internal static partial class Interop
         internal static unsafe void SslCtxSetAlpnProtos(SafeSslHandle ctx, List<SslApplicationProtocol> protocols)
         {
             SafeCreateHandle cfProtocolsRefs = null;
-            SafeCreateHandle[] cfProtocolRefs = null;
+            SafeCreateHandle[] cfProtocolsArrayRef = null;
             try
             {
-               if (protocols.Count == 1 && protocols[0] == SslApplicationProtocol.Http2)
+                if (protocols.Count == 1 && protocols[0] == SslApplicationProtocol.Http2)
                 {
                     cfProtocolsRefs = s_cfAlpnHttp211Protocols;
                 }
@@ -609,13 +609,13 @@ internal static partial class Interop
                 else
                 {
                     // we did not match common case. This is more expensive path allocating Core Foundation objects.
-                    cfProtocolRefs = new  SafeCreateHandle[protocols.Count];
-                    IntPtr[] protocolsPtr = new  System.IntPtr[protocols.Count];
+                    cfProtocolsArrayRef = new SafeCreateHandle[protocols.Count];
+                    IntPtr[] protocolsPtr = new System.IntPtr[protocols.Count];
 
                     for (int i = 0; i < protocols.Count; i++)
                     {
-                        cfProtocolRefs[i] = CoreFoundation.CFStringCreateWithCString(protocols[i].ToString());
-                        protocolsPtr[i] = cfProtocolRefs[i].DangerousGetHandle();
+                        cfProtocolsArrayRef[i] = CoreFoundation.CFStringCreateWithCString(protocols[i].ToString());
+                        protocolsPtr[i] = cfProtocolsArrayRef[i].DangerousGetHandle();
                     }
 
                     cfProtocolsRefs = CoreFoundation.CFArrayCreate(protocolsPtr, (UIntPtr)protocols.Count);
@@ -630,11 +630,11 @@ internal static partial class Interop
             }
             finally
             {
-                if (cfProtocolRefs != null)
+                if (cfProtocolsArrayRef != null)
                 {
-                    for (int i = 0; i < cfProtocolRefs.Length ; i++)
+                    for (int i = 0; i < cfProtocolsArrayRef.Length ; i++)
                     {
-                        cfProtocolRefs[i]?.Dispose();
+                        cfProtocolsArrayRef[i]?.Dispose();
                     }
 
                     cfProtocolsRefs?.Dispose();

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -42,6 +42,7 @@ namespace System
     {
         public static bool IsReflectionEmitSupported;
         public static bool SupportsAlpn { get { throw null; } }
+        public static bool SupportsClientAlpn { get { throw null; } }
         public static bool ClientWebSocketPartialMessagesSupported { get { throw null; } }
         public static bool HasWindowsShell { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -50,6 +50,8 @@ namespace System
         public static bool SupportsAlpn => (IsWindows && !IsWindows7) ||
             (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
             (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
+        public static bool SupportsClientAlpn => SupportsAlpn ||
+            (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && PlatformDetection.OSXVersion > new Version(10, 12));
 
         // Officially, .Net Native only supports processes running in an AppContainer. However, the majority of tests still work fine
         // in a normal Win32 process and we often do so as running in an AppContainer imposes a substantial tax in debuggability

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -159,7 +159,7 @@ int32_t AppleCryptoNative_SslSetTargetName(SSLContextRef sslContext,
     return *pOSStatus == noErr;
 }
 
-DLLEXPORT int32_t AppleCryptoNative_SSLSetALPNProtocols(SSLContextRef sslContext,
+int32_t AppleCryptoNative_SSLSetALPNProtocols(SSLContextRef sslContext,
                                                         CFArrayRef protocols,
                                                         int32_t* pOSStatus)
 {
@@ -177,7 +177,7 @@ DLLEXPORT int32_t AppleCryptoNative_SSLSetALPNProtocols(SSLContextRef sslContext
     return *pOSStatus == noErr;
 }
 
-DLLEXPORT int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext, CFDataRef* protocol)
+int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext, CFDataRef* protocol)
 {
     if (sslContext == NULL || protocol == NULL)
         return -1;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -6,11 +6,12 @@
 #include <dlfcn.h>
 
 // 10.13.4 introduced public API but linking would fail on all prior versions.
+// For that reason we use function pointers instead of direct call.
 // This can be revisited after we drop support for 10.12.
 
 static OSStatus (*SSLSetALPNProtocolsPtr)(SSLContextRef context, CFArrayRef protocols) = NULL;
-static OSStatus (*SSLCopyALPNProtocolsPtr)(SSLContextRef context, CFArrayRef *protocols) = NULL;
-// end of private ALPN.
+static OSStatus (*SSLCopyALPNProtocolsPtr)(SSLContextRef context, CFArrayRef* protocols) = NULL;
+// end of ALPN.
 
 SSLContextRef AppleCryptoNative_SslCreateContext(int32_t isServer)
 {
@@ -68,8 +69,7 @@ int32_t AppleCryptoNative_SslSetMaxProtocolVersion(SSLContextRef sslContext, PAL
     return SSLSetProtocolVersionMax(sslContext, protocol);
 }
 
-int32_t
-AppleCryptoNative_SslCopyCertChain(SSLContextRef sslContext, SecTrustRef* pChainOut, int32_t* pOSStatus)
+int32_t AppleCryptoNative_SslCopyCertChain(SSLContextRef sslContext, SecTrustRef* pChainOut, int32_t* pOSStatus)
 {
     if (pChainOut != NULL)
         *pChainOut = NULL;
@@ -115,14 +115,12 @@ static int32_t AppleCryptoNative_SslSetSessionOption(SSLContextRef sslContext,
     return *pOSStatus == noErr;
 }
 
-int32_t
-AppleCryptoNative_SslSetBreakOnServerAuth(SSLContextRef sslContext, int32_t setBreak, int32_t* pOSStatus)
+int32_t AppleCryptoNative_SslSetBreakOnServerAuth(SSLContextRef sslContext, int32_t setBreak, int32_t* pOSStatus)
 {
     return AppleCryptoNative_SslSetSessionOption(sslContext, kSSLSessionOptionBreakOnServerAuth, setBreak, pOSStatus);
 }
 
-int32_t
-AppleCryptoNative_SslSetBreakOnClientAuth(SSLContextRef sslContext, int32_t setBreak, int32_t* pOSStatus)
+int32_t AppleCryptoNative_SslSetBreakOnClientAuth(SSLContextRef sslContext, int32_t setBreak, int32_t* pOSStatus)
 {
     return AppleCryptoNative_SslSetSessionOption(sslContext, kSSLSessionOptionBreakOnClientAuth, setBreak, pOSStatus);
 }
@@ -161,7 +159,9 @@ int32_t AppleCryptoNative_SslSetTargetName(SSLContextRef sslContext,
     return *pOSStatus == noErr;
 }
 
-DLLEXPORT int32_t AppleCryptoNative_SSLSetALPNProtocols(SSLContextRef sslContext, CFArrayRef protocols, int32_t* pOSStatus)
+DLLEXPORT int32_t AppleCryptoNative_SSLSetALPNProtocols(SSLContextRef sslContext,
+                                                        CFArrayRef protocols,
+                                                        int32_t* pOSStatus)
 {
     if (sslContext == NULL || protocols == NULL || pOSStatus == NULL)
         return -1;
@@ -177,7 +177,7 @@ DLLEXPORT int32_t AppleCryptoNative_SSLSetALPNProtocols(SSLContextRef sslContext
     return *pOSStatus == noErr;
 }
 
-DLLEXPORT int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext, CFDataRef *protocol)
+DLLEXPORT int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext, CFDataRef* protocol)
 {
     if (sslContext == NULL || protocol == NULL)
         return -1;
@@ -194,7 +194,8 @@ DLLEXPORT int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext,
 
     if (osStatus == noErr && protocols != NULL && CFArrayGetCount(protocols) > 0)
     {
-        *protocol = CFStringCreateExternalRepresentation(NULL, CFArrayGetValueAtIndex(protocols, 0), kCFStringEncodingASCII, 0);
+        *protocol =
+            CFStringCreateExternalRepresentation(NULL, CFArrayGetValueAtIndex(protocols, 0), kCFStringEncodingASCII, 0);
     }
 
     if (protocols)
@@ -203,8 +204,7 @@ DLLEXPORT int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext,
     return *protocol != NULL;
 }
 
-int32_t
-AppleCryptoNative_SslSetIoCallbacks(SSLContextRef sslContext, SSLReadFunc readFunc, SSLWriteFunc writeFunc)
+int32_t AppleCryptoNative_SslSetIoCallbacks(SSLContextRef sslContext, SSLReadFunc readFunc, SSLWriteFunc writeFunc)
 {
     return SSLSetIOFuncs(sslContext, readFunc, writeFunc);
 }
@@ -264,8 +264,7 @@ AppleCryptoNative_SslWrite(SSLContextRef sslContext, const uint8_t* buf, uint32_
     return PAL_TlsIo_Success;
 }
 
-PAL_TlsIo
-AppleCryptoNative_SslRead(SSLContextRef sslContext, uint8_t* buf, uint32_t bufLen, uint32_t* written)
+PAL_TlsIo AppleCryptoNative_SslRead(SSLContextRef sslContext, uint8_t* buf, uint32_t bufLen, uint32_t* written)
 {
     if (written == NULL)
         return PAL_TlsIo_Unknown;
@@ -299,8 +298,7 @@ AppleCryptoNative_SslRead(SSLContextRef sslContext, uint8_t* buf, uint32_t bufLe
     return OSStatusToPAL_TlsIo(status);
 }
 
-int32_t
-AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringRef cfHostname, CFDateRef notBefore)
+int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringRef cfHostname, CFDateRef notBefore)
 {
     if (sslContext == NULL || notBefore == NULL)
         return -1;
@@ -446,9 +444,8 @@ int32_t AppleCryptoNative_SslGetCipherSuite(SSLContextRef sslContext, uint32_t* 
     return SSLGetNegotiatedCipher(sslContext, pCipherSuiteOut);
 }
 
-__attribute__((constructor))
-static void InitializeAppleCryptoSslShim()
+__attribute__((constructor)) static void InitializeAppleCryptoSslShim()
 {
-    SSLSetALPNProtocolsPtr = (OSStatus (*)(SSLContextRef, CFArrayRef))dlsym(RTLD_DEFAULT, "SSLSetALPNProtocols");
-    SSLCopyALPNProtocolsPtr = (OSStatus (*)(SSLContextRef, CFArrayRef*))dlsym(RTLD_DEFAULT, "SSLCopyALPNProtocols");
+    SSLSetALPNProtocolsPtr = (OSStatus(*)(SSLContextRef, CFArrayRef))dlsym(RTLD_DEFAULT, "SSLSetALPNProtocols");
+    SSLCopyALPNProtocolsPtr = (OSStatus(*)(SSLContextRef, CFArrayRef*))dlsym(RTLD_DEFAULT, "SSLCopyALPNProtocols");
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
@@ -146,15 +146,12 @@ Returns 1 on success, 0 on failure, other values for invalid state.
 Output:
 pOSStatus: Receives the value from SSLSetALPNData()
 */
-DLLEXPORT int32_t AppleCryptoNative_SslCtxSetAlpnProtos(SSLContextRef sslContext,
-                                                     const uint8_t* protocols,
-                                                     int32_t len,
-                                                     int32_t* pOSStatus);
+DLLEXPORT int32_t AppleCryptoNative_SSLSetALPNProtocols(SSLContextRef sslContext, CFArrayRef protocols, int32_t* pOSStatus);
 
 /*
 Get negotiated protocol value from ServerHello.
 */
-DLLEXPORT int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext, const uint8_t** protocol, uint32_t* len);
+DLLEXPORT int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext, CFDataRef *protocol);
 
 /*
 Register the callbacks for reading and writing data to the SSL context.

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
@@ -139,6 +139,24 @@ DLLEXPORT int32_t AppleCryptoNative_SslSetTargetName(SSLContextRef sslContext,
                                                      int32_t* pOSStatus);
 
 /*
+Set list of application protocols for ClientHello.
+
+Returns 1 on success, 0 on failure, other values for invalid state.
+
+Output:
+pOSStatus: Receives the value from SSLSetALPNData()
+*/
+DLLEXPORT int32_t AppleCryptoNative_SslCtxSetAlpnProtos(SSLContextRef sslContext,
+                                                     const uint8_t* protocols,
+                                                     int32_t len,
+                                                     int32_t* pOSStatus);
+
+/*
+Get negotiated protocol value from ServerHello.
+*/
+DLLEXPORT int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext, const uint8_t** protocol, uint32_t* len);
+
+/*
 Register the callbacks for reading and writing data to the SSL context.
 
 Returns the output of SSLSetIOFuncs.

--- a/src/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -46,6 +46,15 @@ namespace System.Net
                 {
                     throw Interop.AppleCrypto.CreateExceptionForOSStatus(osStatus);
                 }
+
+                if (sslAuthenticationOptions.ApplicationProtocols != null)
+                {
+                    // On OSX coretls supports only client side. For server, we will silently ignore the option.
+                    if (!sslAuthenticationOptions.IsServer)
+                    {
+                        Interop.AppleCrypto.SslCtxSetAlpnProtos(_sslContext, sslAuthenticationOptions.ApplicationProtocols);
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -876,9 +876,12 @@ namespace System.Net.Security
             }
 
             output = outgoingSecurity.token;
-
-            byte[] alpnResult = SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
-            _negotiatedApplicationProtocol = alpnResult == null ? default : new SslApplicationProtocol(alpnResult, false);
+            if (_negotiatedApplicationProtocol == default)
+            {
+                // try to get ALPN info unless we already have it. (this function can be called multiple times)
+                byte[] alpnResult = SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
+                _negotiatedApplicationProtocol = alpnResult == null ? default : new SslApplicationProtocol(alpnResult, false);
+            }
 
             if (NetEventSource.IsEnabled)
             {

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -103,8 +103,11 @@ namespace System.Net.Security
 
         internal static byte[] GetNegotiatedApplicationProtocol(SafeDeleteContext context)
         {
-            // OSX SecureTransport does not export APIs to support ALPN, no-op.
-            return null;
+            if (context == null)
+                return null;
+
+            return Interop.AppleCrypto.SslGetAlpnSelected(((SafeDeleteSslContext)context).SslContext);
+
         }
 
         public static SecurityStatusPal EncryptMessage(

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -107,7 +107,6 @@ namespace System.Net.Security
                 return null;
 
             return Interop.AppleCrypto.SslGetAlpnSelected(((SafeDeleteSslContext)context).SslContext);
-
         }
 
         public static SecurityStatusPal EncryptMessage(

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -159,7 +159,7 @@ namespace System.Net.Security
                 }
 
                 // When the handshake is done, and the context is server, check if the alpnHandle target was set to null during ALPN.
-                // If it was, then that indiciates ALPN failed, send failure.
+                // If it was, then that indicates ALPN failed, send failure.
                 // We have this workaround, as openssl supports terminating handshake only from version 1.1.0,
                 // whereas ALPN is supported from version 1.0.2.
                 SafeSslHandle sslContext = ((SafeDeleteSslContext)context).SslContext;

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -193,7 +193,7 @@ namespace System.Net.Security.Tests
         [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(ClientSupportsAlpn))]
         [MemberData(nameof(Http2Servers))]
-        public async Task SslStream_OSX_Alpn_Success(Uri server)
+        public async Task SslStream_Http2_Alpn_Success(Uri server)
         {
             using (TcpClient client = new TcpClient())
             {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -24,6 +24,7 @@ namespace System.Net.Security.Tests
     public class SslStreamAlpnTests
     {
         private static bool BackendSupportsAlpn => PlatformDetection.SupportsAlpn;
+        private static bool ClientSupportsAlpn => PlatformDetection.SupportsClientAlpn;
         readonly ITestOutputHelper _output;
         public static readonly object[][] Http2Servers = Configuration.Http.Http2Servers;
 
@@ -190,8 +191,7 @@ namespace System.Net.Security.Tests
         }
 
         [OuterLoop("Uses external server")]
-        [PlatformSpecific(TestPlatforms.OSX)]
-        [Theory]
+        [ConditionalTheory(nameof(ClientSupportsAlpn))]
         [MemberData(nameof(Http2Servers))]
         public async Task SslStream_OSX_Alpn_Success(Uri server)
         {
@@ -204,8 +204,8 @@ namespace System.Net.Security.Tests
                     {
                         SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
                         {
-                            ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 ,  SslApplicationProtocol.Http11 },
-                            TargetHost =  server.Host
+                            ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 , SslApplicationProtocol.Http11 },
+                            TargetHost = server.Host
                         };
 
                         await clientStream.AuthenticateAsClientAsync(clientOptions, CancellationToken.None);

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Security.Tests
 {
@@ -23,6 +24,14 @@ namespace System.Net.Security.Tests
     public class SslStreamAlpnTests
     {
         private static bool BackendSupportsAlpn => PlatformDetection.SupportsAlpn;
+        readonly ITestOutputHelper _output;
+        public static readonly object[][] Http2Servers = Configuration.Http.Http2Servers;
+
+        public SslStreamAlpnTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
 
         private async Task DoHandshakeWithOptions(SslStream clientSslStream, SslStream serverSslStream, SslClientAuthenticationOptions clientOptions, SslServerAuthenticationOptions serverOptions)
         {
@@ -177,6 +186,38 @@ namespace System.Net.Security.Tests
             finally
             {
                 listener.Stop();
+            }
+        }
+
+        [OuterLoop("Uses external server")]
+        [PlatformSpecific(TestPlatforms.OSX)]
+        [Theory]
+        [MemberData(nameof(Http2Servers))]
+        public async Task SslStream_OSX_Alpn_Success(Uri server)
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                try
+                {
+                    await client.ConnectAsync(server.Host, server.Port);
+                    using (SslStream clientStream = new SslStream(client.GetStream(), leaveInnerStreamOpen: false))
+                    {
+                        SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+                        {
+                            ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 ,  SslApplicationProtocol.Http11 },
+                            TargetHost =  server.Host
+                        };
+
+                        await clientStream.AuthenticateAsClientAsync(clientOptions, CancellationToken.None);
+                        Assert.Equal("h2", clientStream.NegotiatedApplicationProtocol.ToString());
+                    }
+                }
+                catch (Exception e)
+                {
+                    // Failures to connect do not cause test failure.
+                    _output.WriteLine("Unable to connect: {0}", e);
+                }
+
             }
         }
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -217,7 +217,6 @@ namespace System.Net.Security.Tests
                     // Failures to connect do not cause test failure.
                     _output.WriteLine("Unable to connect: {0}", e);
                 }
-
             }
         }
 

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -48,6 +48,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
       <Link>Common\System\Net\Configuration.Certificates.cs</Link>
     </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+      <Link>Common\System\Net\Configuration.Http.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\HttpsTestClient.cs">
       <Link>Common\System\Net\HttpsTestClient.cs</Link>
     </Compile>

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -48,7 +48,7 @@
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
       <Link>Common\System\Net\Configuration.Certificates.cs</Link>
     </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\HttpsTestClient.cs">


### PR DESCRIPTION
This change implements client side ALPN for OSX. 
Server side is currently not supported by coretls on OSX. (see related issue) 

This uses functions available via private header. With 10.13.4, one could use new API but that fails to link on all previous versions. With using this, we can get consistent behavior on all supported OSX versions. 

related to #30492 