### PR TITLE
fix TCP network info on OSX and add tests for that area

### DIFF
--- a/src/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/Native/Unix/System.Native/pal_networkstatistics.c
@@ -333,8 +333,8 @@ int32_t SystemNative_GetActiveTcpConnectionInfos(NativeTcpConnectionInformation*
             ntci->RemoteEndPoint.NumAddressBytes = 16;
         }
 
-        ntci->LocalEndPoint.Port = in_pcb.inp_lport;
-        ntci->RemoteEndPoint.Port = in_pcb.inp_fport;
+        ntci->LocalEndPoint.Port = ntohs(in_pcb.inp_lport);
+        ntci->RemoteEndPoint.Port = ntohs(in_pcb.inp_fport);
     }
 
     free(buffer);
@@ -422,7 +422,7 @@ int32_t SystemNative_GetActiveUdpListeners(IPEndPointInfo* infos, int32_t* infoC
             iepi->NumAddressBytes = 16;
         }
 
-        iepi->Port = in_pcb.inp_lport;
+        iepi->Port = ntohs(in_pcb.inp_lport);
     }
 
     free(buffer);

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
@@ -9,7 +9,7 @@ namespace System.Net.NetworkInformation
 {
     internal class OsxIPGlobalProperties : UnixIPGlobalProperties
     {
-        public unsafe override TcpConnectionInformation[] GetActiveTcpConnections()
+        private unsafe TcpConnectionInformation[] GetTcpConnections(bool listeners)
         {
             int realCount = Interop.Sys.GetEstimatedTcpConnectionCount();
             int infoCount = realCount * 2;
@@ -20,10 +20,25 @@ namespace System.Net.NetworkInformation
             }
 
             TcpConnectionInformation[] connectionInformations = new TcpConnectionInformation[infoCount];
+            int skip = 0;
             for (int i = 0; i < infoCount; i++)
             {
                 Interop.Sys.NativeTcpConnectionInformation nativeInfo = infos[i];
                 TcpState state = nativeInfo.State;
+
+                if (listeners)
+                {
+                    if (state != TcpState.Listen)
+                    {
+                        skip++;
+                        continue;
+                    }
+                }
+                else if (state == TcpState.Listen)
+                {
+                    skip++;
+                    continue;
+                }
 
                 byte[] localBytes = new byte[nativeInfo.LocalEndPoint.NumAddressBytes];
                 fixed (byte* localBytesPtr = localBytes)
@@ -49,16 +64,25 @@ namespace System.Net.NetworkInformation
                 }
 
                 IPEndPoint remote = new IPEndPoint(remoteIPAddress, (int)nativeInfo.RemoteEndPoint.Port);
-                connectionInformations[i] = new SimpleTcpConnectionInformation(local, remote, state);
+                connectionInformations[i - skip] = new SimpleTcpConnectionInformation(local, remote, state);
+            }
+
+            if (skip != 0)
+            {
+                Array.Resize(ref connectionInformations, connectionInformations.Length - skip);
             }
 
             return connectionInformations;
         }
+        public unsafe override TcpConnectionInformation[] GetActiveTcpConnections()
+        {
+            return GetTcpConnections(false);
+        }
 
         public override IPEndPoint[] GetActiveTcpListeners()
         {
-            TcpConnectionInformation[] allConnections = GetActiveTcpConnections();
-            return allConnections.Where(tci => tci.State != TcpState.Listen).Select(tci => tci.RemoteEndPoint).ToArray();
+            TcpConnectionInformation[] allConnections = GetTcpConnections(true);
+            return allConnections.Select(tci => tci.LocalEndPoint).ToArray();
         }
 
         public unsafe override IPEndPoint[] GetActiveUdpListeners()
