### PR TITLE
[release/2.1] Bump package version for S.S.C.Pkcs and add it to packages.builds

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2237,6 +2237,7 @@
         "4.5.1"
       ],
       "BaselineVersion": "4.4.0",
+      "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
@@ -3608,6 +3609,7 @@
         "4.5.0",
         "4.5.1"
       ],
+      "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.4.0": "4.5.0"
       }
@@ -4287,7 +4289,8 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "4.0.4.0": "4.5.1"
       }
     },
     "System.Security.Cryptography.Primitives": {
@@ -5003,10 +5006,10 @@
       ],
       "BaselineVersion": "4.4.0",
       "InboxOn": {
-        "monoandroid10": "Any",
-        "monotouch10": "Any",
         "netcoreapp2.0": "4.1.1.0",
         "netcoreapp2.1": "4.3.0.0",
+        "monoandroid10": "Any",
+        "monotouch10": "Any",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",

--- a/src/System.Security.Cryptography.Pkcs/dir.props
+++ b/src/System.Security.Cryptography.Pkcs/dir.props
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
+    <PackageVersion>4.5.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -39,6 +39,9 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Drawing.Common\pkg\System.Drawing.Common.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
This package authoring was missing from the changes for 2.1.3 servicing, resulting in those fixes not making it to customers.

Fixes #32092.