### PR TITLE
Add pointer overloads for Avx2.BroadcastScalarToVector256

### DIFF
--- a/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -506,6 +506,14 @@ namespace System.Runtime.Intrinsics.X86
         public static unsafe Vector128<long> BroadcastScalarToVector128(long* source) { throw null; }
         public static unsafe Vector128<ulong> BroadcastScalarToVector128(ulong* source) { throw null; }
         public static Vector256<T> BroadcastScalarToVector256<T>(Vector128<T> value) where T : struct { throw null; }
+        public static unsafe Vector256<byte> BroadcastScalarToVector256(byte* source) { throw null; }
+        public static unsafe Vector256<sbyte> BroadcastScalarToVector256(sbyte* source) { throw null; }
+        public static unsafe Vector256<short> BroadcastScalarToVector256(short* source) { throw null; }
+        public static unsafe Vector256<ushort> BroadcastScalarToVector256(ushort* source) { throw null; }
+        public static unsafe Vector256<int> BroadcastScalarToVector256(int* source) { throw null; }
+        public static unsafe Vector256<uint> BroadcastScalarToVector256(uint* source) { throw null; }
+        public static unsafe Vector256<long> BroadcastScalarToVector256(long* source) { throw null; }
+        public static unsafe Vector256<ulong> BroadcastScalarToVector256(ulong* source) { throw null; }
         public static unsafe Vector256<sbyte> BroadcastVector128ToVector256(sbyte* address) { throw null; }
         public static unsafe Vector256<byte> BroadcastVector128ToVector256(byte* address) { throw null; }
         public static unsafe Vector256<short> BroadcastVector128ToVector256(short* address) { throw null; }

--- a/src/System.Runtime.Intrinsics/src/ApiCompatBaseline.netcoreappaot.txt
+++ b/src/System.Runtime.Intrinsics/src/ApiCompatBaseline.netcoreappaot.txt
@@ -1,9 +1,10 @@
 Compat issues with assembly System.Runtime.Intrinsics:
-MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Pclmulqdq.CarrylessMultiply(System.Runtime.Intrinsics.Vector128<System.Int64>, System.Runtime.Intrinsics.Vector128<System.Int64>, System.Byte)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Pclmulqdq.CarrylessMultiply(System.Runtime.Intrinsics.Vector128<System.UInt64>, System.Runtime.Intrinsics.Vector128<System.UInt64>, System.Byte)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.SumAbsoluteDifferences(System.Runtime.Intrinsics.Vector256<System.Byte>, System.Runtime.Intrinsics.Vector256<System.Byte>)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Popcnt.PopCount(System.UInt32)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Popcnt.PopCount(System.UInt64)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Sse2.MultiplyAddAdjacent(System.Runtime.Intrinsics.Vector128<System.Int16>, System.Runtime.Intrinsics.Vector128<System.Int16>)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Sse2.SumAbsoluteDifferences(System.Runtime.Intrinsics.Vector128<System.Byte>, System.Runtime.Intrinsics.Vector128<System.Byte>)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 7
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.BroadcastScalarToVector256(System.Byte*)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.BroadcastScalarToVector256(System.Int16*)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.BroadcastScalarToVector256(System.Int32*)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.BroadcastScalarToVector256(System.Int64*)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.BroadcastScalarToVector256(System.SByte*)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.BroadcastScalarToVector256(System.UInt16*)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.BroadcastScalarToVector256(System.UInt32*)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.Intrinsics.X86.Avx2.BroadcastScalarToVector256(System.UInt64*)' does not exist in the implementation but it does exist in the contract.
+Total Issues: 8


### PR DESCRIPTION
Match CoreCLR change https://github.com/dotnet/coreclr/pull/20193

@CarolEidt @tannergooding @eerhardt 