### PR TITLE
Move resolveContract into corefx

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -90,6 +90,7 @@
     <ExcludeVersioningImport>true</ExcludeVersioningImport>
     <ExcludeSigningImport>true</ExcludeSigningImport>
     <ExcludeDepProjImport>true</ExcludeDepProjImport>
+    <ExcludeResolveContractImport>true</ExcludeResolveContractImport>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -136,6 +136,7 @@
   <Import Project="$(MSBuildThisFileDirectory)eng/depProj.targets" Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
   <Import Project="$(ToolsDir)/Build.Common.targets" Condition="Exists('$(ToolsDir)/Build.Common.targets')" />
   <Import Project="$(MSBuildThisFileDirectory)eng/Resources.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)eng/resolveContract.targets" />
 
   <Import Project="$(ToolSetCommonDirectory)Tools.proj.nuget.g.targets" Condition="Exists('$(ToolSetCommonDirectory)Tools.proj.nuget.g.targets')" />
 

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup Condition="'$(IsReferenceAssembly)' != 'true' AND '$(IsTestProject)' != 'true'">
+    <ContractProject Condition="'$(ContractProject)' == ''">$(SourceDir)/$(MSBuildProjectName)/ref/$(MSBuildProjectName).csproj</ContractProject>
+    <HasMatchingContract Condition="'$(HasMatchingContract)' == '' and Exists('$(ContractProject)')">true</HasMatchingContract>
+    <ContractAssemblyPath Condition="'$(ContractAssemblyPath)' == ''">$(ContractOutputPath)/$(MSBuildProjectName).dll</ContractAssemblyPath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(HasMatchingContract)' == 'true'">
+    <ResolvedMatchingContract Condition="Exists('$(ContractAssemblyPath)')" Include="$(ContractAssemblyPath)" />
+    <!-- If the contract doesn't exist in the default contract output path add a project reference to the contract project to resolve -->
+    <ProjectReference Condition="'@(ResolvedMatchingContract)' == ''" Include="$(ContractProject)">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>ResolvedMatchingContract</OutputItemType>
+    </ProjectReference>
+  </ItemGroup>
+
+  <!-- intentionally empty since we no longer need a target -->
+  <Target Name="ResolveMatchingContract" />
+
+  <Target Name="VerifyMatchingContract" AfterTargets="ResolveReferences">
+    <Error Condition="'$(HasMatchingContract)' == 'true' and !Exists('%(ResolvedMatchingContract.Identity)')" Text="ResolveMatchingContract could not find a matching contract '%(ResolvedMatchingContract.Identity)' not found." />
+  </Target>
+</Project>

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup Condition="'$(IsReferenceAssembly)' != 'true' AND '$(IsTestProject)' != 'true'">
+  <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
     <ContractProject Condition="'$(ContractProject)' == ''">$(SourceDir)/$(MSBuildProjectName)/ref/$(MSBuildProjectName).csproj</ContractProject>
     <HasMatchingContract Condition="'$(HasMatchingContract)' == '' and Exists('$(ContractProject)')">true</HasMatchingContract>
     <ContractAssemblyPath Condition="'$(ContractAssemblyPath)' == ''">$(ContractOutputPath)/$(MSBuildProjectName).dll</ContractAssemblyPath>

--- a/src/System.Drawing.Design.Primitives/ref/System.Drawing.Design.Primitives.cs
+++ b/src/System.Drawing.Design.Primitives/ref/System.Drawing.Design.Primitives.cs
@@ -113,7 +113,6 @@ namespace System.Drawing.Design
         public System.ComponentModel.IComponent[] CreateComponents(System.ComponentModel.Design.IDesignerHost host, System.Collections.IDictionary defaultValues) { throw null; }
         protected virtual System.ComponentModel.IComponent[] CreateComponentsCore(System.ComponentModel.Design.IDesignerHost host) { throw null; }
         protected virtual System.ComponentModel.IComponent[] CreateComponentsCore(System.ComponentModel.Design.IDesignerHost host, System.Collections.IDictionary defaultValues) { throw null; }
-        protected virtual void Deserialize(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override bool Equals(object obj) { throw null; }
         protected virtual object FilterPropertyValue(string propertyName, object value) { throw null; }
         public override int GetHashCode() { throw null; }
@@ -123,7 +122,6 @@ namespace System.Drawing.Design
         public virtual void Lock() { }
         protected virtual void OnComponentsCreated(System.Drawing.Design.ToolboxComponentsCreatedEventArgs args) { }
         protected virtual void OnComponentsCreating(System.Drawing.Design.ToolboxComponentsCreatingEventArgs args) { }
-        protected virtual void Serialize(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
         protected void ValidatePropertyType(string propertyName, object value, System.Type expectedType, bool allowNull) { }


### PR DESCRIPTION
This moves resolveContract logic into corefx.  It also fixes API compat which
hasn't been running for some time due to ResolveMatchingContract property
being set too late to sequence the target.

Fixes #33151

We should be very careful about merging PRs with public API at the moment, as well as merging any PRs after this goes in if the results are stale.