### PR TITLE
Removing duplicate interop structures

### DIFF
--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
 
 internal partial class Interop
 {
@@ -11,21 +14,56 @@ internal partial class Interop
         [DllImport(Libraries.NtDll, ExactSpelling=true)]
         private static extern int RtlGetVersion(ref RTL_OSVERSIONINFOEX lpVersionInformation);
 
-        internal static unsafe string RtlGetVersion()
+        private static unsafe Tuple<uint, uint, uint, string> RtlGetVersionInternal()
         {
             var osvi = new RTL_OSVERSIONINFOEX();
             osvi.dwOSVersionInfoSize = (uint)sizeof(RTL_OSVERSIONINFOEX);
-            const string version = "Microsoft Windows";
+            
             if (RtlGetVersion(ref osvi) == 0)
             {
                 return osvi.szCSDVersion[0] != '\0' ?
-                    string.Format("{0} {1}.{2}.{3} {4}", version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, new string(&(osvi.szCSDVersion[0]))) :
-                    string.Format("{0} {1}.{2}.{3}", version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
+                    new Tuple<uint, uint, uint, string>(osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, new string(&(osvi.szCSDVersion[0]))) :
+                    new Tuple<uint, uint, uint, string>(osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, null);
             }
             else
             {
-                return version;
+                return null;
             }
+        } 
+
+        internal static string RtlGetVersion()
+        {
+            var sb = new StringBuilder();
+            sb.Append("Microsoft Windows");
+            Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
+            if (info != null)
+            {
+                sb.AppendFormat(" {0}.{1}.{2}", info.Item1, info.Item2, info.Item3);
+                if (info.Item4 != null)
+                {
+                    sb.AppendFormat(" {0}", info.Item4);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        internal static uint GetWindowsVersion()
+        {
+            Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
+            return info.Item1;
+        }
+
+        internal static uint GetWindowsMinorVersion()
+        {
+            Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
+            return info.Item2;
+        }
+
+        internal static uint GetWindowsBuildNumber()
+        {
+            Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
+            return info.Item3;
         }
     }
 }

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal partial class Interop
 {
@@ -13,57 +11,26 @@ internal partial class Interop
         [DllImport(Libraries.NtDll, ExactSpelling=true)]
         private static extern int RtlGetVersion(ref RTL_OSVERSIONINFOEX lpVersionInformation);
 
-        private static unsafe Tuple<uint, uint, uint, string> RtlGetVersionInternal()
+        internal static unsafe int RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi)
         {
-            var osvi = new RTL_OSVERSIONINFOEX();
+            osvi = new RTL_OSVERSIONINFOEX();
             osvi.dwOSVersionInfoSize = (uint)sizeof(RTL_OSVERSIONINFOEX);
-            
-            if (RtlGetVersion(ref osvi) == 0)
+            return RtlGetVersion(ref osvi);
+        }
+
+        internal static unsafe string RtlGetVersion()
+        {            
+            const string version = "Microsoft Windows";
+            if (RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) == 0)
             {
                 return osvi.szCSDVersion[0] != '\0' ?
-                    new Tuple<uint, uint, uint, string>(osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, new string(&(osvi.szCSDVersion[0]))) :
-                    new Tuple<uint, uint, uint, string>(osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, null);
+                    string.Format("{0} {1}.{2}.{3} {4}", version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, new string(&(osvi.szCSDVersion[0]))) :
+                    string.Format("{0} {1}.{2}.{3}", version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
             }
             else
             {
-                return null;
+                return version;
             }
-        } 
-
-        internal static string RtlGetVersion()
-        {
-            var sb = new StringBuilder();
-            const string version = "Microsoft Windows";
-            sb.Append(version);
-            Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
-            if (info != null)
-            {
-                sb.AppendFormat(" {0}.{1}.{2}", info.Item1, info.Item2, info.Item3);
-                if (info.Item4 != null)
-                {
-                    sb.AppendFormat(" {0}", info.Item4);
-                }
-            }
-
-            return sb.ToString();
-        }
-
-        internal static uint GetWindowsVersion()
-        {
-            Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
-            return info.Item1;
-        }
-
-        internal static uint GetWindowsMinorVersion()
-        {
-            Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
-            return info.Item2;
-        }
-
-        internal static uint GetWindowsBuildNumber()
-        {
-            Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
-            return info.Item3;
         }
     }
 }

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using Xunit;
 
 internal partial class Interop
 {
@@ -34,7 +33,8 @@ internal partial class Interop
         internal static string RtlGetVersion()
         {
             var sb = new StringBuilder();
-            sb.Append("Microsoft Windows");
+            const string version = "Microsoft Windows";
+            sb.Append(version);
             Tuple<uint, uint, uint, string> info = RtlGetVersionInternal();
             if (info != null)
             {

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -20,16 +20,16 @@ internal partial class Interop
 
         internal static unsafe string RtlGetVersion()
         {            
-            const string version = "Microsoft Windows";
+            const string Version = "Microsoft Windows";
             if (RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) == 0)
             {
                 return osvi.szCSDVersion[0] != '\0' ?
-                    string.Format("{0} {1}.{2}.{3} {4}", version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, new string(&(osvi.szCSDVersion[0]))) :
-                    string.Format("{0} {1}.{2}.{3}", version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
+                    string.Format("{0} {1}.{2}.{3} {4}", Version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber, new string(&(osvi.szCSDVersion[0]))) :
+                    string.Format("{0} {1}.{2}.{3}", Version, osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
             }
             else
             {
-                return version;
+                return Version;
             }
         }
     }

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -36,10 +36,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentProcess_IntPtr.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GetCurrentProcess_IntPtr.cs</Link>
     </Compile>
-    <!--Does not work as needs SafeTokenHandle 
-    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenProcessToken.cs">
-      <Link>Common\Interop\Windows\advapi32\Interop.OpenProcessToken.cs</Link>
-	</Compile>-->
     <Compile Include="..\..\Common\src\System\PasteArguments.Windows.cs">
       <Link>Common\System\PasteArguments.Windows.cs</Link>
     </Compile>

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -42,6 +42,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlGetVersion.cs">
+      <Link>Common\Interop\Windows\NtDll\Interop.RtlGetVersion.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs</Link>
     </Compile>

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -36,6 +36,10 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentProcess_IntPtr.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GetCurrentProcess_IntPtr.cs</Link>
     </Compile>
+    <!--Does not work as needs SafeTokenHandle 
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenProcessToken.cs">
+      <Link>Common\Interop\Windows\advapi32\Interop.OpenProcessToken.cs</Link>
+	</Compile>-->
     <Compile Include="..\..\Common\src\System\PasteArguments.Windows.cs">
       <Link>Common\System\PasteArguments.Windows.cs</Link>
     </Compile>

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -39,6 +39,9 @@
     <Compile Include="..\..\Common\src\System\PasteArguments.Windows.cs">
       <Link>Common\System\PasteArguments.Windows.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs">
+      <Link>Common\Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs</Link>
     </Compile>

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -34,7 +34,7 @@ namespace System
         public static bool IsFedora => false;
         public static bool IsWindowsNanoServer => (IsNotWindowsIoTCore && GetInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
         public static bool IsWindowsServerCore => GetInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase);
-        public static int WindowsVersion => GetWindowsVersion();
+        public static int WindowsVersion => (int)Interop.NtDll.GetWindowsVersion();
         public static bool IsMacOsHighSierraOrHigher { get; } = false;
         public static Version ICUVersion => new Version(0, 0, 0, 0);
         public static bool IsRedHatFamily => false;
@@ -44,13 +44,13 @@ namespace System
         public static bool IsNotRedHatFamily6 => true;
 
         public static bool IsWindows10Version1607OrGreater => 
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
+            Interop.NtDll.GetWindowsVersion() == 10 && Interop.NtDll.GetWindowsMinorVersion() == 0 && Interop.NtDll.GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater => 
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
+            Interop.NtDll.GetWindowsVersion() == 10 && Interop.NtDll.GetWindowsMinorVersion() == 0 && Interop.NtDll.GetWindowsBuildNumber() >= 15063;
         public static bool IsWindows10Version1709OrGreater => 
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16299;
+            Interop.NtDll.GetWindowsVersion() == 10 && Interop.NtDll.GetWindowsMinorVersion() == 0 && Interop.NtDll.GetWindowsBuildNumber() >= 16299;
         public static bool IsWindows10Version1803OrGreater =>
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 17134;
+            Interop.NtDll.GetWindowsVersion() == 10 && Interop.NtDll.GetWindowsMinorVersion() == 0 && Interop.NtDll.GetWindowsBuildNumber() >= 17134;
 
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP =>  
@@ -93,8 +93,8 @@ namespace System
         }
 
         public static bool IsWindows => true;
-        public static bool IsWindows7 => GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
-        public static bool IsWindows8x => GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);
+        public static bool IsWindows7 => Interop.NtDll.GetWindowsVersion() == 6 && Interop.NtDll.GetWindowsMinorVersion() == 1;
+        public static bool IsWindows8x => Interop.NtDll.GetWindowsVersion() == 6 && (Interop.NtDll.GetWindowsMinorVersion() == 2 || Interop.NtDll.GetWindowsMinorVersion() == 3);
 
         public static string LibcRelease => "glibc_not_found";
         public static string LibcVersion => "glibc_not_found";
@@ -204,22 +204,6 @@ namespace System
             return productType;
         }
 
-        private static unsafe int GetWindowsMinorVersion()
-        {
-            var osvi = new Interop.NtDll.RTL_OSVERSIONINFOEX();
-            osvi.dwOSVersionInfoSize = (uint)sizeof(Interop.NtDll.RTL_OSVERSIONINFOEX);
-            Assert.Equal(0, RtlGetVersion(ref osvi));
-            return (int)osvi.dwMinorVersion;
-        }
-
-        private static unsafe int GetWindowsBuildNumber()
-        {
-            var osvi = new Interop.NtDll.RTL_OSVERSIONINFOEX();
-            osvi.dwOSVersionInfoSize = (uint)sizeof(Interop.NtDll.RTL_OSVERSIONINFOEX);
-            Assert.Equal(0, RtlGetVersion(ref osvi));
-            return (int)osvi.dwBuildNumber;
-        }
-
         private const int PRODUCT_IOTUAP = 0x0000007B;
         private const int PRODUCT_IOTUAPCOMMERCIAL = 0x00000083;
         private const int PRODUCT_CORE = 0x00000065;
@@ -240,16 +224,6 @@ namespace System
             out int pdwReturnedProductType
         );
 
