### PR TITLE
Implement Socket.Send/ReceiveAsync cancellation support on Windows

### DIFF
--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -237,6 +237,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Winsock\WSABuffer.cs">
       <Link>Interop\Windows\Winsock\WSABuffer.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.CancelIoEx.cs">
+      <Link>Common\Interop\Windows\Interop.CancelIoEx.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetFileCompletionNotificationModes.cs">
       <Link>Interop\Windows\kernel32\Interop.SetFileCompletionNotificationModes.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -184,9 +184,6 @@ namespace System.Net.Sockets
             return ReceiveAsync((Memory<byte>)buffer, socketFlags, fromNetworkStream, default).AsTask();
         }
 
-        // TODO https://github.com/dotnet/corefx/issues/24430:
-        // Fully plumb cancellation down into socket operations.
-
         internal ValueTask<int> ReceiveAsync(Memory<byte> buffer, SocketFlags socketFlags, bool fromNetworkStream, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -201,14 +198,16 @@ namespace System.Net.Sockets
                 saea.SetBuffer(buffer);
                 saea.SocketFlags = socketFlags;
                 saea.WrapExceptionsInIOExceptions = fromNetworkStream;
-                return saea.ReceiveAsync(this);
+                return saea.ReceiveAsync(this, cancellationToken);
             }
-            else
-            {
-                // We couldn't get a cached instance, due to a concurrent receive operation on the socket.
-                // Fall back to wrapping APM.
-                return new ValueTask<int>(ReceiveAsyncApm(buffer, socketFlags));
-            }
+
+            // We couldn't get a cached instance, due to a concurrent receive operation on the socket.
+            // Fall back to wrapping APM.
+            Task<int> apmTask = ReceiveAsyncApm(buffer, socketFlags);
+            return new ValueTask<int>(
+                cancellationToken.CanBeCanceled && !apmTask.IsCompleted ?
+                    WaitWithCancellationAsync(apmTask, cancellationToken) :
+                    apmTask);
         }
 
         /// <summary>Implements Task-returning ReceiveAsync on top of Begin/EndReceive.</summary>
@@ -350,14 +349,16 @@ namespace System.Net.Sockets
                 saea.SetBuffer(MemoryMarshal.AsMemory(buffer));
                 saea.SocketFlags = socketFlags;
                 saea.WrapExceptionsInIOExceptions = false;
-                return saea.SendAsync(this);
+                return saea.SendAsync(this, cancellationToken);
             }
-            else
-            {
-                // We couldn't get a cached instance, due to a concurrent send operation on the socket.
-                // Fall back to wrapping APM.
-                return new ValueTask<int>(SendAsyncApm(buffer, socketFlags));
-            }
+
+            // We couldn't get a cached instance, due to a concurrent send operation on the socket.
+            // Fall back to wrapping APM.
+            Task<int> apmTask = SendAsyncApm(buffer, socketFlags);
+            return new ValueTask<int>(
+                cancellationToken.CanBeCanceled && !apmTask.IsCompleted ?
+                    WaitWithCancellationAsync(apmTask, cancellationToken) :
+                    apmTask);
         }
 
         internal ValueTask SendAsyncForNetworkStream(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken)
@@ -374,14 +375,16 @@ namespace System.Net.Sockets
                 saea.SetBuffer(MemoryMarshal.AsMemory(buffer));
                 saea.SocketFlags = socketFlags;
                 saea.WrapExceptionsInIOExceptions = true;
-                return saea.SendAsyncForNetworkStream(this);
+                return saea.SendAsyncForNetworkStream(this, cancellationToken);
             }
-            else
-            {
-                // We couldn't get a cached instance, due to a concurrent send operation on the socket.
-                // Fall back to wrapping APM.
-                return new ValueTask(SendAsyncApm(buffer, socketFlags));
-            }
+
+            // We couldn't get a cached instance, due to a concurrent send operation on the socket.
+            // Fall back to wrapping APM.
+            Task<int> apmTask = SendAsyncApm(buffer, socketFlags);
+            return new ValueTask(
+                cancellationToken.CanBeCanceled && !apmTask.IsCompleted ?
+                    WaitWithCancellationAsync(apmTask, cancellationToken) :
+                    apmTask);
         }
 
         /// <summary>Implements Task-returning SendAsync on top of Begin/EndSend.</summary>
@@ -468,6 +471,27 @@ namespace System.Net.Sockets
                 catch (Exception e) { innerTcs.TrySetException(e); }
             }, tcs);
             return tcs.Task;
