### PR TITLE
Enable TargetFrameworkAttribute generation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -257,7 +257,6 @@
     <NoStdLib>true</NoStdLib>
     <NoExplicitReferenceToStdLib>true</NoExplicitReferenceToStdLib>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
   </PropertyGroup>
 

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/AssemblyAttributes.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/AssemblyAttributes.cs
@@ -3,4 +3,3 @@
 // See the LICENSE file in the project root for more information.
 
 [assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute("DUMMY-TFA,Version=v0.0.1")]

--- a/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -41,11 +41,10 @@ namespace System.Tests
         [Fact]
         public void TargetFrameworkTest()
         {
-            // On Uap we use the Microsoft.DotNet.XUnitRunnerUap instead of the RemoteExecutorConsoleApp
-            string targetFrameworkName = PlatformDetection.IsUap ? ".NETCore,Version=v5.0" : "DUMMY-TFA";
-            RemoteInvoke((_targetFrameworkName) => {
-                Assert.Contains(_targetFrameworkName, AppContext.TargetFrameworkName);
-            }, targetFrameworkName).Dispose();
+            RemoteInvoke(() => {
+                Assert.NotEmpty(AppContext.TargetFrameworkName);
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/26456
Fixes https://github.com/dotnet/corefx/issues/26457

@eerhardt I assume you disabled the target framework attribute generation because we haven't had set it before?