### PR TITLE
Support ECDSA OID friendly names for ECDH.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/ECCng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/ECCng.ImportExport.cs
@@ -565,14 +565,17 @@ namespace System.Security.Cryptography
             {
                 case "nistP256":
                 case "ECDH_P256":
+                case "ECDSA_P256":
                     return AlgorithmName.ECDHP256;
 
                 case "nistP384":
                 case "ECDH_P384":
+                case "ECDSA_P384":
                     return AlgorithmName.ECDHP384;
 
                 case "nistP521":
                 case "ECDH_P521":
+                case "ECDSA_P521":
                     return AlgorithmName.ECDHP521;
             }
 

--- a/src/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanTests.cs
@@ -35,6 +35,20 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             }
         }
 
+        [Theory]
+        [InlineData("1.3.132.0.35", 521)] //secp521r1
+        [InlineData("1.3.132.0.34", 384)] //secp384r1
+        [InlineData("1.2.840.10045.3.1.7", 256)] //secp256v1
+        public static void ECCurve_ctor_SEC2_OID_From_Value(string oidValue, int expectedKeySize)
+        {
+            ECCurve ecCurve = ECCurve.CreateFromValue(oidValue);
+            using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create(ecCurve))
+            {
+                Assert.Equal(expectedKeySize, ecdh.KeySize);
+                ecdh.Exercise();
+            }
+        }
+
         [Fact]
         public static void Equivalence_Hash()
         {


### PR DESCRIPTION
Pre-Windows 10 CNG will resolve SEC 2 OIDs to having an algorithm family name with "ECDSA" identifiers which were not mapped to the ECDH algorithm family.

Fixes #32914 

/cc @bartonjs 