### PR TITLE
disable ConnectTimeout_TimesOutSSLAuth_Throws

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -558,6 +558,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop]
         [Fact]
+        [ActiveIssue(30032)]
         public async Task ConnectTimeout_TimesOutSSLAuth_Throws()
         {
             var releaseServer = new TaskCompletionSource<bool>();


### PR DESCRIPTION
related to #30032

It seems like we agreed on code changes. Disabling this test for now as it creates lot of noise.  