### PR TITLE
StringSearching.cs synced with coreclr

### DIFF
--- a/src/Common/src/CoreLib/System/String.Searching.cs
+++ b/src/Common/src/CoreLib/System/String.Searching.cs
@@ -52,7 +52,7 @@ namespace System
                     return CompareInfo.Invariant.IndexOf(this, value, GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.Ordinal:
-                    return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.Ordinal);
+                    return IndexOf(value);
 
                 case StringComparison.OrdinalIgnoreCase:
                     return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.OrdinalIgnoreCase);


### PR DESCRIPTION
Related Issue https://github.com/dotnet/corefx/issues/33047
There was a difference in the files in coreclr and corefx. This PR corrects that