### PR TITLE
Remove no longer throws if certificate isn't in store

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509Store.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509Store.cs
@@ -23,6 +23,7 @@ internal static partial class Interop
         private static extern int AppleCryptoNative_X509StoreRemoveCertificate(
             SafeKeychainItemHandle cert,
             SafeKeychainHandle keychain,
+            bool isReadOnlyMode,
             out int pOSStatus);
 
         internal static void X509StoreAddCertificate(SafeKeychainItemHandle certOrIdentity, SafeKeychainHandle keychain)
@@ -42,10 +43,10 @@ internal static partial class Interop
             }
         }
 
-        internal static void X509StoreRemoveCertificate(SafeKeychainItemHandle certHandle, SafeKeychainHandle keychain)
+        internal static void X509StoreRemoveCertificate(SafeKeychainItemHandle certHandle, SafeKeychainHandle keychain, bool isReadOnlyMode)
         {
             int osStatus;
-            int ret = AppleCryptoNative_X509StoreRemoveCertificate(certHandle, keychain, out osStatus);
+            int ret = AppleCryptoNative_X509StoreRemoveCertificate(certHandle, keychain, isReadOnlyMode, out osStatus);
 
             if (ret == 0)
             {
@@ -55,6 +56,7 @@ internal static partial class Interop
             const int SuccessOrNoMatch = 1;
             const int UserTrustExists = 2;
             const int AdminTrustExists = 3;
+            const int ReadOnlyDelete = 4;
 
             switch (ret)
             {
@@ -64,6 +66,8 @@ internal static partial class Interop
                     throw new CryptographicException(SR.Cryptography_X509Store_WouldModifyUserTrust);
                 case AdminTrustExists:
                     throw new CryptographicException(SR.Cryptography_X509Store_WouldModifyAdminTrust);
+                case ReadOnlyDelete:
+                    throw new CryptographicException(SR.Cryptography_X509_StoreReadOnly);
                 default:
                     Debug.Fail($"Unexpected result from AppleCryptoNative_X509StoreRemoveCertificate: {ret}");
                     throw new CryptographicException();

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
@@ -224,6 +224,105 @@ static OSStatus DeleteInKeychain(CFTypeRef needle, SecKeychainRef haystack)
     return status;
 }
 
+static bool IsCertInKeychain(CFTypeRef needle, SecKeychainRef haystack)
+{
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    if (query == NULL)
+        return errSecAllocate;
+
+    const void* constHaystack = haystack;
+    CFTypeRef result = NULL;
+    CFArrayRef searchList = CFArrayCreate(NULL, &constHaystack, 1, &kCFTypeArrayCallBacks);
+
+    if (searchList == NULL)
+    {
+        CFRelease(query);
+        return errSecAllocate;
+    }
+
+    CFArrayRef itemMatch = CFArrayCreate(NULL, (const void**)(&needle), 1, &kCFTypeArrayCallBacks);
+
+    if (itemMatch == NULL)
+    {
+        CFRelease(searchList);
+        CFRelease(query);
+        return errSecAllocate;
+    }
+
+    CFDictionarySetValue(query, kSecReturnRef, kCFBooleanTrue);
+    CFDictionarySetValue(query, kSecMatchSearchList, searchList);
+    CFDictionarySetValue(query, kSecMatchItemList, itemMatch);
+    CFDictionarySetValue(query, kSecClass, kSecClassCertificate);
+    OSStatus status = SecItemCopyMatching(query, &result);
+
+    bool ret = true;
+
+    if (status == errSecItemNotFound)
+    {
+        ret = false;
+    }
+
+    if (status == noErr)
+    {
+        CFDictionarySetValue(query, kSecClass, kSecClassIdentity);
+        status = SecItemCopyMatching(query, &result);
+    }
+
+    if (status == errSecItemNotFound)
+    {
+        ret = false;
+    }
+
+    CFRelease(itemMatch);
+    CFRelease(searchList);
+    CFRelease(query);
+
+    return ret;
+}
+
+static int32_t CheckTrustSettings(SecCertificateRef cert)
+{
+    const int32_t kErrorUserTrust = 2;
+    const int32_t kErrorAdminTrust = 3;
+
+    OSStatus status = noErr;
+    CFArrayRef settings = NULL;
+    if (status == noErr)
+    {
+        status = SecTrustSettingsCopyTrustSettings(cert, kSecTrustSettingsDomainUser, &settings);
+    }
+
+    if (settings != NULL)
+    {
+        CFRelease(settings);
+        settings = NULL;
+    }
+
+    if (status == noErr)
+    {
+        CFRelease(cert);
+        return kErrorUserTrust;
+    }
+
+    status = SecTrustSettingsCopyTrustSettings(cert, kSecTrustSettingsDomainAdmin, &settings);
+
+    if (settings != NULL)
+    {
+        CFRelease(settings);
+        settings = NULL;
+    }
+
+    if (status == noErr)
+    {
+        CFRelease(cert);
+        return kErrorAdminTrust;
+    }
+
+    return 0;
+}
+
 int32_t AppleCryptoNative_X509StoreAddCertificate(CFTypeRef certOrIdentity, SecKeychainRef keychain, int32_t* pOSStatus)
 {
     if (pOSStatus != NULL)
@@ -315,7 +414,7 @@ int32_t AppleCryptoNative_X509StoreAddCertificate(CFTypeRef certOrIdentity, SecK
 }
 
 int32_t
-AppleCryptoNative_X509StoreRemoveCertificate(CFTypeRef certOrIdentity, SecKeychainRef keychain, int32_t* pOSStatus)
+AppleCryptoNative_X509StoreRemoveCertificate(CFTypeRef certOrIdentity, SecKeychainRef keychain, uint8_t isReadOnlyMode, int32_t* pOSStatus)
 {
     if (pOSStatus != NULL)
         *pOSStatus = noErr;
@@ -350,40 +449,27 @@ AppleCryptoNative_X509StoreRemoveCertificate(CFTypeRef certOrIdentity, SecKeycha
         return -1;
     }
 
-    const int32_t kErrorUserTrust = 2;
-    const int32_t kErrorAdminTrust = 3;
+    const int32_t kErrorReadonlyDelete = 4;
 
-    CFArrayRef settings = NULL;
+    int32_t ret = 0;
 
-    if (status == noErr)
+    if (isReadOnlyMode)
     {
-        status = SecTrustSettingsCopyTrustSettings(cert, kSecTrustSettingsDomainUser, &settings);
+        ret = kErrorReadonlyDelete;
+    }
+    else
+    {
+        ret = CheckTrustSettings(cert);
     }
 
-    if (settings != NULL)
+    if (ret != 0)
     {
-        CFRelease(settings);
-        settings = NULL;
-    }
+        if (!IsCertInKeychain(cert, keychain))
+        {
+            return 1;
+        }
 
-    if (status == noErr)
-    {
-        CFRelease(cert);
-        return kErrorUserTrust;
-    }
-
-    status = SecTrustSettingsCopyTrustSettings(cert, kSecTrustSettingsDomainAdmin, &settings);
-
-    if (settings != NULL)
-    {
-        CFRelease(settings);
-        settings = NULL;
-    }
-
-    if (status == noErr)
-    {
-        CFRelease(cert);
-        return kErrorAdminTrust;
+        return ret;
     }
 
     *pOSStatus = DeleteInKeychain(cert, keychain);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
@@ -261,13 +261,7 @@ static bool IsCertInKeychain(CFTypeRef needle, SecKeychainRef haystack)
 
     if (status == errSecItemNotFound)
     {
-        CFDictionarySetValue(query, kSecClass, kSecClassIdentity);
-        status = SecItemCopyMatching(query, &result);
-
-        if (status == errSecItemNotFound)
-        {
-            ret = false;
-        }
+        ret = false;
     }
 
     CFRelease(itemMatch);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
@@ -261,18 +261,13 @@ static bool IsCertInKeychain(CFTypeRef needle, SecKeychainRef haystack)
 
     if (status == errSecItemNotFound)
     {
-        ret = false;
-    }
-
-    if (status == noErr)
-    {
         CFDictionarySetValue(query, kSecClass, kSecClassIdentity);
         status = SecItemCopyMatching(query, &result);
-    }
 
-    if (status == errSecItemNotFound)
-    {
-        ret = false;
+        if (status == errSecItemNotFound)
+        {
+            ret = false;
+        }
     }
 
     CFRelease(itemMatch);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.h
@@ -129,10 +129,11 @@ Returns
 1 on success (including no item to delete),
 2 on blocking user trust modification,
 3 on blocking system trust modification,
+4 on deleting an existing certificate while in read only mode,
 any other value is invalid
 
 Output:
 pOSStatus: Receives the last OSStatus value..
 */
 DLLEXPORT int32_t
-AppleCryptoNative_X509StoreRemoveCertificate(CFTypeRef certOrIdentity, SecKeychainRef keychain, int32_t* pOSStatus);
+AppleCryptoNative_X509StoreRemoveCertificate(CFTypeRef certOrIdentity, SecKeychainRef keychain, uint8_t isReadOnlyMode, int32_t* pOSStatus);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
@@ -71,7 +71,7 @@ namespace Internal.Cryptography.Pal
                 AppleCertificatePal applePal = (AppleCertificatePal)cert;
 
                 var handle = (SafeKeychainItemHandle)applePal.IdentityHandle ?? applePal.CertificateHandle;
-                Interop.AppleCrypto.X509StoreRemoveCertificate(handle, _keychainHandle, this._readonly);
+                Interop.AppleCrypto.X509StoreRemoveCertificate(handle, _keychainHandle, _readonly);
             }
 
             public SafeHandle SafeHandle => _keychainHandle;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
@@ -86,7 +86,9 @@ namespace Internal.Cryptography.Pal
                             if (applePal.IdentityHandle == identityHandle && applePal.CertificateHandle == certHandle)
                             {
                                 if (_readonly)
+                                {
                                     throw new CryptographicException(SR.Cryptography_X509_StoreReadOnly);
+                                }
 
                                 var handle = (SafeKeychainItemHandle)applePal.IdentityHandle ?? applePal.CertificateHandle;
                                 Interop.AppleCrypto.X509StoreRemoveCertificate(handle, _keychainHandle);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.AppleKeychainStore.cs
@@ -68,34 +68,10 @@ namespace Internal.Cryptography.Pal
 
             public void Remove(ICertificatePal cert)
             {
-                // First check if the certificate is even in the keychain
                 AppleCertificatePal applePal = (AppleCertificatePal)cert;
-                using (SafeCFArrayHandle certs = Interop.AppleCrypto.KeychainEnumerateCerts(_keychainHandle))
-                {
-                    long count = Interop.CoreFoundation.CFArrayGetCount(certs);
 
-                    for (int i = 0; i < count; i++)
-                    {
-                        IntPtr itemHandle = Interop.CoreFoundation.CFArrayGetValueAtIndex(certs, i);
-
-                        SafeSecCertificateHandle certHandle;
-                        SafeSecIdentityHandle identityHandle;
-
-                        if (Interop.AppleCrypto.X509DemuxAndRetainHandle(itemHandle, out certHandle, out identityHandle))
-                        {
-                            if (applePal.IdentityHandle == identityHandle && applePal.CertificateHandle == certHandle)
-                            {
-                                if (_readonly)
-                                {
-                                    throw new CryptographicException(SR.Cryptography_X509_StoreReadOnly);
-                                }
-
-                                var handle = (SafeKeychainItemHandle)applePal.IdentityHandle ?? applePal.CertificateHandle;
-                                Interop.AppleCrypto.X509StoreRemoveCertificate(handle, _keychainHandle);
-                            }
-                        }
-                    }
-                }
+                var handle = (SafeKeychainItemHandle)applePal.IdentityHandle ?? applePal.CertificateHandle;
+                Interop.AppleCrypto.X509StoreRemoveCertificate(handle, _keychainHandle, this._readonly);
             }
 
             public SafeHandle SafeHandle => _keychainHandle;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -201,7 +201,8 @@ namespace Internal.Cryptography.Pal
 
         public void Remove(ICertificatePal certPal)
         {
-            if (!Directory.Exists(_storePath)) { return; }
+            if (!Directory.Exists(_storePath))
+                return;
 
             OpenSslX509CertificateReader cert = (OpenSslX509CertificateReader)certPal;
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -201,6 +201,8 @@ namespace Internal.Cryptography.Pal
 
         public void Remove(ICertificatePal certPal)
         {
+            if (!Directory.Exists(_storePath)) { return; }
+
             OpenSslX509CertificateReader cert = (OpenSslX509CertificateReader)certPal;
 
             using (X509Certificate2 copy = new X509Certificate2(cert.DuplicateHandles()))

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -283,29 +283,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        public static void RemoveReadOnlyThrowsWhenFound()
+        public static void RemoveReadOnlyNonExistingDoesNotThrow()
         {
-            // This test is unfortunate, in that it will mostly never test.
-            // In order to do so it would have to open the store ReadWrite, put in a known value,
-            // and call Remove on a ReadOnly copy.
-            //
-            // Just calling Remove on the first item found could also work (when the store isn't empty),
-            // but if it fails the cost is too high.
-            //
-            // So what's the purpose of this test, you ask? To record why we're not unit testing it.
-            // And someone could test it manually if they wanted.
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
             using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
             {
                 store.Open(OpenFlags.ReadOnly);
-
-                using (var coll = new ImportedCollection(store.Certificates))
-                {
-                    if (coll.Collection.Contains(cert))
-                    {
-                        Assert.ThrowsAny<CryptographicException>(() => store.Remove(cert));
-                    }
-                }
+                store.Remove(cert);
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -283,6 +283,33 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void RemoveReadOnlyThrowsWhenFound()
+        {
+            // This test is unfortunate, in that it will mostly never test.
+            // In order to do so it would have to open the store ReadWrite, put in a known value,
+            // and call Remove on a ReadOnly copy.
+            //
+            // Just calling Remove on the first item found could also work (when the store isn't empty),
+            // but if it fails the cost is too high.
+            //
+            // So what's the purpose of this test, you ask? To record why we're not unit testing it.
+            // And someone could test it manually if they wanted.
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                store.Open(OpenFlags.ReadOnly);
+
+                using (var coll = new ImportedCollection(store.Certificates))
+                {
+                    if (coll.Collection.Contains(cert))
+                    {
+                        Assert.ThrowsAny<CryptographicException>(() => store.Remove(cert));
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public static void RemoveReadOnlyNonExistingDoesNotThrow()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))


### PR DESCRIPTION
X509Store.Remove used to throw an exception on OSX when the store is opened ReadOnly, even when the certificate being removed isn't actually in the keychain. It now checks for the existence of the certificate first, before throwing an exception that the store is readonly to match the behaviour on other platforms. This should fix #31050.

Note that this is a rather naive first implementation. I couldn't find a clean way of checking if the certificate is in the store. The existing tests in the inner loop still succeed, but I could very well be that the outer loop tests will fail, so that's why I'm already opening a pull request for this.