### PR TITLE
Expose Regex Escape & Unescape Span overloads

### DIFF
--- a/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -157,6 +157,7 @@ namespace System.Text.RegularExpressions
         public System.Text.RegularExpressions.RegexOptions Options { get { throw null; } }
         public bool RightToLeft { get { throw null; } }
         public static string Escape(string str) { throw null; }
+        public static bool TryEscape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten) { throw null; }
         public string[] GetGroupNames() { throw null; }
         public int[] GetGroupNumbers() { throw null; }
         public string GroupNameFromNumber(int i) { throw null; }
@@ -199,6 +200,7 @@ namespace System.Text.RegularExpressions
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
         public static string Unescape(string str) { throw null; }
+        public static bool TryUnescape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten) { throw null; }
         protected bool UseOptionC() { throw null; }
         protected bool UseOptionR() { throw null; }
         protected internal static void ValidateMatchTimeout(System.TimeSpan matchTimeout) { }

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -14,6 +14,7 @@
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />
     <Compile Include="System\Text\RegularExpressions\CaptureCollection.cs" />
+    <Compile Include="System\Text\RegularExpressions\CharCategory.cs" />
     <Compile Include="System\Text\RegularExpressions\CollectionDebuggerProxy.cs" />
     <Compile Include="System\Text\RegularExpressions\Group.cs" />
     <Compile Include="System\Text\RegularExpressions\GroupCollection.cs" />
@@ -29,7 +30,6 @@
     <Compile Include="System\Text\RegularExpressions\Regex.Split.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Timeout.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexBoyerMoore.cs" />
-    <Compile Include="System\Text\RegularExpressions\RegexCharCategory.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCode.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCompilationInfo.cs" />

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -9,6 +9,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreappaot-Debug;netcoreappaot-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Buffers\SpanHelper.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />
@@ -16,22 +17,26 @@
     <Compile Include="System\Text\RegularExpressions\CollectionDebuggerProxy.cs" />
     <Compile Include="System\Text\RegularExpressions\Group.cs" />
     <Compile Include="System\Text\RegularExpressions\GroupCollection.cs" />
+    <Compile Include="System\Text\RegularExpressions\InputWalker.cs" />
     <Compile Include="System\Text\RegularExpressions\Match.cs" />
     <Compile Include="System\Text\RegularExpressions\MatchCollection.cs" />
     <Compile Include="System\Text\RegularExpressions\Reference.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Cache.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.cs" />
+    <Compile Include="System\Text\RegularExpressions\Regex.Escape.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Match.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Replace.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Split.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Timeout.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexBoyerMoore.cs" />
+    <Compile Include="System\Text\RegularExpressions\RegexCharCategory.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCode.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCompilationInfo.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexFCD.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexInterpreter.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexMatchTimeoutException.cs" />
+    <Compile Include="System\Text\RegularExpressions\ParserMin.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexNode.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexOptions.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexParseError.cs" />

