### PR TITLE
Check for the specific in-use version of OpenSSL when working with libcurl

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Initialization.cs
@@ -26,11 +26,11 @@ internal static partial class Interop
 #if !SYSNETHTTP_NO_OPENSSL
             string opensslVersion = Interop.Http.GetSslVersionDescription();
             if (string.IsNullOrEmpty(opensslVersion) ||
-                opensslVersion.IndexOf(Interop.Http.OpenSsl10Description, StringComparison.OrdinalIgnoreCase) != -1)
+                opensslVersion.IndexOf(Interop.Http.OpenSslDescriptionPrefix, StringComparison.OrdinalIgnoreCase) != -1)
             {
-                // CURL uses OpenSSL which we must initialize first to guarantee thread-safety
-                // Only initialize for OpenSSL/1.0, any newer versions may have mismatched
-                // pointers, resulting in segfaults.
+                // CURL uses OpenSSL which we must initialize first to guarantee thread-safety.
+                // We'll wake up whatever OpenSSL we're going to run against, but might later determine that
+                // they aren't compatible.
                 CryptoInitializer.Initialize();
             }
 #endif

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -47,8 +48,67 @@ internal static partial class Interop
         [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_GetSslVersionDescription")]
         internal static extern string GetSslVersionDescription();
 
-        internal const string OpenSsl10Description = "openssl/1.0";
+        internal const string OpenSslDescriptionPrefix = "OpenSSL/";
         internal const string SecureTransportDescription = "SecureTransport";
         internal const string LibreSslDescription = "LibreSSL";
+
+#if !SYSNETHTTP_NO_OPENSSL
+        private static readonly Lazy<string> s_requiredOpenSslDescription =
+            new Lazy<string>(() => DetermineRequiredOpenSslDescription());
+
+        private static readonly Lazy<bool> s_hasMatchingOpenSsl =
+            new Lazy<bool>(() => RequiredOpenSslDescription == GetSslVersionDescription());
+
+        internal static string RequiredOpenSslDescription => s_requiredOpenSslDescription.Value;
+        internal static bool HasMatchingOpenSslVersion => s_hasMatchingOpenSsl.Value;
+
+        private static string DetermineRequiredOpenSslDescription()
+        {
+            uint ver = Interop.OpenSsl.OpenSslVersionNumber();
+
+            // OpenSSL version numbers are encoded as
+            // 0xMNNFFPPS: major (one nybble), minor (one byte, unaligned),
+            // "fix" (one byte, unaligned), patch (one byte, unaligned), status (one nybble)
+            //
+            // e.g. 1.0.2a final is 0x1000201F
+            //
+            // libcurl's OpenSSL vtls backend ignores status in the version string.
+            // Major, minor, and fix are encoded (by libcurl) as unpadded hex
+            // (0 => "0", 15 => "f", 16 => "10").
+            //
+            // Patch is encoded as in the way OpenSSL would do it.
+            // 0x00 => ""
+            // 0x01 => "a"
+            // 0x1a (26) => "z"
+            // 0x1b (27) => "za"
+            // 0x34 (52) => "zz"
+            // 0x35 (53) should probably be "zza", but it never came up, and is not currently
+            // handled correctly by libcurl (which would call it "z{").
+
+            byte patchValue = (byte)((ver & 0xFF0) >> 4);
+            string patch = string.Empty;
+
+            if (patchValue > 52)
+            {
+                Debug.Fail($"OpenSSL version ({ver:8X}) patch value ({patchValue}) is out of range");
+                throw new InvalidOperationException();
+            }
+            else if (patchValue > 26)
+            {
+                Span<char> patchStr = stackalloc char[2];
+                patchStr[0] = 'z';
+                // backtick is ('a'-1)
+                patchStr[1] = (char)('`' + (patchValue - 26));
+                patch = new string(patchStr);
+            }
+            else if (patchValue > 0)
+            {
+                // backtick is ('a'-1)
+                patch = new string((char)('`' + patchValue), 1);
+            }
+
+            return $"{OpenSslDescriptionPrefix}{ver >> 28:x}.{(byte)(ver >> 20):x}.{(byte)(ver >> 12):x}{patch}";
+        }
+#endif
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         private static Version s_opensslVersion;
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslVersionNumber")]
-        private static extern uint OpenSslVersionNumber();
+        internal static extern uint OpenSslVersionNumber();
 
         internal static Version OpenSslVersion
         {

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -507,6 +507,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
@@ -55,7 +55,7 @@ namespace System.Net.Http
 
                 // Configure the options.  Our best support is when targeting OpenSSL/1.0.  For other backends,
                 // we fall back to a minimal amount of support, and may throw a PNSE based on the options requested.
-                if (CurlSslVersionDescription.IndexOf(Interop.Http.OpenSsl10Description, StringComparison.OrdinalIgnoreCase) != -1)
+                if (Interop.Http.HasMatchingOpenSslVersion)
                 {
                     // Register the callback with libcurl.  We need to register even if there's no user-provided
                     // server callback and even if there are no client certificates, because we support verifying
@@ -169,12 +169,12 @@ namespace System.Net.Http
             {
                 if (certProvider != null)
                 {
-                    throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_clientcerts_notsupported_sslbackend, CurlVersionDescription, CurlSslVersionDescription, Interop.Http.OpenSsl10Description));
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_clientcerts_notsupported_sslbackend, CurlVersionDescription, CurlSslVersionDescription, Interop.Http.RequiredOpenSslDescription));
                 }
 
                 if (easy._handler.CheckCertificateRevocationList)
                 {
-                    throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_revocation_notsupported_sslbackend, CurlVersionDescription, CurlSslVersionDescription, Interop.Http.OpenSsl10Description));
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_revocation_notsupported_sslbackend, CurlVersionDescription, CurlSslVersionDescription, Interop.Http.RequiredOpenSslDescription));
                 }
 
                 if (easy._handler.ServerCertificateCustomValidationCallback != null)
