### PR TITLE
Treat the 'algorithm' parameter in Digest HTTP authentication as case-insensitive.

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
@@ -248,11 +248,11 @@ namespace System.Net.Test.Common
             }
 
             if (string.IsNullOrEmpty(algorithm))
-                algorithm = "sha-256";
+                algorithm = "MD5";
 
             // Calculate response and compare with the client response hash.
             string a1 = options.Username + ":" + realm + ":" + options.Password;
-            if (algorithm.Contains("sess"))
+            if (algorithm.Contains("sess", StringComparison.OrdinalIgnoreCase))
             {
                 a1 = ComputeHash(a1, algorithm) + ":" + nonce;
 
@@ -288,7 +288,7 @@ namespace System.Net.Test.Common
         {
             // Disable MD5 insecure warning.
 #pragma warning disable CA5351
-            using (HashAlgorithm hash = algorithm.Contains("SHA-256") ? SHA256.Create() : (HashAlgorithm)MD5.Create())
+            using (HashAlgorithm hash = algorithm.Contains("SHA-256", StringComparison.OrdinalIgnoreCase) ? SHA256.Create() : (HashAlgorithm)MD5.Create())
 #pragma warning restore CA5351
             {
                 Encoding enc = Encoding.UTF8;

--- a/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
@@ -252,7 +252,7 @@ namespace System.Net.Test.Common
 
             // Calculate response and compare with the client response hash.
             string a1 = options.Username + ":" + realm + ":" + options.Password;
-            if (algorithm.Contains("sess", StringComparison.OrdinalIgnoreCase))
+            if (algorithm.EndsWith("sess", StringComparison.OrdinalIgnoreCase))
             {
                 a1 = ComputeHash(a1, algorithm) + ":" + nonce;
 
@@ -288,7 +288,7 @@ namespace System.Net.Test.Common
         {
             // Disable MD5 insecure warning.
 #pragma warning disable CA5351
-            using (HashAlgorithm hash = algorithm.Contains("SHA-256", StringComparison.OrdinalIgnoreCase) ? SHA256.Create() : (HashAlgorithm)MD5.Create())
+            using (HashAlgorithm hash = algorithm.StartsWith("SHA-256", StringComparison.OrdinalIgnoreCase) ? SHA256.Create() : (HashAlgorithm)MD5.Create())
 #pragma warning restore CA5351
             {
                 Encoding enc = Encoding.UTF8;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -141,7 +141,7 @@ namespace System.Net.Http
 
             // Calculate response
             string a1 = credential.UserName + ":" + realm + ":" + credential.Password;
-            if (algorithm.IndexOf("sess", StringComparison.OrdinalIgnoreCase) != -1)
+            if (algorithm.EndsWith("sess", StringComparison.OrdinalIgnoreCase))
             {
                 a1 = ComputeHash(a1, algorithm) + ":" + nonce + ":" + cnonce;
             }
@@ -212,7 +212,7 @@ namespace System.Net.Http
         {
             // Disable MD5 insecure warning.
 #pragma warning disable CA5351
-            using (HashAlgorithm hash = algorithm.Contains(Sha256, StringComparison.OrdinalIgnoreCase) ? SHA256.Create() : (HashAlgorithm)MD5.Create())
+            using (HashAlgorithm hash = algorithm.StartsWith(Sha256, StringComparison.OrdinalIgnoreCase) ? SHA256.Create() : (HashAlgorithm)MD5.Create())
 #pragma warning restore CA5351
             {
                 Span<byte> result = stackalloc byte[hash.HashSize / 8]; // HashSize is in bits

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -49,7 +49,10 @@ namespace System.Net.Http
             string algorithm;
             if (digestResponse.Parameters.TryGetValue(Algorithm, out algorithm))
             {
-                if (algorithm != Sha256 && algorithm != Md5 && algorithm != Sha256Sess && algorithm != MD5Sess)
+                if (!algorithm.Equals(Sha256, StringComparison.OrdinalIgnoreCase) &&
+                    !algorithm.Equals(Md5, StringComparison.OrdinalIgnoreCase) &&
+                    !algorithm.Equals(Sha256Sess, StringComparison.OrdinalIgnoreCase) &&
+                    !algorithm.Equals(MD5Sess, StringComparison.OrdinalIgnoreCase))
                 {
                     if (NetEventSource.IsEnabled) NetEventSource.Error(digestResponse, "Algorithm not supported: {algorithm}");
                     return null;
@@ -138,7 +141,7 @@ namespace System.Net.Http
 
             // Calculate response
             string a1 = credential.UserName + ":" + realm + ":" + credential.Password;
-            if (algorithm.IndexOf("sess") != -1)
+            if (algorithm.IndexOf("sess", StringComparison.OrdinalIgnoreCase) != -1)
             {
                 a1 = ComputeHash(a1, algorithm) + ":" + nonce + ":" + cnonce;
             }
@@ -209,7 +212,7 @@ namespace System.Net.Http
         {
             // Disable MD5 insecure warning.
 #pragma warning disable CA5351
-            using (HashAlgorithm hash = algorithm.Contains(Sha256) ? SHA256.Create() : (HashAlgorithm)MD5.Create())
+            using (HashAlgorithm hash = algorithm.Contains(Sha256, StringComparison.OrdinalIgnoreCase) ? SHA256.Create() : (HashAlgorithm)MD5.Create())
 #pragma warning restore CA5351
             {
                 Span<byte> result = stackalloc byte[hash.HashSize / 8]; // HashSize is in bits

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -147,6 +147,7 @@ namespace System.Net.Http.Functional.Tests
             yield return new object[] { "basic", true };
 
             yield return new object[] { $"Digest realm=\"testrealm\", nonce=\"{Convert.ToBase64String(Encoding.UTF8.GetBytes($"{DateTimeOffset.UtcNow}:XMh;z+$5|`i6Hx}}\", qop=auth-int, algorithm=MD5"))}\"", true };
+            yield return new object[] { $"Digest realm=\"testrealm\", nonce=\"{Convert.ToBase64String(Encoding.UTF8.GetBytes($"{DateTimeOffset.UtcNow}:XMh;z+$5|`i6Hx}}\", qop=auth-int, algorithm=md5"))}\"", true };
             yield return new object[] { $"Basic realm=\"testrealm\", " +
                     $"Digest realm=\"testrealm\", nonce=\"{Convert.ToBase64String(Encoding.UTF8.GetBytes($"{DateTimeOffset.UtcNow}:XMh;z+$5|`i6Hx}}"))}\", algorithm=MD5", true };
 

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -713,6 +713,12 @@ namespace System.Net.Http.Functional.Tests
             yield return new object[] { "Digest realm=withoutquotes, nonce=withoutquotes", false };
             yield return new object[] { "Digest realm=\"testrealm\" nonce=\"testnonce\"", false };
             yield return new object[] { "Digest realm=\"testrealm1\", nonce=\"testnonce1\" Digest realm=\"testrealm2\", nonce=\"testnonce2\"", false };
+
+            // These tests check that the algorithm parameter is treated in case insensitive way.
+            // WinHTTP only supports plain MD5, so other algorithms are included here.
+            yield return new object[] { $"Digest realm=\"testrealm\", algorithm=md5-Sess, nonce=\"testnonce\"", true };
+            yield return new object[] { $"Digest realm=\"testrealm\", algorithm=sha-256, nonce=\"testnonce\"", true };
+            yield return new object[] { $"Digest realm=\"testrealm\", algorithm=sha-256-SESS, nonce=\"testnonce\"", true };
         }
     }
 


### PR DESCRIPTION
Issue #32408

The HTTP Digest authentication is specified in [RFC 7616](https://tools.ietf.org/html/rfc7616.html). It specifies the syntax using [ABNF](https://tools.ietf.org/html/rfc5234), which explicitly states `ABNF strings are case insensitive and the character set for these strings is US-ASCII.`

This solves a compatibility issue when connecting to certain servers that send "md5" in lower case. This previously worked with the WinHTTP handler and the bug only affects the new Sockets handler. A backport to 2.1 and 2.2 should be considered.