### PR TITLE
socket handler does not depend on platfrom curl

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -319,6 +319,12 @@ namespace System.Net.Http.Functional.Tests
 #if TargetsWindows
                 return true;
 #else
+                if (UseSocketsHttpHandler)
+                {
+                    // Socket Handler is independent of platform curl.
+                    return true;
+                }
+
                 return TestHelper.NativeHandlerSupportsSslConfiguration();
 #endif
             }


### PR DESCRIPTION
fixes #32502

add back fragment of code removed by #32483
SocketHttpHandler is independent of curl and native platform capabilities.