### PR TITLE
Add overloads to File.Move and FileInfo.MoveTo that accept overwrite parameter (#31511)

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.MoveFileEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.MoveFileEx.cs
@@ -25,7 +25,7 @@ internal partial class Interop
         /// </summary>
         /// <param name="src">Source file or directory</param>
         /// <param name="dst">Destination file or directory</param>
-        /// <param name="overwrite">True to overwrite existing destination file. False to fail if destination file already exists. NOTE: must pass false for directories as overwrite of directories is not supported.</param>
+        /// <param name="overwrite">True to overwrite existing destination file. NOTE: must pass false for directories as overwrite of directories is not supported.</param>
         /// <returns></returns>
         internal static bool MoveFile(string src, string dst, bool overwrite)
         {

--- a/src/Common/src/Interop/Windows/kernel32/Interop.MoveFileEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.MoveFileEx.cs
@@ -32,7 +32,7 @@ internal partial class Interop
             src = PathInternal.EnsureExtendedPrefixIfNeeded(src);
             dst = PathInternal.EnsureExtendedPrefixIfNeeded(dst);
 
-            uint flags = MOVEFILE_WRITE_THROUGH | MOVEFILE_COPY_ALLOWED;
+            uint flags = MOVEFILE_COPY_ALLOWED;
             if (overwrite)
             {
                 flags |= MOVEFILE_REPLACE_EXISTING;

--- a/src/Common/src/Interop/Windows/kernel32/Interop.MoveFileEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.MoveFileEx.cs
@@ -12,7 +12,6 @@ internal partial class Interop
     {
         const uint MOVEFILE_REPLACE_EXISTING = 0x01;
         const uint MOVEFILE_COPY_ALLOWED = 0x02;
-        const uint MOVEFILE_WRITE_THROUGH = 0x08;
 
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use MoveFile.

--- a/src/Common/src/Interop/Windows/kernel32/Interop.MoveFileEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.MoveFileEx.cs
@@ -10,17 +10,35 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
+        const uint MOVEFILE_REPLACE_EXISTING = 0x01;
+        const uint MOVEFILE_COPY_ALLOWED = 0x02;
+        const uint MOVEFILE_WRITE_THROUGH = 0x08;
+
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use MoveFile.
         /// </summary>
         [DllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern bool MoveFileExPrivate(string src, string dst, uint flags);
 
-        internal static bool MoveFile(string src, string dst)
+        /// <summary>
+        /// Moves a file or directory, optionally overwriting existing destination file. NOTE: overwrite must be false for directories.
+        /// </summary>
+        /// <param name="src">Source file or directory</param>
+        /// <param name="dst">Destination file or directory</param>
+        /// <param name="overwrite">True to overwrite existing destination file. False to fail if destination file already exists. NOTE: must pass false for directories as overwrite of directories is not supported.</param>
+        /// <returns></returns>
+        internal static bool MoveFile(string src, string dst, bool overwrite)
         {
             src = PathInternal.EnsureExtendedPrefixIfNeeded(src);
             dst = PathInternal.EnsureExtendedPrefixIfNeeded(dst);
-            return MoveFileExPrivate(src, dst, 2 /* MOVEFILE_COPY_ALLOWED */);
+
+            uint flags = MOVEFILE_WRITE_THROUGH | MOVEFILE_COPY_ALLOWED;
+            if (overwrite)
+            {
+                flags |= MOVEFILE_REPLACE_EXISTING;
+            }
+            
+            return MoveFileExPrivate(src, dst, flags);
         }
     }
 }

--- a/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
+++ b/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
@@ -128,6 +128,7 @@ namespace System.IO
         public static System.DateTime GetLastWriteTime(string path) { throw null; }
         public static System.DateTime GetLastWriteTimeUtc(string path) { throw null; }
         public static void Move(string sourceFileName, string destFileName) { }
+        public static void Move(string sourceFileName, string destFileName, bool overwrite) { }
         public static System.IO.FileStream Open(string path, System.IO.FileMode mode) { throw null; }
         public static System.IO.FileStream Open(string path, System.IO.FileMode mode, System.IO.FileAccess access) { throw null; }
         public static System.IO.FileStream Open(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { throw null; }
@@ -186,6 +187,7 @@ namespace System.IO
         public void Decrypt() { }
         public void Encrypt() { }
         public void MoveTo(string destFileName) { }
+        public void MoveTo(string destFileName, bool overwrite) { }
         public System.IO.FileStream Open(System.IO.FileMode mode) { throw null; }
         public System.IO.FileStream Open(System.IO.FileMode mode, System.IO.FileAccess access) { throw null; }
         public System.IO.FileStream Open(System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { throw null; }

--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -620,6 +620,11 @@ namespace System.IO
         // 
         public static void Move(string sourceFileName, string destFileName)
         {
+            Move(sourceFileName, destFileName, false);
+        }
+
+        public static void Move(string sourceFileName, string destFileName, bool overwrite)
+        {
             if (sourceFileName == null)
                 throw new ArgumentNullException(nameof(sourceFileName), SR.ArgumentNull_FileName);
             if (destFileName == null)
@@ -637,7 +642,7 @@ namespace System.IO
                 throw new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, fullSourceFileName), fullSourceFileName);
             }
 
-            FileSystem.MoveFile(fullSourceFileName, fullDestFileName);
+            FileSystem.MoveFile(fullSourceFileName, fullDestFileName, overwrite);
         }
 
         public static void Encrypt(string path)

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
@@ -122,6 +122,14 @@ namespace System.IO
         // This method does work across volumes.
         public void MoveTo(string destFileName)
         {
+            MoveTo(destFileName, false);
+        }
+
+        // Moves a given file to a new location and potentially a new file name.
+        // Optionally overwrites existing file.
+        // This method does work across volumes.
+        public void MoveTo(string destFileName, bool overwrite)
+        {
             if (destFileName == null)
                 throw new ArgumentNullException(nameof(destFileName));
             if (destFileName.Length == 0)
@@ -138,7 +146,7 @@ namespace System.IO
             if (!Exists)
                 throw new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, FullName), FullName);
 
-            FileSystem.MoveFile(FullPath, fullDestFileName);
+            FileSystem.MoveFile(FullPath, fullDestFileName, overwrite);
 
             FullPath = fullDestFileName;
             OriginalPath = destFileName;

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -108,7 +108,7 @@ namespace System.IO
             // If overwrite is allowed then just call rename
             if (overwrite)
             {
-                if (Interop.libc.rename(sourceFullPath, destFullPath) < 0)
+                if (Interop.Sys.Rename(sourceFullPath, destFullPath) < 0)
                 {
                     Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
                     if (errorInfo.Error == Interop.Error.EXDEV) // rename fails across devices / mount points

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -115,7 +115,7 @@ namespace System.IO
                     {
                         CopyFile(sourceFullPath, destFullPath, overwrite);
                     }
-                    else if (errorInfo.Error == Interop.Error.ENOENT && !Directory.Exists(Path.GetDirectoryName(destFullPath))) // The parent directory of destFile can't be found
+                    else
                     {
                         // Windows distinguishes between whether the directory or the file isn't found,
                         // and throws a different exception in these cases.  We attempt to approximate that
@@ -124,11 +124,9 @@ namespace System.IO
                         // worst case in such a race condition (which could occur if the file system is
                         // being manipulated concurrently with these checks) is that we throw a
                         // FileNotFoundException instead of DirectoryNotFoundexception.
-                        throw Interop.GetExceptionForIoErrno(errorInfo, destFullPath, isDirectory: true);
-                    }
-                    else
-                    {
-                        throw Interop.GetExceptionForIoErrno(errorInfo);
+                        throw Interop.GetExceptionForIoErrno(errorInfo, destFullPath,
+                            isDirectory: errorInfo.Error == Interop.Error.ENOENT && !Directory.Exists(Path.GetDirectoryName(destFullPath))   // The parent directory of destFile can't be found
+                            );
                     }
                 }
 

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -78,6 +78,11 @@ namespace System.IO
 
         public static void MoveFile(string sourceFullPath, string destFullPath)
         {
+            MoveFile(sourceFullPath, destFullPath, false);
+        }
+
+        public static void MoveFile(string sourceFullPath, string destFullPath, bool overwrite)
+        {
             // The desired behavior for Move(source, dest) is to not overwrite the destination file
             // if it exists. Since rename(source, dest) will replace the file at 'dest' if it exists,
             // link/unlink are used instead. However, if the source path and the dest path refer to
@@ -87,6 +92,8 @@ namespace System.IO
             // way (e.g. source file doesn't exist, dest file doesn't exist, rename fails, etc.), we
             // just fall back to trying the link/unlink approach and generating any exceptional messages
             // from there as necessary.
+            //
+            // Rename is also appropriate for overwrite=true with same source/dest file
             Interop.Sys.FileStatus sourceStat, destStat;
             if (Interop.Sys.LStat(sourceFullPath, out sourceStat) == 0 && // source file exists
                 Interop.Sys.LStat(destFullPath, out destStat) == 0 && // dest file exists
@@ -98,6 +105,37 @@ namespace System.IO
                 return;
             }
 
+            // If overwrite is allowed then just call rename
+            if (overwrite)
+            {
+                if (Interop.libc.rename(sourceFullPath, destFullPath) < 0)
+                {
+                    Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+                    if (errorInfo.Error == Interop.Error.EXDEV) // rename fails across devices / mount points
+                    {
+                        CopyFile(sourceFullPath, destFullPath, overwrite);
+                    }
+                    else if (errorInfo.Error == Interop.Error.ENOENT && !Directory.Exists(Path.GetDirectoryName(destFullPath))) // The parent directory of destFile can't be found
+                    {
+                        // Windows distinguishes between whether the directory or the file isn't found,
+                        // and throws a different exception in these cases.  We attempt to approximate that
+                        // here; there is a race condition here, where something could change between
+                        // when the error occurs and our checks, but it's the best we can do, and the
+                        // worst case in such a race condition (which could occur if the file system is
+                        // being manipulated concurrently with these checks) is that we throw a
+                        // FileNotFoundException instead of DirectoryNotFoundexception.
+                        throw Interop.GetExceptionForIoErrno(errorInfo, destFullPath, isDirectory: true);
+                    }
+                    else
+                    {
+                        throw Interop.GetExceptionForIoErrno(errorInfo);
+                    }
+                }
+
+                // Rename or CopyFile complete
+                return;
+            }
+            
             if (Interop.Sys.Link(sourceFullPath, destFullPath) < 0)
             {
                 // If link fails, we can fall back to doing a full copy, but we'll only do so for

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -328,7 +328,7 @@ namespace System.IO
 
         public static void MoveDirectory(string sourceFullPath, string destFullPath)
         {
-            if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath, false))
+            if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath, overwrite: false))
             {
                 int errorCode = Marshal.GetLastWin32Error();
 

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -328,7 +328,7 @@ namespace System.IO
 
         public static void MoveDirectory(string sourceFullPath, string destFullPath)
         {
-            if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath))
+            if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath, false))
             {
                 int errorCode = Marshal.GetLastWin32Error();
 
@@ -343,9 +343,9 @@ namespace System.IO
             }
         }
 
