### PR TITLE
Add API to enable comparision of corefx's OpenSSL with a 3rd party P/Invoke

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
@@ -64,7 +64,7 @@ internal static partial class Interop
 
         private static string DetermineRequiredOpenSslDescription()
         {
-            uint ver = Interop.OpenSsl.OpenSslVersionNumber();
+            long ver = Interop.OpenSsl.OpenSslVersionNumber();
 
             // OpenSSL version numbers are encoded as
             // 0xMNNFFPPS: major (one nybble), minor (one byte, unaligned),
@@ -107,7 +107,7 @@ internal static partial class Interop
                 patch = new string((char)('`' + patchValue), 1);
             }
 
-            return $"{OpenSslDescriptionPrefix}{ver >> 28:x}.{(byte)(ver >> 20):x}.{(byte)(ver >> 12):x}{patch}";
+            return $"{OpenSslDescriptionPrefix}{(ver >> 28) & 0xF:x}.{(byte)(ver >> 20):x}.{(byte)(ver >> 12):x}{patch}";
         }
 #endif
     }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         private static Version s_opensslVersion;
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslVersionNumber")]
-        internal static extern uint OpenSslVersionNumber();
+        internal static extern long OpenSslVersionNumber();
 
         internal static Version OpenSslVersion
         {
@@ -20,8 +20,20 @@ internal static partial class Interop
             {
                 if (s_opensslVersion == null)
                 {
-                    uint versionNumber = OpenSslVersionNumber();
-                    s_opensslVersion = new Version((int)(versionNumber >> 28), (int)((versionNumber >> 20) & 0xff), (int)((versionNumber >> 12) & 0xff));
+                    // OpenSSL version numbers are encoded as
+                    // 0xMNNFFPPS: major (one nybble), minor (one byte, unaligned),
+                    // "fix" (one byte, unaligned), patch (one byte, unaligned), status (one nybble)
+                    //
+                    // e.g. 1.0.2a final is 0x1000201F
+                    //
+                    // Currently they don't exceed 29-bit values, but we use long here to account
+                    // for the expanded range on their 64-bit C-long return value.
+                    long versionNumber = OpenSslVersionNumber();
+                    int major = (int)((versionNumber >> 28) & 0xF);
+                    int minor = (int)((versionNumber >> 20) & 0xFF);
+                    int fix = (int)((versionNumber >> 12) & 0xFF);
+
+                    s_opensslVersion = new Version(major, minor, fix);
                 }
 
                 return s_opensslVersion;

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
@@ -2,42 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     internal static partial class OpenSsl
     {
-        private static Version s_opensslVersion;
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslVersionNumber")]
         internal static extern long OpenSslVersionNumber();
-
-        internal static Version OpenSslVersion
-        {
-            get
-            {
-                if (s_opensslVersion == null)
-                {
-                    // OpenSSL version numbers are encoded as
-                    // 0xMNNFFPPS: major (one nybble), minor (one byte, unaligned),
-                    // "fix" (one byte, unaligned), patch (one byte, unaligned), status (one nybble)
-                    //
-                    // e.g. 1.0.2a final is 0x1000201F
-                    //
-                    // Currently they don't exceed 29-bit values, but we use long here to account
-                    // for the expanded range on their 64-bit C-long return value.
-                    long versionNumber = OpenSslVersionNumber();
-                    int major = (int)((versionNumber >> 28) & 0xF);
-                    int minor = (int)((versionNumber >> 20) & 0xFF);
-                    int fix = (int)((versionNumber >> 12) & 0xFF);
-
-                    s_opensslVersion = new Version(major, minor, fix);
-                }
-
-                return s_opensslVersion;
-            }
-        }
     }
 }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPKeyHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPKeyHandle.Unix.cs
@@ -67,6 +67,13 @@ namespace System.Security.Cryptography
         }
 
 #if !INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
+        /// <summary>
+        /// The runtime version number for the loaded version of OpenSSL.
+        /// </summary>
+        /// <remarks>
+        /// For OpenSSL 1.1+ this is the result of <code>OpenSSL_version_num()</code>,
+        /// for OpenSSL 1.0.x this is the result of <code>SSLeay()</code>.
+        /// </remarks>
         public static long OpenSslVersion { get; } = Interop.OpenSsl.OpenSslVersionNumber();
 #endif
     }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPKeyHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPKeyHandle.Unix.cs
