### PR TITLE
Make test drop container name stable

### DIFF
--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -77,6 +77,9 @@
     <HelixArchLabel>$(ArchGroup)</HelixArchLabel>
     <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
     <MaxRetryCount>1</MaxRetryCount>
+    <TestsBlobPrefix>tests/</TestsBlobPrefix>
+    <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-Windows_NT -->
+    <ContainerName Condition="'$(ContainerName)' == ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(OSGroup)-$(ArchGroup)</ContainerName>
   </PropertyGroup>
 
   <Target Name="CoreFXPreCloudBuild" >

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -78,8 +78,12 @@
     <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
     <MaxRetryCount>1</MaxRetryCount>
     <TestsBlobPrefix>tests/</TestsBlobPrefix>
-    <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-Windows_NT -->
-    <ContainerName Condition="'$(ContainerName)' == ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(OSGroup)-$(ArchGroup)</ContainerName>
+    <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windows -->
+    <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
+    <ProcessedOSGroup>$(OSGroup.ToLower())</ProcessedOSGroup>
+    <ProcessedOSGroup Condition="'$(TargetsWindows)' == 'true'">windows</ProcessedOSGroup>
+    <ProcessedArchGroup>$(ArchGroup.ToLower())</ProcessedArchGroup>
+    <ContainerName Condition="'$(ContainerName)' == ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)</ContainerName>
   </PropertyGroup>
 
   <Target Name="CoreFXPreCloudBuild" >

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -77,7 +77,6 @@
     <HelixArchLabel>$(ArchGroup)</HelixArchLabel>
     <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
     <MaxRetryCount>1</MaxRetryCount>
-    <TestsBlobPrefix>tests/</TestsBlobPrefix>
     <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windows-x64 -->
     <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
     <ProcessedOSGroup>$(OSGroup.ToLower())</ProcessedOSGroup>

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -77,10 +77,10 @@
     <HelixArchLabel>$(ArchGroup)</HelixArchLabel>
     <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
     <MaxRetryCount>1</MaxRetryCount>
-    <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windowsnt-x64-netcoreapp-master -->
+    <!-- Unique container name and blob prefix per build and configuration, e.g., corefx-beta-12345-01/tests-master-windowsnt-x64-netcoreapp-master -->
     <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
-    <RawContainerName Condition="'$(Branch)' != ''">corefx-$(Branch)-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(OSGroup)-$(ArchGroup)-$(TargetGroup)</RawContainerName>
-    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(RawContainerName.ToLower())', "[^A-Za-z0-9-]+", ""))</ContainerName>
+    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true'">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
+    <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">tests-$(Branch)-$(OSGroup)-$(ArchGroup)-$(TargetGroup)</HelixBlobPrefix>
     <!-- If this is an official build, set the test drop to be public -->
     <IsDropPublic Condition="'$(IsOffical)' == 'true'">true</IsDropPublic>
   </PropertyGroup>

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -77,11 +77,11 @@
     <HelixArchLabel>$(ArchGroup)</HelixArchLabel>
     <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
     <MaxRetryCount>1</MaxRetryCount>
-    <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windows-x64 -->
+    <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windowsnt-x64-netcoreapp-master -->
     <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
