### PR TITLE
Add a bytes to struct overload to AsnXml Decode

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1/Rc2CbcParameters.xml.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1/Rc2CbcParameters.xml.cs
@@ -25,6 +25,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
+        internal static Rc2CbcParameters Decode(ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
+        {
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
+        }
+        
+        internal static Rc2CbcParameters Decode(Asn1Tag expectedTag, ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
+        {
+            AsnReader reader = new AsnReader(encoded, ruleSet);
+            
+            Decode(reader, expectedTag, out Rc2CbcParameters decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
         internal static void Decode(AsnReader reader, out Rc2CbcParameters decoded)
         {
             if (reader == null)

--- a/src/Common/src/System/Security/Cryptography/Asn1/asn.xslt
+++ b/src/Common/src/System/Security/Cryptography/Asn1/asn.xslt
@@ -74,6 +74,20 @@ namespace <xsl:value-of select="@namespace" />
             writer.PopSequence(tag);
         }
 
+        internal static <xsl:value-of select="@name" /> Decode(ReadOnlyMemory&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
+        {
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
+        }
+        
+        internal static <xsl:value-of select="@name" /> Decode(Asn1Tag expectedTag, ReadOnlyMemory&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
+        {
+            AsnReader reader = new AsnReader(encoded, ruleSet);
+            
+            Decode(reader, expectedTag, out <xsl:value-of select="@name" /> decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
         internal static void Decode(AsnReader reader, out <xsl:value-of select="@name" /> decoded)
         {
             if (reader == null)
@@ -137,6 +151,15 @@ namespace <xsl:value-of select="@namespace" />
             {
                 throw new CryptographicException();
             }
+        }
+
+        internal static <xsl:value-of select="@name" /> Decode(ReadOnlyMemory&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
+        {
+            AsnReader reader = new AsnReader(encoded, ruleSet);
+            
+            Decode(reader, out <xsl:value-of select="@name" /> decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
         }
 
         internal static void Decode(AsnReader reader, out <xsl:value-of select="@name" /> decoded)

--- a/src/Common/src/System/Security/Cryptography/PasswordBasedEncryption.cs
+++ b/src/Common/src/System/Security/Cryptography/PasswordBasedEncryption.cs
@@ -609,9 +609,9 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
                 }
 
-                Rc2CbcParameters.Decode(
-                    new AsnReader(encryptionScheme.Parameters.Value, AsnEncodingRules.BER),
-                    out Rc2CbcParameters rc2Parameters);
+                Rc2CbcParameters rc2Parameters = Rc2CbcParameters.Decode(
+                    encryptionScheme.Parameters.Value,
+                    AsnEncodingRules.BER);
 
                 // iv is the eight-octet initialization vector
                 if (rc2Parameters.Iv.Length != 8)

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/AsnHelpers.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/AsnHelpers.cs
@@ -65,9 +65,9 @@ namespace Internal.Cryptography.Pal.AnyOS
                             break;
                         }
 
-                        Rc2CbcParameters.Decode(
-                            new AsnReader(asn.Parameters.Value, AsnEncodingRules.BER),
-                            out Rc2CbcParameters rc2Params);
+                        Rc2CbcParameters rc2Params = Rc2CbcParameters.Decode(
+                            asn.Parameters.Value,
+                            AsnEncodingRules.BER);
 
                         int keySize = rc2Params.GetEffectiveKeyBits();
 

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
@@ -98,9 +98,9 @@ namespace Internal.Cryptography.Pal.AnyOS
                     throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
                 }
 
-                Rc2CbcParameters.Decode(
-                    new AsnReader(contentEncryptionAlgorithm.Parameters.Value, AsnEncodingRules.BER),
-                    out Rc2CbcParameters rc2Params);
+                Rc2CbcParameters rc2Params = Rc2CbcParameters.Decode(
+                    contentEncryptionAlgorithm.Parameters.Value,
+                    AsnEncodingRules.BER);
 
                 alg.KeySize = rc2Params.GetEffectiveKeyBits();
                 alg.IV = rc2Params.Iv.ToArray();

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignedAttributesSet.xml.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignedAttributesSet.xml.cs
@@ -55,6 +55,15 @@ namespace System.Security.Cryptography.Pkcs
             }
         }
 
+        internal static SignedAttributesSet Decode(ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
+        {
+            AsnReader reader = new AsnReader(encoded, ruleSet);
+            
+            Decode(reader, out SignedAttributesSet decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
         internal static void Decode(AsnReader reader, out SignedAttributesSet decoded)
         {
             if (reader == null)

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
@@ -46,9 +46,9 @@ namespace System.Security.Cryptography.Pkcs
 
             if (_signedAttributesMemory.HasValue)
             {
-                SignedAttributesSet.Decode(
-                    new AsnReader(_signedAttributesMemory.Value, AsnEncodingRules.BER),
-                    out SignedAttributesSet signedSet);
+                SignedAttributesSet signedSet = SignedAttributesSet.Decode(
+                    _signedAttributesMemory.Value,
+                    AsnEncodingRules.BER);
 
                 _signedAttributes = signedSet.SignedAttributes;
                 Debug.Assert(_signedAttributes != null);


### PR DESCRIPTION
The reader-based decode cannot assert that the reader is empty, because it is
used to read values out of a collection, and fields out of a SEQUENCE or CHOICE.
It emits the answer via an out parameter to facilitate easier copying on
populating struct fields.

This new overload takes bytes, and is expected to consume all of them, so it
makes more sense to return the value.  A caller wishing to do a decode of only
the first encoded value in the bytes can use the AsnReader-taking overload.