### PR TITLE
Add ChunkBy extension for LINQ

### DIFF
--- a/src/System.Linq/ref/System.Linq.cs
+++ b/src/System.Linq/ref/System.Linq.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Linq
 {
     public static partial class Enumerable
@@ -39,6 +38,7 @@ namespace System.Linq
         public static System.Nullable<float> Average<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, System.Nullable<float>> selector) { throw null; }
         public static float Average<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, float> selector) { throw null; }
         public static System.Collections.Generic.IEnumerable<TResult> Cast<TResult>(this System.Collections.IEnumerable source) { throw null; }
+        public static System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>> ChunkBy<TSource>( this System.Collections.Generic.IEnumerable<TSource> source, int count) { throw null; }
         public static System.Collections.Generic.IEnumerable<TSource> Concat<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second) { throw null; }
         public static bool Contains<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource value) { throw null; }
         public static bool Contains<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource value, System.Collections.Generic.IEqualityComparer<TSource> comparer) { throw null; }
@@ -192,6 +192,7 @@ namespace System.Linq
         public static System.Collections.Generic.IEnumerable<TSource> Where<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, int, bool> predicate) { throw null; }
         public static System.Collections.Generic.IEnumerable<TResult> Zip<TFirst, TSecond, TResult>(this System.Collections.Generic.IEnumerable<TFirst> first, System.Collections.Generic.IEnumerable<TSecond> second, System.Func<TFirst, TSecond, TResult> resultSelector) { throw null; }
     }
+
     public partial interface IGrouping<out TKey, out TElement> : System.Collections.Generic.IEnumerable<TElement>, System.Collections.IEnumerable
     {
         TKey Key { get; }

--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -6,6 +6,9 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Linq\ChunkBy.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <ContractProject Include="..\ref\System.Linq.csproj">
       <TargetGroup>netcoreapp</TargetGroup>
     </ContractProject>

--- a/src/System.Linq/src/System/Linq/ChunkBy.cs
+++ b/src/System.Linq/src/System/Linq/ChunkBy.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System.Linq
+{
+    public static partial class Enumerable
+    {
+        /// <summary>
+        /// Chunks the elements of a sequence according to a amount and creates a result value from each group and its max capacity.
+        /// </summary>
+        /// <param name="source">An <see cref="IEnumerable{T}"/> whose elements to chunk.</param>
+        /// <param name="size">The max capacity for each chunk.</param>
+        /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
+        /// <returns>An <see cref="IEnumerable{T}"/> with chunks.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentException">When <paramref name="size"/> is below 1.</exception>
+        public static IEnumerable<IEnumerable<TSource>> ChunkBy<TSource>(this IEnumerable<TSource> source, int size)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (size < 1)
+            {
+                throw new ArgumentException($"Parameter: '{nameof(size)}' ({size}) can not be below 1.");
+            }
+
+            return CreateChunks(source, size);
+        }
+
+        private static IEnumerable<IEnumerable<TSource>> CreateChunks<TSource>(IEnumerable<TSource> source, int size)
+        {
+            var index = 0;
+            var elements = new TSource[size];
+            var count = 0;
+
+            foreach (TSource element in source)
+            {
+                elements[count] = element;
+                checked
+                {
+                    index++;
+                }
+
+                count = index % size;
+                if (count == 0)
+                {
+                    yield return elements;
+                    elements = new TSource[size];
+                }
+            }
+
+            // Avoids returning empty chunks.
+            if (count > 0)
+            {
+                yield return new ArraySegment<TSource>(elements, 0, count);
+            }
+        }
+    }
+}

--- a/src/System.Linq/tests/ChunkBy.cs
+++ b/src/System.Linq/tests/ChunkBy.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public class ChunkBy
+    {
+        [Fact]
+        public void Transform_Enumerable_Of_10_Into_Chunks_With_Size_3()
+        {
+            const int chunkSize = 3;
+            IEnumerable<IEnumerable<int>> arr = Enumerable.Range(0, 10).ChunkBy(chunkSize);
+
+            IEnumerable<IEnumerable<int>> expected = new[]
+            {
+                new[] {0, 1, 2},
+                new[] {3, 4, 5},
+                new[] {6, 7, 8},
+                new[] {9},
+            };
+            Assert.Equal(expected, arr);
+        }
+
+        [Fact]
+        public void Transform_Enumerable_Of_10_Into_Chunks_With_Size_10()
+        {
+            const int chunkSize = 10;
+            IEnumerable<IEnumerable<int>> arr = Enumerable.Range(0, 100).ChunkBy(chunkSize);
+
+            IEnumerable<int>[] expected =
+            {
+                Enumerable.Range(0, 10),
+                Enumerable.Range(10, 10),
+                Enumerable.Range(20, 10),
+                Enumerable.Range(30, 10),
+                Enumerable.Range(40, 10),
+                Enumerable.Range(50, 10),
+                Enumerable.Range(60, 10),
+                Enumerable.Range(70, 10),
+                Enumerable.Range(80, 10),
+                Enumerable.Range(90, 10),
+            };
+            Assert.Equal(expected, arr);
+        }
+
+        [Fact]
+        public void Transform_Enumerable_Of_100_Into_Chunks_With_Size_Eleven()
+        {
+            const int chunkSize = 11;
+            IEnumerable<IEnumerable<int>> arr = Enumerable.Range(0, 100).ChunkBy(chunkSize);
+
+            IEnumerable<int>[] expected =
+            {
+                Enumerable.Range(0, 11),
+                Enumerable.Range(11, 11),
+                Enumerable.Range(22, 11),
+                Enumerable.Range(33, 11),
+                Enumerable.Range(44, 11),
+                Enumerable.Range(55, 11),
+                Enumerable.Range(66, 11),
+                Enumerable.Range(77, 11),
+                Enumerable.Range(88, 11),
+                Enumerable.Range(99, 1),
+            };
+            Assert.Equal(expected, arr);
+        }
+
+        [Fact]
+        public void Supplying_Negative_Size_Throws_ArgumentException() => Assert.Throws<ArgumentException>(
+            () => Enumerable.Range(0, 10).ChunkBy(-1));
+
+        [Fact]
+        public void Supplying_Null_Enumerable_Throws_ArgumentNullException()
+        {
+            IEnumerable<int> enumerable = null;
+            Assert.Throws<ArgumentNullException>("source", () => enumerable.ChunkBy(4));
+        }
+    }
+}

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="AsEnumerableTests.cs" />
     <Compile Include="AverageTests.cs" />
     <Compile Include="CastTests.cs" />
+    <Compile Include="ChunkBy.cs" />
     <Compile Include="ConcatTests.cs" />
     <Compile Include="ConsistencyTests.cs" />
     <Compile Include="ContainsTests.cs" />


### PR DESCRIPTION
Add `IEnumerable<T>` extension for creating sub-sequences.
