### PR TITLE
Process.Close check for null before using variable

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -859,18 +859,18 @@ namespace System.Diagnostics
                 {
                     if (_standardOutput != null && (_outputStreamReadMode == StreamReadMode.AsyncMode || _outputStreamReadMode == StreamReadMode.Undefined))
                     {
-                        if (_output != null && _outputStreamReadMode == StreamReadMode.AsyncMode)
+                        if (_outputStreamReadMode == StreamReadMode.AsyncMode)
                         {
-                            _output.CancelOperation();
+                            _output?.CancelOperation();
                         }
                         _standardOutput.Close();
                     }
 
                     if (_standardError != null && (_errorStreamReadMode == StreamReadMode.AsyncMode || _errorStreamReadMode == StreamReadMode.Undefined))
                     {
-                        if (_error != null && _errorStreamReadMode == StreamReadMode.AsyncMode)
+                        if (_errorStreamReadMode == StreamReadMode.AsyncMode)
                         {
-                            _error.CancelOperation();
+                            _error?.CancelOperation();
                         }
                         _standardError.Close();
                     }
@@ -888,9 +888,6 @@ namespace System.Diagnostics
 
                     _output = null;
                     _error = null;
-
-                    _pendingOutputRead = false;
-                    _pendingErrorRead = false;
 
                     CloseCore();
                     Refresh();

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -859,7 +859,7 @@ namespace System.Diagnostics
                 {
                     if (_standardOutput != null && (_outputStreamReadMode == StreamReadMode.AsyncMode || _outputStreamReadMode == StreamReadMode.Undefined))
                     {
-                        if (_outputStreamReadMode == StreamReadMode.AsyncMode)
+                        if (_output != null && _outputStreamReadMode == StreamReadMode.AsyncMode)
                         {
                             _output.CancelOperation();
                         }
@@ -868,7 +868,7 @@ namespace System.Diagnostics
 
                     if (_standardError != null && (_errorStreamReadMode == StreamReadMode.AsyncMode || _errorStreamReadMode == StreamReadMode.Undefined))
                     {
-                        if (_errorStreamReadMode == StreamReadMode.AsyncMode)
+                        if (_error != null && _errorStreamReadMode == StreamReadMode.AsyncMode)
                         {
                             _error.CancelOperation();
                         }
@@ -888,6 +888,9 @@ namespace System.Diagnostics
 
                     _output = null;
                     _error = null;
+
+                    _pendingOutputRead = false;
+                    _pendingErrorRead = false;
 
                     CloseCore();
                     Refresh();

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1369,26 +1369,22 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => process.Start());
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
-        public void Start_RedirectStandardOutput_StartAgainWithoutRedirect()
+        public void Start_RedirectStandardOutput_StartAgain_DoesntThrow()
         {
-            var process = new Process
+            using (Process process = CreateProcess(() =>
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "cmd",
-                    Arguments = "/C dir",
-                    RedirectStandardOutput = true,
-                }
-            };
+                Console.WriteLine("hello world");
+                return SuccessExitCode;
+            }))
+            {
+                process.StartInfo.RedirectStandardOutput = true;
 
-            process.Start();
-            process.BeginOutputReadLine();
+                Assert.True(process.Start());
+                process.BeginOutputReadLine();
 
-            process.Start();
-
-            process.Dispose();
+                Assert.True(process.Start());
+            }
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1369,6 +1369,28 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => process.Start());
         }
 
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [Fact]
+        public void Start_RedirectStandardOutput_StartAgainWithoutRedirect()
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "cmd",
+                    Arguments = "/C dir",
+                    RedirectStandardOutput = true,
+                }
+            };
+
+            process.Start();
+            process.BeginOutputReadLine();
+
+            process.Start();
+
+            process.Dispose();
+        }
+
         [Fact]
         public void Start_Disposed_ThrowsObjectDisposedException()
         {


### PR DESCRIPTION
Fix when `Process.Close` throws `NullReferenceException` on `RedirectStandardOutput `or `RedirectStandardError`.

Steps to reproduce:

    process.Start
    process.BeginOutputReadLine
    process.Start
    process.Dispose

Actual result:

    System.NullReferenceException : Object reference not set to an instance of an object.

	Stack Trace:
        System.Diagnostics.Process.Close()
        System.Diagnostics.Process.Dispose(Boolean disposing)

Exception occurs in `Close` method:

```C#
    if (_standardOutput != null && (_outputStreamReadMode == StreamReadMode.AsyncMode || _outputStreamReadMode == StreamReadMode.Undefined))
    {
        if (_outputStreamReadMode == StreamReadMode.AsyncMode)
        {
            _output.CancelOperation(); // <-- _output is null
        }
        _standardOutput.Close();
    }
```