### PR TITLE
Add declaredType parameter in some DataContract Serialization methods

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -212,7 +212,7 @@ namespace System.Runtime.Serialization.Json
             this.PushKnownTypes(this.rootTypeDataContract);
             this.PushKnownTypes(memberTypeContract);
             XmlQualifiedName qname = ParseQualifiedName(typeName);
-            DataContract contract = ResolveDataContractFromKnownTypes(qname.Name, TrimNamespace(qname.Namespace), memberTypeContract);
+            DataContract contract = ResolveDataContractFromKnownTypes(qname.Name, TrimNamespace(qname.Namespace), memberTypeContract, null);
 
             this.PopKnownTypes(this.rootTypeDataContract);
             this.PopKnownTypes(memberTypeContract);
@@ -249,7 +249,7 @@ namespace System.Runtime.Serialization.Json
 
         internal void VerifyType(DataContract dataContract)
         {
-            DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/);
+            DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/, null);
             if (knownContract == null || knownContract.UnderlyingType != dataContract.UnderlyingType)
             {
                 throw System.ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DcTypeNotFoundOnSerialize, DataContract.GetClrTypeFullName(dataContract.UnderlyingType), dataContract.StableName.Name, dataContract.StableName.Namespace)));

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -207,55 +207,6 @@ namespace System.Runtime.Serialization.Json
             xmlReader.MoveToElement();
         }
 
-        internal DataContract ResolveDataContractFromType(string typeName, string typeNs, DataContract memberTypeContract)
-        {
-            this.PushKnownTypes(this.rootTypeDataContract);
-            this.PushKnownTypes(memberTypeContract);
-            XmlQualifiedName qname = ParseQualifiedName(typeName);
-            DataContract contract = ResolveDataContractFromKnownTypes(qname.Name, TrimNamespace(qname.Namespace), memberTypeContract, null);
-
-            this.PopKnownTypes(this.rootTypeDataContract);
-            this.PopKnownTypes(memberTypeContract);
-            return contract;
-        }
-
-        internal void CheckIfTypeNeedsVerifcation(DataContract declaredContract, DataContract runtimeContract)
-        {
-            bool verifyType = true;
-            CollectionDataContract collectionContract = declaredContract as CollectionDataContract;
-            if (collectionContract != null && collectionContract.UnderlyingType.IsInterface)
-            {
-                switch (collectionContract.Kind)
-                {
-                    case CollectionKind.Dictionary:
-                    case CollectionKind.GenericDictionary:
-                        verifyType = declaredContract.Name == runtimeContract.Name;
-                        break;
-
-                    default:
-                        Type t = collectionContract.ItemType.MakeArrayType();
-                        verifyType = (t != runtimeContract.UnderlyingType);
-                        break;
-                }
-            }
-
-            if (verifyType)
-            {
-                this.PushKnownTypes(declaredContract);
-                VerifyType(runtimeContract);
-                this.PopKnownTypes(declaredContract);
-            }
-        }
-
-        internal void VerifyType(DataContract dataContract)
-        {
-            DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/, null);
-            if (knownContract == null || knownContract.UnderlyingType != dataContract.UnderlyingType)
-            {
-                throw System.ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DcTypeNotFoundOnSerialize, DataContract.GetClrTypeFullName(dataContract.UnderlyingType), dataContract.StableName.Name, dataContract.StableName.Namespace)));
-            }
-        }
-
         internal string TrimNamespace(string serverTypeNamespace)
         {
             if (!string.IsNullOrEmpty(serverTypeNamespace))

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -344,35 +344,6 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        internal void CheckIfTypeNeedsVerifcation(DataContract declaredContract, DataContract runtimeContract)
-        {
-            if (WriteTypeInfo(null, runtimeContract, declaredContract))
-            {
-                VerifyType(runtimeContract);
-            }
-        }
-
-        internal void VerifyType(DataContract dataContract)
-        {
-            bool knownTypesAddedInCurrentScope = false;
-            if (dataContract.KnownDataContracts != null)
-            {
-                scopedKnownTypes.Push(dataContract.KnownDataContracts);
-                knownTypesAddedInCurrentScope = true;
-            }
-
-            DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/, null);
-            if (knownContract == null || knownContract.UnderlyingType != dataContract.UnderlyingType)
-            {
-                throw System.ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DcTypeNotFoundOnSerialize, DataContract.GetClrTypeFullName(dataContract.UnderlyingType), dataContract.StableName.Name, dataContract.StableName.Namespace)));
-            }
-
-            if (knownTypesAddedInCurrentScope)
-            {
-                scopedKnownTypes.Pop();
-            }
-        }
-
         internal void WriteJsonISerializable(XmlWriterDelegator xmlWriter, ISerializable obj)
         {
             Type objType = obj.GetType();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -361,7 +361,7 @@ namespace System.Runtime.Serialization.Json
                 knownTypesAddedInCurrentScope = true;
             }
 
