### PR TITLE
Fix ALPN detection logic (for non-portable shim builds)

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/configure.cmake
+++ b/src/Native/Unix/System.Security.Cryptography.Native/configure.cmake
@@ -2,7 +2,7 @@ include(CheckLibraryExists)
 include(CheckFunctionExists)
 
 set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
-set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
 
 check_function_exists(
     EC_GF2m_simple_method


### PR DESCRIPTION
I happened to notice the configure output give an unexpected answer when building on FreeBSD, and then confirmed that it gives the wrong answer when building non-portable on Linux.

Now it gives the right answer on both.