### PR TITLE
Catch exception thrown by HttpConnection constructor and close connection

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
@@ -116,7 +116,16 @@ namespace System.Net
                 return;
             }
 
-            HttpConnection conn = new HttpConnection(accepted, epl, epl._secure, epl._cert);
+            HttpConnection conn;
+            try
+            {
+                conn = new HttpConnection(accepted, epl, epl._secure, epl._cert);
+            }
+            catch
+            {
+                accepted.Close();
+                return;
+            }
             lock (epl._unregisteredConnections)
             {
                 epl._unregisteredConnections[conn] = conn;

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
@@ -126,6 +126,7 @@ namespace System.Net
                 accepted.Close();
                 return;
             }
+
             lock (epl._unregisteredConnections)
             {
                 epl._unregisteredConnections[conn] = conn;


### PR DESCRIPTION
It's a port from Mono where the issue is fixed (https://github.com/mono/mono/blob/master/mcs/class/System/System.Net/EndPointListener.cs#L117).

Fixes #32280