### PR TITLE
Add launchSettings.json files to test projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,6 @@ Session.vim
 # Private test configuration and binaries.
 config.ps1
 **/IISApplications
+
+# VS debug support files
+launchSettings.json

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -59,10 +59,15 @@
     <LaunchSettingsOutputFileFullPath Condition="'$(LaunchSettingsOutputFileFullPath)' == ''">$(AppDesignerFolder)/launchSettings.json</LaunchSettingsOutputFileFullPath>
     <LaunchSettingsInputFileFullPath Condition="'$(LaunchSettingsInputFileFullPath)' == ''">$(ToolsDir)tests.targets</LaunchSettingsInputFileFullPath>
 
-    <CompileDependsOn>
+    <PrepareForRunDependsOn>
       GenerateLaunchSettingsFile;
-      $(CompileDependsOn);
-    </CompileDependsOn>
+      $(PrepareForRunDependsOn);
+    </PrepareForRunDependsOn>
+
+    <CleanDependsOn>
+      CleanLaunchSettingsFile;
+      $(CleanDependsOn);
+    </CleanDependsOn>
   </PropertyGroup>
 
   <!-- Create debug support files -->
@@ -86,11 +91,15 @@
       </LaunchSettingsFileContent>
     </PropertyGroup>
 
-    <MakeDir Directories="$(AppDesignerFolder)" />
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(LaunchSettingsOutputFileFullPath)))" />
     <WriteLinesToFile File="$(LaunchSettingsOutputFileFullPath)"
                       Lines="$(LaunchSettingsFileContent)"
                       Overwrite="true" />
 
