### PR TITLE
Fix some warnings, which are possibly being treated as errors in some builds.

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1058,7 +1058,7 @@ int32_t SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t multicastOp
 }
 
 #if defined(__APPLE__) && __APPLE__
-static int32_t GetMaxLingerTime()
+static int32_t GetMaxLingerTime(void)
 {
     static volatile int32_t MaxLingerTime = -1;
     c_static_assert(sizeof_member(xsocket, so_linger) == 2);
@@ -1084,7 +1084,7 @@ static int32_t GetMaxLingerTime()
     return maxLingerTime;
 }
 #else
-static int32_t GetMaxLingerTime()
+static int32_t GetMaxLingerTime(void)
 {
     // On other platforms, the maximum linger time is locked to the smaller of
     // 65535 (the maximum time for winsock) and the maximum signed value that

--- a/src/Native/Unix/System.Native/pal_tcpstate.c
+++ b/src/Native/Unix/System.Native/pal_tcpstate.c
@@ -11,7 +11,7 @@
 #elif HAVE_TCP_H_TCPSTATE_ENUM
 #include <netinet/tcp.h>
 #else
-#warning System doesn't have TCP states defined in either tcp.h or tcp_fsm.h; falling back to always returning unknown.
+#warning System does not have TCP states defined in either tcp.h or tcp_fsm.h; falling back to always returning unknown.
 #endif
 
 int32_t SystemNative_MapTcpState(int32_t tcpState)


### PR DESCRIPTION
Specifics:

1.

In C: void f(void) and void f() are not the same thing.
They are the same in C++.
Usually void f(void) is what you mean -- take no parameters.
void f() means take any parameters -- i.e. unprototyped K&R code.
The C++ equivalent of that is void f(...), which is not valid C,
as C requires at least some fixed parameters (if you go so
far as to declare the ... part)

2.

`#warning foo doesn't bar`

warns about the unbalanced quote.
Just avoid the informality of contractions and say "does not".

The build with related warnings is:
    https://jenkins.mono-project.com/job/test-mono-pull-request-i386/20087/parsed_console/log.html

and it has other warnings, and unspecified warnings are being treated as errors.
So at least fix what is trivial.

The other warnings are related to duplicate typedefs, or their suppresson.