### PR TITLE
Don't trim IMarshal

### DIFF
--- a/src/System.Runtime.InteropServices/src/ILLinkTrim.xml
+++ b/src/System.Runtime.InteropServices/src/ILLinkTrim.xml
@@ -1,0 +1,6 @@
+<linker>
+  <assembly fullname="System.Runtime.InteropServices">
+    <!-- IMarshal is internal and never directly called, but needed by COM -->
+    <type fullname="System.Runtime.InteropServices.IMarshal" />
+  </assembly>
+</linker>


### PR DESCRIPTION
The linker was trimming out IMarshal because it saw the interface was never used by managed code.

This does get used by COM and the interface being present but empty breaks native code when it attempts to call an method that is missing from the interface.

/cc @luqunl @Tanya-Solyanik 