-        public static void MoveFile(string sourceFullPath, string destFullPath)
+        public static void MoveFile(string sourceFullPath, string destFullPath, bool overwrite)
         {
-            if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath))
+            if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath, overwrite))
             {
                 throw Win32Marshal.GetExceptionForLastWin32Error();
             }

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -16,6 +16,25 @@ namespace System.IO.Tests
             File.Move(sourceFile, destFile);
         }
 
+        public virtual void Move(string sourceFile, string destFile, bool overwrite)
+        {
+            File.Move(sourceFile, destFile, overwrite);
+        }
+
+        private void MoveDestinationFileDoesNotExist(bool overwrite)
+        {
+            string srcPath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+
+            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
+            File.WriteAllBytes(srcPath, srcContents);
+
+            Move(srcPath, destPath, overwrite);
+
+            Assert.False(File.Exists(srcPath));
+            Assert.Equal(srcContents, File.ReadAllBytes(destPath));
+        }
+
         #endregion
 
         #region UniversalTests
@@ -91,6 +110,35 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void BasicMoveWithOverwriteFileExists()
+        {
+            string srcPath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+
+            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
+            File.WriteAllBytes(srcPath, srcContents);
+            File.WriteAllBytes(destPath, destContents);
+
+            Move(srcPath, destPath, true);
+
+            Assert.False(File.Exists(srcPath));
+            Assert.Equal(srcContents, File.ReadAllBytes(destPath));
+        }
+
+        [Fact]
+        public void BasicMoveWithOverwriteFileDoesNotExist()
+        {
+            MoveDestinationFileDoesNotExist(true);
+        }
+
+        [Fact]
+        public void BasicMoveWithoutOverwriteFileDoesNotExist()
+        {
+            MoveDestinationFileDoesNotExist(false);
+        }
+
+        [Fact]
         public void MoveNonEmptyFile()
         {
             FileInfo testFileSource = new FileInfo(GetTestFilePath());
@@ -126,6 +174,23 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => Move(testFileSource.FullName, testFileDest.FullName));
             Assert.True(File.Exists(testFileSource.FullName));
             Assert.True(File.Exists(testFileDest.FullName));
