### PR TITLE
detect permission problem and handle exception accordingly

### DIFF
--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -510,7 +510,14 @@ namespace System.IO.Ports
 
             if (tempHandle.IsInvalid)
             {
-                throw new ArgumentException(SR.Arg_InvalidSerialPort, nameof(portName));
+                if (Interop.Error.EACCES == Interop.Sys.GetLastError())
+                {
+                    throw new UnauthorizedAccessException(string.Format(SR.UnauthorizedAccess_IODenied_Port, portName));
+                }
+                else
+                {
+                    throw new ArgumentException(SR.Arg_InvalidSerialPort, nameof(portName));
+                }
             }
 
             try

--- a/src/System.IO.Ports/tests/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Support/TCSupport.cs
@@ -156,6 +156,7 @@ namespace Legacy.Support
 
                         openablePortNames.Add(portName);
                     }
+                    catch (UnauthorizedAccessException) { }
                     catch (Exception e)
                     {
                         PrintInfo("Exception opening port {0}: {1}", portName, e);


### PR DESCRIPTION
fixes #32204 

OpenEveryPortName will fail if serial ports are detected but test has no access to them.
