### PR TITLE
Remove unneeded enumerator index

### DIFF
--- a/src/System.Console/src/System/ConsoleColor.cs
+++ b/src/System.Console/src/System/ConsoleColor.cs
@@ -9,21 +9,21 @@ namespace System
 
     public enum ConsoleColor
     {
-        Black = 0,
-        DarkBlue = 1,
-        DarkGreen = 2,
-        DarkCyan = 3,
-        DarkRed = 4,
-        DarkMagenta = 5,
-        DarkYellow = 6,
-        Gray = 7,
-        DarkGray = 8,
-        Blue = 9,
-        Green = 10,
-        Cyan = 11,
-        Red = 12,
-        Magenta = 13,
-        Yellow = 14,
-        White = 15
+        Black,
+        DarkBlue,
+        DarkGreen,
+        DarkCyan,
+        DarkRed,
+        DarkMagenta,
+        DarkYellow,
+        Gray,
+        DarkGray,
+        Blue,
+        Green,
+        Cyan,
+        Red,
+        Magenta,
+        Yellow,
+        White
     }
 }


### PR DESCRIPTION
The color enumerator doesn't need an index because it starts at 0 and enumerator indexes count from 0 by default.