### PR TITLE
Get coverlet perf gains and remove copy of tracker

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -21,7 +21,7 @@
     <NuGetTargetMonikerShort Condition="'$(TargetGroup)' == 'uap' OR '$(TargetGroup)' == 'uapaot'">netstandard2.0</NuGetTargetMonikerShort>
     <!-- Coverlet related properties -->
     <CoverletPackageId>coverlet.msbuild</CoverletPackageId>
-    <CoverletPackageVersion>2.2.1</CoverletPackageVersion>
+    <CoverletPackageVersion>2.3.0</CoverletPackageVersion>
     <!-- In case the project language is not set -->
     <Language Condition="'$(Language)' == ''">unknown</Language>
     <!-- Don't warn if some dependencies were rolled forward -->
@@ -336,21 +336,6 @@
         <Private>false</Private>
         <NuGetPackageId>$(XUnitTestAdapterPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(XUnitPackageVersion)</NuGetPackageVersion>
-      </ReferenceCopyLocalPaths>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="AddCoverletDependencies" BeforeTargets="ResolveReferences" >
-    <Error Condition="!Exists('$(PackagesDir)$(CoverletPackageId)/$(CoverletPackageVersion)/build/netstandard2.0/coverlet.tracker.dll')"
-            Text="Error: looks the package $(PackagesDir)$(CoverletPackageId)/$(CoverletPackageVersion) not restored or missing coverlet.tracker.dll."
-    />
-    <ItemGroup>
-      <ReferenceCopyLocalPaths
-        Include="$(PackagesDir)$(CoverletPackageId)/$(CoverletPackageVersion)/build/netstandard2.0/coverlet.tracker.dll"
-      >
-        <Private>false</Private>
-        <NuGetPackageId>$(CoverletPackageId)</NuGetPackageId>
-        <NuGetPackageVersion>$(CoverletPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This upgrade brings a large perf gain from coverlet and removes the copy of the "tracker" file not needed on this version.

This should be merged only after https://github.com/dotnet/buildtools/commit/4833b99fade5e0201e8051cd95bf33fe471a7775 reaches corefx (by mistake I submitted it straight to master but since it should not affect anything in CI or otherwise, I am keeping it).