### PR TITLE
Disable restore for our projects under src directory

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -25,6 +25,9 @@
     Microsoft.WorkflowBuildExtensions.targets target that always runs in VS
     -->
     <GenerateCompiledExpressionsTempFilePathForEditing></GenerateCompiledExpressionsTempFilePathForEditing>
+
+    <!-- Disable restoring of package references in our projects -->
+    <RestoreProjectStyle>None</RestoreProjectStyle>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
We only want to be able to restore projects under
the external folder even if they might have PackageReferences
in their projects. To block this we are setting RestoreProjectStyle
to None.

@ViktorHofer this should fix the issue we are seeing building in VS.

PTAL @ericstj 