@@ -122,7 +146,7 @@ namespace System.Net.NetworkInformation
         public override TcpStatistics GetTcpIPv4Statistics()
         {
             // OSX does not provide separated TCP-IPv4 and TCP-IPv6 stats.
-            throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            return new OsxTcpStatistics();
         }
 
         public override TcpStatistics GetTcpIPv6Statistics()

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Sockets;
+using System.Net.Test.Common;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.NetworkInformation.Tests
+{
+    public class IPGlobalPropertiesTest
+    {
+        private readonly ITestOutputHelper _log;
+        public static readonly object[][] Loopbacks = new[]
+        {
+            new object[] { IPAddress.Loopback },
+            new object[] { IPAddress.IPv6Loopback },
+        };
+
+        public IPGlobalPropertiesTest()
+        {
+            _log = TestLogging.GetInstance();
+        }
+
+        [Fact]
+        public void IPGlobalProperties_AccessAllMethods_NoErrors()
+        {
+            IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
+
+            TcpConnectionInformation[] activeConnections = gp.GetActiveTcpConnections();
+            IPEndPoint[] tcpListeners = gp.GetActiveTcpListeners();
+            IPEndPoint[] udpListeners = gp.GetActiveUdpListeners();
+
+            IPGlobalStatistics v4IpStat = gp.GetIPv4GlobalStatistics();
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // OSX does not provide IPv6  stats.
+                IPGlobalStatistics v6IpStat = gp.GetIPv6GlobalStatistics();
+            }
+
+            IcmpV4Statistics v4IcmpStat = gp.GetIcmpV4Statistics();
+            IcmpV6Statistics v6IcmpStat = gp.GetIcmpV6Statistics();
+            TcpStatistics v4TcpSTat = gp.GetTcpIPv4Statistics();
+            TcpStatistics v6TcpStat = gp.GetTcpIPv6Statistics();
+            UdpStatistics v4UdpStat = gp.GetUdpIPv4Statistics();
+            UdpStatistics v6UdpStat = gp.GetUdpIPv6Statistics();
+        }
+
+        [Theory]
+        [MemberData(nameof(Loopbacks))]
+        public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
+        {
+            using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                server.Bind(new IPEndPoint(address, 0));
+                server.Listen(1);
+                _log.WriteLine("listening on {0}", server.LocalEndPoint);
+
+                IPEndPoint[] tcpListeners = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners();
+                bool found = false;
+                foreach (IPEndPoint ep in tcpListeners)
+                {
+                    if (ep.Equals(server.LocalEndPoint))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                Assert.True(found);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Loopbacks))]
+        public async Task IPGlobalProperties_TcpActiveConnections_Succeed(IPAddress address)
+        {
+            using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            using (var client = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                server.Bind(new IPEndPoint(address, 0));
+                server.Listen(1);
+                _log.WriteLine("listening on {0}", server.LocalEndPoint);
+
+                await client.ConnectAsync(server.LocalEndPoint);
+
+                TcpConnectionInformation[] tcpCconnections = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();
+                bool found = false;
+                foreach (TcpConnectionInformation ti in tcpCconnections)
+                {
+                    if (ti.LocalEndPoint.Equals(client.LocalEndPoint) && ti.RemoteEndPoint.Equals(client.RemoteEndPoint) &&
+                         (ti.State == TcpState.Established))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                Assert.True(found);
+            }
+        }
+
+        [Fact]
+        public void IPGlobalProperties_TcpActiveConnections_NotListening()
+        {
+            TcpConnectionInformation[] tcpCconnections = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();
+            foreach (TcpConnectionInformation ti in tcpCconnections)
+            {
+                Assert.NotEqual(TcpState.Listen, ti.State);
+            }
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="IPInterfacePropertiesTest_Linux.cs" />
     <Compile Include="IPInterfacePropertiesTest_OSX.cs" />
     <Compile Include="IPInterfacePropertiesTest_Windows.cs" />
+    <Compile Include="IPGlobalPropertiesTest.cs" />
     <Compile Include="MiscParsingTests.cs" />
     <Compile Include="MockMapTcpState.cs" />
     <Compile Include="NetworkAddressChangedTests.cs" />


### PR DESCRIPTION
fixes #32727, related to  #32816

The root cause  for not finding expected port is fact that kernel returns port in network byte order. 
The other problem was that GetActiveTcpListeners() had wrong condition with "tci.State != TcpState.Listen" and got everything but listeners. 

Documentation for GetActiveTcpConnections() states that it returns all TCP connections in state other than Listen. That make sense as the listener is really not a connection.

Since there were no tests for the touched functions I added few tests. 
 