### PR TITLE
Ref Assembly for MemoryExtensions.Contains (CoreFX)

### DIFF
--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -1281,27 +1281,27 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Contains_Match_Char() // Adapted from IndexOf_Match_SingleLetter
+        public static void Contains_Match_Char()
         {
             Assert.False("".Contains('a'));
             Assert.False("".AsSpan().Contains('a'));
 
-            // Use a long enough length to incur vectorization code
+            // Use a long-enough string to incur vectorization code
             for (var length = 1; length < 250; length++)
             {
-                char[] a = new char[length];
+                char[] ca = new char[length];
                 for (int i = 0; i < length; i++)
                 {
-                    a[i] = (char)(i + 1);
+                    ca[i] = (char)(i + 1);
                 }
 
-                var str = new string(a);
-                var span = new Span<char>(a);
-                var ros = new ReadOnlySpan<char>(a);
+                var str = new string(ca);
+                var span = new Span<char>(ca);
+                var ros = new ReadOnlySpan<char>(ca);
 
                 for (var targetIndex = 0; targetIndex < length; targetIndex++)
                 {
-                    var target = a[targetIndex];
+                    char target = ca[targetIndex];
                     var found = str.Contains(target);
                     Assert.True(found);
 

--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -1281,6 +1281,40 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void Contains_Match_Char() // Adapted from IndexOf_Match_SingleLetter
+        {
+            Assert.False("".Contains('a'));
+            Assert.False("".AsSpan().Contains('a'));
+
+            // Use a long enough length to incur vectorization code
+            for (var length = 1; length < 250; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (char)(i + 1);
+                }
+
+                var str = new string(a);
+                var span = new Span<char>(a);
+                var ros = new ReadOnlySpan<char>(a);
+
+                for (var targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    var target = a[targetIndex];
+                    var found = str.Contains(target);
+                    Assert.True(found);
+
+                    found = span.Contains(target);
+                    Assert.True(found);
+
+                    found = ros.Contains(target);
+                    Assert.True(found);
+                }
+            }
+        }
+
+        [Fact]
         public static void MakeSureNoContainsChecksGoOutOfRange_StringComparison()
         {
             for (int length = 0; length < 100; length++)

--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -1281,40 +1281,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Contains_Match_Char()
-        {
-            Assert.False("".Contains('a'));
-            Assert.False("".AsSpan().Contains('a'));
-
-            // Use a long-enough string to incur vectorization code
-            for (var length = 1; length < 250; length++)
-            {
-                char[] ca = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    ca[i] = (char)(i + 1);
-                }
-
-                var str = new string(ca);
-                var span = new Span<char>(ca);
-                var ros = new ReadOnlySpan<char>(ca);
-
-                for (var targetIndex = 0; targetIndex < length; targetIndex++)
-                {
-                    char target = ca[targetIndex];
-                    var found = str.Contains(target);
-                    Assert.True(found);
-
-                    found = span.Contains(target);
-                    Assert.True(found);
-
-                    found = ros.Contains(target);
-                    Assert.True(found);
-                }
-            }
-        }
-
-        [Fact]
         public static void MakeSureNoContainsChecksGoOutOfRange_StringComparison()
         {
             for (int length = 0; length < 100; length++)

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -35,6 +35,8 @@ namespace System
         public static int BinarySearch<T, TComparable>(this System.Span<T> span, TComparable comparable) where TComparable : System.IComparable<T> { throw null; }
         public static int CompareTo(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> other, System.StringComparison comparisonType) { throw null; }
         public static bool Contains(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> value, System.StringComparison comparisonType) { throw null; }
+        public static bool Contains<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T> { throw null; }
+        public static bool Contains<T>(this System.Span<T> span, T value) where T : System.IEquatable<T> { throw null; }
         public static void CopyTo<T>(this T[] source, System.Memory<T> destination) { }
         public static void CopyTo<T>(this T[] source, System.Span<T> destination) { }
         public static bool EndsWith(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> value, System.StringComparison comparisonType) { throw null; }

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -35,6 +35,7 @@ namespace System
         public static int BinarySearch<T, TComparable>(this System.Span<T> span, TComparable comparable) where TComparable : System.IComparable<T> { throw null; }
         public static int CompareTo(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> other, System.StringComparison comparisonType) { throw null; }
         public static bool Contains(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> value, System.StringComparison comparisonType) { throw null; }
+
         public static bool Contains<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T> { throw null; }
         public static bool Contains<T>(this System.Span<T> span, T value) where T : System.IEquatable<T> { throw null; }
         public static void CopyTo<T>(this T[] source, System.Memory<T> destination) { }

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -35,7 +35,6 @@ namespace System
         public static int BinarySearch<T, TComparable>(this System.Span<T> span, TComparable comparable) where TComparable : System.IComparable<T> { throw null; }
         public static int CompareTo(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> other, System.StringComparison comparisonType) { throw null; }
         public static bool Contains(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> value, System.StringComparison comparisonType) { throw null; }
-
         public static bool Contains<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T> { throw null; }
         public static bool Contains<T>(this System.Span<T> span, T value) where T : System.IEquatable<T> { throw null; }
         public static void CopyTo<T>(this T[] source, System.Memory<T> destination) { }

--- a/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
@@ -16,7 +16,7 @@ namespace System.Net
 
         internal static unsafe IPAddress Parse(ReadOnlySpan<char> ipSpan, bool tryParse)
         {
-            if (ipSpan.IndexOf(':') >= 0)
+            if (ipSpan.Contains(':'))
             {
                 // The address is parsed as IPv6 if and only if it contains a colon. This is valid because
                 // we don't support/parse a port specification at the end of an IPv4 address.

--- a/src/System.Runtime/tests/System/StringTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/StringTests.netcoreapp.cs
@@ -249,6 +249,40 @@ namespace System.Tests
             }, str).Dispose();
         }
 
+        [Fact]
+        public static void Contains_Match_Char()
+        {
+            Assert.False("".Contains('a'));
+            Assert.False("".AsSpan().Contains('a'));
+
+            // Use a long-enough string to incur vectorization code
+            for (var length = 1; length < 250; length++)
+            {
+                char[] ca = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    ca[i] = (char)(i + 1);
+                }
+
+                var str = new string(ca);
+                var span = new Span<char>(ca);
+                var ros = new ReadOnlySpan<char>(ca);
+
+                for (var targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    char target = ca[targetIndex];
+                    var found = str.Contains(target);
+                    Assert.True(found);
+
+                    found = span.Contains(target);
+                    Assert.True(found);
+
+                    found = ros.Contains(target);
+                    Assert.True(found);
+                }
+            }
+        }
+
         [Theory]
         [InlineData(StringComparison.CurrentCulture)]
         [InlineData(StringComparison.CurrentCultureIgnoreCase)]


### PR DESCRIPTION
- Create signatures on ref assembly for `MemoryExtensions.Contains`, aligned with corresponding methods in coreclr.
- See https://github.com/dotnet/corefx/issues/27526
- Units