### PR TITLE
Use natural language in Microsoft.CSharp error messages

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -204,7 +204,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
         public static string GetMessage(MessageID id)
         {
-            return id.ToString();
+            string idStr = id.ToString();
+            return SR.GetResourceString(idStr, idStr);
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -261,5 +320,53 @@
   </data>
   <data name="BadNonTrailingNamedArgument" xml:space="preserve">
     <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
+  <data name="AnonMethod" xml:space="preserve">
+    <value>anonymous method</value>
+  </data>
+  <data name="ERRORSYM" xml:space="preserve">
+    <value>&lt;error&gt;</value>
+  </data>
+  <data name="GlobalNamespace" xml:space="preserve">
+    <value>&lt;global namespace&gt;</value>
+  </data>
+  <data name="Lambda" xml:space="preserve">
+    <value>lambda expression</value>
+  </data>
+  <data name="MethodGroup" xml:space="preserve">
+    <value>method group</value>
+  </data>
+  <data name="NULL" xml:space="preserve">
+    <value>&lt;null&gt;</value>
+  </data>
+  <data name="SK_ALIAS" xml:space="preserve">
+    <value>using alias</value>
+  </data>
+  <data name="SK_CLASS" xml:space="preserve">
+    <value>type</value>
+  </data>
+  <data name="SK_EVENT" xml:space="preserve">
+    <value>event</value>
+  </data>
+  <data name="SK_FIELD" xml:space="preserve">
+    <value>field</value>
+  </data>
+  <data name="SK_METHOD" xml:space="preserve">
+    <value>method</value>
+  </data>
+  <data name="SK_NAMESPACE" xml:space="preserve">
+    <value>namespace</value>
+  </data>
+  <data name="SK_PROPERTY" xml:space="preserve">
+    <value>property</value>
+  </data>
+  <data name="SK_TYVAR" xml:space="preserve">
+    <value>type parameter</value>
+  </data>
+  <data name="SK_UNKNOWN" xml:space="preserve">
+    <value>element</value>
+  </data>
+  <data name="SK_VARIABLE" xml:space="preserve">
+    <value>variable</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes #26630

I got all the values I added to the .resx by inspecting the .resx of the .NET Framework Microsoft.CSharp library with dotPeek. Unfortunately dotPeek only shows the neutral language resources so I couldn't do it for other languages.