### PR TITLE
Optimize interpretation of some unary expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
@@ -21,14 +21,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((short)((short)obj - 1)));
+                    data[index] = unchecked((short)((short)obj - 1));
                 }
                 return 1;
             }
@@ -38,14 +36,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((int)obj - 1));
+                    data[index] = ScriptingRuntimeHelpers.Int32ToObject(unchecked(((int)obj - 1)));
                 }
                 return 1;
             }
@@ -55,14 +51,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((long)obj - 1));
+                    data[index] = unchecked((long)obj - 1);
                 }
                 return 1;
             }
@@ -72,14 +66,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((ushort)((ushort)obj - 1)));
+                    data[index] = unchecked((ushort)((ushort)obj - 1));
                 }
                 return 1;
             }
@@ -89,14 +81,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((uint)obj - 1));
+                    data[index] = unchecked((uint)obj - 1);
                 }
                 return 1;
             }
@@ -106,14 +96,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((ulong)obj - 1));
+                    data[index] = unchecked((ulong)obj - 1);
                 }
                 return 1;
             }
@@ -123,14 +111,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((float)obj - 1));
+                    data[index] = unchecked((float)obj - 1);
                 }
                 return 1;
             }
@@ -140,14 +126,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((double)obj - 1));
+                    data[index] = unchecked((double)obj - 1);
                 }
                 return 1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
@@ -21,14 +21,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((short)(1 + (short)obj)));
+                    data[index] = unchecked((short)(1 + (short)obj));
                 }
                 return 1;
             }
@@ -38,14 +36,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(1 + (int)obj));
+                    data[index] = ScriptingRuntimeHelpers.Int32ToObject(unchecked(1 + (int)obj));
                 }
                 return 1;
             }
@@ -55,14 +51,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(1 + (long)obj));
+                    data[index] = unchecked(1 + (long)obj);
                 }
                 return 1;
             }
@@ -72,14 +66,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((ushort)(1 + (ushort)obj)));
+                    data[index] = unchecked((ushort)(1 + (ushort)obj));
                 }
                 return 1;
             }
@@ -89,14 +81,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(1 + (uint)obj));
+                    data[index] = unchecked(1 + (uint)obj);
                 }
                 return 1;
             }
@@ -106,14 +96,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(1 + (ulong)obj));
+                    data[index] = unchecked(1 + (ulong)obj);
                 }
                 return 1;
             }
@@ -123,14 +111,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(1 + (float)obj));
+                    data[index] = unchecked(1 + (float)obj);
                 }
                 return 1;
             }
@@ -140,14 +126,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(1 + (double)obj));
+                    data[index] = unchecked(1 + (double)obj);
                 }
                 return 1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -21,14 +21,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((short)(-(short)obj)));
+                    data[index] = unchecked((short)(-(short)obj));
                 }
                 return 1;
             }
@@ -38,14 +36,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(-(int)obj));
+                    data[index] = ScriptingRuntimeHelpers.Int32ToObject(unchecked(-(int)obj));
                 }
                 return 1;
             }
@@ -55,14 +51,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(-(long)obj));
+                    data[index] = unchecked(-(long)obj);
                 }
                 return 1;
             }
@@ -72,14 +66,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(-(float)obj);
+                    data[index] = -(float)obj;
                 }
                 return 1;
             }
@@ -89,14 +81,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(-(double)obj);
+                    data[index] = -(double)obj;
                 }
                 return 1;
             }
@@ -132,14 +122,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(checked(-(int)obj));
+                    data[index] = ScriptingRuntimeHelpers.Int32ToObject(checked(-(int)obj));
                 }
                 return 1;
             }
@@ -149,14 +137,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(checked((short)(-(short)obj)));
+                    data[index] = checked((short)(-(short)obj));
                 }
                 return 1;
             }
@@ -166,14 +152,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(checked(-(long)obj));
+                    data[index] = checked(-(long)obj);
                 }
                 return 1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
@@ -20,14 +20,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(!(bool)value);
+                    data[index] = (bool)obj ? Utils.BoxedFalse : Utils.BoxedTrue;
                 }
                 return 1;
             }
@@ -37,14 +35,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(~(long)value);
+                    data[index] = ~(long)obj;
                 }
                 return 1;
             }
@@ -54,14 +50,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(~(int)value);
+                    data[index] = ScriptingRuntimeHelpers.Int32ToObject(~(int)obj);
                 }
                 return 1;
             }
@@ -71,14 +65,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push((short)(~(short)value));
+                    data[index] = (short)(~(short)obj);
                 }
                 return 1;
             }
@@ -88,14 +80,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(~(ulong)value);
+                    data[index] = ~(ulong)obj;
                 }
                 return 1;
             }
@@ -105,14 +95,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(~(uint)value);
+                    data[index] = ~(uint)obj;
                 }
                 return 1;
             }
@@ -122,14 +110,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((ushort)(~(ushort)value)));
+                    data[index] = unchecked((ushort)(~(ushort)obj));
                 }
                 return 1;
             }
@@ -139,14 +125,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((byte)(~(byte)value)));
+                    data[index] = unchecked((byte)(~(byte)obj));
                 }
                 return 1;
             }
@@ -156,14 +140,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object[] data = frame.Data;
+                int index = frame.StackIndex - 1;
+                object obj = data[index];
+                if (obj != null)
                 {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push((sbyte)(~(sbyte)value));
+                    data[index] = (sbyte)(~(sbyte)obj);
                 }
                 return 1;
             }


### PR DESCRIPTION
Apply optimizations similar to those for binary arithmetic expression evaluation to unary expressions. In particular, reduce the use of `Pop` and `Push` with redundant stack index calculations, and remove `Push(null)` for the case where the operand is already `null`.

Note: I attempted and tested the use of a `ref object` local to point to the top of the stack and perform edits to the operand slot that way (nice and concise `ref object obj = ref frame.Data[frame.StackIndex - 1]` to do away with the first three lines everywhere), but it turns out that was consistently a bit slower than indexing into the array twice (once for read and once for write). Smallest repro to show the difference:

```csharp
public static void Faster(object[] objs, int i)
{
    object obj = objs[i];
    objs[i] = (int)obj + 1;
}

public static void Slower(object[] objs, int i)
{
    ref object obj = ref objs[i];
    obj = (int)obj + 1;
}
```