+        }
+
+        /// <summary>Waits for the provided task to complete, and in the interim cancels pending operations on the socket if cancellation is requested.</summary>
+        private async Task<int> WaitWithCancellationAsync(Task<int> task, CancellationToken cancellationToken)
+        {
+            Debug.Assert(cancellationToken.CanBeCanceled);
+            using (cancellationToken.UnsafeRegister(s => SocketPal.CancelPendingOperations((Socket)s), this))
+            {
+                try
+                {
+                    return await task.ConfigureAwait(false);
+                }
+                catch (SocketException se)
+                {
+                    if (se.SocketErrorCode == SocketError.OperationAborted)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                    throw;
+                }
+            }
         }
 
         /// <summary>Validates the supplied array segment, throwing if its array or indices are null or out-of-bounds, respectively.</summary>
@@ -820,7 +844,9 @@ namespace System.Net.Sockets
             /// when the operation does complete.
             /// </summary>
             private Action<object> _continuation = s_availableSentinel;
+            /// <summary>Captured ExecutionContext to use when invoking the continuation.</summary>
             private ExecutionContext _executionContext;
+            /// <summary>Context or scheduler to which continuations should be queued.</summary>
             private object _scheduler;
             /// <summary>Current token value given to a ValueTask and then verified against the value it passes back to us.</summary>
             /// <remarks>
@@ -829,6 +855,19 @@ namespace System.Net.Sockets
             /// it's already being reused by someone else.
             /// </remarks>
             private short _token;
+            /// <summary>CancellationToken associated with the current operation.</summary>
+            private CancellationToken _cancellationToken;
+            /// <summary>Cancellation registration for the current operation.</summary>
+            private CancellationTokenRegistration _cancellationRegistration;
+            /// <summary>Flag used to communicate between the threads initiating and completing operations.</summary>
+            private byte _cancellationState;
+
+            /// <summary>Indicates that cancelation isn't applicable for the operation.</summary>
+            private const byte CancellationState_None = 0;
+            /// <summary>Indicates that a cancellation callback is in the process of being registered.</summary>
+            private const byte CancellationState_Registering = 1;
+            /// <summary>Indicates that a cancellation callback has been registered.</summary>
+            private const byte CancellationState_Registered = 2;
 
             /// <summary>Initializes the event args.</summary>
             /// <param name="socket">The associated socket.</param>
