### PR TITLE
Disable problematic Linq.Parallel test.

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -605,6 +605,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [ActiveIssue(21876, TestPlatforms.Linux)]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]


### PR DESCRIPTION
This test has been [consistently failing](https://mc.dot.net/#/product/netcore/30/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fcli~2F/build/20181008.01/workItem/System.Linq.Parallel.Tests/analysis/xunit/System.Linq.Parallel.Tests.ParallelQueryCombinationTests~2FSequenceEqual_OperationCanceledException(operation:%20Union-Right)) on RedHat 6.9 in the daily runs.

I'm going to disable it for now, until @tarekgh gets a chance to take a look at the issue.

The failure is tracked in issue #21876.