### PR TITLE
Reset SocketAsyncEventArgs in-use flag when BeginGetHostAddresses throws

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3871,7 +3871,15 @@ namespace System.Net.Sockets
                 e.StartOperationCommon(this, SocketAsyncOperation.Connect);
                 e.StartOperationConnect(multipleConnectAsync, userSocket: true);
 
-                pending = multipleConnectAsync.StartConnectAsync(e, dnsEP);
+                try
+                {
+                    pending = multipleConnectAsync.StartConnectAsync(e, dnsEP);
+                }
+                catch
+                {
+                    e.Complete(); // Clear in-use flag on event args object.
+                    throw;
+                }
             }
             else
             {
@@ -3972,7 +3980,15 @@ namespace System.Net.Sockets
                 e.StartOperationCommon(attemptSocket, SocketAsyncOperation.Connect);
                 e.StartOperationConnect(multipleConnectAsync, userSocket: false);
 
-                pending = multipleConnectAsync.StartConnectAsync(e, dnsEP);
+                try
+                {
+                    pending = multipleConnectAsync.StartConnectAsync(e, dnsEP);
+                }
+                catch
+                {
+                    e.Complete(); // Clear in-use flag on event args object.
+                    throw;
+                }
             }
             else
             {


### PR DESCRIPTION
Socket.ConnectAsync when provided with a DnsEndPoint uses Dns.BeginGetHostAddresses to do the DNS resolution.  BeginGetHostAddresses synchronously throws an ArgumentException if the host name parses to either IPAddress.Any or IPAddress.IPv6Any.  Socket.ConnectAsync marks the SocketAsyncEventArgs as in use prior to making this call, but then doesn't reset that flag if this BeginGetHostAddresses call throws, leaving the SocketAsyncEventArgs unusuable for any future operations.  That in turn causes a problem for any usage that pools SocketAsyncEventArgs, as it's designed to be used for, and as we do in SocketsHttpHandler.

Fixes https://github.com/dotnet/corefx/issues/32971
cc: @davidsh, @geoffkizer, @Priya91