@@ -845,12 +884,26 @@ namespace System.Net.Sockets
 
             private void Release()
             {
+                _cancellationToken = default;
                 _token++;
                 Volatile.Write(ref _continuation, s_availableSentinel);
             }
 
             protected override void OnCompleted(SocketAsyncEventArgs _)
             {
+                // _cancellationState will be None if cancellation can't happen,
+                // Registering if it's in the process of being registered, and
+                // Registered if it's been registered.  If cancellation may happen,
+                // we spin until it's been registered, so that we can safely unregister.
+                // That way, there's no concern about leaking a registration.
+                if (_cancellationState != CancellationState_None)
+                {
+                    var sw = new SpinWait();
+                    while (Volatile.Read(ref _cancellationState) == CancellationState_Registering) sw.SpinOnce();
+                    _cancellationRegistration.Dispose();
+                    _cancellationState = CancellationState_None;
+                }
+
                 // When the operation completes, see if OnCompleted was already called to hook up a continuation.
                 // If it was, invoke the continuation.
                 Action<object> c = _continuation;
@@ -885,13 +938,29 @@ namespace System.Net.Sockets
 
             /// <summary>Initiates a receive operation on the associated socket.</summary>
             /// <returns>This instance.</returns>
-            public ValueTask<int> ReceiveAsync(Socket socket)
+            public ValueTask<int> ReceiveAsync(Socket socket, CancellationToken cancellationToken)
             {
                 Debug.Assert(Volatile.Read(ref _continuation) == null, $"Expected null continuation to indicate reserved for use");
 
-                if (socket.ReceiveAsync(this))
+                if (cancellationToken.CanBeCanceled)
                 {
-                    return new ValueTask<int>(this, _token);
+                    _cancellationState = CancellationState_Registering;
+                    if (socket.ReceiveAsync(this))
+                    {
+                        // Store the token and the registration, then let the callback know that it can safely dispose of the registration.
+                        _cancellationToken = cancellationToken;
+                        _cancellationRegistration = cancellationToken.UnsafeRegister(s => SocketPal.CancelPendingOperations((Socket)s), socket);
+                        Volatile.Write(ref _cancellationState, CancellationState_Registered);
+                        return new ValueTask<int>(this, _token);
+                    }
+                }
+                else
+                {
+                    _cancellationState = CancellationState_None;
+                    if (socket.ReceiveAsync(this))
+                    {
+                        return new ValueTask<int>(this, _token);
+                    }
                 }
 
                 int bytesTransferred = BytesTransferred;
@@ -906,13 +975,29 @@ namespace System.Net.Sockets
 
             /// <summary>Initiates a send operation on the associated socket.</summary>
             /// <returns>This instance.</returns>
-            public ValueTask<int> SendAsync(Socket socket)
+            public ValueTask<int> SendAsync(Socket socket, CancellationToken cancellationToken)
             {
                 Debug.Assert(Volatile.Read(ref _continuation) == null, $"Expected null continuation to indicate reserved for use");
 
-                if (socket.SendAsync(this))
+                if (cancellationToken.CanBeCanceled)
                 {
-                    return new ValueTask<int>(this, _token);
+                    _cancellationState = CancellationState_Registering;
+                    if (socket.SendAsync(this))
+                    {
+                        // Store the token and the registration, then let the callback know that it can safely dispose of the registration.
+                        _cancellationToken = cancellationToken;
+                        _cancellationRegistration = cancellationToken.UnsafeRegister(s => SocketPal.CancelPendingOperations((Socket)s), socket);
+                        Volatile.Write(ref _cancellationState, CancellationState_Registered);
+                        return new ValueTask<int>(this, _token);
+                    }
+                }
+                else
+                {
+                    _cancellationState = CancellationState_None;
+                    if (socket.SendAsync(this))
+                    {
+                        return new ValueTask<int>(this, _token);
+                    }
                 }
 
                 int bytesTransferred = BytesTransferred;
@@ -925,13 +1010,29 @@ namespace System.Net.Sockets
                     new ValueTask<int>(Task.FromException<int>(CreateException(error)));
             }
 
-            public ValueTask SendAsyncForNetworkStream(Socket socket)
+            public ValueTask SendAsyncForNetworkStream(Socket socket, CancellationToken cancellationToken)
             {
                 Debug.Assert(Volatile.Read(ref _continuation) == null, $"Expected null continuation to indicate reserved for use");
 
-                if (socket.SendAsync(this))
+                if (cancellationToken.CanBeCanceled)
                 {
-                    return new ValueTask(this, _token);
+                    _cancellationState = CancellationState_Registering;
+                    if (socket.SendAsync(this))
+                    {
+                        // Store the token and the registration, then let the callback know that it can safely dispose of the registration.
+                        _cancellationToken = cancellationToken;
+                        _cancellationRegistration = cancellationToken.UnsafeRegister(s => SocketPal.CancelPendingOperations((Socket)s), socket);
+                        Volatile.Write(ref _cancellationState, CancellationState_Registered);
+                        return new ValueTask(this, _token);
+                    }
+                }
+                else
+                {
+                    _cancellationState = CancellationState_None;
+                    if (socket.SendAsync(this))
+                    {
+                        return new ValueTask(this, _token);
+                    }
                 }
 
                 SocketError error = SocketError;
@@ -1054,12 +1155,13 @@ namespace System.Net.Sockets
 
                 SocketError error = SocketError;
                 int bytes = BytesTransferred;
+                CancellationToken cancellationToken = _cancellationToken;
 
                 Release();
 
                 if (error != SocketError.Success)
                 {
-                    ThrowException(error);
+                    ThrowException(error, cancellationToken);
                 }
                 return bytes;
             }
@@ -1072,12 +1174,13 @@ namespace System.Net.Sockets
                 }
 
                 SocketError error = SocketError;
+                CancellationToken cancellationToken = _cancellationToken;
 
                 Release();
 
                 if (error != SocketError.Success)
                 {
-                    ThrowException(error);
+                    ThrowException(error, cancellationToken);
                 }
             }
 
@@ -1085,7 +1188,15 @@ namespace System.Net.Sockets
 
             private void ThrowMultipleContinuationsException() => throw new InvalidOperationException(SR.InvalidOperation_MultipleContinuations);
 
-            private void ThrowException(SocketError error) => throw CreateException(error);
+            private void ThrowException(SocketError error, CancellationToken cancellationToken)
+            {
+                if (error == SocketError.OperationAborted)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                throw CreateException(error);
+            }
 
             private Exception CreateException(SocketError error)
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -851,6 +851,11 @@ namespace System.Net.Sockets
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
+        public static void CancelPendingOperations(Socket socket)
+        {
+            // TODO https://github.com/dotnet/corefx/issues/24430:
+        }
+
         public static SocketError Listen(SafeSocketHandle handle, int backlog)
         {
             Interop.Error err = Interop.Sys.Listen(handle, backlog);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -93,6 +93,16 @@ namespace System.Net.Sockets
             return errorCode == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;
         }
 
