### PR TITLE
fix parsing for TCP info on Linux

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -122,7 +122,7 @@ namespace System.Net.NetworkInformation
             // TCP6 Connections
             for (int i = 1; i < v6connections.Length; i++) // Skip first line header.
             {
-                TcpConnectionInformation ti = ParseTcpConnectionInformationFromLine(v4connections[i]);
+                TcpConnectionInformation ti = ParseTcpConnectionInformationFromLine(v6connections[i]);
                 if (ti.State == TcpState.Listen)
                 {
                     endPoints[index] = ti.LocalEndPoint;

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -46,19 +46,41 @@ namespace System.Net.NetworkInformation
             // First line is header in each file.
             TcpConnectionInformation[] connections = new TcpConnectionInformation[v4connections.Length + v6connections.Length - 2];
             int index = 0;
+            int skip = 0;
 
             // TCP Connections
             for (int i = 1; i < v4connections.Length; i++) // Skip first line header.
             {
                 string line = v4connections[i];
-                connections[index++] = ParseTcpConnectionInformationFromLine(line);
+                connections[index] = ParseTcpConnectionInformationFromLine(line);
+                if (connections[index].State == TcpState.Listen)
+                {
+                    skip++;
+                }
+                else
+                {
+                    index++;
+                }
             }
 
             // TCP6 Connections
             for (int i = 1; i < v6connections.Length; i++) // Skip first line header.
             {
                 string line = v6connections[i];
-                connections[index++] = ParseTcpConnectionInformationFromLine(line);
+                connections[index] = ParseTcpConnectionInformationFromLine(line);
+                if (connections[index].State == TcpState.Listen)
+                {
+                    skip++;
+                }
+                else
+                {
+                    index++;
+                }
+            }
+
+            if (skip != 0)
+            {
+                Array.Resize(ref connections, connections.Length - skip);
             }
 
             return connections;
@@ -80,21 +102,41 @@ namespace System.Net.NetworkInformation
             /// First line is header in each file.
             IPEndPoint[] endPoints = new IPEndPoint[v4connections.Length + v6connections.Length - 2];
             int index = 0;
+            int skip = 0;
 
             // TCP Connections
             for (int i = 1; i < v4connections.Length; i++) // Skip first line header.
             {
-                string line = v4connections[i];
-                IPEndPoint endPoint = ParseLocalConnectionInformation(line);
-                endPoints[index++] = endPoint;
+                TcpConnectionInformation ti = ParseTcpConnectionInformationFromLine(v4connections[i]);
+                if (ti.State == TcpState.Listen)
+                {
+                    endPoints[index] = ti.LocalEndPoint;
+                    index ++;
+                }
+                else
+                {
+                    skip++;
+                }
             }
 
             // TCP6 Connections
             for (int i = 1; i < v6connections.Length; i++) // Skip first line header.
             {
-                string line = v6connections[i];
-                IPEndPoint endPoint = ParseLocalConnectionInformation(line);
-                endPoints[index++] = endPoint;
+                TcpConnectionInformation ti = ParseTcpConnectionInformationFromLine(v4connections[i]);
+                if (ti.State == TcpState.Listen)
+                {
+                    endPoints[index] = ti.LocalEndPoint;
+                    index ++;
+                }
+                else
+                {
+                    skip++;
+                }
+            }
+
+            if (skip != 0)
+            {
+                Array.Resize(ref endPoints, endPoints.Length - skip);
             }
 
             return endPoints;

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -111,7 +111,7 @@ namespace System.Net.NetworkInformation
                 if (ti.State == TcpState.Listen)
                 {
                     endPoints[index] = ti.LocalEndPoint;
-                    index ++;
+                    index++;
                 }
                 else
                 {
@@ -126,7 +126,7 @@ namespace System.Net.NetworkInformation
                 if (ti.State == TcpState.Listen)
                 {
                     endPoints[index] = ti.LocalEndPoint;
-                    index ++;
+                    index++;
                 }
                 else
                 {

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
@@ -39,7 +39,7 @@ namespace System.Net.NetworkInformation.Tests
             FileUtil.NormalizeLineEndings("tcp6", tcp6File);
 
             TcpConnectionInformation[] infos = StringParsingHelpers.ParseActiveTcpConnectionsFromFiles(tcpFile, tcp6File);
-            Assert.Equal(11, infos.Length);
+            Assert.Equal(10, infos.Length);
             ValidateInfo(infos[0], new IPEndPoint(0xFFFFFF01L, 0x01BD), new IPEndPoint(0L, 0), TcpState.Established);
             ValidateInfo(infos[1], new IPEndPoint(0x12345678L, 0x008B), new IPEndPoint(0L, 0), TcpState.SynSent);
             ValidateInfo(infos[2], new IPEndPoint(0x0101007FL, 0x0035), new IPEndPoint(0L, 0), TcpState.SynReceived);
@@ -75,12 +75,6 @@ namespace System.Net.NetworkInformation.Tests
                 new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0xA69B),
                 new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0x0277),
                 TcpState.LastAck);
-
-            ValidateInfo(
-                infos[10],
-                new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0xA697),
-                new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0x0277),
-                TcpState.Listen);
         }
 
         [Fact]