-            DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/);
+            DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/, null);
             if (knownContract == null || knownContract.UnderlyingType != dataContract.UnderlyingType)
             {
                 throw System.ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DcTypeNotFoundOnSerialize, DataContract.GetClrTypeFullName(dataContract.UnderlyingType), dataContract.StableName.Name, dataContract.StableName.Namespace)));

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerContext.cs
@@ -233,7 +233,7 @@ namespace System.Runtime.Serialization
 
         internal bool IsKnownType(DataContract dataContract, Type declaredType)
         {
-            DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/ /*, declaredType */);
+            DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/, declaredType);
             return knownContract != null && knownContract.UnderlyingType == dataContract.UnderlyingType;
         }
 
@@ -263,7 +263,7 @@ namespace System.Runtime.Serialization
             return dataContract;
         }
 
-        protected DataContract ResolveDataContractFromKnownTypes(string typeName, string typeNs, DataContract memberTypeContract)
+        protected DataContract ResolveDataContractFromKnownTypes(string typeName, string typeNs, DataContract memberTypeContract, Type declaredType)
         {
             XmlQualifiedName qname = new XmlQualifiedName(typeName, typeNs);
             DataContract dataContract;
@@ -273,7 +273,7 @@ namespace System.Runtime.Serialization
             }
             else
             {
-                Type dataContractType = _dataContractResolver.ResolveName(typeName, typeNs, null, KnownTypeResolver);
+                Type dataContractType = _dataContractResolver.ResolveName(typeName, typeNs, declaredType, KnownTypeResolver);
                 dataContract = dataContractType == null ? null : GetDataContract(dataContractType);
             }
             if (dataContract == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -117,20 +117,20 @@ namespace System.Runtime.Serialization
 #endif
         {
             DataContract dataContract = GetDataContract(id, declaredTypeHandle);
-            return InternalDeserialize(xmlReader, name, ns, ref dataContract);
+            return InternalDeserialize(xmlReader, name, ns, Type.GetTypeFromHandle(declaredTypeHandle), ref dataContract);
         }
 
         internal virtual object InternalDeserialize(XmlReaderDelegator xmlReader, Type declaredType, string name, string ns)
         {
             DataContract dataContract = GetDataContract(declaredType);
-            return InternalDeserialize(xmlReader, name, ns, ref dataContract);
+            return InternalDeserialize(xmlReader, name, ns, declaredType, ref dataContract);
         }
 
         internal virtual object InternalDeserialize(XmlReaderDelegator xmlReader, Type declaredType, DataContract dataContract, string name, string ns)
         {
             if (dataContract == null)
                 GetDataContract(declaredType);
-            return InternalDeserialize(xmlReader, name, ns, ref dataContract);
+            return InternalDeserialize(xmlReader, name, ns, declaredType, ref dataContract);
         }
 
         protected bool TryHandleNullOrRef(XmlReaderDelegator reader, Type declaredType, string name, string ns, ref object retObj)
@@ -158,7 +158,7 @@ namespace System.Runtime.Serialization
             return false;
         }
 
