### PR TITLE
Removing some double/single perf scenarios that conflict due to the generated xunit display name

### DIFF
--- a/src/System.Runtime/tests/Performance/Perf.Double.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Double.cs
@@ -22,7 +22,7 @@ namespace System.Tests
         [InlineData(-3.14159265358979324, 1_000_000)]       // Negative pi
         [InlineData(-2.71828182845904524, 1_000_000)]       // Negative e
         [InlineData(-1.0, 1_000_000)]                       // Negative One
-        [InlineData(-2.2250738585072014E-308, 100_000)]     // Max Negative Normal
+        // [InlineData(-2.2250738585072014E-308, 100_000)]     // Max Negative Normal
         [InlineData(-2.2250738585072009E-308, 100_000)]     // Min Negative Subnormal
         [InlineData(-double.Epsilon, 100_000)]              // Max Negative Subnormal (Negative Epsilon)
         [InlineData(-0.0, 10_000_000)]                      // Negative Zero
@@ -30,7 +30,7 @@ namespace System.Tests
         [InlineData(0.0, 10_000_000)]                       // Positive Zero
         [InlineData(double.Epsilon, 100_000)]               // Min Positive Subnormal (Positive Epsilon)
         [InlineData(2.2250738585072009E-308, 100_000)]      // Max Positive Subnormal
-        [InlineData(2.2250738585072014E-308, 100_000)]      // Min Positive Normal
+        // [InlineData(2.2250738585072014E-308, 100_000)]      // Min Positive Normal
         [InlineData(1.0, 1_000_000)]                        // Positive One
         [InlineData(2.71828182845904524, 1_000_000)]        // Positive e
         [InlineData(3.14159265358979324, 1_000_000)]        // Positive pi
@@ -56,7 +56,7 @@ namespace System.Tests
         [InlineData("-3.1415926535897931", 1_000_000)]      // Negative pi
         [InlineData("-2.7182818284590451", 1_000_000)]      // Negative e
         [InlineData("-1", 1_000_000)]                       // Negative One
-        [InlineData("-2.2250738585072014E-308", 100_000)]   // Max Negative Normal
+        // [InlineData("-2.2250738585072014E-308", 100_000)]   // Max Negative Normal
         [InlineData("-2.2250738585072009E-308", 100_000)]   // Min Negative Subnormal
         [InlineData("-4.94065645841247E-324", 100_000)]     // Max Negative Subnormal (Negative Epsilon)
         [InlineData("-0.0", 10_000_000)]                    // Negative Zero
@@ -64,7 +64,7 @@ namespace System.Tests
         [InlineData("0", 10_000_000)]                       // Positive Zero
         [InlineData("4.94065645841247E-324", 100_000)]      // Min Positive Subnormal (Positive Epsilon)
         [InlineData("2.2250738585072009E-308", 100_000)]    // Max Positive Subnormal
-        [InlineData("2.2250738585072014E-308", 100_000)]    // Min Positive Normal
+        // [InlineData("2.2250738585072014E-308", 100_000)]    // Min Positive Normal
         [InlineData("1", 1_000_000)]                        // Positive One
         [InlineData("2.7182818284590451", 1_000_000)]       // Positive e
         [InlineData("3.1415926535897931", 1_000_000)]       // Positive pi
@@ -90,7 +90,7 @@ namespace System.Tests
         [InlineData("zh", -3.14159265358979324, 1_000_000)]     // Negative pi
         [InlineData("zh", -2.71828182845904524, 1_000_000)]     // Negative e
         [InlineData("zh", -1.0, 1_000_000)]                     // Negative One
-        [InlineData("zh", -2.2250738585072014E-308, 100_000)]   // Max Negative Normal
+        // [InlineData("zh", -2.2250738585072014E-308, 100_000)]   // Max Negative Normal
         [InlineData("zh", -2.2250738585072009E-308, 100_000)]   // Min Negative Subnormal
         [InlineData("zh", -double.Epsilon, 100_000)]            // Max Negative Subnormal (Negative Epsilon)
         [InlineData("zh", -0.0, 10_000_000)]                    // Negative Zero
@@ -98,7 +98,7 @@ namespace System.Tests
         [InlineData("zh", 0.0, 10_000_000)]                     // Positive Zero
         [InlineData("zh", double.Epsilon, 100_000)]             // Min Positive Subnormal (Positive Epsilon)
         [InlineData("zh", 2.2250738585072009E-308, 100_000)]    // Max Positive Subnormal
