### PR TITLE
Skip some Http auth tests on UAP

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -725,6 +725,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Needs to be rewritten to use RemoteInvoke")]
         [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_ServerNeedsBasicAuthAndSetDefaultCredentials_StatusCodeUnauthorized()
@@ -1272,6 +1273,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Needs to be rewritten to use RemoteInvoke")]
         [Fact]
         [OuterLoop("Uses external server")]
         public async Task GetAsync_CredentialIsNetworkCredentialUriRedirect_StatusCodeUnauthorized()


### PR DESCRIPTION
Some Http auth related tests have begun failing all the time on Outerloop UWP runs:

* GetAsync_ServerNeedsBasicAuthAndSetDefaultCredentials_StatusCodeUnauthorized
* GetAsync_CredentialIsNetworkCredentialUriRedirect_StatusCodeUnauthorized

The UAP version of Http stack uses WinRT APIs (which use WinInet).  And there is
implicit caching of credentials per-process due to WinInet. So, we need to disable
these tests on UAP similar to other tests in this file.

I used SkipOnTargetFramework instead of ActiveIssue (similar to other tests we skipped
on UAP) because we are not considering revising the tests in the short term. So, we
aren't tracking this work item actively.