### PR TITLE
disable HTTP/2 multiplexing on osx 10.13

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.cs
@@ -164,7 +164,7 @@ namespace System.Net.Http
             Interop.Http.CurlFeatures features = Interop.Http.GetSupportedFeatures();
             s_supportsSSL = (features & Interop.Http.CurlFeatures.CURL_VERSION_SSL) != 0;
             s_supportsAutomaticDecompression = (features & Interop.Http.CurlFeatures.CURL_VERSION_LIBZ) != 0;
-            s_supportsHttp2Multiplexing = (features & Interop.Http.CurlFeatures.CURL_VERSION_HTTP2) != 0 && Interop.Http.GetSupportsHttp2Multiplexing();
+            s_supportsHttp2Multiplexing = (features & Interop.Http.CurlFeatures.CURL_VERSION_HTTP2) != 0 && Interop.Http.GetSupportsHttp2Multiplexing() && !UseSingletonMultiAgent;
 
             if (NetEventSource.IsEnabled)
             {


### PR DESCRIPTION
This change effectively disables HTTP/2 on OSX 10.13 to stabilize tests.
Note that this is actually product change. When I was looking at test failures it turned out that the content is actually getting corrupted and and tests do fail for valid reason. 
Also note, that the tests only fail in normal parallel runs and they run ok when single test is selected or if '-parallel none' is used for XUnit. 

Just a s a background info: Both 10.13 and 10.12 do ship with curl 7.54.0.
However 10.12 is configured with SecureTransport and without HTTP/2 support so all test to http/2 endpoints will fall back to HTTP/1.1. 10.13 links with libhttp2 and uses reopensll as SSL backend. 

Testing: 
This change greatly stabilized my local test runs. I still do see test failures but they are primarily because of DNS (device not find exception)


