### PR TITLE
Optimize IOrderedEnumerable.Take(1)

### DIFF
--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -281,8 +281,13 @@ namespace System.Linq
             return map;
         }
 
-        internal TElement ElementAt(TElement[] elements, int count, int idx) =>
-            elements[QuickSelect(ComputeMap(elements, count), count - 1, idx)];
+        internal TElement ElementAt(TElement[] elements, int count, int idx)
+        {
+            int[] map = ComputeMap(elements, count);
+            return idx == 0 ?
+                elements[Min(map, count)] :
+                elements[QuickSelect(map, count - 1, idx)];
+        }
 
         protected abstract void QuickSort(int[] map, int left, int right);
 
@@ -293,6 +298,8 @@ namespace System.Linq
         // Finds the element that would be at idx if the collection was sorted.
         // Time complexity: O(n) best and average case. O(n^2) worse case.
         protected abstract int QuickSelect(int[] map, int right, int idx);
+
+        protected abstract int Min(int[] map, int count);
     }
 
     internal sealed class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
@@ -488,6 +495,19 @@ namespace System.Linq
             while (left < right);
 
             return map[idx];
+        }
+
+        protected override int Min(int[] map, int count)
+        {
+            int index = 0;
+            for (int i = 1; i < count; i++)
+            {
+                if (CompareKeys(map[i], map[index]) < 0)
+                {
+                    index = i;
+                }
+            }
+            return map[index];
         }
     }
 }

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -422,5 +422,24 @@ namespace System.Linq.Tests
             Array.Sort(randomized);
             Assert.Equal(randomized, ordered);
         }
+
+        [Theory]
+        [InlineData(new[] { 1 })]
+        [InlineData(new[] { 1, 2 })]
+        [InlineData(new[] { 2, 1 })]
+        [InlineData(new[] { 1, 2, 3, 4, 5 })]
+        [InlineData(new[] { 5, 4, 3, 2, 1 })]
+        [InlineData(new[] { 4, 3, 2, 1, 5, 9, 8, 7, 6 })]
+        [InlineData(new[] { 2, 4, 6, 8, 10, 5, 3, 7, 1, 9 })]
+        public void TakeOne(IEnumerable<int> source)
+        {
+            int count = 0;
+            foreach (int x in source.OrderBy(i => i).Take(1))
+            {
+                count++;
+                Assert.Equal(source.Min(), x);
+            }
+            Assert.Equal(1, count);
+        }
     }
 }

--- a/src/System.Linq/tests/Performance/Perf.Linq.cs
+++ b/src/System.Linq/tests/Performance/Perf.Linq.cs
@@ -42,6 +42,35 @@ namespace System.Linq.Tests
                     yield return new object[] { size, iteration };
         }
 
+        private static int[] QuickSortWorstCase(int n)
+        {
+            int OddPos(int k)
+            {
+                int s = k;
+                while (s * 2 < n)
+                    s *= 2;
+                return (n - 1) % s + 1;
+            }
+
+            int[] a = new int[n];
+            for (int x = 1; x <= n; x++)
+            {
+                if (x % 2 == 0)
+                {
+                    a[x / 2 - 1] = x;
+                }
+                else if (x == n)
+                {
+                    a[n / 2] = x;
+                }
+                else
+                {
+                    a[n - OddPos(x)] = x;
+                }
+            }
+            return a;
+        }
+
         private class BaseClass
         {
             public int Value;
@@ -229,6 +258,12 @@ namespace System.Linq.Tests
                     }
                 }
             }
+        }
+
+        [Benchmark]
+        public void OrderBy_TakeOne()
+        {
+            Perf_LinqTestBase.MeasureIteration(QuickSortWorstCase(10000).OrderBy(i => i).Take(1), 10);
         }
 
         #endregion


### PR DESCRIPTION
Calls like `array.OrderBy(x => x).Take(1)` use `EnumerableSorter.ElementAt` that invokes `QuickSelect`. `Take(1)` is just the Minimum for `OrderedEnumerable` and can implemented more efficiently. The Minimum-based implementation has a big impact on the worst case time complexity: now it's `O(N)` instead of `O(N^2)`.

The performance test results:

```
Before:

| Metric   | Unit | Iterations |  Average | STDEV.S |      Min |      Max
|:-------- |:----:|:----------:| --------:| -------:| --------:| --------:
| Duration | msec |     2      | 8913.304 |  69.896 | 8863.880 | 8962.728

After:

| Metric   | Unit | Iterations | Average | STDEV.S |   Min |   Max
|:-------- |:----:|:----------:| -------:| -------:| -----:| -----:
| Duration | msec |    1000    |   2.765 |   0.330 | 2.555 | 6.162
```

