### PR TITLE
{RO}Span<char> add IndexOfAny 4,5 tests change many tests to 6+

### DIFF
--- a/src/System.Memory/tests/ReadOnlySpan/IndexOfAny.char.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOfAny.char.cs
@@ -325,7 +325,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfFour_Char()
         {
             ReadOnlySpan<char> sp = new ReadOnlySpan<char>(Array.Empty<char>());
-            ReadOnlySpan<char> values = stackalloc[] { (char)0, (char)0, (char)0, (char)0 };
+            ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0 };
             int idx = sp.IndexOfAny<char>(values);
             Assert.Equal(-1, idx);
         }
@@ -345,7 +345,7 @@ namespace System.SpanTests
                 for (int i = 0; i < length; i++)
                 {
                     int index = rnd.Next(0, 4);
-                    ReadOnlySpan<char> values = stackalloc[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4] };
+                    ReadOnlySpan<char> values = new char[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(0, idx);
                 }
@@ -394,7 +394,7 @@ namespace System.SpanTests
             for (int length = 0; length < byte.MaxValue; length++)
             {
                 char[] a = new char[length];
-                ReadOnlySpan<char> values = stackalloc[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
+                ReadOnlySpan<char> values = new char[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
                 int idx = span.IndexOfAny(values);
@@ -421,7 +421,7 @@ namespace System.SpanTests
                 a[length - 5] = (char)200;
 
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
-                ReadOnlySpan<char> values = stackalloc[] { (char)200, (char)200, (char)200, (char)200 };
+                ReadOnlySpan<char> values = new char[] { (char)200, (char)200, (char)200, (char)200 };
                 int idx = span.IndexOfAny<char>(values);
                 Assert.Equal(length - 5, idx);
             }
@@ -436,7 +436,7 @@ namespace System.SpanTests
                 a[0] = (char)99;
                 a[length + 1] = (char)98;
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a, 1, length - 1);
-                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)98, (char)99, (char)99 };
+                ReadOnlySpan<char> values = new char[] { (char)99, (char)98, (char)99, (char)99 };
                 int index = span.IndexOfAny<char>(values);
                 Assert.Equal(-1, index);
             }
@@ -447,7 +447,7 @@ namespace System.SpanTests
                 a[0] = (char)99;
                 a[length + 1] = (char)99;
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a, 1, length - 1);
-                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)99, (char)99, (char)99 };
+                ReadOnlySpan<char> values = new char[] { (char)99, (char)99, (char)99, (char)99 };
                 int index = span.IndexOfAny<char>(values);
                 Assert.Equal(-1, index);
             }
@@ -457,7 +457,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfFive_Char()
         {
             ReadOnlySpan<char> sp = new ReadOnlySpan<char>(Array.Empty<char>());
-            ReadOnlySpan<char> values = stackalloc[] { (char)0, (char)0, (char)0, (char)0, (char)0 };
+            ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)0 };
             int idx = sp.IndexOfAny<char>(values);
             Assert.Equal(-1, idx);
         }
@@ -477,7 +477,7 @@ namespace System.SpanTests
                 for (int i = 0; i < length; i++)
                 {
                     int index = rnd.Next(0, 5);
-                    ReadOnlySpan<char> values = stackalloc[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4], (char)targets[(index + 1) % 5] };
+                    ReadOnlySpan<char> values = new char[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4], (char)targets[(index + 1) % 5] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(0, idx);
                 }
@@ -526,7 +526,7 @@ namespace System.SpanTests
             for (int length = 0; length < byte.MaxValue; length++)
             {
                 char[] a = new char[length];
-                ReadOnlySpan<char> values = stackalloc[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
+                ReadOnlySpan<char> values = new char[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
                 int idx = span.IndexOfAny(values);
@@ -554,7 +554,7 @@ namespace System.SpanTests
                 a[length - 6] = (char)200;
 
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
-                ReadOnlySpan<char> values = stackalloc[] { (char)200, (char)200, (char)200, (char)200, (char)200 };
+                ReadOnlySpan<char> values = new char[] { (char)200, (char)200, (char)200, (char)200, (char)200 };
                 int idx = span.IndexOfAny<char>(values);
                 Assert.Equal(length - 6, idx);
             }
@@ -569,7 +569,7 @@ namespace System.SpanTests
                 a[0] = (char)99;
                 a[length + 1] = (char)98;
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a, 1, length - 1);
-                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)98, (char)99, (char)99, (char)99 };
+                ReadOnlySpan<char> values = new char[] { (char)99, (char)98, (char)99, (char)99, (char)99 };
                 int index = span.IndexOfAny<char>(values);
                 Assert.Equal(-1, index);
             }
@@ -580,7 +580,7 @@ namespace System.SpanTests
                 a[0] = (char)99;
                 a[length + 1] = (char)99;
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a, 1, length - 1);
-                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)99, (char)99, (char)99, (char)99 };
+                ReadOnlySpan<char> values = new char[] { (char)99, (char)99, (char)99, (char)99, (char)99 };
                 int index = span.IndexOfAny<char>(values);
                 Assert.Equal(-1, index);
             }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOfAny.char.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOfAny.char.cs
