### PR TITLE
Add SignerIdentifierType.NoSignature support to SignedCms

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Oids.cs
+++ b/src/Common/src/System/Security/Cryptography/Oids.cs
@@ -78,6 +78,9 @@ namespace System.Security.Cryptography
 
         internal const string Mgf1 = "1.2.840.113549.1.1.8";
 
+        // PKCS#7
+        internal const string NoSignature = "1.3.6.1.5.5.7.6.2";
+
         // X500 Names
         internal const string CommonName = "2.5.4.3";
         internal const string Organization = "2.5.4.10";

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -202,6 +202,9 @@
   <data name="Cryptography_Cms_NoSignerCert" xml:space="preserve">
     <value>No signer certificate was provided. This platform does not implement the certificate picker UI.</value>
   </data>
+  <data name="Cryptography_Cms_NoSignerCertSilent" xml:space="preserve">
+    <value>No signer certificate was provided.</value>
+  </data>
   <data name="Cryptography_Cms_NoSignerAtIndex" xml:space="preserve">
     <value>The signed cryptographic message does not have a signer for the specified signer index.</value>
   </data>
@@ -213,6 +216,9 @@
   </data>
   <data name="Cryptography_Cms_Sign_Empty_Content" xml:space="preserve">
     <value>Cannot create CMS signature for empty content.</value>
+  </data>
+  <data name="Cryptography_Cms_Sign_No_Signature_First_Signer" xml:space="preserve">
+    <value>CmsSigner has to be the first signer with NoSignature.</value>
   </data>
   <data name="Cryptography_Cms_SignerNotFound" xml:space="preserve">
     <value>Cannot find the original signer.</value>

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -224,14 +224,27 @@ namespace System.Security.Cryptography.Pkcs
                 newSignerInfo.UnsignedAttributes = PkcsHelpers.NormalizeAttributeSet(attrs.ToArray());
             }
 
