### PR TITLE
Port 'Use longer timeout for first attempt at sending CPR' to 2.1

### DIFF
--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -339,6 +339,13 @@ namespace System
         /// </summary>
         private static bool s_everReceivedCursorPositionResponse;
 
+        /// <summary>
+        /// Tracks if this is out first attempt to send a cursor posotion request. If it is, we start the
+        /// timer immediately (i.e. minChar = 0), but we use a slightly longer timeout to avoid the CPR response
+        /// being written to the console.
+        /// </summary>
+        private static bool s_firstCursorPositionRequest = true;
+
         /// <summary>Gets the current cursor position.  This involves both writing to stdout and reading stdin.</summary>
         private static unsafe void GetCursorPosition(out int left, out int top)
         {
@@ -367,13 +374,15 @@ namespace System
             {
                 // Because the CPR request/response protocol involves blocking until we get a certain
                 // response from the terminal, we want to avoid doing so if we don't know the terminal
-                // will definitely response.  As such, we start with minChars == 0, which causes the
+                // will definitely respond.  As such, we start with minChars == 0, which causes the
                 // terminal's read timer to start immediately.  Once we've received a response for
                 // a request such that we know the terminal supports the protocol, we then specify
                 // minChars == 1.  With that, the timer won't start until the first character is
                 // received.  This makes the mechanism more reliable when there are high latencies
-                // involved in reading/writing, such as when accessing a remote system.
-                Interop.Sys.InitializeConsoleBeforeRead(minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: 10);
+                // involved in reading/writing, such as when accessing a remote system. We also extend
+                // the timeout on the very first request to 15 seconds, to account for potential latency
+                // before we know if we will receive a response.
+                Interop.Sys.InitializeConsoleBeforeRead(minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
                 try
                 {
                     // Write out the cursor position report request.
@@ -447,6 +456,7 @@ namespace System
                 finally
                 {
                     Interop.Sys.UninitializeConsoleAfterRead();
+                    s_firstCursorPositionRequest = false;
                 }
 
 


### PR DESCRIPTION
#### Description
This is a follow-up to our last fix for #30406. The CloudShell team has reported that the fix mostly works, except that we sometimes still get CPR codes printed to the console on the very first CPR request. This makes sense, as we only start using the less aggressive timeout after we've received the first response. This change extends the timeout from 1 to 15 seconds for the first request, then goes back to 1 for subsequent requests, while still maintaining the check for s_everReceivedCursorPositionResponse in case we don't ever receive a response. @jianyunt has already tested this out & has reported that it works for Cloudshell's scenario, and I haven't seen any new strange behavior locally. Once this is in it will also need to be ported to release/2.1.
 
#### Customer Impact
CloudShell is seeing unexpected behavior in the shell upon our first CPR request - they see CPR response codes printed to the console as if they were user input.

#### Regression?
No 

#### Risk
Testing has looked good so far, but there is a chance CloudShell could discover that the configuration of our timeouts is still not perfect. At the least, it should improve their experience.

Issue - https://github.com/dotnet/corefx/issues/30406