### PR TITLE
Remove [Flags] from RegistryKeyPermissionCheck

### DIFF
--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKeyPermissionCheck.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKeyPermissionCheck.cs
@@ -6,7 +6,6 @@ using System;
 
 namespace Microsoft.Win32
 {
-    [Flags]
 #if REGISTRY_ASSEMBLY
     public
 #else


### PR DESCRIPTION
This attribute doesn't exist in refs (https://github.com/dotnet/corefx/blob/master/src/Microsoft.Win32.Registry/ref/Microsoft.Win32.Registry.cs#L108) and this enum is not used as a flag anywhere