### PR TITLE
Port 'Pass --build-id=sha1 to linker explicitly' to 1.0.0

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -97,6 +97,8 @@ endif ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL Linux)
    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
+   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=sha1")
+   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=sha1")
 endif ()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)


### PR DESCRIPTION
Without this, some Linux native binaries don't get a `BuildId` marker set, which causes the MSDL symbol server to reject them. We never caught this before because the old Symbol publish tool didn't publish these binaries.

CC @mikem8361 @leecow @weshaggard @bartonjs @stephentoub 

Port of https://github.com/dotnet/corefx/pull/9614

#### Description
This fixes an issue where some Linux native binaries were being built without a `BuildId` marker metadata. The symbol servers we publish to require that binaries have this marker, as they use it to create an ID for indexing. Without it, our symbol publish will fail during official releases (this happened this Tuesday, causing us to scramble and delay the release by a few hours).
 
#### Customer Impact
Customers had a bad experience on Release day because of this, as it caused the 1.x.x servicing release to be delayed. Fixing it will prevent this from causing that to happen again.

#### Regression?
No 

#### Risk
None that I'm aware of