@@ -92,20 +86,9 @@ namespace System.Net.NetworkInformation.Tests
             FileUtil.NormalizeLineEndings("tcp6", tcp6File);
 
             IPEndPoint[] listeners = StringParsingHelpers.ParseActiveTcpListenersFromFiles(tcpFile, tcp6File);
-            Assert.Equal(11, listeners.Length);
-
-            Assert.Equal(new IPEndPoint(0xFFFFFF01, 0x01Bd), listeners[0]);
-            Assert.Equal(new IPEndPoint(0x12345678, 0x008B), listeners[1]);
-            Assert.Equal(new IPEndPoint(0x0101007F, 0x0035), listeners[2]);
-            Assert.Equal(new IPEndPoint(0x0100007F, 0x0277), listeners[3]);
-            Assert.Equal(new IPEndPoint(0x0100007F, 0x0277), listeners[4]);
-
-            Assert.Equal(new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000000000000"), 0x01BD), listeners[5]);
-            Assert.Equal(new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000000000000"), 0x008B), listeners[6]);
-            Assert.Equal(new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0x0277), listeners[7]);
-            Assert.Equal(new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0xA696), listeners[8]);
-            Assert.Equal(new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0xA69B), listeners[9]);
-            Assert.Equal(new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0xA697), listeners[10]);
+            // There is only one socket in Listening state
+            Assert.Equal(1, listeners.Length);
+            Assert.Equal(new IPEndPoint(StringParsingHelpers.ParseHexIPAddress("00000000000000000000000001000000"), 0xA697), listeners[0]);
         }
 
         [Fact]


### PR DESCRIPTION
related to #32727

With this change GetActiveTcpListeners() returns only socket in LISTENING state and GetActiveTcpConnections() shows all but listeners - as documentation states. 

I will add test when I have final fix for #32727.

```
Listeners
0.0.0.0:139
0.0.0.0:80
0.0.0.0:22
127.0.0.1:6010
127.0.0.1:6011
127.0.0.1:6012
127.0.0.1:6013
0.0.0.0:445
127.0.0.1:6014
0.0.0.0:139
0.0.0.0:80
0.0.0.0:22
127.0.0.1:6010
127.0.0.1:6011
127.0.0.1:6012
127.0.0.1:6013
0.0.0.0:445
127.0.0.1:6014
Active
10.211.55.5:22 = 10.211.55.2:61630 Established
10.211.55.5:22 = 10.211.55.2:50357 Established
10.211.55.5:22 = 10.211.55.2:50356 Established
10.211.55.5:22 = 10.211.55.2:57085 Established
10.211.55.5:22 = 10.211.55.2:60080 Established
```

