### PR TITLE
Do no suppress finalization of RequestContextBase due to native mem leak (#32454)

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
@@ -44,6 +44,7 @@ namespace System.Net
         {
             Debug.Assert(_memoryBlob == null, "RequestContextBase::Dispose()|Dispose() called before ReleasePins().");
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
@@ -17,11 +17,7 @@ namespace System.Net
         // Must call this from derived class' constructors.
         protected void BaseConstruction(Interop.HttpApi.HTTP_REQUEST* requestBlob)
         {
-            if (requestBlob == null)
-            {
-                GC.SuppressFinalize(this);
-            }
-            else
+            if (requestBlob != null)
             {
                 _memoryBlob = requestBlob;
             }
@@ -107,19 +103,11 @@ namespace System.Net
                 return;
             }
 
-            if (_memoryBlob == null)
-            {
-                GC.ReRegisterForFinalize(this);
-            }
             _memoryBlob = requestBlob;
         }
 
         protected void UnsetBlob()
         {
-            if (_memoryBlob != null)
-            {
-                GC.SuppressFinalize(this);
-            }
             _memoryBlob = null;
         }
 


### PR DESCRIPTION
`RequestContextBase` was modified to use native memory allocation per #25563. Even though this is freed in the finalizer, `GC.SuppressFinalize` was called without regard for the new allocation resulting in a memory leak (#32454). This removes finalizer suppression in all cases except when `Dispose` is explicitly called.