### PR TITLE
System.Security: Use RandomNumberGenerator.Fill

### DIFF
--- a/src/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -18,8 +18,6 @@ namespace Internal.Cryptography
     //
     internal sealed class UniversalCryptoEncryptor : UniversalCryptoTransform
     {
-        private static readonly RandomNumberGenerator s_randomNumberGenerator = RandomNumberGenerator.Create();
-
         public UniversalCryptoEncryptor(PaddingMode paddingMode, BasicSymmetricCipher basicSymmetricCipher)
             : base(paddingMode, basicSymmetricCipher)
         {
@@ -82,7 +80,7 @@ namespace Internal.Cryptography
                     result = new byte[count + padBytes];
                     
                     Buffer.BlockCopy(block, offset, result, 0, count);
-                    s_randomNumberGenerator.GetBytes(result, count + 1, padBytes - 1);
+                    RandomNumberGenerator.Fill(result.AsSpan(count + 1, padBytes - 1));
                     result[result.Length - 1] = (byte)padBytes;
 
                     break;

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.cs
@@ -32,14 +32,14 @@ namespace Internal.Cryptography
         public sealed override void GenerateIV()
         {
             byte[] iv = new byte[BlockSize / BitsPerByte];
-            s_rng.GetBytes(iv);
+            RandomNumberGenerator.Fill(iv);
             IV = iv;
         }
 
         public sealed override void GenerateKey()
         {
             byte[] key = new byte[KeySize / BitsPerByte];
-            s_rng.GetBytes(key);
+            RandomNumberGenerator.Fill(key);
             Key = key;
         }
 
@@ -70,6 +70,5 @@ namespace Internal.Cryptography
         }
 
         private const int BitsPerByte = 8;
-        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.cs
@@ -11,7 +11,6 @@ namespace Internal.Cryptography
     internal sealed partial class DesImplementation : DES
     {
         private const int BitsPerByte = 8;
-        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
 
         public override ICryptoTransform CreateDecryptor()
         {
@@ -36,18 +35,18 @@ namespace Internal.Cryptography
         public override void GenerateIV()
         {
             byte[] iv = new byte[BlockSize / BitsPerByte];
-            s_rng.GetBytes(iv);
+            RandomNumberGenerator.Fill(iv);
             IV = iv;
         }
 
         public sealed override void GenerateKey()
         {
             byte[] key = new byte[KeySize / BitsPerByte];
-            s_rng.GetBytes(key);
+            RandomNumberGenerator.Fill(key);
             // Never hand back a weak or semi-weak key
             while (IsWeakKey(key) || IsSemiWeakKey(key))
             {
-                s_rng.GetBytes(key);
+                RandomNumberGenerator.Fill(key);
             }
             KeyValue = key;
         }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
@@ -35,10 +35,7 @@ namespace Internal.Cryptography
         public static byte[] GenerateRandom(int count)
         {
             byte[] buffer = new byte[count];
-            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
-            {
-                rng.GetBytes(buffer);
-            }
+            RandomNumberGenerator.Fill(buffer);
             return buffer;
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.cs
@@ -11,7 +11,6 @@ namespace Internal.Cryptography
     internal sealed partial class RC2Implementation : RC2
     {
         private const int BitsPerByte = 8;
-        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
 
         public override int EffectiveKeySize
         {
@@ -49,14 +48,14 @@ namespace Internal.Cryptography
         public override void GenerateIV()
         {
             byte[] iv = new byte[BlockSize / BitsPerByte];
-            s_rng.GetBytes(iv);
+            RandomNumberGenerator.Fill(iv);
             IV = iv;
         }
 
         public sealed override void GenerateKey()
         {
             byte[] key = new byte[KeySize / BitsPerByte];
-            s_rng.GetBytes(key);
+            RandomNumberGenerator.Fill(key);
             Key = key;
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.cs
@@ -11,7 +11,6 @@ namespace Internal.Cryptography
     internal sealed partial class TripleDesImplementation : TripleDES
     {
         private const int BitsPerByte = 8;
-        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
 
         public override ICryptoTransform CreateDecryptor()
         {
@@ -36,14 +35,14 @@ namespace Internal.Cryptography
         public override void GenerateIV()
         {
             byte[] iv = new byte[BlockSize / BitsPerByte];
-            s_rng.GetBytes(iv);
+            RandomNumberGenerator.Fill(iv);
             IV = iv;
         }
 
         public sealed override void GenerateKey()
         {
             byte[] key = new byte[KeySize / BitsPerByte];
-            s_rng.GetBytes(key);
+            RandomNumberGenerator.Fill(key);
             Key = key;
         }
 

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -173,10 +173,7 @@ namespace Internal.Cryptography
         public static byte[] GenerateRandom(int count)
         {
             byte[] buffer = new byte[count];
-            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
-            {
-                rng.GetBytes(buffer);
-            }
+            RandomNumberGenerator.Fill(buffer);
             return buffer;
         }
     }

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DESCryptoServiceProvider.Windows.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DESCryptoServiceProvider.Windows.cs
@@ -12,7 +12,6 @@ namespace System.Security.Cryptography
     public sealed class DESCryptoServiceProvider : DES
     {
         private const int BitsPerByte = 8;
-        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
 
         public DESCryptoServiceProvider()
         {
@@ -23,11 +22,11 @@ namespace System.Security.Cryptography
         public override void GenerateKey()
         {
             var key = new byte[8];
-            s_rng.GetBytes(key);
+            RandomNumberGenerator.Fill(key);
             // Never hand back a weak or semi-weak key
             while (IsWeakKey(key) || IsSemiWeakKey(key))
             {
-                s_rng.GetBytes(key);
+                RandomNumberGenerator.Fill(key);
             }
             KeyValue = key;
         }
@@ -35,7 +34,7 @@ namespace System.Security.Cryptography
         public override void GenerateIV()
         {
             var iv = new byte[8];
-            s_rng.GetBytes(iv);
+            RandomNumberGenerator.Fill(iv);
             IVValue = iv;
         }
 
@@ -85,7 +84,7 @@ namespace System.Security.Cryptography
                 if (Mode.UsesIv())
                 {
                     rgbIV = new byte[8];
-                    s_rng.GetBytes(rgbIV);
+                    RandomNumberGenerator.Fill(rgbIV);
                 }
             }
             else

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RC2CryptoServiceProvider.Windows.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RC2CryptoServiceProvider.Windows.cs
@@ -13,7 +13,6 @@ namespace System.Security.Cryptography
     {
         private bool _use40bitSalt = false;
         private const int BitsPerByte = 8;
-        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
 
         private static KeySizes[] s_legalKeySizes =
         {
@@ -66,7 +65,7 @@ namespace System.Security.Cryptography
         public override void GenerateKey()
         {
             var key = new byte[KeySizeValue / 8];
-            s_rng.GetBytes(key);
+            RandomNumberGenerator.Fill(key);
             KeyValue = key;
         }
 
@@ -74,7 +73,7 @@ namespace System.Security.Cryptography
         {
             // Block size is always 64 bits so IV is always 64 bits == 8 bytes
             var iv = new byte[8];
-            s_rng.GetBytes(iv);
+            RandomNumberGenerator.Fill(iv);
             IVValue = iv;
         }
 
@@ -92,7 +91,7 @@ namespace System.Security.Cryptography
                 if (Mode.UsesIv())
                 {
                     rgbIV = new byte[8];
-                    s_rng.GetBytes(rgbIV);
+                    RandomNumberGenerator.Fill(rgbIV);
                 }
             }
             else

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
@@ -309,11 +309,7 @@ namespace System.Security.Cryptography.X509Certificates
             Debug.Assert(_generator != null);
 
             byte[] serialNumber = new byte[8];
-
-            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
-            {
-                rng.GetBytes(serialNumber);
-            }
+            RandomNumberGenerator.Fill(serialNumber);
 
             using (X509Certificate2 certificate = Create(
                 SubjectName,

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
@@ -398,12 +398,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 intermed2Serial[1] = 2;
                 leafSerial[1] = 1;
 
-                using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
-                {
-                    rng.GetBytes(intermed1Serial, 2, intermed1Serial.Length - 2);
-                    rng.GetBytes(intermed2Serial, 2, intermed2Serial.Length - 2);
-                    rng.GetBytes(leafSerial, 2, leafSerial.Length - 2);
-                }
+                RandomNumberGenerator.Fill(intermed1Serial.AsSpan(2, intermed1Serial.Length - 2));
+                RandomNumberGenerator.Fill(intermed2Serial.AsSpan(2, intermed2Serial.Length - 2));
+                RandomNumberGenerator.Fill(leafSerial.AsSpan(2, leafSerial.Length - 2));
 
                 X509Certificate2 intermed1Tmp =
                     intermed1Request.Create(rootCertWithKey.SubjectName, rootGenerator, now, intermedEnd, intermed1Serial);

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
@@ -398,9 +398,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 intermed2Serial[1] = 2;
                 leafSerial[1] = 1;
 
-                RandomNumberGenerator.Fill(intermed1Serial.AsSpan(2, intermed1Serial.Length - 2));
-                RandomNumberGenerator.Fill(intermed2Serial.AsSpan(2, intermed2Serial.Length - 2));
-                RandomNumberGenerator.Fill(leafSerial.AsSpan(2, leafSerial.Length - 2));
+                RandomNumberGenerator.Fill(intermed1Serial.AsSpan(2));
+                RandomNumberGenerator.Fill(intermed2Serial.AsSpan(2));
+                RandomNumberGenerator.Fill(leafSerial.AsSpan(2));
 
                 X509Certificate2 intermed1Tmp =
                     intermed1Request.Create(rootCertWithKey.SubjectName, rootGenerator, now, intermedEnd, intermed1Serial);


### PR DESCRIPTION
Avoid creating RandomNumberGenerator objects when not necessary. /cc @bartonjs 