### PR TITLE
Fix copy-paste error in xml doc comment

### DIFF
--- a/src/Common/src/CoreLib/System/ValueTuple.cs
+++ b/src/Common/src/CoreLib/System/ValueTuple.cs
@@ -476,7 +476,7 @@ namespace System
         public T1 Item1;
 
         /// <summary>
-        /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// The current <see cref="ValueTuple{T1, T2}"/> instance's second component.
         /// </summary>
         public T2 Item2;
 


### PR DESCRIPTION
I checked over the file. This appears to be the only place where the mistake was made.