### PR TITLE
Disable EncryptDecrypt_Read() test on the Home editions of Windows

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -72,6 +72,7 @@ namespace System
         public static bool IsNotNetNativeRunningAsConsoleApp { get { throw null; } }
         public static bool IsNotOneCoreUAP { get { throw null; } }
         public static bool IsNotWindows8x { get { throw null; } }
+        public static bool IsNotWindowsHomeEdition { get { throw null; } }
         public static bool IsNotWindowsIoTCore { get { throw null; } }
         public static bool IsNotWindowsNanoServer { get { throw null; } }
         public static bool IsNotWindowsServerCore { get { throw null; } }
@@ -105,6 +106,7 @@ namespace System
         public static bool IsWindows7 { get { throw null; } }
         public static bool IsWindows8x { get { throw null; } }
         public static bool IsWindowsAndElevated { get { throw null; } }
+        public static bool IsWindowsHomeEdition { get { throw null; } }
         public static bool IsWindowsIoTCore { get { throw null; } }
         public static bool IsWindowsNanoServer { get { throw null; } }
         public static bool IsWindowsServerCore { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -14,6 +14,7 @@ namespace System
     public static partial class PlatformDetection
     {
         public static bool IsWindowsIoTCore => false;
+        public static bool IsWindowsHomeEdition => false;
         public static bool IsWindows => false;
         public static bool IsWindows7 => false;
         public static bool IsWindows8x => false;

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -70,6 +70,28 @@ namespace System
             }
         }
 
+        public static bool IsWindowsHomeEdition
+        {
+            get
+            {
+                int productType = GetWindowsProductType();
+                switch (productType)
+                {
+                    case PRODUCT_CORE:
+                    case PRODUCT_CORE_COUNTRYSPECIFIC:
+                    case PRODUCT_CORE_N:
+                    case PRODUCT_CORE_SINGLELANGUAGE:
+                    case PRODUCT_HOME_BASIC:
+                    case PRODUCT_HOME_BASIC_N:
+                    case PRODUCT_HOME_PREMIUM:
+                    case PRODUCT_HOME_PREMIUM_N:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+
         public static bool IsWindows => true;
         public static bool IsWindows7 => GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
         public static bool IsWindows8x => GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);
@@ -228,6 +250,14 @@ namespace System
 
         private const int PRODUCT_IOTUAP = 0x0000007B;
         private const int PRODUCT_IOTUAPCOMMERCIAL = 0x00000083;
+        private const int PRODUCT_CORE = 0x00000065;
+        private const int PRODUCT_CORE_COUNTRYSPECIFIC = 0x00000063;
+        private const int PRODUCT_CORE_N = 0x00000062;
+        private const int PRODUCT_CORE_SINGLELANGUAGE = 0x00000064;
+        private const int PRODUCT_HOME_BASIC = 0x00000002;
+        private const int PRODUCT_HOME_BASIC_N = 0x00000005;
+        private const int PRODUCT_HOME_PREMIUM = 0x00000003;
+        private const int PRODUCT_HOME_PREMIUM_N = 0x0000001A;
 
         [DllImport("kernel32.dll", SetLastError = false)]
         private static extern bool GetProductInfo(

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -31,6 +31,7 @@ namespace System
         public static bool IsNotWindowsNanoServer => !IsWindowsNanoServer;
         public static bool IsNotWindowsServerCore => !IsWindowsServerCore;
         public static bool IsNotWindowsIoTCore => !IsWindowsIoTCore;
+        public static bool IsNotWindowsHomeEdition => !IsWindowsHomeEdition;
         public static bool IsDrawingSupported => (IsNotWindowsNanoServer && IsNotWindowsIoTCore);
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;

--- a/src/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -32,7 +32,7 @@ namespace System.IO.Tests
             Assert.Throws<PlatformNotSupportedException>(() => File.Decrypt(null));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection.IsNotWindowsHomeEdition))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "File encryption is not supported on this platform.")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public static void EncryptDecrypt_Read()

--- a/src/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -32,6 +32,8 @@ namespace System.IO.Tests
             Assert.Throws<PlatformNotSupportedException>(() => File.Decrypt(null));
         }
 
+        // On Windows Nano Server and Home Edition, file encryption with File.Encrypt(string path) throws an IOException
+        // because EFS (Encrypted File System), its underlying technology, is not available on these operating systems.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection.IsNotWindowsHomeEdition))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "File encryption is not supported on this platform.")]
         [PlatformSpecific(TestPlatforms.Windows)]


### PR DESCRIPTION
`build-tests.cmd` currently fails on the Home editions of Windows, e.g. Windows 10 Home, because `System.IO.Tests.EncryptDecrypt.EncryptDecrypt_Read()` calls `File.Encrypt(string path)` which is not supported on these editions and thus throws an `IOException`. This PR disables the test for `File.Encrypt` on Windows 7/8.1/10 Home, so that all tests succeed.