-        [DllImport("ntdll.dll", ExactSpelling=true)]
-        private static extern int RtlGetVersion(ref Interop.NtDll.RTL_OSVERSIONINFOEX lpVersionInformation);
-
-        private static unsafe int GetWindowsVersion()
-        {
-            var osvi = new Interop.NtDll.RTL_OSVERSIONINFOEX();
-            osvi.dwOSVersionInfoSize = (uint)sizeof(Interop.NtDll.RTL_OSVERSIONINFOEX);
-            Assert.Equal(0, RtlGetVersion(ref osvi));
-            return (int)osvi.dwMajorVersion;
-        }
 
         [DllImport("kernel32.dll", ExactSpelling = true)]
         private static extern int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -176,22 +176,7 @@ namespace System
                     return false;
                 }
 
-                IntPtr processToken;
-                Assert.True(OpenProcessToken(GetCurrentProcess(), TOKEN_READ, out processToken));
-
-                try
-                {
-                    uint tokenInfo;
-                    uint returnLength;
-                    Assert.True(GetTokenInformation(
-                        processToken, TokenElevation, out tokenInfo, sizeof(uint), out returnLength));
-
-                    s_isWindowsElevated = tokenInfo == 0 ? 0 : 1;
-                }
-                finally
-                {
-                    Interop.Kernel32.CloseHandle(processToken);
-                }
+                s_isWindowsElevated = AdminHelpers.IsProcessElevated() ? 1 : 0;
 
                 return s_isWindowsElevated == 1;
             }
