### PR TITLE
rootfs added

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.MountPoints.FormatInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MountPoints.FormatInfo.cs
@@ -113,6 +113,7 @@ internal static partial class Interop
             ramfs = 0x858458F6,
             reiserfs = 0x52654973,
             romfs = 0x7275,
+            rootfs = 0x53464846,
             rpc_pipefs = 0x67596969,
             samba = 0x517B,
             securityfs = 0x73636673,

--- a/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -84,13 +84,5 @@ namespace System.IO.FileSystem.DriveInfoTests
             var root = new DriveInfo("/");
             Assert.Throws<PlatformNotSupportedException>(() => root.VolumeLabel = root.Name);
         }
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsSubsystemForLinux))]
-        public void DriveFormatOnWsl()
-        {
-            DriveInfo di = new DriveInfo(Path.GetTempPath());
-            Assert.Equal("rootfs", di.DriveFormat);
-            Assert.Equal(DriveType.Ram, di.DriveType);
-        }
     }
 }

--- a/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -84,5 +84,13 @@ namespace System.IO.FileSystem.DriveInfoTests
             var root = new DriveInfo("/");
             Assert.Throws<PlatformNotSupportedException>(() => root.VolumeLabel = root.Name);
         }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsSubsystemForLinux))]
+        public void DriveFormatOnWSl()
+        {
+            DriveInfo di = new DriveInfo(Path.GetTempPath());
+            Assert.Equal("rootfs", di.DriveFormat);
+            Assert.Equal(DriveType.Ram, di.DriveType);
+        }
     }
 }

--- a/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -86,7 +86,7 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsSubsystemForLinux))]
-        public void DriveFormatOnWSl()
+        public void DriveFormatOnWsl()
         {
             DriveInfo di = new DriveInfo(Path.GetTempPath());
             Assert.Equal("rootfs", di.DriveFormat);


### PR DESCRIPTION
df -Th
```
Filesystem     Type   Size  Used Avail Use% Mounted on
rootfs         lxfs   953G  694G  260G  73% /
none           tmpfs  953G  694G  260G  73% /dev
none           tmpfs  953G  694G  260G  73% /run
none           tmpfs  953G  694G  260G  73% /run/lock
none           tmpfs  953G  694G  260G  73% /run/shm
none           tmpfs  953G  694G  260G  73% /run/user
C:             drvfs  953G  694G  260G  73% /mnt/c
D:             drvfs  238G   56G  183G  24% /mnt/d
E:          drvfs  954G   13G  942G   2% /mnt/e
```
cat /etc/fstab
```
LABEL=cloudimg-rootfs   /        ext4   defaults        0 0
```


Currently on WSL the driveformat returns null because enum value 0x53464846 is not found



