### PR TITLE
Setting the lastWriteTime And LastAccessTime no longer drops any ticks i.e granularity upto nanoseconds

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -204,7 +204,7 @@ namespace System.IO
             Span<Interop.Sys.TimeSpec> buf = stackalloc Interop.Sys.TimeSpec[2];
 
             long seconds = time.ToUnixTimeSeconds();
-            long nanoseconds = (time.ToUnixTimeMilliseconds() - seconds * 1000) * 1_000_000;
+            long nanoseconds = (time.UtcDateTime.Ticks - DateTimeOffset.UnixEpoch.Ticks) * NanosecondsPerTick - seconds * 1_000_000_000;
 
             if (isAccessTime)
             {

--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -204,7 +204,10 @@ namespace System.IO
             Span<Interop.Sys.TimeSpec> buf = stackalloc Interop.Sys.TimeSpec[2];
 
             long seconds = time.ToUnixTimeSeconds();
-            long nanoseconds = (time.UtcDateTime.Ticks - DateTimeOffset.UnixEpoch.Ticks) * NanosecondsPerTick - seconds * 1_000_000_000;
+
+            const long TicksPerMillisecond = 10000;
+            const long TicksPerSecond = TicksPerMillisecond * 1000;
+            long nanoseconds = (time.UtcDateTime.Ticks - DateTimeOffset.UnixEpoch.Ticks - seconds * TicksPerSecond) * NanosecondsPerTick;
 
             if (isAccessTime)
             {

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -109,6 +109,20 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void SetUptoNanoSeconds()
+        {
+            string firstFile = GetTestFilePath();
+            File.WriteAllText(firstFile, "");
+
+            DateTime dateTime = DateTime.UtcNow;
+            File.SetLastWriteTimeUtc(firstFile, dateTime);
+            long ticks = File.GetLastWriteTimeUtc(firstFile).Ticks;
+
+            Assert.Equal(dateTime, File.GetLastWriteTimeUtc(firstFile));
+            Assert.True(dateTime.Ticks == ticks, $"First File Ticks\t{ticks}\nSecond File Ticks\t{dateTime.Ticks}");
+        }
+
+        [Fact]
         public void SetLastAccessTimeTicks()
         {
             string firstFile = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -108,18 +108,33 @@ namespace System.IO.Tests
             Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
         }
 
-        [Fact]
-        public void SetUptoNanoSeconds()
+        [ConditionalFact(nameof(isNotHFS))] // OSX HFS driver format does not support nanosecond granularity.
+        public void SetUptoNanoseconds()
         {
-            string firstFile = GetTestFilePath();
-            File.WriteAllText(firstFile, "");
+            string file = GetTestFilePath();
+            File.WriteAllText(file, "");
 
             DateTime dateTime = DateTime.UtcNow;
-            File.SetLastWriteTimeUtc(firstFile, dateTime);
-            long ticks = File.GetLastWriteTimeUtc(firstFile).Ticks;
+            File.SetLastWriteTimeUtc(file, dateTime);
+            long ticks = File.GetLastWriteTimeUtc(file).Ticks;
 
-            Assert.Equal(dateTime, File.GetLastWriteTimeUtc(firstFile));
-            Assert.True(dateTime.Ticks == ticks, $"First File Ticks\t{ticks}\nSecond File Ticks\t{dateTime.Ticks}");
+            Assert.Equal(dateTime, File.GetLastWriteTimeUtc(file));
+            Assert.Equal(ticks, dateTime.Ticks);
+        }
+
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.OSX)] // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
+        public void SetDateTimeMax()
+        {
+            string file = GetTestFilePath();
+            File.WriteAllText(file, "");
+
+            DateTime dateTime = new DateTime(9999, 4, 11, 23, 47, 17, 21, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(file, dateTime);
+            long ticks = File.GetLastWriteTimeUtc(file).Ticks;
+
+            Assert.Equal(dateTime, File.GetLastWriteTimeUtc(file));
+            Assert.Equal(ticks, dateTime.Ticks);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/32115