--- a/src/System.Text.RegularExpressions/src/System/Buffers/SpanHelper.cs
+++ b/src/System.Text.RegularExpressions/src/System/Buffers/SpanHelper.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Buffers
+{
+    internal static class SpanHelper
+    {
+        public static string CopyInput(this ReadOnlySpan<char> input, bool targetSpan, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
+            if (targetSpan)
+            {
+                spanSuccess = input.TryCopyTo(destination);
+                charsWritten = spanSuccess ? input.Length : 0;
+
+                return null;
+            }
+            else
+            {
+                spanSuccess = false;
+                charsWritten = 0;
+                return input.ToString();
+            }
+        }
+
+        public static string CopyOutput(this ValueStringBuilder vsb, bool targetSpan, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
+            if (targetSpan)
+            {
+                spanSuccess = vsb.TryCopyTo(destination, out charsWritten);
+                return null;
+            }
+            else
+            {
+                spanSuccess = false;
+                charsWritten = 0;
+                return vsb.ToString();
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CharCategory.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CharCategory.cs
@@ -4,7 +4,7 @@
 
 namespace System.Text.RegularExpressions
 {
-    internal class RegexCharCategory
+    internal class CharCategory
     {
         private const byte Q = 5;    // quantifier
         private const byte S = 4;    // ordinary stopper
@@ -15,7 +15,8 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// For categorizing ASCII characters.
         /// </summary>
-        private static readonly byte[] s_category = new byte[] {
+        private static ReadOnlySpan<byte> Category => new byte[]
+        {
             // 0 1 2 3 4 5 6 7 8 9 A B C D E F 0 1 2 3 4 5 6 7 8 9 A B C D E F
                0,0,0,0,0,0,0,0,0,X,X,0,X,X,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
             //   ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ?
@@ -23,31 +24,32 @@ namespace System.Text.RegularExpressions
             // @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _
                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,S,S,0,S,0,
             // ' a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~
-               0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,Q,S,0,0,0};
+               0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,Q,S,0,0,0
+        };
 
         /// <summary>
         /// Returns true for those characters that terminate a string of ordinary chars.
         /// </summary>
-        public static bool IsSpecial(char ch) => (ch <= '|' && s_category[ch] >= S);
+        public static bool IsSpecial(char ch) => (ch <= '|' && Category[ch] >= S);
 
         /// <summary>
         /// Returns true for those characters that terminate a string of ordinary chars.
         /// </summary>
-        public static bool IsStopperX(char ch) => (ch <= '|' && s_category[ch] >= X);
+        public static bool IsStopperX(char ch) => (ch <= '|' && Category[ch] >= X);
 
         /// <summary>
         /// Returns true for those characters that begin a quantifier.
         /// </summary>
-        public static bool IsQuantifier(char ch) => (ch <= '{' && s_category[ch] >= Q);
+        public static bool IsQuantifier(char ch) => (ch <= '{' && Category[ch] >= Q);
 
         /// <summary>
         /// Returns true for whitespace.
         /// </summary>
-        public static bool IsSpace(char ch) => (ch <= ' ' && s_category[ch] == X);
+        public static bool IsSpace(char ch) => (ch <= ' ' && Category[ch] == X);
 
         /// <summary>
         /// Returns true for chars that should be escaped.
         /// </summary>
-        public static bool IsMetachar(char ch) => (ch <= '|' && s_category[ch] >= E);
+        public static bool IsMetachar(char ch) => (ch <= '|' && Category[ch] >= E);
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/InputWalker.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/InputWalker.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.RegularExpressions
+{
+    internal ref struct InputWalker
+    {
+        public ReadOnlySpan<char> Input { get; }
+
+        public int Position { get; private set; }
+
+        public InputWalker(ReadOnlySpan<char> input)
+        {
+            Input = input;
+            Position = 0;
+        }
+
+        /// <summary>
+        /// Returns the char at the right of the current parsing position and advances to the right.
+        /// </summary>
+        public char RightCharMoveRight()
+        {
+            return Input[Position++];
+        }
+
+        /// <summary>
+        /// Moves the current parsing position one to the left.
+        /// </summary>
+        public void MoveLeft()
+        {
+            --Position;
+        }
+
+        /// <summary>
+        /// Number of characters to the right of the current parsing position.
+        /// </summary>
+        public int CharsRight()
+        {
+            return Input.Length - Position;
+        }
+
+        /// <summary>
+        /// Returns the char right of the current parsing position.
+        /// </summary>
+        /// <returns></returns>
+        public char RightChar()
+        {
+            return Input[Position];
+        }
+
+        /// <summary>
+        /// Moves the current position to the right.
+        /// </summary>
+        public void MoveRight(int i = 1)
+        {
+            Position += i;
+        }
+
+        /// <summary>
+        /// Returns the current parsing position.
+        /// </summary>
+        public int Textpos()
+        {
+            return Position;
+        }
+
+        /// <summary>
+        /// Zaps to a specific parsing position.
+        /// </summary>
+        /// <param name="position"></param>
+        public void Textto(int position)
+        {
+            Position = position;
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ParserMin.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ParserMin.cs
@@ -1,0 +1,173 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.RegularExpressions
+{
+    internal ref struct ParserMin
+    {
+        private readonly RegexOptions _options;
+        private InputWalker _pattern;
+
+        public int Position => _pattern.Position;
+
+        public ParserMin(ReadOnlySpan<char> pattern, RegexOptions options = RegexOptions.None)
+        {
+            _options = options;
+            _pattern = new InputWalker(pattern);
+        }
+
+        /// <summary>
+        /// Scans \ code for escape codes that map to single Unicode chars.
+        /// </summary>
+        public char ScanCharEscape()
+        {
+            char ch = _pattern.RightCharMoveRight();
+
+            if (ch >= '0' && ch <= '7')
+            {
+                _pattern.MoveLeft();
+                return ScanOctal();
+            }
+
+            switch (ch)
+            {
+                case 'x':
+                    return ScanHex(2);
+                case 'u':
+                    return ScanHex(4);
+                case 'a':
+                    return '\u0007';
+                case 'b':
+                    return '\b';
+                case 'e':
+                    return '\u001B';
+                case 'f':
+                    return '\f';
+                case 'n':
+                    return '\n';
+                case 'r':
+                    return '\r';
+                case 't':
+                    return '\t';
+                case 'v':
+                    return '\u000B';
+                case 'c':
+                    return ScanControl();
+                default:
+                    if (!_options.UseOptionE() && RegexCharClass.IsWordChar(ch))
+                        throw MakeException(RegexParseError.UnrecognizedEscape, SR.Format(SR.UnrecognizedEscape, ch));
+                    return ch;
+            }
+        }
+
+        /// <summary>
+        /// Returns n <= 0xF for a hex digit.
+        /// </summary>
+        private static int HexDigit(char ch)
+        {
+            int d;
+
+            if ((uint)(d = ch - '0') <= 9)
+                return d;
+
+            if (unchecked((uint)(d = ch - 'a')) <= 5)
+                return d + 0xa;
+
+            if ((uint)(d = ch - 'A') <= 5)
+                return d + 0xa;
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Scans exactly c hex digits (c=2 for \xFF, c=4 for \uFFFF)
+        /// </summary>
+        private char ScanHex(int c)
+        {
+            int i = 0;
+            int d;
+
+            if (_pattern.CharsRight() >= c)
+            {
+                for (; c > 0 && ((d = HexDigit(_pattern.RightCharMoveRight())) >= 0); c -= 1)
+                {
+                    i *= 0x10;
+                    i += d;
+                }
+            }
+
+            if (c > 0)
+                throw MakeException(RegexParseError.TooFewHex, SR.TooFewHex);
+
+            return (char)i;
+        }
+
+        /// <summary>
+        /// Grabs and converts an ASCII control character.
+        /// </summary>
+        private char ScanControl()
+        {
+            if (_pattern.CharsRight() == 0)
+                throw MakeException(RegexParseError.MissingControl, SR.MissingControl);
+
+            char ch = _pattern.RightCharMoveRight();
+
+            // \ca interpreted as \cA
+
+            if (ch >= 'a' && ch <= 'z')
+                ch = (char)(ch - ('a' - 'A'));
+
+            if (unchecked(ch = (char)(ch - '@')) < ' ')
+                return ch;
+
+            throw MakeException(RegexParseError.UnrecognizedControl, SR.UnrecognizedControl);
+        }
+
+        /// <summary>
+        /// Scans up to three octal digits (stops before exceeding 0377).
+        /// </summary>
+        private char ScanOctal()
+        {
+            // Consume octal chars only up to 3 digits and value 0377
+            int c = 3;
+            int d;
+            int i;
+
+            if (c > _pattern.CharsRight())
+                c = _pattern.CharsRight();
+
+            for (i = 0; c > 0 && unchecked((uint)(d = _pattern.RightChar() - '0')) <= 7; c -= 1)
+            {
+                _pattern.MoveRight();
+                i *= 8;
+                i += d;
+                if (_options.UseOptionE() && i >= 0x20)
+                    break;
+            }
+
+            // Octal codes only go up to 255.  Any larger and the behavior that Perl follows
+            // is simply to truncate the high bits.
+            i &= 0xFF;
+
+            return (char)i;
+        }
+
+        /// <summary>
+        /// Zaps to a specific parsing position.
+        /// </summary>
+        /// <param name="position"></param>
+        public void AdvanceTo(int position)
+        {
+            _pattern.Textto(position);
+        }
+
+        /// <summary>
+        /// Fills in a RegexParseException
+        /// </summary>
+        private RegexParseException MakeException(RegexParseError error, string message)
+        {
+            return new RegexParseException(error, _pattern.Position, SR.Format(SR.MakeException, _pattern.Input.ToString(), _pattern.Position, message));
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Escape.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Escape.cs
@@ -1,0 +1,185 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+
+namespace System.Text.RegularExpressions
+{
+    public partial class Regex
+    {
+        private const int EscapeMaxBufferSize = 256;
+
+        /// <summary>
+        /// Escapes a minimal set of metacharacters (\, *, +, ?, |, {, [, (, ), ^, $, ., #, and
+        /// whitespace) by replacing them with their \ codes. This converts a string so that
+        /// it can be used as a constant within a regular expression safely. (Note that the
+        /// reason # and whitespace must be escaped is so the string can be used safely
+        /// within an expression parsed with x mode. If future Regex features add
+        /// additional metacharacters, developers should depend on Escape to escape those
+        /// characters as well.)
+        /// </summary>
+        public static string Escape(string str)
+        {
+            if (str == null)
+                throw new ArgumentNullException(nameof(str));
+
+            return Escape(targetSpan: false, str.AsSpan(), Span<char>.Empty, out _, out _);
+        }
+
+        /// <summary>
+        /// Escapes a minimal set of metacharacters (\, *, +, ?, |, {, [, (, ), ^, $, ., #, and
+        /// whitespace) by replacing them with their \ codes. This converts a string so that
+        /// it can be used as a constant within a regular expression safely. (Note that the
+        /// reason # and whitespace must be escaped is so the string can be used safely
+        /// within an expression parsed with x mode. If future Regex features add
+        /// additional metacharacters, developers should depend on Escape to escape those
+        /// characters as well.)
+        /// </summary>
+        /// <returns>Returns the amount of chars written into the output Span.</returns>
+        public static bool TryEscape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten)
+        {
+            Escape(targetSpan: true, str, destination, out charsWritten, out bool spanSuccess);
+
+            return spanSuccess;
+        }
+
+        /// <summary>
+        /// Unescapes any escaped characters in the input string.
+        /// </summary>
+        public static string Unescape(string str)
+        {
+            if (str == null)
+                throw new ArgumentNullException(nameof(str));
+
+            return Unescape(targetSpan: false, str.AsSpan(), Span<char>.Empty, out _, out _);
+        }
+
+        /// <summary>
+        /// Unescapes any escaped characters in the input text.
+        /// </summary>
+        public static bool TryUnescape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten)
+        {
+            Unescape(targetSpan: true, str, destination, out charsWritten, out bool spanSuccess);
+
+            return spanSuccess;
+        }
+
+        /// <summary>
+        /// Escapes all metacharacters (including |,(,),[,{,|,^,$,*,+,?,\, spaces and #)
+        /// </summary>
+        private static string Escape(bool targetSpan, ReadOnlySpan<char> input, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (RegexCharCategory.IsMetachar(input[i]))
+                {
+                    return EscapeImpl(targetSpan, input, i, destination, out charsWritten, out spanSuccess);
+                }
+            }
+
+            // If nothing to escape, return the input.
+            return input.CopyInput(targetSpan, destination, out charsWritten, out spanSuccess);
+        }
+
+        private static string EscapeImpl(bool targetSpan, ReadOnlySpan<char> input, int i, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
+            // For small inputs we allocate on the stack. In most cases a buffer three 
+            // times larger the original string should be sufficient as usually not all 
+            // characters need to be encoded.
+            // For larger string we rent the input string's length plus a fixed 
+            // conservative amount of chars from the ArrayPool.
+            Span<char> buffer = input.Length <= (EscapeMaxBufferSize / 3) ? stackalloc char[EscapeMaxBufferSize] : default;
+            ValueStringBuilder vsb = !buffer.IsEmpty ?
+                new ValueStringBuilder(buffer) :
+                new ValueStringBuilder(input.Length + 200);
+
+            char ch = input[i];
+            vsb.Append(input.Slice(0, i));
+
+            do
+            {
+                vsb.Append('\\');
+                switch (ch)
+                {
+                    case '\n':
+                        ch = 'n';
+                        break;
+                    case '\r':
+                        ch = 'r';
+                        break;
+                    case '\t':
+                        ch = 't';
+                        break;
+                    case '\f':
+                        ch = 'f';
+                        break;
+                }
+                vsb.Append(ch);
+                i++;
+                int lastpos = i;
+
+                while (i < input.Length)
+                {
+                    ch = input[i];
+                    if (RegexCharCategory.IsMetachar(ch))
+                        break;
+
+                    i++;
+                }
+
+                vsb.Append(input.Slice(lastpos, i - lastpos));
+            } while (i < input.Length);
+
+            return vsb.CopyOutput(targetSpan, destination, out charsWritten, out spanSuccess);
+        }
+
+        /// <summary>
+        /// Unescapes all metacharacters (including (,),[,],{,},|,^,$,*,+,?,\, spaces and #)
+        /// </summary>
+        private static string Unescape(bool targetSpan, ReadOnlySpan<char> input, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (input[i] == '\\')
+                {
+                    return UnescapeImpl(targetSpan, input, i, destination, out charsWritten, out spanSuccess);
+                }
+            }
+
+            // If nothing to escape, return the input.
+            return input.CopyInput(targetSpan, destination, out charsWritten, out spanSuccess);
+        }
+
+        public static string UnescapeImpl(bool targetSpan, ReadOnlySpan<char> input, int i, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
+            var parser = new ParserMin(input);
+
+            // In the worst case the escaped string has the same length.
+            // For small inputs we use stack allocation.
+            Span<char> buffer = input.Length <= EscapeMaxBufferSize ? stackalloc char[EscapeMaxBufferSize] : default;
+            ValueStringBuilder vsb = !buffer.IsEmpty ?
+                new ValueStringBuilder(buffer) :
+                new ValueStringBuilder(input.Length);
+
+            vsb.Append(input.Slice(0, i));
+            do
+            {
+                i++;
+                parser.AdvanceTo(i);
+                if (i < input.Length)
+                {
+                    vsb.Append(parser.ScanCharEscape());
+                }
+                i = parser.Position;
+
+                int lastpos = i;
+                while (i < input.Length && input[i] != '\\')
+                    i++;
+                vsb.Append(input.Slice(lastpos, i - lastpos));
+            } while (i < input.Length);
+
+            return vsb.CopyOutput(targetSpan, destination, out charsWritten, out spanSuccess);
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Escape.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Escape.cs
@@ -24,7 +24,7 @@ namespace System.Text.RegularExpressions
             if (str == null)
                 throw new ArgumentNullException(nameof(str));
 
-            return Escape(targetSpan: false, str.AsSpan(), Span<char>.Empty, out _, out _);
+            return EscapeImpl(targetSpan: false, str.AsSpan(), Span<char>.Empty, out _, out _);
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace System.Text.RegularExpressions
         /// <returns>Returns the amount of chars written into the output Span.</returns>
         public static bool TryEscape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten)
         {
-            Escape(targetSpan: true, str, destination, out charsWritten, out bool spanSuccess);
+            EscapeImpl(targetSpan: true, str, destination, out charsWritten, out bool spanSuccess);
 
             return spanSuccess;
         }
@@ -52,7 +52,7 @@ namespace System.Text.RegularExpressions
             if (str == null)
                 throw new ArgumentNullException(nameof(str));
 
-            return Unescape(targetSpan: false, str.AsSpan(), Span<char>.Empty, out _, out _);
+            return UnescapeImpl(targetSpan: false, str.AsSpan(), Span<char>.Empty, out _, out _);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public static bool TryUnescape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten)
         {
-            Unescape(targetSpan: true, str, destination, out charsWritten, out bool spanSuccess);
+            UnescapeImpl(targetSpan: true, str, destination, out charsWritten, out bool spanSuccess);
 
             return spanSuccess;
         }
@@ -68,11 +68,11 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Escapes all metacharacters (including |,(,),[,{,|,^,$,*,+,?,\, spaces and #)
         /// </summary>
-        private static string Escape(bool targetSpan, ReadOnlySpan<char> input, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        private static string EscapeImpl(bool targetSpan, ReadOnlySpan<char> input, Span<char> destination, out int charsWritten, out bool spanSuccess)
         {
             for (int i = 0; i < input.Length; i++)
             {
-                if (RegexCharCategory.IsMetachar(input[i]))
+                if (CharCategory.IsMetachar(input[i]))
                 {
                     return EscapeImpl(targetSpan, input, i, destination, out charsWritten, out spanSuccess);
                 }
@@ -122,7 +122,7 @@ namespace System.Text.RegularExpressions
                 while (i < input.Length)
                 {
                     ch = input[i];
-                    if (RegexCharCategory.IsMetachar(ch))
+                    if (CharCategory.IsMetachar(ch))
                         break;
 
                     i++;
@@ -137,7 +137,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Unescapes all metacharacters (including (,),[,],{,},|,^,$,*,+,?,\, spaces and #)
         /// </summary>
-        private static string Unescape(bool targetSpan, ReadOnlySpan<char> input, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        private static string UnescapeImpl(bool targetSpan, ReadOnlySpan<char> input, Span<char> destination, out int charsWritten, out bool spanSuccess)
         {
             for (int i = 0; i < input.Length; i++)
             {
@@ -151,7 +151,7 @@ namespace System.Text.RegularExpressions
             return input.CopyInput(targetSpan, destination, out charsWritten, out spanSuccess);
         }
 
-        public static string UnescapeImpl(bool targetSpan, ReadOnlySpan<char> input, int i, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        private static string UnescapeImpl(bool targetSpan, ReadOnlySpan<char> input, int i, Span<char> destination, out int charsWritten, out bool spanSuccess)
         {
             var parser = new ParserMin(input);
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -232,34 +232,6 @@ namespace System.Text.RegularExpressions
 #endif // FEATURE_COMPILEAPIS
 
         /// <summary>
-        /// Escapes a minimal set of metacharacters (\, *, +, ?, |, {, [, (, ), ^, $, ., #, and
-        /// whitespace) by replacing them with their \ codes. This converts a string so that
-        /// it can be used as a constant within a regular expression safely. (Note that the
-        /// reason # and whitespace must be escaped is so the string can be used safely
-        /// within an expression parsed with x mode. If future Regex features add
-        /// additional metacharacters, developers should depend on Escape to escape those
-        /// characters as well.)
-        /// </summary>
-        public static string Escape(string str)
-        {
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
-
-            return RegexParser.Escape(str);
-        }
-
-        /// <summary>
-        /// Unescapes any escaped characters in the input string.
-        /// </summary>
-        public static string Unescape(string str)
-        {
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
-
-            return RegexParser.Unescape(str);
-        }
-
-        /// <summary>
         /// Returns the options passed into the constructor
         /// </summary>
         public RegexOptions Options => roptions;
@@ -457,7 +429,7 @@ namespace System.Text.RegularExpressions
                 if (factory != null)
                     runner = factory.CreateInstance();
                 else
-                    runner = new RegexInterpreter(_code, UseOptionInvariant() ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
+                    runner = new RegexInterpreter(_code, roptions.UseOptionInvariant() ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
             }
 
             Match match;
@@ -473,26 +445,21 @@ namespace System.Text.RegularExpressions
             }
 
 #if DEBUG
-            if (Debug && match != null)
+            if (roptions.IsDebug() && match != null)
                 match.Dump();
 #endif
             return match;
         }
 
-        protected bool UseOptionC() => (roptions & RegexOptions.Compiled) != 0;
+        protected bool UseOptionC() => roptions.UseOptionC();
 
-        /*
-         * True if the L option was set
-         */
-        protected internal bool UseOptionR() => (roptions & RegexOptions.RightToLeft) != 0;
-
-        internal bool UseOptionInvariant() => (roptions & RegexOptions.CultureInvariant) != 0;
+        protected internal bool UseOptionR() => roptions.UseOptionR();
 
 #if DEBUG
         /// <summary>
         /// True if the regex has debugging enabled
         /// </summary>
-        internal bool Debug => (roptions & RegexOptions.Debug) != 0;
+        internal bool Debug => roptions.IsDebug();
 #endif
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -445,7 +445,7 @@ namespace System.Text.RegularExpressions
             }
 
 #if DEBUG
-            if (roptions.IsDebug() && match != null)
+            if (Debug && match != null)
                 match.Dump();
 #endif
             return match;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharCategory.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharCategory.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.RegularExpressions
+{
+    internal class RegexCharCategory
+    {
+        private const byte Q = 5;    // quantifier
+        private const byte S = 4;    // ordinary stopper
+        private const byte Z = 3;    // ScanBlank stopper
+        private const byte X = 2;    // whitespace
+        private const byte E = 1;    // should be escaped
+
+        /// <summary>
+        /// For categorizing ASCII characters.
+        /// </summary>
+        private static readonly byte[] s_category = new byte[] {
+            // 0 1 2 3 4 5 6 7 8 9 A B C D E F 0 1 2 3 4 5 6 7 8 9 A B C D E F
+               0,0,0,0,0,0,0,0,0,X,X,0,X,X,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+            //   ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ?
+               X,0,0,Z,S,0,0,0,S,S,Q,Q,0,0,S,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,Q,
+            // @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _
+               0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,S,S,0,S,0,
+            // ' a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~
+               0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,Q,S,0,0,0};
+
+        /// <summary>
+        /// Returns true for those characters that terminate a string of ordinary chars.
+        /// </summary>
+        public static bool IsSpecial(char ch) => (ch <= '|' && s_category[ch] >= S);
+
+        /// <summary>
+        /// Returns true for those characters that terminate a string of ordinary chars.
+        /// </summary>
+        public static bool IsStopperX(char ch) => (ch <= '|' && s_category[ch] >= X);
+
+        /// <summary>
+        /// Returns true for those characters that begin a quantifier.
+        /// </summary>
+        public static bool IsQuantifier(char ch) => (ch <= '{' && s_category[ch] >= Q);
+
+        /// <summary>
+        /// Returns true for whitespace.
+        /// </summary>
+        public static bool IsSpace(char ch) => (ch <= ' ' && s_category[ch] == X);
+
+        /// <summary>
+        /// Returns true for chars that should be escaped.
+        /// </summary>
+        public static bool IsMetachar(char ch) => (ch <= '|' && s_category[ch] >= E);
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -23,4 +23,59 @@ namespace System.Text.RegularExpressions
         ECMAScript              = 0x0100, // "e"
         CultureInvariant        = 0x0200,
     }
+
+    internal static class RegexOptionsExtensions
+    {
+        /// <summary>
+        /// True if N option disabling '(' autocapture is on.
+        /// </summary>
+        public static bool UseOptionN(this RegexOptions options) => (options & RegexOptions.ExplicitCapture) != 0;
+
+        /// <summary>
+        /// True if I option enabling case-insensitivity is on.
+        /// </summary>
+        public static bool UseOptionI(this RegexOptions options) => (options & RegexOptions.IgnoreCase) != 0;
+
+        /// <summary>
+        /// True if M option altering meaning of $ and ^ is on.
+        /// </summary>
+        public static bool UseOptionM(this RegexOptions options) => (options & RegexOptions.Multiline) != 0;
+
+        /// <summary>
+        /// True if S option altering meaning of . is on.
+        /// </summary>
+        public static bool UseOptionS(this RegexOptions options) => (options & RegexOptions.Singleline) != 0;
+
+        /// <summary>
+        /// True if X option enabling whitespace/comment mode is on.
+        /// </summary>
+        public static bool UseOptionX(this RegexOptions options) => (options & RegexOptions.IgnorePatternWhitespace) != 0;
+
+        /// <summary>
+        /// True if E option enabling ECMAScript behavior is on.
+        /// </summary>
+        public static bool UseOptionE(this RegexOptions options) => (options & RegexOptions.ECMAScript) != 0;
+
+        /// <summary>
+        /// True if Invariant option enabling culture invariant behavior is on.
+        /// </summary>
+        public static bool UseOptionInvariant(this RegexOptions options) => (options & RegexOptions.CultureInvariant) != 0;
+
+        /// <summary>
+        /// True if C option enabling compiled regexes is on.
+        /// </summary>
+        public static bool UseOptionC(this RegexOptions options) => (options & RegexOptions.Compiled) != 0;
+
+        /// <summary>
+        /// True if R option enabling right-to-left mode is on.
+        /// </summary>
+        public static bool UseOptionR(this RegexOptions options) => (options & RegexOptions.RightToLeft) != 0;
+
+#if DEBUG
+        /// <summary>
+        /// True if the regex has debugging enabled
+        /// </summary>
+        public static bool IsDebug(this RegexOptions options) => (options & RegexOptions.Debug) != 0;
+#endif
+    }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -154,10 +154,10 @@ namespace System.Text.RegularExpressions
                 // move past all of the normal characters.  We'll stop when we hit some kind of control character,
                 // or if IgnorePatternWhiteSpace is on, we'll stop when we see some whitespace.
                 if (_options.UseOptionX())
-                    while (CharsRight() > 0 && (!RegexCharCategory.IsStopperX(ch = RightChar()) || (ch == '{' && !IsTrueQuantifier())))
+                    while (CharsRight() > 0 && (!CharCategory.IsStopperX(ch = RightChar()) || (ch == '{' && !IsTrueQuantifier())))
                         MoveRight();
                 else
-                    while (CharsRight() > 0 && (!RegexCharCategory.IsSpecial(ch = RightChar()) || (ch == '{' && !IsTrueQuantifier())))
+                    while (CharsRight() > 0 && (!CharCategory.IsSpecial(ch = RightChar()) || (ch == '{' && !IsTrueQuantifier())))
                         MoveRight();
 
                 int endpos = Textpos();
@@ -166,9 +166,9 @@ namespace System.Text.RegularExpressions
 
                 if (CharsRight() == 0)
                     ch = '!'; // nonspecial, means at end
-                else if (RegexCharCategory.IsSpecial(ch = RightChar()))
+                else if (CharCategory.IsSpecial(ch = RightChar()))
                 {
-                    isQuantifier = RegexCharCategory.IsQuantifier(ch);
+                    isQuantifier = CharCategory.IsQuantifier(ch);
                     MoveRight();
                 }
                 else
@@ -845,7 +845,7 @@ namespace System.Text.RegularExpressions
             {
                 for (; ;)
                 {
-                    while (CharsRight() > 0 && RegexCharCategory.IsSpace(RightChar()))
+                    while (CharsRight() > 0 && CharCategory.IsSpace(RightChar()))
                         MoveRight();
 
                     if (CharsRight() == 0)
@@ -1801,7 +1801,7 @@ namespace System.Text.RegularExpressions
             int startpos = Textpos();
             char ch = CharAt(startpos);
             if (ch != '{')
-                return RegexCharCategory.IsQuantifier(ch);
+                return CharCategory.IsQuantifier(ch);
 
             int pos = startpos;
             int nChars = CharsRight();

--- a/src/System.Text.RegularExpressions/tests/Regex.EscapeUnescape.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.EscapeUnescape.Tests.cs
@@ -16,7 +16,13 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("", "")]
         public static void Escape(string str, string expected)
         {
+            // Use Escape(string)
             Assert.Equal(expected, Regex.Escape(str));
+
+            // Use Escape(ReadOnlySpan, Span)
+            Span<char> output = stackalloc char[255];
+            bool success = Regex.TryEscape(str.AsSpan(), output, out int charsWritten);
+            SpanTestHelper.VerifySpan(expected, output, charsWritten, success);
         }
 
         [Fact]
@@ -35,6 +41,11 @@ namespace System.Text.RegularExpressions.Tests
         public void Unescape(string str, string expected)
         {
             Assert.Equal(expected, Regex.Unescape(str));
+
+            // Use Escape(ReadOnlySpan, Span)
+            Span<char> output = stackalloc char[255];
+            bool success = Regex.TryUnescape(str.AsSpan(), output, out int charsWritten);
+            SpanTestHelper.VerifySpan(expected, output, charsWritten, success);
         }
 
         [Fact]

--- a/src/System.Text.RegularExpressions/tests/SpanTestHelper.cs
+++ b/src/System.Text.RegularExpressions/tests/SpanTestHelper.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Text.RegularExpressions.Tests
+{
+    internal static class SpanTestHelper
+    {
+        public static void VerifySpan(string expected, Span<char> output, int charsWritten, bool success)
+        {
+            Assert.True(success);
+            Assert.Equal(expected.Length, charsWritten);
+            Assert.Equal(expected, output.Slice(0, charsWritten).ToString());
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\src\System\Text\RegularExpressions\RegexParseError.cs">
       <Link>System\Text\RegularExpressions\RegexParseError.cs</Link>
     </Compile>
+    <Compile Include="SpanTestHelper.cs" />
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>


### PR DESCRIPTION
Unfortunately using the common path for the Escape string version decreases performance and allocation significantly. I'll probably duplicate code paths to avoid the performance drop. Please notice the performance and huge allocation improvements for Unescape.

Adding a minimal parser for escape / unescape. The end goal is to converge the RegexParser and the ParserMin back into one but that requires collection support for ReadOnlySpan<char> lookups.

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763
Intel Core i7-6600U CPU 2.60GHz (Max: 2.61GHz) (Skylake), 1 CPU, 4 logical and 2 physical cores
  [Host] : .NET Core ? (CoreCLR 4.6.27021.03, CoreFX 4.6.27121.0), 64bit RyuJIT

Job=.NET Core 3.0 regex  Runtime=Core  Toolchain=InProcessToolchain  

```

## Before

|        Method |      Mean |    Error |    StdDev |      Gen 0 | Allocated |
|-------------- |----------:|---------:|----------:|-----------:|----------:|
|   RegexEscape(string) |  93.35 ms | 1.745 ms | 1.7920 ms | 35333.3333 |   70.8 MB |
| RegexUnescape(string) | 106.74 ms | 1.020 ms | 0.9538 ms | 51200.0000 | 102.54 MB |

## After

|        Method |      Mean |    Error |   StdDev |    Median |      Gen 0 | Allocated |
|-------------- |----------:|---------:|---------:|----------:|-----------:|----------:|
|   RegexEscape(string) | 118.22 ms | 2.875 ms | 2.689 ms | 118.09 ms | 37800.0000 |  75.68 MB |
| RegexUnescape(string) |  99.92 ms | 1.931 ms | 1.983 ms |  98.48 ms | 18800.0000 |  37.84 MB |