### PR TITLE
Remove unnecessary EventLogEntry ctor

### DIFF
--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
@@ -32,11 +32,6 @@ namespace System.Diagnostics
             GC.SuppressFinalize(this);
         }
 
-        private EventLogEntry(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
         /// <summary>
         /// The machine on which this event log resides.
         /// </summary>


### PR DESCRIPTION
The type isn't [Serializable] and the ctor is private.

Per discussion at https://github.com/dotnet/corefx/pull/32654#discussion_r223196364.

cc: @jkotas, @ViktorHofer 