### PR TITLE
Fix #33069 leak while creating processes simultaneously from two threads causes spurious deadlocks 

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -227,7 +227,7 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     // avoids problems where the parent process uses members of Process, like ProcessName, when the
     // Process is still the clone of this one. This is a best-effort attempt, so ignore any errors.
     // If the child fails to exec we use the pipe to pass the errno to the parent process.
-#ifdef HAVE_PIPE2
+#if HAVE_PIPE2
     pipe2(waitForChildToExecPipe, O_CLOEXEC);
 #else
     SystemNative_Pipe(waitForChildToExecPipe, PAL_O_CLOEXEC);

--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -282,6 +282,13 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     *stderrFd = stderrFds[READ_END_OF_PIPE];
 
 done:;
+#if !HAVE_PIPE2
+    if (haveProcessCreateLock)
+    {
+        pthread_mutex_unlock(&ProcessCreateLock);
+    }
+#endif
+
     int priorErrno = errno;
 
     // Regardless of success or failure, close the parent's copy of the child's end of
@@ -308,13 +315,6 @@ done:;
         }
         CloseIfOpen(waitForChildToExecPipe[READ_END_OF_PIPE]);
     }
-
-#if !HAVE_PIPE2
-    if (haveProcessCreateLock)
-    {
-        pthread_mutex_unlock(&ProcessCreateLock);
-    }
-#endif
 
     // If we failed, close everything else and give back error values in all out arguments.
     if (!success)

--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -208,7 +208,7 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
         success = false;
         goto done;
     }
-    haveProcessCreateLock = 1;
+    haveProcessCreateLock = true;
 #endif
 
     // Open pipes for any requests to redirect stdin/stdout/stderr and set the

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -349,7 +349,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)] // OSX doesn't support throwing on Process.Start
         public void TestStartOnUnixWithBadFormat()
         {
             string path = GetTestFilePath();
@@ -360,23 +359,6 @@ namespace System.Diagnostics.Tests
 
             Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
             Assert.NotEqual(0, e.NativeErrorCode);
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.OSX)] // OSX doesn't support throwing on Process.Start
-        public void TestStartOnOSXWithBadFormat()
-        {
-            string path = GetTestFilePath();
-            File.Create(path).Dispose();
-            int mode = Convert.ToInt32("744", 8);
-
-            Assert.Equal(0, chmod(path, mode)); // execute permissions
-
-            using (Process p = Process.Start(path))
-            {
-                p.WaitForExit();
-                Assert.NotEqual(0, p.ExitCode);
-            }
         }
 
         [Fact]


### PR DESCRIPTION
Fix issue #33069 by not trying to create processes in parallel when the APIs requried to do so safely are missing.

Somebody fixed this for Windows a long time ago. I only had to do the Unix case.