### PR TITLE
Fix string error handling for failed DNS lookup 

### DIFF
--- a/src/Common/src/CoreLib/Interop/Unix/Interop.Errors.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/Interop.Errors.cs
@@ -101,6 +101,9 @@ internal static partial class Interop
         EHOSTDOWN        = 0x10070,           // Host is down.
         ENODATA          = 0x10071,           // No data available.
 
+        // Custom Error codes to track errors beyond kernel interface.
+        EHOSTNFND        = 0x20001,             // Name lookup failed
+
         // POSIX permits these to have the same value and we make them always equal so
         // that CoreFX cannot introduce a dependency on distinguishing between them that
         // would not work on all platforms.

--- a/src/Common/src/CoreLib/Interop/Unix/Interop.Errors.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/Interop.Errors.cs
@@ -102,7 +102,7 @@ internal static partial class Interop
         ENODATA          = 0x10071,           // No data available.
 
         // Custom Error codes to track errors beyond kernel interface.
-        EHOSTNFND        = 0x20001,             // Name lookup failed
+        EHOSTNOTFOUND    = 0x20001,           // Name lookup failed
 
         // POSIX permits these to have the same value and we make them always equal so
         // that CoreFX cannot introduce a dependency on distinguishing between them that

--- a/src/Common/src/System/Net/Sockets/SocketErrorPal.Unix.cs
+++ b/src/Common/src/System/Net/Sockets/SocketErrorPal.Unix.cs
@@ -97,7 +97,7 @@ namespace System.Net.Sockets
             { SocketError.Disconnecting, Interop.Error.ESHUTDOWN },
             { SocketError.Fault, Interop.Error.EFAULT },
             { SocketError.HostDown, Interop.Error.EHOSTDOWN },
-            { SocketError.HostNotFound, Interop.Error.EHOSTNFND },
+            { SocketError.HostNotFound, Interop.Error.EHOSTNOTFOUND },
             { SocketError.HostUnreachable, Interop.Error.EHOSTUNREACH },
             { SocketError.InProgress, Interop.Error.EINPROGRESS },
             { SocketError.Interrupted, Interop.Error.EINTR },

--- a/src/Common/src/System/Net/Sockets/SocketErrorPal.Unix.cs
+++ b/src/Common/src/System/Net/Sockets/SocketErrorPal.Unix.cs
@@ -81,7 +81,7 @@ namespace System.Net.Sockets
         {
             // This is *mostly* an inverse mapping of s_nativeErrorToSocketError.  However, some options have multiple mappings and thus
             // can't be inverted directly.  Other options don't have a mapping from native to SocketError, but when presented with a SocketError,
-            // we want to provide the closest relevant Error possible, e.g. EINPROGRESS maps to SocketError.InProgress, and vice versa, but 
+            // we want to provide the closest relevant Error possible, e.g. EINPROGRESS maps to SocketError.InProgress, and vice versa, but
             // SocketError.IOPending also maps closest to EINPROGRESS.  As such, roundtripping won't necessarily provide the original value 100% of the time,
             // but it's the best we can do given the mismatch between Interop.Error and SocketError.
 
@@ -97,7 +97,7 @@ namespace System.Net.Sockets
             { SocketError.Disconnecting, Interop.Error.ESHUTDOWN },
             { SocketError.Fault, Interop.Error.EFAULT },
             { SocketError.HostDown, Interop.Error.EHOSTDOWN },
-            { SocketError.HostNotFound, Interop.Error.ENXIO }, // not perfect, but closest match available
+            { SocketError.HostNotFound, Interop.Error.EHOSTNFND },
             { SocketError.HostUnreachable, Interop.Error.EHOSTUNREACH },
             { SocketError.InProgress, Interop.Error.EINPROGRESS },
             { SocketError.Interrupted, Interop.Error.EINTR },

--- a/src/Native/Unix/System.Native/pal_errno.c
+++ b/src/Native/Unix/System.Native/pal_errno.c
@@ -379,8 +379,8 @@ int32_t SystemNative_ConvertErrorPalToPlatform(int32_t error)
             return EHOSTDOWN;
         case Error_ENODATA:
             return ENODATA;
-        case Error_EHOSTNFND:
-            return -(Error_EHOSTNFND);
+        case Error_EHOSTNOTFOUND:
+            return -(Error_EHOSTNOTFOUND);
         case Error_ENONSTANDARD:
             break; // fall through to assert
     }
