### PR TITLE
Build managed code and packages for WebAssembly/netcoreappaot

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -145,6 +145,7 @@
     <_portableOS Condition="'$(_runtimeOSFamily)' == 'win'">win</_portableOS>
     <_portableOS Condition="'$(_runtimeOSFamily)' == 'osx'">osx</_portableOS>
     <_portableOS Condition="'$(_runtimeOSFamily)' == 'FreeBSD'">freebsd</_portableOS>
+    <_portableOS Condition="'$(RuntimeOS)' == 'WebAssembly'">webassembly</_portableOS>
 
     <_runtimeOS>$(RuntimeOS)</_runtimeOS>
     <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.4.0.0'">ubuntu.14.04</_runtimeOS>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -151,6 +151,9 @@
     <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.4.0.0'">ubuntu.14.04</_runtimeOS>
     <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
     <ToolRuntimeRID>$(_runtimeOS)-x64</ToolRuntimeRID>
+    
+    <!-- There are no WebAssembly tools, so treat them as Windows -->
+    <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'WebAssembly'">win-x64</ToolRuntimeRID>
     <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(ToolRuntimeRID)</MicrosoftNetCoreIlasmPackageRuntimeId>
 
     <!-- support cross-targeting by choosing a RID to restore when running on a different machine that what we're build for -->

--- a/external/runtime/Configurations.props
+++ b/external/runtime/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap10.0.16299;
       uap10.0.16299aot;

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -14,6 +14,9 @@
     <BinPlaceILCInputFolder>false</BinPlaceILCInputFolder>
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsAOT)'=='true' AND '$(ArchGroup)'=='wasm'">
+    <NugetRuntimeIdentifier>win10-x86</NugetRuntimeIdentifier>
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetsAOT)'=='true'">
     <PackageReference Include="Microsoft.TargetingPack.Private.NETNative">
       <Version Condition="'$(TargetGroup)'=='uapaot' OR '$(TargetGroup)'=='netcoreappaot'">1.1.0-$(ProjectNTfsExpectedPrerelease)</Version>
@@ -50,6 +53,10 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
+    <Target Name="DumpStuff" BeforeTargets="ResolveNuGetPackages">
+        <Message Text="TargetsAOT: '$(TargetsAOT)' ArchGroup: '$(ArchGroup)' OSGroup: '$(OSGroup)' NugetRuntimeIdentifier: '$(NugetRuntimeIdentifier)'" Importance="high" />
+    </Target>
+    
   <ItemGroup>
     <!-- For IL rewrite tools of crossgen dll from CoreClr we need the respective IL and respective pdbs -->
     <!-- For crossgen dlls save respective pdbs too -->

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -14,9 +14,13 @@
     <BinPlaceILCInputFolder>false</BinPlaceILCInputFolder>
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
   </PropertyGroup>
+  
+  <!-- There isn't a WebAssembly runtime package yet, but the Windows AOT package has the right surface area 
+  to build against. -->  
   <PropertyGroup Condition="'$(TargetsAOT)'=='true' AND '$(ArchGroup)'=='wasm'">
     <NugetRuntimeIdentifier>win10-x86</NugetRuntimeIdentifier>
   </PropertyGroup>
+    
   <ItemGroup Condition="'$(TargetsAOT)'=='true'">
     <PackageReference Include="Microsoft.TargetingPack.Private.NETNative">
       <Version Condition="'$(TargetGroup)'=='uapaot' OR '$(TargetGroup)'=='netcoreappaot'">1.1.0-$(ProjectNTfsExpectedPrerelease)</Version>
@@ -53,10 +57,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
-    <Target Name="DumpStuff" BeforeTargets="ResolveNuGetPackages">
-        <Message Text="TargetsAOT: '$(TargetsAOT)' ArchGroup: '$(ArchGroup)' OSGroup: '$(OSGroup)' NugetRuntimeIdentifier: '$(NugetRuntimeIdentifier)'" Importance="high" />
-    </Target>
-    
   <ItemGroup>
     <!-- For IL rewrite tools of crossgen dll from CoreClr we need the respective IL and respective pdbs -->
     <!-- For crossgen dlls save respective pdbs too -->

--- a/external/tools/Configurations.props
+++ b/external/tools/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       netfx;
       uap10.0.16299;

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
@@ -32,5 +32,8 @@
     <OfficialBuildRID Include="tizen.5.0.0-armel">
       <Platform>armel</Platform>
     </OfficialBuildRID>
+    <OfficialBuildRID Include="webassembly-wasm-aot">
+      <Platform>wasm</Platform>
+    </OfficialBuildRID>
   </ItemGroup>
 </Project>

