### PR TITLE
Temporarily disable coverage for CoreLib

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -55,7 +55,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
         def isLocal = (localType == 'local')
 
         def newJobName = 'code_coverage_windows'
-        def batchCommand = 'call build.cmd && call build-tests.cmd -coverage -outerloop -- /p:IsCIBuild=true /p:CodeCoverageAssemblies="System.Private.CoreLib"'
+        def batchCommand = 'call build.cmd && call build-tests.cmd -coverage -outerloop -- /p:IsCIBuild=true'
         if (isLocal) {
             newJobName = "${newJobName}_local"
             batchCommand = "${batchCommand}"


### PR DESCRIPTION
CI code coverage is currently busted: it either crashes or timeouts on System.Transactions.Local.Tests when it is combined with coverage for CoreLib. This is an attempt to get some coverage numbers by temporarily disabling coverage for CoreLib, if that works I will change the coverage of CoreLib to be explicit per test project instead of wholesale for the run (as mentioned in #32420).

/cc @ViktorHofer 