@@ -322,10 +322,275 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void ZeroLengthIndexOfFour_Char()
+        {
+            ReadOnlySpan<char> sp = new ReadOnlySpan<char>(Array.Empty<char>());
+            ReadOnlySpan<char> values = stackalloc[] { (char)0, (char)0, (char)0, (char)0 };
+            int idx = sp.IndexOfAny<char>(values);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfFour_Char()
+        {
+            Random rnd = new Random(42);
+
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+
+                char[] targets = { default, (char)99, (char)98, (char)97 };
+
+                for (int i = 0; i < length; i++)
+                {
+                    int index = rnd.Next(0, 4);
+                    ReadOnlySpan<char> values = stackalloc[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(0, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMatchFour_Char()
+        {
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (char)(i + 1);
+                }
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+
+                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)0, (char)0, (char)0 };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)a[targetIndex + 1], (char)a[targetIndex + 2], (char)a[targetIndex + 3] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + 3] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex + 3, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchFour_Char()
+        {
+            Random rnd = new Random(42);
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                ReadOnlySpan<char> values = stackalloc[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchFour_Char()
+        {
+            for (int length = 5; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    char val = (char)(i + 1);
+                    a[i] = val == (char)200 ? (char)201 : val;
+                }
+
+                a[length - 1] = (char)200;
+                a[length - 2] = (char)200;
+                a[length - 3] = (char)200;
+                a[length - 4] = (char)200;
+                a[length - 5] = (char)200;
+
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+                ReadOnlySpan<char> values = stackalloc[] { (char)200, (char)200, (char)200, (char)200 };
+                int idx = span.IndexOfAny<char>(values);
+                Assert.Equal(length - 5, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeFour_Char()
+        {
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length + 2];
+                a[0] = (char)99;
+                a[length + 1] = (char)98;
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a, 1, length - 1);
+                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)98, (char)99, (char)99 };
+                int index = span.IndexOfAny<char>(values);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length + 2];
+                a[0] = (char)99;
+                a[length + 1] = (char)99;
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a, 1, length - 1);
+                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)99, (char)99, (char)99 };
+                int index = span.IndexOfAny<char>(values);
+                Assert.Equal(-1, index);
+            }
+        }
+
+        [Fact]
+        public static void ZeroLengthIndexOfFive_Char()
+        {
+            ReadOnlySpan<char> sp = new ReadOnlySpan<char>(Array.Empty<char>());
+            ReadOnlySpan<char> values = stackalloc[] { (char)0, (char)0, (char)0, (char)0, (char)0 };
+            int idx = sp.IndexOfAny<char>(values);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfFive_Char()
+        {
+            Random rnd = new Random(42);
+
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+
+                char[] targets = { default, (char)99, (char)98, (char)97, (char)96 };
+
+                for (int i = 0; i < length; i++)
+                {
+                    int index = rnd.Next(0, 5);
+                    ReadOnlySpan<char> values = stackalloc[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4], (char)targets[(index + 1) % 5] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(0, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMatchFive_Char()
+        {
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (char)(i + 1);
+                }
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+
+                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)0, (char)0, (char)0, (char)0 };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 4; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)a[targetIndex + 1], (char)a[targetIndex + 2], (char)a[targetIndex + 3], (char)a[targetIndex + 4] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 4; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + 4] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex + 4, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchFive_Char()
+        {
+            Random rnd = new Random(42);
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                ReadOnlySpan<char> values = stackalloc[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchFive_Char()
+        {
+            for (int length = 6; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    char val = (char)(i + 1);
+                    a[i] = val == (char)200 ? (char)201 : val;
+                }
+
+                a[length - 1] = (char)200;
+                a[length - 2] = (char)200;
+                a[length - 3] = (char)200;
+                a[length - 4] = (char)200;
+                a[length - 5] = (char)200;
+                a[length - 6] = (char)200;
+
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+                ReadOnlySpan<char> values = stackalloc[] { (char)200, (char)200, (char)200, (char)200, (char)200 };
+                int idx = span.IndexOfAny<char>(values);
+                Assert.Equal(length - 6, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeFive_Char()
+        {
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length + 2];
+                a[0] = (char)99;
+                a[length + 1] = (char)98;
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a, 1, length - 1);
+                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)98, (char)99, (char)99, (char)99 };
+                int index = span.IndexOfAny<char>(values);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length + 2];
+                a[0] = (char)99;
+                a[length + 1] = (char)99;
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a, 1, length - 1);
+                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)99, (char)99, (char)99, (char)99 };
+                int index = span.IndexOfAny<char>(values);
+                Assert.Equal(-1, index);
+            }
+        }
+
+        [Fact]
         public static void ZeroLengthIndexOfMany_Char()
         {
             ReadOnlySpan<char> sp = new ReadOnlySpan<char>(Array.Empty<char>());
-            ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { (char)0, (char)0, (char)0, (char)0 });
+            ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { (char)0, (char)0, (char)0, (char)0, (char)0, (char)0 });
             int idx = sp.IndexOfAny(values);
             Assert.Equal(-1, idx);
 
@@ -342,7 +607,7 @@ namespace System.SpanTests
                 char[] a = new char[length];
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
-                ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { default, (char)99, (char)98, (char)0 });
+                ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { default, (char)99, (char)98, (char)97, (char)96, (char)0 });
 
                 for (int i = 0; i < length; i++)
                 {
@@ -366,23 +631,23 @@ namespace System.SpanTests
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
-                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { a[targetIndex], (char)0, (char)0, (char)0 });
+                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { a[targetIndex], (char)0, (char)0, (char)0, (char)0, (char)0 });
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(targetIndex, idx);
                 }
 
-                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                for (int targetIndex = 0; targetIndex < length - 5; targetIndex++)
                 {
-                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { a[targetIndex], a[targetIndex + 1], a[targetIndex + 2], a[targetIndex + 3] });
+                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { a[targetIndex], a[targetIndex + 1], a[targetIndex + 2], a[targetIndex + 3], a[targetIndex + 4], a[targetIndex + 5] });
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(targetIndex, idx);
                 }
 
-                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                for (int targetIndex = 0; targetIndex < length - 5; targetIndex++)
                 {
-                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { (char)0, (char)0, (char)0, a[targetIndex + 3] });
+                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { (char)0, (char)0, (char)0, (char)0, (char)0, a[targetIndex + 5] });
                     int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex + 3, idx);