+        public static unsafe void CancelPendingOperations(Socket socket)
+        {
+            // Ignore any failures; this is opportunistic cancellation only.
+            try
+            {
+                Interop.Kernel32.CancelIoEx(socket.SafeHandle, null);
+            }
+            catch { }
+        }
+
         public static SocketError Listen(SafeSocketHandle handle, int backlog)
         {
             SocketError errorCode = Interop.Winsock.listen(handle, backlog);

--- a/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.netcoreapp.cs
@@ -349,6 +349,46 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(24430, TestPlatforms.AnyUnix)]
+        [Fact]
+        public async Task ReadAsync_CancelPendingRead_DoesntImpactSubsequentReads()
+        {
+            await RunWithConnectedNetworkStreamsAsync(async (server, client) =>
+            {
+                CancellationTokenSource cts;
+                for (int i = 0; i < 3; i++)
+                {
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.ReadAsync(new byte[1], 0, 1, new CancellationToken(true)));
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await client.ReadAsync(new Memory<byte>(new byte[1]), new CancellationToken(true)); });
+
+                    cts = new CancellationTokenSource();
+
+                    Task<int> t1 = client.ReadAsync(new byte[1], 0, 1, cts.Token);
+                    Task<int> t2 = client.ReadAsync(new byte[1], 0, 1, cts.Token);
+                    ValueTask<int> t3 = client.ReadAsync(new Memory<byte>(new byte[1]), cts.Token);
+                    ValueTask<int> t4 = client.ReadAsync(new Memory<byte>(new byte[1]), cts.Token);
+
+                    Assert.False(t1.IsCompleted);
+                    Assert.False(t2.IsCompleted);
+                    Assert.False(t3.IsCompleted);
+                    Assert.False(t4.IsCompleted);
+
+                    cts.Cancel();
+
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t1);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t2);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await t3; });
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await t4; });
+
+                    byte[] buffer = new byte[1];
+                    await server.WriteAsync(new ReadOnlyMemory<byte>(new byte[1] { (byte)(42+i)}));
+                    int bytesRead = await client.ReadAsync(new Memory<byte>(buffer));
+                    Assert.Equal(1, bytesRead);
+                    Assert.Equal(42 + i, buffer[0]);
+                }
+            });
+        }
+
         private sealed class CustomSynchronizationContext : SynchronizationContext
         {
             public override void Post(SendOrPostCallback d, object state)

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.netcoreapp.cs
@@ -33,6 +33,48 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [ActiveIssue(24430, TestPlatforms.AnyUnix)]
+        [Fact]
+        public async Task CanceledDuringOperation_Throws()
+        {
+            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.BindToAnonymousPort(IPAddress.Loopback);
+                listener.Listen(1);
+
+                await client.ConnectAsync(listener.LocalEndPoint);
+                using (Socket server = await listener.AcceptAsync())
+                {
+                    ValueTask<int> vt1 = default, vt2 = default;
+                    CancellationTokenSource cts;
+
+                    for (int len = 0; len < 2; len++)
+                    {
+                        cts = new CancellationTokenSource();
+                        vt1 = server.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                        Assert.False(vt1.IsCompleted);
+                        cts.Cancel();
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt1);
+                    }
+
+                    for (int len = 0; len < 2; len++)
+                    {
+                        cts = new CancellationTokenSource();
+                        vt1 = server.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                        vt2 = server.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                        Assert.False(vt1.IsCompleted);
+                        cts.Cancel();
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt1);
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt2);
+                    }
+
+                    await server.SendAsync((ReadOnlyMemory<byte>)new byte[1], SocketFlags.None);
+                    Assert.Equal(1, await client.ReceiveAsync((Memory<byte>)new byte[10], SocketFlags.None));
+                }
+            }
+        }
+
         [Fact]
         public async Task DisposedSocket_ThrowsOperationCanceledException()
         {


### PR DESCRIPTION
In .NET Core 2.1 we added Socket.Send/ReceiveAsync overloads that worked with {ReadOnly}Memory, and in doing so also added CancellationToken arguments, but in 2.1 those implementations only did an up-front check for cancellation and then ignored the token for the remainder of the operation.

This PR addresses that on Windows, and provides most of the boilerplate for on Unix, which can be addressed subsequently.

I initially implemented a more invasive approach, where all SocketAsyncEventArgs instances would store a registration and a native overlapped pointer to use to cancel just that operation.  But it turns out that CancelIoEx may up canceling all pending I/O on the socket, anyway, even if a single native overlapped is provided.  And it was unfortunate that we needed two very different solutions for Windows and Unix.  So, I simplified, and now almost all of the logic is shared across platforms, with a cancellation registration resulting in a call into the SocketPal to cancel pending operations on the socket.  On Windows this method is implemented with CancelIoEx, and on Unix we can subsequently implement it to clear out the explicit queues we maintain for async operations.

Contributes to https://github.com/dotnet/corefx/issues/24430
cc: @geoffkizer, @davidsh, @wfurt 