### PR TITLE
Remove allocations from Uri.Host with IPv6 host

### DIFF
--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Collections.Generic;
-using System.Text;
-using System.Globalization;
 
 namespace System
 {
@@ -15,55 +14,70 @@ namespace System
         // fields
 
         private const int NumberOfLabels = 8;
-        // Lower case hex, no leading zeros
-        private const string CanonicalNumberFormat = "{0:x}";
-        private const string EmbeddedIPv4Format = ":{0:d}.{1:d}.{2:d}.{3:d}";
-        private const char Separator = ':';
 
         // methods
 
-        internal static string ParseCanonicalName(string str, int start, ref bool isLoopback, ref string scopeId)
+        internal static unsafe string ParseCanonicalName(string str, int start, ref bool isLoopback, ref string scopeId)
         {
-            unsafe
-            {
-                ushort* numbers = stackalloc ushort[NumberOfLabels];
-                // optimized zeroing of 8 shorts = 2 longs
-                ((long*)numbers)[0] = 0L;
-                ((long*)numbers)[1] = 0L;
-                isLoopback = Parse(str, numbers, start, ref scopeId);
-                return '[' + CreateCanonicalName(numbers) + ']';
-            }
-        }
+            ushort* numbers = stackalloc ushort[NumberOfLabels];
+            // optimized zeroing of 8 shorts = 2 longs
+            ((long*)numbers)[0] = 0L;
+            ((long*)numbers)[1] = 0L;
+            isLoopback = Parse(str, numbers, start, ref scopeId);
 
-        internal static unsafe string CreateCanonicalName(ushort* numbers)
-        {
             // RFC 5952 Sections 4 & 5 - Compressed, lower case, with possible embedded IPv4 addresses.
 
             // Start to finish, inclusive.  <-1, -1> for no compression
             KeyValuePair<int, int> range = FindCompressionRange(numbers);
             bool ipv4Embedded = ShouldHaveIpv4Embedded(numbers);
 
-            StringBuilder builder = new StringBuilder();
+            Span<char> stackSpace = stackalloc char[48]; // large enough for any IPv6 string, including brackets
+            stackSpace[0] = '[';
+            int pos = 1;
+            int charsWritten;
+            bool success;
             for (int i = 0; i < NumberOfLabels; i++)
             {
                 if (ipv4Embedded && i == (NumberOfLabels - 2))
                 {
+                    stackSpace[pos++] = ':';
+                    
                     // Write the remaining digits as an IPv4 address
-                    builder.AppendFormat(CultureInfo.InvariantCulture, EmbeddedIPv4Format,
-                        numbers[i] >> 8, numbers[i] & 0xFF, numbers[i + 1] >> 8, numbers[i + 1] & 0xFF);
+                    success = (numbers[i] >> 8).TryFormat(stackSpace.Slice(pos), out charsWritten);
+                    Debug.Assert(success);
+                    pos += charsWritten;
+
+                    stackSpace[pos++] = '.';
+                    success = (numbers[i] & 0xFF).TryFormat(stackSpace.Slice(pos), out charsWritten);
+                    Debug.Assert(success);
+                    pos += charsWritten;
+
+                    stackSpace[pos++] = '.';
+                    success = (numbers[i + 1] >> 8).TryFormat(stackSpace.Slice(pos), out charsWritten);
+                    Debug.Assert(success);
+                    pos += charsWritten;
+
+                    stackSpace[pos++] = '.';
+                    success = (numbers[i + 1] & 0xFF).TryFormat(stackSpace.Slice(pos), out charsWritten);
+                    Debug.Assert(success);
+                    pos += charsWritten;
                     break;
                 }
 
                 // Compression; 1::1, ::1, 1::
                 if (range.Key == i)
-                { // Start compression, add :
-                    builder.Append(Separator);
+                {
+                    // Start compression, add :
+                    stackSpace[pos++] = ':';
                 }
+
                 if (range.Key <= i && range.Value == (NumberOfLabels - 1))
-                { // Remainder compressed; 1::
-                    builder.Append(Separator);
+                {
+                    // Remainder compressed; 1::
+                    stackSpace[pos++] = ':';
                     break;
                 }
+
                 if (range.Key <= i && i <= range.Value)
                 {
                     continue; // Compressed
@@ -71,12 +85,15 @@ namespace System
 
                 if (i != 0)
                 {
-                    builder.Append(Separator);
+                    stackSpace[pos++] = ':';
                 }
-                builder.AppendFormat(CultureInfo.InvariantCulture, CanonicalNumberFormat, numbers[i]);
+                success = numbers[i].TryFormat(stackSpace.Slice(pos), out charsWritten, format: "x");
+                Debug.Assert(success);
+                pos += charsWritten;
             }
 
-            return builder.ToString();
+            stackSpace[pos++] = ']';
+            return new string(stackSpace.Slice(0, pos));
         }
 
         // RFC 5952 Section 4.2.3

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System
 {


### PR DESCRIPTION
There are a bunch of allocations we can avoid when accessing Uri.Host for the first time on an instance (such that it needs to create the host string) when the host is an IPv6 address string, including multiple StringBuilders (and their char[]s), a bunch of boxed Int16s and/or Int32s, a bunch of sub strings inside of StringBuilder's formatting, and sometimes a params object[] array (if the address contains an embedded IPv4 address).

This commit changes the implementation to just format into a stack-allocated span rather than using StringBuilder, making the only allocation that for the resulting host string. It also improves throughput of accessing Uri.Host for the first time on an instance with such a host by ~2x.

cc: @rmkerr, @davidsh, @geoffkizer 