### PR TITLE
MemoryExtensions.Contains (27526)

### DIFF
--- a/src/Common/src/CoreLib/System/Guid.cs
+++ b/src/Common/src/CoreLib/System/Guid.cs
@@ -427,7 +427,7 @@ namespace System
             }
 
             // Check for dashes
-            bool dashesExistInString = guidString.IndexOf('-') >= 0;
+            bool dashesExistInString = guidString.Contains('-');
 
             if (dashesExistInString)
             {

--- a/src/Common/src/CoreLib/System/MemoryExtensions.Fast.cs
+++ b/src/Common/src/CoreLib/System/MemoryExtensions.Fast.cs
@@ -83,19 +83,12 @@ namespace System
             return CompareInfo.EqualsOrdinalIgnoreCase(ref MemoryMarshal.GetReference(span), ref MemoryMarshal.GetReference(value), span.Length);
         }
 
-        // TODO https://github.com/dotnet/corefx/issues/27526
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool Contains(this ReadOnlySpan<char> source, char value)
-        {
-            for (int i = 0; i < source.Length; i++)
-            {
-                if (source[i] == value)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+            => SpanHelpers.Contains(
+                ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(source)),
+                Unsafe.As<T, char>(ref value),
+                source.Length);
 
         /// <summary>
         /// Compares the specified <paramref name="span"/> and <paramref name="other"/> using the specified <paramref name="comparisonType"/>,

--- a/src/Common/src/CoreLib/System/MemoryExtensions.cs
+++ b/src/Common/src/CoreLib/System/MemoryExtensions.cs
@@ -182,26 +182,22 @@ namespace System
             return true;
         }
 
-        // TODO: Is this optimization required?
-        private static readonly Type s_byte = typeof(byte);
-        private static readonly Type s_char = typeof(char);
-
         /// <summary>
         /// Searches for the specified value and returns true if found. If not found, returns false. Values are compared using IEquatable{T}.Equals(T).
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="span">The span to search.</param>
         /// <param name="value">The value to search for.</param>
-        public static bool Contains<T>(this Span<T> span, T value)
+        public static bool Contains<T>(this Span<T> span, in T value)
             where T : IEquatable<T>
         {
-            if (typeof(T) == s_byte)
+            if (typeof(T) == typeof(byte))
                 return SpanHelpers.Contains(
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
 
-            if (typeof(T) == s_char)
+            if (typeof(T) == typeof(char))
                 return SpanHelpers.Contains(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, char>(ref value),
@@ -217,16 +213,16 @@ namespace System
         /// <param name="span">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Contains<T>(this ReadOnlySpan<T> span, T value)
+        public static bool Contains<T>(this ReadOnlySpan<T> span, in T value)
             where T : IEquatable<T>
         {
-            if (typeof(T) == s_byte)
+            if (typeof(T) == typeof(byte))
                 return SpanHelpers.Contains(
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
 
-            if (typeof(T) == s_char)
+            if (typeof(T) == typeof(char))
                 return SpanHelpers.Contains(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, char>(ref value),

--- a/src/Common/src/CoreLib/System/MemoryExtensions.cs
+++ b/src/Common/src/CoreLib/System/MemoryExtensions.cs
@@ -182,6 +182,59 @@ namespace System
             return true;
         }
 
+        // TODO: Is this optimization required?
+        private static readonly Type s_byte = typeof(byte);
+        private static readonly Type s_char = typeof(char);
+
+        /// <summary>
+        /// Searches for the specified value and returns true if found. If not found, returns false. Values are compared using IEquatable{T}.Equals(T).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        public static bool Contains<T>(this Span<T> span, T value)
+            where T : IEquatable<T>
+        {
+            if (typeof(T) == s_byte)
+                return SpanHelpers.Contains(
+                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                    Unsafe.As<T, byte>(ref value),
+                    span.Length);
+
+            if (typeof(T) == s_char)
+                return SpanHelpers.Contains(
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                    Unsafe.As<T, char>(ref value),
+                    span.Length);
+
+            return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified value and returns true if found. If not found, returns false. Values are compared using IEquatable{T}.Equals(T).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Contains<T>(this ReadOnlySpan<T> span, T value)
+            where T : IEquatable<T>
+        {
+            if (typeof(T) == s_byte)
+                return SpanHelpers.Contains(
+                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                    Unsafe.As<T, byte>(ref value),
+                    span.Length);
+
+            if (typeof(T) == s_char)
+                return SpanHelpers.Contains(
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                    Unsafe.As<T, char>(ref value),
+                    span.Length);
+            
+            return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
+        }
+
         /// <summary>
         /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
         /// </summary>
@@ -196,6 +249,7 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+
             if (typeof(T) == typeof(char))
                 return SpanHelpers.IndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
@@ -238,6 +292,7 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+
             if (typeof(T) == typeof(char))
                 return SpanHelpers.LastIndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
@@ -322,6 +377,7 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+
             if (typeof(T) == typeof(char))
                 return SpanHelpers.IndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
@@ -364,6 +420,7 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+
             if (typeof(T) == typeof(char))
                 return SpanHelpers.LastIndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),

--- a/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Numerics;
-
 using Internal.Runtime.CompilerServices;
 
 #if BIT64
@@ -16,7 +15,7 @@ using nuint = System.UInt32;
 
 namespace System
 {
-    internal static partial class SpanHelpers
+    internal static partial class SpanHelpers // .Byte
     {
         public static int IndexOf(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
         {
@@ -94,6 +93,97 @@ namespace System
                     index = tempIndex;
             }
             return index;
+        }
+
+        // Code adapted from IndexOf(...)
+        public static unsafe bool Contains(ref byte searchSpace, byte value, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            if (length == 0) return false;
+
+            uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)length;
+
+            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
+            {
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+            }
+
+            SequentialScan:
+            while ((byte*)nLength >= (byte*)8)
+            {
+                nLength -= 8;
+
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 0) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
+                {
+                    return true;
+                }
+
+                index += 8;
+            }
+
+            if ((byte*)nLength >= (byte*)4)
+            {
+                nLength -= 4;
+
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 0) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
+                {
+                    return true;
+                }
+
+                index += 4;
+            }
+
+            while ((byte*)nLength > (byte*)0)
+            {
+                nLength--;
+
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                    return true;
+
+                index++;
+            }
+
+            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
+            {
+                nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+
+                // Get comparison Vector
+                Vector<byte> vComparison = new Vector<byte>(value);
+
+                while ((byte*)nLength > (byte*)index)
+                {
+                    var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index)));
+                    if (Vector<byte>.Zero.Equals(vMatches))
+                    {
+                        index += Vector<byte>.Count;
+                        continue;
+                    }
+
+                    return true;
+                }
+
+                if ((int)(byte*)index < length)
+                {
+                    nLength = (IntPtr)(length - (int)(byte*)index);
+                    goto SequentialScan;
+                }
+            }
+
+            return false;
         }
 
         public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)

