### PR TITLE
Remove the ActiveIssue attribute from a disabled-but-passing test

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
@@ -21,7 +21,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3892, TestPlatforms.AnyUnix)]
         public static void PrintMultiComponentRdn()
         {
             byte[] encoded = (


### PR DESCRIPTION
The MultiComponentRdn test was indirectly fixed by switching from the
P/Invoke-based X500NameEncoder.OpenSslDecode to
X500NameEncoder.ManagedDecode.

Fixed on macOS by #16445 (ManagedDecode was written to fill in gaps from our needs to macOS public API)
Fixed on the remaining Unixes by #30572 (switch remaining Unixes to ManagedDecode).

Fixes #3892.