### PR TITLE
Fix extract out of directory

### DIFF
--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -98,6 +98,8 @@ namespace System.IO.Compression
             // Note that this will give us a good DirectoryInfo even if destinationDirectoryName exists:
             DirectoryInfo di = Directory.CreateDirectory(destinationDirectoryName);
             string destinationDirectoryFullPath = di.FullName;
+            if (!destinationDirectoryFullPath.EndsWith(Path.DirectorySeparatorChar))
+                destinationDirectoryFullPath += Path.DirectorySeparatorChar;
 
             string fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, source.FullName));
 

--- a/src/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -46,6 +46,21 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        [Theory]
+        [InlineData("../Foo")]
+        [InlineData("../Barbell")]
+        public void ExtractOutOfRoot(string entryName)
+        {
+            string archivePath = GetTestFilePath();
+            using (FileStream stream = new FileStream(archivePath, FileMode.Create))
+            using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                ZipArchiveEntry entry = archive.CreateEntry(entryName);
+            }
+
+            DirectoryInfo destination = Directory.CreateDirectory(Path.Combine(GetTestFilePath(), "Bar"));
+            Assert.Throws<IOException>(() => ZipFile.ExtractToDirectory(archivePath, destination.FullName));
+        }
 
         /// <summary>
         /// This test ensures that a zipfile with path names that are invalid to this OS will throw errors

--- a/src/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -49,6 +49,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("../Foo")]
         [InlineData("../Barbell")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Second case fails.")]
         public void ExtractOutOfRoot(string entryName)
         {
             string archivePath = GetTestFilePath();


### PR DESCRIPTION
Without ensuring a trailing directory separator you cannot compare paths for nesting.  `/Foo/Bar` does not contain `/Foo/Barber`, but does contain `/Foo/Bar/Bell`. This adds the separator and tests.