+                    Assert.Equal(targetIndex + 5, idx);
                 }
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOfAny.char.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOfAny.char.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -66,7 +67,7 @@ namespace System.SpanTests
         {
             Random rnd = new Random(42);
 
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
@@ -75,7 +76,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int index = rnd.Next(0, 2) == 0 ? 0 : 1;
+                    int index = rnd.Next(0, targets.Length) == 0 ? 0 : 1;
                     char target0 = targets[index];
                     char target1 = targets[(index + 1) % 2];
                     int idx = span.IndexOfAny(target0, target1);
@@ -87,13 +88,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchTwo_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -126,7 +123,7 @@ namespace System.SpanTests
         public static void TestNoMatchTwo_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 0; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 char target0 = (char)rnd.Next(1, 256);
@@ -141,7 +138,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchTwo_Char()
         {
-            for (int length = 3; length < byte.MaxValue; length++)
+            for (int length = 3; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -163,7 +160,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeTwo_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -173,7 +170,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -197,7 +194,7 @@ namespace System.SpanTests
         {
             Random rnd = new Random(42);
 
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
@@ -206,7 +203,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int index = rnd.Next(0, 3);
+                    int index = rnd.Next(0, targets.Length);
                     char target0 = targets[index];
                     char target1 = targets[(index + 1) % 2];
                     char target2 = targets[(index + 1) % 3];
@@ -219,13 +216,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchThree_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -261,7 +254,7 @@ namespace System.SpanTests
         public static void TestNoMatchThree_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 0; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 char target0 = (char)rnd.Next(1, 256);
@@ -277,7 +270,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchThree_Char()
         {
-            for (int length = 4; length < byte.MaxValue; length++)
+            for (int length = 4; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -300,7 +293,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeThree_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -310,7 +303,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -335,7 +328,7 @@ namespace System.SpanTests
         {
             Random rnd = new Random(42);
 
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
@@ -344,7 +337,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int index = rnd.Next(0, 4);
+                    int index = rnd.Next(0, targets.Length);
                     ReadOnlySpan<char> values = new char[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(0, idx);
@@ -355,13 +348,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchFour_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -380,7 +369,7 @@ namespace System.SpanTests
 
                 for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
                 {
-                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + 3] };
+                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)a[targetIndex + 3] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(targetIndex + 3, idx);
                 }
@@ -391,7 +380,7 @@ namespace System.SpanTests
         public static void TestNoMatchFour_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 0; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> values = new char[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
@@ -405,7 +394,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchFour_Char()
         {
-            for (int length = 5; length < byte.MaxValue; length++)
+            for (int length = 5; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -430,7 +419,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeFour_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -441,7 +430,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -467,7 +456,7 @@ namespace System.SpanTests
         {
             Random rnd = new Random(42);
 
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
@@ -476,7 +465,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int index = rnd.Next(0, 5);
+                    int index = rnd.Next(0, targets.Length);
                     ReadOnlySpan<char> values = new char[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4], (char)targets[(index + 1) % 5] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(0, idx);
@@ -487,13 +476,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchFive_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -523,7 +508,7 @@ namespace System.SpanTests
         public static void TestNoMatchFive_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 0; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> values = new char[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
@@ -537,7 +522,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchFive_Char()
         {
-            for (int length = 6; length < byte.MaxValue; length++)
+            for (int length = 6; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -563,7 +548,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeFive_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -574,7 +559,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -602,7 +587,7 @@ namespace System.SpanTests
         [Fact]
         public static void DefaultFilledIndexOfMany_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
@@ -620,13 +605,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchMany_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -656,7 +637,7 @@ namespace System.SpanTests
         public static void TestMatchValuesLargerMany_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 2; length < byte.MaxValue; length++)
+            for (int length = 2; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 int expectedIndex = length / 2;
@@ -690,7 +671,7 @@ namespace System.SpanTests
         public static void TestNoMatchMany_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 char[] targets = new char[length];
@@ -710,7 +691,7 @@ namespace System.SpanTests
         public static void TestNoMatchValuesLargerMany_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 char[] targets = new char[length * 2];
@@ -729,7 +710,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchMany_Char()
         {
-            for (int length = 5; length < byte.MaxValue; length++)
+            for (int length = 5; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -754,7 +735,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeMany_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -765,7 +746,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOfAny.char.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOfAny.char.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using Xunit;
 
@@ -88,33 +89,37 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchTwo_Char()
         {
-            for (int length = 1; length <= byte.MaxValue + 1; length++)
+            for (int length = Vector<short>.Count; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
-                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
-                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                for (int i = 0; i < Vector<short>.Count; i++)
                 {
-                    char target0 = a[targetIndex];
-                    char target1 = (char)0;
-                    int idx = span.IndexOfAny(target0, target1);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    ReadOnlySpan<char> span = new ReadOnlySpan<char>(a).Slice(i);
 
-                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
-                {
-                    char target0 = a[targetIndex];
-                    char target1 = a[targetIndex + 1];
-                    int idx = span.IndexOfAny(target0, target1);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    for (int targetIndex = 0; targetIndex < length - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = a[targetIndex + i];
+                        char target1 = (char)0;
+                        int idx = span.IndexOfAny(target0, target1);
+                        Assert.Equal(targetIndex, idx);
+                    }
 
-                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
-                {
-                    char target0 = (char)0;
-                    char target1 = a[targetIndex + 1];
-                    int idx = span.IndexOfAny(target0, target1);
-                    Assert.Equal(targetIndex + 1, idx);
+                    for (int targetIndex = 0; targetIndex < length - 1 - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = a[targetIndex + i];
+                        char target1 = a[targetIndex + i + 1];
+                        int idx = span.IndexOfAny(target0, target1);
+                        Assert.Equal(targetIndex, idx);
+                    }
+
+                    for (int targetIndex = 0; targetIndex < length - 1 - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = (char)0;
+                        char target1 = a[targetIndex + i + 1];
+                        int idx = span.IndexOfAny(target0, target1);
+                        Assert.Equal(targetIndex + 1, idx);
+                    }
                 }
             }
         }
@@ -216,36 +221,39 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchThree_Char()
         {
-            for (int length = 1; length <= byte.MaxValue + 1; length++)
+            for (int length = Vector<short>.Count; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
-                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
-
-                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                for (int i = 0; i < Vector<short>.Count; i++)
                 {
-                    char target0 = a[targetIndex];
-                    char target1 = (char)0;
-                    char target2 = (char)0;
-                    int idx = span.IndexOfAny(target0, target1, target2);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    ReadOnlySpan<char> span = new ReadOnlySpan<char>(a).Slice(i);
 
-                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
-                {
-                    char target0 = a[targetIndex];
-                    char target1 = a[targetIndex + 1];
-                    char target2 = a[targetIndex + 2];
-                    int idx = span.IndexOfAny(target0, target1, target2);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    for (int targetIndex = 0; targetIndex < length - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = a[targetIndex + i];
+                        char target1 = (char)0;
+                        char target2 = (char)0;
+                        int idx = span.IndexOfAny(target0, target1, target2);
+                        Assert.Equal(targetIndex, idx);
+                    }
 
-                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
-                {
-                    char target0 = (char)0;
-                    char target1 = (char)0;
-                    char target2 = a[targetIndex + 2];
-                    int idx = span.IndexOfAny(target0, target1, target2);
-                    Assert.Equal(targetIndex + 2, idx);
+                    for (int targetIndex = 0; targetIndex < length - 2 - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = a[targetIndex + i];
+                        char target1 = a[targetIndex + i + 1];
+                        char target2 = a[targetIndex + i + 2];
+                        int idx = span.IndexOfAny(target0, target1, target2);
+                        Assert.Equal(targetIndex, idx);
+                    }
+
+                    for (int targetIndex = 0; targetIndex < length - 2 - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = (char)0;
+                        char target1 = (char)0;
+                        char target2 = a[targetIndex + i + 2];
+                        int idx = span.IndexOfAny(target0, target1, target2);
+                        Assert.Equal(targetIndex + 2, idx);
+                    }
                 }
             }
         }
@@ -348,30 +356,34 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchFour_Char()
         {
-            for (int length = 1; length <= byte.MaxValue + 1; length++)
+            for (int length = Vector<short>.Count; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
-                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
 
-                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                for (int i = 0; i < Vector<short>.Count; i++)
                 {
-                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)0, (char)0, (char)0 };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    ReadOnlySpan<char> span = new ReadOnlySpan<char>(a).Slice(i);
 
-                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
-                {
-                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)a[targetIndex + 1], (char)a[targetIndex + 2], (char)a[targetIndex + 3] };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    for (int targetIndex = 0; targetIndex < length - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)a[targetIndex + i], (char)0, (char)0, (char)0 };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex, idx);
+                    }
 
-                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
-                {
-                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)a[targetIndex + 3] };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex + 3, idx);
+                    for (int targetIndex = 0; targetIndex < length - 3 - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)a[targetIndex + i], (char)a[targetIndex + i + 1], (char)a[targetIndex + i + 2], (char)a[targetIndex + i + 3] };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex, idx);
+                    }
+
+                    for (int targetIndex = 0; targetIndex < length - 3 - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)a[targetIndex + i + 3] };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex + 3, idx);
+                    }
                 }
             }
         }
@@ -476,30 +488,33 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchFive_Char()
         {
-            for (int length = 1; length <= byte.MaxValue + 1; length++)
+            for (int length = Vector<short>.Count; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
-                ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
-
-                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                for (int i = 0; i < Vector<short>.Count; i++)
                 {
-                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)0, (char)0, (char)0, (char)0 };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    ReadOnlySpan<char> span = new ReadOnlySpan<char>(a).Slice(i);
 
-                for (int targetIndex = 0; targetIndex < length - 4; targetIndex++)
-                {
-                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)a[targetIndex + 1], (char)a[targetIndex + 2], (char)a[targetIndex + 3], (char)a[targetIndex + 4] };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    for (int targetIndex = 0; targetIndex < length - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)a[targetIndex + i], (char)0, (char)0, (char)0, (char)0 };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex, idx);
+                    }
 
-                for (int targetIndex = 0; targetIndex < length - 4; targetIndex++)
-                {
-                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + 4] };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex + 4, idx);
+                    for (int targetIndex = 0; targetIndex < length - 4 - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)a[targetIndex + i], (char)a[targetIndex + i + 1], (char)a[targetIndex + i + 2], (char)a[targetIndex + i + 3], (char)a[targetIndex + i + 4] };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex, idx);
+                    }
+
+                    for (int targetIndex = 0; targetIndex < length - 4 - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + i + 4] };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex + 4, idx);
+                    }
                 }
             }
         }

