### PR TITLE
Expose FileOptions.NoBuffering flag and support O_DIRECT on Linux

### DIFF
--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.OpenFlags.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.OpenFlags.cs
@@ -22,6 +22,7 @@ internal static partial class Interop
             O_EXCL    = 0x0040,
             O_TRUNC   = 0x0080,
             O_SYNC    = 0x0100,
+            O_DIRECT  = 0x0200,
         }
     }
 }

--- a/src/Common/src/CoreLib/System/IO/FileOptions.cs
+++ b/src/Common/src/CoreLib/System/IO/FileOptions.cs
@@ -18,7 +18,7 @@ namespace System.IO
         None = 0,
         WriteThrough = unchecked((int)0x80000000),
         Asynchronous = unchecked((int)0x40000000), // FILE_FLAG_OVERLAPPED
-        // NoBuffering = 0x20000000,
+        NoBuffering = 0x20000000,
         RandomAccess = 0x10000000,
         DeleteOnClose = 0x04000000,
         SequentialScan = 0x08000000,

--- a/src/Common/src/CoreLib/System/IO/FileStream.Unix.cs
+++ b/src/Common/src/CoreLib/System/IO/FileStream.Unix.cs
@@ -179,12 +179,17 @@ namespace System.IO
             // - Encrypted: No equivalent on Unix and is ignored
             // - RandomAccess: Implemented after open if posix_fadvise is available
             // - SequentialScan: Implemented after open if posix_fadvise is available
-            // - WriteThrough: Handled here
+            // - WriteThrough & NoBuffering: Handled here
             if ((options & FileOptions.WriteThrough) != 0)
             {
                 flags |= Interop.Sys.OpenFlags.O_SYNC;
             }
 
+            if ((options & FileOptions.NoBuffering) != 0)
+            {
+                flags |= Interop.Sys.OpenFlags.O_DIRECT;
+            }
+            
             return flags;
         }
 

--- a/src/Common/src/CoreLib/System/IO/FileStream.cs
+++ b/src/Common/src/CoreLib/System/IO/FileStream.cs
@@ -200,7 +200,7 @@ namespace System.IO
                 throw new ArgumentOutOfRangeException(badArg, SR.ArgumentOutOfRange_Enum);
 
             // NOTE: any change to FileOptions enum needs to be matched here in the error validation
-            if (options != FileOptions.None && (options & ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted | (FileOptions)0x20000000 /* NoBuffering */)) != 0)
+            if (options != FileOptions.None && (options & ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted | FileOptions.NoBuffering)) != 0)
                 throw new ArgumentOutOfRangeException(nameof(options), SR.ArgumentOutOfRange_Enum);
 
             if (bufferSize <= 0)

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -240,7 +240,7 @@ static int32_t ConvertOpenFlags(int32_t flags)
             return -1;
     }
 
-    if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC))
+    if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC | PAL_O_DIRECT))
     {
         assert_msg(false, "Unknown Open flag", (int)flags);
         return -1;
@@ -258,6 +258,8 @@ static int32_t ConvertOpenFlags(int32_t flags)
         ret |= O_TRUNC;
     if (flags & PAL_O_SYNC)
         ret |= O_SYNC;
+    if (flags & PAL_O_DIRECT)
+        ret |= O_DIRECT;
 
     assert(ret != -1);
     return ret;

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -139,6 +139,7 @@ enum
     PAL_O_EXCL = 0x0040,    // When combined with CREAT, fails if file already exists
     PAL_O_TRUNC = 0x0080,   // Truncate file to length 0 if it already exists
     PAL_O_SYNC = 0x0100,    // Block writes call will block until physically written
+    PAL_O_DIRECT = 0x0200,  // Try to minimize cache effects of the I/O to and from file.
 };
 
 /**


### PR DESCRIPTION
Changes needed for #32313. It was approved in coreclr already between the lines.