### PR TITLE
Skip trusted certificates when populating the store.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -61,6 +61,9 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PemReadX509FromBio")]
         internal static extern SafeX509Handle PemReadX509FromBio(SafeBioHandle bio);
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PemReadX509FromBioAux")]
+        internal static extern SafeX509Handle PemReadX509FromBioAux(SafeBioHandle bio);
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509GetSerialNumber")]
         private static extern SafeSharedAsn1IntegerHandle X509GetSerialNumber_private(SafeX509Handle x);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -362,6 +362,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     RENAMED_FUNCTION(OPENSSL_sk_value, sk_value) \
     FALLBACK_FUNCTION(OpenSSL_version_num) \
     REQUIRED_FUNCTION(PEM_read_bio_PKCS7) \
+    REQUIRED_FUNCTION(PEM_read_bio_X509) \
     REQUIRED_FUNCTION(PEM_read_bio_X509_AUX) \
     REQUIRED_FUNCTION(PEM_read_bio_X509_CRL) \
     REQUIRED_FUNCTION(PEM_write_bio_X509_CRL) \
@@ -708,6 +709,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define OPENSSL_sk_value OPENSSL_sk_value_ptr
 #define OpenSSL_version_num OpenSSL_version_num_ptr
 #define PEM_read_bio_PKCS7 PEM_read_bio_PKCS7_ptr
+#define PEM_read_bio_X509 PEM_read_bio_X509_ptr
 #define PEM_read_bio_X509_AUX PEM_read_bio_X509_AUX_ptr
 #define PEM_read_bio_X509_CRL PEM_read_bio_X509_CRL_ptr
 #define PEM_write_bio_X509_CRL PEM_write_bio_X509_CRL_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -101,6 +101,11 @@ X509* CryptoNative_X509Duplicate(X509* x509)
 
 X509* CryptoNative_PemReadX509FromBio(BIO* bio)
 {
+    return PEM_read_bio_X509(bio, NULL, NULL, NULL);
+}
+
+X509* CryptoNative_PemReadX509FromBioAux(BIO* bio)
+{
     return PEM_read_bio_X509_AUX(bio, NULL, NULL, NULL);
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -114,11 +114,18 @@ Returns the duplicated X509 instance.
 DLLEXPORT X509* CryptoNative_X509Duplicate(X509* x509);
 
 /*
-Shims the PEM_read_bio_X509_AUX method.
+Shims the PEM_read_bio_X509 method.
 
 Returns the read X509 instance.
 */
 DLLEXPORT X509* CryptoNative_PemReadX509FromBio(BIO* bio);
+
+/*
+Shims the PEM_read_bio_X509_AUX method.
+
+Returns the read X509 instance.
+*/
+DLLEXPORT X509* CryptoNative_PemReadX509FromBioAux(BIO* bio);
 
 /*
 Shims the X509_get_serialNumber method.

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -166,6 +166,22 @@ namespace Internal.Cryptography.Pal
 
         internal static bool TryReadX509Pem(SafeBioHandle bio, out ICertificatePal certPal)
         {
+            SafeX509Handle cert = Interop.Crypto.PemReadX509FromBioAux(bio);
+
+            if (cert.IsInvalid)
+            {
+                cert.Dispose();
+                certPal = null;
+                Interop.Crypto.ErrClearError();
+                return false;
+            }
+
+            certPal = new OpenSslX509CertificateReader(cert);
+            return true;
+        }
+
+        internal static bool TryReadX509PemNoAux(SafeBioHandle bio, out ICertificatePal certPal)
+        {
             SafeX509Handle cert = Interop.Crypto.PemReadX509FromBio(bio);
 
             if (cert.IsInvalid)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -270,8 +270,6 @@ namespace Internal.Cryptography.Pal
                     // The additional data contains the appropriate usage (e.g. emailProtection, serverAuth, ...).
                     // Because corefx doesn't validate for a specific usage, derived certificates are rejected.
                     // For now, we skip the certificates with AUX data and use the regular certificates.
-                    // In the future, we should look at validating with a specific usage and prefer
-                    // the trusted certificates over the regular certificates when loading the store.
                     while (OpenSslX509CertificateReader.TryReadX509PemNoAux(fileBio, out pal) ||
                         OpenSslX509CertificateReader.TryReadX509Der(fileBio, out pal))
                     {


### PR DESCRIPTION
Some distros ship with two variants of the same certificate.
One is the regular format ('BEGIN CERTIFICATE') and the other
contains additional AUX-data ('BEGIN TRUSTED CERTIFICATE').
The additional data contains the appropriate usage (e.g. emailProtection, serverAuth, ...).
Because corefx doesn't validate for a specific usage, derived certificates are rejected.
For now, we skip the certificates with AUX data and use the regular certificates.
In the future, we should look at validating with a specific usage and prefer
the trusted certificates over the regular certificates when loading the store.