### PR TITLE
Disable nt auth tests on Nano

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
@@ -109,7 +109,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]    // HttpListener doesn't support nt auth on non-Windows platforms
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsNotWindowsNanoServer))]    // HttpListener doesn't support nt auth on non-Windows platforms
         [InlineData(true, HttpStatusCode.OK)]
         [InlineData(true, HttpStatusCode.Unauthorized)]
         [InlineData(false, HttpStatusCode.OK)]


### PR DESCRIPTION
The recent PR #32146 added these new tests.  But they fail on Nano SKU because HttpListener is not supported since http.sys is not present on Nano.