### PR TITLE
System.Security: Fix SubjectIdentifierType.NoSignature implementation in SignedCms

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Oids.cs
+++ b/src/Common/src/System/Security/Cryptography/Oids.cs
@@ -135,6 +135,9 @@ namespace System.Security.Cryptography
         internal const string HmacWithSha384 = RsaDsiDigestAlgorithmPrefix + "10";
         internal const string HmacWithSha512 = RsaDsiDigestAlgorithmPrefix + "11";
 
+        // PKCS#7
+        internal const string NoSignature = "1.3.6.1.5.5.7.6.2";
+
         // Elliptic Curve curve identifiers
         internal const string secp256r1 = "1.2.840.10045.3.1.7";
         internal const string secp384r1 = "1.3.132.0.34";

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -205,6 +205,9 @@
   <data name="Cryptography_Cms_NoSignerAtIndex" xml:space="preserve">
     <value>The signed cryptographic message does not have a signer for the specified signer index.</value>
   </data>
+  <data name="Cryptography_Cms_RecipientCertificateNotFound" xml:space="preserve">
+    <value>The recipient certificate is not specified.</value>
+  </data>
   <data name="Cryptography_Cms_RecipientNotFound" xml:space="preserve">
     <value>The enveloped-data message does not contain the specified recipient.</value>
   </data>

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -202,11 +202,11 @@
   <data name="Cryptography_Cms_NoSignerCert" xml:space="preserve">
     <value>No signer certificate was provided. This platform does not implement the certificate picker UI.</value>
   </data>
+  <data name="Cryptography_Cms_NoSignerCertSilent" xml:space="preserve">
+    <value>No signer certificate was provided.</value>
+  </data>
   <data name="Cryptography_Cms_NoSignerAtIndex" xml:space="preserve">
     <value>The signed cryptographic message does not have a signer for the specified signer index.</value>
-  </data>
-  <data name="Cryptography_Cms_RecipientCertificateNotFound" xml:space="preserve">
-    <value>The recipient certificate is not specified.</value>
   </data>
   <data name="Cryptography_Cms_RecipientNotFound" xml:space="preserve">
     <value>The enveloped-data message does not contain the specified recipient.</value>

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -224,22 +224,30 @@ namespace System.Security.Cryptography.Pkcs
                 newSignerInfo.UnsignedAttributes = PkcsHelpers.NormalizeAttributeSet(attrs.ToArray());
             }
 
-            bool signed = CmsSignature.Sign(
-                dataHash,
-                hashAlgorithmName,
-                Certificate,
-                PrivateKey,
-                silent,
-                out Oid signatureAlgorithm,
-                out ReadOnlyMemory<byte> signatureValue);
-
-            if (!signed)
+            if (SignerIdentifierType != SubjectIdentifierType.NoSignature)
             {
-                throw new CryptographicException(SR.Cryptography_Cms_CannotDetermineSignatureAlgorithm);
-            }
+                bool signed = CmsSignature.Sign(
+                    dataHash,
+                    hashAlgorithmName,
+                    Certificate,
+                    PrivateKey,
+                    silent,
+                    out Oid signatureAlgorithm,
+                    out ReadOnlyMemory<byte> signatureValue);
 
-            newSignerInfo.SignatureValue = signatureValue;
-            newSignerInfo.SignatureAlgorithm.Algorithm = signatureAlgorithm;
+                if (!signed)
+                {
+                    throw new CryptographicException(SR.Cryptography_Cms_CannotDetermineSignatureAlgorithm);
+                }
+
+                newSignerInfo.SignatureValue = signatureValue;
+                newSignerInfo.SignatureAlgorithm.Algorithm = signatureAlgorithm;
+            }
+            else
+            {
+                newSignerInfo.SignatureValue = dataHash;
+                newSignerInfo.SignatureAlgorithm.Algorithm = new Oid(Oids.NoSignature, null);
+            }
 
             X509Certificate2Collection certs = new X509Certificate2Collection();
             certs.AddRange(Certificates);

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -249,7 +249,7 @@ namespace System.Security.Cryptography.Pkcs
                 signer.Certificate == null)
             {
                 if (silent)
-                    throw new InvalidOperationException(SR.Cryptography_Cms_RecipientCertificateNotFound);
+                    throw new InvalidOperationException(SR.Cryptography_Cms_NoSignerCertSilent);
                 else
                     throw new PlatformNotSupportedException(SR.Cryptography_Cms_NoSignerCert);
             }

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -248,7 +248,16 @@ namespace System.Security.Cryptography.Pkcs
             {
                 throw new CryptographicException(SR.Cryptography_Cms_Sign_Empty_Content);
             }
