### PR TITLE
Addresses Regex Perf Issue 32764

### DIFF
--- a/src/System.Text.RegularExpressions/tests/RegexCompilationInfoTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexCompilationInfoTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -64,20 +63,6 @@ namespace System.Text.RegularExpressions.Tests
             RegexCompilationInfo regexCompilationInfo = Instance;
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => 
                 regexCompilationInfo.MatchTimeout = matchTimeout);            
-        }
-
-        [Fact]
-        public void Compile_To_Assembly()
-        {
-            var rex = new Regex(".*(/Common.Controls.Wpf;component/Themes/)[^/]*.xaml", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            const string noMatch = "This is a long string which contains no matches at all. Sorry for that";
-            var sw = Stopwatch.StartNew();
-            for(int i=0;i<100*1000;i++)
-            {
-                Assert.False(rex.IsMatch(noMatch));
-            }
-            sw.Stop();
-            Console.WriteLine($"Did take: {sw.Elapsed.TotalSeconds}s");
         }
 
         [Theory]

--- a/src/System.Text.RegularExpressions/tests/RegexCompilationInfoTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexCompilationInfoTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -63,6 +64,20 @@ namespace System.Text.RegularExpressions.Tests
             RegexCompilationInfo regexCompilationInfo = Instance;
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => 
                 regexCompilationInfo.MatchTimeout = matchTimeout);            
+        }
+
+        [Fact]
+        public void Compile_To_Assembly()
+        {
+            var rex = new Regex(".*(/Common.Controls.Wpf;component/Themes/)[^/]*.xaml", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            const string noMatch = "This is a long string which contains no matches at all. Sorry for that";
+            var sw = Stopwatch.StartNew();
+            for(int i=0;i<100*1000;i++)
+            {
+                Assert.False(rex.IsMatch(noMatch));
+            }
+            sw.Stop();
+            Console.WriteLine($"Did take: {sw.Elapsed.TotalSeconds}s");
         }
 
         [Theory]

--- a/src/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -17,8 +17,8 @@ namespace System.Text.RegularExpressions.Tests
             var turkish = new CultureInfo("tr-TR");
             string input = "Iıİi";
 
-            var cultInvariantRegex = Create(input, CultureInfo.InvariantCulture, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-            var turkishRegex =       Create(input, turkish,                      RegexOptions.IgnoreCase);
+            Regex[] cultInvariantRegex = Create(input, CultureInfo.InvariantCulture, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            Regex[] turkishRegex =       Create(input, turkish,                      RegexOptions.IgnoreCase);
 
             // same input and regex does match so far so good
             Assert.All(cultInvariantRegex, rex => Assert.Equal(true, rex.IsMatch(input)) );

--- a/src/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace System.Text.RegularExpressions.Tests
+{
+    public class RegexCultureTests
+    {
+        /// <summary>
+        /// See https://en.wikipedia.org/wiki/Dotted_and_dotless_I 
+        /// </summary>
+        [Fact]
+        public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture()
+        {
+            var turkish = new CultureInfo("tr-TR");
+            string input = "Iıİi";
+
+            var cultInvariantRegex = Create(input, CultureInfo.InvariantCulture, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            var turkishRegex =       Create(input, turkish,                      RegexOptions.IgnoreCase);
+
+            // same input and regex does match so far so good
+            Assert.All(cultInvariantRegex, rex => Assert.Equal(true, rex.IsMatch(input)) );
+
+            // when the Regex was created with a turkish locale the lower cased turkish version will
+            // no longer match the input string which contains upper and lower case iiiis hence even the input string 
+            // will no longer match
+            Assert.All(turkishRegex,       rex => Assert.Equal(false, rex.IsMatch(input)));
+
+            // Now comes the tricky part depending on the use locale in ToUpper the results differ
+            // Hence the regular expression will not match if different locales were used
+            Assert.All(cultInvariantRegex, rex => Assert.Equal(true, rex.IsMatch(input.ToLowerInvariant())));
+            Assert.All(cultInvariantRegex, rex => Assert.Equal(false, rex.IsMatch(input.ToLower(turkish))));
+
+            Assert.All(turkishRegex, rex => Assert.Equal(false, rex.IsMatch(input.ToLowerInvariant())));
+            Assert.All(turkishRegex, rex => Assert.Equal(true, rex.IsMatch(input.ToLower(turkish))));
+        }
+
+        /// <summary>
+        /// Create regular expression once compiled and once interpreted to check if both behave the same
+        /// </summary>
+        /// <param name="input">Input regex string</param>
+        /// <param name="info">thread culture to use when creating the regex</param>
+        /// <param name="additional">Additional regex options</param>
+        /// <returns></returns>
+        Regex[] Create(string input, CultureInfo info, RegexOptions additional)
+        {
+            CultureInfo current = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = info;
+
+                // When RegexOptions.IgnoreCase is supplied the current thread culture is used to lowercase the input string.
+                // Except if RegexOptions.CultureInvariant is additionally added locale dependent effects on the generated code or state machine may happen.
+                var localizedRegex = new Regex[] { new Regex(input, additional), new Regex(input, RegexOptions.Compiled | additional) };
+                return localizedRegex;
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = current;
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="Regex.Match.Tests.cs" />
     <Compile Include="Regex.Tests.Common.cs" />
     <Compile Include="RegexCompilationHelper.cs" />
+    <Compile Include="RegexCultureTests.cs" />
     <Compile Include="RegexParserTests.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexParseError.cs">
       <Link>System\Text\RegularExpressions\RegexParseError.cs</Link>


### PR DESCRIPTION
This fix should save ca 40% for the common case when many Char.ToLower calls are emitted which access CultureInfo.CurrentCulture for compiled Regex Queries.