### PR TITLE
Remove tests for two unsupported features

### DIFF
--- a/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.Windows.cs
+++ b/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.Windows.cs
@@ -14,32 +14,6 @@ namespace System.Runtime.Loader.Tests
 
     public partial class AssemblyLoadContextTest
     {
-        class DelegateMarshallingTest : TestBase
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            public void Execute()
-            {
-                // Delegate marshaling for types within collectible assemblies is not supported.
-                Assert.Throws<NotSupportedException>(() =>
-                {
-                    MethodInfo methodReference = _testClassTypes[0].GetMethod("TestDelegateMarshalling");
-                    Assert.NotNull(methodReference);
-                    methodReference.Invoke(null, BindingFlags.DoNotWrapExceptions, Type.DefaultBinder, null, null);
-                });
-            }
-        }
-
-        [Fact]
-        public static void Unsupported_DelegateMarshalling()
-        {
-            var test = new DelegateMarshallingTest();
-            test.CreateContextAndLoadAssembly();
-            test.Execute();
-            test.UnloadAndClearContext();
-            test.CheckContextUnloaded();
-        }
-
-
         class COMInteropTest : TestBase
         {
             [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs
@@ -429,7 +429,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
-        public static void Unsupported_ThreadStaticAndFixedAddressValueType()
+        public static void Unsupported_FixedAddressValueType()
         {
             var asmName = new AssemblyName(TestAssemblyNotSupported);
             var alc = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Path };
@@ -440,9 +440,8 @@ namespace System.Runtime.Loader.Tests
             ReflectionTypeLoadException exception = Assert.Throws<ReflectionTypeLoadException>(() => asm.DefinedTypes);
 
             // Expecting two exceptions:
-            //  Collectible type 'System.Runtime.Loader.Tests.TestClassNotSupported_ThreadStatic' may not have Thread or Context static members
             //  Collectible type 'System.Runtime.Loader.Tests.TestClassNotSupported_FixedAddressValueType' has unsupported FixedAddressValueTypeAttribute applied to a field
-            Assert.Equal(2, exception.LoaderExceptions.Length);
+            Assert.Equal(1, exception.LoaderExceptions.Length);
             Assert.True(exception.LoaderExceptions.All(exp => exp is TypeLoadException));
         }
 

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Test.AssemblyNotSupported/TestClassNotSupported.cs
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Test.AssemblyNotSupported/TestClassNotSupported.cs
@@ -6,17 +6,6 @@ using System.Runtime.CompilerServices;
 
 namespace System.Runtime.Loader.Tests
 {
-    public class TestClassNotSupported_ThreadStatic
-    {
-        [ThreadStatic]
-        public static object ThisIsAThreadStatic;
-
-        public struct S<T>
-        {
-            public T Value;
-        }
-    }
-
     public class TestClassNotSupported_FixedAddressValueType
     {
         public struct S<T>


### PR DESCRIPTION
The thread statics and delegate marshalling are now being enabled for
collectible classes, so disable the corresponding tests.