### PR TITLE
Reduce memory allocations on read performance counters.

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.RegConnectRegistry.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.RegConnectRegistry.cs
@@ -2,9 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
+
+#if REGISTRY_ASSEMBLY
+using Microsoft.Win32.SafeHandles;
+#else
+using Internal.Win32.SafeHandles;
+#endif
 
 internal partial class Interop
 {

--- a/src/System.Diagnostics.PerformanceCounter/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.PerformanceCounter/src/Resources/Strings.resx
@@ -339,4 +339,16 @@
   <data name="Perflib_InvalidOperation_CounterRefValue" xml:space="preserve">
     <value>Cannot locate raw counter data location for CounterSet '{0}', Counter '{1}, in Instance '{2}'.</value>
   </data>
+  <data name="Arg_DllInitFailure" xml:space="preserve">
+    <value>One machine (either '{0}' or local) may not have remote administration enabled, or both machines may not be running the remote registry service.</value>
+  </data>
+  <data name="Arg_RegKeyNoRemoteConnect" xml:space="preserve">
+    <value>No remote connection to '{0}' while trying to read the registry.</value>
+  </data>
+  <data name="ObjectDisposed_CategorySampleClosed" xml:space="preserve">
+    <value>Cannot access a closed category sample.</value>
+  </data>
+  <data name="UnauthorizedAccess_RegistryKeyGeneric_Key" xml:space="preserve">
+    <value>Access to the registry key '{0}' is denied.</value>
+  </data>
 </root>

--- a/src/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -30,6 +30,7 @@
     <Compile Include="System\Diagnostics\PerformanceCounterLib.cs" />
     <Compile Include="System\Diagnostics\PerformanceCounterManager.cs" />
     <Compile Include="System\Diagnostics\PerformanceCounterType.cs" />
+    <Compile Include="System\Diagnostics\PerformanceDataRegistryKey.cs" />
     <Compile Include="System\Diagnostics\SharedPerformanceCounter.cs" />
     <Compile Include="System\Diagnostics\SystemDiagnosticsSection.cs" />
     <Compile Include="System\Diagnostics\TraceInternal.cs" />
@@ -52,6 +53,18 @@
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FormatMessage.cs">
+      <Link>Common\CoreLib\Interop\Windows\Interop.FormatMessage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.RegConnectRegistry.cs">
+      <Link>Common\Interop\Windows\advapi32\Interop.RegConnectRegistry.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\advapi32\Interop.RegCloseKey.cs">
+      <Link>Common\CoreLib\Interop\Windows\Interop.RegCloseKey.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\advapi32\Interop.RegQueryValueEx.cs">
+      <Link>Common\CoreLib\Interop\Windows\advapi32\Interop.RegQueryValueEx.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.GetTokenInformation.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.GetTokenInformation.cs</Link>
     </Compile>
@@ -60,6 +73,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.ProcessOptions.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.ProcessOptions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.TOKEN_INFORMATION_CLASS.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.TOKEN_INFORMATION_CLASS.cs</Link>
@@ -163,6 +182,7 @@
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true'">
     <Reference Include="Microsoft.Win32.Registry" />
     <Reference Include="Microsoft.Win32.Primitives" />
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.ComponentModel.Primitives" />

--- a/src/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -44,6 +44,21 @@
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Interop.BOOL.cs">
       <Link>Common\CoreLib\Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FormatMessage.cs">
+      <Link>Common\CoreLib\Interop\Windows\Interop.FormatMessage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\advapi32\Interop.RegCloseKey.cs">
+      <Link>Common\CoreLib\Interop\Windows\Interop.RegCloseKey.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\advapi32\Interop.RegQueryValueEx.cs">
+      <Link>Common\CoreLib\Interop\Windows\advapi32\Interop.RegQueryValueEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
@@ -52,18 +67,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FormatMessage.cs">
-      <Link>Common\CoreLib\Interop\Windows\Interop.FormatMessage.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.RegConnectRegistry.cs">
-      <Link>Common\Interop\Windows\advapi32\Interop.RegConnectRegistry.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\advapi32\Interop.RegCloseKey.cs">
-      <Link>Common\CoreLib\Interop\Windows\Interop.RegCloseKey.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\advapi32\Interop.RegQueryValueEx.cs">
-      <Link>Common\CoreLib\Interop\Windows\advapi32\Interop.RegQueryValueEx.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.GetTokenInformation.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.GetTokenInformation.cs</Link>
@@ -74,11 +77,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.ProcessOptions.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.ProcessOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs">
-      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs">
-      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.RegConnectRegistry.cs">
+      <Link>Common\Interop\Windows\advapi32\Interop.RegConnectRegistry.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.TOKEN_INFORMATION_CLASS.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.TOKEN_INFORMATION_CLASS.cs</Link>

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounter.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounter.cs
@@ -211,9 +211,11 @@ namespace System.Diagnostics
                     // This is the same thing that NextSample does, except that it doesn't try to get the actual counter
                     // value.  If we wanted the counter value, we would need to have an instance name. 
                     Initialize();
-                    CategorySample categorySample = PerformanceCounterLib.GetCategorySample(currentMachineName, currentCategoryName);
-                    CounterDefinitionSample counterSample = categorySample.GetCounterDefinitionSample(_counterName);
-                    _counterType = counterSample._counterType;
+                    using (CategorySample categorySample = PerformanceCounterLib.GetCategorySample(currentMachineName, currentCategoryName))
+                    {
+                        CounterDefinitionSample counterSample = categorySample.GetCounterDefinitionSample(_counterName);
+                        _counterType = counterSample._counterType;
+                    }
                 }
 
                 return (PerformanceCounterType)_counterType;
