### PR TITLE
Fix Units for Span.Contains

### DIFF
--- a/src/System.Globalization/tests/Performance/Perf.CompareInfo.cs
+++ b/src/System.Globalization/tests/Performance/Perf.CompareInfo.cs
@@ -32,8 +32,8 @@ namespace System.Globalization.Tests
             new object[] { "es-ES", "$", "&", CompareOptions.IgnoreSymbols },
             new object[] { "", GenerateInputString('A', 10, '5', 5), GenerateInputString('A', 10, '5', 6), CompareOptions.Ordinal },
             new object[] { "", GenerateInputString('A', 100, 'X', 70), GenerateInputString('A', 100, 'X', 70), CompareOptions.OrdinalIgnoreCase },
-            new object[] { "ja-JP", GenerateInputString('A', 100, 'X', 70), GenerateInputString('A', 100, 'x', 70), CompareOptions.OrdinalIgnoreCase },
-            new object[] { "en-US", GenerateInputString('A', 1000, 'X', 500), GenerateInputString('A', 1000, 'X', 500), CompareOptions.None },
+            new object[] { "ja-JP", GenerateInputString('A', 100, 'D', 70), GenerateInputString('A', 100, 'd', 70), CompareOptions.OrdinalIgnoreCase },
+            new object[] { "en-US", GenerateInputString('A', 1000, 'G', 500), GenerateInputString('A', 1000, 'G', 500), CompareOptions.None },
             new object[] { "en-US", GenerateInputString('\u3060', 1000, 'x', 500), GenerateInputString('\u3060', 1000, 'x', 10), CompareOptions.None },
             new object[] { "es-ES", GenerateInputString('\u3060', 100, '\u3059', 50), GenerateInputString('\u3060', 100, '\u3059', 50), CompareOptions.Ordinal },
             new object[] { "tr-TR", GenerateInputString('\u3060', 5000, '\u3059', 2501), GenerateInputString('\u3060', 5000, '\u3059', 2500), CompareOptions.Ordinal }

--- a/src/System.Memory/tests/Performance/Perf.Span.Contains.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.Contains.cs
@@ -196,7 +196,7 @@ namespace System.Memory.Tests
             new object[] { "Hello Worldbbbbbbbbbbbbbbcbbbbbbbbbbbbbbbbbbba!", 'y' },
             new object[] { GenerateInputString('A', 10, '5', 5), '5' },
             new object[] { GenerateInputString('A', 100, 'X', 70), 'x' },
-            new object[] { GenerateInputString('A', 1000, 'X', 500), 'X' },
+            new object[] { GenerateInputString('A', 1000, 'G', 500), 'G' },
             new object[] { GenerateInputString('\u3060', 1000, 'x', 500), 'x' },
             new object[] { GenerateInputString('\u3060', 100, '\u3059', 50), '\u3059' }
         };

--- a/src/System.Memory/tests/Performance/Perf.Span.Contains.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.Contains.cs
@@ -187,7 +187,7 @@ namespace System.Memory.Tests
         {
             new object[] { "string1", '1' },
             new object[] { "foobardzsdzs", 'z' },
-            new object[] { "StrIng", "I" },
+            new object[] { "StrIng", 'I' },
             new object[] { "\u3060", '\u305F' },
             new object[] { "ABCDE", 'c' },
             new object[] { "More Test's", '\'' },

--- a/src/System.Memory/tests/Performance/Perf.Span.Contains.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.Contains.cs
@@ -196,7 +196,6 @@ namespace System.Memory.Tests
             new object[] { "Hello Worldbbbbbbbbbbbbbbcbbbbbbbbbbbbbbbbbbba!", 'y' },
             new object[] { GenerateInputString('A', 10, '5', 5), '5' },
             new object[] { GenerateInputString('A', 100, 'X', 70), 'x' },
-            new object[] { GenerateInputString('A', 100, 'X', 70), 'x' },
             new object[] { GenerateInputString('A', 1000, 'X', 500), 'X' },
             new object[] { GenerateInputString('\u3060', 1000, 'x', 500), 'x' },
             new object[] { GenerateInputString('\u3060', 100, '\u3059', 50), '\u3059' }

--- a/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
@@ -190,8 +190,8 @@ namespace System.Memory.Tests
             new object[] { "Hello Worldbbbbbbbbbbbbbbcbbbbbbbbbbbbbbbbbbba!", "y", StringComparison.Ordinal },
             new object[] { GenerateInputString('A', 10, '5', 5), "5", StringComparison.InvariantCulture },
             new object[] { GenerateInputString('A', 100, 'X', 70), "x", StringComparison.InvariantCultureIgnoreCase },
-            new object[] { GenerateInputString('A', 100, 'X', 70), "x", StringComparison.OrdinalIgnoreCase },
-            new object[] { GenerateInputString('A', 1000, 'X', 500), "X", StringComparison.Ordinal },
+            new object[] { GenerateInputString('A', 100, 'D', 70), "d", StringComparison.OrdinalIgnoreCase },
+            new object[] { GenerateInputString('A', 1000, 'G', 500), "G", StringComparison.Ordinal },
             new object[] { GenerateInputString('\u3060', 1000, 'x', 500), "x", StringComparison.Ordinal },
             new object[] { GenerateInputString('\u3060', 100, '\u3059', 50), "\u3059", StringComparison.Ordinal }
         };


### PR DESCRIPTION
Related to this PR: https://github.com/dotnet/corefx/pull/32293

Fixes this issue:
https://github.com/dotnet/corefx/pull/32293#issuecomment-422970084

* There's a typo in one of the test cases; perhaps this causes a spurious `Xunit` error.
* Test cases end up generating duplicate names