### PR TITLE
Move ReinitializeConsole to the SignalHandlerLoop thread

### DIFF
--- a/src/Native/Unix/System.Native/pal_console.c
+++ b/src/Native/Unix/System.Native/pal_console.c
@@ -306,8 +306,9 @@ int32_t SystemNative_SetSignalForBreak(int32_t signalForBreak)
 void ReinitializeConsole()
 {
     // pal_signal.cpp calls this on SIGCONT/SIGCHLD.
+    // This runs on the SignalHandlerLoop thread because changing the console mode
+    // may be unsafe on the signal handler.
     // This can happen when SystemNative_InitializeConsole was not called.
-    // This gets called on a signal handler, we may only use async-signal-safe functions.
 
     // If the process was suspended while reading, we need to
     // re-initialize the console for the read, as the attributes


### PR DESCRIPTION
Changing the application mode in ReinitializeConsole may be
unsafe on a signal handler and lead to hangs as reported in
https://github.com/dotnet/corefx/issues/31559.

This moves the handling from the signal handler to the
SignalHandlerLoop thread.