### PR TITLE
Fix ServiceController name population perf

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.GetServiceDisplayName.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.GetServiceDisplayName.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Advapi32
+    {
+        [DllImport(Libraries.Advapi32, EntryPoint = "GetServiceDisplayNameW", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
+        private static extern bool GetServiceDisplayNamePrivate(IntPtr SCMHandle, string serviceName, char[] displayName, ref int displayNameLength);
+
+        public static string GetServiceDisplayName(IntPtr SCMHandle, string serviceName)
+        {
+            // Get the size of buffer required
+            int bufLen = 0;
+            bool success = GetServiceDisplayNamePrivate(SCMHandle, serviceName, null, ref bufLen);
+            char[] buffer = null;
+
+            if (!success && Marshal.GetLastWin32Error() == Interop.Errors.ERROR_INSUFFICIENT_BUFFER)
+            {
+                bufLen++; // Does not include null
+                buffer = ArrayPool<char>.Shared.Rent(bufLen);
+
+                try
+                {
+                    success = GetServiceDisplayNamePrivate(SCMHandle, serviceName, buffer, ref bufLen);
+                    if (success)
+                        return new string(buffer, 0, bufLen);
+                }
+                finally
+                {
+                    ArrayPool<char>.Shared.Return(buffer);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/advapi32/Interop.GetServiceKeyName.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.GetServiceKeyName.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Advapi32
+    {
+        [DllImport(Libraries.Advapi32, EntryPoint = "GetServiceKeyNameW", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
+        private static extern bool GetServiceKeyNamePrivate(IntPtr SCMHandle, string displayName, char[] shortName, ref int shortNameLength);
+
+        public static string GetServiceKeyName(IntPtr SCMHandle, string displayName)
+        {
+            // Get the size of buffer required
+            int bufLen = 0;
+            bool success = GetServiceKeyNamePrivate(SCMHandle, displayName, null, ref bufLen);
+            char[] buffer = null;
+
+            if (!success && Marshal.GetLastWin32Error() == Interop.Errors.ERROR_INSUFFICIENT_BUFFER)
+            {
+                bufLen++; // Does not include null
+                buffer = ArrayPool<char>.Shared.Rent(bufLen);
+
+                try
+                {
+                    success = GetServiceKeyNamePrivate(SCMHandle, displayName, buffer, ref bufLen);
+                    if (success)
+                        return new string(buffer, 0, bufLen);
+                }
+                finally
+                {
+                    ArrayPool<char>.Shared.Return(buffer);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/System.ServiceProcess.ServiceController/src/Resources/Strings.resx
+++ b/src/System.ServiceProcess.ServiceController/src/Resources/Strings.resx
@@ -62,10 +62,10 @@
     <value>Arguments within the 'args' array passed to Start cannot be null.</value>
   </data>
   <data name="BadMachineName" xml:space="preserve">
-    <value>MachineName value {0} is invalid.</value>
+    <value>MachineName '{0}' is invalid.</value>
   </data>
   <data name="CannotStart" xml:space="preserve">
-    <value>Cannot start service {0} on computer '{1}'.</value>
+    <value>Cannot start service '{0}' on computer '{1}'.</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
     <value>The value of argument '{0}' ({1}) is invalid for Enum type '{2}'.</value>
@@ -77,22 +77,22 @@
     <value>MachineName was not set.</value>
   </data>
   <data name="NoService" xml:space="preserve">
-    <value>Service {0} was not found on computer '{1}'.</value>
+    <value>Service '{0}' was not found on computer '{1}'.</value>
   </data>
   <data name="OpenSC" xml:space="preserve">
     <value>Cannot open Service Control Manager on computer '{0}'. This operation might require other privileges.</value>
   </data>
   <data name="OpenService" xml:space="preserve">
-    <value>Cannot open {0} service on computer '{1}'.</value>
+    <value>Cannot open '{0}' service on computer '{1}'.</value>
   </data>
   <data name="PauseService" xml:space="preserve">
-    <value>Cannot pause {0} service on computer '{1}'.</value>
+    <value>Cannot pause '{0}' service on computer '{1}'.</value>
   </data>
   <data name="ResumeService" xml:space="preserve">
-    <value>Cannot resume {0} service on computer '{1}'.</value>
+    <value>Cannot resume '{0}' service on computer '{1}'.</value>
   </data>
   <data name="StopService" xml:space="preserve">
-    <value>Cannot stop {0} service on computer '{1}'.</value>
+    <value>Cannot stop '{0}' service on computer '{1}'.</value>
   </data>
   <data name="Timeout" xml:space="preserve">
     <value>Time out has expired and the operation has not been completed.</value>
@@ -107,7 +107,7 @@
     <value>Cannot change service name when the service is running.</value>
   </data>
   <data name="ServiceName" xml:space="preserve">
-    <value>Service name {0} contains invalid characters, is empty, or is too long (max length = {1}).</value>
+    <value>Service name '{0}' contains invalid characters, is empty, or is too long (max length = {1}).</value>
   </data>
   <data name="NoServices" xml:space="preserve">
     <value>Service has not been supplied. At least one object derived from ServiceBase is required in order to run.</value>
@@ -179,18 +179,18 @@
     <value>Failed in handling the PowerEvent. The error that occurred was: {0}.</value>
   </data>
   <data name="InstallOK" xml:space="preserve">
-    <value>Service {0} has been successfully installed.</value>
+    <value>Service '{0}' has been successfully installed.</value>
   </data>
   <data name="TryToStop" xml:space="preserve">
-    <value>Attempt to stop service {0}.</value>
+    <value>Attempt to stop service '{0}'.</value>
   </data>
   <data name="ServiceRemoving" xml:space="preserve">
-    <value>Service {0} is being removed from the system...</value>
+    <value>Service '{0}' is being removed from the system...</value>
   </data>
   <data name="ServiceRemoved" xml:space="preserve">
-    <value>Service {0} was successfully removed from the system.</value>
+    <value>Service '{0}'' was successfully removed from the system.</value>
   </data>
   <data name="ControlService" xml:space="preserve">
-    <value>Cannot control {0} service on computer '{1}'.</value>
+    <value>Cannot control '{0}' service on computer '{1}'.</value>
   </data>
 </root>

--- a/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
+++ b/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
@@ -33,6 +33,12 @@
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.EnumServicesStatusEx.cs">
       <Link>Common\Interop\Windows\Interop.EnumServicesStatusEx.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.GetServiceDisplayName.cs">
+      <Link>Common\Interop\Windows\Interop.GetServiceDisplayName.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.GetServiceKeyName.cs">
+      <Link>Common\Interop\Windows\Interop.GetServiceKeyName.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenSCManager.cs">
       <Link>Common\Interop\Windows\Interop.OpenSCManager.cs</Link>
     </Compile>
@@ -93,6 +99,7 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetGroup.StartsWith('netcoreapp')) OR ('$(TargetGroup)' == 'netstandard' AND '$(TargetsWindows)' == 'true')">
     <Reference Include="Microsoft.Win32.Primitives" />
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Console" />
     <Reference Include="System.ComponentModel.Primitives" />

--- a/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using Xunit;
 
 namespace System.ServiceProcess.Tests
@@ -59,6 +60,14 @@ namespace System.ServiceProcess.Tests
             Assert.True(foundOtherSvc, "foundOtherSvc");
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public static void ConstructWithBadServiceName(string value)
+        {
+            Assert.Throws<ArgumentException>(() => new ServiceController(value));
+        }
+
         [Fact]
         public static void GetDevices()
         {
@@ -85,6 +94,90 @@ namespace System.ServiceProcess.Tests
             Assert.Equal(devices[0].DisplayName, actual.DisplayName);
             Assert.Equal(devices[0].ServiceType, actual.ServiceType);
             Assert.Equal(devices[0].MachineName, actual.MachineName);
+        }
+
+        [Fact]
+        public static void NonExistentService_GetStatus()
+        {
+            var controller = new ServiceController(Guid.NewGuid().ToString("N"));
+            Exception exception = Assert.Throws<InvalidOperationException>(() => controller.Status);
+            Assert.IsType<Win32Exception>(exception.InnerException);
+        }
+
+        [Fact]
+        public static void NonExistentService_GetDisplayName()
+        {
+            var controller = new ServiceController(Guid.NewGuid().ToString("N"));
+            Exception exception = Assert.Throws<InvalidOperationException>(() => controller.DisplayName);
+            Assert.IsType<Win32Exception>(exception.InnerException);
+        }
+
+        [Fact]
+        public static void SetNameToNonexistentService_GetStatus()
+        {
+            var controller = new ServiceController();
+            controller.ServiceName = Guid.NewGuid().ToString("N");
+            Exception exception = Assert.Throws<InvalidOperationException>(() => controller.Status);
+            Assert.IsType<Win32Exception>(exception.InnerException);
+        }
+
+        [Fact]
+        public static void SetNameToNonexistentService_GetDisplayName()
+        {
+            var controller = new ServiceController();
+            controller.ServiceName = Guid.NewGuid().ToString("N");
+            Exception exception = Assert.Throws<InvalidOperationException>(() => controller.DisplayName);
+            Assert.IsType<Win32Exception>(exception.InnerException);
+        }
+
+        [Fact]
+        public static void SetDisplayNameToNonexistentService_GetStatus()
+        {
+            var controller = new ServiceController();
+            controller.DisplayName = Guid.NewGuid().ToString("N");
+            Exception exception = Assert.Throws<InvalidOperationException>(() => controller.Status);
+            Assert.IsType<Win32Exception>(exception.InnerException);
+        }
+
+        [Fact]
+        public static void SetDisplayNameToNonexistentService_GetServiceName()
+        {
+            var controller = new ServiceController();
+            controller.DisplayName = Guid.NewGuid().ToString("N");
+            Exception exception = Assert.Throws<InvalidOperationException>(() => controller.ServiceName);
+            Assert.IsType<Win32Exception>(exception.InnerException);
+        }
+
+        [Fact]
+        public static void SetServiceName_GetDisplayName()
+        {
+            var keyIsoDisplayName = new ServiceController(KeyIsoSvcName).DisplayName;
+
+            var controller = new ServiceController();
+            controller.ServiceName = KeyIsoSvcName;
+            Assert.Equal(keyIsoDisplayName, controller.DisplayName);
+        }
+
+        [Fact]
+        public static void SetDisplayName_GetServiceName()
+        {
+            var keyIsoDisplayName = new ServiceController(KeyIsoSvcName).DisplayName;
+
+            var controller = new ServiceController();
+            controller.DisplayName = keyIsoDisplayName;
+            Assert.Equal(KeyIsoSvcName.ToLowerInvariant(), controller.ServiceName.ToLowerInvariant());
+        }
+
+        [Fact]
+        public static void GetStatusByBothNames()
+        {
+            var controller = new ServiceController(KeyIsoSvcName);
+            Assert.Equal(KeyIsoSvcName, controller.ServiceName);
+            Assert.NotEmpty(controller.DisplayName);
+
+            controller = new ServiceController(controller.DisplayName);
+            Assert.Equal(KeyIsoSvcName.ToLowerInvariant(), controller.ServiceName.ToLowerInvariant());
+            Assert.NotEmpty(controller.DisplayName);
         }
 
         [Fact]


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/31877

* Regression was caused by an unexplained change in Project K in 2014 to populate name and display name by enumerating every service on the machine examining their names. Revert back to use the direct Win32 API calls. Modernize the interop.
* Tidy up some strings.
* Write tests to get code coverage of various name population codepaths.
* Fix several existing issues uncovered by tests, in some cases introduced since .NET Framework.
* Inline one method for clarity.
```
BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.228 (1803/April2018Update/Redstone4)
Intel Core i7-2760QM CPU 2.40GHz (Sandy Bridge), 1 CPU, 8 logical and 4 physical cores
Frequency=2336175 Hz, Resolution=428.0501 ns, Timer=TSC
.NET Core SDK=2.1.400
  [Host] : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  Clr    : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3132.0
  Core   : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
```
 Method |  Job | Runtime |     Mean |     Error |    StdDev |
------- |----- |-------- |---------:|----------:|----------:|
   GetStatus |  Clr |     Clr | 195.6 us | 3.8735 us | 9.8594 us |
   GetStatus| Core |    Core | 2,588.3 us | 14.756 us | 11.521 us |
   GetStatusFixed | Core |    Core | 181.6 us | 0.7662 us | 0.6398 us |

I also noticed that .NET Framework was using raw IntPtr for the SCM handle but apparently that doesn't help it significantly:

Method |     Mean |    Error |   StdDev |
------------------ |---------:|---------:|---------:|
IntPtr | 186.8 us | 2.791 us | 2.611 us |
 SafeServiceHandle | 186.2 us | 2.077 us | 1.842 us |