### PR TITLE
Fix Timer rooting issue with SocketsHttpHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -96,7 +96,17 @@ namespace System.Net.Http
                         restoreFlow = true;
                     }
 
-                    _cleaningTimer = new Timer(s => ((HttpConnectionPoolManager)s).RemoveStalePools(), this, Timeout.Infinite, Timeout.Infinite);
+                    // Create the timer.  Ensure the Timer has a weak reference to this manager; otherwise, it
+                    // can introduce a cycle that keeps the HttpConnectionPoolManager rooted by the Timer
+                    // implementation until the handler is Disposed (or indefinitely if it's not).
+                    _cleaningTimer = new Timer(s =>
+                    {
+                        var wr = (WeakReference<HttpConnectionPoolManager>)s;
+                        if (wr.TryGetTarget(out HttpConnectionPoolManager thisRef))
+                        {
+                            thisRef.RemoveStalePools();
+                        }
+                    }, new WeakReference<HttpConnectionPoolManager>(this), Timeout.Infinite, Timeout.Infinite);
                 }
                 finally
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1142,6 +1142,48 @@ namespace System.Net.Http.Functional.Tests
             }, secure.ToString()).Dispose();
         }
 
+        [OuterLoop]
+        [Fact]
+        public void HandlerDroppedWithoutDisposal_NotKeptAlive()
+        {
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            HandlerDroppedWithoutDisposal_NotKeptAliveCore(tcs);
+            for (int i = 0; i < 10; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+            Assert.True(tcs.Task.IsCompleted);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void HandlerDroppedWithoutDisposal_NotKeptAliveCore(TaskCompletionSource<bool> setOnFinalized)
+        {
+            // This relies on knowing that in order for the connection pool to operate, it needs
+            // to maintain a reference to the supplied IWebProxy.  As such, we provide a proxy
+            // that when finalized will set our event, so that we can determine the state associated
+            // with a handler has gone away.
+            IWebProxy p = new PassthroughProxyWithFinalizerCallback(() => setOnFinalized.TrySetResult(true));
+
+            // Make a bunch of requests and drop the associated HttpClient instances after making them, without disposal.
+            Task.WaitAll((from i in Enumerable.Range(0, 10)
+                          select LoopbackServer.CreateClientAndServerAsync(
+                              url => new HttpClient(new SocketsHttpHandler { Proxy = p }).GetStringAsync(url),
+                              server => server.AcceptConnectionSendResponseAndCloseAsync())).ToArray());
+        }
+
+        private sealed class PassthroughProxyWithFinalizerCallback : IWebProxy
+        {
+            private readonly Action _callback;
+
+            public PassthroughProxyWithFinalizerCallback(Action callback) => _callback = callback;
+            ~PassthroughProxyWithFinalizerCallback() => _callback();
+
+            public ICredentials Credentials { get; set; }
+            public Uri GetProxy(Uri destination) => destination;
+            public bool IsBypassed(Uri host) => true;
+        }
+
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not support custom proxies.")]
         [Fact]
         public async Task ProxyAuth_SameConnection_Succeeds()


### PR DESCRIPTION
We have an unexpected rooted cycle that's unexpectedly keeping an HttpConnectionPoolManager and all of its state alive indefinitely (though generally several minutes) if the HttpClient/SocketsHttpHandler isn't Disposed.

HttpConnectionPoolManager creates a "cleaning timer" that runs every now and then in order to remove stale connection pools that are no longer needed.  In order to do that, the Timer is passed the HttpConnectionManagerPool as state.  That normally wouldn't be a problem, except that the HttpConnectionManagerPool then stores a strong reference to the Timer, creating a cycle: Timer -> TimerHolder -> TimerQueueTimer -> HttpConnectionPoolManager -> Timer.  The TimerQueueTimer is rooted by the underlying timer implementation, with it stored in a static array.  And TimerHolder has a finalizer that disposes of the Timer, but it's being kept alive as part of the cycle.

To break the cycle, we give the Timer a weak reference (rather than strong reference) to the HttpConnectionPoolManager.

Fixes https://github.com/dotnet/corefx/issues/31262
cc: @davidsh, @geoffkizer, @davidfowl 