### PR TITLE
Added Socket.SafeHandle

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSAEventSelect.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSAEventSelect.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError WSAEventSelect(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SafeHandle Event,
             [In] AsyncEventBits NetworkEvents);
 

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSAGetOverlappedResult.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSAGetOverlappedResult.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static unsafe extern bool WSAGetOverlappedResult(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] NativeOverlapped* overlapped,
             [Out] out uint bytesTransferred,
             [In] bool wait,

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSAIoctl.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSAIoctl.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         // Used with SIOGETEXTENSIONFUNCTIONPOINTER - we're assuming that will never block.
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError WSAIoctl(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] int ioControlCode,
             [In, Out] ref Guid guid,
             [In] int guidSize,

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASocketW.SafeCloseSocket.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASocketW.SafeCloseSocket.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern SafeCloseSocket.InnerSafeCloseSocket WSASocketW(
+        internal static extern SafeSocketHandle.InnerSafeCloseSocket WSASocketW(
                                                 [In] AddressFamily addressFamily,
                                                 [In] SocketType socketType,
                                                 [In] ProtocolType protocolType,

--- a/src/Common/src/Interop/Windows/Winsock/Interop.accept.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.accept.cs
@@ -10,9 +10,9 @@ internal static partial class Interop
 {
     internal static partial class Winsock
     {
-        // Blocking call - requires IntPtr instead of SafeCloseSocket.
+        // Blocking call - requires IntPtr instead of SafeSocketHandle.
         [DllImport(Interop.Libraries.Ws2_32, ExactSpelling = true, SetLastError = true)]
-        internal static extern SafeCloseSocket.InnerSafeCloseSocket accept(
+        internal static extern SafeSocketHandle.InnerSafeCloseSocket accept(
             [In] IntPtr socketHandle,
             [Out] byte[] socketAddress,
             [In, Out] ref int socketAddressSize);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.bind.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.bind.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError bind(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] byte[] socketAddress,
             [In] int socketAddressSize);
     }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.getpeername.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.getpeername.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError getpeername(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [Out] byte[] socketAddress,
             [In, Out] ref int socketAddressSize);
     }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.getsockname.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.getsockname.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError getsockname(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [Out] byte[] socketAddress,
             [In, Out] ref int socketAddressSize);
     }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.getsockopt.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.getsockopt.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError getsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [Out] out int optionValue,
@@ -19,7 +19,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError getsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [Out] byte[] optionValue,
@@ -27,7 +27,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError getsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [Out] out Linger optionValue,
@@ -35,7 +35,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError getsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [Out] out IPMulticastRequest optionValue,
@@ -43,7 +43,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError getsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [Out] out IPv6MulticastRequest optionValue,

--- a/src/Common/src/Interop/Windows/Winsock/Interop.ioctlsocket.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.ioctlsocket.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError ioctlsocket(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] int cmd,
             [In, Out] ref int argp);
     }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.listen.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.listen.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError listen(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] int backlog);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.setsockopt.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.setsockopt.cs
@@ -20,7 +20,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError setsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [In] ref int optionValue,
@@ -28,7 +28,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError setsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [In] byte[] optionValue,
@@ -36,7 +36,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError setsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [In] ref IntPtr pointer,
@@ -44,7 +44,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError setsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [In] ref Linger linger,
@@ -52,7 +52,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError setsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [In] ref IPMulticastRequest mreq,
@@ -60,7 +60,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError setsockopt(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] SocketOptionLevel optionLevel,
             [In] SocketOptionName optionName,
             [In] ref IPv6MulticastRequest mreq,

--- a/src/Common/src/Interop/Windows/Winsock/Interop.shutdown.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.shutdown.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern SocketError shutdown(
-            [In] SafeCloseSocket socketHandle,
+            [In] SafeSocketHandle socketHandle,
             [In] int how);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/SafeNativeOverlapped.cs
