### PR TITLE
Add tests as output artifacts to build and publish pipelines for Official Builds

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -122,6 +122,21 @@
                     ManifestCommit="$(ManifestCommit)" />
   </Target>
 
+  <Target Name="PublishTestsToAzureBlobFeed" AfterTargets="PublishToAzureBlobFeed">
+    <ItemGroup>
+      <ItemsToPush Include="$(FinalTestArchivesPattern)">
+        <RelativeBlobPath>%(RecursiveDir)</RelativeBlobPath>
+        <WorkItemId>%(Filename)</WorkItemId>
+        <PayloadUri>%(RecursiveDir)</PayloadUri>
+      </ItemsToPush>
+    </ItemGroup>
+    <Error Condition="'@(ItemsToPush->Count())' == 0" Text="ItemsToPush for tests is empty." />
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(ItemsToPush)"
+                    PublishFlatContainer="true"/>
+  </Target>
+
   <Target Name="PublishSymbolsToAzureBlobFeed" Condition="'$(PublishSymbols)' == 'true'" >
     <ItemGroup>
       <ItemsToPush Include="$(FinalSymbolsPackagesPattern)" />

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -28,7 +28,6 @@
     <ArchivesRoot>$(TestWorkingDir)$(OSPlatformConfig)/archive/</ArchivesRoot>
     <TestArchivesRoot>$(ArchivesRoot)tests/</TestArchivesRoot>
 
-    <TestListFilename>$(TestArchivesRoot)TestList.json</TestListFilename>
     <AzureTestsRoot>corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-tests/</AzureTestsRoot>
   </PropertyGroup>
 
@@ -81,6 +80,8 @@
     <!-- The SignFiles target needs OutDir to be defined -->
     <OutDir>$(PackageDownloadDirectory)</OutDir>
     <AzureFeedTestsRoot>tests/</AzureFeedTestsRoot>
+    <TestListFilename>TestList.json</TestListFilename>
+    <TestListPath>$(PackagesDir)AzureTransfer\$(AzureTestsRoot)$(TestListFilename)</TestListPath>
   </PropertyGroup>
 
   <Target Name="GetPackagesToSign">
@@ -118,18 +119,45 @@
   <Target Name="PublishTestsToAzureBlobFeed" AfterTargets="PublishToAzureBlobFeed">
     <ItemGroup>
       <TestsToPush Include="$(FinalTestArchivesPattern)" />
-    </ItemGroup>
-    <ItemGroup>
       <TestsToPush>
