### PR TITLE
[release/uwp6.2] Clear Authorization Headers on Redirect

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2563,7 +2563,7 @@
         "netstandard2.0": "4.1.1.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
-        "uap10.0.16299": "4.2.1.0",
+        "uap10.0.16299": "4.2.1.1",
         "win8": "4.0.0.0",
         "wpa81": "4.0.0.0",
         "xamarinios10": "Any",

--- a/src/System.Net.Http/dir.props
+++ b/src/System.Net.Http/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.2.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.1.1</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
@@ -82,7 +82,8 @@ namespace System.Net.Http
                 RTHttpRequestMessage rtRequest = await ConvertRequestAsync(
                     request,
                     requestHttpMethod,
-                    skipRequestContentIfPresent).ConfigureAwait(false);
+                    skipRequestContentIfPresent,
+                    redirects > 0).ConfigureAwait(false);
 
                 RTHttpResponseMessage rtResponse;
                 try
@@ -251,7 +252,8 @@ namespace System.Net.Http
         private async Task<RTHttpRequestMessage> ConvertRequestAsync(
             HttpRequestMessage request,
             HttpMethod httpMethod,
-            bool skipRequestContentIfPresent)
+            bool skipRequestContentIfPresent,
+            bool isRedirect)
         {
             RTHttpRequestMessage rtRequest = new RTHttpRequestMessage(
                 new RTHttpMethod(httpMethod.Method),
@@ -297,8 +299,11 @@ namespace System.Net.Http
             {
                 foreach (string value in headerPair.Value)
                 {
-                    bool success = rtRequest.Headers.TryAppendWithoutValidation(headerPair.Key, value);
-                    Debug.Assert(success);
+                    if (!isRedirect || headerPair.Key != HttpKnownHeaderNames.Authorization)
+                    {
+                        bool success = rtRequest.Headers.TryAppendWithoutValidation(headerPair.Key, value);
+                        Debug.Assert(success);
+                    }
                 }
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -166,30 +166,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop]
-        [Theory, MemberData(nameof(RedirectStatusCodes))]
-        public async Task DefaultHeaders_SetCredentials_ClearedOnRedirect(int statusCode)
-        {
-            HttpClientHandler handler = new HttpClientHandler();
-            using (var client = new HttpClient(handler))
-            {
-                string credentialString = _credential.UserName + ":" + _credential.Password;
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentialString);
-                Uri uri = Configuration.Http.RedirectUriForDestinationUri(
-                    secure: false,
-                    statusCode: statusCode,
-                    destinationUri: Configuration.Http.RemoteEchoServer,
-                    hops: 1);
-                _output.WriteLine("Uri: {0}", uri);
-                using (HttpResponseMessage response = await client.GetAsync(uri))
-                {
-                    string responseText = await response.Content.ReadAsStringAsync();
-                    _output.WriteLine(responseText);
-                    Assert.False(TestHelper.JsonMessageContainsKey(responseText, "Authorization"));
-                }
-            }
-        }
-
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsUap))]
         public void Ctor_ExpectedDefaultPropertyValues_UapPlatform()
         {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -166,6 +166,30 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop]
+        [Theory, MemberData(nameof(RedirectStatusCodes))]
+        public async Task DefaultHeaders_SetCredentials_ClearedOnRedirect(int statusCode)
+        {
+            HttpClientHandler handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                string credentialString = _credential.UserName + ":" + _credential.Password;
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentialString);
+                Uri uri = Configuration.Http.RedirectUriForDestinationUri(
+                    secure: false,
+                    statusCode: statusCode,
+                    destinationUri: Configuration.Http.RemoteEchoServer,
+                    hops: 1);
+                _output.WriteLine("Uri: {0}", uri);
+                using (HttpResponseMessage response = await client.GetAsync(uri))
+                {
+                    string responseText = await response.Content.ReadAsStringAsync();
+                    _output.WriteLine(responseText);
+                    Assert.False(TestHelper.JsonMessageContainsKey(responseText, "Authorization"));
+                }
+            }
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsUap))]
         public void Ctor_ExpectedDefaultPropertyValues_UapPlatform()
         {


### PR DESCRIPTION
When a user has added an Authorization header manually (ie, not via Credentials), we currently do not strip that header on redirect. Headers added with HttpClient.DefaultRequestHeaders and headers added directly to the request using request.Headers.Add() are both affected.

The correct behavior is to strip all Authorization headers on redirect, and that is the behavior implemented in .NET Framework. This change implements that behavior on redirect, by modifying the function that builds RTHttpRequestMessage objects.

UWP 6.2: Bump System.Net.Http AssemblyVersion As needed for servicing Windows store apps.

UWP 6.2: Update packageIndex to reference new System.Net.Http AssemblyVersion.