### PR TITLE
Update unit tests to account for Memory<T> changes

### DIFF
--- a/src/System.Memory/tests/MemoryMarshal/CreateFromPinnedArray.cs
+++ b/src/System.Memory/tests/MemoryMarshal/CreateFromPinnedArray.cs
@@ -34,7 +34,7 @@ namespace System.SpanTests
             Memory<string> pinnedMemory = MemoryMarshal.CreateFromPinnedArray(a, 4, 3);
             pinnedMemory.Validate("94", "95", "96");
         }
-        
+
         [Fact]
         public static void CreateFromPinnedArrayIntSliceRemainsPinned()
         {
@@ -46,25 +46,23 @@ namespace System.SpanTests
 
             Memory<int> slice = pinnedMemory.Slice(0);
             TestMemory<int> testSlice = Unsafe.As<Memory<int>, TestMemory<int>>(ref slice);
-            Assert.Equal(testPinnedMemory._index, testSlice._index);
-            Assert.Equal(testPinnedMemory._length, testSlice._length);
+            Assert.Equal(3 | (1 << 31), testSlice._index);
+            Assert.Equal(5, testSlice._length);
 
             slice = pinnedMemory.Slice(0, pinnedMemory.Length);
             testSlice = Unsafe.As<Memory<int>, TestMemory<int>>(ref slice);
-            Assert.Equal(testPinnedMemory._index, testSlice._index);
-            Assert.Equal(testPinnedMemory._length, testSlice._length);
+            Assert.Equal(3 | (1 << 31), testSlice._index);
+            Assert.Equal(5, testSlice._length);
 
-            int expectedLength = testPinnedMemory._length - 1;
             slice = pinnedMemory.Slice(1);
             testSlice = Unsafe.As<Memory<int>, TestMemory<int>>(ref slice);
-            Assert.Equal(testPinnedMemory._index + 1, testSlice._index);
-            Assert.Equal(expectedLength, testSlice._length);
+            Assert.Equal(4 | (1 << 31), testSlice._index);
+            Assert.Equal(4, testSlice._length);
 
-            expectedLength = 2 | (1 << 31);
             slice = pinnedMemory.Slice(1, 2);
             testSlice = Unsafe.As<Memory<int>, TestMemory<int>>(ref slice);
-            Assert.Equal(testPinnedMemory._index + 1, testSlice._index);
-            Assert.Equal(expectedLength, testSlice._length);
+            Assert.Equal(4 | (1 << 31), testSlice._index);
+            Assert.Equal(2, testSlice._length);
         }
         
         [Fact]
@@ -78,25 +76,23 @@ namespace System.SpanTests
 
             ReadOnlyMemory<int> slice = pinnedMemory.Slice(0);
             TestMemory<int> testSlice = Unsafe.As<ReadOnlyMemory<int>, TestMemory<int>>(ref slice);
-            Assert.Equal(testPinnedMemory._index, testSlice._index);
-            Assert.Equal(testPinnedMemory._length, testSlice._length);
+            Assert.Equal(3 | (1 << 31), testSlice._index);
+            Assert.Equal(5, testSlice._length);
 
             slice = pinnedMemory.Slice(0, pinnedMemory.Length);
             testSlice = Unsafe.As<ReadOnlyMemory<int>, TestMemory<int>>(ref slice);
-            Assert.Equal(testPinnedMemory._index, testSlice._index);
-            Assert.Equal(testPinnedMemory._length, testSlice._length);
+            Assert.Equal(3 | (1 << 31), testSlice._index);
+            Assert.Equal(5, testSlice._length);
 
-            int expectedLength = testPinnedMemory._length - 1;
             slice = pinnedMemory.Slice(1);
             testSlice = Unsafe.As<ReadOnlyMemory<int>, TestMemory<int>>(ref slice);
-            Assert.Equal(testPinnedMemory._index + 1, testSlice._index);
-            Assert.Equal(expectedLength, testSlice._length);
+            Assert.Equal(4 | (1 << 31), testSlice._index);
+            Assert.Equal(4, testSlice._length);
 
-            expectedLength = 2 | (1 << 31);
             slice = pinnedMemory.Slice(1, 2);
             testSlice = Unsafe.As<ReadOnlyMemory<int>, TestMemory<int>>(ref slice);
-            Assert.Equal(testPinnedMemory._index + 1, testSlice._index);
-            Assert.Equal(expectedLength, testSlice._length);
+            Assert.Equal(4 | (1 << 31), testSlice._index);
+            Assert.Equal(2, testSlice._length);
         }
 
         [Fact]

--- a/src/System.Memory/tests/MemoryMarshal/CreateFromPinnedArray.cs
+++ b/src/System.Memory/tests/MemoryMarshal/CreateFromPinnedArray.cs
@@ -42,8 +42,6 @@ namespace System.SpanTests
             Memory<int> pinnedMemory = MemoryMarshal.CreateFromPinnedArray(a, 3, 5);
             pinnedMemory.Validate(93, 94, 95, 96, 97);
 
-            TestMemory<int> testPinnedMemory = Unsafe.As<Memory<int>, TestMemory<int>>(ref pinnedMemory);
-
             Memory<int> slice = pinnedMemory.Slice(0);
             TestMemory<int> testSlice = Unsafe.As<Memory<int>, TestMemory<int>>(ref slice);
             Assert.Equal(3 | (1 << 31), testSlice._index);
@@ -71,8 +69,6 @@ namespace System.SpanTests
             int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             ReadOnlyMemory<int> pinnedMemory = MemoryMarshal.CreateFromPinnedArray(a, 3, 5);
             pinnedMemory.Validate(93, 94, 95, 96, 97);
-
-            TestMemory<int> testPinnedMemory = Unsafe.As<ReadOnlyMemory<int>, TestMemory<int>>(ref pinnedMemory);
 
             ReadOnlyMemory<int> slice = pinnedMemory.Slice(0);
             TestMemory<int> testSlice = Unsafe.As<ReadOnlyMemory<int>, TestMemory<int>>(ref slice);


### PR DESCRIPTION
Updates unit tests to account for internal implementation changes at https://github.com/dotnet/coreclr/pull/20386.
This PR will fail until the coreclr PR goes through and corefx takes the new build.