@@ -402,7 +402,7 @@ static int32_t SystemNative_ConvertErrorPalToGai(int32_t error)
 {
     switch (error)
     {
-        case -(Error_EHOSTNFND):
+        case -(Error_EHOSTNOTFOUND):
             return EAI_NONAME;
     }
     // Fall-through for unknown codes. gai_strerror() will handle that.
@@ -425,7 +425,7 @@ const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffer, int32_t 
         // Not a system error
         SafeStringCopy(buffer, (size_t)bufferSize, gai_strerror(SystemNative_ConvertErrorPalToGai(platformErrno)));
         return buffer;
-   }
+    }
 
 // Note that we must use strerror_r because plain strerror is not
 // thread-safe.

--- a/src/Native/Unix/System.Native/pal_errno.c
+++ b/src/Native/Unix/System.Native/pal_errno.c
@@ -7,6 +7,7 @@
 #include "pal_utilities.h"
 
 #include <errno.h>
+#include <netdb.h>
 
 // ENODATA is not defined in FreeBSD 10.3 but is defined in 11.0
 #if defined(__FreeBSD__) & !defined(ENODATA)
@@ -378,6 +379,8 @@ int32_t SystemNative_ConvertErrorPalToPlatform(int32_t error)
             return EHOSTDOWN;
         case Error_ENODATA:
             return ENODATA;
+        case Error_EHOSTNFND:
+            return -(Error_EHOSTNFND);
         case Error_ENONSTANDARD:
             break; // fall through to assert
     }
@@ -395,6 +398,20 @@ int32_t SystemNative_ConvertErrorPalToPlatform(int32_t error)
     return -1;
 }
 
+static int32_t SystemNative_ConvertErrorPalToGai(int32_t error)
+{
+    switch (error)
+    {
+        case -(Error_EHOSTNFND):
+            return EAI_NONAME;
+    }
+    // Fall-through for unknown codes. gai_strerror() will handle that.
+
+    return error;
+}
+
+
+
 const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
 {
     assert(buffer != NULL);
@@ -402,6 +419,13 @@ const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffer, int32_t 
 
     if (bufferSize < 0)
         return NULL;
+
+    if (platformErrno < 0)
+    {
+        // Not a system error
+        SafeStringCopy(buffer, (size_t)bufferSize, gai_strerror(SystemNative_ConvertErrorPalToGai(platformErrno)));
+        return buffer;
+   }
 
 // Note that we must use strerror_r because plain strerror is not
 // thread-safe.

--- a/src/Native/Unix/System.Native/pal_errno.h
+++ b/src/Native/Unix/System.Native/pal_errno.h
@@ -111,6 +111,9 @@ typedef enum
     Error_EHOSTDOWN = 0x10070,       // Host is down.
     Error_ENODATA = 0x10071,         // No data available.
 
+    // Error codes to track errors beyond kernel.
+    Error_EHOSTNFND = 0x20001,       // Name lookup failed.
+
     // POSIX permits these to have the same value and we make them
     // always equal so that we cannot introduce a dependency on
     // distinguishing between them that would not work on all

--- a/src/Native/Unix/System.Native/pal_errno.h
+++ b/src/Native/Unix/System.Native/pal_errno.h
@@ -112,7 +112,7 @@ typedef enum
     Error_ENODATA = 0x10071,         // No data available.
 
     // Error codes to track errors beyond kernel.
-    Error_EHOSTNFND = 0x20001,       // Name lookup failed.
+    Error_EHOSTNOTFOUND = 0x20001,   // Name lookup failed.
 
     // POSIX permits these to have the same value and we make them
     // always equal so that we cannot introduce a dependency on

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -174,7 +174,6 @@ namespace System.Net.NameResolution.PalTests
             var ex = new  SocketException((int)SocketError.HostNotFound);
 
             Assert.Equal(-1, ex.Message.IndexOf("Device"));
-            Assert.NotEqual(-1,  ex.Message.IndexOf("not known"));
         }
     }
 }

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -166,5 +166,15 @@ namespace System.Net.NameResolution.PalTests
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(hostEntry);
         }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void Exception_HostNotFound_Success()
+        {
+            var ex = new  SocketException((int)SocketError.HostNotFound);
+
+            Assert.Equal(-1, ex.Message.IndexOf("Device"));
+            Assert.NotEqual(-1,  ex.Message.IndexOf("not known"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #13309 "Device not configured" from Dns.GetHostEntryAsync on macOS

As I mentioned in liked issue, errno is really valid just for kernel calls. 
DNS lookup is not kernel function so mapping outcome to errno does not work well. 

This change calls gai_strerror inside of StrrError as needed to get proper error string for failures in getaddrinfo() (note that the EAI_ error are negative on Linux but positive on OSX and BSD)

With this change exception will look like bellow and it will be generally consistent with OSX, Linux and FreeBSD.

```
System.Net.Http.HttpRequestException: nodename nor servname provided, or not known ---> System.Net.Sockets.SocketException: nodename nor servname provided, or not known
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean allowHttp2, CancellationToken cancellationToken)
```  