### PR TITLE
Port: Fix NetworkInterfaces exception when forwarding conf file is not available in linux system (#32350)

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPv4InterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPv4InterfaceProperties.cs
@@ -34,9 +34,28 @@ namespace System.Net.NetworkInformation
 
         private bool GetIsForwardingEnabled()
         {
-            // /proc/sys/net/ipv4/conf/<name>/forwarding
-            string path = Path.Combine(NetworkFiles.Ipv4ConfigFolder, _linuxNetworkInterface.Name, NetworkFiles.ForwardingFileName);
-            return StringParsingHelpers.ParseRawIntFile(path) == 1;
+            string[] paths = new string[]
+            {
+                // /proc/sys/net/ipv4/conf/<name>/forwarding
+                Path.Join(NetworkFiles.Ipv4ConfigFolder, _linuxNetworkInterface.Name, NetworkFiles.ForwardingFileName),
+                // Fall back to global forwarding config /proc/sys/net/ipv4/ip_forward
+                NetworkFiles.Ipv4GlobalForwardingFile
+            };
+
+            for (int i = 0; i < paths.Length; i++)
+            {
+                // Actual layout is specific to kernel version and it could change over time.
+                // If the kernel version we're running on doesn't have this files we don't want to fail, but instead continue. We've hit this exceptions in Windows Subsystem for Linux in the past.
+                // Also the /proc directory may not be mounted or accessible for other reasons. Therefore we catch these potential exceptions and return false instead.
+                try
+                {
+                    return StringParsingHelpers.ParseRawIntFile(paths[i]) == 1;
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+
+            return false;
         }
 
         private int GetMtu()

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkFiles.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkFiles.cs
@@ -12,6 +12,7 @@ namespace System.Net.NetworkInformation
         public const string SnmpV6StatsFile = "/proc/net/snmp6";
         public const string Ipv4ConfigFolder = "/proc/sys/net/ipv4/conf";
         public const string Ipv6ConfigFolder = "/proc/sys/net/ipv6/conf";
+        public const string Ipv4GlobalForwardingFile = "/proc/sys/net/ipv4/ip_forward";
         public const string Ipv4RouteFile = "/proc/net/route";
         public const string Ipv6RouteFile = "/proc/net/ipv6_route";
         public const string SockstatFile = "/proc/net/sockstat";


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/26476

Port of PR https://github.com/dotnet/corefx/pull/32350 -- Issue: https://github.com/dotnet/corefx/issues/26476

Partner issue (live share) https://github.com/Microsoft/vscode-remote/issues/105

**Description**
When trying to get all NetworkInterfaces inside WSL, there is a file not found exception when trying to get the `/proc/sys/net/ipv4/conf/<interface>/forwarding` file because the kernel is different and has a lot of this `/proc/` files missing and they use the global flag set in `/proc/sys/net/ipv4/ip_forward` file.

Kernel versions could change and we're not guaranteed that the /proc/ directory is going to always be mounted correctly, so this fix protects us from those cases as well.

**Customer Impact**
We had a report from some Microsoft Internal customers that are trying to run a host in WSL and try to query the network adapters in order to open a connection.

**Regresion?**
no

**Risk**
Minimal

cc: @danmosemsft 
