### PR TITLE
Add SqlFacetAttribute

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.NetCoreApp.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.NetCoreApp.cs
@@ -5,6 +5,19 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+namespace Microsoft.SqlServer.Server
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(10624), AllowMultiple=false, Inherited=false)]
+    public partial class SqlFacetAttribute : System.Attribute
+    {
+        public SqlFacetAttribute() { }
+        public bool IsFixedLength { get { throw null; } set { } }
+        public bool IsNullable { get { throw null; } set { } }
+        public int MaxSize { get { throw null; } set { } }
+        public int Precision { get { throw null; } set { } }
+        public int Scale { get { throw null; } set { } }
+    }
+}
 namespace System.Data.SqlClient
 {
     public partial class SqlDataReader : System.Data.Common.IDbColumnSchemaGenerator

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.NetCoreApp.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.NetCoreApp.cs
@@ -7,7 +7,7 @@
 
 namespace Microsoft.SqlServer.Server
 {
-    [System.AttributeUsageAttribute((System.AttributeTargets)(10624), AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue | System.AttributeTargets.Parameter, AllowMultiple=false, Inherited=false)]
     public partial class SqlFacetAttribute : System.Attribute
     {
         public SqlFacetAttribute() { }

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlFacetAttribute.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlFacetAttribute.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.SqlServer.Server
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public class SqlFacetAttribute : Attribute
+    {
+        /// <summary>
+        /// Is this a fixed size field?
+        /// </summary>
+        public bool IsFixedLength
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The maximum size of the field (in bytes or characters depending on the field type)
+        ///  or -1 if the size can be unlimited.
+        /// </summary>
+        public int MaxSize
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Precision, only valid for numeric types.
+        /// </summary>
+        public int Precision
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Scale, only valid for numeric types. 
+        /// </summary>
+        public int Scale
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Is this field nullable?
+        /// </summary>
+        public bool IsNullable
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlFacetAttribute.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlFacetAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SqlServer.Server
 
         /// <summary>
         /// The maximum size of the field (in bytes or characters depending on the field type)
-        ///  or -1 if the size can be unlimited.
+        /// or -1 if the size can be unlimited.
         /// </summary>
         public int MaxSize
         {

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(OSGroup)' != 'AnyOS' AND '$(TargetsNetCoreApp)' == 'true'">
     <Compile Include="System\Data\SqlClient\PoolBlockingPeriod.cs" />
+    <Compile Include="Microsoft\SqlServer\Server\SqlFacetAttribute.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(OSGroup)' != 'AnyOS'">
     <Compile Include="Microsoft\SqlServer\Server\ITypedGetters.cs" />

--- a/src/System.Data.SqlClient/tests/FunctionalTests/Configurations.props
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/Configurations.props
@@ -4,6 +4,8 @@
     <BuildConfigurations>
       netstandard-Unix;
       netstandard-Windows_NT;
+      netcoreapp-Unix;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlFacetAttributeTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlFacetAttributeTest.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.SqlServer.Server;
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class SqlFacetAttributeTests
+    {
+        [Fact]
+        public void Basic()
+        {
+            var attrib = new SqlFacetAttribute();
+
+            attrib.IsFixedLength = true;
+            attrib.IsNullable = false;
+            attrib.MaxSize = 123;
+            attrib.Precision = 234;
+            attrib.Scale = 345;
+
+            Assert.Equal(true, attrib.IsFixedLength);
+            Assert.Equal(false, attrib.IsNullable);
+            Assert.Equal(123, attrib.MaxSize);
+            Assert.Equal(234, attrib.Precision);
+            Assert.Equal(345, attrib.Scale);
+        }
+    }
+}
+ 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -27,7 +27,7 @@
     <Compile Include="TestTdsServer.cs" />
     <Compile Include="..\ManualTests\DataCommon\DataTestUtility.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">  
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="SqlFacetAttributeTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -16,7 +16,7 @@
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="FakeDiagnosticListenerObserver.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
-    <Compile Include="SqlDataRecordTest.cs" /> 
+    <Compile Include="SqlDataRecordTest.cs" />
     <Compile Include="SqlMetaDataTest.cs" />
     <Compile Include="SqlParameterTest.cs" />
     <Compile Include="SqlClientFactoryTest.cs" />

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -16,7 +16,7 @@
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="FakeDiagnosticListenerObserver.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
-    <Compile Include="SqlDataRecordTest.cs" />
+    <Compile Include="SqlDataRecordTest.cs" /> 
     <Compile Include="SqlMetaDataTest.cs" />
     <Compile Include="SqlParameterTest.cs" />
     <Compile Include="SqlClientFactoryTest.cs" />
@@ -26,6 +26,9 @@
     <Compile Include="SqlConnectionBasicTests.cs" />
     <Compile Include="TestTdsServer.cs" />
     <Compile Include="..\ManualTests\DataCommon\DataTestUtility.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">  
+    <Compile Include="SqlFacetAttributeTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ManualTests\SQL\UdtTest\UDTs\Address\Address.csproj">


### PR DESCRIPTION
Microsoft.SqlServer.Types [package](https://www.nuget.org/packages/Microsoft.SqlServer.Types/) does not support .NET Core. 

[API Port](https://github.com/Microsoft/dotnet-apiport) scan says it needs 7 types that are missing from 2.1. 

6 of them have since been added in master. Adding SqlFacetAttribute, which is a trivial type, should make it entirely compatible.

System.Data.SqlClient is a complex package: hopefully I got the configuration authoring correct. I put the ref in .netcoreapp.cs because it is already in-box in UAP -- @weshaggard is that correct? That meant I had to add a netcoreapp configuration to the tests, which lacked one.
