### PR TITLE
Update SafeBuffer Initialize tests to reflect new exception type.

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -25,12 +25,11 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/7829")]
-        public void Initialize_NumBytesTimesSizeOfEachElement_ThrowsOverflowException()
+        public void Initialize_NumBytesTimesSizeOfEachElement_ThrowsArgumentOutOfRangeException()
         {
             var buffer = new SubBuffer(true);
-            Assert.Throws<OverflowException>(() => buffer.Initialize(uint.MaxValue, uint.MaxValue));
-            Assert.Throws<OverflowException>(() => buffer.Initialize<int>(uint.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Initialize(uint.MaxValue, uint.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Initialize<int>(uint.MaxValue));
         }
 
         [Fact]

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -28,8 +28,8 @@ namespace System.Runtime.InteropServices.Tests
         public void Initialize_NumBytesTimesSizeOfEachElement_ThrowsArgumentOutOfRangeException()
         {
             var buffer = new SubBuffer(true);
-            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Initialize(uint.MaxValue, uint.MaxValue));
-            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Initialize<int>(uint.MaxValue));
+            AssertExtensions.Throws<ArgumentOutOfRangeException, OverflowException>(() => buffer.Initialize(uint.MaxValue, uint.MaxValue));
+            AssertExtensions.Throws<ArgumentOutOfRangeException, OverflowException>(() => buffer.Initialize<int>(uint.MaxValue));
         }
 
         [Fact]

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -25,11 +25,20 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void Initialize_NumBytesTimesSizeOfEachElement_ThrowsArgumentOutOfRangeException()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void Initialize_NumBytesTimesSizeOfEachElement_NetFramework_ThrowsOverflowException()
         {
             var buffer = new SubBuffer(true);
-            AssertExtensions.Throws<ArgumentOutOfRangeException, OverflowException>(() => buffer.Initialize(uint.MaxValue, uint.MaxValue));
-            AssertExtensions.Throws<ArgumentOutOfRangeException, OverflowException>(() => buffer.Initialize<int>(uint.MaxValue));
+            AssertExtensions.Throws<OverflowException>(() => buffer.Initialize(uint.MaxValue, uint.MaxValue));
+            AssertExtensions.Throws<OverflowException>(() => buffer.Initialize<int>(uint.MaxValue));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void Initialize_NumBytesTimesSizeOfEachElement_ThrowsArgumentOutOfRangeExceptionIfNot64Bit()
+        {
+            AssertExtensions.ThrowsIf<ArgumentOutOfRangeException>(!Environment.Is64BitProcess, () => buffer.Initialize(uint.MaxValue, uint.MaxValue));
+            AssertExtensions.ThrowsIf<ArgumentOutOfRangeException>(!Environment.Is64BitProcess, () => buffer.Initialize<int>(uint.MaxValue));
         }
 
         [Fact]

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -29,14 +29,15 @@ namespace System.Runtime.InteropServices.Tests
         public void Initialize_NumBytesTimesSizeOfEachElement_NetFramework_ThrowsOverflowException()
         {
             var buffer = new SubBuffer(true);
-            AssertExtensions.Throws<OverflowException>(() => buffer.Initialize(uint.MaxValue, uint.MaxValue));
-            AssertExtensions.Throws<OverflowException>(() => buffer.Initialize<int>(uint.MaxValue));
+            Assert.Throws<OverflowException>(() => buffer.Initialize(uint.MaxValue, uint.MaxValue));
+            Assert.Throws<OverflowException>(() => buffer.Initialize<int>(uint.MaxValue));
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Initialize_NumBytesTimesSizeOfEachElement_ThrowsArgumentOutOfRangeExceptionIfNot64Bit()
         {
+            var buffer = new SubBuffer(true);
             AssertExtensions.ThrowsIf<ArgumentOutOfRangeException>(!Environment.Is64BitProcess, () => buffer.Initialize(uint.MaxValue, uint.MaxValue));
             AssertExtensions.ThrowsIf<ArgumentOutOfRangeException>(!Environment.Is64BitProcess, () => buffer.Initialize<int>(uint.MaxValue));
         }

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -20,10 +20,8 @@ namespace System.Runtime.Serialization.Formatters.Tests
 {
     public partial class BinaryFormatterTests : RemoteExecutorTestBase
     {
-        private static unsafe bool Is64Bit => sizeof(void*) == 8;
-
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
-        [ConditionalTheory(nameof(Is64Bit))]
+        [ConditionalTheory(nameof(Environment.Is64BitProcess))]
         [InlineData(2 * 6_584_983 - 2)] // previous limit
         [InlineData(2 * 7_199_369 - 2)] // last pre-computed prime number
         public void SerializeHugeObjectGraphs(int limit)

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
     public partial class BinaryFormatterTests : RemoteExecutorTestBase
     {
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
-        [ConditionalTheory(nameof(Environment.Is64BitProcess))]
+        [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [InlineData(2 * 6_584_983 - 2)] // previous limit
         [InlineData(2 * 7_199_369 - 2)] // last pre-computed prime number
         public void SerializeHugeObjectGraphs(int limit)

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ProjectGuid>{13CE5E71-D373-4EA6-B3CB-166FF089A42A}</ProjectGuid>
     <SkipIncludeNewtonsoftJson>true</SkipIncludeNewtonsoftJson>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Update exception type thrown to match new behavior from dotnet/coreclr#20132