### PR TITLE
Add correctness tests for String.GetHashCodeOrdinalIgnoreCase

### DIFF
--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -235,6 +235,7 @@
     <Compile Include="System\LazyTests.netcoreapp.cs" />
     <Compile Include="System\SByteTests.netcoreapp.cs" />
     <Compile Include="System\StringComparerTests.netcoreapp.cs" />
+    <Compile Include="System\StringGetHashCodeTests.netcoreapp.cs" />
     <Compile Include="System\StringTests.netcoreapp.cs" />
     <Compile Include="System\TimeSpanTests.netcoreapp.cs" />
     <Compile Include="System\TypedReferenceTests.cs" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
+++ b/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
@@ -82,7 +82,7 @@ namespace System.Tests
                 yield return new object[] { "ABCDEFGH".Substring(0, i) };
             }
 
-            // 0 through 16 char mixed case mostly-ASCII string with a non-ASCII character
+            // 16 char mixed case mostly-ASCII string plus one non-ASCII character inserted at various locations
             // tests fallback logic for OrdinalIgnoreCase hash
 
             for (int i = 0; i <= 16; i++)

--- a/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
+++ b/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
@@ -35,6 +35,16 @@ namespace System.Tests
             Assert.Equal(SuccessExitCode, exitCode);
         }
 
+        [Theory]
+        [MemberData(nameof(GetHashCodeOrdinalIgnoreCase_TestData))]
+        public void GetHashCode_OrdinalIgnoreCase_ReturnsSameHashCodeAsUpperCaseOrdinal(string input)
+        {
+            // As an implementation detail, the OrdinalIgnoreCase hash code calculation is simply the hash code
+            // of the upper-invariant version of the input string.
+
+            Assert.Equal(input.ToUpperInvariant().GetHashCode(), input.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        }
+
         public static IEnumerable<object[]> GetHashCode_TestData()
         {
             for (int i = 0; i < s_GetHashCodes.Length; i++)
@@ -60,5 +70,25 @@ namespace System.Tests
             () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.Ordinal); },
             () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.OrdinalIgnoreCase); }
         };
+
+        public static IEnumerable<object[]> GetHashCodeOrdinalIgnoreCase_TestData()
+        {
+            // 0 through 8 char lowercase & uppercase ASCII strings
+            // tests the various branches within the hash code calculation routines
+
+            for (int i = 0; i <= 8; i++)
+            {
+                yield return new object[] { "abcdefgh".Substring(0, i) };
+                yield return new object[] { "ABCDEFGH".Substring(0, i) };
+            }
+
+            // 0 through 16 char mixed case mostly-ASCII string with a non-ASCII character
+            // tests fallback logic for OrdinalIgnoreCase hash
+
+            for (int i = 0; i <= 16; i++)
+            {
+                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u00E9" /* LATIN SMALL LETTER E WITH ACUTE */) };
+            }
+        }
     }
 }

--- a/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
+++ b/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
@@ -88,7 +88,16 @@ namespace System.Tests
             for (int i = 0; i <= 16; i++)
             {
                 yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u00E9" /* LATIN SMALL LETTER E WITH ACUTE */) };
+                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u044D" /* CYRILLIC SMALL LETTER E */) };
+                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u0131" /* LATIN SMALL LETTER DOTLESS I */) };
             }
+
+            // Various texts copied from Microsoft's non-U.S. home pages, for further localization tests
+
+            yield return new object[] { "Игры и развлечения без границ в формате 4K." }; // ru-RU
+            yield return new object[] { "Poder portátil." }; // es-ES
+            yield return new object[] { "想像を超えた、パフォーマンスを。" }; // ja-JP
+            yield return new object[] { "Élégant et performant." }; // fr-FR
         }
     }
 }

--- a/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
+++ b/src/System.Runtime/tests/System/StringGetHashCodeTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public class StringGetHashCodeTests : RemoteExecutorTestBase
+    public partial class StringGetHashCodeTests : RemoteExecutorTestBase
     {
         /// <summary>
         /// Ensure that hash codes are randomized by getting the hash in two processes
@@ -33,16 +33,6 @@ namespace System.Tests
                 }
             } while (exitCode != SuccessExitCode && retry < 3);
             Assert.Equal(SuccessExitCode, exitCode);