--- a/src/System.Memory/tests/Span/IndexOfAny.char.cs
+++ b/src/System.Memory/tests/Span/IndexOfAny.char.cs
@@ -323,10 +323,275 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void ZeroLengthIndexOfFour_Char()
+        {
+            Span<char> sp = new Span<char>(Array.Empty<char>());
+            ReadOnlySpan<char> values = stackalloc[] { (char)0, (char)0, (char)0, (char)0 };
+            int idx = sp.IndexOfAny<char>(values);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfFour_Char()
+        {
+            Random rnd = new Random(42);
+
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                Span<char> span = new Span<char>(a);
+
+                char[] targets = { default, (char)99, (char)98, (char)97 };
+
+                for (int i = 0; i < length; i++)
+                {
+                    int index = rnd.Next(0, 4);
+                    ReadOnlySpan<char> values = stackalloc[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(0, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMatchFour_Char()
+        {
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (char)(i + 1);
+                }
+                Span<char> span = new Span<char>(a);
+
+                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)0, (char)0, (char)0 };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)a[targetIndex + 1], (char)a[targetIndex + 2], (char)a[targetIndex + 3] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + 3] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex + 3, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchFour_Char()
+        {
+            Random rnd = new Random(42);
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                ReadOnlySpan<char> values = stackalloc[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
+                Span<char> span = new Span<char>(a);
+
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchFour_Char()
+        {
+            for (int length = 5; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    char val = (char)(i + 1);
+                    a[i] = val == (char)200 ? (char)201 : val;
+                }
+
+                a[length - 1] = (char)200;
+                a[length - 2] = (char)200;
+                a[length - 3] = (char)200;
+                a[length - 4] = (char)200;
+                a[length - 5] = (char)200;
+
+                Span<char> span = new Span<char>(a);
+                ReadOnlySpan<char> values = stackalloc[] { (char)200, (char)200, (char)200, (char)200 };
+                int idx = span.IndexOfAny<char>(values);
+                Assert.Equal(length - 5, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeFour_Char()
+        {
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length + 2];
+                a[0] = (char)99;
+                a[length + 1] = (char)98;
+                Span<char> span = new Span<char>(a, 1, length - 1);
+                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)98, (char)99, (char)99 };
+                int index = span.IndexOfAny<char>(values);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length + 2];
+                a[0] = (char)99;
+                a[length + 1] = (char)99;
+                Span<char> span = new Span<char>(a, 1, length - 1);
+                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)99, (char)99, (char)99 };
+                int index = span.IndexOfAny<char>(values);
+                Assert.Equal(-1, index);
+            }
+        }
+
+        [Fact]
+        public static void ZeroLengthIndexOfFive_Char()
+        {
+            Span<char> sp = new Span<char>(Array.Empty<char>());
+            ReadOnlySpan<char> values = stackalloc[] { (char)0, (char)0, (char)0, (char)0, (char)0 };
+            int idx = sp.IndexOfAny<char>(values);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfFive_Char()
+        {
+            Random rnd = new Random(42);
+
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                Span<char> span = new Span<char>(a);
+
+                char[] targets = { default, (char)99, (char)98, (char)97, (char)96 };
+
+                for (int i = 0; i < length; i++)
+                {
+                    int index = rnd.Next(0, 5);
+                    ReadOnlySpan<char> values = stackalloc[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4], (char)targets[(index + 1) % 5] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(0, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMatchFive_Char()
+        {
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (char)(i + 1);
+                }
+                Span<char> span = new Span<char>(a);
+
+                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)0, (char)0, (char)0, (char)0 };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 4; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)a[targetIndex + 1], (char)a[targetIndex + 2], (char)a[targetIndex + 3], (char)a[targetIndex + 4] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 4; targetIndex++)
+                {
+                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + 4] };
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex + 4, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchFive_Char()
+        {
+            Random rnd = new Random(42);
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                ReadOnlySpan<char> values = stackalloc[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
+                Span<char> span = new Span<char>(a);
+
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchFive_Char()
+        {
+            for (int length = 6; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length];
+                for (int i = 0; i < length; i++)
+                {
+                    char val = (char)(i + 1);
+                    a[i] = val == (char)200 ? (char)201 : val;
+                }
+
+                a[length - 1] = (char)200;
+                a[length - 2] = (char)200;
+                a[length - 3] = (char)200;
+                a[length - 4] = (char)200;
+                a[length - 5] = (char)200;
+                a[length - 6] = (char)200;
+
+                Span<char> span = new Span<char>(a);
+                ReadOnlySpan<char> values = stackalloc[] { (char)200, (char)200, (char)200, (char)200, (char)200 };
+                int idx = span.IndexOfAny<char>(values);
+                Assert.Equal(length - 6, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeFive_Char()
+        {
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length + 2];
+                a[0] = (char)99;
+                a[length + 1] = (char)98;
+                Span<char> span = new Span<char>(a, 1, length - 1);
+                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)98, (char)99, (char)99, (char)99 };
+                int index = span.IndexOfAny<char>(values);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                char[] a = new char[length + 2];
+                a[0] = (char)99;
+                a[length + 1] = (char)99;
+                Span<char> span = new Span<char>(a, 1, length - 1);
+                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)99, (char)99, (char)99, (char)99 };
+                int index = span.IndexOfAny<char>(values);
+                Assert.Equal(-1, index);
+            }
+        }
+
+        [Fact]
         public static void ZeroLengthIndexOfMany_Char()
         {
             Span<char> sp = new Span<char>(Array.Empty<char>());
-            ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { (char)0, (char)0, (char)0, (char)0 });
+            ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { (char)0, (char)0, (char)0, (char)0, (char)0, (char)0 });
             int idx = sp.IndexOfAny(values);
             Assert.Equal(-1, idx);
 