-        [InlineData("zh", 2.2250738585072014E-308, 100_000)]    // Min Positive Normal
+        // [InlineData("zh", 2.2250738585072014E-308, 100_000)]    // Min Positive Normal
         [InlineData("zh", 1.0, 1_000_000)]                      // Positive One
         [InlineData("zh", 2.71828182845904524, 1_000_000)]      // Positive e
         [InlineData("zh", 3.14159265358979324, 1_000_000)]      // Positive pi
@@ -150,12 +150,12 @@ namespace System.Tests
             double[] edgeTestValues =       // 100_000 iterations
             {
                 double.MinValue,            // Min Negative Normal
-                -2.2250738585072014E-308,   // Max Negative Normal
+                // -2.2250738585072014E-308,   // Max Negative Normal
                 -2.2250738585072009E-308,   // Min Negative Subnormal
                 -double.Epsilon,            // Max Negative Subnormal (Negative Epsilon)
                 double.Epsilon,             // Min Positive Subnormal (Positive Epsilon)
                 2.2250738585072009E-308,    // Max Positive Subnormal
-                2.2250738585072014E-308,    // Min Positive Normal
+                // 2.2250738585072014E-308,    // Min Positive Normal
                 double.MaxValue,            // Max Positive Normal
             };
 

--- a/src/System.Runtime/tests/Performance/Perf.Double.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Double.cs
@@ -16,6 +16,7 @@ namespace System.Tests
         private volatile string _string;
         private volatile bool _bool;
 
+        // Reenable commented out test cases when https://github.com/xunit/xunit/issues/1822 is fixed.
         [Benchmark]
         [InlineData(double.NegativeInfinity, 10_000_000)]   // Negative Infinity
         [InlineData(double.MinValue, 100_000)]              // Min Negative Normal