-        }
-
-        [Theory]
-        [MemberData(nameof(GetHashCodeOrdinalIgnoreCase_TestData))]
-        public void GetHashCode_OrdinalIgnoreCase_ReturnsSameHashCodeAsUpperCaseOrdinal(string input)
-        {
-            // As an implementation detail, the OrdinalIgnoreCase hash code calculation is simply the hash code
-            // of the upper-invariant version of the input string.
-
-            Assert.Equal(input.ToUpperInvariant().GetHashCode(), input.GetHashCode(StringComparison.OrdinalIgnoreCase));
         }
 
         public static IEnumerable<object[]> GetHashCode_TestData()
@@ -70,34 +60,5 @@ namespace System.Tests
             () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.Ordinal); },
             () => { return CultureInfo.CurrentCulture.CompareInfo.GetHashCode("abc", CompareOptions.OrdinalIgnoreCase); }
         };
-
-        public static IEnumerable<object[]> GetHashCodeOrdinalIgnoreCase_TestData()
-        {
-            // 0 through 8 char lowercase & uppercase ASCII strings
-            // tests the various branches within the hash code calculation routines
-
-            for (int i = 0; i <= 8; i++)
-            {
-                yield return new object[] { "abcdefgh".Substring(0, i) };
-                yield return new object[] { "ABCDEFGH".Substring(0, i) };
-            }
-
-            // 16 char mixed case mostly-ASCII string plus one non-ASCII character inserted at various locations
-            // tests fallback logic for OrdinalIgnoreCase hash
-
-            for (int i = 0; i <= 16; i++)
-            {
-                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u00E9" /* LATIN SMALL LETTER E WITH ACUTE */) };
-                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u044D" /* CYRILLIC SMALL LETTER E */) };
-                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u0131" /* LATIN SMALL LETTER DOTLESS I */) };
-            }
-
-            // Various texts copied from Microsoft's non-U.S. home pages, for further localization tests
-
-            yield return new object[] { "Игры и развлечения без границ в формате 4K." }; // ru-RU
-            yield return new object[] { "Poder portátil." }; // es-ES
-            yield return new object[] { "想像を超えた、パフォーマンスを。" }; // ja-JP
-            yield return new object[] { "Élégant et performant." }; // fr-FR
-        }
     }
 }

--- a/src/System.Runtime/tests/System/StringGetHashCodeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/StringGetHashCodeTests.netcoreapp.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Tests
+{
+    public partial class StringGetHashCodeTests
+    {
+        [Theory]
+        [MemberData(nameof(GetHashCodeOrdinalIgnoreCase_TestData))]
+        public void GetHashCode_OrdinalIgnoreCase_ReturnsSameHashCodeAsUpperCaseOrdinal(string input)
+        {
+            // As an implementation detail, the OrdinalIgnoreCase hash code calculation is simply the hash code
+            // of the upper-invariant version of the input string.
+
+            Assert.Equal(input.ToUpperInvariant().GetHashCode(), input.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        }
+        
+        public static IEnumerable<object[]> GetHashCodeOrdinalIgnoreCase_TestData()
+        {
+            // 0 through 8 char lowercase & uppercase ASCII strings
+            // tests the various branches within the hash code calculation routines
+
+            for (int i = 0; i <= 8; i++)
+            {
+                yield return new object[] { "abcdefgh".Substring(0, i) };
+                yield return new object[] { "ABCDEFGH".Substring(0, i) };
+            }
+
+            // 16 char mixed case mostly-ASCII string plus one non-ASCII character inserted at various locations
+            // tests fallback logic for OrdinalIgnoreCase hash
+
+            for (int i = 0; i <= 16; i++)
+            {
+                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u00E9" /* LATIN SMALL LETTER E WITH ACUTE */) };
+                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u044D" /* CYRILLIC SMALL LETTER E */) };
+                yield return new object[] { "AaBbCcDdEeFfGgHh".Insert(i, "\u0131" /* LATIN SMALL LETTER DOTLESS I */) };
+            }
+
+            // Various texts copied from Microsoft's non-U.S. home pages, for further localization tests
+
+            yield return new object[] { "Игры и развлечения без границ в формате 4K." }; // ru-RU
+            yield return new object[] { "Poder portátil." }; // es-ES
+            yield return new object[] { "想像を超えた、パフォーマンスを。" }; // ja-JP
+            yield return new object[] { "Élégant et performant." }; // fr-FR
+        }
+    }
+}


### PR DESCRIPTION
This just tests the relationship between String.GetHashCode and String.GetHashCodeOrdinalIgnoreCase to ensure that we're not breaking the logic of one.

There will be a separate PR with Marvin-specific tests to validate the implementation.