### PR TITLE
Respect bufferSize on SocketHttpHandler's ContentLengthReadStream

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -98,7 +98,7 @@ namespace System.Net.Http
                     return Task.CompletedTask;
                 }
 
-                Task copyTask = _connection.CopyToExactLengthAsync(destination, _contentBytesRemaining, cancellationToken);
+                Task copyTask = _connection.CopyToContentLengthAsync(destination, _contentBytesRemaining, bufferSize, cancellationToken);
                 if (copyTask.IsCompletedSuccessfully)
                 {
                     Finish();


### PR DESCRIPTION
When a response includes a Content-Length header and the caller uses CopyToAsync to extract all data from the resulting stream, we're currently ignoring the supplied bufferSize, as we just repeatedly copy through the HttpConnection's existing read buffer.  For short responses, this is fine.  For longer responses, on a slower connection, this is also fine.  But for longer responses on a fast connection where the data is available quickly and often fills the buffer, we can end up making many more network requests than is necessary. HttpConnection's default buffer size is 4K, and although it can grow, it only does so when the response headers need it.  In contrast, the default buffer size used by Stream.CopyToAsync is 80K, and a developer can specify any bufferSize they want in order to control the memory vs throughput trade-off. To better handle this, this commit allows for ContentLengthReadStream to temporarily swap out the HttpConnection's buffer for a larger one pulled from ArrayPool.Shared, just as does the base Stream.CopyToAsync.  This allows it to respect the supplied bufferSize, while not draining the shared pool of large buffers for extended periods of time, only while the processing of the response is in progress.

This can have a significant impact on throughput when the data arrives as fast as it can be read and written to the destination.  Here's a little benchmark that transfers various sized response bodies with Content-Length from localhost to localhost, so relatively little overhead / close to best expected case. The results for very short lengths vary a bit from run to run of the benchmark so any small improvements or regressions there are in the noise, but the relative size of the improvements for the longer lengths are stable at 40-50% (with the default 80K buffer size used by Stream.CopyToAsync, but that can be changed by a caller now to control this).

Before:
```
              Method |         Mean |        Error |        StdDev |       Median |
-------------------- |-------------:|-------------:|--------------:|-------------:|
         ReadStream1 |     149.5 us |     2.950 us |      3.623 us |     149.2 us |
        ReadStream10 |     147.5 us |     2.185 us |      2.044 us |     148.0 us |
       ReadStream100 |     145.6 us |     2.908 us |      3.572 us |     145.4 us |
      ReadStream1000 |     154.9 us |     4.257 us |      4.731 us |     153.3 us |
     ReadStream10000 |     170.3 us |     3.273 us |      3.214 us |     169.4 us |
    ReadStream100000 |     234.2 us |     5.230 us |      4.368 us |     233.9 us |
   ReadStream1000000 |   1,359.6 us |    54.912 us |    157.554 us |   1,369.4 us |
  ReadStream10000000 |  12,766.5 us |   347.510 us |    570.968 us |  12,630.4 us |
 ReadStream100000000 | 135,758.3 us | 3,625.424 us | 10,632.740 us | 131,189.9 us |
```
After:
```
              Method |        Mean |        Error |       StdDev |
-------------------- |------------:|-------------:|-------------:|
         ReadStream1 |    147.1 us |     2.523 us |     2.107 us |
        ReadStream10 |    148.0 us |     2.814 us |     2.764 us |
       ReadStream100 |    155.2 us |     3.023 us |     3.235 us |
      ReadStream1000 |    154.8 us |     3.094 us |     4.907 us |
     ReadStream10000 |    166.2 us |     3.146 us |     2.942 us |
    ReadStream100000 |    197.7 us |     3.893 us |     4.923 us |
   ReadStream1000000 |    705.5 us |    16.618 us |    48.999 us |
  ReadStream10000000 |  7,591.9 us |   156.894 us |   302.281 us |
 ReadStream100000000 | 74,671.9 us | 1,442.159 us | 1,480.991 us |
```

Code:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Attributes.Jobs;
using BenchmarkDotNet.Running;
using System;
using System.IO;
using System.Net;
using System.Net.Http;
using System.Net.Sockets;
using System.Text;
using System.Threading;
using System.Threading.Tasks;

[InProcess]
public class Test
{
    private static Socket s_listener;
    private static HttpClient s_client = new HttpClient();
    private static string s_uri;

    [Benchmark] public Task ReadStream1() => ReadStream(1);
    [Benchmark] public Task ReadStream10() => ReadStream(10);
    [Benchmark] public Task ReadStream100() => ReadStream(100);
    [Benchmark] public Task ReadStream1000() => ReadStream(1000);
    [Benchmark] public Task ReadStream10000() => ReadStream(10000);
    [Benchmark] public Task ReadStream100000() => ReadStream(100000);
    [Benchmark] public Task ReadStream1000000() => ReadStream(1000000);
    [Benchmark] public Task ReadStream10000000() => ReadStream(10000000);
    [Benchmark] public Task ReadStream100000000() => ReadStream(100000000);

    private async Task ReadStream(int length)
    {
        using (Stream s = await s_client.GetStreamAsync(s_uri + length))
        {
            await s.CopyToAsync(Stream.Null);
        }
    }

    public static void Main()
    {
        s_listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
        s_listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
        s_listener.Listen(int.MaxValue);
        var ep = (IPEndPoint)s_listener.LocalEndPoint;
        s_uri = $"http://{ep.Address}:{ep.Port}/?length=";

        Task.Run(async () =>
        {
            while (true)
            {
                Socket s = await s_listener.AcceptAsync();
                var ignored = Task.Run(async () =>
                {
                    byte[] buffer = Array.Empty<byte>();

                    using (var serverStream = new NetworkStream(s, true))
                    using (var reader = new StreamReader(serverStream))
                    {
                        while (true)
                        {
                            string firstLine = await reader.ReadLineAsync();
                            int startPos = firstLine.IndexOf("length=") + "length=".Length;
                            int endPos = firstLine.IndexOf(" ", startPos);
                            int length = int.Parse(firstLine.AsSpan(startPos, endPos - startPos));
                            if (buffer.Length < length) buffer = new byte[length];

                            while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
                            await s.SendAsync(Encoding.ASCII.GetBytes("HTTP/1.1 200 OK\r\nContent-Length: " + length + "\r\n\r\n"), default);
                            await s.SendAsync(new ReadOnlyMemory<byte>(buffer, 0, length), default);
                        }
                    }
                });
            }
        });

        BenchmarkRunner.Run<Test>();
    }
}
```

Closes https://github.com/dotnet/corefx/issues/32801
cc: @geoffkizer, @davidsh, @mikeharder 