### PR TITLE
Move depProj.targets into corefx

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -89,6 +89,7 @@
     <ExcludeResourcesImport>true</ExcludeResourcesImport>
     <ExcludeVersioningImport>true</ExcludeVersioningImport>
     <ExcludeSigningImport>true</ExcludeSigningImport>
+    <ExcludeDepProjImport>true</ExcludeDepProjImport>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -133,6 +133,7 @@
     </BinPlaceConfiguration>
   </ItemGroup>
 
+  <Import Project="$(MSBuildThisFileDirectory)eng/depProj.targets" Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
   <Import Project="$(ToolsDir)/Build.Common.targets" Condition="Exists('$(ToolsDir)/Build.Common.targets')" />
   <Import Project="$(MSBuildThisFileDirectory)eng/Resources.targets" />
 

--- a/eng/depProj.targets
+++ b/eng/depProj.targets
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+***********************************************************************************************
+depProj.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+This file defines the steps in the standard build process specific for NuGet deployment
+projects. The remainder of the build process is defined in Microsoft.Common.targets, 
+which is imported by this file.
+
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MIT license.
+See the LICENSE file in the project root for more information.
+***********************************************************************************************
+-->
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Deployment project
+       Restores NuGet dependencies and copies them to the output directory.
+       
+       NuGetTargetMoniker - determined by the TargetFramework* and TargetPlatform* 
+                            properties of the project, can be overidden.
+       NuGetRuntimeIdentifier - defaults to <empty> (""), can be overidden.
+       NuGetDeploySourceItem - defaults to ReferenceCopyLocalPaths, can be overidden to
+                               specify Reference (for compile assets) or Analyzer(for
+                               analyzer assets)
+                         
+       For the appropriate behavior of P2P references the project should set the 
+       TargetName and TargetExt to match one of the files that will be copied
+       from the packages.
+  -->
+
+  <PropertyGroup>
+    <NuGetDeploySourceItem Condition="'$(NuGetDeploySourceItem)' == ''">ReferenceCopyLocalPaths</NuGetDeploySourceItem>
+
+    <!-- suppress the attempt to copy build output. -->
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+
+    <!-- Unless overridden, use no runtime identifier. This is transformed in packageresolve.targets. 
+         We specify "None" here to avoid being assigned the default runtime for projects which set CopyNuGetImplementations=true. -->
+    <NuGetRuntimeIdentifier Condition="'$(NuGetRuntimeIdentifier)' == ''">None</NuGetRuntimeIdentifier>
+
+    <!-- make sure we tell nuget targets to copy, even if output type would not by default -->
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
+  </PropertyGroup>
+
+  <Target Name="CoreCompile">
+
+    <Error Condition="'$(NuGetDeploySourceItem)' != 'ReferenceCopyLocalPaths' AND
+                      '$(NuGetDeploySourceItem)' != 'Reference' AND
+                      '$(NuGetDeploySourceItem)' != 'Analyzer'"
+           Text="Unexpected value for NuGetDeploySourceItem:'$(NuGetDeploySourceItem)'.  Expected ReferenceCopyLocalPaths, Reference, or Analyzer." />
+
+    <ItemGroup>
+      <!-- Don't set IntermediateAssembly since this is not produced -->
+      <IntermediateAssembly Remove="@(IntermediateAssembly)" />
+
+      <NuGetDeploy Include="@($(NuGetDeploySourceItem))"/>
+
+      <!-- filter to only items that came from packages -->
+      <!-- the following condition must be applied after the include because msbuild doesn't seem
+           to support property-defined-item-names in a metadata statement -->
+      <NuGetDeploy Remove="@(NuGetDeploy)" Condition="'%(NuGetDeploy.NuGetPackageId)' == ''" />
+
+      <!-- remove all existing items from NuGet packages we'll be defining these in our own item -->
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''"/>
+      <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' != ''"/>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' != ''"/>
+
+      <!-- add items defined by NuGetDeployItem property to Content so that we get clean behavior -->
+      <ContentWithTargetPath Include="@(NuGetDeploy)">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <TargetPath>%(NuGetDeploy.SubFolder)%(FileName)%(Extension)</TargetPath>
+      </ContentWithTargetPath>
+    </ItemGroup>
+
+    <Error Condition="'@(NuGetDeploy)' == ''" Text="Error no assets were resolved from NuGet packages." />
+    <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'$(TargetDir)%(FileName)%(Extension)')" />
+
+    <!-- Include marker files if an extension has been provided -->
+    <!-- internal builds use this to distinguish files which have already been signed -->
+    <Touch Condition="'$(DeployMarkerExtension)' != ''" Files="@(NuGetDeploy->'$(TargetDir)%(FileName)$(DeployMarkerExtension)')" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites"/>
+    </Touch>
+  </Target>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+
+  <!-- Required by Common.Targets but not used for depproj -->
+  <Target Name="CreateManifestResourceNames" />
+
+  <PropertyGroup>
+    <!-- don't use TargetingPackReference, we do our own filtering -->
+    <SkipFilterTargetingPackResolvedNugetPackages>true</SkipFilterTargetingPackResolvedNugetPackages>
+  </PropertyGroup>
+  
+  <!-- Support filtering to a subset of packages or files -->
+  <Target Name="FilterNugetPackages" 
+          AfterTargets="ResolveNuGetPackages"
+          Condition="'@(PackageToInclude)' != '' OR '@(PackageToExclude)' != '' OR '@(FileToInclude)' != '' OR '@(FileToExclude)' != ''">
+    <ItemGroup>
+      <_nuGetDeploy Include="@($(NuGetDeploySourceItem))"/>
+      <_nuGetDeployByFileName Include="@(_nuGetDeploy->'%(FileName)')">
+        <OriginalItemSpec>%(Identity)</OriginalItemSpec>
+      </_nuGetDeployByFileName>
+
+      <_nuGetDeployByFileNameToRemove Include="@(_nuGetDeployByFileName)" Exclude="@(FileToInclude)" Condition="'@(FileToInclude)' != ''" />
+      <_filteredNuGetDeployByFileName Include="@(_nuGetDeployByFileName)" Exclude="@(_nuGetDeployByFileNameToRemove);@(FileToExclude)" />
+      
+      <_nuGetDeployByPackageId Include="@(_filteredNuGetDeployByFileName->'%(NuGetPackageId)')" />
+
+      <_nuGetDeployByPackageIdToRemove Include="@(_nuGetDeployByPackageId)" Exclude="@(PackageToInclude)" Condition="'@(PackageToInclude)' != ''" />
+      <_filteredNuGetDeployByPackageId Include="@(_nuGetDeployByPackageId)" Exclude="@(_nuGetDeployByPackageIdToRemove);@(PackageToExclude)" />
+
+      <ReferenceCopyLocalPaths Condition="'$(NuGetDeploySourceItem)' == 'ReferenceCopyLocalPaths'" Remove="@(ReferenceCopyLocalPaths)" />
+      <Reference Condition="'$(NuGetDeploySourceItem)' == 'Reference'" Remove="@(Reference)" />
+      <Analyzer Condition="'$(NuGetDeploySourceItem)' == 'Analyzer'" Remove="@(Analyzer)" />
+    </ItemGroup>
+    
+    <CreateItem Include="@(_filteredNuGetDeployByPackageId->'%(OriginalItemSpec)')">
+      <Output TaskParameter="Include" ItemName="$(NuGetDeploySourceItem)" />
+    </CreateItem>
+  </Target>
+
+</Project>


### PR DESCRIPTION
This moves the depProj targets into CoreFx.

In a follow up PR I will remove the packageResolve.targets and clean up depProj.targets a bit.