### PR TITLE
Increase timeout for starting test service

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
@@ -105,7 +105,7 @@ namespace System.ServiceProcess.Tests
                         {
                             svc.Start();
                             if (!ServiceName.StartsWith("PropagateExceptionFromOnStart"))
-                                svc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(30));
+                                svc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(120));
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #32882

We already increased the timeout for stopping the test service (5524eeaf7e867db4f0bc613f0a53a4e3583b160f) and it seemed to stabilize that. Same change for starting the service.