### PR TITLE
Fix all configurations warnings when trying to download coreclr symbols

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -358,7 +358,7 @@
     <!-- Constructed shared fx path for testing -->
     <UseDotNetNativeToolchain Condition="$(_bc_TargetGroup.EndsWith('aot'))">true</UseDotNetNativeToolchain>
     <!-- System.Private.* comes from test ilc, so the symbol packages for those versions will no exist, this is to avoid warnings -->
-    <DownloadCoreCLRSymbols Condition="'$(UseDotNetNativeToolchain)'=='true'">false</DownloadCoreCLRSymbols>
+    <DownloadCoreCLRSymbols Condition="'$(UseDotNetNativeToolchain)' == 'true' OR '$(BuildAllConfigurations)' == 'true' OR '$(DotNetBuildFromSource)' == 'true'">false</DownloadCoreCLRSymbols>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
     <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(ConfigurationGroup)/</PackageOutputPath>

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -99,7 +99,6 @@
   <PropertyGroup>
     <SymbolPackagesDir>$(PackagesDir)symbolpackages/</SymbolPackagesDir>
     <DotNetAssetRootUrl Condition="'$(DotNetAssetRootUrl)' == ''">https://dotnetfeed.blob.core.windows.net/dotnet-core/assets/</DotNetAssetRootUrl>
-    <DownloadCoreCLRSymbols Condition="'$(DotNetBuildFromSource)' == 'true'">false</DownloadCoreCLRSymbols>
   </PropertyGroup>
 
   <Target Name="CalculateCoreCLRSymbolPackageProperties"


### PR DESCRIPTION
There are a lot of warnings when building all configurations leg because it tries to download symbols for ILC and UWP packages. We don't really need to try and download this symbols since they're only used for testing purposes (dumpling, code coverage, etc) and we don't run product tests in all configuration legs. 