### PR TITLE
Improve bad_mac_address Message

### DIFF
--- a/src/System.Net.NetworkInformation/src/Resources/Strings.resx
+++ b/src/System.Net.NetworkInformation/src/Resources/Strings.resx
@@ -74,7 +74,7 @@
     <value>{0} can only be called once for each asynchronous operation.</value>
   </data>
   <data name="net_bad_mac_address" xml:space="preserve">
-    <value>An invalid physical address was specified.</value>
+    <value>An invalid physical address was specified: '{0}'.</value>
   </data>
   <data name="net_collection_readonly" xml:space="preserve">
     <value>The collection is read-only.</value>

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
@@ -177,7 +177,7 @@ namespace System.Net.NetworkInformation
                     throw new FormatException(SR.Format(SR.net_bad_mac_address, address));
                 }
 
-                //we had too many characters after the last dash
+                // we had too many characters after the last dash
                 if (hasDashes && validCount >= 2)
                 {
                     throw new FormatException(SR.Format(SR.net_bad_mac_address, address));
@@ -195,7 +195,7 @@ namespace System.Net.NetworkInformation
                 validCount++;
             }
 
-            //we too few characters after the last dash
+            // we too few characters after the last dash
             if (validCount < 2)
             {
                 throw new FormatException(SR.Format(SR.net_bad_mac_address, address));

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
@@ -134,14 +134,14 @@ namespace System.Net.NetworkInformation
 
                 if ((address.Length + 1) % 3 != 0)
                 {
-                    throw new FormatException(SR.net_bad_mac_address);
+                    throw new FormatException(SR.Format(SR.net_bad_mac_address, address));
                 }
             }
             else
             {
                 if (address.Length % 2 > 0)
                 {
-                    throw new FormatException(SR.net_bad_mac_address);
+                    throw new FormatException(SR.Format(SR.net_bad_mac_address, address));
                 }
 
                 buffer = new byte[address.Length / 2];
@@ -169,18 +169,18 @@ namespace System.Net.NetworkInformation
                     }
                     else
                     {
-                        throw new FormatException(SR.net_bad_mac_address);
+                        throw new FormatException(SR.Format(SR.net_bad_mac_address, address));
                     }
                 }
                 else
                 {
-                    throw new FormatException(SR.net_bad_mac_address);
+                    throw new FormatException(SR.Format(SR.net_bad_mac_address, address));
                 }
 
                 //we had too many characters after the last dash
                 if (hasDashes && validCount >= 2)
                 {
-                    throw new FormatException(SR.net_bad_mac_address);
+                    throw new FormatException(SR.Format(SR.net_bad_mac_address, address));
                 }
 
                 if (validCount % 2 == 0)
@@ -198,7 +198,7 @@ namespace System.Net.NetworkInformation
             //we too few characters after the last dash
             if (validCount < 2)
             {
-                throw new FormatException(SR.net_bad_mac_address);
+                throw new FormatException(SR.Format(SR.net_bad_mac_address, address));
             }
 
             return new PhysicalAddress(buffer);

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/PhysicalAddressTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/PhysicalAddressTest.cs
@@ -73,7 +73,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Theory]
-        [InlineData("42", new byte[] { 0x42, })]
+        [InlineData("42", new byte[] { 0x42 })]
         [InlineData("69-4F", new byte[] { 0x69, 0x4f })]
         [InlineData("40-DC-27", new byte[] { 0x40, 0xdc, 0x27 })]
         [InlineData("8E-35-99-87", new byte[] { 0x8e, 0x35, 0x99, 0x87 })]

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/PhysicalAddressTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/PhysicalAddressTest.cs
@@ -103,7 +103,8 @@ namespace System.Net.NetworkInformation.Tests
         [InlineData("AE88.D6EC.A720")]
         public void Parse_Invalid_ThrowsFormatException(string address)
         {
-            Assert.Throws<FormatException>(() => PhysicalAddress.Parse(address));
+            FormatException ex = Assert.Throws<FormatException>(() => PhysicalAddress.Parse(address));
+            Assert.Contains(address, ex.Message);
         }
     }
 }


### PR DESCRIPTION
As discussed here in [#Pull: 32724](https://github.com/dotnet/corefx/pull/32724)

A attempt to improve the `FormatException` if only the stack trace in a log file is available.