@@ -343,7 +608,7 @@ namespace System.SpanTests
                 char[] a = new char[length];
                 Span<char> span = new Span<char>(a);
 
-                ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { default, (char)99, (char)98, (char)0 });
+                ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { default, (char)99, (char)98, (char)97, (char)96, (char)0 });
 
                 for (int i = 0; i < length; i++)
                 {
@@ -367,23 +632,23 @@ namespace System.SpanTests
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
-                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { a[targetIndex], (char)0, (char)0, (char)0 });
+                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { a[targetIndex], (char)0, (char)0, (char)0, (char)0, (char)0 });
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(targetIndex, idx);
                 }
 
-                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                for (int targetIndex = 0; targetIndex < length - 5; targetIndex++)
                 {
-                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { a[targetIndex], a[targetIndex + 1], a[targetIndex + 2], a[targetIndex + 3] });
+                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { a[targetIndex], a[targetIndex + 1], a[targetIndex + 2], a[targetIndex + 3], a[targetIndex + 4], a[targetIndex + 5] });
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(targetIndex, idx);
                 }
 
-                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                for (int targetIndex = 0; targetIndex < length - 5; targetIndex++)
                 {
-                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { (char)0, (char)0, (char)0, a[targetIndex + 3] });
+                    ReadOnlySpan<char> values = new ReadOnlySpan<char>(new char[] { (char)0, (char)0, (char)0, (char)0, (char)0, a[targetIndex + 5] });
                     int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex + 3, idx);
+                    Assert.Equal(targetIndex + 5, idx);
                 }
             }
         }

