### PR TITLE
Fix int indexer in OrderedDictionary

### DIFF
--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -172,10 +172,7 @@ namespace System.Collections.Specialized
         {
             get
             {
-                if (_objectsArray == null)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index));
-                }
+                EnsureObjectsArray();
                 return ((DictionaryEntry)_objectsArray[index]).Value;
             }
             set


### PR DESCRIPTION
Refactor int indexer in OrderedDictionary as requested in https://github.com/dotnet/corefx/pull/32001#discussion_r219901744

/cc @stephentoub 