### PR TITLE
Allow MemoryPool.Shared devirtualization

### DIFF
--- a/src/System.Memory/src/System/Buffers/MemoryPool.cs
+++ b/src/System.Memory/src/System/Buffers/MemoryPool.cs
@@ -9,7 +9,13 @@ namespace System.Buffers
     /// </summary>
     public abstract class MemoryPool<T> : IDisposable
     {
-        private static readonly MemoryPool<T> s_shared = new ArrayMemoryPool<T>();
+        // Store the shared ArrayMemoryPool in a field of its derived sealed type so the Jit can "see" the exact type
+        // when the Shared property is inlined which will allow it to devirtualize calls made on it.
+        //
+        // Roslyn proposal https://github.com/dotnet/roslyn/issues/30797 where field initalizer, 
+        // backing field and property could be combined via `{ get } = ` to support devirtualization 
+        // by having the auto-backing field be created as the derived type rather than the exposed type.
+        private static readonly ArrayMemoryPool<T> s_shared = new ArrayMemoryPool<T>();
 
         /// <summary>
         /// Returns a singleton instance of a MemoryPool based on arrays.


### PR DESCRIPTION
Store the shared `ArrayMemoryPool` in a field of its derived sealed type so the Jit can "see" the exact type when the `MemoryPool<T>.Shared` property is inlined which will allow it to devirtualize calls made on it.

Is a Roslyn proposal https://github.com/dotnet/roslyn/issues/30797 by @stephentoub where field initalizer, backing field and property could be combined via `{ get } = ` to support devirtualization by having the auto-backing field be created as the derived type rather than the exposed type.

Similar scenario to `ArrayPool<T>.Shared` https://github.com/dotnet/coreclr/pull/20637

@AndyAyersMS 
```csharp
var mem = MemoryPool<byte>.Shared.Rent();
```
might be a double devirt inline "opportunity" as `MemoryPool<T>.Shared.Rent` is

`MemoryPool<T>.Shared.Rent`
=> `ArrayMemoryPool<T>.Rent` 
=> `new ArrayMemoryPoolBuffer` 
=> `ArrayPool<T>.Shared.Rent`
=> `TlsOverPerCoreLockedStacksArrayPool<T>.Rent`

/cc @ahsonkhan @jaredpar 