### PR TITLE
Remove test for unsupported delegate marshalling

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetFunctionPointerForDelegateTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetFunctionPointerForDelegateTests.cs
@@ -88,28 +88,6 @@ namespace System.Runtime.InteropServices.Tests
             AssertExtensions.Throws<ArgumentException>("delegate", () => Marshal.GetFunctionPointerForDelegate(d));
         }
 
-#if !netstandard // TODO: Enable for netstandard2.1
-        [Fact]
-        public void GetFunctionPointerForDelegate_DelegateCollectible_ThrowsNotSupportedException()
-        {
-            MethodInfo targetMethod = typeof(GetFunctionPointerForDelegateTests).GetMethod(nameof(Method));
-
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type", TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
-            ConstructorBuilder constructorBuilder = typeBuilder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new Type[] { typeof(object), typeof(IntPtr) });
-            constructorBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-
-            MethodBuilder methodBuilder = typeBuilder.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, targetMethod.ReturnType, targetMethod.GetParameters().Select(p => p.ParameterType).ToArray());
-            methodBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-
-            Type type = typeBuilder.CreateType();
-
-            Delegate d = targetMethod.CreateDelegate(type);
-            Assert.Throws<NotSupportedException>(() => Marshal.GetFunctionPointerForDelegate(d));
-        }
-#endif
-
         public delegate void GenericDelegate<T>(T t);
         public delegate void NonGenericDelegate(string t);
 


### PR DESCRIPTION
The GetFunctionPointerForDelegateTests had one subtest that was testing
that an attempt to use delegate marshalling in collectible types will
result in an exception as it was not supported. But the support is
coming in coreclr, so this test needs to be deleted.