### PR TITLE
Fix Tizen runtime OS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -150,7 +150,8 @@
     <_portableOS Condition="'$(RuntimeOS)' == 'WebAssembly'">webassembly</_portableOS>
 
     <_runtimeOS>$(RuntimeOS)</_runtimeOS>
-    <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.4.0.0'">ubuntu.14.04</_runtimeOS>
+    <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.4.0.0'">linux</_runtimeOS>
+    <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.5.0.0'">linux</_runtimeOS>
     <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
     <ToolRuntimeRID>$(_runtimeOS)-x64</ToolRuntimeRID>
     


### PR DESCRIPTION
This fixes Runtime OS used for Tizen, which was incorrect and started to lead to build fails after #31512:

On `https://dotnet.myget.org/feed/dotnet-core` `runtime.ubuntu.14.04-x64.microsoft.netcore.ildasm` is currently not updated, `runtime.linux-x64.microsoft.netcore.ildasm` is updated

cc @alpencolt 
