### PR TITLE
Fix flaky 100-Continue test on CurlHandler

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
@@ -118,6 +118,9 @@ namespace System.Net.Http.Functional.Tests
             private readonly Task _connectionClosed;
             private readonly TaskCompletionSource<bool> _sendingContent;
 
+            // The content needs to be large enough to force Expect: 100-Continue behavior in libcurl.
+            private readonly string _longContent = new String('a', 1025);
+
             public SynchronizedSendContent(TaskCompletionSource<bool> sendingContent, Task connectionClosed)
             {
                 _connectionClosed = connectionClosed;
@@ -128,12 +131,12 @@ namespace System.Net.Http.Functional.Tests
             {
                 _sendingContent.SetResult(true);
                 await _connectionClosed;
-                await stream.WriteAsync(Encoding.UTF8.GetBytes(s_simpleContent));
+                await stream.WriteAsync(Encoding.UTF8.GetBytes(_longContent));
             }
 
             protected override bool TryComputeLength(out long length)
             {
-                length = s_simpleContent.Length;
+                length = _longContent.Length;
                 return true;
             }
         }


### PR DESCRIPTION
One of the 100-Continue tests failed in the daily runs today. The test failure was similar to #27519, which was caused by lack of support for 100-Continue in WinHttpHandler.

CurlHandler wasn't actually using 100-Continue in the test, as it is only enabled for content larger than 1024 bytes. That behavior caused the test to sporadically fail.

This change increases the size of the content used by the test, so that Expect: 100-Continue will actually be enabled.

Fixes: #32643