### PR TITLE
Optimize RemoveAt() method in OrderedDictionary class

### DIFF
--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -367,8 +367,8 @@ namespace System.Collections.Specialized
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
-            EnsureObjectsTable();
-            EnsureObjectsArray();
+            // The 'index >= Count' check above ensures
+            // that the '_objectsArray' and '_objectsTable' objects are initialized.
             object key = ((DictionaryEntry)_objectsArray[index]).Key;
             _objectsArray.RemoveAt(index);
             _objectsTable.Remove(key);


### PR DESCRIPTION
Continue #32001 to address unresolved comment.

/cc @danmosemsft @safern 

@safern Insert() have 'index > Count' not 'index >= Count' check so I leave it as is.