### PR TITLE
Better email address attribute

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -28,14 +28,22 @@ namespace System.ComponentModel.DataAnnotations
                 return false;
             }
 
-            return ValidateEmailViaRegex(valueAsString);
-
-            bool ValidateEmailViaRegex() {
-                const string pattern = @"^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$";
-                const RegexOptions options = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
-                const Regex regex = new Regex(pattern, options);
-                return regex.Match(valueAsString).Length > 0;
+            // only return true if there is only 1 '@' character
+            // and it is neither the first nor the last character
+            bool found = false;
+            for (int i = 0; i < valueAsString.Length; i++)
+            {
+                if (valueAsString[i] == '@')
+                {
+                    if (found || i == 0 || i == valueAsString.Length - 1)
+                    {
+                        return false;
+                    }
+                    found = true;
+                }
             }
+
+            return found;
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -28,22 +28,14 @@ namespace System.ComponentModel.DataAnnotations
                 return false;
             }
 
-            // only return true if there is only 1 '@' character
-            // and it is neither the first nor the last character
-            bool found = false;
-            for (int i = 0; i < valueAsString.Length; i++)
-            {
-                if (valueAsString[i] == '@')
-                {
-                    if (found || i == 0 || i == valueAsString.Length - 1)
-                    {
-                        return false;
-                    }
-                    found = true;
-                }
-            }
+            return ValidateEmailViaRegex(valueAsString);
 
-            return found;
+            bool ValidateEmailViaRegex() {
+                const string pattern = @"^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$";
+                const RegexOptions options = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
+                const Regex regex = new Regex(pattern, options);
+                return regex.Match(valueAsString).Length > 0;
+            }
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/EmailAddressAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/EmailAddressAttributeTests.cs
@@ -35,6 +35,8 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new TestCase(new EmailAddressAttribute(), "someName");
             yield return new TestCase(new EmailAddressAttribute(), "someName@");
             yield return new TestCase(new EmailAddressAttribute(), "someName@a@b.com");
+            yield return new TestCase(new EmailAddressAttribute(), "someName@.com");
+            yield return new TestCase(new EmailAddressAttribute(), "someName@com");
         }
 
         [Fact]


### PR DESCRIPTION
Hi,
Today I found out that EmailAddressAttribute is quite bad.
First of all, now email string can contain only one `@` char.
RFC 2821 specifies `Abc\@def@example.com` as valid address (https://haacked.com/archive/2007/08/21/i-knew-how-to-validate-an-email-address-until-i.aspx/), so I think that we need better validation.

Second, mail address `mail@.com` is not valid, but EmailAddressAttribute recognizes it as valid.

I've prepared some tests (I will push more later today). 
Can we solve it with regular expressions? I can provide new implementation in next few days. 