+        }
+
+        [Fact]
+        public void MoveOntoExistingFileNoOverwrite()
+        {
+            string srcPath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+
+            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
+            File.WriteAllBytes(srcPath, srcContents);
+            File.WriteAllBytes(destPath, destContents);
+
+            Assert.Throws<IOException>(() => Move(srcPath, destPath, false));
+            Assert.True(File.Exists(srcPath));
+            Assert.True(File.Exists(destPath));
+            Assert.Equal(destContents, File.ReadAllBytes(destPath));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -7,32 +7,13 @@ using System.Linq;
 
 namespace System.IO.Tests
 {
-    public class File_Move : FileSystemTest
+    public partial class File_Move : FileSystemTest
     {
         #region Utilities
 
         public virtual void Move(string sourceFile, string destFile)
         {
             File.Move(sourceFile, destFile);
-        }
-
-        public virtual void Move(string sourceFile, string destFile, bool overwrite)
-        {
-            File.Move(sourceFile, destFile, overwrite);
-        }
-
-        private void MoveDestinationFileDoesNotExist(bool overwrite)
-        {
-            string srcPath = GetTestFilePath();
-            string destPath = GetTestFilePath();
-
-            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
-            File.WriteAllBytes(srcPath, srcContents);
-
-            Move(srcPath, destPath, overwrite);
-
-            Assert.False(File.Exists(srcPath));
-            Assert.Equal(srcContents, File.ReadAllBytes(destPath));
         }
 
         #endregion
@@ -110,35 +91,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void BasicMoveWithOverwriteFileExists()
-        {
-            string srcPath = GetTestFilePath();
-            string destPath = GetTestFilePath();
-
-            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
-            byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
-            File.WriteAllBytes(srcPath, srcContents);
-            File.WriteAllBytes(destPath, destContents);
-
-            Move(srcPath, destPath, true);
-
-            Assert.False(File.Exists(srcPath));
-            Assert.Equal(srcContents, File.ReadAllBytes(destPath));
-        }
-
-        [Fact]
-        public void BasicMoveWithOverwriteFileDoesNotExist()
-        {
-            MoveDestinationFileDoesNotExist(true);
-        }
-
-        [Fact]
-        public void BasicMoveWithoutOverwriteFileDoesNotExist()
-        {
-            MoveDestinationFileDoesNotExist(false);
-        }
-
-        [Fact]
         public void MoveNonEmptyFile()
         {
             FileInfo testFileSource = new FileInfo(GetTestFilePath());
@@ -174,23 +126,6 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => Move(testFileSource.FullName, testFileDest.FullName));
             Assert.True(File.Exists(testFileSource.FullName));
             Assert.True(File.Exists(testFileDest.FullName));
-        }
-
-        [Fact]
-        public void MoveOntoExistingFileNoOverwrite()
-        {
-            string srcPath = GetTestFilePath();
-            string destPath = GetTestFilePath();
-
-            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
-            byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
-            File.WriteAllBytes(srcPath, srcContents);
-            File.WriteAllBytes(destPath, destContents);
-
-            Assert.Throws<IOException>(() => Move(srcPath, destPath, false));
-            Assert.True(File.Exists(srcPath));
-            Assert.True(File.Exists(destPath));
-            Assert.Equal(destContents, File.ReadAllBytes(destPath));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/File/Move.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.netcoreapp.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Linq;
+
+namespace System.IO.Tests
+{
+    public partial class File_Move
+    {
+        #region Utilities
+
+        public virtual void Move(string sourceFile, string destFile, bool overwrite)
+        {
+            File.Move(sourceFile, destFile, overwrite);
+        }
+
+        private void MoveDestinationFileDoesNotExist(bool overwrite)
+        {   
+            string srcPath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+
+            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
+            File.WriteAllBytes(srcPath, srcContents);
+
+            Move(srcPath, destPath, overwrite);
+
+            Assert.False(File.Exists(srcPath));
+            Assert.Equal(srcContents, File.ReadAllBytes(destPath));
+        }
+
+        #endregion
+
+        [Fact]
+        public void BasicMoveWithOverwriteFileExists()
+        {
+            string srcPath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+
+            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
+            File.WriteAllBytes(srcPath, srcContents);
+            File.WriteAllBytes(destPath, destContents);
+
+            Move(srcPath, destPath, true);
+
+            Assert.False(File.Exists(srcPath));
+            Assert.Equal(srcContents, File.ReadAllBytes(destPath));
+        }
+
+        [Fact]
+        public void BasicMoveWithOverwriteFileDoesNotExist()
+        {
+            MoveDestinationFileDoesNotExist(true);
+        }
+
+        [Fact]
+        public void BasicMoveWithoutOverwriteFileDoesNotExist()
+        {
+            MoveDestinationFileDoesNotExist(false);
+        }
+
+        [Fact]
+        public void MoveOntoExistingFileNoOverwrite()
+        {
+            string srcPath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+
+            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
+            File.WriteAllBytes(srcPath, srcContents);
+            File.WriteAllBytes(destPath, destContents);
+
+            Assert.Throws<IOException>(() => Move(srcPath, destPath, false));
+            Assert.True(File.Exists(srcPath));
+            Assert.True(File.Exists(destPath));
+            Assert.Equal(destContents, File.ReadAllBytes(destPath));
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileInfo/MoveTo.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/MoveTo.cs
@@ -6,16 +6,11 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    public class FileInfo_MoveTo : File_Move
+    public partial class FileInfo_MoveTo : File_Move
     {
         public override void Move(string sourceFile, string destFile)
         {
             new FileInfo(sourceFile).MoveTo(destFile);
-        }
-
-        public override void Move(string sourceFile, string destFile, bool overwrite)
-        {
-            new FileInfo(sourceFile).MoveTo(destFile, overwrite);
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/FileInfo/MoveTo.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/MoveTo.cs
@@ -13,6 +13,11 @@ namespace System.IO.Tests
             new FileInfo(sourceFile).MoveTo(destFile);
         }
 
+        public override void Move(string sourceFile, string destFile, bool overwrite)
+        {
+            new FileInfo(sourceFile).MoveTo(destFile, overwrite);
+        }
+
         [Fact]
         public override void NonExistentPath()
         {

--- a/src/System.IO.FileSystem/tests/FileInfo/MoveTo.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/MoveTo.netcoreapp.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class FileInfo_MoveTo
+    {
+        public override void Move(string sourceFile, string destFile, bool overwrite)
+        {
+            new FileInfo(sourceFile).MoveTo(destFile, overwrite);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -15,8 +15,7 @@
     <Compile Include="Base\StaticGetSetTimes.cs" />
     <Compile Include="Directory\EnumerableTests.cs" />
     <Compile Include="FileInfo\GetSetAttributesCommon.cs" />
-    <Compile Include="FileInfo\IsReadOnly.cs" />
-    <Compile Include="FileInfo\MoveTo.netcoreapp.cs" />
+    <Compile Include="FileInfo\IsReadOnly.cs" />    
     <Compile Include="FileInfo\Replace.cs" />
     <Compile Include="FileStream\Handle.cs" />
     <Compile Include="Directory\GetLogicalDrives.cs" />
@@ -26,7 +25,6 @@
     <Compile Include="FileSystemTest.cs" />
     <Compile Include="File\EncryptDecrypt.cs" />
     <Compile Include="File\GetSetAttributesCommon.cs" />
-    <Compile Include="File\Move.netcoreapp.cs" />
     <Compile Include="File\Replace.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
@@ -37,9 +35,11 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="File\AppendAsync.cs" />
+	<Compile Include="File\Move.netcoreapp.cs" />
     <Compile Include="File\ReadWriteAllLinesAsync.cs" />
     <Compile Include="File\ReadWriteAllBytesAsync.cs" />
     <Compile Include="File\ReadWriteAllTextAsync.cs" />
+	<Compile Include="FileInfo\MoveTo.netcoreapp.cs" />
     <Compile Include="FileStream\ReadWriteSpan.netcoreapp.cs" />
     <Compile Include="Enumeration\ConstructionTests.netcoreapp.cs" />
     <Compile Include="Enumeration\SpecialDirectoryTests.netcoreapp.cs" />

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -16,6 +16,7 @@
     <Compile Include="Directory\EnumerableTests.cs" />
     <Compile Include="FileInfo\GetSetAttributesCommon.cs" />
     <Compile Include="FileInfo\IsReadOnly.cs" />
+    <Compile Include="FileInfo\MoveTo.netcoreapp.cs" />
     <Compile Include="FileInfo\Replace.cs" />
     <Compile Include="FileStream\Handle.cs" />
     <Compile Include="Directory\GetLogicalDrives.cs" />
@@ -25,6 +26,7 @@
     <Compile Include="FileSystemTest.cs" />
     <Compile Include="File\EncryptDecrypt.cs" />
     <Compile Include="File\GetSetAttributesCommon.cs" />
+    <Compile Include="File\Move.netcoreapp.cs" />
     <Compile Include="File\Replace.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">


### PR DESCRIPTION
Issue #31511 
- Add overloads to `File.Move` and `FileInfo.MoveTo` that accept overwrite parameter
- Add unit tests
- ~Set `MOVEFILE_WRITE_THROUGH` per [here](https://github.com/dotnet/corefx/issues/31511#issuecomment-409686200)~ Moved to PR #33078 