@@ -161,17 +162,17 @@ namespace System.Tests
 
             foreach (string format in formats)
             {
-                foreach (float testValue in specialTestValues)
+                foreach (double testValue in specialTestValues)
                 {
                     yield return new object[] { format, testValue, 10_000_000 };
                 }
 
-                foreach (float testValue in normalTestValues)
+                foreach (double testValue in normalTestValues)
                 {
                     yield return new object[] { format, testValue, 1_000_000 };
                 }
 
-                foreach (float testValue in edgeTestValues)
+                foreach (double testValue in edgeTestValues)
                 {
                     yield return new object[] { format, testValue, 100_000 };
                 }

--- a/src/System.Runtime/tests/Performance/Perf.Single.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Single.cs
@@ -22,7 +22,7 @@ namespace System.Tests
         [InlineData(-3.14159265f, 1_000_000)]               // Negative pi
         [InlineData(-2.71828183f, 1_000_000)]               // Negative e
         [InlineData(-1.0f, 1_000_000)]                      // Negative One
-        [InlineData(-1.17549435E-38f, 100_000)]             // Max Negative Normal
+        // [InlineData(-1.17549435E-38f, 100_000)]             // Max Negative Normal
         [InlineData(-1.17549421E-38f, 100_000)]             // Min Negative Subnormal
         [InlineData(-float.Epsilon, 100_000)]               // Max Negative Subnormal (Negative Epsilon)
         [InlineData(-0.0f, 10_000_000)]                     // Negative Zero
@@ -30,7 +30,7 @@ namespace System.Tests
         [InlineData(0.0f, 10_000_000)]                      // Positive Zero
         [InlineData(float.Epsilon, 100_000)]                // Min Positive Subnormal (Positive Epsilon)
         [InlineData(1.17549421E-38f, 100_000)]              // Max Positive Subnormal
-        [InlineData(1.17549435E-38f, 100_000)]              // Min Positive Normal
+        // [InlineData(1.17549435E-38f, 100_000)]              // Min Positive Normal
         [InlineData(1.0f, 1_000_000)]                       // Positive One
         [InlineData(2.71828183f, 1_000_000)]                // Positive e
         [InlineData(3.14159265f, 1_000_000)]                // Positive pi
@@ -56,7 +56,7 @@ namespace System.Tests
         [InlineData("-3.14159274", 1_000_000)]              // Negative pi
         [InlineData("-2.71828175", 1_000_000)]              // Negative e
         [InlineData("-1", 1_000_000)]                       // Negative One
-        [InlineData("-1.17549435E-38", 100_000)]            // Max Negative Normal
+        // [InlineData("-1.17549435E-38", 100_000)]            // Max Negative Normal
         [InlineData("-1.17549421E-38", 100_000)]            // Min Negative Subnormal
         [InlineData("-1.401298E-45", 100_000)]              // Max Negative Subnormal (Negative Epsilon)
         [InlineData("-0.0", 10_000_000)]                    // Negative Zero
@@ -64,7 +64,7 @@ namespace System.Tests
         [InlineData("0", 10_000_000)]                       // Positive Zero
         [InlineData("1.401298E-45", 100_000)]               // Min Positive Subnormal (Positive Epsilon)
         [InlineData("1.17549421E-38", 100_000)]             // Max Positive Subnormal
-        [InlineData("1.17549435E-38", 100_000)]             // Min Positive Normal
+        // [InlineData("1.17549435E-38", 100_000)]             // Min Positive Normal
         [InlineData("1", 1_000_000)]                        // Positive One
         [InlineData("2.71828175", 1_000_000)]               // Positive e
         [InlineData("3.14159274", 1_000_000)]               // Positive pi
@@ -90,7 +90,7 @@ namespace System.Tests
         [InlineData("zh", -3.14159265f, 1_000_000)]             // Negative pi
         [InlineData("zh", -2.71828183f, 1_000_000)]             // Negative e
         [InlineData("zh", -1.0f, 1_000_000)]                    // Negative One
-        [InlineData("zh", -1.17549435E-38f, 100_000)]           // Max Negative Normal
+        // [InlineData("zh", -1.17549435E-38f, 100_000)]           // Max Negative Normal
         [InlineData("zh", -1.17549421E-38f, 100_000)]           // Min Negative Subnormal
         [InlineData("zh", -float.Epsilon, 100_000)]             // Max Negative Subnormal (Negative Epsilon)
         [InlineData("zh", -0.0f, 10_000_000)]                   // Negative Zero
@@ -98,7 +98,7 @@ namespace System.Tests
         [InlineData("zh", 0.0f, 10_000_000)]                    // Positive Zero
         [InlineData("zh", float.Epsilon, 100_000)]              // Min Positive Subnormal (Positive Epsilon)
         [InlineData("zh", 1.17549421E-38f, 100_000)]            // Max Positive Subnormal
-        [InlineData("zh", 1.17549435E-38f, 100_000)]            // Min Positive Normal
+        // [InlineData("zh", 1.17549435E-38f, 100_000)]            // Min Positive Normal
         [InlineData("zh", 1.0f, 1_000_000)]                     // Positive One
         [InlineData("zh", 2.71828183f, 1_000_000)]              // Positive e
         [InlineData("zh", 3.14159265f, 1_000_000)]              // Positive pi
@@ -150,12 +150,12 @@ namespace System.Tests
             float[] edgeTestValues =        // 100_000 iterations
             {
                 float.MinValue,             // Min Negative Normal
-                -1.17549435E-38f,           // Max Negative Normal
+                // -1.17549435E-38f,           // Max Negative Normal
                 -1.17549421E-38f,           // Min Negative Subnormal
                 -float.Epsilon,             // Max Negative Subnormal (Negative Epsilon)
                 float.Epsilon,              // Min Positive Subnormal (Positive Epsilon)
                 1.17549421E-38f,            // Max Positive Subnormal
-                1.17549435E-38f,            // Min Positive Normal
+                // 1.17549435E-38f,            // Min Positive Normal
                 float.MaxValue,             // Max Positive Normal
             };
 

--- a/src/System.Runtime/tests/Performance/Perf.Single.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Single.cs
@@ -16,6 +16,7 @@ namespace System.Tests
         private volatile string _string;
         private volatile bool _bool;
 
+        // Reenable commented out test cases when https://github.com/xunit/xunit/issues/1822 is fixed.
         [Benchmark]
         [InlineData(float.NegativeInfinity, 10_000_000)]    // Negative Infinity
         [InlineData(float.MinValue, 100_000)]               // Min Negative Normal


### PR DESCRIPTION
This is tracked by https://github.com/xunit/xunit/issues/1822

CC. @ViktorHofer, @danmosemsft 