### PR TITLE
Add netcoreappaot to build pipeline

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -130,238 +130,272 @@
       "BuildParameters": {
         "PB_PipelineBuildMSBuildArguments": "/p:EnableProfileGuidedOptimization=true"
       },
-      "Definitions": [
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "arm",
-            "PB_BuildArguments": "-buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "-buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:EnableCloudTest=false /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm",
-            "SubType": "netcoreapp"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "arm64",
-            "PB_BuildArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_CreateHelixArguments": "/p:ArchGroup=arm64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:EnableCloudTest=false /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm64",
-            "SubType": "netcoreapp"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "x64",
-            "PB_BuildArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4+Windows.10.Nano.Amd64+Windows.10.Amd64.Core+Windows.7.Amd64+Windows.81.Amd64",
-            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x64",
-            "SubType": "netcoreapp"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "x86",
-            "PB_BuildArguments": "-buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "-buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4+Windows.10.Amd64.Core+Windows.7.Amd64+Windows.81.Amd64",
-            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x86",
-            "SubType": "netcoreapp"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "arm",
-            "PB_BuildArguments": "-framework=uap -buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
-            "PB_BuildTestsArguments": "-framework=uap -buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Arm64",
-            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm",
-            "SubType": "uap"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "x64",
-            "PB_BuildArguments": "-framework=uap -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
-            "PB_BuildTestsArguments": "-framework=uap -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x64",
-            "SubType": "uap"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "x86",
-            "PB_BuildArguments": "-framework=uap -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
-            "PB_BuildTestsArguments": "-framework=uap -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x86",
-            "SubType": "uap"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "arm",
-            "PB_BuildArguments": "-framework=uapaot -buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_BuildTestsArguments": "-framework=uapaot -buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64",
-            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:SecondaryQueue=Windows.10.Arm64 /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm",
-            "SubType": "uapaot"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
-          "Parameters": {
-            "PB_Platform": "arm64",
-            "PB_BuildArguments": "-framework=uapaot -buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm64",
-            "SubType": "uapaot"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "x64",
-            "PB_BuildArguments": "-framework=uapaot -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_BuildTestsArguments": "-framework=uapaot -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x64",
-            "SubType": "uapaot"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "x86",
-            "PB_BuildArguments": "-framework=uapaot -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_BuildTestsArguments": "-framework=uapaot -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x86",
-            "SubType": "uapaot"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
-          "Parameters": {
-            "PB_Platform": "x64",
-            "PB_BuildArguments": "-allConfigurations -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:BuildAllConfigurations=true /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x64",
-            "SubType": "AllConfigurations"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "x64",
-            "PB_BuildArguments": "-framework=netfx -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "-framework=netfx -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=netfx /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=netfx /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/desktop/cli/\""
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x64",
-            "SubType": "netfx"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
-          "Parameters": {
-            "PB_Platform": "x86",
-            "PB_BuildArguments": "-framework=netfx -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "-framework=netfx -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=netfx /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=netfx /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/desktop/cli/\""
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x86",
-            "SubType": "netfx"
-          }
-        }
-      ]
+        "Definitions": [
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "arm",
+                    "PB_BuildArguments": "-buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+                    "PB_BuildTestsArguments": "-buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:EnableCloudTest=false /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "arm",
+                    "SubType": "netcoreapp"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "arm64",
+                    "PB_BuildArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+                    "PB_BuildTestsArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=arm64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:EnableCloudTest=false /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "arm64",
+                    "SubType": "netcoreapp"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x64",
+                    "PB_BuildArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+                    "PB_BuildTestsArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4+Windows.10.Nano.Amd64+Windows.10.Amd64.Core+Windows.7.Amd64+Windows.81.Amd64",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x64",
+                    "SubType": "netcoreapp"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x86",
+                    "PB_BuildArguments": "-buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+                    "PB_BuildTestsArguments": "-buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4+Windows.10.Amd64.Core+Windows.7.Amd64+Windows.81.Amd64",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x86",
+                    "SubType": "netcoreapp"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x64",
+                    "PB_BuildArguments": "-framework=netcoreappaot -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_BuildTestsArguments": "-framework=netcoreappaot -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=netcoreappaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x86",
+                    "SubType": "netcoreappaot"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x86",
+                    "PB_BuildArguments": "-framework=netcoreappaot -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_BuildTestsArguments": "-framework=netcoreappaot -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=netcoreappaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x86",
+                    "SubType": "netcoreappaot"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "arm",
+                    "PB_BuildArguments": "-framework=uap -buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
+                    "PB_BuildTestsArguments": "-framework=uap -buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Arm64",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "arm",
+                    "SubType": "uap"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x64",
+                    "PB_BuildArguments": "-framework=uap -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
+                    "PB_BuildTestsArguments": "-framework=uap -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x64",
+                    "SubType": "uap"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x86",
+                    "PB_BuildArguments": "-framework=uap -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
+                    "PB_BuildTestsArguments": "-framework=uap -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x86",
+                    "SubType": "uap"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "arm",
+                    "PB_BuildArguments": "-framework=uapaot -buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_BuildTestsArguments": "-framework=uapaot -buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:SecondaryQueue=Windows.10.Arm64 /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "arm",
+                    "SubType": "uapaot"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+                "Parameters": {
+                    "PB_Platform": "arm64",
+                    "PB_BuildArguments": "-framework=uapaot -buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "arm64",
+                    "SubType": "uapaot"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x64",
+                    "PB_BuildArguments": "-framework=uapaot -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_BuildTestsArguments": "-framework=uapaot -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x64",
+                    "SubType": "uapaot"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x86",
+                    "PB_BuildArguments": "-framework=uapaot -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_BuildTestsArguments": "-framework=uapaot -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x86",
+                    "SubType": "uapaot"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+                "Parameters": {
+                    "PB_Platform": "x64",
+                    "PB_BuildArguments": "-allConfigurations -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:BuildAllConfigurations=true /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)"
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x64",
+                    "SubType": "AllConfigurations"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x64",
+                    "PB_BuildArguments": "-framework=netfx -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+                    "PB_BuildTestsArguments": "-framework=netfx -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=netfx /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=netfx /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/desktop/cli/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x64",
+                    "SubType": "netfx"
+                }
+            },
+            {
+                "Name": "DotNet-CoreFx-Trusted-Windows",
+                "Parameters": {
+                    "PB_Platform": "x86",
+                    "PB_BuildArguments": "-framework=netfx -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+                    "PB_BuildTestsArguments": "-framework=netfx -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=netfx /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=netfx /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/desktop/cli/\""
+                },
+                "ReportingParameters": {
+                    "OperatingSystem": "Windows",
+                    "Type": "build/product/",
+                    "Platform": "x86",
+                    "SubType": "netfx"
+                }
+            }
+        ]
     },
     {
       "Name": "Publish Packages",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -130,272 +130,272 @@
       "BuildParameters": {
         "PB_PipelineBuildMSBuildArguments": "/p:EnableProfileGuidedOptimization=true"
       },
-        "Definitions": [
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "arm",
-                    "PB_BuildArguments": "-buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-                    "PB_BuildTestsArguments": "-buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:EnableCloudTest=false /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "arm",
-                    "SubType": "netcoreapp"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "arm64",
-                    "PB_BuildArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-                    "PB_BuildTestsArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=arm64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:EnableCloudTest=false /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "arm64",
-                    "SubType": "netcoreapp"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x64",
-                    "PB_BuildArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-                    "PB_BuildTestsArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4+Windows.10.Nano.Amd64+Windows.10.Amd64.Core+Windows.7.Amd64+Windows.81.Amd64",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x64",
-                    "SubType": "netcoreapp"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x86",
-                    "PB_BuildArguments": "-buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-                    "PB_BuildTestsArguments": "-buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4+Windows.10.Amd64.Core+Windows.7.Amd64+Windows.81.Amd64",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x86",
-                    "SubType": "netcoreapp"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x64",
-                    "PB_BuildArguments": "-framework=netcoreappaot -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_BuildTestsArguments": "-framework=netcoreappaot -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=netcoreappaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x86",
-                    "SubType": "netcoreappaot"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x86",
-                    "PB_BuildArguments": "-framework=netcoreappaot -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_BuildTestsArguments": "-framework=netcoreappaot -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=netcoreappaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x86",
-                    "SubType": "netcoreappaot"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "arm",
-                    "PB_BuildArguments": "-framework=uap -buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
-                    "PB_BuildTestsArguments": "-framework=uap -buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Arm64",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "arm",
-                    "SubType": "uap"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x64",
-                    "PB_BuildArguments": "-framework=uap -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
-                    "PB_BuildTestsArguments": "-framework=uap -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x64",
-                    "SubType": "uap"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x86",
-                    "PB_BuildArguments": "-framework=uap -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
-                    "PB_BuildTestsArguments": "-framework=uap -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x86",
-                    "SubType": "uap"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "arm",
-                    "PB_BuildArguments": "-framework=uapaot -buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_BuildTestsArguments": "-framework=uapaot -buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:SecondaryQueue=Windows.10.Arm64 /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "arm",
-                    "SubType": "uapaot"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
-                "Parameters": {
-                    "PB_Platform": "arm64",
-                    "PB_BuildArguments": "-framework=uapaot -buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "arm64",
-                    "SubType": "uapaot"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x64",
-                    "PB_BuildArguments": "-framework=uapaot -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_BuildTestsArguments": "-framework=uapaot -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x64",
-                    "SubType": "uapaot"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x86",
-                    "PB_BuildArguments": "-framework=uapaot -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_BuildTestsArguments": "-framework=uapaot -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x86",
-                    "SubType": "uapaot"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
-                "Parameters": {
-                    "PB_Platform": "x64",
-                    "PB_BuildArguments": "-allConfigurations -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:BuildAllConfigurations=true /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)"
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x64",
-                    "SubType": "AllConfigurations"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x64",
-                    "PB_BuildArguments": "-framework=netfx -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-                    "PB_BuildTestsArguments": "-framework=netfx -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=netfx /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=netfx /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/desktop/cli/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x64",
-                    "SubType": "netfx"
-                }
-            },
-            {
-                "Name": "DotNet-CoreFx-Trusted-Windows",
-                "Parameters": {
-                    "PB_Platform": "x86",
-                    "PB_BuildArguments": "-framework=netfx -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-                    "PB_BuildTestsArguments": "-framework=netfx -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-                    "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=netfx /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-                    "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
-                    "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=netfx /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/desktop/cli/\""
-                },
-                "ReportingParameters": {
-                    "OperatingSystem": "Windows",
-                    "Type": "build/product/",
-                    "Platform": "x86",
-                    "SubType": "netfx"
-                }
-            }
-        ]
+      "Definitions": [
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "arm",
+            "PB_BuildArguments": "-buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_BuildTestsArguments": "-buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:EnableCloudTest=false /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm",
+            "SubType": "netcoreapp"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "arm64",
+            "PB_BuildArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_BuildTestsArguments": "-buildArch=arm64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_CreateHelixArguments": "/p:ArchGroup=arm64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:EnableCloudTest=false /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm64",
+            "SubType": "netcoreapp"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_BuildTestsArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4+Windows.10.Nano.Amd64+Windows.10.Amd64.Core+Windows.7.Amd64+Windows.81.Amd64",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "SubType": "netcoreapp"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_BuildArguments": "-buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_BuildTestsArguments": "-buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4+Windows.10.Amd64.Core+Windows.7.Amd64+Windows.81.Amd64",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "SubType": "netcoreapp"
+          }
+        },        
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_BuildArguments": "-framework=netcoreappaot -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_BuildTestsArguments": "-framework=netcoreappaot -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=netcoreappaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "SubType": "netcoreappaot"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-framework=netcoreappaot -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_BuildTestsArguments": "-framework=netcoreappaot -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=netcoreappaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "SubType": "netcoreappaot"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "arm",
+            "PB_BuildArguments": "-framework=uap -buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-framework=uap -buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Arm64",
+            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm",
+            "SubType": "uap"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-framework=uap -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-framework=uap -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "SubType": "uap"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_BuildArguments": "-framework=uap -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-framework=uap -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=uap /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=uap /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "SubType": "uap"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "arm",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=arm -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_BuildTestsArguments": "-framework=uapaot -buildArch=arm -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64",
+            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:SecondaryQueue=Windows.10.Arm64 /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm",
+            "SubType": "uapaot"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+          "Parameters": {
+            "PB_Platform": "arm64",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm64",
+            "SubType": "uapaot"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_BuildTestsArguments": "-framework=uapaot -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "SubType": "uapaot"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_BuildTestsArguments": "-framework=uapaot -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=uapaot /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "SubType": "uapaot"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-allConfigurations -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:BuildAllConfigurations=true /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "SubType": "AllConfigurations"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-framework=netfx -buildArch=x64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_BuildTestsArguments": "-framework=netfx -buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10 /p:TargetGroup=netfx /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:TargetGroup=netfx /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/desktop/cli/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "SubType": "netfx"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_BuildArguments": "-framework=netfx -buildArch=x86 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_BuildTestsArguments": "-framework=netfx -buildArch=x86 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10 /p:TargetGroup=netfx /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_TargetQueue": "Windows.10.Amd64.ClientRS4",
+            "PB_CreateHelixArguments": "/p:ArchGroup=x86 /p:TargetGroup=netfx /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/desktop/cli/\""
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "SubType": "netfx"
+          }
+        }
+      ]
     },
     {
       "Name": "Publish Packages",


### PR DESCRIPTION
Adds netcoreappaot x86 and x64 builds and testing to the build pipeline to get outer loop coverage. This is mostly copied from netcoreapp. This will run out of the feature/ExperimentalBuilds branch to avoid interfering with product builds.