### PR TITLE
[release/2.1] Ensure that TrySetECDHNamedCurve is always called, enabling ECDHE ciphersuites

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -68,6 +68,12 @@ static long TrySetECDHNamedCurve(SSL_CTX* ctx)
 
 extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
 {
+    // Ensure that ECDHE is available
+    if (TrySetECDHNamedCurve(ctx) == 0)
+    {
+        ERR_clear_error();
+    }
+
     // protocols may be 0, meaning system default, in which case let OpenSSL do what OpenSSL wants.
     if (protocols == 0)
     {
@@ -102,10 +108,6 @@ extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols proto
 #endif
 
     SSL_CTX_set_options(ctx, protocolOptions);
-    if (TrySetECDHNamedCurve(ctx) == 0)
-    {
-        ERR_clear_error();
-    }
 }
 
 extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx)


### PR DESCRIPTION
Moves the call to TrySetECDHNamedCurve above the early abort when the server default protocols are selected.

This ensures that when SslStream is used as a TLS server that the ECDHE ciphersuites are available for "Perfect Forward Secrecy".

By using an SslStream-based TLS server and the openssl s_client utility as a client, verified that the ciphersuite went from ECDH-ECDSA-AES256-GCM-SHA384 to ECDHE-ECDSA-AES256-GCM-SHA384 (and AES256-GCM-SHA384 to ECDHE-RSA-AES256-GCM-SHA384 for RSA).

Port of #32023 to release/2.1.
Fixes #31420.