@@ -235,19 +220,6 @@ namespace System
             return (int)osvi.dwBuildNumber;
         }
 
-        private const uint TokenElevation = 20;
-        private const uint STANDARD_RIGHTS_READ = 0x00020000;
-        private const uint TOKEN_QUERY = 0x0008;
-        private const uint TOKEN_READ = STANDARD_RIGHTS_READ | TOKEN_QUERY;
-
-        [DllImport("advapi32.dll", SetLastError = true, ExactSpelling = true)]
-        private static extern bool GetTokenInformation(
-            IntPtr TokenHandle,
-            uint TokenInformationClass,
-            out uint TokenInformation,
-            uint TokenInformationLength,
-            out uint ReturnLength);
-
         private const int PRODUCT_IOTUAP = 0x0000007B;
         private const int PRODUCT_IOTUAPCOMMERCIAL = 0x00000083;
         private const int PRODUCT_CORE = 0x00000065;
@@ -281,12 +253,5 @@ namespace System
 
         [DllImport("kernel32.dll", ExactSpelling = true)]
         private static extern int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);
-
-        [DllImport("advapi32.dll", SetLastError = true, ExactSpelling = true)]
-        private static extern bool OpenProcessToken(IntPtr ProcessHandle, uint DesiredAccess, out IntPtr TokenHandle);
-
-        // The process handle does NOT need closing
-        [DllImport("kernel32.dll", ExactSpelling = true)]
-        private static extern IntPtr GetCurrentProcess();
     }
 }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -34,7 +34,7 @@ namespace System
         public static bool IsFedora => false;
         public static bool IsWindowsNanoServer => (IsNotWindowsIoTCore && GetInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
         public static bool IsWindowsServerCore => GetInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase);
