### PR TITLE
disable sourcelink on FreeBSD

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -269,8 +269,8 @@
     <!-- Empty DebugType when building for netfx and in windows so that it is set to full or pdbonly later -->
     <DebugType Condition="'$(TargetsNetFx)' == 'true' AND '$(RunningOnUnix)' != 'true'"></DebugType>
 
-    <!-- Rhel 6 doesn't support the source control git package so disable SourceLink -->
-    <EnableSourceLink Condition="$(RuntimeOS.StartsWith('rhel.6'))">false</EnableSourceLink>
+    <!-- Rhel 6 and FreeBSD doesn't support the source control git package so disable SourceLink -->
+    <EnableSourceLink Condition="$(RuntimeOS.StartsWith('rhel.6')) OR '$(_runtimeOSFamily)' == 'FreeBSD'">false</EnableSourceLink>
   </PropertyGroup>
 
   <!-- Set up Default symbol and optimization for Configuration -->


### PR DESCRIPTION
build passes the error I'v seen before where it fails with unsupported platform. 