### PR TITLE
Erase temporary copies of plaintext during de/padding operations

### DIFF
--- a/src/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -97,7 +97,18 @@ namespace Internal.Cryptography
             byte[] outputData;
             if (ciphertext.Length > 0)
             {
-                outputData = DepadBlock(decryptedBytes, 0, decryptedBytes.Length);
+                unsafe
+                {
+                    fixed (byte* decryptedBytesPtr = decryptedBytes)
+                    {
+                        outputData = DepadBlock(decryptedBytes, 0, decryptedBytes.Length);
+
+                        if (outputData != decryptedBytes)
+                        {
+                            CryptographicOperations.ZeroMemory(decryptedBytes);
+                        }
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
When symmetric block padding is added, or removed, the
UniversalCryptoDecryptor and UniversalCryptoEncryptor classes make a
temporary buffer to hold the padded result (for encryption this is the input to
the cryptographic transform, for decryption it is the output before calling
DepadBlock).

While these buffers are usually marked as unused by the GC in short order, and
overwritten by new objects in short order, some applications are more sensitive
to having plaintext residuals in memory; and we should clear these out before
abandoning them to the garbage collector.