-    <ProcessedOSGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(OSGroup.ToLower())', "[^A-Za-z0-9-]+", ""))</ProcessedOSGroup>
-    <ProcessedArchGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(ArchGroup.ToLower())', "[^A-Za-z0-9-]+", ""))</ProcessedArchGroup>
-    <ProcessedTargetGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetGroup.ToLower())', "[^A-Za-z0-9-]+", ""))</ProcessedTargetGroup>
+    <ProcessedOSGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(OSGroup.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedOSGroup>
+    <ProcessedArchGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(ArchGroup.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedArchGroup>
+    <ProcessedTargetGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetGroup.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedTargetGroup>
     <ProcessedBranch Condition="'$(Branch)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(Branch.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedBranch>
     <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)-$(ProcessedTargetGroup)-$(ProcessedBranch)</ContainerName>
   </PropertyGroup>

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -78,7 +78,7 @@
     <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
     <MaxRetryCount>1</MaxRetryCount>
     <TestsBlobPrefix>tests/</TestsBlobPrefix>
-    <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windows -->
+    <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windows-x64 -->
     <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
     <ProcessedOSGroup>$(OSGroup.ToLower())</ProcessedOSGroup>
     <ProcessedOSGroup Condition="'$(TargetsWindows)' == 'true'">windows</ProcessedOSGroup>

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -82,6 +82,7 @@
     <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true'">corefx-tests</ContainerName>
     <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">$(Branch)/$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)/$(TargetGroup)/$(RuntimeOS)-$(ArchGroup)/</HelixBlobPrefix>
     <!-- If this is an official build, set the test drop to be public -->
+    <!-- Warn: internal builds should use a non-default container name, and set IsDropPublic to false -->
     <IsDropPublic Condition="'$(IsOfficial)' == 'true'">true</IsDropPublic>
   </PropertyGroup>
 

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -77,10 +77,10 @@
     <HelixArchLabel>$(ArchGroup)</HelixArchLabel>
     <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
     <MaxRetryCount>1</MaxRetryCount>
-    <!-- Unique container name and blob prefix per build and configuration, e.g., corefx-tests/master/beta-12345-01/netcoreapp/windowsnt-x64 -->
-    <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
+    <!-- Unique container name and blob prefix per build and configuration, e.g., corefx-tests/master/beta-12345-01/netcoreapp/win10-x64 -->
+    <RuntimeOS Condition="'$(RuntimeOS)' == ''">$(TargetOS)</RuntimeOS>
     <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true'">corefx-tests</ContainerName>
-    <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">$(Branch)/$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)/$(TargetGroup)/$(OSGroup)-$(ArchGroup)/</HelixBlobPrefix>
+    <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">$(Branch)/$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)/$(TargetGroup)/$(RuntimeOS)-$(ArchGroup)/</HelixBlobPrefix>
     <!-- If this is an official build, set the test drop to be public -->
     <IsDropPublic Condition="'$(IsOfficial)' == 'true'">true</IsDropPublic>
   </PropertyGroup>

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -82,7 +82,7 @@
     <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true'">corefx-tests</ContainerName>
     <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">$(Branch)/$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)/$(TargetGroup)/$(OSGroup)-$(ArchGroup)/</HelixBlobPrefix>
     <!-- If this is an official build, set the test drop to be public -->
-    <IsDropPublic Condition="'$(IsOffical)' == 'true'">true</IsDropPublic>
+    <IsDropPublic Condition="'$(IsOfficial)' == 'true'">true</IsDropPublic>
   </PropertyGroup>
 
   <Target Name="CoreFXPreCloudBuild" >

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -79,10 +79,11 @@
     <MaxRetryCount>1</MaxRetryCount>
     <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windows-x64 -->
     <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
-    <ProcessedOSGroup>$(OSGroup.ToLower())</ProcessedOSGroup>
-    <ProcessedOSGroup Condition="'$(TargetsWindows)' == 'true'">windows</ProcessedOSGroup>
-    <ProcessedArchGroup>$(ArchGroup.ToLower())</ProcessedArchGroup>
-    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' != ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)-$(TargetGroup)</ContainerName>
+    <ProcessedOSGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(OSGroup.ToLower())', "[^A-Za-z0-9-]+", ""))</ProcessedOSGroup>
+    <ProcessedArchGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(ArchGroup.ToLower())', "[^A-Za-z0-9-]+", ""))</ProcessedArchGroup>
+    <ProcessedTargetGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetGroup.ToLower())', "[^A-Za-z0-9-]+", ""))</ProcessedTargetGroup>
+    <ProcessedBranch Condition="'$(Branch)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(Branch.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedBranch>
+    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)-$(ProcessedTargetGroup)-$(ProcessedBranch)</ContainerName>
   </PropertyGroup>
 
   <Target Name="CoreFXPreCloudBuild" >

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -82,7 +82,7 @@
     <ProcessedOSGroup>$(OSGroup.ToLower())</ProcessedOSGroup>
     <ProcessedOSGroup Condition="'$(TargetsWindows)' == 'true'">windows</ProcessedOSGroup>
     <ProcessedArchGroup>$(ArchGroup.ToLower())</ProcessedArchGroup>
-    <ContainerName Condition="'$(ContainerName)' == ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)</ContainerName>
+    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' != ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)</ContainerName>
   </PropertyGroup>
 
   <Target Name="CoreFXPreCloudBuild" >

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -79,11 +79,10 @@
     <MaxRetryCount>1</MaxRetryCount>
     <!-- Unique container name per build and configuration, e.g., corefx-beta-12345-01-windowsnt-x64-netcoreapp-master -->
     <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
