### PR TITLE
fix port detection in containers

### DIFF
--- a/src/System.IO.Ports/src/Resources/Strings.resx
+++ b/src/System.IO.Ports/src/Resources/Strings.resx
@@ -151,7 +151,7 @@
     <value>SerialPort does not support encoding '{0}'.  The supported encodings include ASCIIEncoding, UTF8Encoding, UnicodeEncoding, UTF32Encoding, and most single or double byte code pages.  For a complete list please see the documentation.</value>
   </data>
   <data name="Arg_InvalidSerialPort" xml:space="preserve">
-    <value>The given port name does not start with COM/com or does not resolve to a valid serial port.</value>
+    <value>The given port name ({0}) does not resolve to a valid serial port.</value>
   </data>
   <data name="Arg_InvalidSerialPortExtended" xml:space="preserve">
     <value>The given port name is invalid.  It may be a valid port, but not a serial port.</value>

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.Linux.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.Linux.cs
@@ -26,7 +26,11 @@ namespace System.IO.Ports
                 {
                     if (Directory.Exists(sysUsbDir + entry.Name) || File.Exists(entry.FullName + "/device/id"))
                     {
-                        ports.Add("/dev/" + entry.Name);
+                        string deviceName = "/dev/" + entry.Name;
+                        if (File.Exists(deviceName))
+                        {
+                            ports.Add(deviceName);
+                        }
                     }
                 }
 

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -501,7 +501,7 @@ namespace System.IO.Ports
 
             if (portName == null)
             {
-                throw new ArgumentException(SR.Arg_InvalidSerialPort, nameof(portName));
+                throw new ArgumentNullException(nameof(portName));
             }
 
             // Error checking done in SerialPort.
@@ -516,7 +516,7 @@ namespace System.IO.Ports
                 }
                 else
                 {
-                    throw new ArgumentException(SR.Arg_InvalidSerialPortExtended, portName);
+                    throw new ArgumentException(SR.Format(SR.Arg_InvalidSerialPort, portName), nameof(portName));
                 }
             }
 

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -516,7 +516,7 @@ namespace System.IO.Ports
                 }
                 else
                 {
-                    throw new ArgumentException(SR.Arg_InvalidSerialPort, nameof(portName));
+                    throw new ArgumentException(SR.Arg_InvalidSerialPortExtended, portName);
                 }
             }
 

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -590,11 +590,14 @@ namespace System.IO.Ports
         internal SerialStream(string portName, int baudRate, Parity parity, int dataBits, StopBits stopBits, int readTimeout, int writeTimeout, Handshake handshake,
             bool dtrEnable, bool rtsEnable, bool discardNull, byte parityReplace)
         {
-            if ((portName == null) ||
-                !portName.StartsWith("COM", StringComparison.OrdinalIgnoreCase) || 
+            if (portName == null)
+            {
+                 throw new ArgumentNullException(nameof(portName));
+            }
+            else if (!portName.StartsWith("COM", StringComparison.OrdinalIgnoreCase) ||
                 !uint.TryParse(portName.Substring(3), out uint portNumber))
             {
-                throw new ArgumentException(SR.Arg_InvalidSerialPort, nameof(portName));
+                throw new ArgumentException(SR.Format(SR.Arg_InvalidSerialPort, portName), nameof(portName));
             }
 
             // Error checking done in SerialPort.
@@ -612,7 +615,7 @@ namespace System.IO.Ports
 
                 // Allowing FILE_TYPE_UNKNOWN for legitimate serial device such as USB to serial adapter device 
                 if ((fileType != Interop.Kernel32.FileTypes.FILE_TYPE_CHAR) && (fileType != Interop.Kernel32.FileTypes.FILE_TYPE_UNKNOWN))
-                    throw new ArgumentException(SR.Arg_InvalidSerialPort, nameof(portName));
+                    throw new ArgumentException(SR.Format(SR.Arg_InvalidSerialPort, portName), nameof(portName));
 
                 _handle = tempHandle;
 


### PR DESCRIPTION
fixes  #32204

The last failure has nothing to do with Alpine it self. 
However we run Alpine tests in containers and the /sysfs sees ports from host but they are not available in guest. 

This change improves port detection and eliminates unaccessible one. 

I also updated the error message when port cannot be opened:
> System.ArgumentException: The given port name is invalid.  It may be a valid port, but not a serial port.

The extended version does not have references to COM.

We get ENOENT errno so we could possibly make exception more specific but "port name invalid" may be sufficient hint. 