-        protected object InternalDeserialize(XmlReaderDelegator reader, string name, string ns, ref DataContract dataContract)
+        protected object InternalDeserialize(XmlReaderDelegator reader, string name, string ns, Type declaredType, ref DataContract dataContract)
         {
             object retObj = null;
             if (TryHandleNullOrRef(reader, dataContract.UnderlyingType, name, ns, ref retObj))
@@ -173,7 +173,7 @@ namespace System.Runtime.Serialization
 
             if (attributes.XsiTypeName != null)
             {
-                dataContract = ResolveDataContractFromKnownTypes(attributes.XsiTypeName, attributes.XsiTypeNamespace, dataContract);
+                dataContract = ResolveDataContractFromKnownTypes(attributes.XsiTypeName, attributes.XsiTypeNamespace, dataContract, declaredType);
                 if (dataContract == null)
                 {
                     if (DataContractResolver == null)
@@ -187,7 +187,7 @@ namespace System.Runtime.Serialization
 
             if (dataContract.IsISerializable && attributes.FactoryTypeName != null)
             {
-                DataContract factoryDataContract = ResolveDataContractFromKnownTypes(attributes.FactoryTypeName, attributes.FactoryTypeNamespace, dataContract);
+                DataContract factoryDataContract = ResolveDataContractFromKnownTypes(attributes.FactoryTypeName, attributes.FactoryTypeNamespace, dataContract, declaredType);
                 if (factoryDataContract != null)
                 {
                     if (factoryDataContract.IsISerializable)
@@ -658,7 +658,7 @@ namespace System.Runtime.Serialization
 
         protected virtual DataContract ResolveDataContractFromTypeName()
         {
-            return (attributes.XsiTypeName == null) ? null : ResolveDataContractFromKnownTypes(attributes.XsiTypeName, attributes.XsiTypeNamespace, null /*memberTypeContract*/);
+            return (attributes.XsiTypeName == null) ? null : ResolveDataContractFromKnownTypes(attributes.XsiTypeName, attributes.XsiTypeNamespace, null /*memberTypeContract*/, null);
         }
 
         private ExtensionDataMember ReadExtensionDataMember(XmlReaderDelegator xmlReader, int memberIndex)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContextComplex.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContextComplex.cs
@@ -127,7 +127,7 @@ namespace System.Runtime.Serialization
             }
             ReadAttributes(xmlReader);
             string objectId = GetObjectId();
-            object oldObj = InternalDeserialize(xmlReader, name, ns, ref dataContract);
+            object oldObj = InternalDeserialize(xmlReader, name, ns, declaredType, ref dataContract);
             object obj = DataContractSurrogateCaller.GetDeserializedObject(_serializationSurrogateProvider, oldObj, dataContract.UnderlyingType, declaredType);
             ReplaceDeserializedObject(objectId, oldObj, obj);
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs
@@ -271,7 +271,7 @@ namespace System.Runtime.Serialization
             {
                 if (!IsKnownType(dataContract, declaredType))
                 {
-                    DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/);
+                    DataContract knownContract = ResolveDataContractFromKnownTypes(dataContract.StableName.Name, dataContract.StableName.Namespace, null /*memberTypeContract*/, declaredType);
                     if (knownContract == null || knownContract.UnderlyingType != dataContract.UnderlyingType)
                     {
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DcTypeNotFoundOnSerialize, DataContract.GetClrTypeFullName(dataContract.UnderlyingType), dataContract.StableName.Name, dataContract.StableName.Namespace)));

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1120,6 +1120,7 @@ public static partial class DataContractSerializerTests
 
         Assert.True(myresolver.ResolveNameInvoked, "myresolver.ResolveNameInvoked is false");
         Assert.True(myresolver.TryResolveTypeInvoked, "myresolver.TryResolveTypeInvoked is false");
+        Assert.True(myresolver.DeclaredTypeIsNotNull, "myresolver.DeclaredTypeIsNotNull is false");
         Assert.True(input.OnSerializingMethodInvoked, "input.OnSerializingMethodInvoked is false");
         Assert.True(input.OnSerializedMethodInvoked, "input.OnSerializedMethodInvoked is false");
         Assert.True(output.OnDeserializingMethodInvoked, "output.OnDeserializingMethodInvoked is false");

--- a/src/System.Runtime.Serialization.Xml/tests/MyResolver.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/MyResolver.cs
@@ -10,10 +10,12 @@ internal class MyResolver : DataContractResolver
 {
     public bool ResolveNameInvoked = false;
     public bool TryResolveTypeInvoked = false;
+    public bool DeclaredTypeIsNotNull = false;
 
     public override Type ResolveName(string typeName, string typeNamespace, Type declaredType, DataContractResolver knownTypeResolver)
     {
         ResolveNameInvoked = true;
+        DeclaredTypeIsNotNull = declaredType != null;
         return knownTypeResolver.ResolveName(typeName, typeNamespace, declaredType, null);
     }
 


### PR DESCRIPTION
Fixes #32239 
For some reason, `XmlObjectSerializerReadContext.InternalDeserialize()` methods drops `declaredType` parameter which causes the declaredType is always null when override method: `public override Type ResolveName(string typeName, string typeNamespace, Type declaredType, DataContractResolver knownTypeResolver)` Adding it in related methods.
@mconnew @huanwu @Lxiamail 