### PR TITLE
Update Documentation references to old removed build scripts

### DIFF
--- a/Documentation/building/cross-building.md
+++ b/Documentation/building/cross-building.md
@@ -49,11 +49,11 @@ Once the rootfs has been generated, it will be possible to cross compile CoreFX.
 
 So, without `ROOTFS_DIR`:
 
-    lgs@ubuntu ~/git/corefx/ $ ./build-native.sh -debug -buildArch=arm -- verbose cross
+    lgs@ubuntu ~/git/corefx/ $ ./src/Native/build-native.sh debug arm verbose cross
 
 And with:
 
-    lgs@ubuntu ~/git/corefx/ $ ROOTFS_DIR=/home/lgs/corefx-cross/arm ./build-native.sh -debug -buildArch=arm -- verbose cross
+    lgs@ubuntu ~/git/corefx/ $ ROOTFS_DIR=/home/lgs/corefx-cross/arm ./src/Native/build-native.sh debug arm verbose cross
 
 As usual the generated binaries will be found in `bin/BuildOS.BuildArch.BuildType/native` as following:
 

--- a/Documentation/building/cross-platform-testing.md
+++ b/Documentation/building/cross-platform-testing.md
@@ -24,13 +24,13 @@ instructions assume you are building for Linux, but are easily modifiable for OS
    respect to object sizes and layout so you need to ensure you have either a
    release coreclr and release System.Private.Corelib or debug coreclr and debug System.Private.Corelib.
 3. A Linux build of CoreFX. We currently have experimental support for building
-   CoreFX on Linux via `build.sh`. 
+   CoreFX on Linux via `build.sh`.
    The other option is:
 
-   * Build the managed parts of CoreFX on Windows. To do so run `build-managed.cmd -os=Linux`. It is okay to build a Debug version of CoreFX and run it
+   * Build the managed parts of CoreFX on Windows. To do so run `build.cmd /p:BuildNative=false -os=Linux`. It is okay to build a Debug version of CoreFX and run it
    on top of a release CoreCLR (which is exactly what we do in Jenkins).
 
-   * Build the native parts of CoreFX on Linux. To do so run `./build-native.sh` from the root of your CoreFX repo.
+   * Build the native parts of CoreFX on Linux. To do so run `./src/Native/build-native.sh` from the root of your CoreFX repo.
 
 4. The packages folder which contains all the packages restored from NuGet and
    MyGet when building CoreFX.

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -8,7 +8,6 @@ Building CoreFX on FreeBSD, Linux and OS X
 4. Run the build script `./build.sh`
 
 Calling the script `build.sh` builds both the native and managed code.
-Only use it when the parameters that you are passing to the script apply for both components. Otherwise, use the scripts `build-native.sh` and `build-managed.sh` respectively.
 
 For more information about the different options when building, run `build.sh -?` and look at examples in the [developer-guide](../project-docs/developer-guide.md).
 
@@ -52,7 +51,7 @@ For Ubuntu 14.04, install the following packages:
 `sudo apt-get install libunwind8 libicu52 curl`
 
 For Ubuntu 16.04 LTS / Bash on Ubuntu on Windows you may need to replace libicu52 with libicu55.
-Ubuntu 16.10 and Ubuntu 17.04 will require libicu57. 
+Ubuntu 16.10 and Ubuntu 17.04 will require libicu57.
 
 `sudo apt-get install libunwind8 libicu55 curl`
 

--- a/Documentation/building/versioning.md
+++ b/Documentation/building/versioning.md
@@ -19,7 +19,7 @@ The version is composed by two parts; the build number major and the build numbe
 Calculating BuildNumberMajor
 ----------------------------
 
-The BuildNumberMajor is represented by 5 digits, and is determined by calculating the time that has happened between the latest commit's date(SeedDate) and a VersionComparisonDate that gets passed in. In the case where VersionComparisonDate is not passed in, we will use April 1st 1996 as default. The reason why we use this specific date, is to ensure that the version produced by SeedDate is higher than the already shipped versions of the same library. The first portion of the BuildNumberMajor (first 3 digits) represent the number of month(s) since the VersionComparisonDate. The second portion of the BuildNumberMajor (last 2 digits) represent the day of the month of SeedDate. This part of the version is reproducible. 
+The BuildNumberMajor is represented by 5 digits, and is determined by calculating the time that has happened between the latest commit's date(SeedDate) and a VersionComparisonDate that gets passed in. In the case where VersionComparisonDate is not passed in, we will use April 1st 1996 as default. The reason why we use this specific date, is to ensure that the version produced by SeedDate is higher than the already shipped versions of the same library. The first portion of the BuildNumberMajor (first 3 digits) represent the number of month(s) since the VersionComparisonDate. The second portion of the BuildNumberMajor (last 2 digits) represent the day of the month of SeedDate. This part of the version is reproducible.
 
 Calculating BuildNumberMinor
 ----------------------------
