### PR TITLE
 Remove unnecessary params keyword from System.Reflection.Tests.TypeInfoTests.ImplementedInterfaces test method signature

### DIFF
--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -474,7 +474,7 @@ namespace System.Reflection.Tests
         [InlineData(typeof(CompoundClass3<InheritedInteraface>), new Type[] { typeof(GenericInterface1<InheritedInteraface>), typeof(TI_NonGenericInterface1) })]
         [InlineData(typeof(CompoundClass4<>), new Type[] { typeof(GenericInterface1<string>), typeof(TI_NonGenericInterface1) })]
         [InlineData(typeof(CompoundClass4<string>), new Type[] { typeof(GenericInterface1<string>), typeof(TI_NonGenericInterface1) })]
-        public void ImplementedInterfaces(Type type, params Type[] expected)
+        public void ImplementedInterfaces(Type type, Type[] expected)
         {
             TypeInfo typeInfo = type.GetTypeInfo();
             Type[] implementedInterfaces = type.GetTypeInfo().ImplementedInterfaces.ToArray();


### PR DESCRIPTION
All the inline data contains `Type[]` as the second argument so there is no need to use `params` keyword.