### PR TITLE
Delete UapAot ApiCompatBaselines that should not be needed

### DIFF
--- a/src/System.Numerics.Vectors/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Numerics.Vectors/src/ApiCompatBaseline.uapaot.txt
@@ -1,1 +1,0 @@
-MembersMustExist : Member 'System.Numerics.Vector<T>..ctor(System.Span<T>)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime.Extensions/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime.Extensions/src/ApiCompatBaseline.uapaot.txt
@@ -1,7 +1,0 @@
-Compat issues with assembly System.Runtime:
-MembersMustExist : Member 'System.IO.Path.Join(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.IO.Path.Join(System.String, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.IO.TextWriter.Write(System.Text.StringBuilder)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.IO.TextWriter.WriteAsync(System.Text.StringBuilder, System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.IO.TextWriter.WriteLine(System.Text.StringBuilder)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.IO.TextWriter.WriteLineAsync(System.Text.StringBuilder, System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
@@ -1,4 +1,0 @@
-Compat issues with assembly System.Runtime:
-TypeCannotChangeClassification : Type 'System.DateTimeOffset' is marked as readonly in the contract so it must also be marked readonly in the implementation.
-TypeCannotChangeClassification : Type 'System.TimeSpan' is marked as readonly in the contract so it must also be marked readonly in the implementation.
-TypeCannotChangeClassification : Type 'System.Runtime.Serialization.SerializationEntry' is marked as readonly in the contract so it must also be marked readonly in the implementation.

--- a/src/System.Threading/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Threading/src/ApiCompatBaseline.uapaot.txt
@@ -1,2 +1,0 @@
-Compat issues with assembly System.Threading:
-TypeCannotChangeClassification : Type 'System.Threading.AsyncLocalValueChangedArgs<T>' is marked as readonly in the contract so it must also be marked readonly in the implementation.


### PR DESCRIPTION
The existence of these files should be a ship blocker for UapAot, but we keep shipping with things baselined out that our customers then hit.