### PR TITLE
Wiring up Debug with TraceListeners, also refactoring TraceInternal and DefaultTraceListener

### DIFF
--- a/src/System.Diagnostics.Debug/tests/DebugTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebugTests.cs
@@ -342,7 +342,7 @@ namespace System.Diagnostics.Tests
             }
 
             FieldInfo writeCoreHook = typeof(DebugProvider).GetField("s_WriteCore", BindingFlags.Static | BindingFlags.NonPublic);
-            Debug.SetProvider(WriteLogger.s_instance);
+            s_defaultProvider = Debug.SetProvider(WriteLogger.s_instance);
 
             var originalWriteCoreHook = writeCoreHook.GetValue(null);
             writeCoreHook.SetValue(null, new Action<string>(WriteLogger.s_instance.WriteCore));
@@ -370,7 +370,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        private static readonly DebugProvider s_defaultProvider = new DebugProvider();
+        private static DebugProvider s_defaultProvider;
         private class WriteLogger : DebugProvider
         {
             public static readonly WriteLogger s_instance = new WriteLogger();

--- a/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
+++ b/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
@@ -9,6 +9,12 @@
     <TestRuntime>true</TestRuntime>
   </PropertyGroup>
   <ItemGroup>
+    <TargetingPackExclusions Include="System.Diagnostics.Debug" />
+    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ReferenceFromRuntime Include="System.Runtime" />
+    <ReferenceFromRuntime Include="System.Threading" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="DebuggerTypeProxyAttributeTests.cs" />
     <Compile Include="DebuggerDisplayAttributeTests.cs" />
     <Compile Include="DebuggerBrowsableAttributeTests.cs" />

--- a/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
+++ b/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
@@ -59,18 +59,21 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections" />
-    <Reference Include="System.Collections.NonGeneric" />
-    <Reference Include="System.Collections.Specialized" />
-    <Reference Include="System.ComponentModel.Primitives" />
-    <Reference Include="System.Diagnostics.Debug" />
-    <Reference Include="System.Diagnostics.Process" />
-    <Reference Include="System.Diagnostics.Tools" />
-    <Reference Include="System.IO.FileSystem" />
-    <Reference Include="System.Resources.ResourceManager" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Extensions" />
-    <Reference Include="System.Runtime.InteropServices" />
-    <Reference Include="System.Threading" />
+    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />
+    <ProjectReference Include="..\..\System.Collections.NonGeneric\src\System.Collections.NonGeneric.csproj" />
+    <ProjectReference Include="..\..\System.Collections.Specialized\src\System.Collections.Specialized.csproj " />
+    <ProjectReference Include="..\..\System.ComponentModel.Primitives\src\System.ComponentModel.Primitives.csproj " />
+    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj " />
+    <ProjectReference Include="..\..\System.Diagnostics.Process\src\System.Diagnostics.Process.csproj " />
+    <ProjectReference Include="..\..\System.Diagnostics.Tools\src\System.Diagnostics.Tools.csproj " />
+    <ProjectReference Include="..\..\System.IO.FileSystem\src\System.IO.FileSystem.csproj " />
+    <ProjectReference Include="..\..\System.Resources.ResourceManager\src\System.Resources.ResourceManager.csproj " />
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.InteropServices\src\System.Runtime.InteropServices.csproj" />
+    <ProjectReference Include="..\..\System.Threading\src\System.Threading.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <ReferenceFromRuntime Include="System.Private.CoreLib" />
   </ItemGroup>
 </Project>

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
@@ -119,6 +119,7 @@ namespace System.Diagnostics
             WriteAssert(stackTrace, message, detailMessage);
             if (AssertUiEnabled)
             {
+                // DefaultTraceDebugProvider.ShowDialog can be customized to show a dialog when AssertUiEnabled is true
                 s_provider.ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
             }
             else if (Debugger.IsAttached)

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
@@ -22,8 +22,6 @@ namespace System.Diagnostics
         private class DefaultTraceDebugProvider : DebugProvider
         {
             private const int InternalWriteSize = 16384;
-            public DefaultTraceDebugProvider() { }
-            public override void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)  { }
             
             public override void Write(string message)
             {
@@ -116,13 +114,14 @@ namespace System.Diagnostics
             {
                 stackTrace = "";
             }
-            WriteAssert(stackTrace, message, detailMessage);
+            // Tracked by #32955: WriteAssert should write "stackTrace" rather than string.Empty. 
+            WriteAssert(string.Empty, message, detailMessage);
             if (AssertUiEnabled)
             {
-                // DefaultTraceDebugProvider.ShowDialog can be customized to show a dialog when AssertUiEnabled is true
-                s_provider.ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
+                // Tracked by #32955: Currently AssertUiEnabled is true by default but we are not calling Enviroment.FailFast as Debug.Fail does 
+                // s_provider.ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
             }
-            else if (Debugger.IsAttached)
+            if (Debugger.IsAttached)
             {
                 Debugger.Break();
             }
@@ -138,6 +137,7 @@ namespace System.Diagnostics
 
         private void WriteAssert(string stackTrace, string message, string detailMessage)
         {
+            // Tracked by #32955: WriteAssert should indent "assertMessage" same way Debug.Fail does.
             string assertMessage = SR.DebugAssertBanner + Environment.NewLine
                                             + SR.DebugAssertShortMessage + Environment.NewLine
                                             + message + Environment.NewLine

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
@@ -4,7 +4,6 @@
 
 #define DEBUG
 #define TRACE
-using DebugProvider = System.Diagnostics.Debug.DebugProvider;
 using System;
 using System.IO;
 using System.Text;

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
@@ -23,9 +23,7 @@ namespace System.Diagnostics
         private class DefaultTraceDebugProvider : DebugProvider
         {
             private const int InternalWriteSize = 16384;
-            private static readonly Lazy<DebugProvider> lazy = new Lazy<DebugProvider>(() => new DefaultTraceDebugProvider());
-            public static DebugProvider s_instance { get { return lazy.Value; } }
-            private DefaultTraceDebugProvider() { }
+            public DefaultTraceDebugProvider() { }
             public override void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)  { }
             
             public override void Write(string message)
@@ -48,7 +46,7 @@ namespace System.Diagnostics
             }
         }
 
-        private static readonly DebugProvider s_provider = DefaultTraceDebugProvider.s_instance;
+        private static readonly DebugProvider s_provider = new DefaultTraceDebugProvider();
         private bool _assertUIEnabled; 
         private bool _settingsInitialized;
         private string _logFileName;
@@ -113,7 +111,7 @@ namespace System.Diagnostics
             string stackTrace;
             try
             {
-                stackTrace = new StackTrace(fNeedFileInfo:true);
+                stackTrace = new StackTrace(fNeedFileInfo:true).ToString();
             }
             catch
             {

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -14,9 +14,7 @@ namespace System.Diagnostics
     {
         private class TraceProvider : DebugProvider
         {
-            private static readonly Lazy<DebugProvider> lazy = new Lazy<DebugProvider>(() => new TraceProvider());
-            public static DebugProvider s_instance { get { return lazy.Value; } }
-            private TraceProvider() { }
+            public TraceProvider() { }
             public override void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
             {
                 base.ShowDialog(stackTrace, message, detailMessage, errorSource);
@@ -24,7 +22,7 @@ namespace System.Diagnostics
             public override void Write(string message) { TraceInternal.Write(message); }
         }
 
-        private static readonly DebugProvider s_debugProvider = TraceProvider.s_instance;
+        private static readonly DebugProvider s_provider = new TraceProvider();
         private static volatile string s_appName = null;
         private static volatile TraceListenerCollection s_listeners;
         private static volatile bool s_autoFlush;
@@ -59,7 +57,7 @@ namespace System.Diagnostics
                             s_listeners.Add(defaultListener);
                             // This is where we override default DebugProvider because we know
                             // for sure that we have some Listeners to write to.
-                            Debug.SetProvider(s_debugProvider);
+                            Debug.SetProvider(s_provider);
                         }
                     }
                 }

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using DebugProvider = System.Diagnostics.Debug.DebugProvider;
 using System.Threading;
 using System.IO;
 using System.Collections;

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -13,11 +13,6 @@ namespace System.Diagnostics
     {
         private class TraceProvider : DebugProvider
         {
-            public TraceProvider() { }
-            public override void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
-            {
-                base.ShowDialog(stackTrace, message, detailMessage, errorSource);
-            }
             public override void Write(string message) { TraceInternal.Write(message); }
         }
 


### PR DESCRIPTION
This PR shows how we can update TraceInternal and DefaultTraceListener in corefx to make use of SetProvider. In this PR I just add reference to System.Private.CoreLib to be able to access SetProvider, since it is not API Approved yet.

This PR is related to the following coreclr PR: https://github.com/dotnet/coreclr/pull/20419
The coreclr PR:
- adds DebugProvider class containing default implementation for ShowDialog and Write. 
- adds SetProvider API.
- removed Debug delegates used in DebugTests in corefx. The tests are just verifying the string gets formatted as expected. It can be moved to TraceListener tests.

Note: 
- I am pushing this PR up to show how Debug can be Wired to TraceListeners using SetProvider API.
- The coreclr PR can be merged as-is without without the diff in this corefx PR.

Related to: dotnet/corefx#3708, dotnet/corefx#31003

cc: @danmosemsft @jkotas @eerhardt 