### PR TITLE
Update package index for removed System.Memory package

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2552,8 +2552,7 @@
         "xamarinwatchos10": "Any"
       },
       "AssemblyVersionInPackageVersion": {
-        "4.0.1.0": "4.5.0",
-        "4.1.0.0": "4.6.0"
+        "4.0.1.0": "4.5.0"
       }
     },
     "System.Messaging": {


### PR DESCRIPTION
While helping @ahsonkhan understand an issue we realized that packages that depend on System.Memory are still getting a dependency on a package that is no longer built from master, because when this package was deleted the assembly version to package version mapping was not updated in the packageIndex.json.

It seems that the all configurations leg (package validation tests) should catch these issues right? 

cc: @weshaggard @ericstj @ViktorHofer 