@@ -542,22 +544,26 @@ namespace System.Diagnostics
             string currentMachineName = _machineName;
 
             Initialize();
-            CategorySample categorySample = PerformanceCounterLib.GetCategorySample(currentMachineName, currentCategoryName);
-            CounterDefinitionSample counterSample = categorySample.GetCounterDefinitionSample(_counterName);
-            _counterType = counterSample._counterType;
-            if (!categorySample._isMultiInstance)
-            {
-                if (_instanceName != null && _instanceName.Length != 0)
-                    throw new InvalidOperationException(SR.Format(SR.InstanceNameProhibited, _instanceName));
 
-                return counterSample.GetSingleValue();
-            }
-            else
-            {
-                if (_instanceName == null || _instanceName.Length == 0)
-                    throw new InvalidOperationException(SR.Format(SR.InstanceNameRequired));
 
-                return counterSample.GetInstanceValue(_instanceName);
+            using (CategorySample categorySample = PerformanceCounterLib.GetCategorySample(currentMachineName, currentCategoryName))
+            {
+                CounterDefinitionSample counterSample = categorySample.GetCounterDefinitionSample(_counterName);
+                _counterType = counterSample._counterType;
+                if (!categorySample._isMultiInstance)
+                {
+                    if (_instanceName != null && _instanceName.Length != 0)
+                        throw new InvalidOperationException(SR.Format(SR.InstanceNameProhibited, _instanceName));
+
+                    return counterSample.GetSingleValue();
+                }
+                else
+                {
+                    if (_instanceName == null || _instanceName.Length == 0)
+                        throw new InvalidOperationException(SR.Format(SR.InstanceNameRequired));
+
+                    return counterSample.GetInstanceValue(_instanceName);
+                }
             }
         }
 

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
@@ -105,19 +105,21 @@ namespace System.Diagnostics
         {
             get
             {
-                CategorySample categorySample = PerformanceCounterLib.GetCategorySample(_machineName, _categoryName);
-
-                // If we get MultiInstance, we can be confident it is correct.  If it is single instance, though
-                // we need to check if is a custom category and if the IsMultiInstance value is set in the registry.
-                // If not we return Unknown
-                if (categorySample._isMultiInstance)
-                    return PerformanceCounterCategoryType.MultiInstance;
-                else
+                using (CategorySample categorySample = PerformanceCounterLib.GetCategorySample(_machineName, _categoryName))
                 {
-                    if (PerformanceCounterLib.IsCustomCategory(".", _categoryName))
-                        return PerformanceCounterLib.GetCategoryType(".", _categoryName);
+
+                    // If we get MultiInstance, we can be confident it is correct.  If it is single instance, though
+                    // we need to check if is a custom category and if the IsMultiInstance value is set in the registry.
+                    // If not we return Unknown
+                    if (categorySample._isMultiInstance)
+                        return PerformanceCounterCategoryType.MultiInstance;
                     else
-                        return PerformanceCounterCategoryType.SingleInstance;
+                    {
+                        if (PerformanceCounterLib.IsCustomCategory(".", _categoryName))
+                            return PerformanceCounterLib.GetCategoryType(".", _categoryName);
+                        else
+                            return PerformanceCounterCategoryType.SingleInstance;
+                    }
                 }
             }
         }
