### PR TITLE
Remove Clear Operation from GetModifyEnumerables()

### DIFF
--- a/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
@@ -190,19 +190,6 @@ namespace System.Collections.Tests
                     return false;
                 };
             }
-            if ((operations & ModifyOperation.Clear) == ModifyOperation.Clear)
-            {
-                yield return (IEnumerable<KeyValuePair<TKey, TValue>> enumerable) =>
-                {
-                    IDictionary<TKey, TValue> casted = ((IDictionary<TKey, TValue>)enumerable);
-                    if (casted.Count() > 0)
-                    {
-                        casted.Clear();
-                        return true;
-                    }
-                    return false;
-                };
-            }
             //throw new InvalidOperationException(string.Format("{0:G}", operations));
         }
 

--- a/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
@@ -190,6 +190,19 @@ namespace System.Collections.Tests
                     return false;
                 };
             }
+            if ((operations & ModifyOperation.Clear) == ModifyOperation.Clear)
+            {
+                yield return (IEnumerable<KeyValuePair<TKey, TValue>> enumerable) =>
+                {
+                    IDictionary<TKey, TValue> casted = ((IDictionary<TKey, TValue>)enumerable);
+                    if (casted.Count() > 0)
+                    {
+                        casted.Clear();
+                        return true;
+                    }
+                    return false;
+                };
+            }
             //throw new InvalidOperationException(string.Format("{0:G}", operations));
         }
 

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
@@ -163,19 +163,6 @@ namespace System.Collections.Tests
                     return false;
                 };
             }
-            if ((operations & ModifyOperation.Clear) == ModifyOperation.Clear)
-            {
-                yield return (IEnumerable enumerable) =>
-                {
-                    IDictionary casted = ((IDictionary)enumerable);
-                    if (casted.Count > 0)
-                    {
-                        casted.Clear();
-                        return true;
-                    }
-                    return false;
-                };
-            }
         }
 
         /// <summary>

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
@@ -163,6 +163,19 @@ namespace System.Collections.Tests
                     return false;
                 };
             }
+            if ((operations & ModifyOperation.Clear) == ModifyOperation.Clear)
+            {
+               yield return (IEnumerable enumerable) =>
+               {
+                   IDictionary casted = ((IDictionary)enumerable);
+                   if (casted.Count > 0)
+                   {
+                       casted.Clear();
+                       return true;
+                   }
+                   return false;
+               };
+            }
         }
 
         /// <summary>

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
@@ -13,9 +13,9 @@ namespace System.Collections.Tests
     /// </summary>
     public abstract partial class Dictionary_Generic_Tests<TKey, TValue> : IDictionary_Generic_Tests<TKey, TValue>
     {
-        protected override ModifyOperation ModifyEnumeratorThrows => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorThrows : ModifyOperation.Add | ModifyOperation.Insert | ModifyOperation.Clear;
+        protected override ModifyOperation ModifyEnumeratorThrows => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorThrows : ModifyOperation.Add | ModifyOperation.Insert;
 
-        protected override ModifyOperation ModifyEnumeratorAllowed => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorAllowed : ModifyOperation.Remove;
+        protected override ModifyOperation ModifyEnumeratorAllowed => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorAllowed : ModifyOperation.Remove | ModifyOperation.Clear;
 
         #region IDictionary<TKey, TValue Helper Methods
 

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
@@ -16,9 +16,9 @@ namespace System.Collections.Tests
             return new Dictionary<string, string>();
         }
 
-        protected override ModifyOperation ModifyEnumeratorThrows => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorThrows : ModifyOperation.Add | ModifyOperation.Insert | ModifyOperation.Clear;
+        protected override ModifyOperation ModifyEnumeratorThrows => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorThrows : ModifyOperation.Add | ModifyOperation.Insert;
 
-        protected override ModifyOperation ModifyEnumeratorAllowed => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorAllowed : ModifyOperation.Remove;
+        protected override ModifyOperation ModifyEnumeratorAllowed => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorAllowed : ModifyOperation.Remove | ModifyOperation.Clear;
 
         /// <summary>
         /// Creates an object that is dependent on the seed given. The object may be either


### PR DESCRIPTION
Connected to a .NET Native-side change in which the enumerator of a Dictionary object is no longer invalidated by a `Clear` 
Upgrade Maestro PR at #32344 