### PR TITLE
Add ReferenceAssemblies.props to eng directory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -72,7 +72,9 @@
     <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(DotNetRoot)</DotnetCliPath>
     <ToolHostCmd Condition="'$(ToolHostCmd)'==''">"$(DotNetRoot)dotnet"</ToolHostCmd>
   </PropertyGroup>
+
   <!-- Choose .targets files that come from Arcade rather than from buildtools -->
+  <!-- TODO: Remove when buildtools dependency removed. -->
   <PropertyGroup>
     <ExcludeNotSupportedImport>true</ExcludeNotSupportedImport>
     <ExcludePartialFacadesImport>true</ExcludePartialFacadesImport>
@@ -398,6 +400,9 @@
     <!-- Disable VS Test SDK references if the .NET Native toolchain is used. -->
     <IncludeVSTestReferences Condition="'$(UseDotNetNativeToolchain)' == 'true'">false</IncludeVSTestReferences>
   </PropertyGroup>
+
+  <!-- Import it at the end of the props file to override the OutputPath for reference assemblies and use common directory props -->
+  <Import Project="$(MSBuildThisFileDirectory)eng/ReferenceAssemblies.props" />
 
   <!-- Use Roslyn Compilers to build -->
   <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false' and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -77,6 +77,7 @@
     <ExcludeNotSupportedImport>true</ExcludeNotSupportedImport>
     <ExcludePartialFacadesImport>true</ExcludePartialFacadesImport>
     <ExcludeApiCompatImport>true</ExcludeApiCompatImport>
+    <ExcludeReferenceAssembliesImport>true</ExcludeReferenceAssembliesImport>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->
@@ -279,11 +280,6 @@
     <Deterministic>false</Deterministic>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsReferenceAssembly)' == 'true'">
-    <!-- disable warnings about unused fields -->
-    <NoWarn>$(NoWarn);0169;0649</NoWarn>
-  </PropertyGroup>
-
   <!-- Set up some common paths -->
   <PropertyGroup>
     <CommonPath>$(SourceDir)Common\src</CommonPath>
@@ -306,7 +302,6 @@
 
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
 
-    <OutputPathSubfolder Condition="'$(IsCompatAssembly)'=='true'">/Compat</OutputPathSubfolder>
     <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
 
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(RootIntermediateOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/</BaseIntermediateOutputPath>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,6 +16,11 @@
            Text="The tools directory [$(ToolsDir)] does not exist. Please run init-tools.cmd in your repo to ensure the tools are installed before attempting to build an individual project." />
   </Target>
 
+  <!-- Sets output paths and other reference assembly specific properties.
+       We need to import them in the targets file so that it is imported after SDK Common targets,
+       because it overrides TargetDir and TargetPath properties.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)eng/ReferenceAssemblies.props" />
   <Import Project="buildvertical.targets" />
 
   <!-- Corefx-specific binplacing properties -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,11 +16,6 @@
            Text="The tools directory [$(ToolsDir)] does not exist. Please run init-tools.cmd in your repo to ensure the tools are installed before attempting to build an individual project." />
   </Target>
 
-  <!-- Sets output paths and other reference assembly specific properties.
-       We need to import them in the targets file so that it is imported after SDK Common targets,
-       because it overrides TargetDir and TargetPath properties.
-  -->
-  <Import Project="$(MSBuildThisFileDirectory)eng/ReferenceAssemblies.props" />
   <Import Project="buildvertical.targets" />
 
   <!-- Corefx-specific binplacing properties -->

