### PR TITLE
Add Microsoft-Windows-DotNETRuntime to the list of framework EventSources

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -36,7 +36,8 @@ namespace BasicEventSourceTests
                     eventSource.Name != "System.Buffers.ArrayPoolEventSource" &&
                     eventSource.Name != "System.Threading.SynchronizationEventSource" &&
                     eventSource.Name != "System.Runtime.InteropServices.InteropEventProvider" &&
-                    eventSource.Name != "System.Reflection.Runtime.Tracing"
+                    eventSource.Name != "System.Reflection.Runtime.Tracing" &&
+                    eventSource.Name != "Microsoft-Windows-DotNETRuntime"
                     )
                 {
                     eventSourceNames += eventSource.Name + " ";


### PR DESCRIPTION
Port #31691 to release/2.2.