### PR TITLE
Allow package relationships to be written multiple times

### DIFF
--- a/src/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
@@ -468,7 +468,8 @@ namespace System.IO.Packaging
         /// <param name="part">part to persist to</param>
         private void WriteRelationshipPart(PackagePart part)
         {
-            using (IgnoreFlushAndCloseStream s = new IgnoreFlushAndCloseStream(part.GetStream()))
+            using (Stream partStream = part.GetStream())
+            using (IgnoreFlushAndCloseStream s = new IgnoreFlushAndCloseStream(partStream))
             {
                 s.SetLength(0);    // truncate to resolve PS 954048
 

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -33,6 +33,37 @@ namespace System.IO.Packaging.Tests
         }
 
         [Fact]
+        public void WriteRelationsTwice()
+        {
+            FileInfo tempGuidFile = GetTempFileInfoWithExtension(".zip");
+
+            using (Package package = Package.Open(tempGuidFile.FullName, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            {
+                //first part
+                PackagePart packagePart = package.CreatePart(PackUriHelper.CreatePartUri(new Uri("MyFile1.xml", UriKind.Relative)),
+                                                             System.Net.Mime.MediaTypeNames.Application.Octet);
+                using (packagePart.GetStream(FileMode.Create))
+                {
+                    //do stuff with stream - not necessary to reproduce bug
+                }
+                package.CreateRelationship(PackUriHelper.CreatePartUri(new Uri("MyFile1.xml", UriKind.Relative)),
+                                           TargetMode.Internal, "http://my-fancy-relationship.com");
+
+                package.Flush();
+
+                //create second part after flush
+                packagePart = package.CreatePart(PackUriHelper.CreatePartUri(new Uri("MyFile2.xml", UriKind.Relative)),
+                                                 System.Net.Mime.MediaTypeNames.Application.Octet);
+                using (packagePart.GetStream(FileMode.Create))
+                {
+                    //do stuff with stream - not necessary to reproduce bug
+                }
+                package.CreateRelationship(PackUriHelper.CreatePartUri(new Uri("MyFile2.xml", UriKind.Relative)),
+                                           TargetMode.Internal, "http://my-fancy-relationship.com");
+            }
+        }
+
+        [Fact]
         public void T201_FileFormatException()
         {
             var e = new FileFormatException();


### PR DESCRIPTION
The package in .Net Core throws an exception when the package is closed after a relationship was added twice.

InternalRelationshipCollection.WriteRelationshipPart creates a part stream inside a IgnoreFlushAndCloseStream, but only the IgnoreFlushAndCloseStream is wrapped in a using. To fix this the part stream was also wrapped in a using.

Fixes #32296 