### PR TITLE
Add conditional attribute tests to ensure we're always running conditional tests

### DIFF
--- a/src/CoreFx.Private.TestUtilities/tests/ConditionalAttributeTests.cs
+++ b/src/CoreFx.Private.TestUtilities/tests/ConditionalAttributeTests.cs
@@ -59,7 +59,7 @@ namespace CoreFx.Private.TestUtilities.Tests
                 where TTestCase : ITestCase
         {
             List<TTestCase> result = testCases.ToList();
-            result.Sort((x, y) => StringComparer.OrdinalIgnoreCase.Compare(x.TestMethod.Method.Name, y.TestMethod.Method.Name));
+            result.Sort((x, y) => StringComparer.Ordinal.Compare(x.TestMethod.Method.Name, y.TestMethod.Method.Name));
             return result;
         }
     }

--- a/src/CoreFx.Private.TestUtilities/tests/ConditionalAttributeTests.cs
+++ b/src/CoreFx.Private.TestUtilities/tests/ConditionalAttributeTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace CoreFx.Private.TestUtilities.Tests
+{
+    [TestCaseOrderer("CoreFx.Private.TestUtilities.Tests.AlphabeticalOrderer", "CoreFx.Private.TestUtilities.Tests")]
+    public class ConditionalAttributeTests : IClassFixture<ConditionalAttributeFixture>
+    {
+        // The tests under this class are to validate that ConditionalFact and ConditionalAttribute tests are being executed correctly
+        // In the past we have had cases where infrastructure changes broke this feature and tests where not running in certain framework.
+        // This test class is test order dependent so do not rename the tests.
+        // If new tests need to be added, follow the same naming pattern ConditionalAttribute{LetterToOrderTest} and then add a Validate{TestName}.
+
+        // Private shared instance containing the shared properties used to validate the tests are running correctly.
+        private readonly ConditionalAttributeFixture _fixture;
+
+        public static bool AlwaysTrue => true;
+
+        // The fixture object is injected by xunit.
+        public ConditionalAttributeTests(ConditionalAttributeFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [ConditionalFact(nameof(AlwaysTrue))]
+        public void ConditionalAttributeA()
+        {
+            _fixture.ConditionalFactExecuted = true;
+        }
+
+        [ConditionalTheory(nameof(AlwaysTrue))]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void ConditionalAttributeB(int _)
+        {
+            _fixture.ConditionalTheoryCount++;
+        }
+
+        [Fact]
+        public void ValidateConditionalFact()
+        {
+            Assert.True(_fixture.ConditionalFactExecuted);
+        }
+
+        [Fact]
+        public void ValidateConditionalTheory()
+        {
+            Assert.Equal(3, _fixture.ConditionalTheoryCount);
+        }
+    }
+
+    // A shared instance of this class will get created and will be injected into ConditionalAttributeTests class for every test.
+    public class ConditionalAttributeFixture
+    {
+        public bool ConditionalFactExecuted { get; set; }
+        public int ConditionalTheoryCount { get; set; }
+    }
+
+    // We need this TestCaseOrderer in order to guarantee that the ConditionalAttributeTests are always executed in the same order.
+    public class AlphabeticalOrderer : ITestCaseOrderer
+    {
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+                where TTestCase : ITestCase
+        {
+            List<TTestCase> result = testCases.ToList();
+            result.Sort((x, y) => StringComparer.OrdinalIgnoreCase.Compare(x.TestMethod.Method.Name, y.TestMethod.Method.Name));
+            return result;
+        }
+    }
+}

--- a/src/CoreFx.Private.TestUtilities/tests/ConditionalAttributeTests.cs
+++ b/src/CoreFx.Private.TestUtilities/tests/ConditionalAttributeTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/src/CoreFx.Private.TestUtilities/tests/ConditionalAttributeTests.cs
+++ b/src/CoreFx.Private.TestUtilities/tests/ConditionalAttributeTests.cs
@@ -12,28 +12,22 @@ using Xunit.Sdk;
 namespace CoreFx.Private.TestUtilities.Tests
 {
     [TestCaseOrderer("CoreFx.Private.TestUtilities.Tests.AlphabeticalOrderer", "CoreFx.Private.TestUtilities.Tests")]
-    public class ConditionalAttributeTests : IClassFixture<ConditionalAttributeFixture>
+    public class ConditionalAttributeTests
     {
         // The tests under this class are to validate that ConditionalFact and ConditionalAttribute tests are being executed correctly
         // In the past we have had cases where infrastructure changes broke this feature and tests where not running in certain framework.
         // This test class is test order dependent so do not rename the tests.
         // If new tests need to be added, follow the same naming pattern ConditionalAttribute{LetterToOrderTest} and then add a Validate{TestName}.
 
-        // Private shared instance containing the shared properties used to validate the tests are running correctly.
-        private readonly ConditionalAttributeFixture _fixture;
+        private static bool s_conditionalFactExecuted;
+        private static int s_conditionalTheoryCount;
 
         public static bool AlwaysTrue => true;
-
-        // The fixture object is injected by xunit.
-        public ConditionalAttributeTests(ConditionalAttributeFixture fixture)
-        {
-            _fixture = fixture;
-        }
 
         [ConditionalFact(nameof(AlwaysTrue))]
         public void ConditionalAttributeA()
         {
-            _fixture.ConditionalFactExecuted = true;
+            s_conditionalFactExecuted = true;
         }
 
         [ConditionalTheory(nameof(AlwaysTrue))]
@@ -42,27 +36,20 @@ namespace CoreFx.Private.TestUtilities.Tests
         [InlineData(3)]
         public void ConditionalAttributeB(int _)
         {
-            _fixture.ConditionalTheoryCount++;
+            s_conditionalTheoryCount++;
         }
 
         [Fact]
         public void ValidateConditionalFact()
         {
-            Assert.True(_fixture.ConditionalFactExecuted);
+            Assert.True(s_conditionalFactExecuted);
         }
 
         [Fact]
         public void ValidateConditionalTheory()
         {
-            Assert.Equal(3, _fixture.ConditionalTheoryCount);
+            Assert.Equal(3, s_conditionalTheoryCount);
         }
-    }
-
-    // A shared instance of this class will get created and will be injected into ConditionalAttributeTests class for every test.
-    public class ConditionalAttributeFixture
-    {
-        public bool ConditionalFactExecuted { get; set; }
-        public int ConditionalTheoryCount { get; set; }
     }
 
     // We need this TestCaseOrderer in order to guarantee that the ConditionalAttributeTests are always executed in the same order.

--- a/src/CoreFx.Private.TestUtilities/tests/CoreFx.Private.TestUtilities.Tests.csproj
+++ b/src/CoreFx.Private.TestUtilities/tests/CoreFx.Private.TestUtilities.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssertExtensionTests.cs" />
+    <Compile Include="ConditionalAttributeTests.cs" />
     <Compile Include="TheoryExtensionTests.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I wasn't sure if we want the AlphabeticalOrderer which will only be used by this test class to live in our extensions assembly in arcade.

Fixes: https://github.com/dotnet/corefx/issues/32227

cc: @danmosemsft @ViktorHofer 