-            
+
+            if (signer.SignerIdentifierType != SubjectIdentifierType.NoSignature &&
+                signer.Certificate == null)
+            {
+                if (silent)
+                    throw new InvalidOperationException(SR.Cryptography_Cms_RecipientCertificateNotFound);
+                else
+                    throw new PlatformNotSupportedException(SR.Cryptography_Cms_NoSignerCert);
+            }
+
             // If we had content already, use that now.
             // (The second signer doesn't inherit edits to signedCms.ContentInfo.Content)
             ReadOnlyMemory<byte> content = _heldContent ?? ContentInfo.Content;

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -34,6 +34,10 @@ namespace System.Security.Cryptography.Pkcs
         // and thus we need to be reslilient against modification.
         private string _contentType;
 
+        // Holds the value from the constructor for use by the parameterless ComputeSignature
+        // method.
+        private SubjectIdentifierType _signerIdentifierType;
+
         public int Version { get; private set; }
         public ContentInfo ContentInfo { get; private set; }
         public bool Detached { get; private set; }
@@ -45,12 +49,7 @@ namespace System.Security.Cryptography.Pkcs
             if (contentInfo.Content == null)
                 throw new ArgumentNullException("contentInfo.Content");
 
-            // signerIdentifierType is ignored.
-            // In .NET Framework it is used for the signer type of a prompt-for-certificate signer.
-            // In .NET Core we don't support prompting.
-            //
-            // .NET Framework turned any unknown value into IssuerAndSerialNumber, so no exceptions
-            // are required, either.
+            _signerIdentifierType = signerIdentifierType;
 
             ContentInfo = contentInfo;
             Detached = detached;
@@ -227,10 +226,7 @@ namespace System.Security.Cryptography.Pkcs
             return wrappedContent;
         }
 
-        public void ComputeSignature()
-        {
-            throw new PlatformNotSupportedException(SR.Cryptography_Cms_NoSignerCert);
-        }
+        public void ComputeSignature() => ComputeSignature(new CmsSigner(_signerIdentifierType), true);
 
         public void ComputeSignature(CmsSigner signer) => ComputeSignature(signer, true);
 

--- a/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
@@ -687,6 +687,19 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        public static void CannotSignWithNoCertificate()
+        {
+            ContentInfo ci = new ContentInfo(new byte[1]);
+            SignedCms cms = new SignedCms(ci);
+
+            // Should throw when no certificate is specified
+            Assert.Throws<InvalidOperationException>(() => cms.ComputeSignature(new CmsSigner(SubjectIdentifierType.IssuerAndSerialNumber), true));
+
+            // Should not throw when no certificate is specified
+            cms.ComputeSignature(new CmsSigner(SubjectIdentifierType.NoSignature));
+        }
+
+        [Fact]
         public static void EncodeDoesNotPreserveOrder_DecodeDoes()
         {
             SignedCms cms = new SignedCms();


### PR DESCRIPTION
Fix for #32171 and #32187.

- Fixes calculating the signature for `SubjectIdentifierType.NoSignature` by emitting the special `No signature (szOID_PKIX_NO_SIGNATURE)` algorithm identifier and storing the data hash in the signature value. This matches what NetFX implements.
- Implements the parameter-less `SignedCms.ComputeSignature` method by storing the value of `SubjectIdentifierType` from the constructor and using it to create new `CmsSigner` object. The utility of this is very limited since it will throw exception for anything but `SubjectIdentifierType.NoSignature`. Contrary to the official documentation it specifies the default value for `silent` parameter as `true`, which matches the behavior of NetFX 4.7.2.
- Added check for unspecified `Certificate` in `CmsSigner` passed to the `SignedCms.ComputeSignature` method. Now it will throw `InvalidOperationException` (for silent mode) or `PlatformNotSupportedException` (for non-silent UI mode) instead of crashing with `NullReferenceException`.
- Added unit tests. They fail on NetFX due to bug mentioned in #32187. Workaround is to pass some dummy certificate as a parameter to `CmsSigner`.