### PR TITLE
Comment fixed. Regex cache is LRU not MRU. Refs #27278

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
@@ -18,7 +18,7 @@ namespace System.Text.RegularExpressions
         // the cache of code and factories that are currently loaded:
         // Dictionary for large cache
         private static readonly Dictionary<CachedCodeEntryKey, CachedCodeEntry> s_cache = new Dictionary<CachedCodeEntryKey, CachedCodeEntry>(s_cacheSize);
-         // linked list for MRU and for small cache
+         // linked list for LRU and for small cache
         private static int s_cacheCount = 0;
         private static CachedCodeEntry s_cacheFirst;
         private static CachedCodeEntry s_cacheLast;

--- a/src/System.Text.RegularExpressions/tests/Performance/Perf.Regex.Cache.cs
+++ b/src/System.Text.RegularExpressions/tests/Performance/Perf.Regex.Cache.cs
@@ -49,7 +49,7 @@ namespace System.Text.RegularExpressions.Tests
         [Benchmark]
         [MeasureGCAllocations]
         [InlineData(400_000, 7, 15)]         // default size, most common
-        [InlineData(400_000, 1, 15)]         // default size, to test MRU
+        [InlineData(400_000, 1, 15)]         // default size, to test LRU
         [InlineData(40_000, 7, 0)]          // cache turned off
         [InlineData(40_000, 1_600, 15)]    // default size, to compare when cache used
         [InlineData(40_000, 1_600, 800)]    // larger size, to test cache is not O(n)
@@ -82,7 +82,7 @@ namespace System.Text.RegularExpressions.Tests
         [Benchmark]
         [MeasureGCAllocations]
         [InlineData(400_000, 7, 15)]         // default size, most common
-        [InlineData(400_000, 1, 15)]         // default size, to test MRU
+        [InlineData(400_000, 1, 15)]         // default size, to test LRU
         [InlineData(40_000, 7, 0)]          // cache turned off
         [InlineData(40_000, 1_600, 15)]    // default size, to compare when cache used
         [InlineData(40_000, 1_600, 800)]    // larger size, to test cache is not O(n)


### PR DESCRIPTION
Fixing comment. The cache follows Last Recently Used item removal policy not Most Recently Used. 