### PR TITLE
Finally fix Api Catalog drop

### DIFF
--- a/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <BaseIntermediateOutputPath>bin</BaseIntermediateOutputPath>
+    <NuGetTargetMoniker Condition="'$(NugetMonikerVersion)' != ''">.NETCoreApp,Version=v$(NugetMonikerVersion)</NuGetTargetMoniker>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+    <!-- Setting NETCoreAppMaximumVersion to a high version so that the sdk doesn't complain if we're restoring/publishing for a higher version than the sdk. -->
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
+    <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RuntimeIdentifiers).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
+    <DisableImplicitFrameworkReferences Condition="$(TargetFramework.Contains('netcoreapp'))">true</DisableImplicitFrameworkReferences>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
@@ -1,19 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <PreserveCompilationContext>true</PreserveCompilationContext>
-    <!-- Setting NETCoreAppMaximumVersion to a high version so that the sdk doesn't complain if we're restoring/publishing for a higher version than the sdk. -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-    <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RuntimeIdentifiers).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
-    <DisableImplicitFrameworkReferences Condition="$(TargetFramework.Contains('netcoreapp'))">true</DisableImplicitFrameworkReferences>
-    <NuGetTargetMoniker Condition="'$(NugetMonikerVersion)' != ''">.NETCoreApp,Version=v$(NugetMonikerVersion)</NuGetTargetMoniker>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="$(CompatibilityPackageVersion)" />
    </ItemGroup>
    <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(PrivateCorefxPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="3.0.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="3.0.0-*" />
    </ItemGroup>
    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />


### PR DESCRIPTION
I moved props to Directory.Build.props since there are some props that need to be set before common props file is imported and also I don't want corefx's Directory.Build.props to change my output paths. 

Also, I disable Directory.Build.targets import so that corefx's root targets are not imported, which may lead to other errors, I want this to be an standalone project.

I updated AspNet package reference to the new metapackage: https://github.com/aspnet/Announcements/issues/314

cc: @weshaggard 

@dotnet-bot skip CI