### PR TITLE
Unix: fix UDP ReuseAddress with non .NET Core UDP clients

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1812,11 +1812,11 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
     //
     if (socketOptionLevel == SocketOptionLevel_SOL_SOCKET)
     {
-        // Windows supports 3 address sharing modes:
-        // - not sharing      (SO_EXCLUSIVEADDRUSE=1, SO_REUSEADDR=0)
-        // - explicit sharing (SO_EXCLUSIVEADDRUSE=0, SO_REUSEADDR=1)
-        // - implicit sharing (SO_EXCLUSIVEADDRUSE=0, SO_REUSEADDR=0)
-        // On Unix we can share or not share, there is no implicit sharing.
+        // Windows supports 3 address reuse modes:
+        // - reuse not allowed        (SO_EXCLUSIVEADDRUSE=1, SO_REUSEADDR=0)
+        // - reuse explicily allowed  (SO_EXCLUSIVEADDRUSE=0, SO_REUSEADDR=1)
+        // - reuse implicitly allowed (SO_EXCLUSIVEADDRUSE=0, SO_REUSEADDR=0)
+        // On Unix we can reuse or not, there is no implicit reuse.
         // We make both SocketOptionName_SO_REUSEADDR and SocketOptionName_SO_EXCLUSIVEADDRUSE control SO_REUSEPORT/SO_REUSEADDR.
         if (socketOptionName == SocketOptionName_SO_EXCLUSIVEADDRUSE || socketOptionName == SocketOptionName_SO_REUSEADDR)
         {
@@ -1840,10 +1840,10 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
                 }
             }
 
-            // An application that sets SO_REUSEPORT/SO_REUSEADDR can share the endpoint with another
+            // An application that sets SO_REUSEPORT/SO_REUSEADDR can reuse the endpoint with another
             // application that sets the same option. If one application sets SO_REUSEPORT and another
             // sets SO_REUSEADDR the second application will fail to bind. We set both options, this
-            // enables sharing with applications that set one or both options.
+            // enables reuse with applications that set one or both options.
             int err = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &value, (socklen_t)optionLen);
             if (err == 0)
             {

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1840,10 +1840,10 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
                 }
             }
 
-            // An application that sets SO_REUSEPORT/SO_REUSEADDR can share the with another application
-            // that sets the same option. If one application sets SO_REUSEPORT and another sets SO_REUSEADDR
-            // the second application will fail to bind the port. We set both options, this enables sharing
-            // with applications that set one or both options.
+            // An application that sets SO_REUSEPORT/SO_REUSEADDR can share the endpoint with another
+            // application that sets the same option. If one application sets SO_REUSEPORT and another
+            // sets SO_REUSEADDR the second application will fail to bind. We set both options, this
+            // enables sharing with applications that set one or both options.
             int err = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &value, (socklen_t)optionLen);
             if (err == 0)
             {

--- a/src/System.Net.Sockets/tests/FunctionalTests/Configurations.props
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Configurations.props
@@ -2,8 +2,10 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard;
-      netcoreapp;
+      netstandard-Windows_NT;
+      netstandard-Unix;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.Unix.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.Unix.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net.Sockets.Tests
+{
+    public partial class SocketOptionNameTest
+    {
+        [DllImport("libc", SetLastError = true)]
+        private unsafe static extern int setsockopt(int socket, int level, int option_name, void* option_value, uint option_len);
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.Windows.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.Windows.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Sockets.Tests
+{
+    public partial class SocketOptionNameTest
+    {
+        private unsafe static int setsockopt(int socket, int level, int option_name, void* option_value, uint option_len)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -490,9 +490,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [DllImport("libc", SetLastError = true)]
-        private unsafe static extern int setsockopt(int socket, int level, int option_name, void* option_value, uint option_len);
-
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.OSX)]
         public unsafe void ReuseAddressUdp()

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace System.Net.Sockets.Tests
 {
-    public class SocketOptionNameTest
+    public partial class SocketOptionNameTest
     {
         private static bool SocketsReuseUnicastPortSupport => Capability.SocketsReuseUnicastPortSupport().HasValue;
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -107,6 +107,12 @@
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="SocketOptionNameTest.Unix.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="SocketOptionNameTest.Windows.cs" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Accept.cs" />

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -44,6 +44,8 @@
     <Compile Include="SocketAsyncEventArgsTest.cs" />
     <Compile Include="SocketAsyncEventArgsTest.netcoreapp.cs" Condition="'$(TargetGroup)' != 'netstandard'" />
     <Compile Include="SocketOptionNameTest.cs" />
+    <Compile Include="SocketOptionNameTest.Unix.cs" Condition="'$(TargetsUnix)' == 'true'" />
+    <Compile Include="SocketOptionNameTest.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="MulticastOptionTest.cs" />
     <Compile Include="UdpClientTest.cs" />
     <Compile Include="UnixDomainSocketTest.netcoreapp.cs" Condition="'$(TargetGroup)' != 'netstandard'" />
@@ -106,12 +108,6 @@
     <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
-    <Compile Include="SocketOptionNameTest.Unix.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="SocketOptionNameTest.Windows.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">


### PR DESCRIPTION
.NET Core sets SO_REUSEPORT to enable reusing the address with other
sockets. This works when the other sockets also set SO_REUSEPORT.

SO_REUSEADDR can also be used for this. When one application uses
SO_REUSEADDR and another uses SO_REUSEPORT, the second application
will fail to bind.

To implement SocketOptionName.ReuseAddress we need to set both options.
This enables sharing with applications that set SO_REUSEPORT,
SO_REUSEADDR or both.