-        public static int WindowsVersion => (int)Interop.NtDll.GetWindowsVersion();
+        public static int WindowsVersion => (int)GetWindowsVersion();
         public static bool IsMacOsHighSierraOrHigher { get; } = false;
         public static Version ICUVersion => new Version(0, 0, 0, 0);
         public static bool IsRedHatFamily => false;
@@ -44,13 +44,13 @@ namespace System
         public static bool IsNotRedHatFamily6 => true;
 
         public static bool IsWindows10Version1607OrGreater => 
-            Interop.NtDll.GetWindowsVersion() == 10 && Interop.NtDll.GetWindowsMinorVersion() == 0 && Interop.NtDll.GetWindowsBuildNumber() >= 14393;
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater => 
-            Interop.NtDll.GetWindowsVersion() == 10 && Interop.NtDll.GetWindowsMinorVersion() == 0 && Interop.NtDll.GetWindowsBuildNumber() >= 15063;
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
         public static bool IsWindows10Version1709OrGreater => 
-            Interop.NtDll.GetWindowsVersion() == 10 && Interop.NtDll.GetWindowsMinorVersion() == 0 && Interop.NtDll.GetWindowsBuildNumber() >= 16299;
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16299;
         public static bool IsWindows10Version1803OrGreater =>
-            Interop.NtDll.GetWindowsVersion() == 10 && Interop.NtDll.GetWindowsMinorVersion() == 0 && Interop.NtDll.GetWindowsBuildNumber() >= 17134;
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 17134;
 
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP =>  
@@ -93,8 +93,8 @@ namespace System
         }
 
         public static bool IsWindows => true;
-        public static bool IsWindows7 => Interop.NtDll.GetWindowsVersion() == 6 && Interop.NtDll.GetWindowsMinorVersion() == 1;
-        public static bool IsWindows8x => Interop.NtDll.GetWindowsVersion() == 6 && (Interop.NtDll.GetWindowsMinorVersion() == 2 || Interop.NtDll.GetWindowsMinorVersion() == 3);
+        public static bool IsWindows7 => GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
+        public static bool IsWindows8x => GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);
 
         public static string LibcRelease => "glibc_not_found";
         public static string LibcVersion => "glibc_not_found";
@@ -227,5 +227,21 @@ namespace System
 
         [DllImport("kernel32.dll", ExactSpelling = true)]
         private static extern int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);
