### PR TITLE
Remove unnecessary code from System.Drawing.Primitives

### DIFF
--- a/src/Common/src/System/Drawing/ColorTable.cs
+++ b/src/Common/src/System/Drawing/ColorTable.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Drawing
@@ -14,34 +13,20 @@ namespace System.Drawing
 
         private static Dictionary<string, Color> GetColors()
         {
-            var dict = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase);
-            FillConstants(dict, typeof(Color));
-            return dict;
+            var colors = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase);
+            foreach (PropertyInfo prop in typeof(Color).GetProperties(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (prop.PropertyType == typeof(Color))
+                    colors[prop.Name] = (Color)prop.GetValue(null, null);
+            }
+
+            return colors;
         }
 
         internal static Dictionary<string, Color> Colors => s_colorConstants.Value;
 
-        private static void FillConstants(Dictionary<string, Color> colors, Type enumType)
-        {
-            const MethodAttributes attrs = MethodAttributes.Public | MethodAttributes.Static;
-            foreach (PropertyInfo prop in enumType.GetProperties())
-            {
-                if (prop.PropertyType == typeof(Color))
-                {
-                    Debug.Assert(prop.GetGetMethod() != null);
-                    Debug.Assert((prop.GetGetMethod().Attributes & attrs) == attrs);
-                    colors[prop.Name] = (Color)prop.GetValue(null, null);
-                }
-            }
-        }
+        internal static bool TryGetNamedColor(string name, out Color result) => Colors.TryGetValue(name, out result);
 
-        internal static bool TryGetNamedColor(string name, out Color result) =>
-            Colors.TryGetValue(name, out result);
-
-        internal static bool IsKnownNamedColor(string name)
-        {
-            Color result;
-            return Colors.TryGetValue(name, out result);
-        }
+        internal static bool IsKnownNamedColor(string name) => Colors.TryGetValue(name, out _);
     }
 }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -360,13 +360,13 @@ namespace System.Drawing
             this.knownColor = unchecked((short)knownColor);
         }
 
-        public byte R => (byte)(((uint)Value & ARGBRedMask) >> ARGBRedShift);
+        public byte R => unchecked((byte)(Value >> ARGBRedShift));
 
-        public byte G => (byte)(((uint)Value & ARGBGreenMask) >> ARGBGreenShift);
+        public byte G => unchecked((byte)(Value >> ARGBGreenShift));
 
-        public byte B => (byte)(((uint)Value & ARGBBlueMask) >> ARGBBlueShift);
+        public byte B => unchecked((byte)(Value >> ARGBBlueShift));
 
-        public byte A => (byte)(((uint)Value & ARGBAlphaMask) >> ARGBAlphaShift);
+        public byte A => unchecked((byte)(Value >> ARGBAlphaShift));
 
         public bool IsKnownColor => (state & StateKnownColorValid) != 0;
 


### PR DESCRIPTION
Remove unnecessary masking from the `R`, `G`, and `B` accessors in `Color`

Use out discard on `ColorTable.IsKnownNamedColor()`

Remove single-use method `ColorTable.FillConstants()`.  This was set up in an earlier version that built separate dictionaries for the web colors and system colors, but it only does web colors now.

/cc @safern 
