### PR TITLE
Make flaky serialport test OuterLoop

### DIFF
--- a/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
+++ b/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
@@ -19,6 +19,7 @@ namespace System.IO.Ports.Tests
         /// Check that all ports either open correctly or fail with UnauthorizedAccessException (which implies they're already open)
         /// </summary>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [OuterLoop] // Occasionally flaky on UAP: https://github.com/dotnet/corefx/issues/32077
         private void OpenEveryPortName()
         {
             foreach (string portName in SerialPort.GetPortNames())


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/issues/32077
Flaky in CI on UAP.