--- a/eng/ReferenceAssemblies.props
+++ b/eng/ReferenceAssemblies.props
@@ -8,14 +8,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
-    <OutputPath>$(ReferenceAssemblyOutputPath)$(AssemblyName)/$(AssemblyVersion)/$(TargetOutputRelPath)</OutputPath>
-    <IntermediateOutputPath>$(RootIntermediateOutputPath)ref/$(AssemblyName)/$(AssemblyVersion)/$(TargetOutputRelPath)</IntermediateOutputPath>
-
-    <!-- When using Sdk-style projects, Microsoft.Common.CurrentVersion.targets gets imported before
-         this file, so we are overwriting OutputPath too late and we need to re-default these properties. -->
-    <OutDir>$(OutputPath)</OutDir>
-    <TargetDir>$([MSBuild]::Escape($([System.IO.Path]::GetFullPath(`$([System.IO.Path]::Combine(`$(MSBuildProjectDirectory)`, `$(OutDir)`))`))))</TargetDir>
-    <TargetPath>$(TargetDir)$(TargetFileName)</TargetPath>
+    <OutputPath>$(ReferenceAssemblyOutputPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</OutputPath>
+    <IntermediateOutputPath>$(RootIntermediateOutputPath)ref/$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
 
     <!-- disable warnings about unused fields -->
     <NoWarn>$(NoWarn);0169;0649</NoWarn>

--- a/eng/ReferenceAssemblies.props
+++ b/eng/ReferenceAssemblies.props
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IsReferenceAssembly Condition="'$(IsReferenceAssembly)'=='' AND ($(MSBuildProjectFullPath.Contains('\ref\')) OR $(MSBuildProjectFullPath.Contains('/ref/')))">true</IsReferenceAssembly>
+
+    <!-- Create a common root output directory for all reference assemblies -->
+    <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$(BaseOutputPath)ref/</ReferenceAssemblyOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
+    <OutputPath>$(ReferenceAssemblyOutputPath)$(AssemblyName)/$(AssemblyVersion)/$(TargetOutputRelPath)</OutputPath>
+    <IntermediateOutputPath>$(RootIntermediateOutputPath)ref/$(AssemblyName)/$(AssemblyVersion)/$(TargetOutputRelPath)</IntermediateOutputPath>
+
+    <!-- When using Sdk-style projects, Microsoft.Common.CurrentVersion.targets gets imported before
+         this file, so we are overwriting OutputPath too late and we need to re-default these properties. -->
+    <OutDir>$(OutputPath)</OutDir>
+    <TargetDir>$([MSBuild]::Escape($([System.IO.Path]::GetFullPath(`$([System.IO.Path]::Combine(`$(MSBuildProjectDirectory)`, `$(OutDir)`))`))))</TargetDir>
+    <TargetPath>$(TargetDir)$(TargetFileName)</TargetPath>
+
+    <!-- disable warnings about unused fields -->
+    <NoWarn>$(NoWarn);0169;0649</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsReferenceAssembly)'=='true'">
+    <!-- All reference assemblies should have the 0x70 flag which prevents them from loading 
+         and the ReferenceAssemblyAttribute. -->
+    <AssemblyInfoLines Include="[assembly:System.Runtime.CompilerServices.ReferenceAssembly]" />
+    <AssemblyInfoLines Include="[assembly:System.Reflection.AssemblyFlags((System.Reflection.AssemblyNameFlags)0x70)]" />
+  </ItemGroup>
+</Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>

--- a/src/System.Runtime/ref/System.Runtime.csproj
+++ b/src/System.Runtime/ref/System.Runtime.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsCoreAssembly>true</IsCoreAssembly>
+    <!-- It is a core assembly because it defines System.Object so we need to pass RuntimeMetadataVersion to the compiler -->
+    <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
     <ProjectGuid>{ADBCF120-3454-4A3C-9D1D-AC4293E795D6}</ProjectGuid>
     <!-- disable warnings about obsolete APIs -->
     <NoWarn>$(NoWarn);0809;0618</NoWarn>


### PR DESCRIPTION
This turns off buildtools import of ReferenceAssemblies.props/targets and moves them to the eng folder instead.

However, this properties can't be imported in Directory.Build.props as the SDK Common targets override's TargetDir and TargetPath, so we need to import them in Directory.Build.targets