### PR TITLE
[WIP] System.Json JsonPrimitive 

### DIFF
--- a/src/System.Json/tests/JsonPrimitiveTests.cs
+++ b/src/System.Json/tests/JsonPrimitiveTests.cs
@@ -41,6 +41,34 @@ namespace System.Json.Tests
             ToString(new JsonPrimitive(value), expected);
         }
 
+        [Theory]
+        [InlineData("00000000-0000-0000-0000-000000000000", "\"00000000-0000-0000-0000-000000000000\"")]
+        public void ToString_Guid(string value, string expected)
+        {
+            ToString(new JsonPrimitive(Guid.Parse(value)), expected);
+        }
+
+        [Theory]
+        [InlineData("1/1/0001 12:00:00 AM +00:00", "\"1/1/0001 12:00:00 AM +00:00\"")]
+        public void ToString_DateTimeOffset(string value, string expected)
+        {
+            ToString(new JsonPrimitive(DateTimeOffset.Parse(value)), expected);
+        }
+
+        [Theory]
+        [InlineData("00:00:00", "\"00:00:00\"")]
+        public void ToString_TimeSpan(string value, string expected)
+        {
+            ToString(new JsonPrimitive(TimeSpan.Parse(value)), expected);
+        }
+
+        [Theory]
+        [InlineData("https://github.com/dotnet/corefx", "\"https://github.com/dotnet/corefx\"")]
+        public void ToString_Uri(string value, string expected)
+        {
+            ToString(new JsonPrimitive(Uri.Parse(value)), expected);
+        }
+
         [Fact]
         public void ToString_Null_WorksDependingOnOverload()
         {

--- a/src/System.Json/tests/JsonPrimitiveTests.cs
+++ b/src/System.Json/tests/JsonPrimitiveTests.cs
@@ -67,7 +67,7 @@ namespace System.Json.Tests
         [InlineData("https://github.com/dotnet/corefx", "\"https://github.com/dotnet/corefx\"")]
         public void ToString_Uri(string value, string expected)
         {
-            ToString(new JsonPrimitive(Uri.Parse(value)), expected);
+            ToString(new JsonPrimitive(new Uri(value)), expected);
         }
 
         [Fact]

--- a/src/System.Json/tests/JsonPrimitiveTests.cs
+++ b/src/System.Json/tests/JsonPrimitiveTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Text;
 using Xunit;


### PR DESCRIPTION
Adding tests to verify roundtrip of `DateTimeOffset`, `Guid`, `TimeSpan`, `Uri`

This is in order to fix:
[JsonPrimitive.cs#L118](https://github.com/dotnet/corefx/blob/master/src/System.Json/src/System/Json/JsonPrimitive.cs#L118) there is `// DateTimeOffset || Guid || TimeSpan || Uri`
