### PR TITLE
Adding trailing directory separator so we can compare paths for nesting.

### DIFF
--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.cs
@@ -160,6 +160,8 @@ namespace System.IO.Compression
             // Note that this will give us a good DirectoryInfo even if destinationDirectoryName exists:
             DirectoryInfo di = Directory.CreateDirectory(destinationDirectoryName);
             string destinationDirectoryFullPath = di.FullName;
+            if (!destinationDirectoryFullPath.EndsWith(Path.DirectorySeparatorChar))
+                destinationDirectoryFullPath += Path.DirectorySeparatorChar;
 
             foreach (ZipArchiveEntry entry in source.Entries)
             {

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -186,6 +186,23 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        [Theory]
+        [InlineData("../Foo")]
+        [InlineData("../Barbell")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Second case fails.")]
+        public void ExtractOutOfRoot(string entryName)
+        {
+            string archivePath = GetTestFilePath();
+            using (FileStream stream = new FileStream(archivePath, FileMode.Create))
+            using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                ZipArchiveEntry entry = archive.CreateEntry(entryName);
+            }
+
+            DirectoryInfo destination = Directory.CreateDirectory(Path.Combine(GetTestFilePath(), "Bar"));
+            Assert.Throws<IOException>(() => ZipFile.ExtractToDirectory(archivePath, destination.FullName));
+        }
+
         [Fact]
         public void CreatedEmptyDirectoriesRoundtrip()
         {


### PR DESCRIPTION
Related to PR #32127

Please note, release/2.2 was missing this change https://github.com/dotnet/corefx/commit/c64068e57d37f7b494dc56c7c426f67a451aafdd
So I had to apply the change from PR #32127 in a different file rather than doing an auto cherry-pick



cc: @JeremyKuhne @danmosemsft @AlexGhiondea 