### PR TITLE
rework connection pool cancellation to avoid deadlock

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -261,10 +261,10 @@ namespace System.Net.Http
                             // be signaled with the created connection when one is returned or
                             // space is available and the provided creation func has successfully
                             // created the connection to be used.
-                            if (NetEventSource.IsEnabled) Trace("Limit reached.  Waiting to create new connection.");
-                            var waiter = new ConnectionWaiter(this, request, cancellationToken);
+                            if (NetEventSource.IsEnabled) Trace("Connection limit reached, enqueuing waiter.");
+                            var waiter = new ConnectionWaiter();
                             EnqueueWaiter(waiter);
-                            return waiter.GetConnectionAsync();
+                            return waiter.GetConnectionAsync(this, request, cancellationToken);
                         }
 
                         // Note that we don't check for _disposed.  We may end up disposing the


### PR DESCRIPTION
Fixes #32262 
Fixes #32000 (hopefully)

We have an issue where cancelling a request while it's waiting for a connection (due to MaxConnectionsPerServer being set) can cause deadlock. See issue #32262 for full details.

To fix this, rework the cancellation handling for requests that are waiting for connections. In particular, we cancel the ConnectionWaiter task but we don't remove the waiter from the waiter queue, so we don't need to take the pool lock on cancellation. Instead, we just throw away any cancelled waiters later when we retrieve them.

Additionally, the logic for transferring a connection count (i.e. an existing connection is being closed, so the waiter should create a new one) is changed so that we don't have to worry about whether the waiter is cancelled by the time the connection is actually created.

I confirmed that this fixes the repro in #32262.

We should consider this for 2.1.x backport.

@dotnet/ncl 

It would be great to get a review from @stephentoub if/when he's available, since he knows this code best.