--- a/src/CoreFx.Private.TestUtilities/src/Configurations.props
+++ b/src/CoreFx.Private.TestUtilities/src/Configurations.props
@@ -11,6 +11,7 @@
       netcoreapp2.0-Windows_NT;
       netcoreapp2.0-Unix;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -186,8 +186,15 @@ exit /B 0
 pushd "%__IntermediatesDir%"
 nmake install
 popd
-IF NOT ERRORLEVEL 1 exit /B 0
-exit /B 1
+IF ERRORLEVEL 1 (
+    goto :Failure
+)
+
+:: Copy results to native_aot since packaging expects a copy there too
+mkdir %__binDir%\%__BuildOS%.%__BuildArch%.%CMAKE_BUILD_TYPE%\native_aot
+copy %__binDir%\%__BuildOS%.%__BuildArch%.%CMAKE_BUILD_TYPE%\native\* %__binDir%\%__BuildOS%.%__BuildArch%.%CMAKE_BUILD_TYPE%\native_aot\
+
+exit /B 0
 
 :Failure
 :: Build failed

--- a/src/System.AppContext/src/Configurations.props
+++ b/src/System.AppContext/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
       uapaot-Windows_NT;

--- a/src/System.Buffers/src/Configurations.props
+++ b/src/System.Buffers/src/Configurations.props
@@ -9,6 +9,7 @@
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
       uapaot-Windows_NT;

--- a/src/System.Collections.Concurrent/src/Configurations.props
+++ b/src/System.Collections.Concurrent/src/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Collections/src/Configurations.props
+++ b/src/System.Collections/src/Configurations.props
@@ -5,6 +5,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Data.Odbc/src/Configurations.props
+++ b/src/System.Data.Odbc/src/Configurations.props
@@ -15,6 +15,7 @@
       netcoreapp-Linux;
       netcoreapp-OSX;
       netcoreapp-Windows_NT;
+      netcoreappaot-WebAssembly;
       netfx-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Data.Odbc/src/System.Data.Odbc.csproj
+++ b/src/System.Data.Odbc/src/System.Data.Odbc.csproj
@@ -122,7 +122,7 @@
       <Link>Common\Interop\Interop.Odbc.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsLinux)' == 'true' OR '$(TargetsFreeBSD)' == 'true'">
+  <ItemGroup Condition="'$(TargetsLinux)' == 'true' OR '$(TargetsFreeBSD)' == 'true' OR '$(TargetsWebAssembly)'=='true'">
     <Compile Include="$(CommonPath)\Interop\Linux\Interop.Libraries.cs">
       <Link>Common\Interop\Linux\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Contracts/src/Configurations.props
+++ b/src/System.Diagnostics.Contracts/src/Configurations.props
@@ -6,6 +6,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Diagnostics.Debug/src/Configurations.props
+++ b/src/System.Diagnostics.Debug/src/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       uap-Windows_NT;
       uapaot-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Diagnostics.Process/src/Configurations.props
+++ b/src/System.Diagnostics.Process/src/Configurations.props
@@ -6,6 +6,7 @@
       netcoreapp-Linux;
       netcoreapp-OSX;
       netcoreapp-Windows_NT;
+      netcoreapp-Unix;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Diagnostics.StackTrace/src/Configurations.props
+++ b/src/System.Diagnostics.StackTrace/src/Configurations.props
@@ -6,6 +6,7 @@
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Diagnostics.Tools/src/Configurations.props
+++ b/src/System.Diagnostics.Tools/src/Configurations.props
@@ -6,6 +6,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Diagnostics.Tracing/src/Configurations.props
+++ b/src/System.Diagnostics.Tracing/src/Configurations.props
@@ -6,6 +6,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Globalization.Calendars/src/Configurations.props
+++ b/src/System.Globalization.Calendars/src/Configurations.props
@@ -5,6 +5,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Globalization/src/Configurations.props
+++ b/src/System.Globalization/src/Configurations.props
@@ -6,6 +6,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.IO.UnmanagedMemoryStream/src/Configurations.props
+++ b/src/System.IO.UnmanagedMemoryStream/src/Configurations.props
@@ -6,6 +6,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Linq.Expressions/src/Configurations.props
+++ b/src/System.Linq.Expressions/src/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       uapaot-Windows_NT;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -5,6 +5,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Numerics.Vectors/src/Configurations.props
+++ b/src/System.Numerics.Vectors/src/Configurations.props
@@ -12,6 +12,7 @@
       netfx-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       $(PackageConfigurations)
     </BuildConfigurations>

