### PR TITLE
Add more CTR.Unregister/Dispose tests

### DIFF
--- a/src/System.Threading.Tasks/tests/CancellationTokenTests.cs
+++ b/src/System.Threading.Tasks/tests/CancellationTokenTests.cs
@@ -1234,6 +1234,39 @@ namespace System.Threading.Tasks.Tests
             SetSynchronizationContext(prevailingSyncCtx);
         }
 
+        [Fact]
+        public static void CancellationTokenRegistration_DisposeDuringCancellation_SuccessfullyRemovedIfNotYetInvoked()
+        {
+            var ctr0running = new ManualResetEventSlim();
+            var ctr2blocked = new ManualResetEventSlim();
+            var ctr2running = new ManualResetEventSlim();
+            var cts = new CancellationTokenSource();
+
+            CancellationTokenRegistration ctr0 = cts.Token.Register(() => ctr0running.Set());
+
+            bool ctr1Invoked = false;
+            CancellationTokenRegistration ctr1 = cts.Token.Register(() => ctr1Invoked = true);
+
+            CancellationTokenRegistration ctr2 = cts.Token.Register(() =>
+            {
+                ctr2running.Set();
+                ctr2blocked.Wait();
+            });
+
+            // Cancel.  This will trigger ctr2 to run, then ctr1, then ctr0.
+            Task.Run(() => cts.Cancel());
+            ctr2running.Wait(); // wait for ctr2 to start running
+
+            // Now that ctr2 is running, dispose ctr1. This should succeed
+            // and ctr1 should not run.
+            ctr1.Dispose();
+
+            // Allow ctr2 to continue.  ctr1 should not run.  ctr0 should, so wait for it.
+            ctr2blocked.Set();
+            ctr0running.Wait();
+            Assert.False(ctr1Invoked);
+        }
+
         #region Helper Classes and Methods
 
         private class TestingSynchronizationContext : SynchronizationContext

--- a/src/System.Threading.Tasks/tests/CancellationTokenTests.netcoreapp.cs
+++ b/src/System.Threading.Tasks/tests/CancellationTokenTests.netcoreapp.cs
@@ -41,7 +41,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [Fact]
-        public static void CancellationTokenRegistration_UnregisterDoesntWaitForCallbackToComplete()
+        public static void CancellationTokenRegistration_UnregisterWhileCallbackRunning_UnregisterDoesntWaitForCallbackToComplete()
         {
             using (var barrier = new Barrier(2))
             {
@@ -59,6 +59,89 @@ namespace System.Threading.Tasks.Tests
                 barrier.SignalAndWait();
                 Assert.False(ctr.Unregister());
                 barrier.SignalAndWait();
+            }
+        }
+
+        [Fact]
+        public static void CancellationTokenRegistration_UnregisterDuringCancellation_SuccessfullyRemovedIfNotYetInvoked()
+        {
+            var ctr0running = new ManualResetEventSlim();
+            var ctr2blocked = new ManualResetEventSlim();
+            var ctr2running = new ManualResetEventSlim();
+            var cts = new CancellationTokenSource();
+
+            CancellationTokenRegistration ctr0 = cts.Token.Register(() => ctr0running.Set());
+
+            bool ctr1Invoked = false;
+            CancellationTokenRegistration ctr1 = cts.Token.Register(() => ctr1Invoked = true);
+
+            CancellationTokenRegistration ctr2 = cts.Token.Register(() =>
+            {
+                ctr2running.Set();
+                ctr2blocked.Wait();
+            });
+
+            // Cancel.  This will trigger ctr2 to run, then ctr1, then ctr0.
+            Task.Run(() => cts.Cancel());
+            ctr2running.Wait(); // wait for ctr2 to start running
+            Assert.False(ctr2.Unregister());
+
+            // Now that ctr2 is running, unregister ctr1. This should succeed
+            // and ctr1 should not run.
+            Assert.True(ctr1.Unregister());
+
+            // Allow ctr2 to continue.  ctr1 should not run.  ctr0 should, so wait for it.
+            ctr2blocked.Set();
+            ctr0running.Wait();
+            Assert.False(ctr0.Unregister());
+            Assert.False(ctr1Invoked);
+        }
+
+        [Fact]
+        public static async Task CancellationTokenRegistration_ConcurrentUnregisterWithCancel_ReturnsFalseOrCallbackInvoked()
+        {
+            using (Barrier barrier = new Barrier(2))
+            {
+                const int Iters = 10_000;
+                CancellationTokenSource cts = new CancellationTokenSource();
+                bool unregisterResult = false, callbackInvoked = false;
+
+                var tasks = new Task[]
+                {
+                    // Register and unregister
+                    Task.Factory.StartNew(() =>
+                    {
+                        for (int i = 0; i < Iters; i++)
+                        {
+                            barrier.SignalAndWait();
+                            CancellationTokenRegistration ctr = cts.Token.Register(() => callbackInvoked = true);
+                            barrier.SignalAndWait();
+                            unregisterResult = ctr.Unregister();
+                            barrier.SignalAndWait();
+                        }
+                    }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
+
+                    // Cancel, and validate the results
+                    Task.Factory.StartNew(() =>
+                    {
+                        for (int i = 0; i < Iters; i++)
+                        {
+                            barrier.SignalAndWait();
+                            barrier.SignalAndWait();
+                            cts.Cancel();
+                            barrier.SignalAndWait();
+
+                            Assert.True(unregisterResult ^ callbackInvoked);
+
+                            unregisterResult = callbackInvoked = false;
+                            cts = new CancellationTokenSource();
+                        }
+                    }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)
+                };
+
+                // wait for one to fail or both to complete
+                await await Task.WhenAny(tasks);
+                await Task.WhenAll(tasks);
             }
         }
     }


### PR DESCRIPTION
Validate the behavior of unregistering a callback during cancellation but before the callback has been invoked.

Depends on the fix in https://github.com/dotnet/coreclr/pull/20145.
Related to https://github.com/dotnet/coreclr/issues/19839.
cc: @kouvel 