--- a/src/System.Memory/tests/Span/IndexOfAny.char.cs
+++ b/src/System.Memory/tests/Span/IndexOfAny.char.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -67,7 +68,7 @@ namespace System.SpanTests
         {
             Random rnd = new Random(42);
 
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 Span<char> span = new Span<char>(a);
@@ -76,7 +77,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int index = rnd.Next(0, 2) == 0 ? 0 : 1;
+                    int index = rnd.Next(0, targets.Length) == 0 ? 0 : 1;
                     char target0 = targets[index];
                     char target1 = targets[(index + 1) % 2];
                     int idx = span.IndexOfAny(target0, target1);
@@ -88,13 +89,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchTwo_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 Span<char> span = new Span<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -127,7 +124,7 @@ namespace System.SpanTests
         public static void TestNoMatchTwo_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 0; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 char target0 = (char)rnd.Next(1, 256);
@@ -142,7 +139,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchTwo_Char()
         {
-            for (int length = 3; length < byte.MaxValue; length++)
+            for (int length = 3; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -164,7 +161,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeTwo_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -174,7 +171,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -198,7 +195,7 @@ namespace System.SpanTests
         {
             Random rnd = new Random(42);
 
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 Span<char> span = new Span<char>(a);
@@ -207,7 +204,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int index = rnd.Next(0, 3);
+                    int index = rnd.Next(0, targets.Length);
                     char target0 = targets[index];
                     char target1 = targets[(index + 1) % 2];
                     char target2 = targets[(index + 1) % 3];
@@ -220,13 +217,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchThree_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 Span<char> span = new Span<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -262,7 +255,7 @@ namespace System.SpanTests
         public static void TestNoMatchThree_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 0; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 char target0 = (char)rnd.Next(1, 256);
@@ -278,7 +271,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchThree_Char()
         {
-            for (int length = 4; length < byte.MaxValue; length++)
+            for (int length = 4; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -301,7 +294,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeThree_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -311,7 +304,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -336,7 +329,7 @@ namespace System.SpanTests
         {
             Random rnd = new Random(42);
 
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 Span<char> span = new Span<char>(a);
@@ -345,7 +338,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int index = rnd.Next(0, 4);
+                    int index = rnd.Next(0, targets.Length);
                     ReadOnlySpan<char> values = new char[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(0, idx);
@@ -356,13 +349,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchFour_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 Span<char> span = new Span<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -381,7 +370,7 @@ namespace System.SpanTests
 
                 for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
                 {
-                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + 3] };
+                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)a[targetIndex + 3] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(targetIndex + 3, idx);
                 }
@@ -392,7 +381,7 @@ namespace System.SpanTests
         public static void TestNoMatchFour_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 0; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> values = new char[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
@@ -406,7 +395,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchFour_Char()
         {
-            for (int length = 5; length < byte.MaxValue; length++)
+            for (int length = 5; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -431,7 +420,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeFour_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -442,7 +431,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -468,7 +457,7 @@ namespace System.SpanTests
         {
             Random rnd = new Random(42);
 
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 Span<char> span = new Span<char>(a);
@@ -477,7 +466,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int index = rnd.Next(0, 5);
+                    int index = rnd.Next(0, targets.Length);
                     ReadOnlySpan<char> values = new char[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4], (char)targets[(index + 1) % 5] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(0, idx);
@@ -488,13 +477,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchFive_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 Span<char> span = new Span<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -524,7 +509,7 @@ namespace System.SpanTests
         public static void TestNoMatchFive_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 0; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 ReadOnlySpan<char> values = new char[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
@@ -538,7 +523,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchFive_Char()
         {
-            for (int length = 6; length < byte.MaxValue; length++)
+            for (int length = 6; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -564,7 +549,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeFive_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -575,7 +560,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -603,7 +588,7 @@ namespace System.SpanTests
         [Fact]
         public static void DefaultFilledIndexOfMany_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 Span<char> span = new Span<char>(a);
@@ -621,13 +606,9 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchMany_Char()
         {
-            for (int length = 0; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
-                char[] a = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    a[i] = (char)(i + 1);
-                }
+                char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
                 Span<char> span = new Span<char>(a);
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
@@ -657,7 +638,7 @@ namespace System.SpanTests
         public static void TestMatchValuesLargerMany_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 2; length < byte.MaxValue; length++)
+            for (int length = 2; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 int expectedIndex = length / 2;
@@ -691,7 +672,7 @@ namespace System.SpanTests
         public static void TestNoMatchMany_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 char[] targets = new char[length];
@@ -711,7 +692,7 @@ namespace System.SpanTests
         public static void TestNoMatchValuesLargerMany_Char()
         {
             Random rnd = new Random(42);
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 char[] targets = new char[length * 2];
@@ -730,7 +711,7 @@ namespace System.SpanTests
         [Fact]
         public static void TestMultipleMatchMany_Char()
         {
-            for (int length = 5; length < byte.MaxValue; length++)
+            for (int length = 5; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length];
                 for (int i = 0; i < length; i++)
@@ -755,7 +736,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeMany_Char()
         {
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;
@@ -766,7 +747,7 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 1; length < byte.MaxValue; length++)
+            for (int length = 1; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = new char[length + 2];
                 a[0] = (char)99;

--- a/src/System.Memory/tests/Span/IndexOfAny.char.cs
+++ b/src/System.Memory/tests/Span/IndexOfAny.char.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using Xunit;
 
@@ -89,33 +90,37 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchTwo_Char()
         {
-            for (int length = 1; length <= byte.MaxValue + 1; length++)
+            for (int length = Vector<short>.Count; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
-                Span<char> span = new Span<char>(a);
 
-                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                for (int i = 0; i < Vector<short>.Count; i++)
                 {
-                    char target0 = a[targetIndex];
-                    char target1 = (char)0;
-                    int idx = span.IndexOfAny(target0, target1);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    Span<char> span = new Span<char>(a).Slice(i);
 
-                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
-                {
-                    char target0 = a[targetIndex];
-                    char target1 = a[targetIndex + 1];
-                    int idx = span.IndexOfAny(target0, target1);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    for (int targetIndex = 0; targetIndex < length - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = a[targetIndex + i];
+                        char target1 = (char)0;
+                        int idx = span.IndexOfAny(target0, target1);
+                        Assert.Equal(targetIndex, idx);
+                    }
 
-                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
-                {
-                    char target0 = (char)0;
-                    char target1 = a[targetIndex + 1];
-                    int idx = span.IndexOfAny(target0, target1);
-                    Assert.Equal(targetIndex + 1, idx);
+                    for (int targetIndex = 0; targetIndex < length - 1 - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = a[targetIndex + i];
+                        char target1 = a[targetIndex + i + 1];
+                        int idx = span.IndexOfAny(target0, target1);
+                        Assert.Equal(targetIndex, idx);
+                    }
+
+                    for (int targetIndex = 0; targetIndex < length - 1 - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = (char)0;
+                        char target1 = a[targetIndex + i + 1];
+                        int idx = span.IndexOfAny(target0, target1);
+                        Assert.Equal(targetIndex + 1, idx);
+                    }
                 }
             }
         }
@@ -217,36 +222,39 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchThree_Char()
         {
-            for (int length = 1; length <= byte.MaxValue + 1; length++)
+            for (int length = Vector<short>.Count; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
-                Span<char> span = new Span<char>(a);
-
-                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                for (int i = 0; i < Vector<short>.Count; i++)
                 {
-                    char target0 = a[targetIndex];
-                    char target1 = (char)0;
-                    char target2 = (char)0;
-                    int idx = span.IndexOfAny(target0, target1, target2);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    Span<char> span = new Span<char>(a).Slice(i);
 
-                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
-                {
-                    char target0 = a[targetIndex];
-                    char target1 = a[targetIndex + 1];
-                    char target2 = a[targetIndex + 2];
-                    int idx = span.IndexOfAny(target0, target1, target2);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    for (int targetIndex = 0; targetIndex < length - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = a[targetIndex + i];
+                        char target1 = (char)0;
+                        char target2 = (char)0;
+                        int idx = span.IndexOfAny(target0, target1, target2);
+                        Assert.Equal(targetIndex, idx);
+                    }
 
-                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
-                {
-                    char target0 = (char)0;
-                    char target1 = (char)0;
-                    char target2 = a[targetIndex + 2];
-                    int idx = span.IndexOfAny(target0, target1, target2);
-                    Assert.Equal(targetIndex + 2, idx);
+                    for (int targetIndex = 0; targetIndex < length - 2 - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = a[targetIndex + i];
+                        char target1 = a[targetIndex + i + 1];
+                        char target2 = a[targetIndex + i + 2];
+                        int idx = span.IndexOfAny(target0, target1, target2);
+                        Assert.Equal(targetIndex, idx);
+                    }
+
+                    for (int targetIndex = 0; targetIndex < length - 2 - Vector<short>.Count; targetIndex++)
+                    {
+                        char target0 = (char)0;
+                        char target1 = (char)0;
+                        char target2 = a[targetIndex + i + 2];
+                        int idx = span.IndexOfAny(target0, target1, target2);
+                        Assert.Equal(targetIndex + 2, idx);
+                    }
                 }
             }
         }
@@ -349,30 +357,34 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchFour_Char()
         {
-            for (int length = 1; length <= byte.MaxValue + 1; length++)
+            for (int length = Vector<short>.Count; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
-                Span<char> span = new Span<char>(a);
 
-                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                for (int i = 0; i < Vector<short>.Count; i++)
                 {
-                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)0, (char)0, (char)0 };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    Span<char> span = new Span<char>(a).Slice(i);
 
-                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
-                {
-                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)a[targetIndex + 1], (char)a[targetIndex + 2], (char)a[targetIndex + 3] };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    for (int targetIndex = 0; targetIndex < length - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)a[targetIndex + i], (char)0, (char)0, (char)0 };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex, idx);
+                    }
 
-                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
-                {
-                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)a[targetIndex + 3] };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex + 3, idx);
+                    for (int targetIndex = 0; targetIndex < length - 3 - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)a[targetIndex + i], (char)a[targetIndex + i + 1], (char)a[targetIndex + i + 2], (char)a[targetIndex + i + 3] };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex, idx);
+                    }
+
+                    for (int targetIndex = 0; targetIndex < length - 3 - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)a[targetIndex + i + 3] };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex + 3, idx);
+                    }
                 }
             }
         }
@@ -477,30 +489,33 @@ namespace System.SpanTests
         [Fact]
         public static void TestMatchFive_Char()
         {
-            for (int length = 1; length <= byte.MaxValue + 1; length++)
+            for (int length = Vector<short>.Count; length <= byte.MaxValue + 1; length++)
             {
                 char[] a = Enumerable.Range(0, length).Select(i => (char)(i + 1)).ToArray();
-                Span<char> span = new Span<char>(a);
-
-                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                for (int i = 0; i < Vector<short>.Count; i++)
                 {
-                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)0, (char)0, (char)0, (char)0 };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    Span<char> span = new Span<char>(a).Slice(i);
 
-                for (int targetIndex = 0; targetIndex < length - 4; targetIndex++)
-                {
-                    ReadOnlySpan<char> values = new char[] { (char)a[targetIndex], (char)a[targetIndex + 1], (char)a[targetIndex + 2], (char)a[targetIndex + 3], (char)a[targetIndex + 4] };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex, idx);
-                }
+                    for (int targetIndex = 0; targetIndex < length - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)a[targetIndex + i], (char)0, (char)0, (char)0, (char)0 };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex, idx);
+                    }
 
-                for (int targetIndex = 0; targetIndex < length - 4; targetIndex++)
-                {
-                    ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + 4] };
-                    int idx = span.IndexOfAny(values);
-                    Assert.Equal(targetIndex + 4, idx);
+                    for (int targetIndex = 0; targetIndex < length - 4 - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)a[targetIndex + i], (char)a[targetIndex + i + 1], (char)a[targetIndex + i + 2], (char)a[targetIndex + i + 3], (char)a[targetIndex + i + 4] };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex, idx);
+                    }
+
+                    for (int targetIndex = 0; targetIndex < length - 4 - Vector<short>.Count; targetIndex++)
+                    {
+                        ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)a[targetIndex + i + 4] };
+                        int idx = span.IndexOfAny(values);
+                        Assert.Equal(targetIndex + 4, idx);
+                    }
                 }
             }
         }

