### PR TITLE
Capture exceptions in returned Task from PipeStream.FlushAsync

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -376,9 +376,15 @@ namespace System.IO.Pipes
 
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
-            // Just throw exceptions -- we do no I/O in this method.
-            Flush();
-            return Task.CompletedTask;
+            try
+            {
+                Flush();
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException(ex);
+            }
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
This maintains backward compat with earlier version which did not override the FlushAsync method.

This is in response to https://github.com/dotnet/corefx/pull/31454/files#r219894949 by @stephentoub 