@@ -65,5 +65,9 @@ namespace System.Security.Cryptography
             safeHandle.SetHandle(handle);
             return safeHandle;
         }
+
+#if !INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
+        public static long OpenSslVersion { get; } = Interop.OpenSsl.OpenSslVersionNumber();
+#endif
     }
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1276,9 +1276,9 @@ Gets the version of openssl library.
 Return values:
 Version number as MNNFFRBB (major minor fix final beta/patch)
 */
-uint32_t CryptoNative_OpenSslVersionNumber()
+int64_t CryptoNative_OpenSslVersionNumber()
 {
-    return (uint32_t)OpenSSL_version_num();
+    return (int64_t)OpenSSL_version_num();
 }
 
 #ifdef NEED_OPENSSL_1_0

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
@@ -72,4 +72,4 @@ DLLEXPORT int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, con
 
 DLLEXPORT int32_t CryptoNative_EnsureOpenSslInitialized(void);
 
-DLLEXPORT uint32_t CryptoNative_OpenSslVersionNumber(void);
+DLLEXPORT int64_t CryptoNative_OpenSslVersionNumber(void);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -72,7 +72,7 @@ Returns 1 on success, 0 on failure.
 static long TrySetECDHNamedCurve(SSL_CTX* ctx)
 {
 #ifdef NEED_OPENSSL_1_0
-    uint32_t version = CryptoNative_OpenSslVersionNumber();
+    int64_t version = CryptoNative_OpenSslVersionNumber();
     long result = 0;
 
     if (version >= OPENSSL_VERSION_1_1_0_RTM)

--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.cs
@@ -93,5 +93,6 @@ namespace System.Security.Cryptography
         public override bool IsInvalid { get { throw null; } }
         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateHandle() { throw null; }
         protected override bool ReleaseHandle() { throw null; }
+        public static long OpenSslVersion { get; }
     }
 }

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -71,6 +71,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.OpenSsl/tests/SafeEvpPKeyHandleTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/SafeEvpPKeyHandleTests.cs
@@ -1,0 +1,30 @@
+﻿using Xunit;
+
+namespace System.Security.Cryptography.OpenSsl.Tests
+{
+    public static class SafeEvpPKeyHandleTests
+    {
+        [Fact]
+        public static void TestOpenSslVersion()
+        {
+            long version = SafeEvpPKeyHandle.OpenSslVersion;
+            long version2 = SafeEvpPKeyHandle.OpenSslVersion;
+
+            Assert.Equal(version, version2);
+
+            // A value representing OpenSSL 1.0.0's development (pre-beta) build.
+            const long MinValue = 0x10000000;
+
+            // Until a platform+build is discovered which violates this constraint, assert that it
+            // is between 1.0.0-devel and (signed) int.MaxValue as a sanity check on reading the
+            // value.
+            //
+            // NOTE: The OpenSslVersion value should not be depended upon for anything other than
+            // an equality check, to assert that a component outside of .NET Core which is utilizing
+            // SafeEvpPKeyHandle is using the same version as .NET Core (to avoid sending the pointers
+            // from one library into another).  The exception is this test, in asserting that we're
+            // getting "sensible" values.
+            Assert.InRange(version, MinValue, int.MaxValue);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -153,5 +153,6 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
     </Compile>
+    <Compile Include="SafeEvpPKeyHandleTests.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds SafeEvpPKeyHandle.OpenSslVersion.

3rd party code which is doing a P/Invoke into OpenSSL (direct or via their own shim) and using RSAOpenSsl..ctor(SafeEvpPKeyHandle) (or DSAOpenSsl or ECDsaOpenSsl) is encouraged to invoke the appropriate version function for their library (`SSLeay()` or `OpenSSL_version_number()`) and compare that against the value of `SafeEvpPKeyHandle.OpenSslVersion`.

As a structural change, this also changes the shim method from a 32-bit to a 64-bit answer, to ensure that we don't truncate in the future if 64-bit OpenSSL changes versioning schemes to exceed a 32-bit value (the native API returns a \*NIX C long).

Fixes #32718.