### PR TITLE
Fixing up various roundtripping/serialization tests that are impacted by the double/single tostring and parse changes

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/DoubleConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DoubleConverterTests.cs
@@ -30,11 +30,25 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertTo_WithContext()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void ConvertTo_WithContext_NetFramework()
         {
             ConvertTo_WithContext(new object[3, 3]
                 {
-                    { (double)1.1, 1.1.ToString(), null },
+                    { (double)1.1, "1.1", null },
+                    { (double)1.1, (float)1.1, CultureInfo.InvariantCulture },
+                    { (double)1.1, (float)1.1, null }
+                },
+                DoubleConverterTests.s_converter);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void ConvertTo_WithContext_NotNetFramework()
+        {
+            ConvertTo_WithContext(new object[3, 3]
+                {
+                    { (double)1.1, "1.1000000000000001", null },
                     { (double)1.1, (float)1.1, CultureInfo.InvariantCulture },
                     { (double)1.1, (float)1.1, null }
                 },

--- a/src/System.ComponentModel.TypeConverter/tests/SingleConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/SingleConverterTests.cs
@@ -30,11 +30,24 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertTo_WithContext()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void ConvertTo_WithContext_NetFramework()
         {
             ConvertTo_WithContext(new object[2, 3]
                 {
-                    { (float)1.1, 1.1f.ToString(), null },
+                    { (float)1.1, "1.1", null },
+                    { (float)1.1, 1, CultureInfo.InvariantCulture }
+                },
+                SingleConverterTests.s_converter);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void ConvertTo_WithContext_NotNetFramework()
+        {
+            ConvertTo_WithContext(new object[2, 3]
+                {
+                    { (float)1.1, "1.10000002", null },
                     { (float)1.1, 1, CultureInfo.InvariantCulture }
                 },
                 SingleConverterTests.s_converter);

--- a/src/System.Drawing.Primitives/tests/DataContractSerializerTests.cs
+++ b/src/System.Drawing.Primitives/tests/DataContractSerializerTests.cs
@@ -87,13 +87,47 @@ namespace System.Drawing.Primitives.Tests
             {
             new RectangleF(0, 0, 0, 0),
             new RectangleF(new PointF(1.5000f,2.5000f), new SizeF(1.5000f,2.5000f)),
-            new RectangleF(1.50001f, -2.5000f, 1.5000f, -2.5000f)
             };
             var serializedStrings = new string[]
             {
             @"<RectangleF xmlns=""http://schemas.datacontract.org/2004/07/System.Drawing"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><height>0</height><width>0</width><x>0</x><y>0</y></RectangleF>",
             @"<RectangleF xmlns=""http://schemas.datacontract.org/2004/07/System.Drawing"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><height>2.5</height><width>1.5</width><x>1.5</x><y>2.5</y></RectangleF>",
+            };
+            for (int i = 0; i < objs.Length; i++)
+            {
+                Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<RectangleF>(objs[i], serializedStrings[i]), objs[i]);
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void DCS_RectangleF_NetFramework()
+        {
+            var objs = new RectangleF[]
+            {
+            new RectangleF(1.50001f, -2.5000f, 1.5000f, -2.5000f)
+            };
+            var serializedStrings = new string[]
+            {
             @"<RectangleF xmlns=""http://schemas.datacontract.org/2004/07/System.Drawing"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><height>-2.5</height><width>1.5</width><x>1.50001</x><y>-2.5</y></RectangleF>"
+            };
+            for (int i = 0; i < objs.Length; i++)
+            {
+                Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<RectangleF>(objs[i], serializedStrings[i]), objs[i]);
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void DCS_RectangleF_NotNetFramework()
+        {
+            var objs = new RectangleF[]
+            {
+            new RectangleF(1.50001f, -2.5000f, 1.5000f, -2.5000f)
+            };
+            var serializedStrings = new string[]
+            {
+            @"<RectangleF xmlns=""http://schemas.datacontract.org/2004/07/System.Drawing"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><height>-2.5</height><width>1.5</width><x>1.50001001</x><y>-2.5</y></RectangleF>"
             };
             for (int i = 0; i < objs.Length; i++)
             {

--- a/src/System.Json/tests/JsonPrimitiveTests.cs
+++ b/src/System.Json/tests/JsonPrimitiveTests.cs
@@ -10,11 +10,7 @@ namespace System.Json.Tests
     public class JsonPrimitiveTests
     {
         [Theory]
-        [InlineData(1.1, "1.1")]
-        [InlineData(-1.1, "-1.1")]
-        [InlineData(1e-20, "1E-20")]
         [InlineData(1e+20, "1E+20")]
-        [InlineData(1e-30, "1E-30")]
         [InlineData(1e+30, "1E+30")]
         [InlineData(double.NaN, "\"NaN\"")]
         [InlineData(double.PositiveInfinity, "\"Infinity\"")]
@@ -26,10 +22,47 @@ namespace System.Json.Tests
 
         [Theory]
         [InlineData(1.1, "1.1")]
+        [InlineData(-1.1, "-1.1")]
+        [InlineData(1e-20, "1E-20")]
+        [InlineData(1e-30, "1E-30")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void ToString_Double_NetFramework(double value, string expected)
+        {
+            ToString(new JsonPrimitive(value), expected);
+        }
+
+        [Theory]
+        [InlineData(1.1, "1.1000000000000001")]
+        [InlineData(-1.1, "-1.1000000000000001")]
+        [InlineData(1e-20, "9.9999999999999995E-21")]
+        [InlineData(1e-30, "1.0000000000000001E-30")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void ToString_Double_NotNetFramework(double value, string expected)
+        {
+            ToString(new JsonPrimitive(value), expected);
+        }
+
+        [Theory]
         [InlineData(float.NaN, "\"NaN\"")]
         [InlineData(float.PositiveInfinity, "\"Infinity\"")]
         [InlineData(float.NegativeInfinity, "\"-Infinity\"")]
         public void ToString_Float(float value, string expected)
+        {
+            ToString(new JsonPrimitive(value), expected);
+        }
+
+        [Theory]
+        [InlineData(1.1, "1.1")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void ToString_Float_NetFramework(float value, string expected)
+        {
+            ToString(new JsonPrimitive(value), expected);
+        }
+
+        [Theory]
+        [InlineData(1.1, "1.10000002")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void ToString_Float_NotNetFramework(float value, string expected)
         {
             ToString(new JsonPrimitive(value), expected);
         }

--- a/src/System.Json/tests/JsonValueTests.cs
+++ b/src/System.Json/tests/JsonValueTests.cs
@@ -309,10 +309,23 @@ namespace System.Json.Tests
             Assert.Equal(ulong.MinValue, (ulong)JsonValue.Parse(new JsonPrimitive(ulong.MinValue).ToString()));
             Assert.Equal(ulong.MaxValue, (ulong)JsonValue.Parse(new JsonPrimitive(ulong.MaxValue).ToString()));
 
-            Assert.Equal("1E-30", JsonValue.Parse("1e-30").ToString());
             Assert.Equal("1E+30", JsonValue.Parse("1e+30").ToString());
         }
-        
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void JsonValue_Parse_MinMax_Integers_ViaJsonPrimitive_NetFramework()
+        {
+            Assert.Equal("1E-30", JsonValue.Parse("1e-30").ToString());
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void JsonValue_Parse_MinMax_Integers_ViaJsonPrimitive_NotNetFramework()
+        {
+            Assert.Equal("1.0000000000000001E-30", JsonValue.Parse("1e-30").ToString());
+        }
+
         [Theory]
         [InlineData("Fact\b\f\n\r\t\"\\/</\0x")]
         [InlineData("\ud800")]

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Decimal.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Decimal.cs
@@ -62,12 +62,6 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            // More compat with .NET behavior - whether or not a 0 keeps the negative sign depends on whether it an "integer" 0 or a "fractional" 0
-            if (number.Digits[0] == 0 && number.Scale == 0)
-            {
-                number.IsNegative = false;
-            }
-
             value = default;
             if (!Number.NumberBufferToDecimal(ref number, ref value))
             {

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Float.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Float.cs
@@ -110,11 +110,6 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            if (number.Digits[0] == 0)
-            {
-                number.IsNegative = false;
-            }
-
             if (!Number.NumberBufferToDouble(ref number, out value))
             {
                 value = default;

--- a/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
+++ b/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
@@ -26,12 +26,6 @@ namespace System
                 return false;
             }
 
-            if (d == 0.0)
-            {
-                // normalize -0.0 to 0.0
-                d = 0.0;
-            }
-
             value = d;
             return true;
         }
@@ -388,7 +382,7 @@ namespace System
             }
 
             if (remaining == 0)
-                return 0;
+                return number.IsNegative ? -0.0 : 0.0;
 
             count = Math.Min(remaining, 9);
             remaining -= count;

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
@@ -3243,7 +3243,8 @@ namespace System.Xml.Tests
             // Write multiple atomic values inside element
             [Theory]
             [XmlWriterInlineData]
-            public void writeValue_1(XmlWriterUtils utils)
+            [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_1_NetFramework(XmlWriterUtils utils)
             {
                 using (XmlWriter w = utils.CreateWriter())
                 {
@@ -3256,10 +3257,28 @@ namespace System.Xml.Tests
                 Assert.True((utils.CompareReader("<Root>2true3.14</Root>")));
             }
 
+            // Write multiple atomic values inside element
+            [Theory]
+            [XmlWriterInlineData]
+            [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_1_NotNetFramework(XmlWriterUtils utils)
+            {
+                using (XmlWriter w = utils.CreateWriter())
+                {
+                    w.WriteStartElement("Root");
+                    w.WriteValue((int)2);
+                    w.WriteValue((bool)true);
+                    w.WriteValue((double)3.14);
+                    w.WriteEndElement();
+                }
+                Assert.True((utils.CompareReader("<Root>2true3.1400000000000001</Root>")));
+            }
+
             // Write multiple atomic values inside attribute
             [Theory]
             [XmlWriterInlineData]
-            public void writeValue_2(XmlWriterUtils utils)
+            [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_2_NetFramework(XmlWriterUtils utils)
             {
                 using (XmlWriter w = utils.CreateWriter())
                 {
@@ -3273,10 +3292,29 @@ namespace System.Xml.Tests
                 Assert.True((utils.CompareReader("<Root attr=\"2true3.14\" />")));
             }
 
+            // Write multiple atomic values inside attribute
+            [Theory]
+            [XmlWriterInlineData]
+            [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_2_NotNetFramework(XmlWriterUtils utils)
+            {
+                using (XmlWriter w = utils.CreateWriter())
+                {
+                    w.WriteStartElement("Root");
+                    w.WriteStartAttribute("attr");
+                    w.WriteValue((int)2);
+                    w.WriteValue((bool)true);
+                    w.WriteValue((double)3.14);
+                    w.WriteEndElement();
+                }
+                Assert.True((utils.CompareReader("<Root attr=\"2true3.1400000000000001\" />")));
+            }
+
             // Write multiple atomic values inside element, separate by WriteWhitespace(' ')
             [Theory]
             [XmlWriterInlineData]
-            public void writeValue_3(XmlWriterUtils utils)
+            [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_3_NetFramework(XmlWriterUtils utils)
             {
                 using (XmlWriter w = utils.CreateWriter())
                 {
@@ -3287,6 +3325,46 @@ namespace System.Xml.Tests
                     w.WriteWhitespace(" ");
                     w.WriteValue((double)3.14);
                     w.WriteWhitespace(" ");
+                    w.WriteEndElement();
+                }
+                Assert.True((utils.CompareReader("<Root>2 true 3.14 </Root>")));
+            }
+
+            // Write multiple atomic values inside element, separate by WriteWhitespace(' ')
+            [Theory]
+            [XmlWriterInlineData]
+            [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_3_NotNetFramework(XmlWriterUtils utils)
+            {
+                using (XmlWriter w = utils.CreateWriter())
+                {
+                    w.WriteStartElement("Root");
+                    w.WriteValue((int)2);
+                    w.WriteWhitespace(" ");
+                    w.WriteValue((bool)true);
+                    w.WriteWhitespace(" ");
+                    w.WriteValue((double)3.14);
+                    w.WriteWhitespace(" ");
+                    w.WriteEndElement();
+                }
+                Assert.True((utils.CompareReader("<Root>2 true 3.1400000000000001 </Root>")));
+            }
+
+            // Write multiple atomic values inside element, separate by WriteString(' ')
+            [Theory]
+            [XmlWriterInlineData]
+            [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_4_NetFramework(XmlWriterUtils utils)
+            {
+                using (XmlWriter w = utils.CreateWriter())
+                {
+                    w.WriteStartElement("Root");
+                    w.WriteValue((int)2);
+                    w.WriteString(" ");
+                    w.WriteValue((bool)true);
+                    w.WriteString(" ");
+                    w.WriteValue((double)3.14);
+                    w.WriteString(" ");
                     w.WriteEndElement();
                 }
                 Assert.True((utils.CompareReader("<Root>2 true 3.14 </Root>")));
@@ -3295,7 +3373,8 @@ namespace System.Xml.Tests
             // Write multiple atomic values inside element, separate by WriteString(' ')
             [Theory]
             [XmlWriterInlineData]
-            public void writeValue_4(XmlWriterUtils utils)
+            [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_4_NotNetFramework(XmlWriterUtils utils)
             {
                 using (XmlWriter w = utils.CreateWriter())
                 {
@@ -3308,13 +3387,14 @@ namespace System.Xml.Tests
                     w.WriteString(" ");
                     w.WriteEndElement();
                 }
-                Assert.True((utils.CompareReader("<Root>2 true 3.14 </Root>")));
+                Assert.True((utils.CompareReader("<Root>2 true 3.1400000000000001 </Root>")));
             }
 
             // Write multiple atomic values inside attribute, separate by WriteWhitespace(' ')
             [Theory]
             [XmlWriterInlineData]
-            public void writeValue_5(XmlWriterUtils utils)
+            [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_5_NetFramework(XmlWriterUtils utils)
             {
                 using (XmlWriter w = utils.CreateWriter())
                 {
@@ -3339,10 +3419,40 @@ namespace System.Xml.Tests
                 Assert.True((utils.CompareReader("<Root attr=\"2 true 3.14 \" />")));
             }
 
+            // Write multiple atomic values inside attribute, separate by WriteWhitespace(' ')
+            [Theory]
+            [XmlWriterInlineData]
+            [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_5_NotNetFramework(XmlWriterUtils utils)
+            {
+                using (XmlWriter w = utils.CreateWriter())
+                {
+                    try
+                    {
+                        w.WriteStartElement("Root");
+                        w.WriteStartAttribute("attr");
+                        w.WriteValue((int)2);
+                        w.WriteWhitespace(" ");
+                        w.WriteValue((bool)true);
+                        w.WriteWhitespace(" ");
+                        w.WriteValue((double)3.14);
+                        w.WriteWhitespace(" ");
+                        w.WriteEndElement();
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        CError.WriteLine(e);
+                        Assert.True(false);
+                    }
+                }
+                Assert.True((utils.CompareReader("<Root attr=\"2 true 3.1400000000000001 \" />")));
+            }
+
             // Write multiple atomic values inside attribute, separate by WriteString(' ')
             [Theory]
             [XmlWriterInlineData]
-            public void writeValue_6(XmlWriterUtils utils)
+            [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_6_NetFramework(XmlWriterUtils utils)
             {
                 using (XmlWriter w = utils.CreateWriter())
                 {
@@ -3357,6 +3467,27 @@ namespace System.Xml.Tests
                     w.WriteEndElement();
                 }
                 Assert.True((utils.CompareReader("<Root attr=\"2 true 3.14 \" />")));
+            }
+
+            // Write multiple atomic values inside attribute, separate by WriteString(' ')
+            [Theory]
+            [XmlWriterInlineData]
+            [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_6_NotNetFramework(XmlWriterUtils utils)
+            {
+                using (XmlWriter w = utils.CreateWriter())
+                {
+                    w.WriteStartElement("Root");
+                    w.WriteStartAttribute("attr");
+                    w.WriteValue((int)2);
+                    w.WriteString(" ");
+                    w.WriteValue((bool)true);
+                    w.WriteString(" ");
+                    w.WriteValue((double)3.14);
+                    w.WriteString(" ");
+                    w.WriteEndElement();
+                }
+                Assert.True((utils.CompareReader("<Root attr=\"2 true 3.1400000000000001 \" />")));
             }
 
             // WriteValue(long)
@@ -3545,7 +3676,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "Byte", "string", true, null )]
             [XmlWriterInlineData(1, "SByte", "string", true, null )]
             [XmlWriterInlineData(1, "Decimal", "string", true, null )]
-            [XmlWriterInlineData(1, "float", "string", true, null )]
             [XmlWriterInlineData(1, "object", "string", true, null )]
             [XmlWriterInlineData(1, "bool", "string", true, "false" )]
             [XmlWriterInlineData(1, "DateTime", "string", true, 1 )]
@@ -3555,7 +3685,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "TimeSpan", "string", true, "PT0S" )]
             [XmlWriterInlineData(1, "Uri", "string", true, null )]
             [XmlWriterInlineData(1, "Double", "string", true, "1.7976931348623157E+308" )]
-            [XmlWriterInlineData(1, "Single", "string", true, null )]
             [XmlWriterInlineData(1, "XmlQualifiedName", "string", true, null )]
             [XmlWriterInlineData(1, "string", "string", true, null )]
 
@@ -3752,7 +3881,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "Byte", "Decimal", true, null )]
             [XmlWriterInlineData(1, "SByte", "Decimal", true, null )]
             [XmlWriterInlineData(1, "Decimal", "Decimal", true, null )]
-            [XmlWriterInlineData(1, "float", "Decimal", true, null )]
             [XmlWriterInlineData(1, "object", "Decimal", true, null )]
             [XmlWriterInlineData(1, "bool", "Decimal", false, null )]
             [XmlWriterInlineData(1, "DateTime", "Decimal", false, null )]
@@ -3762,7 +3890,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "TimeSpan", "Decimal", false, null )]
             [XmlWriterInlineData(1, "Uri", "Decimal", false, null )]
             [XmlWriterInlineData(1, "Double", "Decimal", false, null )]
-            [XmlWriterInlineData(1, "Single", "Decimal", true, null )]
             [XmlWriterInlineData(1, "XmlQualifiedName", "Decimal", false, null )]
             [XmlWriterInlineData(1, "string", "Decimal", true, null )]
 
@@ -3890,7 +4017,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "Byte", "Uri", true, null )]
             [XmlWriterInlineData(1, "SByte", "Uri", true, null )]
             [XmlWriterInlineData(1, "Decimal", "Uri", true, null )]
-            [XmlWriterInlineData(1, "float", "Uri", true, null )]
             [XmlWriterInlineData(1, "object", "Uri", true, null )]
             [XmlWriterInlineData(1, "bool", "Uri", true, "false" )]
             [XmlWriterInlineData(1, "DateTime", "Uri", true, 1 )]
@@ -3900,7 +4026,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "TimeSpan", "Uri", true, "PT0S" )]
             [XmlWriterInlineData(1, "Uri", "Uri", true, null )]
             [XmlWriterInlineData(1, "Double", "Uri", true, "1.7976931348623157E+308" )]
-            [XmlWriterInlineData(1, "Single", "Uri", true, null )]
             [XmlWriterInlineData(1, "XmlQualifiedName", "Uri", true, null )]
             [XmlWriterInlineData(1, "string", "Uri", true, null )]
 
@@ -3913,7 +4038,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "Byte", "Double", true, null )]
             [XmlWriterInlineData(1, "SByte", "Double", true, null )]
             [XmlWriterInlineData(1, "Decimal", "Double", true, 7.92281625142643E+28D )]
-            [XmlWriterInlineData(1, "float", "Double", true, null )]
             [XmlWriterInlineData(1, "object", "Double", true, null )]
             [XmlWriterInlineData(1, "bool", "Double", false, null )]
             [XmlWriterInlineData(1, "DateTime", "Double", false, null )]
@@ -3959,7 +4083,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "Byte", "object", true, null )]
             [XmlWriterInlineData(1, "SByte", "object", true, null )]
             [XmlWriterInlineData(1, "Decimal", "object", true, null )]
-            [XmlWriterInlineData(1, "float", "object", true, null )]
             [XmlWriterInlineData(1, "object", "object", true, null )]
             [XmlWriterInlineData(1, "bool", "object", true, "false" )]
             [XmlWriterInlineData(1, "DateTime", "object", true, 1 )]
@@ -3969,7 +4092,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(1, "TimeSpan", "object", true, "PT0S" )]
             [XmlWriterInlineData(1, "Uri", "object", true, null )]
             [XmlWriterInlineData(1, "Double", "object", true, "1.7976931348623157E+308" )]
-            [XmlWriterInlineData(1, "Single", "object", true, null )]
             [XmlWriterInlineData(1, "XmlQualifiedName", "object", true, null )]
             [XmlWriterInlineData(1, "string", "object", true, null )]
 
@@ -4000,12 +4122,10 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(2, "Byte", "string", true, null )]
             [XmlWriterInlineData(2, "SByte", "string", true, null )]
             [XmlWriterInlineData(2, "Decimal", "string", true, null )]
-            [XmlWriterInlineData(2, "float", "string", true, null )]
             [XmlWriterInlineData(2, "object", "string", true, null )]
             [XmlWriterInlineData(2, "bool", "string", true, "False" )]
             [XmlWriterInlineData(2, "Uri", "string", true, null )]
             [XmlWriterInlineData(2, "Double", "string", true, null )]
-            [XmlWriterInlineData(2, "Single", "string", true, null )]
             [XmlWriterInlineData(2, "XmlQualifiedName", "string", true, null )]
             [XmlWriterInlineData(2, "string", "string", true, null )]
 
@@ -4118,7 +4238,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(2, "Byte", "Decimal", true, null )]
             [XmlWriterInlineData(2, "SByte", "Decimal", true, null )]
             [XmlWriterInlineData(2, "Decimal", "Decimal", true, null )]
-            [XmlWriterInlineData(2, "float", "Decimal", true, null )]
             [XmlWriterInlineData(2, "object", "Decimal", true, null )]
             [XmlWriterInlineData(21, "XmlQualifiedName", "Decimal", false, null )]
             [XmlWriterInlineData(2, "string", "Decimal", true, null )]
@@ -4192,12 +4311,10 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(2, "Byte", "Uri", true, null )]
             [XmlWriterInlineData(2, "SByte", "Uri", true, null )]
             [XmlWriterInlineData(2, "Decimal", "Uri", true, null )]
-            [XmlWriterInlineData(2, "float", "Uri", true, null )]
             [XmlWriterInlineData(2, "object", "Uri", true, null )]
             [XmlWriterInlineData(2, "bool", "Uri", true, "False" )]
             [XmlWriterInlineData(2, "Uri", "Uri", true, null )]
             [XmlWriterInlineData(2, "Double", "Uri", true, null )]
-            [XmlWriterInlineData(2, "Single", "Uri", true, null )]
             [XmlWriterInlineData(2, "XmlQualifiedName", "Uri", true, null )]
             [XmlWriterInlineData(2, "string", "Uri", true, null )]
 
@@ -4210,7 +4327,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(2, "Byte", "Double", true, null )]
             [XmlWriterInlineData(2, "SByte", "Double", true, null )]
             [XmlWriterInlineData(2, "Decimal", "Double", true, 7.92281625142643E+28D )]
-            [XmlWriterInlineData(2, "float", "Double", true, null )]
             [XmlWriterInlineData(2, "object", "Double", true, null )]
             [XmlWriterInlineData(2, "bool", "Double", false, null )]
             [XmlWriterInlineData(2, "Double", "Double", false, null )]
@@ -4239,7 +4355,6 @@ namespace System.Xml.Tests
             [XmlWriterInlineData(2, "Byte", "object", true, null )]
             [XmlWriterInlineData(2, "SByte", "object", true, null )]
             [XmlWriterInlineData(2, "Decimal", "object", true, null )]
-            [XmlWriterInlineData(2, "float", "object", true, null )]
             [XmlWriterInlineData(2, "object", "object", true, null )]
             [XmlWriterInlineData(2, "bool", "object", true, "False" )]
             [XmlWriterInlineData(2, "XmlQualifiedName", "object", true, null )]
@@ -4313,6 +4428,52 @@ namespace System.Xml.Tests
                     CultureInfo.CurrentCulture = origCulture;
                 }
                 Assert.True((isValid));
+            }
+
+            [Theory]
+            [XmlWriterInlineData(1, "float", "Double", true, null )]
+            [XmlWriterInlineData(1, "float", "Uri", true, null )]
+            [XmlWriterInlineData(1, "float", "object", true, null )]
+            [XmlWriterInlineData(1, "float", "string", true, null )]
+            [XmlWriterInlineData(1, "float", "Decimal", true, null )]
+            [XmlWriterInlineData(1, "Single", "Uri", true, null )]
+            [XmlWriterInlineData(1, "Single", "object", true, null )]
+            [XmlWriterInlineData(1, "Single", "string", true, null )]
+            [XmlWriterInlineData(1, "Single", "Decimal", true, null )]
+            [XmlWriterInlineData(2, "float", "Double", true, null )]
+            [XmlWriterInlineData(2, "float", "Uri", true, null )]
+            [XmlWriterInlineData(2, "float", "object", true, null )]
+            [XmlWriterInlineData(2, "float", "string", true, null )]
+            [XmlWriterInlineData(2, "float", "Decimal", true, null )]
+            [XmlWriterInlineData(2, "Single", "Uri", true, null )]
+            [XmlWriterInlineData(2, "Single", "string", true, null )]
+            [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_27_NetFramework(XmlWriterUtils utils, int param, string sourceStr, string destStr, bool isValid, object expVal)
+            {
+                writeValue_27(utils, param, sourceStr, destStr, isValid, expVal);
+            }
+
+            [Theory]
+            [XmlWriterInlineData(1, "float", "Double", true, "-4582.24023" )]
+            [XmlWriterInlineData(1, "float", "Uri", true, "-4582.24023" )]
+            [XmlWriterInlineData(1, "float", "object", true, "-4582.24023" )]
+            [XmlWriterInlineData(1, "float", "string", true, "-4582.24023" )]
+            [XmlWriterInlineData(1, "float", "Decimal", true, "-4582.24023" )]
+            [XmlWriterInlineData(1, "Single", "Uri", true, "-4582.2399999999998" )]
+            [XmlWriterInlineData(1, "Single", "object", true, "-4582.2399999999998" )]
+            [XmlWriterInlineData(1, "Single", "string", true, "-4582.2399999999998" )]
+            [XmlWriterInlineData(1, "Single", "Decimal", true, "-4582.2399999999998" )]
+            [XmlWriterInlineData(2, "float", "Double", true, "-4582.24" )]
+            [XmlWriterInlineData(2, "float", "Uri", true, "-4582.24" )]
+            [XmlWriterInlineData(2, "float", "object", true, "-4582.24" )]
+            [XmlWriterInlineData(2, "float", "string", true, "-4582.24" )]
+            [XmlWriterInlineData(2, "float", "Decimal", true, "-4582.24" )]
+            [XmlWriterInlineData(2, "Single", "Uri", true, "-4582.24" )]
+            [XmlWriterInlineData(2, "Single", "string", true, "-4582.24" )]
+            [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+            public void writeValue_27_NotNetFramework(XmlWriterUtils utils, int param, string sourceStr, string destStr, bool isValid, object expVal)
+            {
+                writeValue_27(utils, param, sourceStr, destStr, isValid, expVal);
             }
 
             [Theory]

--- a/src/System.Private.Xml/tests/XmlConvert/ToTypeTests.cs
+++ b/src/System.Private.Xml/tests/XmlConvert/ToTypeTests.cs
@@ -516,10 +516,10 @@ namespace System.Xml.Tests
         //[Variation("ToString(float) - valid cases")]
         public int ToType34()
         {
-            CError.Compare(XmlConvert.ToString((float)(-4582.24)), "-4582.24", "float");
+            CError.Compare(XmlConvert.ToString((float)(-4582.24)), (-4582.24f).ToString("R", NumberFormatInfo.InvariantInfo), "float");
             CError.Compare(XmlConvert.ToString(float.PositiveInfinity), "INF", "float");
             CError.Compare(XmlConvert.ToString(float.NegativeInfinity), "-INF", "float");
-            CError.Compare(XmlConvert.ToString((float)2.646978e-23), "2.646978E-23", "float");
+            CError.Compare(XmlConvert.ToString((float)2.646978e-23), (2.646978e-23f).ToString("R", NumberFormatInfo.InvariantInfo), "float");
             CError.Compare(XmlConvert.ToString((float)0), "0", "float");
             CError.Compare(XmlConvert.ToString(float.NaN), "NaN", "float");
             CError.Compare(XmlConvert.ToString((float)-0), "0", "float");
@@ -530,10 +530,10 @@ namespace System.Xml.Tests
         public int ToType35()
         {
             // double
-            CError.Compare(XmlConvert.ToString(-4582.24), "-4582.24", "double");
+            CError.Compare(XmlConvert.ToString(-4582.24), (-4582.24).ToString("R", NumberFormatInfo.InvariantInfo), "double");
             CError.Compare(XmlConvert.ToString(double.PositiveInfinity), "INF", "double");
             CError.Compare(XmlConvert.ToString(double.NegativeInfinity), "-INF", "double");
-            CError.Compare(XmlConvert.ToString(243.657745094698e-23), "2.43657745094698E-21", "double");
+            CError.Compare(XmlConvert.ToString(243.657745094698e-23), (243.657745094698e-23).ToString("R", NumberFormatInfo.InvariantInfo), "double");
             CError.Compare(XmlConvert.ToString((double)0), "0", "double");
             CError.Compare(XmlConvert.ToString(double.NaN), "NaN", "double");
             CError.Compare(XmlConvert.ToString((double)-0), "0", "double");

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -122,9 +122,6 @@ public static partial class XmlSerializerTests
         Assert.StrictEqual(SerializeAndDeserialize<double>(0,
 @"<?xml version=""1.0""?>
 <double>0</double>"), 0);
-        Assert.StrictEqual(SerializeAndDeserialize<double>(2.3,
-@"<?xml version=""1.0""?>
-<double>2.3</double>"), 2.3);
         Assert.StrictEqual(SerializeAndDeserialize<double>(double.MinValue,
 @"<?xml version=""1.0""?>
 <double>-1.7976931348623157E+308</double>"), double.MinValue);
@@ -134,23 +131,59 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void Xml_DoubleAsRoot_NetFramework()
+    {
+        Assert.StrictEqual(SerializeAndDeserialize<double>(2.3,
+@"<?xml version=""1.0""?>
+<double>2.3</double>"), 2.3);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void Xml_DoubleAsRoot_NotNetFramework()
+    {
+        Assert.StrictEqual(SerializeAndDeserialize<double>(2.3,
+@"<?xml version=""1.0""?>
+<double>2.2999999999999998</double>"), 2.3);
+    }    
+
+    [Fact]
     public static void Xml_FloatAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2,
-@"<?xml version=""1.0""?>
-<float>-1.2</float>"), (float)-1.2);
         Assert.StrictEqual(SerializeAndDeserialize<float>((float)0,
 @"<?xml version=""1.0""?>
 <float>0</float>"), (float)0);
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3,
-@"<?xml version=""1.0""?>
-<float>2.3</float>"), (float)2.3);
         Assert.StrictEqual(SerializeAndDeserialize<float>(float.MinValue,
 @"<?xml version=""1.0""?>
 <float>-3.40282347E+38</float>"), float.MinValue);
         Assert.StrictEqual(SerializeAndDeserialize<float>(float.MaxValue,
 @"<?xml version=""1.0""?>
 <float>3.40282347E+38</float>"), float.MaxValue);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void Xml_FloatAsRoot_NetFramework()
+    {
+        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2,
+@"<?xml version=""1.0""?>
+<float>-1.2</float>"), (float)-1.2);
+        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3,
+@"<?xml version=""1.0""?>
+<float>2.3</float>"), (float)2.3);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void Xml_FloatAsRoot_NotNetFramework()
+    {
+        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2,
+@"<?xml version=""1.0""?>
+<float>-1.20000005</float>"), (float)-1.2);
+        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3,
+@"<?xml version=""1.0""?>
+<float>2.29999995</float>"), (float)2.3);
     }
 
     [Fact]

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
@@ -2928,11 +2928,51 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
-        public void AddExtObject22(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void AddExtObject22_NetFramework(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
 		Get A String:Hello world
 		Get A Double:22.41276
+		Get A True Boolean:true
+		Get A False Boolean:false
+		Get An Int:10
+		Get Other with ToString() Support:My Custom Object has a value of 22
+		Call function with no return type:</result>";
+
+            MyObject obj = new MyObject(22, _output);
+            m_xsltArg = new XsltArgumentList();
+
+            m_xsltArg.AddExtensionObject(szDefaultNS, obj);
+            if ((LoadXSL("MyObject_ReturnValidTypes.xsl", inputType, readerType) == 1) && (Transform_ArgList("fruits.xml", transformType, docType) == 1))
+            {
+                VerifyResult(expected);
+                return;
+            }
+            else
+                Assert.True(false);
+        }
+
+        //[Variation("Methods returning void and valid types")]
+        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.Reader, DocType.XPathDocument)]
+        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
+        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.Writer, DocType.XPathDocument)]
+        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
+        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.Reader, DocType.XPathDocument)]
+        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.Writer, DocType.XPathDocument)]
+        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
+        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
+        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Reader, DocType.XPathDocument)]
+        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Writer, DocType.XPathDocument)]
+        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
+        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void AddExtObject22_NotNetFramework(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
+        {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		Get A String:Hello world
+		Get A Double:22.412759999999999
 		Get A True Boolean:true
 		Get A False Boolean:false
 		Get An Int:10

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -145,19 +145,46 @@ public static partial class DataContractJsonSerializerTests
     {
         Assert.StrictEqual(SerializeAndDeserialize<double>(-1.2, "-1.2"), -1.2);
         Assert.StrictEqual(SerializeAndDeserialize<double>(0, "0"), 0);
-        Assert.StrictEqual(SerializeAndDeserialize<double>(2.3, "2.3"), 2.3);
         Assert.StrictEqual(SerializeAndDeserialize<double>(double.MinValue, "-1.7976931348623157E+308"), double.MinValue);
         Assert.StrictEqual(SerializeAndDeserialize<double>(double.MaxValue, "1.7976931348623157E+308"), double.MaxValue);
     }
 
     [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_DoubleAsRoot_NetFramework()
+    {
+        Assert.StrictEqual(SerializeAndDeserialize<double>(2.3, "2.3"), 2.3);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_DoubleAsRoot_NotNetFramework()
+    {
+        Assert.StrictEqual(SerializeAndDeserialize<double>(2.3, "2.2999999999999998"), 2.3);
+    }
+
+    [Fact]
     public static void DCJS_FloatAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2, "-1.2"), (float)-1.2);
         Assert.StrictEqual(SerializeAndDeserialize<float>((float)0, "0"), (float)0);
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3, "2.3"), (float)2.3);
         Assert.StrictEqual(SerializeAndDeserialize<float>(float.MinValue, "-3.40282347E+38"), float.MinValue);
         Assert.StrictEqual(SerializeAndDeserialize<float>(float.MaxValue, "3.40282347E+38"), float.MaxValue);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_FloatAsRoot_NetFramework()
+    {
+        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2, "-1.2"), (float)-1.2);
+        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3, "2.3"), (float)2.3);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_FloatAsRoot_NotNetFramework()
+    {
+        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2, "-1.20000005"), (float)-1.2);
+        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3, "2.29999995"), (float)2.3);
     }
 
     [Fact]
@@ -1649,7 +1676,8 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCJS_GenericTypeWithNestedGenerics()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_GenericTypeWithNestedGenerics_NetFramework()
     {
         GenericTypeWithNestedGenerics<int>.InnerGeneric<double> value = new GenericTypeWithNestedGenerics<int>.InnerGeneric<double>()
         {
@@ -1657,6 +1685,20 @@ public static partial class DataContractJsonSerializerTests
             data2 = 4.56
         };
         var deserializedValue = SerializeAndDeserialize<GenericTypeWithNestedGenerics<int>.InnerGeneric<double>>(value, @"{""data1"":123,""data2"":4.56}");
+        Assert.StrictEqual(value.data1, deserializedValue.data1);
+        Assert.StrictEqual(value.data2, deserializedValue.data2);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_GenericTypeWithNestedGenerics_NotNetFramework()
+    {
+        GenericTypeWithNestedGenerics<int>.InnerGeneric<double> value = new GenericTypeWithNestedGenerics<int>.InnerGeneric<double>()
+        {
+            data1 = 123,
+            data2 = 4.56
+        };
+        var deserializedValue = SerializeAndDeserialize<GenericTypeWithNestedGenerics<int>.InnerGeneric<double>>(value, @"{""data1"":123,""data2"":4.5599999999999996}");
         Assert.StrictEqual(value.data1, deserializedValue.data1);
         Assert.StrictEqual(value.data2, deserializedValue.data2);
     }
@@ -1957,7 +1999,8 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCJS_TypeWithAllPrimitiveProperties()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_TypeWithAllPrimitiveProperties_NetFramework()
     {
         TypeWithAllPrimitiveProperties x = new TypeWithAllPrimitiveProperties
         {
@@ -1974,6 +2017,37 @@ public static partial class DataContractJsonSerializerTests
             IntMember = 123
         };
         TypeWithAllPrimitiveProperties y = SerializeAndDeserialize<TypeWithAllPrimitiveProperties>(x, "{\"BooleanMember\":true,\"CharMember\":\"C\",\"DateTimeMember\":\"\\/Date(1467969011000)\\/\",\"DecimalMember\":-14554481076115341312123,\"DoubleMember\":123.456,\"FloatMember\":456.789,\"GuidMember\":\"2054fd3e-e118-476a-9962-1a882be51860\",\"IntMember\":123,\"StringMember\":\"abc\"}");
+        Assert.StrictEqual(x.BooleanMember, y.BooleanMember);
+        //Assert.StrictEqual(x.ByteArrayMember, y.ByteArrayMember);
+        Assert.StrictEqual(x.CharMember, y.CharMember);
+        Assert.StrictEqual(x.DateTimeMember, y.DateTimeMember);
+        Assert.StrictEqual(x.DecimalMember, y.DecimalMember);
+        Assert.StrictEqual(x.DoubleMember, y.DoubleMember);
+        Assert.StrictEqual(x.FloatMember, y.FloatMember);
+        Assert.StrictEqual(x.GuidMember, y.GuidMember);
+        Assert.StrictEqual(x.StringMember, y.StringMember);
+        Assert.StrictEqual(x.IntMember, y.IntMember);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_TypeWithAllPrimitiveProperties_NotNetFramework()
+    {
+        TypeWithAllPrimitiveProperties x = new TypeWithAllPrimitiveProperties
+        {
+            BooleanMember = true,
+            //ByteArrayMember = new byte[] { 1, 2, 3, 4 },
+            CharMember = 'C',
+            DateTimeMember = new DateTime(2016, 7, 8, 9, 10, 11, DateTimeKind.Utc),
+            DecimalMember = new decimal(123, 456, 789, true, 0),
+            DoubleMember = 123.456,
+            FloatMember = 456.789f,
+            GuidMember = Guid.Parse("2054fd3e-e118-476a-9962-1a882be51860"),
+            //public byte[] HexBinaryMember 
+            StringMember = "abc",
+            IntMember = 123
+        };
+        TypeWithAllPrimitiveProperties y = SerializeAndDeserialize<TypeWithAllPrimitiveProperties>(x, "{\"BooleanMember\":true,\"CharMember\":\"C\",\"DateTimeMember\":\"\\/Date(1467969011000)\\/\",\"DecimalMember\":-14554481076115341312123,\"DoubleMember\":123.456,\"FloatMember\":456.789001,\"GuidMember\":\"2054fd3e-e118-476a-9962-1a882be51860\",\"IntMember\":123,\"StringMember\":\"abc\"}");
         Assert.StrictEqual(x.BooleanMember, y.BooleanMember);
         //Assert.StrictEqual(x.ByteArrayMember, y.ByteArrayMember);
         Assert.StrictEqual(x.CharMember, y.CharMember);
@@ -2034,7 +2108,8 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCJS_ArrayOfSingle()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_ArrayOfSingle_NetFramework()
     {
         var value = new float[] { 1.23f, 4.56f, 7.89f };
         var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
@@ -2043,10 +2118,31 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCJS_ArrayOfDouble()
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_ArrayOfSingle_NotNetFramework()
+    {
+        var value = new float[] { 1.23f, 4.56f, 7.89f };
+        var deserialized = SerializeAndDeserialize(value, "[1.23000002,4.55999994,7.88999987]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_ArrayOfDouble_NetFramework()
     {
         var value = new double[] { 1.23, 4.56, 7.89 };
         var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_ArrayOfDouble_NotNetFramework()
+    {
+        var value = new double[] { 1.23, 4.56, 7.89 };
+        var deserialized = SerializeAndDeserialize(value, "[1.23,4.5599999999999996,7.8899999999999997]");
         Assert.StrictEqual(value.Length, deserialized.Length);
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
     }
@@ -2116,7 +2212,8 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCJS_GenericICollectionOfSingle()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_GenericICollectionOfSingle_NetFramework()
     {
         var value = new TypeImplementsGenericICollection<float>() { 1.23f, 4.56f, 7.89f };
         var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
@@ -2125,10 +2222,31 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCJS_GenericICollectionOfDouble()
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_GenericICollectionOfSingle_NotNetFramework()
+    {
+        var value = new TypeImplementsGenericICollection<float>() { 1.23f, 4.56f, 7.89f };
+        var deserialized = SerializeAndDeserialize(value, "[1.23000002,4.55999994,7.88999987]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_GenericICollectionOfDouble_NetFramework()
     {
         var value = new TypeImplementsGenericICollection<double>() { 1.23, 4.56, 7.89 };
         var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_GenericICollectionOfDouble_NotNetFramework()
+    {
+        var value = new TypeImplementsGenericICollection<double>() { 1.23, 4.56, 7.89 };
+        var deserialized = SerializeAndDeserialize(value, "[1.23,4.5599999999999996,7.8899999999999997]");
         Assert.StrictEqual(value.Count, deserialized.Count);
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
     }
@@ -2798,7 +2916,8 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCJS_VerifyIndentation()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_VerifyIndentation_NetFramework()
     {
         var testClass = new TestClass()
         {
@@ -2846,6 +2965,80 @@ public static partial class DataContractJsonSerializerTests
         var value3 = VerifyIndentationOfSerializedXml(
           emptyList,
           "{\r\n  \"floatNum\": 2.3,\r\n  \"intList\": [ ]\r\n}",
+          spaceChars,
+          dcjsSettings);
+        Assert.NotNull(value3);
+        Assert.True(value3.floatNum == 2.3f);
+        Assert.True(value3.intList.Count == 0);
+
+        var jsonTypes = new JsonTypes();
+        dcjsSettings = new DataContractJsonSerializerSettings()
+        {
+            DateTimeFormat = null,
+            UseSimpleDictionaryFormat = true,
+            EmitTypeInformation = EmitTypeInformation.AsNeeded,
+            KnownTypes = new List<Type>() { typeof(Dictionary<string, string>), typeof(List<object>), typeof(int[]) }
+        };
+        spaceChars = "  ";
+        var value4 = VerifyIndentationOfSerializedXml(
+           jsonTypes.ObjectList,
+           "[\r\n  [\r\n    {\r\n      \"__type\": \"KeyValuePairOfstringstring:#System.Collections.Generic\",\r\n      \"key\": \"Title\",\r\n      \"value\": \"Sherlocl Kholmes\"\r\n    }\r\n  ],\r\n  [\r\n    1,\r\n    2,\r\n    3\r\n  ],\r\n  [\r\n    \"hi\",\r\n    1,\r\n    \"there\"\r\n  ]\r\n]",
+           spaceChars,
+           dcjsSettings);
+        Assert.NotNull(value4);
+        Assert.True(value4.Count == 3);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCJS_VerifyIndentation_NotNetFramework()
+    {
+        var testClass = new TestClass()
+        {
+            floatNum = 2.3f,
+            intList = new List<int>() { 2, 3, 4 }
+        };
+
+        string spaceChars = "    ";
+        var dcjsSettings = new DataContractJsonSerializerSettings()
+        {
+            DateTimeFormat = null,
+            UseSimpleDictionaryFormat = false,
+            EmitTypeInformation = EmitTypeInformation.AsNeeded,
+            KnownTypes = new List<Type>()
+        };
+        var value = VerifyIndentationOfSerializedXml(
+            testClass,
+            "{\r\n    \"floatNum\": 2.29999995,\r\n    \"intList\": [\r\n        2,\r\n        3,\r\n        4\r\n    ]\r\n}",
+            spaceChars,
+            dcjsSettings);
+        Assert.NotNull(value);
+        Assert.True(value.floatNum == 2.3f);
+        Assert.True(value.intList[0] == 2);
+        Assert.True(value.intList[1] == 3);
+        Assert.True(value.intList[2] == 4);
+
+        spaceChars = "\n";
+        var value2 = VerifyIndentationOfSerializedXml(
+            testClass,
+            "{\r\n\n\"floatNum\": 2.29999995,\r\n\n\"intList\": [\r\n\n\n2,\r\n\n\n3,\r\n\n\n4\r\n\n]\r\n}",
+            spaceChars,
+            dcjsSettings);
+        Assert.NotNull(value2);
+        Assert.True(value2.floatNum == 2.3f);
+        Assert.True(value2.intList[0] == 2);
+        Assert.True(value2.intList[1] == 3);
+        Assert.True(value2.intList[2] == 4);
+
+        var emptyList = new TestClass()
+        {
+            floatNum = 2.3f,
+            intList = new List<int>()
+        };
+        spaceChars = "  ";
+        var value3 = VerifyIndentationOfSerializedXml(
+          emptyList,
+          "{\r\n  \"floatNum\": 2.29999995,\r\n  \"intList\": [ ]\r\n}",
           spaceChars,
           dcjsSettings);
         Assert.NotNull(value3);

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -129,19 +129,46 @@ public static partial class DataContractSerializerTests
     {
         Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(-1.2, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.2</double>"), -1.2);
         Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(0, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</double>"), 0);
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(2.3, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.3</double>"), 2.3);
         Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(double.MinValue, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.7976931348623157E+308</double>"), double.MinValue);
         Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(double.MaxValue, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">1.7976931348623157E+308</double>"), double.MaxValue);
     }
 
     [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_DoubleAsRoot_NetFramework()
+    {
+        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(2.3, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.3</double>"), 2.3);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_DoubleAsRoot_NotNetFramework()
+    {
+        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(2.3, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.2999999999999998</double>"), 2.3);
+    }
+
+    [Fact]
     public static void DCS_FloatAsRoot()
     {
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)-1.2, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.2</float>"), (float)-1.2);
         Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)0, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</float>"), (float)0);
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)2.3, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.3</float>"), (float)2.3);
         Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>(float.MinValue, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-3.40282347E+38</float>"), float.MinValue);
         Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>(float.MaxValue, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">3.40282347E+38</float>"), float.MaxValue);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_FloatAsRoot_NetFramework()
+    {
+        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)-1.2, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.2</float>"), (float)-1.2);
+        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)2.3, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.3</float>"), (float)2.3);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_FloatAsRoot_NotNetFramework()
+    {
+        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)-1.2, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.20000005</float>"), (float)-1.2);
+        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)2.3, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.29999995</float>"), (float)2.3);
     }
 
     [Fact]
@@ -1819,7 +1846,8 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericTypeWithNestedGenerics()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_GenericTypeWithNestedGenerics_NetFramework()
     {
         GenericTypeWithNestedGenerics<int>.InnerGeneric<double> value = new GenericTypeWithNestedGenerics<int>.InnerGeneric<double>()
         {
@@ -1827,6 +1855,20 @@ public static partial class DataContractSerializerTests
             data2 = 4.56
         };
         var deserializedValue = DataContractSerializerHelper.SerializeAndDeserialize<GenericTypeWithNestedGenerics<int>.InnerGeneric<double>>(value, @"<GenericTypeWithNestedGenerics.InnerGenericOfintdouble2LMUf4bh xmlns=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><data1>123</data1><data2>4.56</data2></GenericTypeWithNestedGenerics.InnerGenericOfintdouble2LMUf4bh>");
+        Assert.StrictEqual(value.data1, deserializedValue.data1);
+        Assert.StrictEqual(value.data2, deserializedValue.data2);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_GenericTypeWithNestedGenerics_NotNetFramework()
+    {
+        GenericTypeWithNestedGenerics<int>.InnerGeneric<double> value = new GenericTypeWithNestedGenerics<int>.InnerGeneric<double>()
+        {
+            data1 = 123,
+            data2 = 4.56
+        };
+        var deserializedValue = DataContractSerializerHelper.SerializeAndDeserialize<GenericTypeWithNestedGenerics<int>.InnerGeneric<double>>(value, @"<GenericTypeWithNestedGenerics.InnerGenericOfintdouble2LMUf4bh xmlns=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><data1>123</data1><data2>4.5599999999999996</data2></GenericTypeWithNestedGenerics.InnerGenericOfintdouble2LMUf4bh>");
         Assert.StrictEqual(value.data1, deserializedValue.data1);
         Assert.StrictEqual(value.data2, deserializedValue.data2);
     }
@@ -2257,7 +2299,8 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCS_TypeWithAllPrimitiveProperties()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_TypeWithAllPrimitiveProperties_NetFramework()
     {
         TypeWithAllPrimitiveProperties x = new TypeWithAllPrimitiveProperties
         {
@@ -2274,6 +2317,37 @@ public static partial class DataContractSerializerTests
             IntMember = 123
         };
         TypeWithAllPrimitiveProperties y = DataContractSerializerHelper.SerializeAndDeserialize<TypeWithAllPrimitiveProperties>(x, @"<TypeWithAllPrimitiveProperties xmlns=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><BooleanMember>true</BooleanMember><CharMember>67</CharMember><DateTimeMember>2016-07-08T09:10:11</DateTimeMember><DecimalMember>-14554481076115341312123</DecimalMember><DoubleMember>123.456</DoubleMember><FloatMember>456.789</FloatMember><GuidMember>2054fd3e-e118-476a-9962-1a882be51860</GuidMember><IntMember>123</IntMember><StringMember>abc</StringMember></TypeWithAllPrimitiveProperties>");
+        Assert.StrictEqual(x.BooleanMember, y.BooleanMember);
+        //Assert.StrictEqual(x.ByteArrayMember, y.ByteArrayMember);
+        Assert.StrictEqual(x.CharMember, y.CharMember);
+        Assert.StrictEqual(x.DateTimeMember, y.DateTimeMember);
+        Assert.StrictEqual(x.DecimalMember, y.DecimalMember);
+        Assert.StrictEqual(x.DoubleMember, y.DoubleMember);
+        Assert.StrictEqual(x.FloatMember, y.FloatMember);
+        Assert.StrictEqual(x.GuidMember, y.GuidMember);
+        Assert.StrictEqual(x.StringMember, y.StringMember);
+        Assert.StrictEqual(x.IntMember, y.IntMember);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_TypeWithAllPrimitiveProperties_NotNetFramework()
+    {
+        TypeWithAllPrimitiveProperties x = new TypeWithAllPrimitiveProperties
+        {
+            BooleanMember = true,
+            //ByteArrayMember = new byte[] { 1, 2, 3, 4 },
+            CharMember = 'C',
+            DateTimeMember = new DateTime(2016, 7, 8, 9, 10, 11),
+            DecimalMember = new decimal(123, 456, 789, true, 0),
+            DoubleMember = 123.456,
+            FloatMember = 456.789f,
+            GuidMember = Guid.Parse("2054fd3e-e118-476a-9962-1a882be51860"),
+            //public byte[] HexBinaryMember 
+            StringMember = "abc",
+            IntMember = 123
+        };
+        TypeWithAllPrimitiveProperties y = DataContractSerializerHelper.SerializeAndDeserialize<TypeWithAllPrimitiveProperties>(x, @"<TypeWithAllPrimitiveProperties xmlns=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><BooleanMember>true</BooleanMember><CharMember>67</CharMember><DateTimeMember>2016-07-08T09:10:11</DateTimeMember><DecimalMember>-14554481076115341312123</DecimalMember><DoubleMember>123.456</DoubleMember><FloatMember>456.789001</FloatMember><GuidMember>2054fd3e-e118-476a-9962-1a882be51860</GuidMember><IntMember>123</IntMember><StringMember>abc</StringMember></TypeWithAllPrimitiveProperties>");
         Assert.StrictEqual(x.BooleanMember, y.BooleanMember);
         //Assert.StrictEqual(x.ByteArrayMember, y.ByteArrayMember);
         Assert.StrictEqual(x.CharMember, y.CharMember);
@@ -2334,7 +2408,8 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfSingle()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_ArrayOfSingle_NetFramework()
     {
         var value = new float[] { 1.23f, 4.56f, 7.89f };
         var deserialized = DataContractSerializerHelper.SerializeAndDeserialize(value, @"<ArrayOffloat xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><float>1.23</float><float>4.56</float><float>7.89</float></ArrayOffloat>");
@@ -2343,10 +2418,31 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfDouble()
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_ArrayOfSingle_NotNetFramework()
+    {
+        var value = new float[] { 1.23f, 4.56f, 7.89f };
+        var deserialized = DataContractSerializerHelper.SerializeAndDeserialize(value, @"<ArrayOffloat xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><float>1.23000002</float><float>4.55999994</float><float>7.88999987</float></ArrayOffloat>");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_ArrayOfDouble_NetFramework()
     {
         var value = new double[] { 1.23, 4.56, 7.89 };
         var deserialized = DataContractSerializerHelper.SerializeAndDeserialize(value, @"<ArrayOfdouble xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><double>1.23</double><double>4.56</double><double>7.89</double></ArrayOfdouble>");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_ArrayOfDouble_NotNetFramework()
+    {
+        var value = new double[] { 1.23, 4.56, 7.89 };
+        var deserialized = DataContractSerializerHelper.SerializeAndDeserialize(value, @"<ArrayOfdouble xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><double>1.23</double><double>4.5599999999999996</double><double>7.8899999999999997</double></ArrayOfdouble>");
         Assert.StrictEqual(value.Length, deserialized.Length);
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
     }
@@ -2456,7 +2552,8 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfSingle()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_GenericICollectionOfSingle_NetFramework()
     {
         var value = new TypeImplementsGenericICollection<float>() { 1.23f, 4.56f, 7.89f };
         var deserialized = DataContractSerializerHelper.SerializeAndDeserialize(value, @"<ArrayOffloat xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><float>1.23</float><float>4.56</float><float>7.89</float></ArrayOffloat>");
@@ -2465,10 +2562,31 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfDouble()
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_GenericICollectionOfSingle_NotNetFramework()
+    {
+        var value = new TypeImplementsGenericICollection<float>() { 1.23f, 4.56f, 7.89f };
+        var deserialized = DataContractSerializerHelper.SerializeAndDeserialize(value, @"<ArrayOffloat xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><float>1.23000002</float><float>4.55999994</float><float>7.88999987</float></ArrayOffloat>");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_GenericICollectionOfDouble_NetFramework()
     {
         var value = new TypeImplementsGenericICollection<double>() { 1.23, 4.56, 7.89 };
         var deserialized = DataContractSerializerHelper.SerializeAndDeserialize(value, @"<ArrayOfdouble xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><double>1.23</double><double>4.56</double><double>7.89</double></ArrayOfdouble>");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_GenericICollectionOfDouble_NotNetFramework()
+    {
+        var value = new TypeImplementsGenericICollection<double>() { 1.23, 4.56, 7.89 };
+        var deserialized = DataContractSerializerHelper.SerializeAndDeserialize(value, @"<ArrayOfdouble xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><double>1.23</double><double>4.5599999999999996</double><double>7.8899999999999997</double></ArrayOfdouble>");
         Assert.StrictEqual(value.Count, deserialized.Count);
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
     }
@@ -2811,7 +2929,8 @@ public static partial class DataContractSerializerTests
     /// Resolver is plugged in and resolves the primitive types. Verify resolver called during ser and deser
     /// </summary>
     [Fact]
-    public static void DCS_BasicRoundTripResolvePrimitiveTypes()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_BasicRoundTripResolvePrimitiveTypes_NetFramework()
     {
         var dataContractSerializerSettings = new DataContractSerializerSettings()
         {
@@ -2823,6 +2942,31 @@ public static partial class DataContractSerializerTests
         };
 
         string baseline = @"<ObjectContainer xmlns=""http://schemas.datacontract.org/2004/07/SerializationTestTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><_data i:type=""a:PrimitiveContainer_foo"" xmlns:a=""http://www.default.com""><a i:type=""a:Boolean_foo"">false</a><array1><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/></array1><b i:type=""a:Byte_foo"">255</b><c i:type=""a:Byte_foo"">0</c><d i:type=""a:Char_foo"">65535</d><e i:type=""a:Decimal_foo"">79228162514264337593543950335</e><f i:type=""a:Decimal_foo"">-1</f><f5 i:type=""a:DateTime_foo"">9999-12-31T23:59:59.9999999</f5><g i:type=""a:Decimal_foo"">-79228162514264337593543950335</g><guidData i:type=""a:Guid_foo"">4bc848b1-a541-40bf-8aa9-dd6ccb6d0e56</guidData><h i:type=""a:Decimal_foo"">1</h><i i:type=""a:Decimal_foo"">0</i><j i:type=""a:Decimal_foo"">0</j><k i:type=""a:Double_foo"">0</k><l i:type=""a:Double_foo"">4.94065645841247E-324</l><lDTO xmlns:b=""http://schemas.datacontract.org/2004/07/System""/><m i:type=""a:Double_foo"">1.7976931348623157E+308</m><n i:type=""a:Double_foo"">-1.7976931348623157E+308</n><nDTO i:type=""a:DateTimeOffset_foo""><DateTime xmlns=""http://schemas.datacontract.org/2004/07/System"">9999-12-31T23:59:59.9999999Z</DateTime><OffsetMinutes xmlns=""http://schemas.datacontract.org/2004/07/System"">0</OffsetMinutes></nDTO><o i:type=""a:Double_foo"">NaN</o><obj/><p i:type=""a:Double_foo"">-INF</p><q i:type=""a:Double_foo"">INF</q><r i:type=""a:Single_foo"">0</r><s i:type=""a:Single_foo"">1.401298E-45</s><strData i:nil=""true""/><t i:type=""a:Single_foo"">-3.40282347E+38</t><timeSpan i:type=""a:TimeSpan_foo"">P10675199DT2H48M5.4775807S</timeSpan><u i:type=""a:Single_foo"">3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v i:type=""a:Single_foo"">NaN</v><w i:type=""a:Single_foo"">-INF</w><x i:type=""a:Single_foo"">INF</x><xmlQualifiedName i:type=""a:XmlQualifiedName_foo"" xmlns:b=""http://www.microsoft.com"">b:WCF</xmlQualifiedName><y i:type=""a:Int32_foo"">0</y><z i:type=""a:Int32_foo"">2147483647</z><z1 i:type=""a:Int32_foo"">-2147483648</z1><z2 i:type=""a:Int64_foo"">0</z2><z3 i:type=""a:Int64_foo"">9223372036854775807</z3><z4 i:type=""a:Int64_foo"">-9223372036854775808</z4><z5/><z6 i:type=""a:SByte_foo"">0</z6><z7 i:type=""a:SByte_foo"">127</z7><z8 i:type=""a:SByte_foo"">-128</z8><z9 i:type=""a:Int16_foo"">0</z9><z91 i:type=""a:Int16_foo"">32767</z91><z92 i:type=""a:Int16_foo"">-32768</z92><z93 i:type=""a:String_foo"">abc</z93><z94 i:type=""a:UInt16_foo"">0</z94><z95 i:type=""a:UInt16_foo"">65535</z95><z96 i:type=""a:UInt16_foo"">0</z96><z97 i:type=""a:UInt32_foo"">0</z97><z98 i:type=""a:UInt32_foo"">4294967295</z98><z99 i:type=""a:UInt32_foo"">0</z99><z990 i:type=""a:UInt64_foo"">0</z990><z991 i:type=""a:UInt64_foo"">18446744073709551615</z991><z992 i:type=""a:UInt64_foo"">0</z992><z993>AQIDBA==</z993></_data><_data2 i:type=""a:PrimitiveContainer_foo"" xmlns:a=""http://www.default.com""><a i:type=""a:Boolean_foo"">false</a><array1><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/></array1><b i:type=""a:Byte_foo"">255</b><c i:type=""a:Byte_foo"">0</c><d i:type=""a:Char_foo"">65535</d><e i:type=""a:Decimal_foo"">79228162514264337593543950335</e><f i:type=""a:Decimal_foo"">-1</f><f5 i:type=""a:DateTime_foo"">9999-12-31T23:59:59.9999999</f5><g i:type=""a:Decimal_foo"">-79228162514264337593543950335</g><guidData i:type=""a:Guid_foo"">4bc848b1-a541-40bf-8aa9-dd6ccb6d0e56</guidData><h i:type=""a:Decimal_foo"">1</h><i i:type=""a:Decimal_foo"">0</i><j i:type=""a:Decimal_foo"">0</j><k i:type=""a:Double_foo"">0</k><l i:type=""a:Double_foo"">4.94065645841247E-324</l><lDTO xmlns:b=""http://schemas.datacontract.org/2004/07/System""/><m i:type=""a:Double_foo"">1.7976931348623157E+308</m><n i:type=""a:Double_foo"">-1.7976931348623157E+308</n><nDTO i:type=""a:DateTimeOffset_foo""><DateTime xmlns=""http://schemas.datacontract.org/2004/07/System"">9999-12-31T23:59:59.9999999Z</DateTime><OffsetMinutes xmlns=""http://schemas.datacontract.org/2004/07/System"">0</OffsetMinutes></nDTO><o i:type=""a:Double_foo"">NaN</o><obj/><p i:type=""a:Double_foo"">-INF</p><q i:type=""a:Double_foo"">INF</q><r i:type=""a:Single_foo"">0</r><s i:type=""a:Single_foo"">1.401298E-45</s><strData i:nil=""true""/><t i:type=""a:Single_foo"">-3.40282347E+38</t><timeSpan i:type=""a:TimeSpan_foo"">P10675199DT2H48M5.4775807S</timeSpan><u i:type=""a:Single_foo"">3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v i:type=""a:Single_foo"">NaN</v><w i:type=""a:Single_foo"">-INF</w><x i:type=""a:Single_foo"">INF</x><xmlQualifiedName i:type=""a:XmlQualifiedName_foo"" xmlns:b=""http://www.microsoft.com"">b:WCF</xmlQualifiedName><y i:type=""a:Int32_foo"">0</y><z i:type=""a:Int32_foo"">2147483647</z><z1 i:type=""a:Int32_foo"">-2147483648</z1><z2 i:type=""a:Int64_foo"">0</z2><z3 i:type=""a:Int64_foo"">9223372036854775807</z3><z4 i:type=""a:Int64_foo"">-9223372036854775808</z4><z5/><z6 i:type=""a:SByte_foo"">0</z6><z7 i:type=""a:SByte_foo"">127</z7><z8 i:type=""a:SByte_foo"">-128</z8><z9 i:type=""a:Int16_foo"">0</z9><z91 i:type=""a:Int16_foo"">32767</z91><z92 i:type=""a:Int16_foo"">-32768</z92><z93 i:type=""a:String_foo"">abc</z93><z94 i:type=""a:UInt16_foo"">0</z94><z95 i:type=""a:UInt16_foo"">65535</z95><z96 i:type=""a:UInt16_foo"">0</z96><z97 i:type=""a:UInt32_foo"">0</z97><z98 i:type=""a:UInt32_foo"">4294967295</z98><z99 i:type=""a:UInt32_foo"">0</z99><z990 i:type=""a:UInt64_foo"">0</z990><z991 i:type=""a:UInt64_foo"">18446744073709551615</z991><z992 i:type=""a:UInt64_foo"">0</z992><z993>AQIDBA==</z993></_data2></ObjectContainer>";
+        var value = new SerializationTestTypes.ObjectContainer(new SerializationTestTypes.PrimitiveContainer());
+
+        var actual = DataContractSerializerHelper.SerializeAndDeserialize(value, baseline, dataContractSerializerSettings);
+        // Throw Exception when verification failed
+        SerializationTestTypes.ComparisonHelper.CompareRecursively(value, actual);
+    }
+
+    /// <summary>
+    /// Roundtrips a Datacontract type  which contains Primitive types assigned to member of type object. 
+    /// Resolver is plugged in and resolves the primitive types. Verify resolver called during ser and deser
+    /// </summary>
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_BasicRoundTripResolvePrimitiveTypes_NotNetFramework()
+    {
+        var dataContractSerializerSettings = new DataContractSerializerSettings()
+        {
+            DataContractResolver = new SerializationTestTypes.PrimitiveTypeResolver(),
+            IgnoreExtensionDataObject = false,
+            KnownTypes = null,
+            MaxItemsInObjectGraph = int.MaxValue,
+            PreserveObjectReferences = false
+        };
+
+        string baseline = @"<ObjectContainer xmlns=""http://schemas.datacontract.org/2004/07/SerializationTestTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><_data i:type=""a:PrimitiveContainer_foo"" xmlns:a=""http://www.default.com""><a i:type=""a:Boolean_foo"">false</a><array1><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/></array1><b i:type=""a:Byte_foo"">255</b><c i:type=""a:Byte_foo"">0</c><d i:type=""a:Char_foo"">65535</d><e i:type=""a:Decimal_foo"">79228162514264337593543950335</e><f i:type=""a:Decimal_foo"">-1</f><f5 i:type=""a:DateTime_foo"">9999-12-31T23:59:59.9999999</f5><g i:type=""a:Decimal_foo"">-79228162514264337593543950335</g><guidData i:type=""a:Guid_foo"">4bc848b1-a541-40bf-8aa9-dd6ccb6d0e56</guidData><h i:type=""a:Decimal_foo"">1</h><i i:type=""a:Decimal_foo"">0</i><j i:type=""a:Decimal_foo"">0</j><k i:type=""a:Double_foo"">0</k><l i:type=""a:Double_foo"">4.9406564584124654E-324</l><lDTO xmlns:b=""http://schemas.datacontract.org/2004/07/System""/><m i:type=""a:Double_foo"">1.7976931348623157E+308</m><n i:type=""a:Double_foo"">-1.7976931348623157E+308</n><nDTO i:type=""a:DateTimeOffset_foo""><DateTime xmlns=""http://schemas.datacontract.org/2004/07/System"">9999-12-31T23:59:59.9999999Z</DateTime><OffsetMinutes xmlns=""http://schemas.datacontract.org/2004/07/System"">0</OffsetMinutes></nDTO><o i:type=""a:Double_foo"">NaN</o><obj/><p i:type=""a:Double_foo"">-INF</p><q i:type=""a:Double_foo"">INF</q><r i:type=""a:Single_foo"">0</r><s i:type=""a:Single_foo"">1.40129846E-45</s><strData i:nil=""true""/><t i:type=""a:Single_foo"">-3.40282347E+38</t><timeSpan i:type=""a:TimeSpan_foo"">P10675199DT2H48M5.4775807S</timeSpan><u i:type=""a:Single_foo"">3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v i:type=""a:Single_foo"">NaN</v><w i:type=""a:Single_foo"">-INF</w><x i:type=""a:Single_foo"">INF</x><xmlQualifiedName i:type=""a:XmlQualifiedName_foo"" xmlns:b=""http://www.microsoft.com"">b:WCF</xmlQualifiedName><y i:type=""a:Int32_foo"">0</y><z i:type=""a:Int32_foo"">2147483647</z><z1 i:type=""a:Int32_foo"">-2147483648</z1><z2 i:type=""a:Int64_foo"">0</z2><z3 i:type=""a:Int64_foo"">9223372036854775807</z3><z4 i:type=""a:Int64_foo"">-9223372036854775808</z4><z5/><z6 i:type=""a:SByte_foo"">0</z6><z7 i:type=""a:SByte_foo"">127</z7><z8 i:type=""a:SByte_foo"">-128</z8><z9 i:type=""a:Int16_foo"">0</z9><z91 i:type=""a:Int16_foo"">32767</z91><z92 i:type=""a:Int16_foo"">-32768</z92><z93 i:type=""a:String_foo"">abc</z93><z94 i:type=""a:UInt16_foo"">0</z94><z95 i:type=""a:UInt16_foo"">65535</z95><z96 i:type=""a:UInt16_foo"">0</z96><z97 i:type=""a:UInt32_foo"">0</z97><z98 i:type=""a:UInt32_foo"">4294967295</z98><z99 i:type=""a:UInt32_foo"">0</z99><z990 i:type=""a:UInt64_foo"">0</z990><z991 i:type=""a:UInt64_foo"">18446744073709551615</z991><z992 i:type=""a:UInt64_foo"">0</z992><z993>AQIDBA==</z993></_data><_data2 i:type=""a:PrimitiveContainer_foo"" xmlns:a=""http://www.default.com""><a i:type=""a:Boolean_foo"">false</a><array1><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/><anyType xmlns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/></array1><b i:type=""a:Byte_foo"">255</b><c i:type=""a:Byte_foo"">0</c><d i:type=""a:Char_foo"">65535</d><e i:type=""a:Decimal_foo"">79228162514264337593543950335</e><f i:type=""a:Decimal_foo"">-1</f><f5 i:type=""a:DateTime_foo"">9999-12-31T23:59:59.9999999</f5><g i:type=""a:Decimal_foo"">-79228162514264337593543950335</g><guidData i:type=""a:Guid_foo"">4bc848b1-a541-40bf-8aa9-dd6ccb6d0e56</guidData><h i:type=""a:Decimal_foo"">1</h><i i:type=""a:Decimal_foo"">0</i><j i:type=""a:Decimal_foo"">0</j><k i:type=""a:Double_foo"">0</k><l i:type=""a:Double_foo"">4.9406564584124654E-324</l><lDTO xmlns:b=""http://schemas.datacontract.org/2004/07/System""/><m i:type=""a:Double_foo"">1.7976931348623157E+308</m><n i:type=""a:Double_foo"">-1.7976931348623157E+308</n><nDTO i:type=""a:DateTimeOffset_foo""><DateTime xmlns=""http://schemas.datacontract.org/2004/07/System"">9999-12-31T23:59:59.9999999Z</DateTime><OffsetMinutes xmlns=""http://schemas.datacontract.org/2004/07/System"">0</OffsetMinutes></nDTO><o i:type=""a:Double_foo"">NaN</o><obj/><p i:type=""a:Double_foo"">-INF</p><q i:type=""a:Double_foo"">INF</q><r i:type=""a:Single_foo"">0</r><s i:type=""a:Single_foo"">1.40129846E-45</s><strData i:nil=""true""/><t i:type=""a:Single_foo"">-3.40282347E+38</t><timeSpan i:type=""a:TimeSpan_foo"">P10675199DT2H48M5.4775807S</timeSpan><u i:type=""a:Single_foo"">3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v i:type=""a:Single_foo"">NaN</v><w i:type=""a:Single_foo"">-INF</w><x i:type=""a:Single_foo"">INF</x><xmlQualifiedName i:type=""a:XmlQualifiedName_foo"" xmlns:b=""http://www.microsoft.com"">b:WCF</xmlQualifiedName><y i:type=""a:Int32_foo"">0</y><z i:type=""a:Int32_foo"">2147483647</z><z1 i:type=""a:Int32_foo"">-2147483648</z1><z2 i:type=""a:Int64_foo"">0</z2><z3 i:type=""a:Int64_foo"">9223372036854775807</z3><z4 i:type=""a:Int64_foo"">-9223372036854775808</z4><z5/><z6 i:type=""a:SByte_foo"">0</z6><z7 i:type=""a:SByte_foo"">127</z7><z8 i:type=""a:SByte_foo"">-128</z8><z9 i:type=""a:Int16_foo"">0</z9><z91 i:type=""a:Int16_foo"">32767</z91><z92 i:type=""a:Int16_foo"">-32768</z92><z93 i:type=""a:String_foo"">abc</z93><z94 i:type=""a:UInt16_foo"">0</z94><z95 i:type=""a:UInt16_foo"">65535</z95><z96 i:type=""a:UInt16_foo"">0</z96><z97 i:type=""a:UInt32_foo"">0</z97><z98 i:type=""a:UInt32_foo"">4294967295</z98><z99 i:type=""a:UInt32_foo"">0</z99><z990 i:type=""a:UInt64_foo"">0</z990><z991 i:type=""a:UInt64_foo"">18446744073709551615</z991><z992 i:type=""a:UInt64_foo"">0</z992><z993>AQIDBA==</z993></_data2></ObjectContainer>";
         var value = new SerializationTestTypes.ObjectContainer(new SerializationTestTypes.PrimitiveContainer());
 
         var actual = DataContractSerializerHelper.SerializeAndDeserialize(value, baseline, dataContractSerializerSettings);
@@ -3745,10 +3889,6 @@ public static partial class DataContractSerializerTests
 
         TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.CharClass(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.CharClass***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.CharClass***\"><c>0</c><c1>65535</c1><c2>0</c2><c3>99</c3></_data><_data2 i:type=\"a:SerializationTestTypes.CharClass***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.CharClass***\"><c>0</c><c1>65535</c1><c2>0</c2><c3>99</c3></_data2></ObjectContainer>");
 
-        TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.AllTypes(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.AllTypes***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>5642b5d2-87c3-a724-2390-997062f3f7a2</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.94065645841247E-324</l><lDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"/><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.401298E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan i:type=\"b:duration\" xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/\">P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data><_data2 i:type=\"a:SerializationTestTypes.AllTypes***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>5642b5d2-87c3-a724-2390-997062f3f7a2</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.94065645841247E-324</l><lDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"/><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.401298E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan i:type=\"b:duration\" xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/\">P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data2></ObjectContainer>");
-
-        TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.AllTypes2(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.AllTypes2***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes2***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>cac76333-577f-7e1f-0389-789b0d97f395</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.94065645841247E-324</l><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.401298E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan>P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data><_data2 i:type=\"a:SerializationTestTypes.AllTypes2***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes2***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>cac76333-577f-7e1f-0389-789b0d97f395</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.94065645841247E-324</l><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.401298E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan>P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data2></ObjectContainer>");
-
         TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.DictContainer(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.DictContainer***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.DictContainer***\"><dictionaryData xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"><b:KeyValueOfbase64Binarybase64Binary><b:Key>S3sf7NHCbkyVtgYKERsK/Q==</b:Key><b:Value>kNwxmEzKsk2TNVihAl7PKQ==</b:Value></b:KeyValueOfbase64Binarybase64Binary><b:KeyValueOfbase64Binarybase64Binary><b:Key>R5hoXhAack+qrhmyR80IeA==</b:Key><b:Value>kYav59VD50mHdRsBJr2UPA==</b:Value></b:KeyValueOfbase64Binarybase64Binary><b:KeyValueOfbase64Binarybase64Binary><b:Key>3WgRcQBK5U2fPjjd+9oBRA==</b:Key><b:Value>r7SFJrYJVkqB25UjGj0Cdg==</b:Value></b:KeyValueOfbase64Binarybase64Binary></dictionaryData></_data><_data2 i:type=\"a:SerializationTestTypes.DictContainer***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.DictContainer***\"><dictionaryData xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"><b:KeyValueOfbase64Binarybase64Binary><b:Key>S3sf7NHCbkyVtgYKERsK/Q==</b:Key><b:Value>kNwxmEzKsk2TNVihAl7PKQ==</b:Value></b:KeyValueOfbase64Binarybase64Binary><b:KeyValueOfbase64Binarybase64Binary><b:Key>R5hoXhAack+qrhmyR80IeA==</b:Key><b:Value>kYav59VD50mHdRsBJr2UPA==</b:Value></b:KeyValueOfbase64Binarybase64Binary><b:KeyValueOfbase64Binarybase64Binary><b:Key>3WgRcQBK5U2fPjjd+9oBRA==</b:Key><b:Value>r7SFJrYJVkqB25UjGj0Cdg==</b:Value></b:KeyValueOfbase64Binarybase64Binary></dictionaryData></_data2></ObjectContainer>");
 
         TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.ListContainer(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.ListContainer***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.ListContainer***\"><listData xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"><b:string>TestData</b:string></listData></_data><_data2 i:type=\"a:SerializationTestTypes.ListContainer***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.ListContainer***\"><listData xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"><b:string>TestData</b:string></listData></_data2></ObjectContainer>");
@@ -3819,6 +3959,24 @@ public static partial class DataContractSerializerTests
             var actual = DataContractSerializerHelper.SerializeAndDeserialize(value, baseline, setting);
             SerializationTestTypes.ComparisonHelper.CompareRecursively(value, actual);
         }
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_BasicPerSerializerRoundTripAndCompare_EnumStruct_NetFramework()
+    {
+        TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.AllTypes(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.AllTypes***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>5642b5d2-87c3-a724-2390-997062f3f7a2</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.94065645841247E-324</l><lDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"/><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.401298E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan i:type=\"b:duration\" xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/\">P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data><_data2 i:type=\"a:SerializationTestTypes.AllTypes***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>5642b5d2-87c3-a724-2390-997062f3f7a2</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.94065645841247E-324</l><lDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"/><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.401298E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan i:type=\"b:duration\" xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/\">P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data2></ObjectContainer>");
+
+        TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.AllTypes2(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.AllTypes2***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes2***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>cac76333-577f-7e1f-0389-789b0d97f395</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.94065645841247E-324</l><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.401298E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan>P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data><_data2 i:type=\"a:SerializationTestTypes.AllTypes2***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes2***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>cac76333-577f-7e1f-0389-789b0d97f395</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.94065645841247E-324</l><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.401298E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan>P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data2></ObjectContainer>");
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_BasicPerSerializerRoundTripAndCompare_EnumStruct_NotNetFramework()
+    {
+        TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.AllTypes(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.AllTypes***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>5642b5d2-87c3-a724-2390-997062f3f7a2</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.9406564584124654E-324</l><lDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"/><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.40129846E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan i:type=\"b:duration\" xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/\">P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data><_data2 i:type=\"a:SerializationTestTypes.AllTypes***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>5642b5d2-87c3-a724-2390-997062f3f7a2</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.9406564584124654E-324</l><lDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"/><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.40129846E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan i:type=\"b:duration\" xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/\">P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data2></ObjectContainer>");
+
+        TestObjectInObjectContainerWithSimpleResolver(new SerializationTestTypes.AllTypes2(), "<ObjectContainer xmlns=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:SerializationTestTypes.AllTypes2***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes2***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>cac76333-577f-7e1f-0389-789b0d97f395</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.9406564584124654E-324</l><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.40129846E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan>P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data><_data2 i:type=\"a:SerializationTestTypes.AllTypes2***\" xmlns:a=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.AllTypes2***\"><a>false</a><array1><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/><anyType xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"/></array1><b>255</b><c>0</c><d>65535</d><e>79228162514264337593543950335</e><enumArrayData><MyEnum1>red</MyEnum1></enumArrayData><enumBase1 i:type=\"b:SerializationTestTypes.MyEnum1***\" xmlns:b=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes.MyEnum1***\">red</enumBase1><f>-1</f><f5>0001-01-01T00:00:00</f5><g>-79228162514264337593543950335</g><guidData>cac76333-577f-7e1f-0389-789b0d97f395</guidData><h>1</h><i>0</i><j>0</j><k>0</k><l>4.9406564584124654E-324</l><m>1.7976931348623157E+308</m><n>-1.7976931348623157E+308</n><nDTO xmlns:b=\"http://schemas.datacontract.org/2004/07/System\"><b:DateTime>9999-12-31T23:59:59.9999999Z</b:DateTime><b:OffsetMinutes>0</b:OffsetMinutes></nDTO><o>NaN</o><obj/><p>-INF</p><q>INF</q><r>0</r><s>1.40129846E-45</s><strData i:nil=\"true\"/><t>-3.40282347E+38</t><timeSpan>P10675199DT2H48M5.4775807S</timeSpan><u>3.40282347E+38</u><uri>http://www.microsoft.com/</uri><v>NaN</v><valType i:type=\"PublicDCStruct\"><Data>Data</Data></valType><w>-INF</w><x>INF</x><q:xmlQualifiedName xmlns:q=\"http://schemas.datacontract.org/2004/07/SerializationTestTypes\" xmlns:b=\"http://www.microsoft.com\">b:WCF</q:xmlQualifiedName><y>0</y><z>2147483647</z><z1>-2147483648</z1><z2>0</z2><z3>9223372036854775807</z3><z4>-9223372036854775808</z4><z5/><z6>0</z6><z7>127</z7><z8>-128</z8><z9>0</z9><z91>32767</z91><z92>-32768</z92><z93>abc</z93><z94>0</z94><z95>65535</z95><z96>0</z96><z97>0</z97><z98>4294967295</z98><z99>0</z99><z990>0</z990><z991>18446744073709551615</z991><z992>0</z992></_data2></ObjectContainer>");
     }
 
 #endregion
@@ -4015,7 +4173,8 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCS_TypeWithPrimitiveKnownTypes()
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_TypeWithPrimitiveKnownTypes_NetFramework()
     {
         var list = new TypeWithPrimitiveKnownTypes();
         list.Add(true);
@@ -4038,6 +4197,47 @@ public static partial class DataContractSerializerTests
         list.Add(ushort.MaxValue);
         list.Add(new Uri("http://foo"));
         var actual = DataContractSerializerHelper.SerializeAndDeserialize(list, "<TypeWithPrimitiveKnownTypes xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><anyType i:type=\"a:boolean\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">true</anyType><anyType i:type=\"a:char\" xmlns:a=\"http://schemas.microsoft.com/2003/10/Serialization/\">99</anyType><anyType i:type=\"a:dateTime\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">0001-01-01T00:00:00.00001</anyType><anyType i:type=\"a:decimal\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">11.1</anyType><anyType i:type=\"a:double\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">22.2</anyType><anyType i:type=\"a:float\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">33.3</anyType><anyType i:type=\"a:guid\" xmlns:a=\"http://schemas.microsoft.com/2003/10/Serialization/\">00000000-0000-0000-0000-000000000000</anyType><anyType i:type=\"a:int\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">11</anyType><anyType i:type=\"a:long\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">1111111111111111111</anyType><anyType i:type=\"a:QName\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\" xmlns:b=\"NS\">b:NAME</anyType><anyType i:type=\"a:short\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">44</anyType><anyType i:type=\"a:byte\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">-1</anyType><anyType i:type=\"a:string\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">test string</anyType><anyType i:type=\"a:duration\" xmlns:a=\"http://schemas.microsoft.com/2003/10/Serialization/\">PT0.00001S</anyType><anyType i:type=\"a:unsignedByte\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">1</anyType><anyType i:type=\"a:unsignedInt\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">4294967295</anyType><anyType i:type=\"a:unsignedLong\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">18446744073709551615</anyType><anyType i:type=\"a:unsignedShort\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">65535</anyType><anyType i:type=\"a:anyURI\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">http://foo/</anyType></TypeWithPrimitiveKnownTypes>");
+        Assert.True(Enumerable.SequenceEqual(list, actual));
+
+        list.Clear();
+        list.Add(new byte[] { 1, 2 });
+        actual = DataContractSerializerHelper.SerializeAndDeserialize(list, "<TypeWithPrimitiveKnownTypes xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><anyType i:type=\"a:base64Binary\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">AQI=</anyType></TypeWithPrimitiveKnownTypes>");
+        Assert.NotNull(actual);
+        Assert.Single(actual);
+        Assert.True(actual[0] is byte[]);
+        Assert.True(((byte[])list[0]).SequenceEqual(((byte[])actual[0])));
+
+        list.Clear();
+        list.Add(new object());
+        actual = DataContractSerializerHelper.SerializeAndDeserialize(list, "<TypeWithPrimitiveKnownTypes xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><anyType/></TypeWithPrimitiveKnownTypes>");
+        Assert.NotNull(actual);
+    }
+
+    [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    public static void DCS_TypeWithPrimitiveKnownTypes_NotNetFramework()
+    {
+        var list = new TypeWithPrimitiveKnownTypes();
+        list.Add(true);
+        list.Add('c');
+        list.Add(new DateTime(100));
+        list.Add(11.1m);
+        list.Add(22.2);
+        list.Add(33.3f);
+        list.Add(new Guid());
+        list.Add(11);
+        list.Add(1111111111111111111L);
+        list.Add(new XmlQualifiedName("NAME", "NS"));
+        list.Add((short)44);
+        list.Add((sbyte)-1);
+        list.Add("test string");
+        list.Add(new TimeSpan(100));
+        list.Add((byte)1);
+        list.Add(uint.MaxValue);
+        list.Add(ulong.MaxValue);
+        list.Add(ushort.MaxValue);
+        list.Add(new Uri("http://foo"));
+        var actual = DataContractSerializerHelper.SerializeAndDeserialize(list, "<TypeWithPrimitiveKnownTypes xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><anyType i:type=\"a:boolean\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">true</anyType><anyType i:type=\"a:char\" xmlns:a=\"http://schemas.microsoft.com/2003/10/Serialization/\">99</anyType><anyType i:type=\"a:dateTime\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">0001-01-01T00:00:00.00001</anyType><anyType i:type=\"a:decimal\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">11.1</anyType><anyType i:type=\"a:double\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">22.199999999999999</anyType><anyType i:type=\"a:float\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">33.2999992</anyType><anyType i:type=\"a:guid\" xmlns:a=\"http://schemas.microsoft.com/2003/10/Serialization/\">00000000-0000-0000-0000-000000000000</anyType><anyType i:type=\"a:int\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">11</anyType><anyType i:type=\"a:long\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">1111111111111111111</anyType><anyType i:type=\"a:QName\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\" xmlns:b=\"NS\">b:NAME</anyType><anyType i:type=\"a:short\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">44</anyType><anyType i:type=\"a:byte\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">-1</anyType><anyType i:type=\"a:string\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">test string</anyType><anyType i:type=\"a:duration\" xmlns:a=\"http://schemas.microsoft.com/2003/10/Serialization/\">PT0.00001S</anyType><anyType i:type=\"a:unsignedByte\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">1</anyType><anyType i:type=\"a:unsignedInt\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">4294967295</anyType><anyType i:type=\"a:unsignedLong\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">18446744073709551615</anyType><anyType i:type=\"a:unsignedShort\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">65535</anyType><anyType i:type=\"a:anyURI\" xmlns:a=\"http://www.w3.org/2001/XMLSchema\">http://foo/</anyType></TypeWithPrimitiveKnownTypes>");
         Assert.True(Enumerable.SequenceEqual(list, actual));
 
         list.Clear();


### PR DESCRIPTION
This fixes up all the tests that are impacted by https://github.com/dotnet/coreclr/pull/19905