### PR TITLE
Fix a few minor issues in Channels

### DIFF
--- a/src/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\VoidResult.cs" />
-    <Compile Include="System\Collections\Generic\Dequeue.cs" />
+    <Compile Include="System\Collections\Generic\Deque.cs" />
     <Compile Include="System\Threading\Channels\BoundedChannel.cs" />
     <Compile Include="System\Threading\Channels\BoundedChannelFullMode.cs" />
     <Compile Include="System\Threading\Channels\Channel.cs" />

--- a/src/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="System\VoidResult.cs" />
     <Compile Include="System\Collections\Generic\Deque.cs" />
+    <Compile Include="System\Threading\Channels\AsyncOperation.cs" />
     <Compile Include="System\Threading\Channels\BoundedChannel.cs" />
     <Compile Include="System\Threading\Channels\BoundedChannelFullMode.cs" />
     <Compile Include="System\Threading\Channels\Channel.cs" />
@@ -19,7 +20,6 @@
     <Compile Include="System\Threading\Channels\Channel_1.cs" />
     <Compile Include="System\Threading\Channels\Channel_2.cs" />
     <Compile Include="System\Threading\Channels\IDebugEnumerator.cs" />
-    <Compile Include="System\Threading\Channels\AsyncOperation.cs" />
     <Compile Include="System\Threading\Channels\SingleConsumerUnboundedChannel.cs" />
     <Compile Include="System\Threading\Channels\UnboundedChannel.cs" />
     <Compile Include="$(CommonPath)\Internal\Padding.cs">

--- a/src/System.Threading.Channels/src/System/Collections/Generic/Deque.cs
+++ b/src/System.Threading.Channels/src/System/Collections/Generic/Deque.cs
@@ -9,7 +9,7 @@ namespace System.Collections.Generic
     /// <summary>Provides a double-ended queue data structure.</summary>
     /// <typeparam name="T">Type of the data stored in the dequeue.</typeparam>
     [DebuggerDisplay("Count = {_size}")]
-    internal sealed class Dequeue<T>
+    internal sealed class Deque<T>
     {
         private T[] _array = Array.Empty<T>();
         private int _head; // First valid element in the queue

--- a/src/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -247,6 +247,7 @@ namespace System.Threading.Channels
                 }
                 else
                 {
+                    sc = null;
                     ts = TaskScheduler.Current;
                     if (ts != TaskScheduler.Default)
                     {

--- a/src/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -20,11 +20,11 @@ namespace System.Threading.Channels
         /// <summary>The maximum capacity of the channel.</summary>
         private readonly int _bufferedCapacity;
         /// <summary>Items currently stored in the channel waiting to be read.</summary>
-        private readonly Dequeue<T> _items = new Dequeue<T>();
+        private readonly Deque<T> _items = new Deque<T>();
         /// <summary>Readers waiting to read from the channel.</summary>
-        private readonly Dequeue<AsyncOperation<T>> _blockedReaders = new Dequeue<AsyncOperation<T>>();
+        private readonly Deque<AsyncOperation<T>> _blockedReaders = new Deque<AsyncOperation<T>>();
         /// <summary>Writers waiting to write to the channel.</summary>
-        private readonly Dequeue<VoidAsyncOperationWithData<T>> _blockedWriters = new Dequeue<VoidAsyncOperationWithData<T>>();
+        private readonly Deque<VoidAsyncOperationWithData<T>> _blockedWriters = new Deque<VoidAsyncOperationWithData<T>>();
         /// <summary>Linked list of WaitToReadAsync waiters.</summary>
         private AsyncOperation<bool> _waitingReadersTail;
         /// <summary>Linked list of WaitToWriteAsync waiters.</summary>

--- a/src/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.cs
@@ -23,10 +23,10 @@ namespace System.Threading.Channels
         /// <returns>true if an item was read; otherwise, false if no item was read.</returns>
         public abstract bool TryRead(out T item);
 
-        /// <summary>Returns a <see cref="Task{Boolean}"/> that will complete when data is available to read.</summary>
+        /// <summary>Returns a <see cref="ValueTask{Boolean}"/> that will complete when data is available to read.</summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the wait operation.</param>
         /// <returns>
-        /// A <see cref="Task{Boolean}"/> that will complete with a <c>true</c> result when data is available to read
+        /// A <see cref="ValueTask{Boolean}"/> that will complete with a <c>true</c> result when data is available to read
         /// or with a <c>false</c> result when no further data will ever be available to be read.
         /// </returns>
         public abstract ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default);

--- a/src/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
@@ -102,7 +102,7 @@ namespace System.Threading.Channels
         /// <summary>Removes all operations from the queue, failing each.</summary>
         /// <param name="operations">The queue of operations to complete.</param>
         /// <param name="error">The error with which to complete each operations.</param>
-        internal static void FailOperations<T, TInner>(Dequeue<T> operations, Exception error) where T : AsyncOperation<TInner>
+        internal static void FailOperations<T, TInner>(Deque<T> operations, Exception error) where T : AsyncOperation<TInner>
         {
             Debug.Assert(error != null);
             while (!operations.IsEmpty)

--- a/src/System.Threading.Channels/src/System/Threading/Channels/ChannelWriter.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/ChannelWriter.cs
@@ -25,10 +25,10 @@ namespace System.Threading.Channels
         /// <returns>true if the item was written; otherwise, false if it wasn't written.</returns>
         public abstract bool TryWrite(T item);
 
-        /// <summary>Returns a <see cref="Task{Boolean}"/> that will complete when space is available to write an item.</summary>
+        /// <summary>Returns a <see cref="ValueTask{Boolean}"/> that will complete when space is available to write an item.</summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the wait operation.</param>
         /// <returns>
-        /// A <see cref="Task{Boolean}"/> that will complete with a <c>true</c> result when space is available to write an item
+        /// A <see cref="ValueTask{Boolean}"/> that will complete with a <c>true</c> result when space is available to write an item
         /// or with a <c>false</c> result when no further writing will be permitted.
         /// </returns>
         public abstract ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default);
@@ -36,7 +36,7 @@ namespace System.Threading.Channels
         /// <summary>Asynchronously writes an item to the channel.</summary>
         /// <param name="item">The value to write to the channel.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the write operation.</param>
-        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous write operation.</returns>
         public virtual ValueTask WriteAsync(T item, CancellationToken cancellationToken = default)
         {
             try

--- a/src/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
@@ -19,7 +19,7 @@ namespace System.Threading.Channels
         /// <summary>The items in the channel.</summary>
         private readonly ConcurrentQueue<T> _items = new ConcurrentQueue<T>();
         /// <summary>Readers blocked reading from the channel.</summary>
-        private readonly Dequeue<AsyncOperation<T>> _blockedReaders = new Dequeue<AsyncOperation<T>>();
+        private readonly Deque<AsyncOperation<T>> _blockedReaders = new Deque<AsyncOperation<T>>();
         /// <summary>Whether to force continuations to be executed asynchronously from producer writes.</summary>
         private readonly bool _runContinuationsAsynchronously;
 


### PR DESCRIPTION
- Fixed some XML comments that incorrectly referred to Task instead of ValueTask
- Renamed the internal Dequeue collection to be Deque to better conform to typical spelling
- Reordered some items in the .csproj to be in alphabetical order
- Fixed a small bug where if a non-default TaskScheduler was set and SynchronizationContext.Current was set to the base SynchronizationContext class (rather than being null), we would end up preferring the SynchronizationContext rather than using the TaskScheduler
- Added tests to validate behavior for when both SynchronizationContext and TaskSchedulers were in play

cc: @tarekgh 