@@ -46,9 +46,9 @@ When trying to get a version of a native binary in non-Windows, there are two wa
 How to force a dev build to produce a specific version
 ======================================================
 
-If you need to manually specify the version you want to produce your build output with, you can accomplish this by running the following from the root of the repo: 
-- `build-managed.cmd -BuildNumberMajor=00001 -BuildNumberMinor=01` in Windows
-- `build-managed.sh  -BuildNumberMajor=00001 -BuildNumberMinor=01` in non-Windows
+If you need to manually specify the version you want to produce your build output with, you can accomplish this by running the following from the root of the repo:
+- `build.cmd /p:BuildNumberMajor=00001 /p:BuildNumberMinor=01` in Windows
+- `build.sh  /p:BuildNumberMajor=00001 /p:BuildNumberMinor=01` in non-Windows
 
 Where is the version being consumed
 ===================================

--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -64,13 +64,12 @@ For information on different configurations see [project-guidelines](../coding-g
 Visual Studio Solution (.sln) files exist for related groups of libraries. These can be loaded to build, debug and test inside the Visual Studio IDE.
 
 Note that when calling the script `build.cmd` attempts to build both the native and managed code.
-Only use it when the parameters that you are passing to the script apply for both components. Otherwise, use the scripts `build-native.cmd` and `build-managed.cmd` respectively.
 
 For more information about the different options when building, run `build.cmd -?` and look at examples in the [developer-guide](../project-docs/developer-guide.md).
 
 ### Running tests from the command line
 
-From the root, use `build-tests.cmd`.
+From the root, use `build.cmd -test`.
 For more details, or to test an individual project, see the [developer guide topic](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md).
 
 ### Running tests from Visual Studio

--- a/Documentation/project-docs/benchmarking.md
+++ b/Documentation/project-docs/benchmarking.md
@@ -52,7 +52,7 @@ If you want to run your benchmarks without spawning a new process per benchmark 
 
 1. Before you start benchmarking the code you need to build entire CoreFX in Release which is going to generate the right CoreRun bits for you:
 
-        C:\Projects\corefx>build.cmd -release -buildArch=x64
+        C:\Projects\corefx>build.cmd -release /p:ArchGroup=x64
 
 After that, you should be able to find `CoreRun.exe` in a location similar to:
 

--- a/Documentation/project-docs/developer-guide.md
+++ b/Documentation/project-docs/developer-guide.md
@@ -30,14 +30,13 @@ The CoreFX build has two logical components, the native build which produces the
 the managed build which produces the MSIL code and NuGet packages that make up CoreFX.
 
 Calling the script `build` attempts to build both the native and managed code.
-Only use it when the parameters that you are passing to the script apply for both components. Otherwise, use the scripts `build-native` and `build-managed` respectively.
 
 The build configurations are generally defaulted based on where you are building (i.e. which OS or which architecture) but we have a few shortcuts for the individual properties that can be passed to the build scripts:
 
 - `-framework` identifies the target framework for the build. It defaults to `netcoreapp` but possible values include `netcoreapp`, `netfx` or `uap`. (msbuild property `TargetGroup`)
 - `-os` identifies the OS for the build. It defaults to the OS you are running on but possible values include `Windows_NT`, `Unix`, `Linux`, or `OSX`. (msbuild property `OSGroup`)
 - `-debug|-release` controls the optimization level the compilers use for the build. It defaults to `Debug`. (msbuild property `ConfigurationGroup`)
-- `-buildArch` identifies the architecture for the build. It defaults to `x64` but possible values include `x64`, `x86`, `arm`, or `arm64`. (msbuild property `ArchGroup`)
+- `/p:ArchGroup` identifies the architecture for the build. It defaults to `x64` but possible values include `x64`, `x86`, `arm`, or `arm64`. (msbuild property `ArchGroup`)
 
 For more details on the build configurations see [project-guidelines](../coding-guidelines/project-guidelines.md#build-pivots).
 
@@ -194,9 +193,9 @@ dotnet msbuild System.Net.NetworkInformation.csproj /t:RebuildAll
 ### Building all for other OSes
 
 By default, building from the root will only build the libraries for the OS you are running on. One can
-build for another OS by specifying `build-managed -os=[value]`.
+build for another OS by specifying `build /p:OSGroup=[value]`.
 
-Note that you cannot generally build native components for another OS but you can for managed components so if you need to do that you can do it at the individual project level or build all via build-managed.
+Note that you cannot generally build native components for another OS but you can for managed components so if you need to do that you can do it at the individual project level or build all via passing `/p:BuildNative=false`.
 
 ### Building in Release or Debug
 
@@ -205,7 +204,7 @@ One can build in Debug or Release mode from the root by doing `build -release` o
 
 ### Building other Architectures
 
-One can build 32- or 64-bit binaries or for any architecture by specifying in the root `build -buildArch=[value]` or in a project `/p:ArchGroup=[value]` after the `dotnet msbuild` command.
+One can build 32- or 64-bit binaries or for any architecture by specifying in the root `build /p:ArchGroup=[value]` or in a project `/p:ArchGroup=[value]` after the `dotnet msbuild` command.
 
 ### Tests
 
@@ -213,7 +212,7 @@ We use the OSS testing framework [xunit](http://xunit.github.io/) with the [Buil
 
 #### Running tests on the command line
 
-By default, the core tests are run as part of `build.cmd` or `build.sh`. If the product binaries are already available, you could do `build-tests` which will build and run the tests.
+Do build tests you need to pass `-test` flag (`build -test`) to build.cmd/sh or if you want to build both you pass `-includetests` flag (`build -includetests`).
 
 For more information about cross-platform testing, please take a look [here](https://github.com/dotnet/corefx/blob/master/Documentation/building/cross-platform-testing.md).
 
@@ -264,7 +263,7 @@ The tests can also be filtered based on xunit trait attributes defined in [`Micr
 Tests marked as `Outerloop` are for scenarios that don't need to run every build. They may take longer than normal tests, cover seldom hit code paths, or require special setup or resources to execute. These tests are excluded by default when testing through `dotnet msbuild` but can be enabled manually by adding the `Outerloop` property e.g.
 
 ```cmd
-build-managed -Outerloop
+build -test -Outerloop
 ```
 
 To run <b>only</b> the Outerloop tests, use the following command:
@@ -424,7 +423,7 @@ Code coverage is built into the corefx build system.  It utilizes OpenCover for 
 
 ```cmd
 :: Run full coverage
-build-tests -Coverage
+build -test -Coverage
 
 :: To run a single project with code coverage enabled pass the /p:Coverage=true property
 cd src\System.Collections.Immutable\tests
@@ -474,7 +473,7 @@ dotnet msbuild /p:CoreCLROverridePath=d:\git\coreclr\bin\Product\Windows_NT.x64.
 
 By convention the project will look for PDBs in a directory under `$(CoreCLROverridePath)/PDB` and if found will also copy them. If not found no PDBs will be copied. If you want to explicitly set the PDB path then you can pass `CoreCLRPDBOverridePath` property to that PDB directory.
 
-Once you have updated your CoreCLR you can run tests however you usually do (via build-tests.cmd, individual test project, in VS, etc) and it should be using your copy of CoreCLR.
+Once you have updated your CoreCLR you can run tests however you usually do (via build.cmd -test, individual test project, in VS, etc) and it should be using your copy of CoreCLR.
 
 If you prefer, you can use a Debug build of System.Private.CoreLib, but if you do you must also use a Debug build of the native portions of the runtime, e.g. coreclr.dll. Tests with a Debug runtime will execute much more slowly than with Release runtime bits.
 

--- a/Documentation/project-docs/performance-tests.md
+++ b/Documentation/project-docs/performance-tests.md
@@ -1,7 +1,7 @@
 Performance Tests
 ======================
 
-This document contains instructions for building, running, and adding Performance tests. 
+This document contains instructions for building, running, and adding Performance tests.
 
 Building and Running Tests
 -----------
@@ -15,7 +15,7 @@ Performance test files (if present) are stored within a library's ```tests/Perfo
  - Windows ```dotnet msbuild /t:BuildAndTest /p:ConfigurationGroup=Release```
  - Linux: ```dotnet msbuild /t:BuildAndTest /p:ConfigurationGroup=Release```
 
-**Note: Because build-tests.cmd/sh runs tests concurrently, do not use it for executing performance tests. If you still want to run them concurrently you need to pass the flag `/p:Performance=true` to it: `build-tests -release -- /p:Performance=true`.**
+**Note: Because test build runs tests concurrently, do not use it for executing performance tests. If you still want to run them concurrently you need to pass the flag `/p:Performance=true` to it: `build -test -release /p:Performance=true`.**
 
 The results files will be dropped in corefx/bin/tests/FLAVOR/TESTLIBRARY/TARGETFRAMEWORK.  The console output will also specify the location of these files.
 
@@ -25,7 +25,7 @@ To see memory usage as well as time, add the following property to the command l
 
 Adding New Performance Tests
 -----------
-Performance tests for CoreFX are built on top of xunit and [the Microsoft xunit-performance framework](https://github.com/Microsoft/xunit-performance/). 
+Performance tests for CoreFX are built on top of xunit and [the Microsoft xunit-performance framework](https://github.com/Microsoft/xunit-performance/).
 
 Performance tests should reside within their own "Performance" folder within the tests directory of a library (e.g. [corefx/src/System.IO.FileSystem/tests/Performance](https://github.com/dotnet/corefx/tree/master/src/System.IO.FileSystem/tests/Performance) contains perf tests for FileSystem).
 


### PR DESCRIPTION
Update docs that reference:
build-tests
build-managed
build-native

The doc update was mostly find then update.

cc @ericstj @safern @ViktorHofer 

@dotnet-bot skip ci