### PR TITLE
Added tests for StringBuilder.Equals ignoring capacity

### DIFF
--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -417,5 +417,33 @@ namespace System.Text.Tests
                 Assert.Equal(outStr, inBuilder.ToString());
             }
         }
+
+        [Fact]
+        public static void EqualsIgnoresCapacity()
+        {
+            var sb1 = new StringBuilder(5);
+            var sb2 = new StringBuilder(10);
+
+            Assert.True(sb1.Equals(sb2));
+
+            sb1.Append("12345");
+            sb2.Append("12345");
+
+            Assert.True(sb1.Equals(sb2));
+        }
+
+        [Fact]
+        public static void EqualsIgnoresMaxCapacity()
+        {
+            var sb1 = new StringBuilder(5, 5);
+            var sb2 = new StringBuilder(5, 10);
+
+            Assert.True(sb1.Equals(sb2));
+
+            sb1.Append("12345");
+            sb2.Append("12345");
+
+            Assert.True(sb1.Equals(sb2));
+        }
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/32932.

The implementation is in https://github.com/dotnet/coreclr/pull/20567.

Note that since I'm having issues building corefx (see https://github.com/dotnet/corefx/issues/32980), I didn't run the tests locally.