### PR TITLE
Ensure ConnectionCloseReadStream uses provided bufferSize

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1398,11 +1398,11 @@ namespace System.Net.Http
 
             int remaining = _readLength - _readOffset;
             return remaining > 0 ?
-                CopyToUntilEofWithExistingBufferedDataAsync(destination, cancellationToken) :
+                CopyToUntilEofWithExistingBufferedDataAsync(destination, bufferSize, cancellationToken) :
                 _stream.CopyToAsync(destination, bufferSize, cancellationToken);
         }
 
-        private async Task CopyToUntilEofWithExistingBufferedDataAsync(Stream destination, CancellationToken cancellationToken)
+        private async Task CopyToUntilEofWithExistingBufferedDataAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             int remaining = _readLength - _readOffset;
             Debug.Assert(remaining > 0);
@@ -1410,7 +1410,7 @@ namespace System.Net.Http
             await CopyFromBufferAsync(destination, remaining, cancellationToken).ConfigureAwait(false);
             _readLength = _readOffset = 0;
 
-            await _stream.CopyToAsync(destination).ConfigureAwait(false);
+            await _stream.CopyToAsync(destination, bufferSize).ConfigureAwait(false);
         }
 
         // Copy *exactly* [length] bytes into destination; throws on end of stream.


### PR DESCRIPTION
SocketHttpHandler will use a ConnectionCloseReadStream as the resulting stream it hands out if the server sent Connection: close.  If CopyToAsync is used from that stream, it falls back to just using CopyToAsync on the underlying stream (usually a NetworkStream or SslStream).  In doing so, though, if there is already some data remaining in the HttpConnection's buffer, it first has to copy the data from that buffer, and then when it goes to use CopyToAsync on the underlying stream, it neglects to pass through the caller provided bufferSize.  This fixes that.

Fixes https://github.com/dotnet/corefx/issues/32800
cc: @geoffkizer, @davidsh