### PR TITLE
Disable test that appears to be causing a hang in System.Net.Http tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -288,6 +288,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(32000)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "WinRT stack can't set MaxConnectionsPerServer < 2")]
         [Fact]
         public async Task MaxConnectionsPerServer_WaitingConnectionsAreCancelable()


### PR DESCRIPTION
This test appears to be the cause of frequent test hangs in CI, starting on August 22nd. It appears that the failures were triggered by the recent xunit upgrade, which potentially changed the timing of the tests. Until we can better identify the cause, we need to disable the test.

Related: #32000