### PR TITLE
Add ThrowNoDefaultConstructorForCollectionException

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -417,6 +417,9 @@
   <data name="NoConversionPossibleTo" xml:space="preserve">
     <value>An internal error has occurred. No conversion is possible to '{0}' - error generating code for serialization.</value>
   </data>
+  <data name="NoDefaultConstructorForCollection" xml:space="preserve">
+    <value>Collection type '{0}' doesn't have default constructor.</value>
+  </data>
   <data name="NoGetMethodForProperty" xml:space="preserve">
     <value>No get method for property '{1}' in type '{0}'.</value>
   </data>

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -82,11 +82,13 @@ namespace System.Runtime.Serialization
             throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.NullValueReturnedForGetOnlyCollection, DataContract.GetClrTypeFullName(type))));
         }
 
+#if uapaot
         // Referenced from generated code in .NET Native's SerializationAssemblyGenerator
         internal static void ThrowNoDefaultConstructorForCollectionException(Type type)
         {
             throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.NoDefaultConstructorForCollection, DataContract.GetClrTypeFullName(type))));
         }
+#endif
 
 #if USE_REFEMIT
         public static void ThrowArrayExceededSizeException(int arraySize, Type type)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -82,6 +82,12 @@ namespace System.Runtime.Serialization
             throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.NullValueReturnedForGetOnlyCollection, DataContract.GetClrTypeFullName(type))));
         }
 
+        // Referenced from generated code in .NET Native's SerializationAssemblyGenerator
+        internal static void ThrowNoDefaultConstructorForCollectionException(Type type)
+        {
+            throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.NoDefaultConstructorForCollection, DataContract.GetClrTypeFullName(type))));
+        }
+
 #if USE_REFEMIT
         public static void ThrowArrayExceededSizeException(int arraySize, Type type)
 #else


### PR DESCRIPTION
This method is referenced from the code generated by SerializationAssemblyGenerator on .NET Native.

Without this method, valid user code might end up with following warning:

```
  MSBUILD : warning : ILTransform : warning ILT0003: Method 'Type647.ReadArrayOfstringFromXml(XmlReaderDelegator, XmlOb
jectSerializerReadContext, XmlDictionaryString, XmlDictionaryString, CollectionDataContract)' will always throw an exception due to the missing method 'XmlObjectSerializerReadContext.ThrowNoDefaultConstructorForCollectionException(Type)'
in assembly 'System.Private.DataContractSerialization'. There may have been a missing assembly, or a dependency on a more recent Windows SDK release. [d:\dd\pn1\src\QA\ToF\tests\FX\Conformance\System.Runtime.Serialization.Json\4.0.0.0\DataContractJsonSerializerTests.csproj]
```

References to this method were added in changeset 1530459 on Project N TFS side. I wasn't able to find any history of SGuy adding this code on the CoreFX side. So I assume this never worked - we just never noticed the compiler warning.