+  </Target>
+
+  <Target Name="CleanLaunchSettingsFile" Condition="Exists('$(LaunchSettingsOutputFileFullPath)')">
+    <Delete Files="$(LaunchSettingsOutputFileFullPath)" />
   </Target>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -83,7 +83,7 @@
     &quot;xUnit.net Console&quot;: {
       &quot;commandName&quot;: &quot;Executable&quot;,
       &quot;executablePath&quot;: &quot;$(StartProgram.Replace('\', '\\'))&quot;,
-      &quot;commandLineArgs&quot;: &quot;$(StartArguments)&quot;,
+      &quot;commandLineArgs&quot;: &quot;$(StartArguments.Replace('\', '\\'))&quot;,
       &quot;workingDirectory&quot;: &quot;$(StartWorkingDirectory.Replace('\', '\\'))&quot;
     }
   }

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -12,6 +12,11 @@
 
   <Import Project="..\Directory.Build.targets" />
 
+  <PropertyGroup Condition="'$(IsInvokableTestProject)' == 'true'">
+    <LaunchSettingsOutputFileFullPath Condition="'$(LaunchSettingsOutputFileFullPath)' == ''">$(AppDesignerFolder)/launchSettings.json</LaunchSettingsOutputFileFullPath>
+    <LaunchSettingsInputFileFullPath Condition="'$(LaunchSettingsInputFileFullPath)' == ''">$(ToolsDir)tests.targets</LaunchSettingsInputFileFullPath>
+  </PropertyGroup>
+
   <Target Name="AddSkipGetTargetFrameworkToProjectReferences" Condition="'@(ProjectReference)' != ''">
     <ItemGroup>
       <ProjectReference>
@@ -54,4 +59,39 @@
   <Target Name="DumpTargets" BeforeTargets="ResolveProjectReferences">
     <Message Text="DumpTargets> $(OutputPath), C=[$(Configuration)], CG=[$(ConfigurationGroup)], OG=[$(OSGroup)], TG=[$(TargetGroup)]" Importance="Low" />
   </Target>
+
+  <Target Name="GenerateLaunchSettingsFiles"
+          Condition="'$(LaunchSettingsOutputFileFullPath)' != '' AND '$(OmitLaunchSettings)' != 'true'"
+          Inputs="$(LaunchSettingsInputFileFullPath)"
+          Outputs="$(LaunchSettingsOutputFileFullPath)">
+
+    <PropertyGroup>
+      <LaunchSettingsFileContent>
+{
+  &quot;profiles&quot;: {
+    &quot;xUnit.net Console&quot;: {
+      &quot;commandName&quot;: &quot;Executable&quot;,
+      &quot;executablePath&quot;: &quot;$(StartProgram.Replace('\', '\\'))&quot;,
+      &quot;commandLineArgs&quot;: &quot;$(StartArguments)&quot;,
+      &quot;workingDirectory&quot;: &quot;$(StartWorkingDirectory.Replace('\', '\\'))&quot;
+    }
+  }
+}
+      </LaunchSettingsFileContent>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(AppDesignerFolder)" />
+    <WriteLinesToFile File="$(LaunchSettingsOutputFileFullPath)"
+                      Lines="$(LaunchSettingsFileContent)"
+                      Overwrite="true" />
+
+  </Target>
+
+  <PropertyGroup>
+    <CompileDependsOn>
+        GenerateLaunchSettingsFiles;
+        $(CompileDependsOn);
+    </CompileDependsOn>
+  </PropertyGroup>
+
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -63,11 +63,6 @@
       GenerateLaunchSettingsFile;
       $(PrepareForRunDependsOn);
     </PrepareForRunDependsOn>
-
-    <CleanDependsOn>
-      CleanLaunchSettingsFile;
-      $(CleanDependsOn);
-    </CleanDependsOn>
   </PropertyGroup>
 
   <!-- Create debug support files -->
@@ -96,10 +91,6 @@
                       Lines="$(LaunchSettingsFileContent)"
                       Overwrite="true" />
 
-  </Target>
-
-  <Target Name="CleanLaunchSettingsFile" Condition="Exists('$(LaunchSettingsOutputFileFullPath)')">
-    <Delete Files="$(LaunchSettingsOutputFileFullPath)" />
   </Target>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -12,11 +12,6 @@
 
   <Import Project="..\Directory.Build.targets" />
 
-  <PropertyGroup Condition="'$(IsInvokableTestProject)' == 'true'">
-    <LaunchSettingsOutputFileFullPath Condition="'$(LaunchSettingsOutputFileFullPath)' == ''">$(AppDesignerFolder)/launchSettings.json</LaunchSettingsOutputFileFullPath>
-    <LaunchSettingsInputFileFullPath Condition="'$(LaunchSettingsInputFileFullPath)' == ''">$(ToolsDir)tests.targets</LaunchSettingsInputFileFullPath>
-  </PropertyGroup>
-
   <Target Name="AddSkipGetTargetFrameworkToProjectReferences" Condition="'@(ProjectReference)' != ''">
     <ItemGroup>
       <ProjectReference>
@@ -60,7 +55,18 @@
     <Message Text="DumpTargets> $(OutputPath), C=[$(Configuration)], CG=[$(ConfigurationGroup)], OG=[$(OSGroup)], TG=[$(TargetGroup)]" Importance="Low" />
   </Target>
 
-  <Target Name="GenerateLaunchSettingsFiles"
+  <PropertyGroup Condition="'$(IsInvokableTestProject)' == 'true'">
+    <LaunchSettingsOutputFileFullPath Condition="'$(LaunchSettingsOutputFileFullPath)' == ''">$(AppDesignerFolder)/launchSettings.json</LaunchSettingsOutputFileFullPath>
+    <LaunchSettingsInputFileFullPath Condition="'$(LaunchSettingsInputFileFullPath)' == ''">$(ToolsDir)tests.targets</LaunchSettingsInputFileFullPath>
+
+    <CompileDependsOn>
+      GenerateLaunchSettingsFile;
+      $(CompileDependsOn);
+    </CompileDependsOn>
+  </PropertyGroup>
+
+  <!-- Create debug support files -->
+  <Target Name="GenerateLaunchSettingsFile"
           Condition="'$(LaunchSettingsOutputFileFullPath)' != '' AND '$(OmitLaunchSettings)' != 'true'"
           Inputs="$(LaunchSettingsInputFileFullPath)"
           Outputs="$(LaunchSettingsOutputFileFullPath)">
@@ -86,12 +92,5 @@
                       Overwrite="true" />
 
   </Target>
-
-  <PropertyGroup>
-    <CompileDependsOn>
-        GenerateLaunchSettingsFiles;
-        $(CompileDependsOn);
-    </CompileDependsOn>
-  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Relates to https://github.com/dotnet/project-system/issues/3763

The code duplication is unfortunate but this is the way how debugging now is configured with sdk style projects. Adding the launchSettings.json files to allow setting xunitoptions and other debugging options from the test project properties.

cc @geoffkizer as you contacted me offline regarding how to only debug a single test in VS. After the change is in you can set a single method like you did before in the test project properties:

![image](https://user-images.githubusercontent.com/7412651/45443272-76eeb200-b6c4-11e8-8ba3-5f88632d3774.png)

Please make sure not to commit changes to the launchSettings.json files.

EDIT: Note that setting breakpoints in a test assembly's code is currently not working and no frames are recorded for such. Settings breakpoints in the src assembly's code does work.