### PR TITLE
Test Lzcnt.LeadingZeroCount usage 

### DIFF
--- a/src/Common/src/CoreLib/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/Common/src/CoreLib/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers.Text
 {
@@ -68,6 +69,12 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(uint value)
         {
+            if (Lzcnt.IsSupported && IntPtr.Size == 8)
+            {
+                int right = 64 - (int)Lzcnt.LeadingZeroCount(value | 1);
+                return (right + 3) >> 2;
+            }
+
             int digits = 1;
             if (value >= 100000)
             {

--- a/src/Common/src/CoreLib/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/Common/src/CoreLib/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -69,12 +69,6 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(uint value)
         {
-            if (Lzcnt.IsSupported && IntPtr.Size == 8)
-            {
-                int right = 64 - (int)Lzcnt.LeadingZeroCount(value | 1);
-                return (right + 3) >> 2;
-            }
-
             int digits = 1;
             if (value >= 100000)
             {
@@ -110,8 +104,11 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountHexDigits(ulong value)
         {
-            // TODO: When x86 intrinsic support comes online, experiment with implementing this using lzcnt.
-            // return 16 - (int)((uint)Lzcnt.LeadingZeroCount(value | 1) >> 3);
+            if (Lzcnt.IsSupported && IntPtr.Size == 8)
+            {
+                int right = 64 - (int)Lzcnt.LeadingZeroCount(value | 1);
+                return (right + 3) >> 2;
+            }
 
             int digits = 1;
 

--- a/src/Common/src/CoreLib/System/Buffers/Utilities.cs
+++ b/src/Common/src/CoreLib/System/Buffers/Utilities.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
 {
@@ -13,6 +14,12 @@ namespace System.Buffers
         internal static int SelectBucketIndex(int bufferSize)
         {
             Debug.Assert(bufferSize >= 0);
+
+            if (Lzcnt.IsSupported)
+            {
+                uint bits = ((uint)bufferSize - 1) >> 4;
+                return 32 - (int)Lzcnt.LeadingZeroCount(bits);
+            }
 
             // bufferSize of 0 will underflow here, causing a huge
             // index which the caller will discard because it is not


### PR DESCRIPTION
*Don't merge*

this PR tests my changes in https://github.com/dotnet/coreclr/pull/19006 on CoreFX CI (whether I need to wrap it up with #if HAS_INTRINSICS or not)