+++ b/src/Common/src/Interop/Windows/Winsock/SafeNativeOverlapped.cs
@@ -12,7 +12,7 @@ namespace System.Net.Sockets
 {
     internal sealed class SafeNativeOverlapped : SafeHandle
     {
-        private readonly SafeCloseSocket _socketHandle;
+        private readonly SafeSocketHandle _socketHandle;
 
         private SafeNativeOverlapped()
             : this(IntPtr.Zero)
@@ -26,7 +26,7 @@ namespace System.Net.Sockets
             SetHandle(handle);
         }
 
-        public unsafe SafeNativeOverlapped(SafeCloseSocket socketHandle, NativeOverlapped* handle)
+        public unsafe SafeNativeOverlapped(SafeSocketHandle socketHandle, NativeOverlapped* handle)
             : this((IntPtr)handle)
         {
             _socketHandle = socketHandle;

--- a/src/Common/src/System/Net/SafeCloseSocketAndEvent.cs
+++ b/src/Common/src/System/Net/SafeCloseSocketAndEvent.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 namespace System.Net.Sockets
 {
-    internal sealed class SafeCloseSocketAndEvent : SafeCloseSocket
+    internal sealed class SafeCloseSocketAndEvent : SafeSocketHandle
     {
         private AutoResetEvent _waitHandle;
 

--- a/src/Common/src/System/Net/SafeSocketHandle.Unix.cs
+++ b/src/Common/src/System/Net/SafeSocketHandle.Unix.cs
@@ -10,7 +10,7 @@ using System.Diagnostics;
 
 namespace System.Net.Sockets
 {
-    internal partial class SafeCloseSocket :
+    internal partial class SafeSocketHandle :
 #if DEBUG
         DebugSafeHandleMinusOneIsInvalid
 #else
@@ -41,7 +41,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public void TransferTrackedState(SafeCloseSocket target)
+        public void TransferTrackedState(SafeSocketHandle target)
         {
             target._trackedOptions = _trackedOptions;
             target.LastConnectFailed = LastConnectFailed;
@@ -181,19 +181,19 @@ namespace System.Net.Sockets
             IsDisconnected = true;
         }
 
-        public static unsafe SafeCloseSocket CreateSocket(IntPtr fileDescriptor)
+        public static unsafe SafeSocketHandle CreateSocket(IntPtr fileDescriptor)
         {
             return CreateSocket(InnerSafeCloseSocket.CreateSocket(fileDescriptor));
         }
 
-        public static unsafe SocketError CreateSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, out SafeCloseSocket socket)
+        public static unsafe SocketError CreateSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, out SafeSocketHandle socket)
         {
             SocketError errorCode;
             socket = CreateSocket(InnerSafeCloseSocket.CreateSocket(addressFamily, socketType, protocolType, out errorCode));
             return errorCode;
         }
 
-        public static unsafe SocketError Accept(SafeCloseSocket socketHandle, byte[] socketAddress, ref int socketAddressSize, out SafeCloseSocket socket)
+        public static unsafe SocketError Accept(SafeSocketHandle socketHandle, byte[] socketAddress, ref int socketAddressSize, out SafeSocketHandle socket)
         {
             SocketError errorCode;
             socket = CreateSocket(InnerSafeCloseSocket.Accept(socketHandle, socketAddress, ref socketAddressSize, out errorCode));
@@ -329,7 +329,7 @@ namespace System.Net.Sockets
                 return res;
             }
 
-            public static unsafe InnerSafeCloseSocket Accept(SafeCloseSocket socketHandle, byte[] socketAddress, ref int socketAddressLen, out SocketError errorCode)
+            public static unsafe InnerSafeCloseSocket Accept(SafeSocketHandle socketHandle, byte[] socketAddress, ref int socketAddressLen, out SocketError errorCode)
             {
                 IntPtr acceptedFd;
                 if (!socketHandle.IsNonBlocking)

--- a/src/Common/src/System/Net/SafeSocketHandle.Unix.cs
+++ b/src/Common/src/System/Net/SafeSocketHandle.Unix.cs
@@ -10,12 +10,7 @@ using System.Diagnostics;
 
 namespace System.Net.Sockets
 {
-    internal partial class SafeSocketHandle :
-#if DEBUG
-        DebugSafeHandleMinusOneIsInvalid
-#else
-        SafeHandleMinusOneIsInvalid
-#endif
+    partial class SafeSocketHandle
     {
         private int _receiveTimeout = -1;
         private int _sendTimeout = -1;
@@ -28,7 +23,7 @@ namespace System.Net.Sockets
         internal bool DualMode { get; set; }
         internal bool ExposedHandleOrUntrackedConfiguration { get; private set; }
 
-        public void RegisterConnectResult(SocketError error)
+        internal void RegisterConnectResult(SocketError error)
         {
             switch (error)
             {
@@ -41,7 +36,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public void TransferTrackedState(SafeSocketHandle target)
+        internal void TransferTrackedState(SafeSocketHandle target)
         {
             target._trackedOptions = _trackedOptions;
             target.LastConnectFailed = LastConnectFailed;
@@ -49,11 +44,11 @@ namespace System.Net.Sockets
             target.ExposedHandleOrUntrackedConfiguration = ExposedHandleOrUntrackedConfiguration;
         }
 
-        public void SetExposed() => ExposedHandleOrUntrackedConfiguration = true;
+        internal void SetExposed() => ExposedHandleOrUntrackedConfiguration = true;
 
-        public bool IsTrackedOption(TrackedSocketOptions option) => (_trackedOptions & option) != 0;
+        internal bool IsTrackedOption(TrackedSocketOptions option) => (_trackedOptions & option) != 0;
 
-        public void TrackOption(SocketOptionLevel level, SocketOptionName name)
+        internal void TrackOption(SocketOptionLevel level, SocketOptionName name)
         {
             // As long as only these options are set, we can support Connect{Async}(IPAddress[], ...).
             switch (level)
@@ -99,7 +94,7 @@ namespace System.Net.Sockets
             ExposedHandleOrUntrackedConfiguration = true;
         }
 
-        public SocketAsyncContext AsyncContext
+        internal SocketAsyncContext AsyncContext
         {
             get
             {
@@ -125,7 +120,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public bool IsNonBlocking
+        internal bool IsNonBlocking
         {
             get
             {
@@ -148,7 +143,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public int ReceiveTimeout
+        internal int ReceiveTimeout
         {
             get
             {
@@ -161,7 +156,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public int SendTimeout
+        internal int SendTimeout
         {
             get
             {
@@ -174,26 +169,26 @@ namespace System.Net.Sockets
             }
         }
 
-        public bool IsDisconnected { get; private set; } = false;
+        internal bool IsDisconnected { get; private set; } = false;
 
-        public void SetToDisconnected()
+        internal void SetToDisconnected()
         {
             IsDisconnected = true;
         }
 
-        public static unsafe SafeSocketHandle CreateSocket(IntPtr fileDescriptor)
+        internal static unsafe SafeSocketHandle CreateSocket(IntPtr fileDescriptor)
         {
             return CreateSocket(InnerSafeCloseSocket.CreateSocket(fileDescriptor));
         }
 
-        public static unsafe SocketError CreateSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, out SafeSocketHandle socket)
+        internal static unsafe SocketError CreateSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, out SafeSocketHandle socket)
         {
             SocketError errorCode;
             socket = CreateSocket(InnerSafeCloseSocket.CreateSocket(addressFamily, socketType, protocolType, out errorCode));
             return errorCode;
         }
 
-        public static unsafe SocketError Accept(SafeSocketHandle socketHandle, byte[] socketAddress, ref int socketAddressSize, out SafeSocketHandle socket)
+        internal static unsafe SocketError Accept(SafeSocketHandle socketHandle, byte[] socketAddress, ref int socketAddressSize, out SafeSocketHandle socket)
         {
             SocketError errorCode;
             socket = CreateSocket(InnerSafeCloseSocket.Accept(socketHandle, socketAddress, ref socketAddressSize, out errorCode));
@@ -286,14 +281,14 @@ namespace System.Net.Sockets
                 return SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
             }
 
-            public static InnerSafeCloseSocket CreateSocket(IntPtr fileDescriptor)
+            internal static InnerSafeCloseSocket CreateSocket(IntPtr fileDescriptor)
             {
                 var res = new InnerSafeCloseSocket();
                 res.SetHandle(fileDescriptor);
                 return res;
             }
 
-            public static unsafe InnerSafeCloseSocket CreateSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, out SocketError errorCode)
+            internal static unsafe InnerSafeCloseSocket CreateSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, out SocketError errorCode)
             {
                 IntPtr fd;
                 Interop.Error error = Interop.Sys.Socket(addressFamily, socketType, protocolType, &fd);
@@ -329,7 +324,7 @@ namespace System.Net.Sockets
                 return res;
             }
 
-            public static unsafe InnerSafeCloseSocket Accept(SafeSocketHandle socketHandle, byte[] socketAddress, ref int socketAddressLen, out SocketError errorCode)
+            internal static unsafe InnerSafeCloseSocket Accept(SafeSocketHandle socketHandle, byte[] socketAddress, ref int socketAddressLen, out SocketError errorCode)
             {
                 IntPtr acceptedFd;
                 if (!socketHandle.IsNonBlocking)

--- a/src/Common/src/System/Net/SafeSocketHandle.Windows.cs
+++ b/src/Common/src/System/Net/SafeSocketHandle.Windows.cs
@@ -9,20 +9,15 @@ using System.Threading;
 
 namespace System.Net.Sockets
 {
-    internal partial class SafeSocketHandle :
-#if DEBUG
-        DebugSafeHandleMinusOneIsInvalid
-#else
-        SafeHandleMinusOneIsInvalid
-#endif
+    partial class SafeSocketHandle
     {
         private ThreadPoolBoundHandle _iocpBoundHandle;
         private bool _skipCompletionPortOnSuccess;
         private object _iocpBindingLock = new object();
 
-        public void SetExposed() { /* nop */ }
+        internal void SetExposed() { /* nop */ }
 
-        public ThreadPoolBoundHandle IOCPBoundHandle
+        internal ThreadPoolBoundHandle IOCPBoundHandle
         {
             get
             {
@@ -30,10 +25,10 @@ namespace System.Net.Sockets
             }
         }
 
-        public ThreadPoolBoundHandle GetThreadPoolBoundHandle() => !_released ? _iocpBoundHandle : null;
+        internal ThreadPoolBoundHandle GetThreadPoolBoundHandle() => !_released ? _iocpBoundHandle : null;
 
         // Binds the Socket Win32 Handle to the ThreadPool's CompletionPort.
-        public ThreadPoolBoundHandle GetOrAllocateThreadPoolBoundHandle(bool trySkipCompletionPortOnSuccess)
+        internal ThreadPoolBoundHandle GetOrAllocateThreadPoolBoundHandle(bool trySkipCompletionPortOnSuccess)
         {
             if (_released)
             {
@@ -91,7 +86,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public bool SkipCompletionPortOnSuccess
+        internal bool SkipCompletionPortOnSuccess
         {
             get
             {

--- a/src/Common/src/System/Net/SafeSocketHandle.Windows.cs
+++ b/src/Common/src/System/Net/SafeSocketHandle.Windows.cs
@@ -9,7 +9,7 @@ using System.Threading;
 
 namespace System.Net.Sockets
 {
-    internal partial class SafeCloseSocket :
+    internal partial class SafeSocketHandle :
 #if DEBUG
         DebugSafeHandleMinusOneIsInvalid
 #else
@@ -100,13 +100,13 @@ namespace System.Net.Sockets
             }
         }
 
-        internal static SafeCloseSocket CreateWSASocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+        internal static SafeSocketHandle CreateWSASocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
             return CreateSocket(InnerSafeCloseSocket.CreateWSASocket(addressFamily, socketType, protocolType));
         }
 
-        internal static SafeCloseSocket Accept(
-            SafeCloseSocket socketHandle,
+        internal static SafeSocketHandle Accept(
+            SafeSocketHandle socketHandle,
             byte[] socketAddress,
             ref int socketAddressSize)
         {
@@ -225,7 +225,7 @@ namespace System.Net.Sockets
                 return result;
             }
 
-            internal static InnerSafeCloseSocket Accept(SafeCloseSocket socketHandle, byte[] socketAddress, ref int socketAddressSize)
+            internal static InnerSafeCloseSocket Accept(SafeSocketHandle socketHandle, byte[] socketAddress, ref int socketAddressSize)
             {
                 InnerSafeCloseSocket result = Interop.Winsock.accept(socketHandle.DangerousGetHandle(), socketAddress, ref socketAddressSize);
                 if (result.IsInvalid)

--- a/src/Common/src/System/Net/SafeSocketHandle.cs
+++ b/src/Common/src/System/Net/SafeSocketHandle.cs
@@ -22,14 +22,14 @@ namespace System.Net.Sockets
     // to block the user thread in case a graceful close has been
     // requested.  (It's not legal to block any other thread - such closes
     // are always abortive.)
-    internal partial class SafeCloseSocket :
+    internal partial class SafeSocketHandle :
 #if DEBUG
         DebugSafeHandleMinusOneIsInvalid
 #else
         SafeHandleMinusOneIsInvalid
 #endif
     {
-        protected SafeCloseSocket() : base(true) { }
+        protected SafeSocketHandle() : base(true) { }
 
         private InnerSafeCloseSocket _innerSocket;
         private volatile bool _released;
@@ -59,7 +59,7 @@ namespace System.Net.Sockets
             }
             catch (Exception e)
             {
-                Debug.Fail("SafeCloseSocket.AddRef after inner socket disposed." + e);
+                Debug.Fail("SafeSocketHandle.AddRef after inner socket disposed." + e);
             }
         }
 
@@ -76,7 +76,7 @@ namespace System.Net.Sockets
             }
             catch (Exception e)
             {
-                Debug.Fail("SafeCloseSocket.Release after inner socket disposed." + e);
+                Debug.Fail("SafeSocketHandle.Release after inner socket disposed." + e);
             }
         }
 #endif
@@ -90,9 +90,9 @@ namespace System.Net.Sockets
 #endif
         }
 
-        private static SafeCloseSocket CreateSocket(InnerSafeCloseSocket socket)
+        private static SafeSocketHandle CreateSocket(InnerSafeCloseSocket socket)
         {
-            SafeCloseSocket ret = new SafeCloseSocket();
+            SafeSocketHandle ret = new SafeSocketHandle();
             CreateSocket(socket, ret);
 
             if (NetEventSource.IsEnabled) NetEventSource.Info(null, ret);
@@ -100,7 +100,7 @@ namespace System.Net.Sockets
             return ret;
         }
 
-        protected static void CreateSocket(InnerSafeCloseSocket socket, SafeCloseSocket target)
+        protected static void CreateSocket(InnerSafeCloseSocket socket, SafeSocketHandle target)
         {
             if (socket != null && socket.IsInvalid)
             {

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
@@ -24,18 +24,13 @@ namespace Microsoft.Win32.SafeHandles
 
         private Socket _namedPipeSocket;
         private SafeHandle _namedPipeSocketHandle;
-        private static PropertyInfo s_safeHandleProperty;
 
         internal SafePipeHandle(Socket namedPipeSocket) : base(ownsHandle: true)
         {
             Debug.Assert(namedPipeSocket != null);
             _namedPipeSocket = namedPipeSocket;
 
-            // TODO: Issue https://github.com/dotnet/corefx/issues/6807
-            // This is unfortunately the only way of getting at the Socket's file descriptor right now, until #6807 is implemented.
-            PropertyInfo safeHandleProperty = s_safeHandleProperty ?? (s_safeHandleProperty = typeof(Socket).GetTypeInfo().GetDeclaredProperty("SafeHandle"));
-            Debug.Assert(safeHandleProperty != null, "Socket.SafeHandle could not be found.");
-            _namedPipeSocketHandle = (SafeHandle)safeHandleProperty?.GetValue(namedPipeSocket, null);
+            _namedPipeSocketHandle = namedPipeSocket.SafeHandle;
 
             bool ignored = false;
             _namedPipeSocketHandle.DangerousAddRef(ref ignored);

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -129,11 +129,11 @@
     <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
       <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SafeCloseSocket.cs">
-      <Link>Common\System\Net\SafeCloseSocket.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\SafeSocketHandle.cs">
+      <Link>Common\System\Net\SafeSocketHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SafeCloseSocket.Windows.cs">
-      <Link>Common\System\Net\SafeCloseSocket.Windows.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\SafeSocketHandle.Windows.cs">
+      <Link>Common\System\Net\SafeSocketHandle.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\SafeCloseSocketAndEvent.cs">
       <Link>Common\System\Net\SafeCloseSocketAndEvent.cs</Link>

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -1,10 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>System.Net.NetworkInformation</AssemblyName>
     <OutputType>Library</OutputType>
     <ProjectGuid>{3CA89D6C-F8D1-4813-9775-F8D249686E31}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
+    <!-- System.Net.Sockets.SafeSocketHandle is defined both in System.Net.Sockets (public)
+         and System.Net.NetworkInformation (internal). -->
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
     <Configurations>netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -186,6 +186,12 @@ namespace System.Net.Sockets
         Unknown = -1,
         Unspecified = 0,
     }
+
+    public sealed class SafeSocketHandle : Microsoft.Win32.SafeHandles.SafeHandleMinusOneIsInvalid
+    {
+        public SafeSocketHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle) { }
+        protected override bool ReleaseHandle() { throw null; }
+    }
     public enum SelectMode
     {
         SelectError = 2,
@@ -231,6 +237,7 @@ namespace System.Net.Sockets
         public int ReceiveBufferSize { get { throw null; } set { } }
         public int ReceiveTimeout { get { throw null; } set { } }
         public System.Net.EndPoint RemoteEndPoint { get { throw null; } }
+        public SafeSocketHandle SafeHandle { get { throw null; } }
         public int SendBufferSize { get { throw null; } set { } }
         public int SendTimeout { get { throw null; } set { } }
         public System.Net.Sockets.SocketType SocketType { get { throw null; } }

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>System.Net.Sockets</AssemblyName>
     <ProjectGuid>{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}</ProjectGuid>
@@ -88,8 +88,8 @@
     <Compile Include="$(CommonPath)\System\Net\RangeValidationHelpers.cs">
       <Link>Common\System\Net\RangeValidationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SafeCloseSocket.cs">
-      <Link>Common\System\Net\SafeCloseSocket.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\SafeSocketHandle.cs">
+      <Link>Common\System\Net\SafeSocketHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\SocketAddress.cs">
       <Link>Common\System\Net\SocketAddress.cs</Link>
@@ -131,8 +131,8 @@
     <Compile Include="System\Net\Sockets\SocketPal.Windows.cs" />
     <Compile Include="System\Net\Sockets\TransmitFileAsyncResult.Windows.cs" />
     <Compile Include="System\Net\Sockets\UnixDomainSocketEndPoint.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\Net\SafeCloseSocket.Windows.cs">
-      <Link>Common\System\Net\SafeCloseSocket.Windows.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\SafeSocketHandle.Windows.cs">
+      <Link>Common\System\Net\SafeSocketHandle.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
       <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
@@ -264,8 +264,8 @@
     <Compile Include="$(CommonPath)\System\Net\InteropIPAddressExtensions.Unix.cs">
       <Link>Common\System\Net\InteropIPAddressExtensions.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SafeCloseSocket.Unix.cs">
-      <Link>Common\System\Net\SafeCloseSocket.Unix.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\SafeSocketHandle.Unix.cs">
+      <Link>Common\System\Net\SafeSocketHandle.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Unix.cs">
       <Link>Common\System\Net\SocketAddressPal.Unix.cs</Link>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
@@ -37,7 +37,7 @@ namespace System.Net.Sockets
 				System.Buffer.BlockCopy(socketAddress, 0, remoteSocketAddress.Buffer, 0, socketAddressLen);
 
 				_acceptedSocket = _listenSocket.CreateAcceptSocket(
-					SafeCloseSocket.CreateSocket(acceptedFileDescriptor),
+					SafeSocketHandle.CreateSocket(acceptedFileDescriptor),
 					_listenSocket._rightEndPoint.Create(remoteSocketAddress));
 			}
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -60,7 +60,7 @@ namespace System.Net.Sockets
             _lockObject = new object();
         }
 
-        public T GetDelegate<T>(SafeCloseSocket socketHandle)
+        public T GetDelegate<T>(SafeSocketHandle socketHandle)
             where T : class
         {
             if (typeof(T) == typeof(AcceptExDelegate))
@@ -115,7 +115,7 @@ namespace System.Net.Sockets
         }
 
         // Private methods that actually load the function pointers.
-        private IntPtr LoadDynamicFunctionPointer(SafeCloseSocket socketHandle, ref Guid guid)
+        private IntPtr LoadDynamicFunctionPointer(SafeSocketHandle socketHandle, ref Guid guid)
         {
             IntPtr ptr = IntPtr.Zero;
             int length;
@@ -147,7 +147,7 @@ namespace System.Net.Sockets
         //       to the fields of the delegate instances are visible before the write to the field
         //       that holds the reference to the delegate instance.
 
-        private void EnsureAcceptEx(SafeCloseSocket socketHandle)
+        private void EnsureAcceptEx(SafeSocketHandle socketHandle)
         {
             if (_acceptEx == null)
             {
@@ -163,7 +163,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private void EnsureGetAcceptExSockaddrs(SafeCloseSocket socketHandle)
+        private void EnsureGetAcceptExSockaddrs(SafeSocketHandle socketHandle)
         {
             if (_getAcceptExSockaddrs == null)
             {
@@ -179,7 +179,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private void EnsureConnectEx(SafeCloseSocket socketHandle)
+        private void EnsureConnectEx(SafeSocketHandle socketHandle)
         {
             if (_connectEx == null)
             {
@@ -195,7 +195,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private void EnsureDisconnectEx(SafeCloseSocket socketHandle)
+        private void EnsureDisconnectEx(SafeSocketHandle socketHandle)
         {
             if (_disconnectEx == null)
             {
@@ -211,7 +211,7 @@ namespace System.Net.Sockets
                 }
             }
         }
-        private void EnsureWSARecvMsg(SafeCloseSocket socketHandle)
+        private void EnsureWSARecvMsg(SafeSocketHandle socketHandle)
         {
             if (_recvMsg == null)
             {
@@ -228,7 +228,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private void EnsureWSARecvMsgBlocking(SafeCloseSocket socketHandle)
+        private void EnsureWSARecvMsgBlocking(SafeSocketHandle socketHandle)
         {
             if (_recvMsgBlocking == null)
             {
@@ -244,7 +244,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private void EnsureTransmitPackets(SafeCloseSocket socketHandle)
+        private void EnsureTransmitPackets(SafeSocketHandle socketHandle)
         {
             if (_transmitPackets == null)
             {
@@ -263,8 +263,8 @@ namespace System.Net.Sockets
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate bool AcceptExDelegate(
-                SafeCloseSocket listenSocketHandle,
-                SafeCloseSocket acceptSocketHandle,
+                SafeSocketHandle listenSocketHandle,
+                SafeSocketHandle acceptSocketHandle,
                 IntPtr buffer,
                 int len,
                 int localAddressLength,
@@ -286,7 +286,7 @@ namespace System.Net.Sockets
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate bool ConnectExDelegate(
-                SafeCloseSocket socketHandle,
+                SafeSocketHandle socketHandle,
                 IntPtr socketAddress,
                 int socketAddressSize,
                 IntPtr buffer,
@@ -296,21 +296,21 @@ namespace System.Net.Sockets
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate bool DisconnectExDelegate(
-                SafeCloseSocket socketHandle, 
+                SafeSocketHandle socketHandle, 
                 NativeOverlapped* overlapped, 
                 int flags, 
                 int reserved);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal delegate bool DisconnectExDelegateBlocking(
-                SafeCloseSocket socketHandle, 
+                SafeSocketHandle socketHandle, 
                 IntPtr overlapped, 
                 int flags, 
                 int reserved);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate SocketError WSARecvMsgDelegate(
-                SafeCloseSocket socketHandle,
+                SafeSocketHandle socketHandle,
                 IntPtr msg,
                 out int bytesTransferred,
                 NativeOverlapped* overlapped,
@@ -326,7 +326,7 @@ namespace System.Net.Sockets
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate bool TransmitPacketsDelegate(
-                SafeCloseSocket socketHandle,
+                SafeSocketHandle socketHandle,
                 IntPtr packetArray,
                 int elementCount,
                 int sendSize,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -51,7 +51,7 @@ namespace System.Net.Sockets
         internal SocketError ReplaceHandle()
         {
             // Copy out values from key options. The copied values should be kept in sync with the
-            // handling in SafeCloseSocket.TrackOption.  Note that we copy these values out first, before
+            // handling in SafeSocketHandle.TrackOption.  Note that we copy these values out first, before
             // we change _handle, so that we can use the helpers on Socket which internally access _handle.
             // Then once _handle is switched to the new one, we can call the setters to propagate the retrieved
             // values back out to the new underlying socket.
@@ -70,7 +70,7 @@ namespace System.Net.Sockets
             if (_handle.IsTrackedOption(TrackedSocketOptions.Ttl)) ttl = Ttl;
 
             // Then replace the handle with a new one
-            SafeCloseSocket oldHandle = _handle;
+            SafeSocketHandle oldHandle = _handle;
             SocketError errorCode = SocketPal.CreateSocket(_addressFamily, _socketType, _protocolType, out _handle);
             oldHandle.TransferTrackedState(_handle);
             oldHandle.Dispose();
@@ -101,7 +101,7 @@ namespace System.Net.Sockets
             throw new PlatformNotSupportedException(SR.net_sockets_connect_multiconnect_notsupported);
         }
 
-        private Socket GetOrCreateAcceptSocket(Socket acceptSocket, bool unused, string propertyName, out SafeCloseSocket handle)
+        private Socket GetOrCreateAcceptSocket(Socket acceptSocket, bool unused, string propertyName, out SafeSocketHandle handle)
         {
             // AcceptSocket is not supported on Unix.
             if (acceptSocket != null)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -25,8 +25,8 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe bool AcceptEx(SafeCloseSocket listenSocketHandle,
-            SafeCloseSocket acceptSocketHandle,
+        internal unsafe bool AcceptEx(SafeSocketHandle listenSocketHandle,
+            SafeSocketHandle acceptSocketHandle,
             IntPtr buffer,
             int len,
             int localAddressLength,
@@ -69,7 +69,7 @@ namespace System.Net.Sockets
                 out remoteSocketAddressLength);
         }
 
-        internal unsafe bool DisconnectEx(SafeCloseSocket socketHandle, NativeOverlapped* overlapped, int flags, int reserved)
+        internal unsafe bool DisconnectEx(SafeSocketHandle socketHandle, NativeOverlapped* overlapped, int flags, int reserved)
         {
             EnsureDynamicWinsockMethods();
             DisconnectExDelegate disconnectEx = _dynamicWinsockMethods.GetDelegate<DisconnectExDelegate>(socketHandle);
@@ -77,7 +77,7 @@ namespace System.Net.Sockets
             return disconnectEx(socketHandle, overlapped, flags, reserved);
         }
 
-        internal bool DisconnectExBlocking(SafeCloseSocket socketHandle, IntPtr overlapped, int flags, int reserved)
+        internal bool DisconnectExBlocking(SafeSocketHandle socketHandle, IntPtr overlapped, int flags, int reserved)
         {
             EnsureDynamicWinsockMethods();
             DisconnectExDelegateBlocking disconnectEx_Blocking = _dynamicWinsockMethods.GetDelegate<DisconnectExDelegateBlocking>(socketHandle);
@@ -85,7 +85,7 @@ namespace System.Net.Sockets
             return disconnectEx_Blocking(socketHandle, overlapped, flags, reserved);
         }
 
-        internal unsafe bool ConnectEx(SafeCloseSocket socketHandle,
+        internal unsafe bool ConnectEx(SafeSocketHandle socketHandle,
             IntPtr socketAddress,
             int socketAddressSize,
             IntPtr buffer,
@@ -99,7 +99,7 @@ namespace System.Net.Sockets
             return connectEx(socketHandle, socketAddress, socketAddressSize, buffer, dataLength, out bytesSent, overlapped);
         }
 
-        internal unsafe SocketError WSARecvMsg(SafeCloseSocket socketHandle, IntPtr msg, out int bytesTransferred, NativeOverlapped* overlapped, IntPtr completionRoutine)
+        internal unsafe SocketError WSARecvMsg(SafeSocketHandle socketHandle, IntPtr msg, out int bytesTransferred, NativeOverlapped* overlapped, IntPtr completionRoutine)
         {
             EnsureDynamicWinsockMethods();
             WSARecvMsgDelegate recvMsg = _dynamicWinsockMethods.GetDelegate<WSARecvMsgDelegate>(socketHandle);
@@ -115,7 +115,7 @@ namespace System.Net.Sockets
             return recvMsg_Blocking(socketHandle, msg, out bytesTransferred, overlapped, completionRoutine);
         }
 
-        internal unsafe bool TransmitPackets(SafeCloseSocket socketHandle, IntPtr packetArray, int elementCount, int sendSize, NativeOverlapped* overlapped, TransmitFileOptions flags)
+        internal unsafe bool TransmitPackets(SafeSocketHandle socketHandle, IntPtr packetArray, int elementCount, int sendSize, NativeOverlapped* overlapped, TransmitFileOptions flags)
         {
             EnsureDynamicWinsockMethods();
             TransmitPacketsDelegate transmitPackets = _dynamicWinsockMethods.GetDelegate<TransmitPacketsDelegate>(socketHandle);
@@ -196,7 +196,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private Socket GetOrCreateAcceptSocket(Socket acceptSocket, bool checkDisconnected, string propertyName, out SafeCloseSocket handle)
+        private Socket GetOrCreateAcceptSocket(Socket acceptSocket, bool checkDisconnected, string propertyName, out SafeSocketHandle handle)
         {
             // If an acceptSocket isn't specified, then we need to create one.
             if (acceptSocket == null)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -289,7 +289,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal SafeSocketHandle SafeHandle
+        public SafeSocketHandle SafeHandle
         {
             get
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Net.Internals;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace System.Net.Sockets
@@ -19,7 +20,7 @@ namespace System.Net.Sockets
     {
         internal const int DefaultCloseTimeout = -1; // NOTE: changing this default is a breaking change.
 
-        private SafeCloseSocket _handle;
+        private SafeSocketHandle _handle;
 
         // _rightEndPoint is null if the socket has not been bound.  Otherwise, it is any EndPoint of the
         // correct type (IPEndPoint, etc).
@@ -115,7 +116,7 @@ namespace System.Net.Sockets
         }
 
         // Called by the class to create a socket to accept an incoming request.
-        private Socket(SafeCloseSocket fd)
+        private Socket(SafeSocketHandle fd)
         {
             // NOTE: If this ctor is ever made public/protected, this check will need
             // to be converted into a runtime exception.
@@ -288,7 +289,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal SafeCloseSocket SafeHandle
+        internal SafeSocketHandle SafeHandle
         {
             get
             {
@@ -1063,7 +1064,7 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddress = IPEndPointExtensions.Serialize(_rightEndPoint);
 
             // This may throw ObjectDisposedException.
-            SafeCloseSocket acceptedSocketHandle;
+            SafeSocketHandle acceptedSocketHandle;
             SocketError errorCode = SocketPal.Accept(
                 _handle,
                 socketAddress.Buffer,
@@ -3636,7 +3637,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_sockets_mustlisten);
             }
 
-            SafeCloseSocket acceptHandle;
+            SafeSocketHandle acceptHandle;
             asyncResult.AcceptSocket = GetOrCreateAcceptSocket(acceptSocket, false, nameof(acceptSocket), out acceptHandle);
 
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"AcceptSocket:{acceptSocket}");
@@ -3792,7 +3793,7 @@ namespace System.Net.Sockets
             }
 
             // Handle AcceptSocket property.
-            SafeCloseSocket acceptHandle;
+            SafeSocketHandle acceptHandle;
             e.AcceptSocket = GetOrCreateAcceptSocket(e.AcceptSocket, true, "AcceptSocket", out acceptHandle);
 
             // Prepare for and make the native call.
@@ -5072,7 +5073,7 @@ namespace System.Net.Sockets
         }
 
         // CreateAcceptSocket - pulls unmanaged results and assembles them into a new Socket object.
-        internal Socket CreateAcceptSocket(SafeCloseSocket fd, EndPoint remoteEP)
+        internal Socket CreateAcceptSocket(SafeSocketHandle fd, EndPoint remoteEP)
         {
             // Internal state of the socket is inherited from listener.
             Debug.Assert(fd != null && !fd.IsInvalid);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1059,7 +1059,7 @@ namespace System.Net.Sockets
             // Called when the socket is closed.
             public void StopAndAbort(SocketAsyncContext context)
             {
-                // We should be called exactly once, by SafeCloseSocket.
+                // We should be called exactly once, by SafeSocketHandle.
                 Debug.Assert(_state != QueueState.Stopped);
 
                 using (Lock())
@@ -1098,7 +1098,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private readonly SafeCloseSocket _socket;
+        private readonly SafeSocketHandle _socket;
         private OperationQueue<ReadOperation> _receiveQueue;
         private OperationQueue<WriteOperation> _sendQueue;
         private SocketAsyncEngine.Token _asyncEngineToken;
@@ -1107,7 +1107,7 @@ namespace System.Net.Sockets
 
         private readonly object _registerLock = new object();
 
-        public SocketAsyncContext(SafeCloseSocket socket)
+        public SocketAsyncContext(SafeSocketHandle socket)
         {
             _socket = socket;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -39,7 +39,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            public bool TryRegister(SafeCloseSocket socket, out Interop.Error error)
+            public bool TryRegister(SafeSocketHandle socket, out Interop.Error error)
             {
                 Debug.Assert(WasAllocated, "Expected WasAllocated to be true");
                 return _engine.TryRegister(socket, _handle, out error);
@@ -389,7 +389,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private bool TryRegister(SafeCloseSocket socket, IntPtr handle, out Interop.Error error)
+        private bool TryRegister(SafeSocketHandle socket, IntPtr handle, out Interop.Error error)
         {
             error = Interop.Sys.TryChangeSocketEventRegistration(_port, socket, Interop.Sys.SocketEvents.None, 
                 Interop.Sys.SocketEvents.Read | Interop.Sys.SocketEvents.Write, handle);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -65,7 +65,7 @@ namespace System.Net.Sockets
             _acceptAddressBufferCount = socketAddressSize;
         }
 
-        internal unsafe SocketError DoOperationAccept(Socket socket, SafeCloseSocket handle, SafeCloseSocket acceptHandle)
+        internal unsafe SocketError DoOperationAccept(Socket socket, SafeSocketHandle handle, SafeSocketHandle acceptHandle)
         {
             if (!_buffer.Equals(default))
             {
@@ -94,7 +94,7 @@ namespace System.Net.Sockets
             CompletionCallback(0, SocketFlags.None, socketError);
         }
 
-        internal unsafe SocketError DoOperationConnect(Socket socket, SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationConnect(Socket socket, SafeSocketHandle handle)
         {
             SocketError socketError = handle.AsyncContext.ConnectAsync(_socketAddress.Buffer, _socketAddress.Size, ConnectCompletionCallback);
             if (socketError != SocketError.IOPending)
@@ -104,7 +104,7 @@ namespace System.Net.Sockets
             return socketError;
         }
 
-        internal SocketError DoOperationDisconnect(Socket socket, SafeCloseSocket handle)
+        internal SocketError DoOperationDisconnect(Socket socket, SafeSocketHandle handle)
         {
             SocketError socketError = SocketPal.Disconnect(socket, handle, _disconnectReuseSocket);
             FinishOperationSync(socketError, 0, SocketFlags.None);
@@ -128,7 +128,7 @@ namespace System.Net.Sockets
             _receivedFlags = receivedFlags;
         }
 
-        internal unsafe SocketError DoOperationReceive(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceive(SafeSocketHandle handle)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;
@@ -154,7 +154,7 @@ namespace System.Net.Sockets
             return errorCode;
         }
 
-        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceiveFrom(SafeSocketHandle handle)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;
@@ -198,7 +198,7 @@ namespace System.Net.Sockets
             _receiveMessageFromPacketInfo = ipPacketInformation;
         }
 
-        internal unsafe SocketError DoOperationReceiveMessageFrom(Socket socket, SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceiveMessageFrom(Socket socket, SafeSocketHandle handle)
         {
             _receiveMessageFromPacketInfo = default(IPPacketInformation);
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
@@ -220,7 +220,7 @@ namespace System.Net.Sockets
             return socketError;
         }
 
-        internal unsafe SocketError DoOperationSend(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationSend(SafeSocketHandle handle)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;
@@ -245,7 +245,7 @@ namespace System.Net.Sockets
             return errorCode;
         }
 
-        internal SocketError DoOperationSendPackets(Socket socket, SafeCloseSocket handle)
+        internal SocketError DoOperationSendPackets(Socket socket, SafeSocketHandle handle)
         {
             Debug.Assert(_sendPacketsElements != null);
             SendPacketsElement[] elements = (SendPacketsElement[])_sendPacketsElements.Clone();
@@ -304,7 +304,7 @@ namespace System.Net.Sockets
             return SocketError.IOPending;
         }
 
-        internal SocketError DoOperationSendTo(SafeCloseSocket handle)
+        internal SocketError DoOperationSendTo(SafeSocketHandle handle)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;
@@ -369,7 +369,7 @@ namespace System.Net.Sockets
         {
             System.Buffer.BlockCopy(_acceptBuffer, 0, remoteSocketAddress.Buffer, 0, _acceptAddressBufferCount);
             _acceptSocket = _currentSocket.CreateAcceptSocket(
-                SafeCloseSocket.CreateSocket(_acceptedFileDescriptor),
+                SafeSocketHandle.CreateSocket(_acceptedFileDescriptor),
                 _currentSocket._rightEndPoint.Create(remoteSocketAddress));
             return SocketError.Success;
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -200,7 +200,7 @@ namespace System.Net.Sockets
             return SocketError.IOPending;
         }
 
-        internal unsafe SocketError DoOperationAccept(Socket socket, SafeCloseSocket handle, SafeCloseSocket acceptHandle)
+        internal unsafe SocketError DoOperationAccept(Socket socket, SafeSocketHandle handle, SafeSocketHandle acceptHandle)
         {
             bool userBuffer = _count != 0;
             Debug.Assert(!userBuffer || (!_buffer.Equals(default) && _count >= _acceptAddressBufferCount));
@@ -234,7 +234,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationConnect(Socket socket, SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationConnect(Socket socket, SafeSocketHandle handle)
         {
             // ConnectEx uses a sockaddr buffer containing the remote address to which to connect.
             // It can also optionally take a single buffer of data to send after the connection is complete.
@@ -268,7 +268,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationDisconnect(Socket socket, SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationDisconnect(Socket socket, SafeSocketHandle handle)
         {
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
@@ -288,11 +288,11 @@ namespace System.Net.Sockets
             }
         }
 
-        internal SocketError DoOperationReceive(SafeCloseSocket handle) => _bufferList == null ? 
+        internal SocketError DoOperationReceive(SafeSocketHandle handle) => _bufferList == null ? 
             DoOperationReceiveSingleBuffer(handle) :
             DoOperationReceiveMultiBuffer(handle);
 
-        internal unsafe SocketError DoOperationReceiveSingleBuffer(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceiveSingleBuffer(SafeSocketHandle handle)
         {
             fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
@@ -325,7 +325,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationReceiveMultiBuffer(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceiveMultiBuffer(SafeSocketHandle handle)
         {
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
@@ -350,7 +350,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceiveFrom(SafeSocketHandle handle)
         {
             // WSARecvFrom uses a WSABuffer array describing buffers in which to 
             // receive data and from which to send data respectively. Single and multiple buffers
@@ -364,7 +364,7 @@ namespace System.Net.Sockets
                 DoOperationReceiveFromMultiBuffer(handle);
         }
 
-        internal unsafe SocketError DoOperationReceiveFromSingleBuffer(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceiveFromSingleBuffer(SafeSocketHandle handle)
         {
             fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
@@ -399,7 +399,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationReceiveFromMultiBuffer(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceiveFromMultiBuffer(SafeSocketHandle handle)
         {
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
@@ -426,7 +426,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationReceiveMessageFrom(Socket socket, SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationReceiveMessageFrom(Socket socket, SafeSocketHandle handle)
         {
             // WSARecvMsg uses a WSAMsg descriptor.
             // The WSAMsg buffer is pinned with a GCHandle to avoid complicating the use of Overlapped.
@@ -556,11 +556,11 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationSend(SafeCloseSocket handle) => _bufferList == null ?
+        internal unsafe SocketError DoOperationSend(SafeSocketHandle handle) => _bufferList == null ?
             DoOperationSendSingleBuffer(handle) :
             DoOperationSendMultiBuffer(handle);
 
-        internal unsafe SocketError DoOperationSendSingleBuffer(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationSendSingleBuffer(SafeSocketHandle handle)
         {
             fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
@@ -592,7 +592,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationSendMultiBuffer(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationSendMultiBuffer(SafeSocketHandle handle)
         {
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
@@ -616,7 +616,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationSendPackets(Socket socket, SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationSendPackets(Socket socket, SafeSocketHandle handle)
         {
             // Cache copy to avoid problems with concurrent manipulation during the async operation.
             Debug.Assert(_sendPacketsElements != null);
@@ -719,7 +719,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationSendTo(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationSendTo(SafeSocketHandle handle)
         {
             // WSASendTo uses a WSABuffer array describing buffers in which to 
             // receive data and from which to send data respectively. Single and multiple buffers
@@ -734,7 +734,7 @@ namespace System.Net.Sockets
                 DoOperationSendToMultiBuffer(handle);
         }
 
-        internal unsafe SocketError DoOperationSendToSingleBuffer(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationSendToSingleBuffer(SafeSocketHandle handle)
         {
             fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
@@ -768,7 +768,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationSendToMultiBuffer(SafeCloseSocket handle)
+        internal unsafe SocketError DoOperationSendToMultiBuffer(SafeSocketHandle handle)
         {
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try

--- a/src/System.Net.Sockets/tests/FunctionalTests/SafeHandleTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SafeHandleTest.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public class SafeHandleTest
+    {
+        [Fact]
+        public static void SafeHandle_NotIsInvalid()
+        {
+            using (var s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            {
+                Assert.False(s.SafeHandle.IsInvalid);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- Renamed `Socket.SafeHandle` to `Socket.SafeCloseSocket`.
- Added `Socket.SafeHandle`. Fixes #13470.
- Use `Socket.SafeHandle` instead of reflection in `SafePipeHandle`. Fixes #11807.

Each change is in a separate commit to make it easier to review.

I also didn't handle this: https://github.com/dotnet/corefx/issues/13470#issuecomment-260738609, because I didn't understand exactly how would it work, any help would be appreciated.