@@ -440,16 +442,18 @@ namespace System.Diagnostics
         /// <internalonly/>
         internal static string[] GetCounterInstances(string categoryName, string machineName)
         {
-            CategorySample categorySample = PerformanceCounterLib.GetCategorySample(machineName, categoryName);
-            if (categorySample._instanceNameTable.Count == 0)
-                return Array.Empty<string>();
+            using (CategorySample categorySample = PerformanceCounterLib.GetCategorySample(machineName, categoryName))
+            {
+                if (categorySample._instanceNameTable.Count == 0)
+                    return Array.Empty<string>();
 
-            string[] instanceNames = new string[categorySample._instanceNameTable.Count];
-            categorySample._instanceNameTable.Keys.CopyTo(instanceNames, 0);
-            if (instanceNames.Length == 1 && instanceNames[0] == PerformanceCounterLib.SingleInstanceName)
-                return Array.Empty<string>();
+                string[] instanceNames = new string[categorySample._instanceNameTable.Count];
+                categorySample._instanceNameTable.Keys.CopyTo(instanceNames, 0);
+                if (instanceNames.Length == 1 && instanceNames[0] == PerformanceCounterLib.SingleInstanceName)
+                    return Array.Empty<string>();
 
-            return instanceNames;
+                return instanceNames;
+            }
         }
 
         /// <summary>
@@ -531,8 +535,10 @@ namespace System.Diagnostics
             if (_categoryName == null)
                 throw new InvalidOperationException(SR.Format(SR.CategoryNameNotSet));
 
-            CategorySample categorySample = PerformanceCounterLib.GetCategorySample(_machineName, _categoryName);
-            return categorySample._instanceNameTable.ContainsKey(instanceName);
+            using (CategorySample categorySample = PerformanceCounterLib.GetCategorySample(_machineName, _categoryName))
+            {
+                return categorySample._instanceNameTable.ContainsKey(instanceName);
+            }
         }
 
         /// <summary>
@@ -573,8 +579,10 @@ namespace System.Diagnostics
             if (_categoryName == null)
                 throw new InvalidOperationException(SR.Format(SR.CategoryNameNotSet));
 
-            CategorySample categorySample = PerformanceCounterLib.GetCategorySample(_machineName, _categoryName);
-            return categorySample.ReadCategory();
+            using (CategorySample categorySample = PerformanceCounterLib.GetCategorySample(_machineName, _categoryName))
+            {
+                return categorySample.ReadCategory();
+            }
         }
     }
 

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -1374,7 +1374,7 @@ namespace System.Diagnostics
 
         internal void ReleaseData(byte[] data)
         {
-            perfDataKey.ReleaseBlob(data);
+            perfDataKey.ReleaseData(data);
         }
 
     }
@@ -1395,7 +1395,7 @@ namespace System.Diagnostics
         }
     }
 
-    internal class CategorySample : IDisposable
+    internal sealed class CategorySample : IDisposable
     {
         internal readonly long _systemFrequency;
         internal readonly long _timeStamp;

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Globalization;
 using System.Security;
@@ -835,7 +836,7 @@ namespace System.Diagnostics
                 return null;
 
             CategorySample sample = null;
-            byte[] dataRef = GetPerformanceData(entry.NameIndex.ToString(CultureInfo.InvariantCulture));
+            byte[] dataRef = GetPerformanceData(entry.NameIndex.ToString(CultureInfo.InvariantCulture), usePool: true);
             if (dataRef == null)
                 throw new InvalidOperationException(SR.Format(SR.CantReadCategory, category));
 
@@ -1012,7 +1013,7 @@ namespace System.Diagnostics
             }
         }
 
-        internal byte[] GetPerformanceData(string item)
+        internal byte[] GetPerformanceData(string item, bool usePool = false)
         {
             if (_performanceMonitor == null)
             {
@@ -1023,7 +1024,12 @@ namespace System.Diagnostics
                 }
             }
 
-            return _performanceMonitor.GetData(item);
+            return _performanceMonitor.GetData(item, usePool);
+        }
+
+        internal void ReleasePerformanceData(byte[] data)
+        {
+            _performanceMonitor.ReleaseData(data);
         }
 
         private Hashtable GetStringTable(bool isHelp)
