### PR TITLE
DriveFormat returns null on WSL

### DIFF
--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -16,7 +16,7 @@ namespace System.IO.Tests
         // AppContainer restricts access to DriveFormat (::GetVolumeInformation)
         private static string driveFormat = PlatformDetection.IsInAppContainer ? string.Empty : new DriveInfo(Path.GetTempPath()).DriveFormat;
 
-        protected static bool isHFS => driveFormat == null ? false : driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase);
+        protected static bool isHFS => driveFormat != null && driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase);
         protected static bool isNotHFS => !isHFS;
 
         public abstract T GetExistingItem();

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -16,7 +16,7 @@ namespace System.IO.Tests
         // AppContainer restricts access to DriveFormat (::GetVolumeInformation)
         private static string driveFormat = PlatformDetection.IsInAppContainer ? string.Empty : new DriveInfo(Path.GetTempPath()).DriveFormat;
 
-        protected static bool isHFS => driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase);
+        protected static bool isHFS => driveFormat == null ? false : driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase);
         protected static bool isNotHFS => !isHFS;
 
         public abstract T GetExistingItem();


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/issues/7597

- will create an issue why driveFormat returns null on WSL
- adding default value false if driveFormat is null