### PR TITLE
Remove all improvement

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -579,6 +579,25 @@ namespace System.Collections.Concurrent
             }
         }
 
+
+        public IEnumerable<TValue> RemoveAll() 
+        {
+            IEnumerable<TValue> values; 
+            int locksAcquired = 0;
+            try
+            {
+                AcquireAllLocks(ref locksAcquired);
+                values = Values;
+                Clear();
+            }
+            finally
+            {
+                ReleaseLocks(0, locksAcquired);
+            }
+            return values;
+        }
+
+
         /// <summary>
         /// Copies the elements of the <see cref="T:System.Collections.Generic.ICollection"/> to an array of
         /// type <see cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>, starting at the

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -568,15 +568,23 @@ namespace System.Collections.Concurrent
             try
             {
                 AcquireAllLocks(ref locksAcquired);
-
-                Tables newTables = new Tables(new Node[DefaultCapacity], _tables._locks, new int[_tables._countPerLock.Length]);
-                _tables = newTables;
-                _budget = Math.Max(1, newTables._buckets.Length / newTables._locks.Length);
+                InternalClear();
+       
             }
             finally
             {
                 ReleaseLocks(0, locksAcquired);
             }
+        }
+
+
+        private void InternalClear()
+        {
+
+            Tables newTables = new Tables(new Node[DefaultCapacity], _tables._locks, new int[_tables._countPerLock.Length]);
+                    _tables = newTables;
+                    _budget = Math.Max(1, newTables._buckets.Length / newTables._locks.Length);
+
         }
 
 
@@ -588,7 +596,7 @@ namespace System.Collections.Concurrent
             {
                 AcquireAllLocks(ref locksAcquired);
                 values = Values;
-                Clear();
+                InternalClear();
             }
             finally
             {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -580,11 +580,9 @@ namespace System.Collections.Concurrent
 
         private void InternalClear()
         {
-
             Tables newTables = new Tables(new Node[DefaultCapacity], _tables._locks, new int[_tables._countPerLock.Length]);
-                    _tables = newTables;
-                    _budget = Math.Max(1, newTables._buckets.Length / newTables._locks.Length);
-
+            _tables = newTables;
+            _budget = Math.Max(1, newTables._buckets.Length / newTables._locks.Length);
         }
 
 


### PR DESCRIPTION
I was recently working with a ConcurrentDictionary. I am producing values into a dictionary and later I would like to atomically clear this list while at the same time receiving the Values from the new cleared dictionary list and this does not seem to be possible. 
Would the proposed solution (or possibly a cleaned up, optimized variant) be acceptable or is there some other recommended data structure to use for these scenarios?  
