### PR TITLE
Add test to check for corrupted StringBuilder state after OutOfMemoryException

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -115,6 +115,7 @@ namespace System
         public static bool IsWindowsSubsystemForLinux { get { throw null; } }
         public static bool IsInAppContainer { get { throw null; } }
         public static bool IsWinRTSupported { get { throw null; } }
+        public static bool IsRobustUnderMemoryPressure { get { throw null; } }
         public static bool IsXmlDsigXsltTransformSupported { get { throw null; } }
         public static string LibcRelease { get { throw null; } }
         public static string LibcVersion { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -134,6 +134,12 @@ namespace System
         // Tracked in: https://github.com/dotnet/corert/issues/3643 in case we change our mind about this.
         public static bool IsInvokingStaticConstructorsSupported => !PlatformDetection.IsNetNative;
 
+        // Tests that allocate large arrays are constrained to run on Windows and MacOSX because it causes
+        // problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
+        // succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
+        // time the memory is accessed which triggers the full memory allocation.
+        public static bool IsRobustUnderMemoryPressure => PlatformDetection.IsWindows | PlatformDetection.IsOSX;
+
         // System.Security.Cryptography.Xml.XmlDsigXsltTransform.GetOutput() relies on XslCompiledTransform which relies
         // heavily on Reflection.Emit
         public static bool IsXmlDsigXsltTransformSupported => !PlatformDetection.IsUap;

--- a/src/System.Memory/tests/ParsersAndFormatters/Parser/ParserTests.2gbOverflow.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/Parser/ParserTests.2gbOverflow.cs
@@ -15,15 +15,8 @@ namespace System.Buffers.Text.Tests
     {
         private const int TwoGiB = int.MaxValue;
 
-        //
-        // NOTE: TestParser2GiBOverflow test is constrained to run on Windows and MacOSX because it causes
-        //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
-        //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
-        //       time the memory is accessed which triggers the full memory allocation.        
-        //
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public static void TestParser2GiBOverflow()
         {
             if (IntPtr.Size < 8)

--- a/src/System.Memory/tests/ReadOnlySpan/BinarySearch.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/BinarySearch.cs
@@ -105,13 +105,8 @@ namespace System.SpanTests
             Assert.Throws<ArgumentNullException>(() => new ReadOnlySpan<int>(new int[] { }).BinarySearch<int, IComparer<int>>(0, null));
         }
 
-        // NOTE: BinarySearch_MaxLength_NoOverflow test is constrained to run on Windows and MacOSX because it causes
-        //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
-        //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
-        //       time the memory is accessed which triggers the full memory allocation.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public unsafe static void BinarySearch_MaxLength_NoOverflow()
         {
             if (sizeof(IntPtr) == sizeof(long))

--- a/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
@@ -129,9 +129,8 @@ namespace System.SpanTests
         // test the two size selection paths in CoptyTo method - memory size that is multiple of 4GB or,
         // a multiple of 4GB + some more size.
         [ActiveIssue(25254)]
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         [InlineData(4L * 1024L * 1024L * 1024L)]
         [InlineData((4L * 1024L * 1024L * 1024L) + 256)]
         public static void CopyToLargeSizeTest(long bufferSize)

--- a/src/System.Memory/tests/ReadOnlySpan/Overflow.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/Overflow.cs
@@ -10,15 +10,8 @@ namespace System.SpanTests
 {
     public static partial class ReadOnlySpanTests
     {
-        // NOTE: IndexOverflow test is constrained to run on Windows and MacOSX because it
-        //       causes problems on Linux due to the way deferred memory allocation works.
-        //       On Linux, the allocation can succeed even if there is not enough memory
-        //       but then the test may get killed by the OOM killer at the time the memory
-        //       is accessed which triggers the full memory allocation.
-
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public static void IndexOverflow()
         {
             // If this test is run in a 32-bit process, the 3GB allocation will fail.

--- a/src/System.Memory/tests/Span/Clear.cs
+++ b/src/System.Memory/tests/Span/Clear.cs
@@ -252,13 +252,8 @@ namespace System.SpanTests
             Assert.Equal<TestValueTypeWithReference>(expected, actual);
         }
 
-        // NOTE: ClearLongerThanUintMaxValueBytes test is constrained to run on Windows and MacOSX because it causes
-        //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
-        //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
-        //       time the memory is accessed which triggers the full memory allocation.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         unsafe static void ClearLongerThanUintMaxValueBytes()
         {
             if (sizeof(IntPtr) == sizeof(long))

--- a/src/System.Memory/tests/Span/CopyTo.cs
+++ b/src/System.Memory/tests/Span/CopyTo.cs
@@ -198,9 +198,8 @@ namespace System.SpanTests
         // test the two size selection paths in CoptyTo method - memory size that is multiple of 4GB or,
         // a multiple of 4GB + some more size.
         [ActiveIssue(25254)]
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         [InlineData(4L * 1024L * 1024L * 1024L)]
         [InlineData((4L * 1024L * 1024L * 1024L) + 256)]
         public static void CopyToLargeSizeTest(long bufferSize)

--- a/src/System.Memory/tests/Span/Overflow.cs
+++ b/src/System.Memory/tests/Span/Overflow.cs
@@ -10,15 +10,8 @@ namespace System.SpanTests
 {
     public static partial class SpanTests
     {
-        // NOTE: IndexOverflow test is constrained to run on Windows and MacOSX because it
-        //       causes problems on Linux due to the way deferred memory allocation works.
-        //       On Linux, the allocation can succeed even if there is not enough memory
-        //       but then the test may get killed by the OOM killer at the time the memory
-        //       is accessed which triggers the full memory allocation.
-
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public static void IndexOverflow()
         {
             // If this test is run in a 32-bit process, the 3GB allocation will fail.
@@ -63,15 +56,8 @@ namespace System.SpanTests
             }
         }
 
-        // NOTE: SliceStartInt32Overflow test is constrained to run on Windows and MacOSX because it
-        //       causes problems on Linux due to the way deferred memory allocation works.
-        //       On Linux, the allocation can succeed even if there is not enough memory
-        //       but then the test may get killed by the OOM killer at the time the memory
-        //       is accessed which triggers the full memory allocation.
-
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop()]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public static void SliceStartInt32Overflow()
         {
             // If this test is run in a 32-bit process, the 3GB allocation will fail.
@@ -107,15 +93,8 @@ namespace System.SpanTests
             }
         }
 
-        // NOTE: ReadOnlySliceStartInt32Overflow test is constrained to run on Windows and MacOSX because it
-        //       causes problems on Linux due to the way deferred memory allocation works.
-        //       On Linux, the allocation can succeed even if there is not enough memory
-        //       but then the test may get killed by the OOM killer at the time the memory
-        //       is accessed which triggers the full memory allocation.
-
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
         [OuterLoop()]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public static void ReadOnlySliceStartInt32Overflow()
         {
             // If this test is run in a 32-bit process, the 3GB allocation will fail.

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -486,12 +486,14 @@ namespace System.Text.Tests
         [OuterLoop]
         public static void Replace_OutOfMemory_DoesNotCorruptState()
         {
+            var random = new Random();
+
             var sb = new StringBuilder();
-            sb.Append('a', 1_000_000);
+            sb.Append('a', 100_000 + random.Next(10_000_000));
 
             try
             {
-                sb.Replace("a", new string('b', 1_000_000));
+                sb.Replace("a", new string('b', 100_000 + random.Next(10_000_000)));
             }
             catch (OutOfMemoryException)
             {

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -418,7 +418,6 @@ namespace System.Text.Tests
             }
         }
 
-<<<<<<< HEAD
         [Fact]
         public static void EqualsIgnoresCapacity()
         {
@@ -465,6 +464,25 @@ namespace System.Text.Tests
             try
             {
                 for(;;) sb.Append("xx");
+            }
+            catch (OutOfMemoryException)
+            {
+            }
+
+            Assert.True(sb.Length <= sb.Capacity);
+            Assert.True(sb.Capacity <= sb.MaxCapacity);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
+        [OuterLoop]
+        public static void Replace_OutOfMemory_DoesNotCorruptState()
+        {
+            var sb = new StringBuilder();
+            sb.Append('a', 1_000_000);
+
+            try
+            {
+                sb.Replace("a", new string('b', 1_000_000));
             }
             catch (OutOfMemoryException)
             {

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -464,8 +464,7 @@ namespace System.Text.Tests
             {
             }
 
-            Assert.True(sb.Length <= sb.Capacity);
-            Assert.True(sb.Capacity <= sb.MaxCapacity);
+            Assert.InRange(sb.Capacity, sb.Length, sb.MaxCapacity);
 
             try
             {
@@ -478,8 +477,7 @@ namespace System.Text.Tests
             {
             }
 
-            Assert.True(sb.Length <= sb.Capacity);
-            Assert.True(sb.Capacity <= sb.MaxCapacity);
+            Assert.InRange(sb.Capacity, sb.Length, sb.MaxCapacity);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
@@ -499,8 +497,7 @@ namespace System.Text.Tests
             {
             }
 
-            Assert.True(sb.Length <= sb.Capacity);
-            Assert.True(sb.Capacity <= sb.MaxCapacity);
+            Assert.InRange(sb.Capacity, sb.Length, sb.MaxCapacity);
         }
     }
 }

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -418,6 +418,7 @@ namespace System.Text.Tests
             }
         }
 
+<<<<<<< HEAD
         [Fact]
         public static void EqualsIgnoresCapacity()
         {
@@ -444,6 +445,33 @@ namespace System.Text.Tests
             sb2.Append("12345");
 
             Assert.True(sb1.Equals(sb2));
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRobustUnderMemoryPressure))]
+        [OuterLoop]
+        public static void Append_OutOfMemory_DoesNotCorruptState()
+        {
+            var sb = new StringBuilder();
+
+            string longString = new string('a', 1000000);
+            try
+            {
+                for(;;) sb.Append(longString);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                for(;;) sb.Append("xx");
+            }
+            catch (OutOfMemoryException)
+            {
+            }
+
+            Assert.True(sb.Length <= sb.Capacity);
+            Assert.True(sb.Capacity <= sb.MaxCapacity);
         }
     }
 }

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -452,20 +452,29 @@ namespace System.Text.Tests
         {
             var sb = new StringBuilder();
 
-            string longString = new string('a', 1000000);
+            string longString = new string('a', 1_000_000 + new Random().Next(1_000_000));
             try
             {
                 for(;;) sb.Append(longString);
             }
-            catch
+            catch (OutOfMemoryException)
             {
             }
+            catch (ArgumentException)
+            {
+            }
+
+            Assert.True(sb.Length <= sb.Capacity);
+            Assert.True(sb.Capacity <= sb.MaxCapacity);
 
             try
             {
                 for(;;) sb.Append("xx");
             }
             catch (OutOfMemoryException)
+            {
+            }
+            catch (ArgumentException)
             {
             }
 


### PR DESCRIPTION
Regression test for dotnet/coreclr#20718 and dotnet/coreclr#20719