@@ -1262,7 +1268,7 @@ namespace System.Diagnostics
 
     internal class PerformanceMonitor
     {
-        private RegistryKey perfDataKey = null;
+        private PerformanceDataRegistryKey perfDataKey = null;
         private string machineName;
 
         internal PerformanceMonitor(string machineName)
@@ -1277,10 +1283,10 @@ namespace System.Diagnostics
             {
                 if (machineName != "." && !string.Equals(machineName, PerformanceCounterLib.ComputerName, StringComparison.OrdinalIgnoreCase))
                 {
-                    perfDataKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.PerformanceData, machineName);
+                    perfDataKey = PerformanceDataRegistryKey.OpenRemoteBaseKey(machineName);
                 }
                 else
-                    perfDataKey = Registry.PerformanceData;
+                    perfDataKey = PerformanceDataRegistryKey.OpenLocal();
             }
             catch (UnauthorizedAccessException)
             {
@@ -1311,7 +1317,7 @@ namespace System.Diagnostics
         // we wait may not be sufficient if the Win32 code keeps running into this deadlock again 
         // and again. A condition very rare but possible in theory. We would get back to the user 
         // in this case with InvalidOperationException after the wait time expires.
-        internal byte[] GetData(string item)
+        internal byte[] GetData(string item, bool usePool)
         {
             int waitRetries = 17;   //2^16*10ms == approximately 10mins
             int waitSleep = 0;
@@ -1323,7 +1329,7 @@ namespace System.Diagnostics
             {
                 try
                 {
-                    data = (byte[])perfDataKey.GetValue(item);
+                    data = perfDataKey.GetValue(item, usePool);
                     return data;
                 }
                 catch (IOException e)
@@ -1366,6 +1372,11 @@ namespace System.Diagnostics
             throw new Win32Exception(error);
         }
 
+        internal void ReleaseData(byte[] data)
+        {
+            perfDataKey.ReleaseBlob(data);
+        }
+
     }
 
     internal class CategoryEntry
@@ -1384,7 +1395,7 @@ namespace System.Diagnostics
         }
     }
 
-    internal class CategorySample
+    internal class CategorySample : IDisposable
     {
         internal readonly long _systemFrequency;
         internal readonly long _timeStamp;
@@ -1396,9 +1407,13 @@ namespace System.Diagnostics
         internal bool _isMultiInstance;
         private CategoryEntry _entry;
         private PerformanceCounterLib _library;
+        private bool _disposed;
+        private byte[] _data;
 
-        internal CategorySample(ReadOnlySpan<byte> data, CategoryEntry entry, PerformanceCounterLib library)
+        internal CategorySample(byte[] rawData, CategoryEntry entry, PerformanceCounterLib library)
         {
+            _data = rawData;
+            ReadOnlySpan<byte> data = rawData;
             _entry = entry;
             _library = library;
             int categoryIndex = entry.NameIndex;
@@ -1531,6 +1546,8 @@ namespace System.Diagnostics
 
         internal string[] GetInstanceNamesFromIndex(int categoryIndex)
         {
+            CheckDisposed();
+
             ReadOnlySpan<byte> data = _library.GetPerformanceData(categoryIndex.ToString(CultureInfo.InvariantCulture));
 
             ref readonly PERF_DATA_BLOCK dataBlock = ref MemoryMarshal.AsRef<PERF_DATA_BLOCK>(data);
@@ -1584,6 +1601,8 @@ namespace System.Diagnostics
 
         internal CounterDefinitionSample GetCounterDefinitionSample(string counter)
         {
+            CheckDisposed();
+
             for (int index = 0; index < _entry.CounterIndexes.Length; ++index)
             {
                 int counterIndex = _entry.CounterIndexes[index];
@@ -1635,6 +1654,26 @@ namespace System.Diagnostics
             }
 
             return data;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            _library.ReleasePerformanceData(_data);
+        }
+
+        private void CheckDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(SR.ObjectDisposed_CategorySampleClosed, nameof(CategorySample));
+            }
         }
     }
 

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Buffers;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
@@ -9,10 +9,6 @@ using System.Runtime.InteropServices;
 using Microsoft.Win32;
 using Internal.Win32.SafeHandles;
 
