### PR TITLE
Fix several typos

### DIFF
--- a/Documentation/building/cross-platform-testing.md
+++ b/Documentation/building/cross-platform-testing.md
@@ -61,7 +61,7 @@ If needed, copy System.Private.Corelib:
 # rsync -v -r  ~/mnt/matell3/d/git/coreclr/bin/Product/ ~/git/coreclr/bin/Product/
 ```
 
-Then, run the tests. We need to pass an explict path to the location of CoreCLR.
+Then, run the tests. We need to pass an explicit path to the location of CoreCLR.
 
 ```
 # ./run-test.sh --coreclr-bins ~/git/coreclr/bin/Product/Linux.x64.Release

--- a/Documentation/building/pinvoke-checker.md
+++ b/Documentation/building/pinvoke-checker.md
@@ -36,4 +36,4 @@ We do not currently apply this check to test binaries as they do not need to run
 ### Implementation
 To enforce this the analyzer consults the list [here](https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/PinvokeAnalyzer_Win32Apis.txt). 
 
-The analyzer is enabled by default when building for Windows, not a test, and not building for UWP. We aim to make all such configurations OneCore compilant, but in the rare cases where a library cannot be, the check can be disabled with `<EnablePInvokeAnalyzer>false<EnablePInvokeAnalyzer>` in the project file.
+The analyzer is enabled by default when building for Windows, not a test, and not building for UWP. We aim to make all such configurations OneCore compliant, but in the rare cases where a library cannot be, the check can be disabled with `<EnablePInvokeAnalyzer>false<EnablePInvokeAnalyzer>` in the project file.

--- a/Documentation/debugging/windows-instructions.md
+++ b/Documentation/debugging/windows-instructions.md
@@ -44,7 +44,7 @@ cd C:\corefx\bin\tests\Windows_NT.AnyCPU.Debug\System.Net.Sockets.Tests\netcorea
 C:\corefx\bin\tests\Windows_NT.AnyCPU.Debug\System.Net.Sockets.Tests\netcoreapp1.0\CoreRun.exe xunit.console.dll System.Net.Sockets.Tests.dll -xml testResults.xml -notrait category=nonwindowstests -notrait category=OuterLoop -notrait category=failing
 ```
 
-* If the test crashes or encounteres a `Debugger.Launch()` method call, WinDBG will automatically start and attach to the `CoreRun.exe` process 
+* If the test crashes or encounters a `Debugger.Launch()` method call, WinDBG will automatically start and attach to the `CoreRun.exe` process 
 
 The following commands will properly configure the debugging extension and fix symbol and source-code references:
 

--- a/Documentation/project-docs/benchmarking.md
+++ b/Documentation/project-docs/benchmarking.md
@@ -72,7 +72,7 @@ class Program
 
         dotnet run -c Release -f netcoreapp2.1 -- -f * --coreRun "C:\Projects\corefx\bin\testhost\netcoreapp-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\9.9.9\CoreRun.exe" --artifacts ".\before"
 
-6. Go to the coresponding CoreFX source folder (an example `corefx\src\System.Collections.Immutable`)
+6. Go to the corresponding CoreFX source folder (an example `corefx\src\System.Collections.Immutable`)
 7. Apply the optimization that you want to test
 8. Rebuild given CoreFX part in Release:
 

--- a/Documentation/project-docs/glossary.md
+++ b/Documentation/project-docs/glossary.md
@@ -107,7 +107,7 @@ var odds = source.Where(obj => obj.Id == 1).ToArray();
 
 One of the big advantages of using LINQ over more common data processing patterns is that the function given to the LINQ function can be converted to an expression and then executed in some other form, like SQL or on another machine across the network. An expression is a in-memory representation of some logic to follow.
 
-For example, in the above sample `source` could actually be a database connection and the function call `Where(obj => obj.Id == 1)` would be conveted to a SQL WHERE clause: `WHERE ID = 1`, and then executed on the SQL server.
+For example, in the above sample `source` could actually be a database connection and the function call `Where(obj => obj.Id == 1)` would be converted to a SQL WHERE clause: `WHERE ID = 1`, and then executed on the SQL server.
 
 #### Parallel LINQ
 


### PR DESCRIPTION
* explict => explicit
* compilant => compliant
* encounteres => encounters
* coresponding => corresponding
* conveted => converted