### PR TITLE
Removed trailing whitespace when no service pack version exists

### DIFF
--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -19,19 +19,9 @@ internal partial class Interop
             const string version = "Microsoft Windows";
             if (RtlGetVersion(ref osvi) == 0)
             {
-                var stringBuilder = new StringBuilder();
-
-                stringBuilder.Append(version);
-                stringBuilder.Append(" ");
-                stringBuilder.AppendFormat("{0}.{1}.{2}", osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
-
-                if (osvi.szCSDVersion[0] != '\0')
-                {
-                    stringBuilder.Append(" ");
-                    stringBuilder.Append(new string(&(osvi.szCSDVersion[0])));
-                }
-
-                return stringBuilder.ToString();
+                return osvi.szCSDVersion[0] != '\0' ?
+                    string.Format("{0} {1}.{2}.{3} {4}", version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, new string(&(osvi.szCSDVersion[0]))) :
+                    string.Format("{0} {1}.{2}.{3}", version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
             }
             else
             {

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -20,8 +20,8 @@ internal partial class Interop
             const string version = "Microsoft Windows";
             if (RtlGetVersion(ref osvi) == 0)
             {
-                return string.Format("{0} {1}.{2}.{3} {4}",
-                    version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, new string(&(osvi.szCSDVersion[0])));
+                return $"{version} {osvi.dwMajorVersion}.{osvi.dwMinorVersion}.{osvi.dwBuildNumber}" +
+                       $"{(string.IsNullOrWhitespace(osvi.szCSDVersion?[0]) ? string.Empty : new string(&(osvi.szCSDVersion[0])))}";
             }
             else
             {

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal partial class Interop
 {

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
-using System.Security;
+using System.Text;
 
 internal partial class Interop
 {
@@ -20,8 +19,19 @@ internal partial class Interop
             const string version = "Microsoft Windows";
             if (RtlGetVersion(ref osvi) == 0)
             {
-                return $"{version} {osvi.dwMajorVersion}.{osvi.dwMinorVersion}.{osvi.dwBuildNumber}" +
-                       $"{(osvi.szCSDVersion[0] == '\0' ? string.Empty : " " + new string(&(osvi.szCSDVersion[0])))}";
+                var stringBuilder = new StringBuilder();
+
+                stringBuilder.Append(version);
+                stringBuilder.Append(" ");
+                stringBuilder.AppendFormat("{0}.{1}.{2}", osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
+
+                if (osvi.szCSDVersion[0] != '\0')
+                {
+                    stringBuilder.Append(" ");
+                    stringBuilder.Append(new string(&(osvi.szCSDVersion[0])));
+                }
+
+                return stringBuilder.ToString();
             }
             else
             {

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -21,7 +21,7 @@ internal partial class Interop
             if (RtlGetVersion(ref osvi) == 0)
             {
                 return $"{version} {osvi.dwMajorVersion}.{osvi.dwMinorVersion}.{osvi.dwBuildNumber}" +
-                       $"{(string.IsNullOrWhitespace(osvi.szCSDVersion?[0]) ? string.Empty : new string(&(osvi.szCSDVersion[0])))}";
+                       $"{(osvi.szCSDVersion[0] == '\0' ? string.Empty : " " + new string(&(osvi.szCSDVersion[0])))}";
             }
             else
             {

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -17,7 +17,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             // sanity check that the test run or CI job
             // was actually run on the OS that it claims to be on
             string dvs = PlatformDetection.GetDistroVersionString();
-            string osd = RuntimeInformation.OSDescription;
+            string osd = RuntimeInformation.OSDescription.Trim();
             string osv = Environment.OSVersion.ToString();
             string osa = RuntimeInformation.OSArchitecture.ToString();
             string pra = RuntimeInformation.ProcessArchitecture.ToString();

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -79,8 +79,6 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void VerifyWindowsDescriptionDoesNotContainTrailingWhitespace()
         {
-            Assert.NotNull(RuntimeInformation.OSDescription);
-            Assert.Same(RuntimeInformation.OSDescription, RuntimeInformation.OSDescription);
             Assert.False(RuntimeInformation.OSDescription.EndsWith(" "));
         }
 

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -77,6 +77,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void VerifyWindowsDescriptionDoesNotContainTrailingWhitespace()
         {
             Assert.False(RuntimeInformation.OSDescription.EndsWith(" "));

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -17,7 +17,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             // sanity check that the test run or CI job
             // was actually run on the OS that it claims to be on
             string dvs = PlatformDetection.GetDistroVersionString();
-            string osd = RuntimeInformation.OSDescription.Trim();
+            string osd = RuntimeInformation.OSDescription;
             string osv = Environment.OSVersion.ToString();
             string osa = RuntimeInformation.OSArchitecture.ToString();
             string pra = RuntimeInformation.ProcessArchitecture.ToString();
@@ -73,6 +73,15 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             Assert.NotNull(RuntimeInformation.OSDescription);
             Assert.Same(RuntimeInformation.OSDescription, RuntimeInformation.OSDescription);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void VerifyWindowsDescriptionDoesNotContainTrailingWhitespace()
+        {
+            Assert.NotNull(RuntimeInformation.OSDescription);
+            Assert.Same(RuntimeInformation.OSDescription, RuntimeInformation.OSDescription);
+            Assert.False(RuntimeInformation.OSDescription.EndsWith(" "));
         }
 
         [Fact, PlatformSpecific(TestPlatforms.Windows)]  // Checks Windows debug name in RuntimeInformation


### PR DESCRIPTION
When calling `RuntimeInformation.OSDescription` on Windows 10, there is trailing whitespace caused by an empty service pack version field in the underlying data structure from the Windows SDK `RtlGetVersion` call. This change aims to check whether the service pack string should actually be included.