### PR TITLE
Bump System.Drawing.Common assembly version

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1734,7 +1734,7 @@
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",
-        "4.0.1.0": "4.6.0"
+        "4.0.2.0": "4.6.0"
       }
     },
     "System.Drawing.Design": {

--- a/src/System.Drawing.Common/Directory.Build.props
+++ b/src/System.Drawing.Common/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
We just bumped this assembly version to 4.0.1.0 in release/2.1 branch. 

Should we instead bump it to 4.1.0.0 to avoid this happening again if we need to service it from the release branch?

