### PR TITLE
Load execution assembly for System.ServiceModel.Primitives.dll instead of reference assembly in Sgen

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -565,9 +565,14 @@ namespace Microsoft.XmlSerializer.Generator
                     return null;
                 }
 
-                if(s_referencedic.ContainsKey(assemblyname))
+                if (s_referencedic.ContainsKey(assemblyname))
                 {
                     string reference = s_referencedic[assemblyname];
+
+                    //for System.ServiceModel.Primitives, we need to load its execution assembly rather than reference assembly
+                    if (assemblyname.Equals("System.ServiceModel.Primitives"))
+                        reference = reference.Replace("ref", "lib");
+
                     if (!string.IsNullOrEmpty(reference))
                     {
                         if (File.Exists(reference))


### PR DESCRIPTION
Fixes #32017
@mconnew @huanwu @Lxiamail 