-    <ProcessedOSGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(OSGroup.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedOSGroup>
-    <ProcessedArchGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(ArchGroup.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedArchGroup>
-    <ProcessedTargetGroup>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetGroup.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedTargetGroup>
-    <ProcessedBranch Condition="'$(Branch)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(Branch.ToLower())', "[^A-Za-z0-9]+", ""))</ProcessedBranch>
-    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)-$(ProcessedTargetGroup)-$(ProcessedBranch)</ContainerName>
+    <RawContainerName Condition="'$(Branch)' != ''">corefx-$(Branch)-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(OSGroup)-$(ArchGroup)-$(TargetGroup)</RawContainerName>
+    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(RawContainerName.ToLower())', "[^A-Za-z0-9-]+", ""))</ContainerName>
+    <!-- If this is an official build, set the test drop to be public -->
+    <IsDropPublic Condition="'$(IsOffical)' == 'true'">true</IsDropPublic>
   </PropertyGroup>
 
   <Target Name="CoreFXPreCloudBuild" >

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -82,7 +82,7 @@
     <ProcessedOSGroup>$(OSGroup.ToLower())</ProcessedOSGroup>
     <ProcessedOSGroup Condition="'$(TargetsWindows)' == 'true'">windows</ProcessedOSGroup>
     <ProcessedArchGroup>$(ArchGroup.ToLower())</ProcessedArchGroup>
-    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' != ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)</ContainerName>
+    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' != ''">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(ProcessedOSGroup)-$(ProcessedArchGroup)-$(TargetGroup)</ContainerName>
   </PropertyGroup>
 
   <Target Name="CoreFXPreCloudBuild" >

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -77,10 +77,10 @@
     <HelixArchLabel>$(ArchGroup)</HelixArchLabel>
     <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
     <MaxRetryCount>1</MaxRetryCount>
-    <!-- Unique container name and blob prefix per build and configuration, e.g., corefx-beta-12345-01/tests-master-windowsnt-x64-netcoreapp-master -->
+    <!-- Unique container name and blob prefix per build and configuration, e.g., corefx-tests/master/beta-12345-01/netcoreapp/windowsnt-x64 -->
     <!-- Azure Storage containers can only contain [a-z, 0-9, -] in their names and $(OSGroup) is "Windows_NT" on Windows... -->
-    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true'">corefx-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
-    <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">tests-$(Branch)-$(OSGroup)-$(ArchGroup)-$(TargetGroup)</HelixBlobPrefix>
+    <ContainerName Condition="'$(ContainerName)' == '' And '$(IsOfficial)' == 'true'">corefx-tests</ContainerName>
+    <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' == '' And '$(IsOfficial)' == 'true' And '$(Branch)' != ''">$(Branch)/$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)/$(TargetGroup)/$(OSGroup)-$(ArchGroup)/</HelixBlobPrefix>
     <!-- If this is an official build, set the test drop to be public -->
     <IsDropPublic Condition="'$(IsOffical)' == 'true'">true</IsDropPublic>
   </PropertyGroup>


### PR DESCRIPTION
# Stable Container Name

Current convention for test uploads to Helix is to not specify a name for the container, which results in containers with names like `build-<random GUID>` (this is the default behavior of `CloudTest.Helix.targets`).  This works well for one time consumption by Helix, but is problematic for reuse and long term accessibility since Helix does not maintain a mapping of GUIDs to build ids for perpetuity.

The proposed stable name is built to uniquely identify an official build orchestration for all OS x Architecture configurations:
```
corefx-tests/$(Branch)/$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)/$(TargetGroup)/$(OS)-$(Arch)

ex: corefx-tests/master/beta-12345-04/netcoreapp/osx-x64
```

The changes to the container name and blob prefix won't change Helix functionality since it operates by following the links specified in metadata sent along with the job dispatch.

# `HelixBlobPrefix`

This PR is dependent on dotnet/buildtools#2169 being merged in and having dotnet/corefx updated via maestro-bot.  The `HelixBlobPrefix` kicks in for official builds and places all the artifacts into a single directory inside a container named after the prerelease label and build numbers, i.e., the stable naming convention described above.

# Public Test Drop

For use with dotnet/buildtools#2164.  The `IsDropPublic` property in `upload-tests.proj` has been set to true for official builds in order to expose the test upload container to the public.  This will allow for consumption by the CoreCLR CI system and developers hoping to rerun CI tests locally.

# Intent

This work is meant to make corefx tests easily consumable during coreclr ci builds and local testing.

CC - @sergiy-k @MattGal @weshaggard @adityamandaleeka @AaronRobinsonMSFT @mmitche 

dotnet/coreclr#19690