-            bool signed = CmsSignature.Sign(
-                dataHash,
-                hashAlgorithmName,
-                Certificate,
-                PrivateKey,
-                silent,
-                out Oid signatureAlgorithm,
-                out ReadOnlyMemory<byte> signatureValue);
+            bool signed;
+            Oid signatureAlgorithm;
+            ReadOnlyMemory<byte> signatureValue;
+
+            if (SignerIdentifierType == SubjectIdentifierType.NoSignature)
+            {
+                signatureAlgorithm = new Oid(Oids.NoSignature, null);
+                signatureValue = dataHash;
+                signed = true;
+            }
+            else
+            {
+                signed = CmsSignature.Sign(
+                    dataHash,
+                    hashAlgorithmName,
+                    Certificate,
+                    PrivateKey,
+                    silent,
+                    out signatureAlgorithm,
+                    out signatureValue);
+            }
 
             if (!signed)
             {

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -46,7 +46,11 @@ namespace System.Security.Cryptography.Pkcs
             if (contentInfo.Content == null)
                 throw new ArgumentNullException("contentInfo.Content");
 
-            // Normalize the subject identifier type
+            // Normalize the subject identifier type the same way as .NET Framework.
+            // This value is only used in the zero-argument ComputeSignature overload,
+            // where it controls whether it succeeds (NoSignature) or throws (anything else),
+            // but in case it ever applies to anything else, make sure we're storing it
+            // faithfully.
             switch (signerIdentifierType)
             {
                 case SubjectIdentifierType.NoSignature:

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
@@ -473,6 +473,11 @@ namespace System.Security.Cryptography.Pkcs
 
         public void CheckHash()
         {
+            if (_signatureAlgorithm.Value != Oids.NoSignature)
+            {
+                throw new CryptographicException(SR.Cryptography_Pkcs_InvalidSignatureParameters);
+            }
+
             if (!CheckHash(compatMode: false) && !CheckHash(compatMode: true))
             {
                 throw new CryptographicException(SR.Cryptography_BadSignature);

--- a/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
@@ -732,6 +732,200 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        public static void AddFirstCounterSigner_NoSignature_NoPrivateKey()
+        {
+            SignedCms cms = new SignedCms();
+            cms.Decode(SignedDocuments.RsaPkcs1OneSignerIssuerAndSerialNumber);
+
+            SignerInfo firstSigner = cms.SignerInfos[0];
+
+            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.GetCertificate())
+            {
+                Action sign = () =>
+                    firstSigner.ComputeCounterSignature(
+                        new CmsSigner(
+                            SubjectIdentifierType.NoSignature,
+                            cert)
+                        {
+                            IncludeOption = X509IncludeOption.None,
+                        });
+
+                if (PlatformDetection.IsFullFramework)
+                {
+                    Assert.ThrowsAny<CryptographicException>(sign);
+                }
+                else
+                {
+                    sign();
+                    cms.CheckHash();
+                }
+            }
+        }
+
+        [Fact]
+        public static void AddFirstCounterSigner_NoSignature()
+        {
+            SignedCms cms = new SignedCms();
+            cms.Decode(SignedDocuments.RsaPkcs1OneSignerIssuerAndSerialNumber);
+
+            SignerInfo firstSigner = cms.SignerInfos[0];
+
+            // A certificate shouldn't really be required here, but on .NET Framework
+            // it will prompt for the counter-signer's certificate if it's null,
+            // even if the signature type is NoSignature.
+            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.TryGetCertificateWithPrivateKey())
+            {
+                firstSigner.ComputeCounterSignature(
+                    new CmsSigner(
+                        SubjectIdentifierType.NoSignature,
+                        cert)
+                    {
+                        IncludeOption = X509IncludeOption.None,
+                    });
+            }
+
+            Assert.ThrowsAny<CryptographicException>(() => cms.CheckSignature(true));
+            cms.CheckHash();
+
+            byte[] encoded = cms.Encode();
+            cms = new SignedCms();
+            cms.Decode(encoded);
+            Assert.ThrowsAny<CryptographicException>(() => cms.CheckSignature(true));
+            cms.CheckHash();
+
+            firstSigner = cms.SignerInfos[0];
+            firstSigner.CheckSignature(verifySignatureOnly: true);
+            Assert.ThrowsAny<CryptographicException>(() => firstSigner.CheckHash());
+
+            SignerInfo firstCounterSigner = firstSigner.CounterSignerInfos[0];
+            Assert.ThrowsAny<CryptographicException>(() => firstCounterSigner.CheckSignature(true));
+
+            if (PlatformDetection.IsFullFramework)
+            {
+                // NetFX's CheckHash only looks at top-level SignerInfos to find the
+                // crypt32 CMS signer ID, so it fails on any check from a countersigner.
+                Assert.ThrowsAny<CryptographicException>(() => firstCounterSigner.CheckHash());
+            }
+            else
+            {
+                firstCounterSigner.CheckHash();
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void AddSecondCounterSignature_NoSignature_WithCert(bool addExtraCert)
+        {
+            AddSecondCounterSignature_NoSignature(withCertificate: true, addExtraCert);
+        }
+
+        [Theory]
+        // On .NET Framework it will prompt for the counter-signer's certificate if it's null,
+        // even if the signature type is NoSignature, so don't run the test there.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void AddSecondCounterSignature_NoSignature_WithoutCert(bool addExtraCert)
+        {
+            AddSecondCounterSignature_NoSignature(withCertificate: false, addExtraCert);
+        }
+
+        private static void AddSecondCounterSignature_NoSignature(bool withCertificate, bool addExtraCert)
+        {
+            X509Certificate2Collection certs;
+            SignedCms cms = new SignedCms();
+            cms.Decode(SignedDocuments.RsaPkcs1OneSignerIssuerAndSerialNumber);
+
+            SignerInfo firstSigner = cms.SignerInfos[0];
+
+            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.TryGetCertificateWithPrivateKey())
+            using (X509Certificate2 cert2 = Certificates.DHKeyAgree1.GetCertificate())
+            {
+                firstSigner.ComputeCounterSignature(
+                    new CmsSigner(cert)
+                    {
+                        IncludeOption = X509IncludeOption.None,
+                    });
+
+                CmsSigner counterSigner;
+
+                if (withCertificate)
+                {
+                    counterSigner = new CmsSigner(SubjectIdentifierType.NoSignature, cert);
+                }
+                else
+                {
+                    counterSigner = new CmsSigner(SubjectIdentifierType.NoSignature);
+                }
+
+                if (addExtraCert)
+                {
+                    counterSigner.Certificates.Add(cert2);
+                }
+
+                firstSigner.ComputeCounterSignature(counterSigner);
+
+                certs = cms.Certificates;
+
+                if (addExtraCert)
+                {
+                    Assert.Equal(2, certs.Count);
+                    Assert.NotEqual(cert2.RawData, certs[0].RawData);
+                    Assert.Equal(cert2.RawData, certs[1].RawData);
+                }
+                else
+                {
+                    Assert.Equal(1, certs.Count);
+                    Assert.NotEqual(cert2.RawData, certs[0].RawData);
+                }
+            }
+
+            Assert.ThrowsAny<CryptographicException>(() => cms.CheckSignature(true));
+            cms.CheckHash();
+
+            byte[] encoded = cms.Encode();
+            cms = new SignedCms();
+            cms.Decode(encoded);
+            Assert.ThrowsAny<CryptographicException>(() => cms.CheckSignature(true));
+            cms.CheckHash();
+
+            firstSigner = cms.SignerInfos[0];
+            firstSigner.CheckSignature(verifySignatureOnly: true);
+            Assert.ThrowsAny<CryptographicException>(() => firstSigner.CheckHash());
+
+            // The NoSignature CounterSigner sorts first.
+            SignerInfo firstCounterSigner = firstSigner.CounterSignerInfos[0];
+            Assert.Equal(SubjectIdentifierType.NoSignature, firstCounterSigner.SignerIdentifier.Type);
+            Assert.ThrowsAny<CryptographicException>(() => firstCounterSigner.CheckSignature(true));
+
+            if (PlatformDetection.IsFullFramework)
+            {
+                // NetFX's CheckHash only looks at top-level SignerInfos to find the
+                // crypt32 CMS signer ID, so it fails on any check from a countersigner.
+                Assert.ThrowsAny<CryptographicException>(() => firstCounterSigner.CheckHash());
+            }
+            else
+            {
+                firstCounterSigner.CheckHash();
+            }
+
+            certs = cms.Certificates;
+
+            if (addExtraCert)
+            {
+                Assert.Equal(2, certs.Count);
+                Assert.Equal("CN=DfHelleKeyAgreement1", certs[1].SubjectName.Name);
+            }
+            else
+            {
+                Assert.Equal(1, certs.Count);
+            }
+
+            Assert.Equal("CN=RSAKeyTransferCapi1", certs[0].SubjectName.Name);
+        }
+
+        [Fact]
         [ActiveIssue(31977, TargetFrameworkMonikers.Uap)]
         public static void EnsureExtraCertsAdded()
         {

--- a/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
@@ -758,6 +758,8 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 {
                     sign();
                     cms.CheckHash();
+                    Assert.ThrowsAny<CryptographicException>(() => cms.CheckSignature(true));
+                    firstSigner.CheckSignature(true);
                 }
             }
         }


### PR DESCRIPTION
This also changes the zero-argument ComputeSignature and moves the PNSE
to later in the flow, since it is successful when the document was in implicit
NoSignature mode.

Fixes #32171.
Fixes #32187.
Replaces #32186.