--- a/src/Common/src/CoreLib/System/SpanHelpers.T.cs
+++ b/src/Common/src/CoreLib/System/SpanHelpers.T.cs
@@ -15,7 +15,7 @@ using System.Numerics;
 
 namespace System
 {
-    internal static partial class SpanHelpers
+    internal static partial class SpanHelpers // .T
     {
         public static int IndexOf<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength)
             where T : IEquatable<T>
@@ -51,6 +51,62 @@ namespace System
                 index++;
             }
             return -1;
+        }
+
+        // Code adapted from IndexOf(...)
+        public static unsafe bool Contains<T>(ref T searchSpace, T value, int length)
+               where T : IEquatable<T>
+        {
+            Debug.Assert(length >= 0);
+
+            if (length == 0) return false;
+
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            while (length >= 8)
+            {
+                length -= 8;
+
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 0)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 1)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 2)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 3)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 4)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 5)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 6)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
+                {
+                    return true;
+                }
+
+                index += 8;
+            }
+
+            if (length >= 4)
+            {
+                length -= 4;
+
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 0)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 1)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 2)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
+                {
+                    return true;
+                }
+
+                index += 4;
+            }
+
+            while (length > 0)
+            {
+                length--;
+
+                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
+                    return true;
+
+                index++;
+            }
+
+            return false;
         }
 
         public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)

--- a/src/Common/src/CoreLib/System/Version.cs
+++ b/src/Common/src/CoreLib/System/Version.cs
@@ -341,7 +341,7 @@ namespace System
                 if (buildEnd != -1)
                 {
                     buildEnd += (minorEnd + 1);
-                    if (input.Slice(buildEnd + 1).IndexOf('.') != -1)
+                    if (input.Slice(buildEnd + 1).Contains('.'))
                     {
                         if (throwOnFailure) throw new ArgumentException(SR.Arg_VersionString, nameof(input));
                         return null;


### PR DESCRIPTION
- Partial fix for #27526 (`IEqualityComparer<T>` methods will be done separately)
- Copy the `IndexOf<T>` code and adapt it to return `true`/`false` instead of the location
- Provide type-specific overloads for `byte` and `char`
- Update relevant call-sites to use `Contains(…)` instead of `IndexOf(…) > -1`