+
+        internal static uint GetWindowsVersion()
+        {
+            Assert.Equal(0, Interop.NtDll.RtlGetVersionEx(out Interop.NtDll.RTL_OSVERSIONINFOEX osvi));
+            return osvi.dwMajorVersion;
+        }
+        internal static uint GetWindowsMinorVersion()
+        {
+            Assert.Equal(0, Interop.NtDll.RtlGetVersionEx(out Interop.NtDll.RTL_OSVERSIONINFOEX osvi));
+            return osvi.dwMinorVersion;
+        }
+        internal static uint GetWindowsBuildNumber()
+        {
+            Assert.Equal(0, Interop.NtDll.RtlGetVersionEx(out Interop.NtDll.RTL_OSVERSIONINFOEX osvi));
+            return osvi.dwBuildNumber;
+        }
     }
 }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -190,7 +190,7 @@ namespace System
                 }
                 finally
                 {
-                    CloseHandle(processToken);
+                    Interop.Kernel32.CloseHandle(processToken);
                 }
 
                 return s_isWindowsElevated == 1;
@@ -281,9 +281,6 @@ namespace System
 
         [DllImport("kernel32.dll", ExactSpelling = true)]
         private static extern int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);
-            
-        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-        private static extern bool CloseHandle(IntPtr handle);
 
         [DllImport("advapi32.dll", SetLastError = true, ExactSpelling = true)]
         private static extern bool OpenProcessToken(IntPtr ProcessHandle, uint DesiredAccess, out IntPtr TokenHandle);

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -221,16 +221,16 @@ namespace System
 
         private static unsafe int GetWindowsMinorVersion()
         {
-            var osvi = new RTL_OSVERSIONINFOEX();
-            osvi.dwOSVersionInfoSize = (uint)sizeof(RTL_OSVERSIONINFOEX);
+            var osvi = new Interop.NtDll.RTL_OSVERSIONINFOEX();
+            osvi.dwOSVersionInfoSize = (uint)sizeof(Interop.NtDll.RTL_OSVERSIONINFOEX);
             Assert.Equal(0, RtlGetVersion(ref osvi));
             return (int)osvi.dwMinorVersion;
         }
 
         private static unsafe int GetWindowsBuildNumber()
         {
-            var osvi = new RTL_OSVERSIONINFOEX();
-            osvi.dwOSVersionInfoSize = (uint)sizeof(RTL_OSVERSIONINFOEX);
+            var osvi = new Interop.NtDll.RTL_OSVERSIONINFOEX();
+            osvi.dwOSVersionInfoSize = (uint)sizeof(Interop.NtDll.RTL_OSVERSIONINFOEX);
             Assert.Equal(0, RtlGetVersion(ref osvi));
             return (int)osvi.dwBuildNumber;
         }
@@ -269,23 +269,12 @@ namespace System
         );
 
         [DllImport("ntdll.dll", ExactSpelling=true)]
-        private static extern int RtlGetVersion(ref RTL_OSVERSIONINFOEX lpVersionInformation);
-
-        [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
-        private unsafe struct RTL_OSVERSIONINFOEX
-        {
-            internal uint dwOSVersionInfoSize;
-            internal uint dwMajorVersion;
-            internal uint dwMinorVersion;
-            internal uint dwBuildNumber;
-            internal uint dwPlatformId;
-            internal fixed char szCSDVersion[128];
-        }
+        private static extern int RtlGetVersion(ref Interop.NtDll.RTL_OSVERSIONINFOEX lpVersionInformation);
 
         private static unsafe int GetWindowsVersion()
         {
-            var osvi = new RTL_OSVERSIONINFOEX();
-            osvi.dwOSVersionInfoSize = (uint)sizeof(RTL_OSVERSIONINFOEX);
+            var osvi = new Interop.NtDll.RTL_OSVERSIONINFOEX();
+            osvi.dwOSVersionInfoSize = (uint)sizeof(Interop.NtDll.RTL_OSVERSIONINFOEX);
             Assert.Equal(0, RtlGetVersion(ref osvi));
             return (int)osvi.dwMajorVersion;
         }


### PR DESCRIPTION
Refs #32438 . Not duplicated structures remain (`kernel32.GetProductInfo` and `kernel32.GetCurrentApplicationUserModelId`)