@@ -187,7 +187,7 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_callback_notsupported_sslbackend, CurlVersionDescription, CurlSslVersionDescription, Interop.Http.OpenSsl10Description));
+                        throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_callback_notsupported_sslbackend, CurlVersionDescription, CurlSslVersionDescription, Interop.Http.RequiredOpenSslDescription));
                     }
                 }
                 else

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.Http.Functional.Tests
 #if TargetsWindows
             true;
 #else
-            Interop.Http.GetSslVersionDescription()?.StartsWith(Interop.Http.OpenSsl10Description, StringComparison.OrdinalIgnoreCase) ?? false;
+            TestHelper.NativeHandlerSupportsSslConfiguration();
 #endif
 
         private static bool CanTestCertificates =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -319,19 +319,7 @@ namespace System.Net.Http.Functional.Tests
 #if TargetsWindows
                 return true;
 #else
-                if (UseSocketsHttpHandler)
-                {
-                    return true;
-                }
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    return false;
-                }
-
-                // For other Unix-based systems it's true if (and only if) the openssl backend
-                // is used with libcurl.
-                return (Interop.Http.GetSslVersionDescription()?.StartsWith(Interop.Http.OpenSsl10Description, StringComparison.OrdinalIgnoreCase) ?? false);
+                return TestHelper.NativeHandlerSupportsSslConfiguration();
 #endif
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
@@ -58,14 +58,7 @@ namespace System.Net.Http.Functional.Tests
                     return true;
                 }
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    return false;
-                }
-
-                // For other Unix-based systems it's true if (and only if) the openssl backend
-                // is used with libcurl.
-                return (Interop.Http.GetSslVersionDescription()?.StartsWith(Interop.Http.OpenSsl10Description, StringComparison.OrdinalIgnoreCase) ?? false);
+                return TestHelper.NativeHandlerSupportsSslConfiguration();
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.Unix.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.Unix.cs
@@ -17,7 +17,6 @@ namespace System.Net.Http.Functional.Tests
     public abstract partial class HttpClientHandler_SslProtocols_Test
     {
         private bool BackendSupportsSslConfiguration =>
-            UseSocketsHttpHandler ||
-            (Interop.Http.GetSslVersionDescription()?.StartsWith(Interop.Http.OpenSsl10Description, StringComparison.OrdinalIgnoreCase) ?? false);
+            UseSocketsHttpHandler || TestHelper.NativeHandlerSupportsSslConfiguration();
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{C85CF035-7804-41FF-9557-48B7C948B58D}</ProjectGuid>
     <DefineConstants Condition="'$(TargetsWindows)'=='true'">$(DefineConstants);TargetsWindows</DefineConstants>
+    <DefineConstants>$(DefineConstants);SYSNETHTTP_NO_OPENSSL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>


### PR DESCRIPTION
Rather than check a generic 1.0/1.1, test for the specific library version that
the crypto shim has loaded.  This makes things work when both libcurl
and the crypto shim are using OpenSSL 1.1 and also prevents a state where two
different copies of the library (at different patch versions) are utilized.

Fixes #32343.
Related to #32006 / #9855.