### PR TITLE
Fix framework package validation build

### DIFF
--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -109,7 +109,7 @@
 
   <Target Name="VerifyClosure"
           DependsOnTargets="GetClosureFiles"
-          AfterTargets="Build"
+          AfterTargets="ValidatePackage"
           Inputs="%(ClosureFile.FileSet)"
           Outputs="batching-on-FileSet-metadata">
     <ItemGroup>
@@ -129,7 +129,7 @@
 
   <Target Name="VerifyDuplicateTypes"
           DependsOnTargets="GetClosureFiles"
-          AfterTargets="Build"
+          AfterTargets="ValidatePackage"
           Inputs="%(ClosureFile.FileSet)"
           Outputs="batching-on-FileSet-metadata">
     <PropertyGroup>
@@ -154,7 +154,7 @@
 
   <Target Name="VerifyNETStandard"
           DependsOnTargets="GetClosureFiles"
-          AfterTargets="Build"
+          AfterTargets="ValidatePackage"
           Inputs="%(ClosureFile.FileSet)"
           Outputs="batching-on-FileSet-metadata">
 


### PR DESCRIPTION
Fixes #31728

When using AfterTargets="Build" msbuild does not let a failing target effect the result
of the called target (build) since the called target and its closure did not fail.

Instead, sequence our targets in the closure of "Build" so that a failing target will
propagate to the build result.

I noticed one other case of this in test.builds and fixed that as well.

