### PR TITLE
Ensure that TrySetECDHNamedCurve is always called, enabling ECDHE ciphersuites

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -69,6 +69,12 @@ static long TrySetECDHNamedCurve(SSL_CTX* ctx)
 
 void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
 {
+    // Ensure that ECDHE is available
+    if (TrySetECDHNamedCurve(ctx) == 0)
+    {
+        ERR_clear_error();
+    }
+
     // protocols may be 0, meaning system default, in which case let OpenSSL do what OpenSSL wants.
     if (protocols == 0)
     {
@@ -103,10 +109,6 @@ void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
 #endif
 
     SSL_CTX_set_options(ctx, protocolOptions);
-    if (TrySetECDHNamedCurve(ctx) == 0)
-    {
-        ERR_clear_error();
-    }
 }
 
 SSL* CryptoNative_SslCreate(SSL_CTX* ctx)


### PR DESCRIPTION
Moves the call to TrySetECDHNamedCurve above the early abort when the server default protocols are selected.

This ensures that when SslStream is used as a TLS server that the ECDHE ciphersuites are available for "Perfect Forward Secrecy".

By using an SslStream-based TLS server and the `openssl s_client` utility as a client, verified that the ciphersuite went from `ECDH-ECDSA-AES256-GCM-SHA384` to `ECDHE-ECDSA-AES256-GCM-SHA384` (and `AES256-GCM-SHA384` to `ECDHE-RSA-AES256-GCM-SHA384` for RSA).

Solution for #31420 in master.