### PR TITLE
Exclude extra allocations in OrderedDictionary

### DIFF
--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -208,6 +208,10 @@ namespace System.Collections.Specialized
         {
             get
             {
+                if (_objectsTable == null)
+                {
+                    return null;
+                }
                 return objectsTable[key];
             }
             set

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Specialized
     /// OrderedDictionary is used by the ParameterCollection because MSAccess relies on ordering of
     /// parameters, while almost all other DBs do not.  DataKeyArray also uses it so
     /// DataKeys can be retrieved by either their name or their index.
-    /// 
+    ///
     /// OrderedDictionary implements IDeserializationCallback because it needs to have the
     /// contained ArrayList and Hashtable deserialized before it tries to get its count and objects.
     /// </para>
@@ -69,7 +69,7 @@ namespace System.Collections.Specialized
         protected OrderedDictionary(SerializationInfo info, StreamingContext context)
         {
             // We can't do anything with the keys and values until the entire graph has been deserialized
-            // and getting Counts and objects won't fail.  For the time being, we'll just cache this.  
+            // and getting Counts and objects won't fail.  For the time being, we'll just cache this.
             // The graph is not valid until OnDeserialization has been called.
             _siInfo = info;
         }
@@ -81,7 +81,11 @@ namespace System.Collections.Specialized
         {
             get
             {
-                return objectsArray.Count;
+                if (_objectsArray == null)
+                {
+                    return 0;
+                }
+                return _objectsArray.Count;
             }
         }
 
@@ -377,7 +381,7 @@ namespace System.Collections.Specialized
         }
 #endregion
 
-#region ISerializable implementation 
+#region ISerializable implementation
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)
@@ -399,7 +403,7 @@ namespace System.Collections.Specialized
         void IDeserializationCallback.OnDeserialization(object sender) {
             OnDeserialization(sender);
         }
-        
+
         protected virtual void OnDeserialization(object sender)
         {
             if (_siInfo == null)

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -207,7 +207,6 @@ namespace System.Collections.Specialized
                 {
                     return null;
                 }
-                EnsureObjectsTable();
                 return _objectsTable[key];
             }
             set
@@ -266,10 +265,14 @@ namespace System.Collections.Specialized
             {
                 throw new NotSupportedException(SR.OrderedDictionary_ReadOnly);
             }
-            EnsureObjectsTable();
-            EnsureObjectsArray();
-            _objectsTable.Clear();
-            _objectsArray.Clear();
+            if (_objectsTable != null)
+            {
+                _objectsTable.Clear();
+            }
+            if (_objectsArray != null)
+            {
+                _objectsArray.Clear();
+            }
         }
 
         /// <devdoc>
@@ -285,6 +288,10 @@ namespace System.Collections.Specialized
         /// </devdoc>
         public bool Contains(object key)
         {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
             if (_objectsTable == null)
             {
                 return false;
@@ -422,6 +429,7 @@ namespace System.Collections.Specialized
             info.AddValue(InitCapacityName, _initialCapacity);
 
             object[] serArray = new object[Count];
+            EnsureObjectsArray();
             _objectsArray.CopyTo(serArray);
             info.AddValue(ArrayListName, serArray);
         }

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -274,7 +274,11 @@ namespace System.Collections.Specialized
         /// </devdoc>
         public bool Contains(object key)
         {
-            return objectsTable.Contains(key);
+            if (_objectsTable == null)
+            {
+                return false;
+            }
+            return _objectsTable.Contains(key);
         }
 
         /// <devdoc>

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -179,7 +179,11 @@ namespace System.Collections.Specialized
         {
             get
             {
-                return ((DictionaryEntry)objectsArray[index]).Value;
+                if (_objectsArray == null)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+                return ((DictionaryEntry)_objectsArray[index]).Value;
             }
             set
             {
@@ -187,7 +191,7 @@ namespace System.Collections.Specialized
                 {
                     throw new NotSupportedException(SR.OrderedDictionary_ReadOnly);
                 }
-                if (index < 0 || index >= objectsArray.Count)
+                if (_objectsArray == null || index < 0 || index >= _objectsArray.Count)
                 {
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -291,9 +291,13 @@ namespace System.Collections.Specialized
 
         private int IndexOfKey(object key)
         {
-            for (int i = 0; i < objectsArray.Count; i++)
+            if (_objectsArray == null)
             {
-                object o = ((DictionaryEntry)objectsArray[i]).Key;
+                return -1;
+            }
+            for (int i = 0; i < _objectsArray.Count; i++)
+            {
+                object o = ((DictionaryEntry)_objectsArray[i]).Key;
                 if (_comparer != null)
                 {
                     if (_comparer.Equals(o, key))


### PR DESCRIPTION
Address #31972.

Add checks in properties to exclude allocations internal HashTable and ArrayList if they are not needed.