--- a/src/System.Memory/tests/Span/IndexOfAny.char.cs
+++ b/src/System.Memory/tests/Span/IndexOfAny.char.cs
@@ -326,7 +326,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfFour_Char()
         {
             Span<char> sp = new Span<char>(Array.Empty<char>());
-            ReadOnlySpan<char> values = stackalloc[] { (char)0, (char)0, (char)0, (char)0 };
+            ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0 };
             int idx = sp.IndexOfAny<char>(values);
             Assert.Equal(-1, idx);
         }
@@ -346,7 +346,7 @@ namespace System.SpanTests
                 for (int i = 0; i < length; i++)
                 {
                     int index = rnd.Next(0, 4);
-                    ReadOnlySpan<char> values = stackalloc[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4] };
+                    ReadOnlySpan<char> values = new char[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(0, idx);
                 }
@@ -395,7 +395,7 @@ namespace System.SpanTests
             for (int length = 0; length < byte.MaxValue; length++)
             {
                 char[] a = new char[length];
-                ReadOnlySpan<char> values = stackalloc[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
+                ReadOnlySpan<char> values = new char[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
                 Span<char> span = new Span<char>(a);
 
                 int idx = span.IndexOfAny(values);
@@ -422,7 +422,7 @@ namespace System.SpanTests
                 a[length - 5] = (char)200;
 
                 Span<char> span = new Span<char>(a);
-                ReadOnlySpan<char> values = stackalloc[] { (char)200, (char)200, (char)200, (char)200 };
+                ReadOnlySpan<char> values = new char[] { (char)200, (char)200, (char)200, (char)200 };
                 int idx = span.IndexOfAny<char>(values);
                 Assert.Equal(length - 5, idx);
             }
@@ -437,7 +437,7 @@ namespace System.SpanTests
                 a[0] = (char)99;
                 a[length + 1] = (char)98;
                 Span<char> span = new Span<char>(a, 1, length - 1);
-                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)98, (char)99, (char)99 };
+                ReadOnlySpan<char> values = new char[] { (char)99, (char)98, (char)99, (char)99 };
                 int index = span.IndexOfAny<char>(values);
                 Assert.Equal(-1, index);
             }
