### PR TITLE
Remove warning about duplicate import of eng\versions.props

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -77,7 +77,7 @@
     <PublishSymbolsPackageVersion>1.0.0-beta-63412-03</PublishSymbolsPackageVersion>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)eng\Versions.props" />
+  <Import Condition="'$(EngVersionPropsFileImported)' != 'true'" Project="$(MSBuildThisFileDirectory)eng\Versions.props" />
 
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Let other projects know we've already imported this file -->
+  <PropertyGroup>
+    <EngVersionPropsFileImported>true</EngVersionPropsFileImported>
+  </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>


### PR DESCRIPTION
This will stop us from trying to import `eng\versions.props` when it's already been imported by the Arcade SDK

CC @Wraith2 @karelz @weshaggard 

For https://github.com/dotnet/corefx/issues/32961