### PR TITLE
Move work out of HttpConnectionPool.ReturnConnection lock

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -59,7 +59,6 @@ namespace System.Net.Http
 
         /// <summary>Initializes the pool.</summary>
         /// <param name="maxConnections">The maximum number of connections allowed to be associated with the pool at any given time.</param>
-        /// 
         public HttpConnectionPool(HttpConnectionPoolManager poolManager, HttpConnectionKind kind, string host, int port, string sslHostName, Uri proxyUri, int maxConnections)
         {
             _poolManager = poolManager;
@@ -848,69 +847,70 @@ namespace System.Net.Http
         /// <param name="connection">The connection to return.</param>
         public void ReturnConnection(HttpConnection connection)
         {
-            List<CachedConnection> list = _idleConnections;
-            lock (SyncObj)
+            TimeSpan lifetime = _poolManager.Settings._pooledConnectionLifetime;
+            bool lifetimeExpired = 
+                lifetime != Timeout.InfiniteTimeSpan &&
+                (lifetime == TimeSpan.Zero || connection.CreationTime + lifetime <= DateTime.UtcNow);
+
+            if (!lifetimeExpired)
             {
-                Debug.Assert(list.Count <= _maxConnections, $"Expected {list.Count} <= {_maxConnections}");
-
-                // Mark the pool as still being active.
-                _usedSinceLastCleanup = true;
-
-                // If this connection has expired, it's not reusable, so dispose of it rather than storing it.
-                // Disposing it will alert any waiters that a connection slot has become available.
-                TimeSpan lifetime = _poolManager.Settings._pooledConnectionLifetime;
-                if (lifetime != Timeout.InfiniteTimeSpan &&
-                    (lifetime == TimeSpan.Zero || connection.CreationTime + lifetime <= DateTime.UtcNow))
+                List<CachedConnection> list = _idleConnections;
+                lock (SyncObj)
                 {
-                    if (NetEventSource.IsEnabled) connection.Trace("Disposing connection returned to the pool. Connection lifetime expired.");
-                    connection.Dispose();
-                    return;
-                }
+                    Debug.Assert(list.Count <= _maxConnections, $"Expected {list.Count} <= {_maxConnections}");
 
-                // If there's someone waiting for a connection and this one's still valid, simply transfer this one to them rather than pooling it.
-                // Note that while we checked connection lifetime above, we don't check idle timeout, as even if idle timeout
-                // is zero, we consider a connection that's just handed from one use to another to never actually be idle.
-                bool receivedUnexpectedData = false;
-                if (_waitersTail != null)
-                {
-                    receivedUnexpectedData = connection.EnsureReadAheadAndPollRead();
-                    if (!receivedUnexpectedData)
+                    // Mark the pool as still being active.
+                    _usedSinceLastCleanup = true;
+
+                    // If there's someone waiting for a connection and this one's still valid, simply transfer this one to them rather than pooling it.
+                    // Note that while we checked connection lifetime above, we don't check idle timeout, as even if idle timeout
+                    // is zero, we consider a connection that's just handed from one use to another to never actually be idle.
+                    bool receivedUnexpectedData = false;
+                    if (_waitersTail != null)
                     {
-                        ConnectionWaiter waiter = DequeueWaiter();
-                        waiter._cancellationTokenRegistration.Dispose();
+                        receivedUnexpectedData = connection.EnsureReadAheadAndPollRead();
+                        if (!receivedUnexpectedData)
+                        {
+                            ConnectionWaiter waiter = DequeueWaiter();
+                            waiter._cancellationTokenRegistration.Dispose();
 
-                        if (NetEventSource.IsEnabled) connection.Trace("Transferring connection returned to pool.");
-                        waiter.SetResult((connection, false, null));
+                            if (NetEventSource.IsEnabled) connection.Trace("Transferring connection returned to pool.");
+                            waiter.SetResult((connection, false, null));
 
+                            return;
+                        }
+                    }
+
+                    // If the connection is still valid, add it to the list.
+                    // If the pool has been disposed of, dispose the connection being returned,
+                    // as the pool is being deactivated. We do this after the above in order to
+                    // use pooled connections to satisfy any requests that pended before the
+                    // the pool was disposed of.  We also dispose of connections if connection
+                    // timeouts are such that the connection would immediately expire, anyway, as
+                    // well as for connections that have unexpectedly received extraneous data / EOF.
+                    if (!receivedUnexpectedData &&
+                        !_disposed &&
+                        _poolManager.Settings._pooledConnectionIdleTimeout != TimeSpan.Zero)
+                    {
+                        // Pool the connection by adding it to the list.
+                        list.Add(new CachedConnection(connection));
+                        if (NetEventSource.IsEnabled) connection.Trace("Stored connection in pool.");
                         return;
                     }
                 }
-
-                // If the pool has been disposed of, dispose the connection being returned,
-                // as the pool is being deactivated. We do this after the above in order to
-                // use pooled connections to satisfy any requests that pended before the
-                // the pool was disposed of.  We also dispose of connections if connection
-                // timeouts are such that the connection would immediately expire, anyway, as
-                // well as for connections that have unexpectedly received extraneous data / EOF.
-                if (receivedUnexpectedData ||
-                    _disposed ||
-                    _poolManager.Settings._pooledConnectionIdleTimeout == TimeSpan.Zero)
-                {
-                    if (NetEventSource.IsEnabled)
-                    {
-                        connection.Trace(
-                            receivedUnexpectedData ? "Disposing connection returned to pool. Read-ahead unexpectedly completed." :
-                            _disposed ? "Disposing connection returned to pool. Pool was disposed." :
-                            "Disposing connection returned to pool. Zero idle timeout.");
-                    }
-                    connection.Dispose();
-                    return;
-                }
-
-                // Pool the connection by adding it to the list.
-                list.Add(new CachedConnection(connection));
-                if (NetEventSource.IsEnabled) connection.Trace("Stored connection in pool.");
             }
+
+            // The connection could be not be reused.  Dispose of it.
+            // Disposing it will alert any waiters that a connection slot has become available.
+            if (NetEventSource.IsEnabled)
+            {
+                connection.Trace(
+                    lifetimeExpired ? "Disposing connection return to pool. Connection lifetime expired." :
+                    _poolManager.Settings._pooledConnectionIdleTimeout == TimeSpan.Zero ? "Disposing connection returned to pool. Zero idle timeout." :
+                    _disposed ? "Disposing connection returned to pool. Pool was disposed." :
+                    "Disposing connection returned to pool. Read-ahead unexpectedly completed.");
+            }
+            connection.Dispose();
         }
 
         public void InvalidateHttp2Connection(Http2Connection connection)


### PR DESCRIPTION
Small tweaks (doesn't move the needle much), but some of the work being done inside the lock can be done before or after it instead.

cc: @geoffkizer, @mikeharder 