-        <RelativeBlobPath>$(AzureFeedTestsRoot)%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>
-        <WorkItemId>%(Filename)</WorkItemId>
-        <PayloadUri>$(AzureFeedTestsRoot)%(RecursiveDir)%(Filename)%(Extension)</PayloadUri>
+        <RelativeBlobPath>$([System.String]::Copy('$(AzureFeedTestsRoot)%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))</RelativeBlobPath> 
       </TestsToPush>
     </ItemGroup>
+
     <Error Condition="'@(ItemsToPush->Count())' == 0" Text="ItemsToPush for tests is empty." />
+
     <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
                     AccountKey="$(AccountKey)"
                     ItemsToPush="@(TestsToPush)"
+                    PublishFlatContainer="true"/>
+
+    <PropertyGroup>
+      <!-- Regex used by BlobFeedAction to extract same information -->
+      <FeedStorageAccount>$([System.Text.RegularExpressions.Regex]::Match($(ExpectedFeedUrl), `(?'feedurl'https:\/\/(?'accountname'[^\.-]+)(?'domain'[^\/]*)\/((?'token'[a-zA-Z0-9+\/]*?\/\d{4}-\d{2}-\d{2})\/)?(?'containername'[^\/]+)\/(?'relativepath'.*\/)?)index\.json`).Groups["accountname"].value)</FeedStorageAccount>
+      <FeedContainerName>$([System.Text.RegularExpressions.Regex]::Match($(ExpectedFeedUrl), `(?'feedurl'https:\/\/(?'accountname'[^\.-]+)(?'domain'[^\/]*)\/((?'token'[a-zA-Z0-9+\/]*?\/\d{4}-\d{2}-\d{2})\/)?(?'containername'[^\/]+)\/(?'relativepath'.*\/)?)index\.json`).Groups["containername"].value)</FeedContainerName>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Add metadata for tests -->
+      <TestsToPush>
+        <WorkItemId>%(Filename)</WorkItemId>
+        <PayloadUri>$([System.String]::Copy('https://$(FeedStorageAccount).blob.core.windows.net/$(FeedContainerName)/$(AzureFeedTestsRoot)%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))</PayloadUri>
+      </TestsToPush>
+    </ItemGroup>
+    
+    <WriteItemsToJson JsonFileName="$(TestListPath)" Items="@(TestsToPush)" ForceJsonArray="true" />
+
+    <ItemGroup>
+      <TestList Include="$(TestListPath)" />
+      <TestList>
+        <!-- TODO: Fix this path to be the same relative path as the downloaded tests.  Right now, AzureTestsRoot will have 0s through it during the Publish phase... -->
+        <RelativeBlobPath>$(AzureFeedTestsRoot)$(AzureTestsRoot)$(OSGroup)-$(ArchGroup)/%(Filename)%(Extension)</RelativeBlobPath>
+      </TestList>
+    </ItemGroup>
+
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(TestList)"
                     PublishFlatContainer="true"/>
   </Target>
 

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -30,10 +30,6 @@
 
     <TestListFilename>$(TestArchivesRoot)TestList.json</TestListFilename>
     <AzureTestsRoot>corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-tests/</AzureTestsRoot>
-
-    <TestArchivesPattern>$(TestArchivesRoot)**/*.zip</TestArchivesPattern>
-    <TestArchivesPattern>$(TestArchivePattern);$(AnyOSTestArchivesRoot)**/*.zip</TestArchivesPattern>
-    <TestArchivesPattern Condition="'$(TargetsUnix)' == 'true'">$(TestArchivePattern);$(UnixTestArchivesRoot)**/*.zip</TestArchivesPattern>
   </PropertyGroup>
 
   <ItemGroup>
@@ -57,16 +53,12 @@
 
   <Target Name="UploadTestsToAzure">
     <ItemGroup>
-      <TestArchives Include="$(TestArchivePattern)"/>
-    </ItemGroup>
-    <ItemGroup>
       <TestArchives>
         <RelativeBlobPath>$(AzureTestsRoot)$(OSGroup)-$(ArchGroup)/%(Filename)%(Extension)</RelativeBlobPath>
       </TestArchives>
     </ItemGroup>
-
     <UploadToAzure
-      AccountKey="$(CloudDropAccountName)"
+      AccountName="$(CloudDropAccountName)"
       AccountKey="$(CloudDropAccessToken)"
       ContainerName="$(ContainerName)"
       Items="@(TestArchives)"
@@ -85,9 +77,10 @@
     <FinalPublishPrivatePattern>$(PackageDownloadDirectory)\**\*Private*.nupkg</FinalPublishPrivatePattern>
     <FinalPublishExperimentalPattern>$(PackageDownloadDirectory)\**\*Experimental*.nupkg</FinalPublishExperimentalPattern>
     <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
-    <FinalTestArchivesPattern>$(PackagesDir)AzureTransfer\$(AzureTestsRoot)\**\*.zip</FinalTestArchivesPattern>
+    <FinalTestArchivesPattern>$(PackagesDir)AzureTransfer\**\*.zip</FinalTestArchivesPattern>
     <!-- The SignFiles target needs OutDir to be defined -->
     <OutDir>$(PackageDownloadDirectory)</OutDir>
+    <AzureFeedTestsRoot>tests\</AzureFeedTestsRoot>
   </PropertyGroup>
 
   <Target Name="GetPackagesToSign">
@@ -125,9 +118,9 @@
   <Target Name="PublishTestsToAzureBlobFeed" AfterTargets="PublishToAzureBlobFeed">
     <ItemGroup>
       <ItemsToPush Include="$(FinalTestArchivesPattern)">
-        <RelativeBlobPath>%(RecursiveDir)</RelativeBlobPath>
+        <RelativeBlobPath>$(AzureFeedTestsRoot)%(RecursiveDir)</RelativeBlobPath>
         <WorkItemId>%(Filename)</WorkItemId>
-        <PayloadUri>%(RecursiveDir)</PayloadUri>
+        <PayloadUri>$(AzureFeedTestsRoot)%(RecursiveDir)</PayloadUri>
       </ItemsToPush>
     </ItemGroup>
     <Error Condition="'@(ItemsToPush->Count())' == 0" Text="ItemsToPush for tests is empty." />

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -29,6 +29,8 @@
     <TestArchivesRoot>$(ArchivesRoot)tests/</TestArchivesRoot>
 
     <TestListFilename>$(TestArchivesRoot)TestList.json</TestListFilename>
+    
+    <CloudDropConnectionString    Condition="'$(CloudDropConnectionString)'==''"   >DefaultEndpointsProtocol=https;AccountName=$(CloudDropAccountName);AccountKey=$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -37,9 +37,12 @@
 
   <!-- Collect test archives for pushing to transfer feed -->
   <ItemGroup>
-    <TestArchives Include="$(TestArchivesRoot)**/*.zip" />
-    <TestArchives Include="$(AnyOSTestArchivesRoot)**/*.zip" />
-    <TestArchives Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" />
+    <TestArchive Include="$(TestArchivesRoot)**/*.zip" />
+    <TestArchive Include="$(AnyOSTestArchivesRoot)**/*.zip" />
+    <TestArchive Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" />
+    <TestArchive>
+      <RelativeBlobPath>$(AzureTestsRoot)$(OSGroup)-$(ArchGroup)/%(Filename)%(Extension)</RelativeBlobPath>
+    </TestArchive>
   </ItemGroup>
 
   <Target Name="CreateContainerName"
@@ -51,23 +54,18 @@
   </Target>
 
   <Target Name="UploadTestsToAzure">
-    <ItemGroup>
-      <TestArchives>
-        <RelativeBlobPath>$(AzureTestsRoot)$(OSGroup)-$(ArchGroup)/%(Filename)%(Extension)</RelativeBlobPath>
-      </TestArchives>
-    </ItemGroup>
     <UploadToAzure
       AccountName="$(CloudDropAccountName)"
       AccountKey="$(CloudDropAccessToken)"
       ContainerName="$(ContainerName)"
-      Items="@(TestArchives)"
+      Items="@(TestArchive)"
       Overwrite="true" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="CreateContainerName">
     <!-- skip uploadToAzure when there are no nupkgs -->
     <CallTarget Targets="UploadToAzure" Condition="'@(_PackagesToPublish)' != ''" />
-    <CallTarget Targets="UploadTestsToAzure" Condition="'@(TestArchives->Count())' != 0" />
+    <CallTarget Targets="UploadTestsToAzure" Condition="'@(TestArchive->Count())' != 0" />
   </Target>
 
   <PropertyGroup>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -80,7 +80,7 @@
     <FinalTestArchivesPattern>$(PackagesDir)AzureTransfer\**\*.zip</FinalTestArchivesPattern>
     <!-- The SignFiles target needs OutDir to be defined -->
     <OutDir>$(PackageDownloadDirectory)</OutDir>
-    <AzureFeedTestsRoot>tests\</AzureFeedTestsRoot>
+    <AzureFeedTestsRoot>tests/</AzureFeedTestsRoot>
   </PropertyGroup>
 
   <Target Name="GetPackagesToSign">
@@ -117,16 +117,19 @@
 
   <Target Name="PublishTestsToAzureBlobFeed" AfterTargets="PublishToAzureBlobFeed">
     <ItemGroup>
-      <ItemsToPush Include="$(FinalTestArchivesPattern)">
-        <RelativeBlobPath>$(AzureFeedTestsRoot)%(RecursiveDir)</RelativeBlobPath>
+      <TestsToPush Include="$(FinalTestArchivesPattern)" />
+    </ItemGroup>
+    <ItemGroup>
+      <TestsToPush>
+        <RelativeBlobPath>$(AzureFeedTestsRoot)%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>
         <WorkItemId>%(Filename)</WorkItemId>
-        <PayloadUri>$(AzureFeedTestsRoot)%(RecursiveDir)</PayloadUri>
-      </ItemsToPush>
+        <PayloadUri>$(AzureFeedTestsRoot)%(RecursiveDir)%(Filename)%(Extension)</PayloadUri>
+      </TestsToPush>
     </ItemGroup>
     <Error Condition="'@(ItemsToPush->Count())' == 0" Text="ItemsToPush for tests is empty." />
     <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
                     AccountKey="$(AccountKey)"
-                    ItemsToPush="@(ItemsToPush)"
+                    ItemsToPush="@(TestsToPush)"
                     PublishFlatContainer="true"/>
   </Target>
 

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -29,8 +29,11 @@
     <TestArchivesRoot>$(ArchivesRoot)tests/</TestArchivesRoot>
 
     <TestListFilename>$(TestArchivesRoot)TestList.json</TestListFilename>
-    
-    <CloudDropConnectionString    Condition="'$(CloudDropConnectionString)'==''"   >DefaultEndpointsProtocol=https;AccountName=$(CloudDropAccountName);AccountKey=$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
+    <AzureTestsRoot>corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-tests/</AzureTestsRoot>
+
+    <TestArchivesPattern>$(TestArchivesRoot)**/*.zip</TestArchivesPattern>
+    <TestArchivesPattern>$(TestArchivePattern);$(AnyOSTestArchivesRoot)**/*.zip</TestArchivesPattern>
+    <TestArchivesPattern Condition="'$(TargetsUnix)' == 'true'">$(TestArchivePattern);$(UnixTestArchivesRoot)**/*.zip</TestArchivesPattern>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,20 +56,23 @@
   </Target>
 
   <Target Name="UploadTestsToAzure">
-    <PropertyGroup>
-      <AzureTestsRoot>$(ContainerName)-tests/</AzureTestsRoot>
-    </PropertyGroup>
+    <ItemGroup>
+      <TestArchives Include="$(TestArchivePattern)"/>
+    </ItemGroup>
+    <ItemGroup>
+      <!-- If we are in the publish phase, we never built the tests, so we need to grab the downloaded ones -->
+      <TestArchives Condition="'@(TestArchives->Count())' == 0" Include="$(FinalTestArchivesPattern)">
+    </ItemGroup>
     <ItemGroup>
       <TestArchives>
-        <WorkItemId>%(Filename)</WorkItemId>
-        <!-- TODO: Verify that the below will actually put the appropriate platform for a given build... -->
-        <!-- TODO: Determine best design for pushing tests, e.g., should the relative path be <build-id>/<arch>/<os>? -->
-        <RelativeBlobPath>$(AzureTestsRoot)$(RuntimeOS)/%(Filename)%(Extension)</RelativeBlobPath>
+        <RelativeBlobPath>$(AzureTestsRoot)$(OSGroup)-$(ArchGroup)/%(Filename)%(Extension)</RelativeBlobPath>
       </TestArchives>
-      <TestArchives>
-        <PayloadUri>$(CloudDropAccountName).blob.core.Windows.net/$(ContainerName)/%(RelativeBlobPath)</PayloadUri>
-      </TestArchives> 
     </ItemGroup>
+
+    <PropertyGroup>
+      <ContainerName Condition="'$(ContainerName)' == ''"></ContainerName>
+      <CloudDropConnectionString Condition="'$(CloudDropConnectionString)'==''">DefaultEndpointsProtocol=https;AccountName=$(CloudDropAccountName);AccountKey=$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
+    </PropertyGroup>
 
     <UploadToAzure
       ConnectionString="$(CloudDropConnectionString)"
@@ -87,6 +93,7 @@
     <FinalPublishPrivatePattern>$(PackageDownloadDirectory)\**\*Private*.nupkg</FinalPublishPrivatePattern>
     <FinalPublishExperimentalPattern>$(PackageDownloadDirectory)\**\*Experimental*.nupkg</FinalPublishExperimentalPattern>
     <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
+    <FinalTestArchivesPattern>$(PackagesDir)AzureTransfer\$(AzureTestsRoot)\**\*.zip</FinalTestArchivesPattern>
     <!-- The SignFiles target needs OutDir to be defined -->
     <OutDir>$(PackageDownloadDirectory)</OutDir>
   </PropertyGroup>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -150,7 +150,6 @@
     <ItemGroup>
       <TestList Include="$(TestListPath)" />
       <TestList>
-        <!-- TODO: Fix this path to be the same relative path as the downloaded tests.  Right now, AzureTestsRoot will have 0s through it during the Publish phase... -->
         <RelativeBlobPath>$(AzureFeedTestsRoot)$(AzureTestsRoot)$(OSGroup)-$(ArchGroup)/%(Filename)%(Extension)</RelativeBlobPath>
       </TestList>
     </ItemGroup>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -71,14 +71,6 @@
       ContainerName="$(ContainerName)"
       Items="@(TestArchives)"
       Overwrite="true" />
-
-    <WriteItemsToJson JsonFileName="$(TestListFilename)" Items="@(TestArchives)" ForeJsonArray="true"/>
-
-    <ItemGroup>
-      <TestList Include="$(TestListFilename)">
-        <RelativeBlobPath>$(AzureTestsRoot)$(RuntimeOS)/%(Filename)%(Extension)</RelativeBlobPath>
-      </TestList>
-    </ItemGroup>
   </Target>
 
   <Target Name="Build" DependsOnTargets="CreateContainerName">

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -6,12 +6,40 @@
   <Import Project="$(PackagesDir)/$(FeedTasksPackage.ToLower())/$(FeedTasksPackageVersion)/build/$(FeedTasksPackage).targets" />
   <Import Project="$(PackagesDir)/$(PublishSymbolsPackage.ToLower())/$(PublishSymbolsPackageVersion)/build/PublishSymbols.targets" />
 
+  <UsingTask TaskName="UploadToAzure"                    AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="WriteItemsToJson"                 AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+
   <PropertyGroup>
     <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)\**\*.nupkg</PublishPattern>
+    
+    <!-- Copied in from upload-tests.proj for locating and pushing tests to transfer feed -->
+    <!-- Test builds consist of the tests that are platform specific in one root, plus others in AnyOS. -->
+    <AnyOSPlatformConfig>AnyOS.AnyCPU.$(ConfigurationGroup)</AnyOSPlatformConfig>
+    <AnyOsArchivesRoot>$(TestWorkingDir)$(AnyOSPlatformConfig)/archive/</AnyOsArchivesRoot>
+    <AnyOSTestArchivesRoot>$(AnyOsArchivesRoot)tests/</AnyOSTestArchivesRoot>
+
+    <!-- Additionally, *NIX variations may need to include their own root folders -->
+    <UnixPlatformConfig>Unix.$(Platform).$(ConfigurationGroup)</UnixPlatformConfig>
+    <UnixArchivesRoot>$(TestWorkingDir)$(UnixPlatformConfig)/archive/</UnixArchivesRoot>
+    <UnixTestArchivesRoot>$(UnixArchivesRoot)tests/</UnixTestArchivesRoot>
+
+    <!-- Finally, these archives represent the zips of tests that are OSPlatform specific 
+         This is used by CloudTest.Helix.Targets to generate relative blob paths for archives. -->
+    <ArchivesRoot>$(TestWorkingDir)$(OSPlatformConfig)/archive/</ArchivesRoot>
+    <TestArchivesRoot>$(ArchivesRoot)tests/</TestArchivesRoot>
+
+    <TestListFilename>$(TestArchivesRoot)TestList.json</TestListFilename>
   </PropertyGroup>
 
   <ItemGroup>
     <_PackagesToPublish Include="$(PublishPattern)" />
+  </ItemGroup>
+
+  <!-- Collect test archives for pushing to transfer feed -->
+  <ItemGroup>
+    <TestArchives Include="$(TestArchivesRoot)**/*.zip" />
+    <TestArchives Include="$(AnyOSTestArchivesRoot)**/*.zip" />
+    <TestArchives Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" />
   </ItemGroup>
 
   <Target Name="CreateContainerName"
@@ -22,9 +50,41 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="UploadTestsToAzure">
+    <PropertyGroup>
+      <AzureTestsRoot>$(ContainerName)-tests/</AzureTestsRoot>
+    </PropertyGroup>
+    <ItemGroup>
+      <TestArchives>
+        <WorkItemId>%(Filename)</WorkItemId>
+        <!-- TODO: Verify that the below will actually put the appropriate platform for a given build... -->
+        <!-- TODO: Determine best design for pushing tests, e.g., should the relative path be <build-id>/<arch>/<os>? -->
+        <RelativeBlobPath>$(AzureTestsRoot)$(RuntimeOS)/%(Filename)%(Extension)</RelativeBlobPath>
+      </TestArchives>
+      <TestArchives>
+        <PayloadUri>$(CloudDropAccountName).blob.core.Windows.net/$(ContainerName)/%(RelativeBlobPath)</PayloadUri>
+      </TestArchives> 
+    </ItemGroup>
+
+    <UploadToAzure
+      ConnectionString="$(CloudDropConnectionString)"
+      ContainerName="$(ContainerName)"
+      Items="@(TestArchives)"
+      Overwrite="true" />
+
+    <WriteItemsToJson JsonFileName="$(TestListFilename)" Items="@(TestArchives)" ForeJsonArray="true"/>
+
+    <ItemGroup>
+      <TestList Include="$(TestListFilename)">
+        <RelativeBlobPath>$(AzureTestsRoot)$(RuntimeOS)/%(Filename)%(Extension)</RelativeBlobPath>
+      </TestList>
+    </ItemGroup>
+  </Target>
+
   <Target Name="Build" DependsOnTargets="CreateContainerName">
     <!-- skip uploadToAzure when there are no nupkgs -->
     <CallTarget Targets="UploadToAzure" Condition="'@(_PackagesToPublish)' != ''" />
+    <CallTarget Targets="UploadTestsToAzure" Condition="'@(TestArchives->Count())' != 0" />
   </Target>
 
   <PropertyGroup>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -60,22 +60,14 @@
       <TestArchives Include="$(TestArchivePattern)"/>
     </ItemGroup>
     <ItemGroup>
-      <!-- If we are in the publish phase, we never built the tests, so we need to grab the downloaded ones -->
-      <TestArchives Condition="'@(TestArchives->Count())' == 0" Include="$(FinalTestArchivesPattern)">
-    </ItemGroup>
-    <ItemGroup>
       <TestArchives>
         <RelativeBlobPath>$(AzureTestsRoot)$(OSGroup)-$(ArchGroup)/%(Filename)%(Extension)</RelativeBlobPath>
       </TestArchives>
     </ItemGroup>
 
-    <PropertyGroup>
-      <ContainerName Condition="'$(ContainerName)' == ''"></ContainerName>
-      <CloudDropConnectionString Condition="'$(CloudDropConnectionString)'==''">DefaultEndpointsProtocol=https;AccountName=$(CloudDropAccountName);AccountKey=$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
-    </PropertyGroup>
-
     <UploadToAzure
-      ConnectionString="$(CloudDropConnectionString)"
+      AccountKey="$(CloudDropAccountName)"
+      AccountKey="$(CloudDropAccessToken)"
       ContainerName="$(ContainerName)"
       Items="@(TestArchives)"
       Overwrite="true" />


### PR DESCRIPTION
# Automate the generation and storage of CoreFX tests during Official Builds and Publishes

These changes will take the tests generated during the Build pipeline and push them to the intermediate blob storage containers used for build artifacts.  This is done by adding an MSBuild target that gets invoked during the "Push Packages to Azure" step in the Build pipeline, specifically in `Publish.proj`.  This same `.proj` file is invoked during the Publish pipeline in the "Packages -> Azure Blob Feed" step, so similarly there is a new target for pushing the tests to the public repo.

These tests will be consumed by the CI builds in dotnet/coreclr, and can be used by developers testing their local builds of CoreCLR against the CoreFX tests.  (see referenced issue in dotnet/coreclr for more details).

# Directory Structure

The tests are pushed to Azure in two places and flow like this:

```
(Official Build) -- tests pushed to Azure --> private blob storage -- tests downloaded from Azure --> (Official Publish) -- tests pushed to Azure Blob feed --> public endpoint
```

The directory structure is straightforward.  During the Build pipeline, a directory structure is added  that contains all the tests named `corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-tests\<OSGroup>-<Arch>\*.zip`.  During the Publish pipeline, the tests are then pushed to the container where the feed resides, and placed in a single directory: `<feed account>.blob.core.windows.net/<feed container>/tests/corefx-<PreReleaseLabel>-<BuildNumberMajor>-<BuildNumberMinor>-tests/<OSGroup>-<Arch>/…`.  The tests in each directory are accompanied by a `TestList.json` file that enumerates all the tests in the directory.

Over time the `tests` directory on the transfer feed will contain the tests of all Official Builds for all OS Groups and Architectures.
```
root of feed container
|
|- tests
    |
    |- corefx-preview1-12345-01-tests
    |    |- Windows_NT-x64    
    |    |    |- TestList.json
    |    |    |- System.Collections.zip
    |    |    |- etc.
    |    |- MacOSX-x64
    |    |    |- TestList.json
    |    |    |- System.Collections.zip
    |    |    |- etc.
    |    |- etc.
    |- etc.
```

# Assumptions
* Tests are built with every Official Build
* the `BuildNumberMajor` and `BuildNumberMinor` MSBuild properties are available during the publish pipeline
* `BuildNumberMajor` and `BuildNumberMinor` are the same for Official Builds across OS-Arch configurations, i.e., the Official Builds for OSX, Windows_NT, and Unix for the same scheduled build will all share the same values for the build number.

CC - @MattGal @mmitche @sergiy-k @adityamandaleeka @A-And @AaronRobinsonMSFT 



dotnet/coreclr#19690