--- a/src/System.Private.Reflection.Metadata.Ecma335/src/Configurations.props
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       uapaot-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Uri/src/Configurations.props
+++ b/src/System.Private.Uri/src/Configurations.props
@@ -6,6 +6,7 @@
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Private.Xml.Linq/src/Configurations.props
+++ b/src/System.Private.Xml.Linq/src/Configurations.props
@@ -5,6 +5,8 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
+      netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Xml/src/Configurations.props
+++ b/src/System.Private.Xml/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
       uapaot-Windows_NT;

--- a/src/System.Reflection.Emit.ILGeneration/src/Configurations.props
+++ b/src/System.Reflection.Emit.ILGeneration/src/Configurations.props
@@ -12,6 +12,8 @@
       netcoreapp-Unix;
       uap-Windows_NT;
       uapaot-Windows_NT;
+      netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       $(PackageConfigurations);
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Reflection.Emit.Lightweight/src/Configurations.props
+++ b/src/System.Reflection.Emit.Lightweight/src/Configurations.props
@@ -10,6 +10,8 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
+      netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       uap-Windows_NT;
       uapaot-Windows_NT;
       $(PackageConfigurations);

--- a/src/System.Reflection.Emit/src/Configurations.props
+++ b/src/System.Reflection.Emit/src/Configurations.props
@@ -10,6 +10,8 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
+      netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       uap-Windows_NT;
       uapaot-Windows_NT;
       $(PackageConfigurations);

--- a/src/System.Reflection.Primitives/src/Configurations.props
+++ b/src/System.Reflection.Primitives/src/Configurations.props
@@ -6,6 +6,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Reflection.TypeExtensions/src/Configurations.props
+++ b/src/System.Reflection.TypeExtensions/src/Configurations.props
@@ -12,6 +12,7 @@
       netfx;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
       uapaot-Windows_NT;

--- a/src/System.Reflection/src/Configurations.props
+++ b/src/System.Reflection/src/Configurations.props
@@ -6,6 +6,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Resources.ResourceManager/src/Configurations.props
+++ b/src/System.Resources.ResourceManager/src/Configurations.props
@@ -6,6 +6,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Runtime.Extensions/src/Configurations.props
+++ b/src/System.Runtime.Extensions/src/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       uapaot-Windows_NT;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Runtime.InteropServices/src/Configurations.props
+++ b/src/System.Runtime.InteropServices/src/Configurations.props
@@ -5,6 +5,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Runtime.Intrinsics/src/ApiCompatBaseline.netcoreappaot.txt
+++ b/src/System.Runtime.Intrinsics/src/ApiCompatBaseline.netcoreappaot.txt
@@ -1,0 +1,4 @@
+Compat issues with assembly System.Runtime.Intrinsics:
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Pclmulqdq.CarrylessMultiply(System.Runtime.Intrinsics.Vector128<System.Int64>, System.Runtime.Intrinsics.Vector128<System.Int64>, System.Byte)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Pclmulqdq.CarrylessMultiply(System.Runtime.Intrinsics.Vector128<System.UInt64>, System.Runtime.Intrinsics.Vector128<System.UInt64>, System.Byte)' does not exist in the implementation but it does exist in the contract.
+Total Issues: 2

--- a/src/System.Runtime.Intrinsics/src/Configurations.props
+++ b/src/System.Runtime.Intrinsics/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Runtime.Intrinsics/src/Configurations.props
+++ b/src/System.Runtime.Intrinsics/src/Configurations.props
@@ -3,8 +3,9 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp-Windows_NT;
-      netcoreappaot-WebAssembly;
+      netcoreappaot-Windows_NT;
       netcoreapp-Unix;
+      netcoreappaot-WebAssembly;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Loader/src/Configurations.props
+++ b/src/System.Runtime.Loader/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
       uapaot-Windows_NT;

--- a/src/System.Runtime/src/Configurations.props
+++ b/src/System.Runtime/src/Configurations.props
@@ -5,6 +5,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Text.Encoding.Extensions/src/Configurations.props
+++ b/src/System.Text.Encoding.Extensions/src/Configurations.props
@@ -5,6 +5,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Text.Encoding/src/Configurations.props
+++ b/src/System.Text.Encoding/src/Configurations.props
@@ -6,6 +6,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Text.RegularExpressions/ref/Configurations.props
+++ b/src/System.Text.RegularExpressions/ref/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
-      netcoreappaot;
       uap;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading.Overlapped/src/Configurations.props
+++ b/src/System.Threading.Overlapped/src/Configurations.props
@@ -6,6 +6,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading.Tasks.Extensions/src/Configurations.props
+++ b/src/System.Threading.Tasks.Extensions/src/Configurations.props
@@ -9,6 +9,7 @@
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Threading.Tasks/src/Configurations.props
+++ b/src/System.Threading.Tasks/src/Configurations.props
@@ -6,6 +6,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading.Thread/src/Configurations.props
+++ b/src/System.Threading.Thread/src/Configurations.props
@@ -6,6 +6,7 @@
       uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading.ThreadPool/src/Configurations.props