The BenchmarkDotNet-based benchmark:

```cs
public enum Pattern
{
    QsWorst, // 2 4 6 8 10 5 3 7 1 9 (Worst QuickSort case)
    Equal, // 0 0 0 0 0 0 0 0 0 0
    Sorted, //  0 1 2 3 4 5 6 7 8 9
    Reversed, // 10 9 8 7 6 5 4 3 2 1
    Shuffled
}

public static class PatternGenerator
{
    private static int OddPos(int n, int k)
    {
        var s = k;
        while (s * 2 < n)
            s *= 2;
        return (n - 1) % s + 1;
    }

    private static int[] QsWorst(int n)
    {
        var a = new int[n];
        for (int x = 1; x <= n; x++)
        {
            if (x % 2 == 0)
                a[x / 2 - 1] = x;
            else if (x == n)
                a[n / 2] = x;
            else
                a[n - OddPos(n, x)] = x;
        }

        return a;
    }

    public static int[] Generate(int n, Pattern pattern)
    {
        switch (pattern)
        {
            case Pattern.QsWorst:
                return QsWorst(n);
            case Pattern.Equal:
                return Enumerable.Range(0, n).Select(x => 0).ToArray();
            case Pattern.Sorted:
                return Enumerable.Range(0, n).Select(x => x).ToArray();
            case Pattern.Reversed:
                return Enumerable.Range(0, n).Select(x => n - x).ToArray();
            case Pattern.Shuffled:
            {
                var rnd = new Random(42);
                return Enumerable.Range(0, n).Select(x => rnd.Next()).ToArray();
            }
            default:
                throw new ArgumentOutOfRangeException(nameof(pattern), pattern, null);
        }
    }
}


public class TakeBenchmark
{
    private int[] array;

    [Params(1000, 10000)] public int N;

    [Params(Pattern.QsWorst, Pattern.Equal, Pattern.Sorted,
            Pattern.Reversed, Pattern.Shuffled)]
    public Pattern Case;

    [GlobalSetup]
    public void Setup() => array = PatternGenerator.Generate(N, Case);

    [Benchmark(Description = "Take(1)")]
    public int Take()
    {
        var sum = 0;
        foreach (var x in array.OrderBy(x => x).Take(1))
            sum += x;
        return sum;
    }
}

class Program
{
    static void Main() => BenchmarkRunner.Run<TakeBenchmark>();
}
```

Before:

|     N |     Case |          Mean |          Error |        StdDev |
|------ |--------- |--------------:|---------------:|--------------:|
|  1000 |    Equal |      42.16 us |      0.4111 us |     0.1068 us |
|  1000 |  QsWorst |   8,853.04 us |    326.7693 us |    84.8771 us |
|  1000 | Reversed |      44.25 us |      2.2270 us |     0.5785 us |
|  1000 | Shuffled |      41.48 us |      0.2996 us |     0.0778 us |
|  1000 |   Sorted |      41.43 us |      0.4115 us |     0.1069 us |
| 10000 |    Equal |     415.93 us |      3.6485 us |     0.9477 us |
| 10000 |  QsWorst | 876,433.01 us | 19,096.6708 us | 4,960.2892 us |
| 10000 | Reversed |     441.04 us |     11.7266 us |     3.0459 us |
| 10000 | Shuffled |     298.97 us |      5.9536 us |     1.5464 us |
| 10000 |   Sorted |     412.12 us |      3.3257 us |     0.8638 us |

After:

|     N |     Case |      Mean |      Error |    StdDev |
|------ |--------- |----------:|-----------:|----------:|
|  1000 |    Equal |  25.50 us |  3.5458 us | 0.9210 us |
|  1000 |  QsWorst |  25.94 us |  2.1703 us | 0.5637 us |
|  1000 | Reversed |  25.54 us |  0.9774 us | 0.2539 us |
|  1000 | Shuffled |  24.39 us |  0.6551 us | 0.1702 us |
|  1000 |   Sorted |  24.23 us |  0.4637 us | 0.1205 us |
| 10000 |    Equal | 250.48 us | 18.0682 us | 4.6931 us |
| 10000 |  QsWorst | 244.50 us |  1.8494 us | 0.4804 us |
| 10000 | Reversed | 250.53 us | 30.2642 us | 7.8610 us |
| 10000 | Shuffled | 243.64 us | 16.0393 us | 4.1662 us |
| 10000 |   Sorted | 241.09 us |  2.6659 us | 0.6925 us |