### PR TITLE
Port Fix Icon overflow bug when image entry is a PNG file

### DIFF
--- a/external/harvestPackages/harvestPackages.props
+++ b/external/harvestPackages/harvestPackages.props
@@ -18,6 +18,7 @@
 <PackageReference Include="System.Configuration.ConfigurationManager">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.Data.SqlClient">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.Diagnostics.DiagnosticSource">  <Version>4.5.0</Version></PackageReference>
+<PackageReference Include="System.Drawing.Common">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.IO.FileSystem.AccessControl">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.IO.Packaging">  <Version>4.5.0</Version></PackageReference>
 <PackageReference Include="System.IO.Pipes.AccessControl">  <Version>4.5.0</Version></PackageReference>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -81,7 +81,7 @@
       <Version>1.0.0-prerelease</Version>
     </PackageReference>
     <PackageReference Include="System.Drawing.Common.TestData">
-      <Version>1.0.6</Version>
+      <Version>1.0.7</Version>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions.TestData">
       <Version>1.0.2</Version>

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1688,7 +1688,8 @@
         "xamarinwatchos10": "Any"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.5.0"
+        "4.0.0.0": "4.5.0",
+        "4.0.1.0": "4.5.1"
       }
     },
     "System.Drawing.Design": {

--- a/src/System.Drawing.Common/dir.props
+++ b/src/System.Drawing.Common/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
+    <PackageVersion>4.5.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/dir.props
+++ b/src/System.Drawing.Common/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <PackageVersion>4.5.1</PackageVersion>
   </PropertyGroup>

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -39,6 +39,7 @@ namespace System.Drawing.Tests
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData("48x48_multiple_entries_4bit.ico")]
         [InlineData("256x256_seven_entries_multiple_bits.ico")]
+        [InlineData("pngwithheight_icon.ico")]
         public void Ctor_FilePath(string name)
         {
             using (var icon = new Icon(Helpers.GetTestBitmapPath(name)))

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{4B93E684-0630-45F4-8F63-6C7788C9892F}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TestDataPackageVersion>1.0.7</TestDataPackageVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
@@ -84,19 +85,19 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.drawing.common.testdata\1.0.6\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
-    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\1.0.6\content\bitmaps\48x48_multiple_entries_4bit.ico">
+    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\48x48_multiple_entries_4bit.ico">
       <LogicalName>System.Drawing.Tests.48x48_multiple_entries_4bit.ico</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\1.0.6\content\bitmaps\bitmap_173x183_indexed_8bit.bmp">
+    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\bitmap_173x183_indexed_8bit.bmp">
       <LogicalName>System.Drawing.Tests.bitmap_173x183_indexed_8bit.bmp</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\1.0.6\content\bitmaps\empty.file">
+    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\empty.file">
       <LogicalName>System.Drawing.Tests.empty.file</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\1.0.6\content\bitmaps\invalid.ico">
+    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\invalid.ico">
       <LogicalName>System.Drawing.Tests.invalid.ico</LogicalName>
     </EmbeddedResource>
     <Compile Include="Printing\MarginsTests.cs" />

--- a/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
+++ b/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
@@ -21,7 +21,7 @@ namespace System.Drawing.Tests
             yield return new object[] { Helpers.GetTestBitmapPath("invalid.ico"), new Size(0, 0) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue(27361)] // Fixed in master: https://github.com/dotnet/corefx/pull/29148/commits/731bb441ac69357cf2fd983a781939a36fa69953
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(Ctor_FileName_TestData))]
         public void Ctor_FileName(string fileName, Size size)
@@ -41,7 +41,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue(27361)] // Fixed in master: https://github.com/dotnet/corefx/pull/29148/commits/731bb441ac69357cf2fd983a781939a36fa69953
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(null, -1, -1)]
         [InlineData(typeof(ClassWithNoNamespace), -1, -1)]
@@ -63,7 +63,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue(27361)] // Fixed in master: https://github.com/dotnet/corefx/pull/29148/commits/731bb441ac69357cf2fd983a781939a36fa69953
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(null, null, -1, -1)]
         [InlineData(null, "invalid.ico", -1, -1)]

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -36,6 +36,9 @@
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)..\src\System.Drawing.Common\pkg\System.Drawing.Common.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -36,7 +36,7 @@
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="$(MSBuildThisFileDirectory)..\src\System.Drawing.Common\pkg\System.Drawing.Common.pkgproj">
+    <Project Include="$(MSBuildThisFileDirectory)System.Drawing.Common\pkg\System.Drawing.Common.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
   </ItemGroup>


### PR DESCRIPTION
Port of PR #31819 -- No issue, internally reported

**Description**
Currently in Unix, whenever an Icon has a PNG image under its images and this image doesn't have the width and height == 0 (as the Windows Vista specs states it should be) it blows up. This happens because currently we only check for the width and height to be == 0, but we don't check if the image header signature describes a PNG image. PNG images are special and in Unix when we find a PNG file under the icon entries, we just store the raw bytes so that Icon.Save works. In this case since we are not checking the header signature, we were treating this special cases as a BMP and getting a stack overflow when trying to read the BMP bytes because PNG raw data is way bigger.

**Customer Impact**
We had a report from some Microsoft Internal customers that are trying to load icons in Unix using .NET Core and are hitting this.

**Regresion?**
no

**Risk**
I don't think there is a big risk here, actually we're adding an extra validation here to not blow up. Plus testing has mitigated the risk.

cc: @danmosemsft 
