### PR TITLE
Fix ParseQueryString behavior when there are multiple values for the same key

### DIFF
--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -59,7 +59,14 @@ namespace System.Web
                 string[] keys = AllKeys;
                 for (int i = 0; i < count; i++)
                 {
-                    sb.AppendFormat("{0}={1}&", keys[i], UrlEncode(this[keys[i]]));
+                    string[] values = GetValues(keys[i]);
+                    if (values != null)
+                    {
+                        foreach (string value in values)
+                        {
+                            sb.AppendFormat("{0}={1}&", keys[i], UrlEncode(value));
+                        }
+                    }
                 }
 
                 return sb.ToString(0, sb.Length - 1);

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -757,8 +757,10 @@ namespace System.Web.Tests
         [Theory]
         [InlineData("")]
         [InlineData("name=foo&desc=foo")]
-        [InlineData("type=foo&type=foo")]
-        public void ParseAndToStringRoundtrip(string input)
+        [InlineData("type=foo&type=bar")]
+        [InlineData("name=&desc=foo")]
+        [InlineData("name=&name=foo")]
+        public void ParseAndToStringMaintainAllKeyValuePairs(string input)
         {
             var values = HttpUtility.ParseQueryString(input);
             var output = values.ToString();

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -753,5 +753,16 @@ namespace System.Web.Tests
         {
             Assert.Equal(encoded, HttpUtility.UrlPathEncode(decoded));
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("name=foo&desc=foo")]
+        [InlineData("type=foo&type=foo")]
+        public void ParseAndToStringRoundtrip(string input)
+        {
+            var values = HttpUtility.ParseQueryString(input);
+            var output = values.ToString();
+            Assert.Equal(input, output);
+        }
     }
 }


### PR DESCRIPTION
Fixes #32575 