### PR TITLE
Environment.GetFolderPath: handle case of an unknown user

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -121,6 +121,7 @@ namespace System
             {
                 Debug.Fail($"Unable to get home directory: {exc}");
             }
+
             if (string.IsNullOrEmpty(home))
             {
                 home = Path.GetTempPath();

--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -112,7 +112,7 @@ namespace System
 
             // All other paths are based on the XDG Base Directory Specification:
             // https://specifications.freedesktop.org/basedir-spec/latest/
-            string home;
+            string home = null;
             try
             {
                 home = PersistedFiles.GetHomeDirectory();
@@ -120,9 +120,11 @@ namespace System
             catch (Exception exc)
             {
                 Debug.Fail($"Unable to get home directory: {exc}");
+            }
+            if (string.IsNullOrEmpty(home))
+            {
                 home = Path.GetTempPath();
             }
-            Debug.Assert(!string.IsNullOrEmpty(home), "Expected non-null or empty HOME");
 
             // TODO: Consider caching (or precomputing and caching) all subsequent results.
             // This would significantly improve performance for repeated access, at the expense


### PR DESCRIPTION
The call to Persistentfiles.GetHomeDirectory may return null when
HOME is unset and there is no entry for the user in /etc/passwd.
This null-case was not covered.

CC @stephentoub @danmosemsft 