### PR TITLE
negative index

### DIFF
--- a/src/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/System.Linq/src/System/Linq/ElementAt.cs
@@ -14,7 +14,7 @@ namespace System.Linq
             {
                 throw Error.ArgumentNull(nameof(source));
             }
-
+            index = (index < 0) ? source.Count() + index : index;
             if (source is IPartition<TSource> partition)
             {
                 TSource element = partition.TryGetElementAt(index, out bool found);
@@ -56,7 +56,7 @@ namespace System.Linq
             {
                 throw Error.ArgumentNull(nameof(source));
             }
-
+            index = (index < 0) ? source.Count() + index : index;
             if (source is IPartition<TSource> partition)
             {
                 return partition.TryGetElementAt(index, out bool _);


### PR DESCRIPTION
python like negative indexes which will cause function to return the queried index from the end of the collection instead.