@@ -448,7 +448,7 @@ namespace System.SpanTests
                 a[0] = (char)99;
                 a[length + 1] = (char)99;
                 Span<char> span = new Span<char>(a, 1, length - 1);
-                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)99, (char)99, (char)99 };
+                ReadOnlySpan<char> values = new char[] { (char)99, (char)99, (char)99, (char)99 };
                 int index = span.IndexOfAny<char>(values);
                 Assert.Equal(-1, index);
             }
@@ -458,7 +458,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfFive_Char()
         {
             Span<char> sp = new Span<char>(Array.Empty<char>());
-            ReadOnlySpan<char> values = stackalloc[] { (char)0, (char)0, (char)0, (char)0, (char)0 };
+            ReadOnlySpan<char> values = new char[] { (char)0, (char)0, (char)0, (char)0, (char)0 };
             int idx = sp.IndexOfAny<char>(values);
             Assert.Equal(-1, idx);
         }
@@ -478,7 +478,7 @@ namespace System.SpanTests
                 for (int i = 0; i < length; i++)
                 {
                     int index = rnd.Next(0, 5);
-                    ReadOnlySpan<char> values = stackalloc[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4], (char)targets[(index + 1) % 5] };
+                    ReadOnlySpan<char> values = new char[] { (char)targets[index], (char)targets[(index + 1) % 2], (char)targets[(index + 1) % 3], (char)targets[(index + 1) % 4], (char)targets[(index + 1) % 5] };
                     int idx = span.IndexOfAny(values);
                     Assert.Equal(0, idx);
                 }
@@ -527,7 +527,7 @@ namespace System.SpanTests
             for (int length = 0; length < byte.MaxValue; length++)
             {
                 char[] a = new char[length];
-                ReadOnlySpan<char> values = stackalloc[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
+                ReadOnlySpan<char> values = new char[] { (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256), (char)rnd.Next(1, 256) };
                 Span<char> span = new Span<char>(a);
 
                 int idx = span.IndexOfAny(values);
@@ -555,7 +555,7 @@ namespace System.SpanTests
                 a[length - 6] = (char)200;
 
                 Span<char> span = new Span<char>(a);
-                ReadOnlySpan<char> values = stackalloc[] { (char)200, (char)200, (char)200, (char)200, (char)200 };
+                ReadOnlySpan<char> values = new char[] { (char)200, (char)200, (char)200, (char)200, (char)200 };
                 int idx = span.IndexOfAny<char>(values);
                 Assert.Equal(length - 6, idx);
             }
@@ -570,7 +570,7 @@ namespace System.SpanTests
                 a[0] = (char)99;
                 a[length + 1] = (char)98;
                 Span<char> span = new Span<char>(a, 1, length - 1);
-                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)98, (char)99, (char)99, (char)99 };
+                ReadOnlySpan<char> values = new char[] { (char)99, (char)98, (char)99, (char)99, (char)99 };
                 int index = span.IndexOfAny<char>(values);
                 Assert.Equal(-1, index);
             }
@@ -581,7 +581,7 @@ namespace System.SpanTests
                 a[0] = (char)99;
                 a[length + 1] = (char)99;
                 Span<char> span = new Span<char>(a, 1, length - 1);
-                ReadOnlySpan<char> values = stackalloc[] { (char)99, (char)99, (char)99, (char)99, (char)99 };
+                ReadOnlySpan<char> values = new char[] { (char)99, (char)99, (char)99, (char)99, (char)99 };
                 int index = span.IndexOfAny<char>(values);
                 Assert.Equal(-1, index);
             }


### PR DESCRIPTION
To cover vectorizing 4 and 5 values in addition to to 1,2,3 https://github.com/dotnet/coreclr/pull/19790#issuecomment-417894761 as this is used  for example in `FileSystemName` with 5 chars
```csharp
private static readonly char[] s_wildcardChars =
{
    '\"', '<', '>', '*', '?'
};
```

/cc @krwq @ahsonkhan @stephentoub 