-#if !netcoreapp
-using MemoryMarshal = System.Diagnostics.PerformanceCounterLib;
-#endif
-
 namespace System.Diagnostics
 {
     internal sealed class PerformanceDataRegistryKey : IDisposable

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
@@ -103,11 +103,6 @@ namespace System.Diagnostics
         {
             if (usePool)
             {
-#if DEBUG
-                // Fill array by garbage to detect early situations when this array is used after return
-                MemoryMarshal.Cast<byte, uint>(data.AsSpan()).Fill(0xBAADF00D);
-#endif
-
                 ArrayPool<byte>.Shared.Return(data);
             }
         }
@@ -119,10 +114,7 @@ namespace System.Diagnostics
 
         public void Dispose()
         {
-            if (!_hkey.IsInvalid)
-            {
-                _hkey.Dispose();
-            }
+            _hkey.Dispose();
         }
 
         private byte[] CreateBlob(int size, in bool usePool)

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
@@ -1,0 +1,119 @@
+﻿using System.Buffers;
+using System.IO;
+using Microsoft.Win32;
+using Internal.Win32.SafeHandles;
+
+namespace System.Diagnostics
+{
+    internal class PerformanceDataRegistryKey
+    {
+        private readonly SafeRegistryHandle _hkey;
+
+        private const int PerformanceData = (int)RegistryHive.PerformanceData;
+
+        private PerformanceDataRegistryKey(SafeRegistryHandle hkey)
+        {
+            _hkey = hkey;
+        }
+
+        public static PerformanceDataRegistryKey OpenRemoteBaseKey(string machineName)
+        {
+            // connect to the specified remote registry
+            SafeRegistryHandle foreignHKey = null;
+            int ret = Interop.Advapi32.RegConnectRegistry(machineName, new SafeRegistryHandle(new IntPtr(PerformanceData), false), out foreignHKey);
+
+            if (ret == Interop.Errors.ERROR_DLL_INIT_FAILED)
+            {
+                // return value indicates an error occurred
+                throw new ArgumentException(SR.Format(SR.Arg_DllInitFailure, machineName));
+            }
+
+            if (ret != 0)
+            {
+                Win32Error(ret, null);
+            }
+
+            if (foreignHKey.IsInvalid)
+            {
+                // return value indicates an error occurred
+                throw new ArgumentException(SR.Format(SR.Arg_RegKeyNoRemoteConnect, machineName));
+            }
+
+            return new PerformanceDataRegistryKey(foreignHKey);
+        }
+
+        public static PerformanceDataRegistryKey OpenLocal()
+        {
+            var key = new SafeRegistryHandle(new IntPtr(PerformanceData), true);
+            return new PerformanceDataRegistryKey(key);
+        }
+
+        public byte[] GetValue(string name, bool usePool)
+        {
+            int size = 65000;
+            int sizeInput = size;
+
+            int ret;
+            int type = 0;
+            byte[] blob = CreateBlob(size, usePool);
+            while (Interop.Errors.ERROR_MORE_DATA == (ret = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref sizeInput)))
+            {
+                if (size == int.MaxValue)
+                {
+                    // ERROR_MORE_DATA was returned however we cannot increase the buffer size beyond Int32.MaxValue
+                    Win32Error(ret, name);
+                }
+                else if (size > (int.MaxValue / 2))
+                {
+                    // at this point in the loop "size * 2" would cause an overflow
+                    size = int.MaxValue;
+                }
+                else
+                {
+                    size *= 2;
+                }
+                sizeInput = size;
+
+                ReleaseBlob(blob, usePool);
+                blob = CreateBlob(size, usePool);
+            }
+
+            if (ret != 0)
+            {
+                Win32Error(ret, name);
+            }
+
+            return blob;
+        }
+
+        public void ReleaseBlob(byte[] blob, bool usePool = true)
+        {
+            if (usePool)
+            {
+                ArrayPool<byte>.Shared.Return(blob);
+            }
+        }
+
+        private byte[] CreateBlob(int size, in bool usePool)
+        {
+            return usePool
+                ? ArrayPool<byte>.Shared.Rent(size)
+                : new byte[size];
+        }
+
+        private static void Win32Error(in int errorCode, string name)
+        {
+            if (errorCode == Interop.Errors.ERROR_ACCESS_DENIED)
+            {
+                throw new UnauthorizedAccessException(SR.Format(SR.UnauthorizedAccess_RegistryKeyGeneric_Key, name));
+            }
+
+            throw new IOException(Interop.Kernel32.GetMessage(errorCode), errorCode);
+        }
+
+        public void Close()
+        {
+            Interop.Advapi32.RegCloseKey(new IntPtr(PerformanceData));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #31639 

I've created own internal wrapper to read data from registry (simplified copy from `Microsoft.Win32.Registry`). 

This wrapper is used to read performance data to `byte[]` rented from `ArrayPool`. 

For correctly release the byte array `CategorySample` (internal) class is now `IDisposable`.