### PR TITLE
Unix: remove Preamble from Console.{Input,Output}Encoding

### DIFF
--- a/src/Common/src/System/Text/ConsoleEncoding.cs
+++ b/src/Common/src/System/Text/ConsoleEncoding.cs
@@ -9,7 +9,7 @@ namespace System.Text
     {
         public static Encoding RemovePreamble(this Encoding encoding)
         {
-            if (encoding.GetPreamble().Length == 0)
+            if (encoding.Preamble.Length == 0)
             {
                 return encoding;
             }

--- a/src/Common/src/System/Text/ConsoleEncoding.cs
+++ b/src/Common/src/System/Text/ConsoleEncoding.cs
@@ -4,6 +4,19 @@
 
 namespace System.Text
 {
+
+    internal static class EncodingExtensions
+    {
+        public static Encoding RemovePreamble(this Encoding encoding)
+        {
+            if (encoding.GetPreamble().Length == 0)
+            {
+                return encoding;
+            }
+            return new ConsoleEncoding(encoding);
+        }
+    }
+
     // StreamWriter calls Encoding.GetPreamble() to write the initial bits to the stream.
     // In case of Console we do not want to write the preamble as the user does not expect these bits.
     // In desktop this is handled by setting an internal property on the StreamWriter HasPreambleBeenWritten = true

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -119,7 +119,7 @@ namespace System
                 StreamWriter.Null :
                 new StreamWriter(
                     stream: outputStream,
-                    encoding: new ConsoleEncoding(OutputEncoding), // This ensures no prefix is written to the stream.
+                    encoding: OutputEncoding.RemovePreamble(), // This ensures no prefix is written to the stream.
                     bufferSize: DefaultConsoleBufferSize,
                     leaveOpen: true) { AutoFlush = true });
         }

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -609,11 +609,9 @@ namespace System
         private static Encoding GetConsoleEncoding()
         {
             Encoding enc = EncodingHelper.GetEncodingFromCharset();
-            if (enc != null)
-            {
-                enc = enc.RemovePreamble();
-            }
-            return enc ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            return enc != null ?
+                enc.RemovePreamble() :
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         }
 
         public static void SetConsoleInputEncoding(Encoding enc)

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -58,7 +58,7 @@ namespace System
                         ref s_stdInReader,
                         () => SyncTextReader.GetSynchronizedTextReader(
                             new StdInReader(
-                                encoding: new ConsoleEncoding(Console.InputEncoding), // This ensures no prefix is written to the stream.
+                                encoding: Console.InputEncoding.RemovePreamble(), // This ensures no prefix is written to the stream.
                                 bufferSize: DefaultBufferSize)));
             }
         }
@@ -74,7 +74,7 @@ namespace System
                     StreamReader.Null :
                     new StreamReader(
                         stream: inputStream,
-                        encoding: new ConsoleEncoding(Console.InputEncoding), // This ensures no prefix is written to the stream.
+                        encoding: Console.InputEncoding.RemovePreamble(), // This ensures no prefix is written to the stream.
                         detectEncodingFromByteOrderMarks: false,
                         bufferSize: DefaultConsoleBufferSize,
                         leaveOpen: true)
@@ -609,6 +609,10 @@ namespace System
         private static Encoding GetConsoleEncoding()
         {
             Encoding enc = EncodingHelper.GetEncodingFromCharset();
+            if (enc != null)
+            {
+                enc = enc.RemovePreamble();
+            }
             return enc ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         }
 

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -58,7 +58,7 @@ namespace System
                         ref s_stdInReader,
                         () => SyncTextReader.GetSynchronizedTextReader(
                             new StdInReader(
-                                encoding: Console.InputEncoding.RemovePreamble(), // This ensures no prefix is written to the stream.
+                                encoding: Console.InputEncoding,
                                 bufferSize: DefaultBufferSize)));
             }
         }
@@ -74,7 +74,7 @@ namespace System
                     StreamReader.Null :
                     new StreamReader(
                         stream: inputStream,
-                        encoding: Console.InputEncoding.RemovePreamble(), // This ensures no prefix is written to the stream.
+                        encoding: Console.InputEncoding,
                         detectEncodingFromByteOrderMarks: false,
                         bufferSize: DefaultConsoleBufferSize,
                         leaveOpen: true)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/32004

CC @wtgodbe 