+++ b/src/System.Threading.ThreadPool/src/Configurations.props
@@ -6,6 +6,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading.Timer/src/Configurations.props
+++ b/src/System.Threading.Timer/src/Configurations.props
@@ -6,6 +6,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading/src/Configurations.props
+++ b/src/System.Threading/src/Configurations.props
@@ -6,6 +6,7 @@
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Xml.ReaderWriter/src/Configurations.props
+++ b/src/System.Xml.ReaderWriter/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       uap-Windows_NT;
       netcoreapp-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Xml.ReaderWriter/src/MatchingRefApiCompatBaseline.netcoreappaot.txt
+++ b/src/System.Xml.ReaderWriter/src/MatchingRefApiCompatBaseline.netcoreappaot.txt
@@ -1,0 +1,1 @@
+MembersMustExist : Member 'System.Xml.XmlReader.CreateSqlReader(System.IO.Stream, System.Xml.XmlReaderSettings, System.Xml.XmlParserContext)' does not exist in the reference but it does exist in the implementation.

--- a/src/System.Xml.XDocument/src/Configurations.props
+++ b/src/System.Xml.XDocument/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       uap-Windows_NT;
       netcoreapp-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Xml.XPath.XDocument/src/Configurations.props
+++ b/src/System.Xml.XPath.XDocument/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       uap-Windows_NT;
       netcoreapp-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
+++ b/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <Compile Include="System\Xml\XPath\XDocumentExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp' or '$(TargetGroup)'=='uap'">
+  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp' or '$(TargetGroup)'=='netcoreappaot' or '$(TargetGroup)'=='uap'">
     <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
     <ProjectReference Include="..\..\System.Private.Xml.Linq\src\System.Private.Xml.Linq.csproj" />
   </ItemGroup>

--- a/src/System.Xml.XPath/src/Configurations.props
+++ b/src/System.Xml.XPath/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       uap-Windows_NT;
       netcoreapp-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Xml.XmlDocument/src/Configurations.props
+++ b/src/System.Xml.XmlDocument/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       uap-Windows_NT;
       netcoreapp-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Xml.XmlSerializer/src/Configurations.props
+++ b/src/System.Xml.XmlSerializer/src/Configurations.props
@@ -5,6 +5,8 @@
       uap-Windows_NT;
       uapaot-Windows_NT;
       netcoreapp-Windows_NT;
+      netcoreappaot-Windows_NT;
+      netcoreappaot-WebAssembly;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Xml.XmlSerializer/src/MatchingRefApiCompatBaseline.netcoreappaot.txt
+++ b/src/System.Xml.XmlSerializer/src/MatchingRefApiCompatBaseline.netcoreappaot.txt
@@ -1,0 +1,6 @@
+Compat issues with assembly System.Xml.XmlSerializer:
+# Used by aot tooling for serializer generation
+MembersMustExist : Member 'System.String System.Xml.Serialization.XmlSerializer.DefaultNamespace' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Xml.Serialization.XmlSerializer.Mode.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Xml.Serialization.XmlSerializer.Mode.set(System.Xml.Serialization.SerializationMode)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Xml.Serialization.XmlSerializer.SetXmlSerializerContract(System.Xml.Serialization.XmlSerializerImplementation)' does not exist in the reference but it does exist in the implementation.

--- a/src/shims/manual/mscorlib.csproj
+++ b/src/shims/manual/mscorlib.csproj
@@ -26,5 +26,14 @@
     <SeedTypePreference Include="System.Reflection.Emit.PropertyBuilder" Assembly="System.Reflection.Emit" />
     <SeedTypePreference Include="System.Reflection.Emit.SignatureHelper" Assembly="System.Reflection.Emit.ILGeneration" />
     <SeedTypePreference Include="System.Reflection.Emit.TypeBuilder" Assembly="System.Reflection.Emit" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.DefaultInterfaceAttribute" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable`1" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.IActivationFactory" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.InterfaceImplementedInVersionAttribute" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.ReadOnlyArrayAttribute" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.ReturnValueNameAttribute" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
+    <SeedTypePreference Include="System.Runtime.InteropServices.WindowsRuntime.WriteOnlyArrayAttribute" Assembly="System.Runtime.InteropServices.WindowsRuntime" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds support for a WebAssembly netcoreappaot configuration for building managed libraries and packages (native already builds). This is enough to produce a NuGet package of libraries that CoreRT's WebAssembly implementation can consume.