### PR TITLE
use proper flags for sendmsg() on Unix

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -775,6 +775,7 @@ static void ConvertMessageHeaderToMsghdr(struct msghdr* header, const MessageHea
     header->msg_iovlen = (__typeof__(header->msg_iovlen))iovlen;
     header->msg_control = messageHeader->ControlBuffer;
     header->msg_controllen = (uint32_t)messageHeader->ControlBufferLen;
+    header->msg_flags = 0;
 }
 
 int32_t SystemNative_GetControlMessageBufferSize(int32_t isIPv4, int32_t isIPv6)
@@ -1266,7 +1267,8 @@ int32_t SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, 
     ConvertMessageHeaderToMsghdr(&header, messageHeader, fd);
 
     ssize_t res;
-    while ((res = sendmsg(fd, &header, flags)) < 0 && errno == EINTR);
+    while ((res = sendmsg(fd, &header, socketFlags)) < 0 && errno == EINTR);
+
     if (res != -1)
     {
         *sent = res;

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1231,7 +1231,7 @@ int32_t SystemNative_ReceiveMessage(intptr_t socket, MessageHeader* messageHeade
 
     assert((int32_t)header.msg_namelen <= messageHeader->SocketAddressLen);
     messageHeader->SocketAddressLen = Min((int32_t)header.msg_namelen, messageHeader->SocketAddressLen);
-    
+
     assert(header.msg_controllen <= (size_t)messageHeader->ControlBufferLen);
     messageHeader->ControlBufferLen = Min((int32_t)header.msg_controllen, messageHeader->ControlBufferLen);
 
@@ -1268,7 +1268,6 @@ int32_t SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, 
 
     ssize_t res;
     while ((res = sendmsg(fd, &header, socketFlags)) < 0 && errno == EINTR);
-
     if (res != -1)
     {
         *sent = res;


### PR DESCRIPTION
I bump to this while investigation #31206 

SendMessage would compute socketFlags but than it would never use it. 
That seems like clear oversight.

 Setting msg_flags may not be necessary but without it the strace looks really confusing: 

```
[pid 27702] sendmsg(24, {msg_name(16)={sa_family=AF_INET, sin_port=htons(12345), sin_addr=inet_addr("127.0.0.1")}, msg_iov(1)=[{"hello world", 11}], msg_controllen=0, msg_flags=MSG_PEEK|MSG_CTRUNC|MSG_TRUNC|MSG_WAITALL|MSG_SYN|MSG_CONFIRM|MSG_ERRQUEUE|MSG_NOSIGNAL|MSG_CMSG_CLOEXEC|0xb260010}, 0) = 11
[pid 27702] sendmsg(24, {msg_name(16)={sa_family=AF_INET, sin_port=htons(12345), sin_addr=inet_addr("127.0.0.1")}, msg_iov(1)=[{"hello world", 11}], msg_controllen=0, msg_flags=MSG_PEEK|MSG_CTRUNC|MSG_TRUNC|MSG_WAITALL|MSG_SYN|MSG_CONFIRM|MSG_ERRQUEUE|MSG_NOSIGNAL|MSG_CMSG_CLOEXEC|0xb260010}, 0) = 11
[pid 27702] sendmsg(24, {msg_name(16)={sa_family=AF_INET, sin_port=htons(12345), sin_addr=inet_addr("127.0.0.1")}, msg_iov(1)=[{"hello world", 11}], msg_controllen=0, msg_flags=0}, 0) = 11
[pid 27702] sendmsg(24, {msg_name(16)={sa_family=AF_INET, sin_port=htons(12345), sin_addr=inet_addr("127.0.0.1")}, msg_iov(1)=[{"hello world", 11}], msg_controllen=0, msg_flags=0}, 0) = 11
[pid 27702] sendmsg(24, {msg_name(16)={sa_family=AF_INET, sin_port=htons(12345), sin_addr=inet_addr("127.0.0.1")}, msg_iov(1)=[{"hello world", 11}], msg_controllen=0, msg_flags=0}, 0) = 11
```

The value  has random value from stack. 

