### PR TITLE
Update compat pack dependency on System.IO.Pipes.AccessControl

### DIFF
--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -35,7 +35,6 @@
     <PrereleaseLibraryPackage Include="System.DirectoryServices.Protocols" />
     <PrereleaseLibraryPackage Include="System.IO.FileSystem.AccessControl" />
     <PrereleaseLibraryPackage Include="System.IO.Packaging" />
-    <PrereleaseLibraryPackage Include="System.IO.Pipes.AccessControl" />
     <PrereleaseLibraryPackage Include="System.IO.Ports" />
     <PrereleaseLibraryPackage Include="System.Management" />
     <PrereleaseLibraryPackage Include="System.Runtime.Caching" />
@@ -65,6 +64,10 @@
     </LibraryPackage>
     <LibraryPackage Include="System.ServiceModel.Security">
       <Version>$(ServiceModelVersion)</Version>
+    </LibraryPackage>
+    <!-- Packages we don't build in master anymore -->
+    <LibraryPackage Include="System.IO.Pipes.AccessControl">
+      <Version>4.5.1</Version>
     </LibraryPackage>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Pipes.AccessControl package was deleted from master in https://github.com/dotnet/corefx/commit/4e76a6c02552422ce07967f4249acad3b71b80ef#diff-565d1930626b9dc3c69e710392897733

So we need to update the compat pack dependency to depend on the latest stable version.

Found with: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=1991782&view=logs

cc: @weshaggard 