### PR TITLE
Update corefx to move outputs under artifacts directory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,19 +51,13 @@
 
   <!-- Common repo directories -->
   <PropertyGroup>
+    <!-- Properties to remove with buildtools removal -->
     <ProjectDir>$(RepoRoot)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
+    <BinDir>$(ProjectDir)artifacts\bin\</BinDir>
 
-    <!-- This name is used to create a GIT repository URL https://github.com/dotnet/$(GitHubRepositoryName) used to find source code for debugging -->
-    <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">corefx</GitHubRepositoryName>
-
-    <!-- Output directories -->
-    <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
-    <RootIntermediateOutputPath>$(MSBuildThisFileDirectory)bin/obj/</RootIntermediateOutputPath>
-
+    <!-- CoreFx sepcific paths -->
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests/</TestWorkingDir>
-    <PackageOutputRoot Condition="'$(PackageOutputRoot)'=='' and '$(NonShippingPackage)' == 'true'">$(BinDir)packages_noship/</PackageOutputRoot>
-    <PackageOutputRoot Condition="'$(PackageOutputRoot)'==''">$(BinDir)packages/</PackageOutputRoot>
 
     <!-- Input Directories -->
     <PackagesDir>$(DotNetRestorePackagesPath)</PackagesDir>
@@ -187,7 +181,7 @@
     <BuildConfigurations Condition="'$(MSBuildProjectExtension)' == '.pkgproj' AND '$(BuildConfigurations)' == ''">package</BuildConfigurations>
 
     <!-- Need to try and keep the same logic as the native builds as we need this for packaging -->
-    <NativeBinDir>$(BinDir)$(OSGroup).$(ArchGroup).$(ConfigurationGroup)/native</NativeBinDir>
+    <NativeBinDir>$(BinDir)native/$(BuildConfiguration)</NativeBinDir>
   </PropertyGroup>
 
   <Import Project="$(BuildConfigurationImportFile)" Condition="Exists('$(BuildConfigurationImportFile)')" />
@@ -340,6 +334,9 @@
 
     <!-- We decided to keep this disabled by default to see some history of way have a look at https://github.com/dotnet/corefx/issues/3140 -->
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
+
+    <!-- Suppress preview message as we are usually using preview SDK versions. -->
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <!-- Set up some common paths -->
@@ -356,18 +353,14 @@
     -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
-    <!-- Suppress preview message as we are usually using preview SDK versions. -->
-    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-
+    <!--
+      OSPlatformConfig and TargetOutputRelPath are used by the test archiving targets in
+      corefx and in our publish test targets (https://github.com/dotnet/buildtools/blob/17f28536524248603108c56a16b5b16dcb5a87ff/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets#L54)
+      Once we refactor our test targets we should try to break this tight coupling so it is only
+      on the corefx side as these are specific to corefx.
+    -->
     <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>
     <TargetOutputRelPath Condition="'$(TargetGroup)'!=''">$(TargetGroup)/</TargetOutputRelPath>
-
-    <BaseOutputPath>$(BinDir)</BaseOutputPath>
-
-    <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
-
-    <BaseIntermediateOutputPath>$(RootIntermediateOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(TargetOutputRelPath)</IntermediateOutputPath>
 
     <RuntimePath Condition="'$(RuntimePath)' == ''">$(BinDir)runtime/$(BuildConfiguration)/</RuntimePath>
     <ShimsTargetRuntimeRoot>$(BinDir)shimsTargetRuntime/</ShimsTargetRuntimeRoot>
@@ -414,8 +407,6 @@
     <!-- System.Private.* comes from test ilc, so the symbol packages for those versions will no exist, this is to avoid warnings -->
     <DownloadCoreCLRSymbols Condition="'$(UseDotNetNativeToolchain)' == 'true' OR '$(BuildAllConfigurations)' == 'true' OR '$(DotNetBuildFromSource)' == 'true'">false</DownloadCoreCLRSymbols>
 
-    <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
-    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(ConfigurationGroup)/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
 
     <!-- interop is not available on NETStandard1.0 -->

--- a/build.proj
+++ b/build.proj
@@ -72,9 +72,9 @@
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
 
   <Target Name="Clean">
-    <RemoveDir Directories="$(BinDir)" />
-    <!-- Temporarily outside BinDir -->
-    <RemoveDir Directories="$(PackageInstallPath)" />
+    <RemoveDir Directories="$(ArtifactsObjDir)" />
+    <RemoveDir Directories="$(ArtifactsBinDir)" />
+    <RemoveDir Directories="$(ArtifactsPackagesDir)" />
   </Target>
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/cross/arm32_ci_script.sh
+++ b/cross/arm32_ci_script.sh
@@ -240,7 +240,7 @@ function cross_build_corefx_with_docker {
 
     __buildCmd="./build.sh /p:ArchGroup=$__buildArch -$__buildConfig /p:RuntimeOS=$__runtimeOS $__portableLinux $__extraCmd"
     $__dockerCmd $__buildCmd
-    sudo chown -R $(id -u -n) ./bin
+    sudo chown -R $(id -u -n) ./artifacts
 }
 
 #Define script variables

--- a/cross/x86_ci_script.sh
+++ b/cross/x86_ci_script.sh
@@ -34,7 +34,7 @@ function cross_build_native_with_docker {
     __buildNativeCmd="./src/Native/build-native.sh x86 $__buildConfig cross"
 
     $__dockerCmd $__buildNativeCmd
-    sudo chown -R $(id -u -n) ./bin
+    sudo chown -R $(id -u -n) ./artifacts
 }
 
 __buildConfig=

--- a/eng/ReferenceAssemblies.props
+++ b/eng/ReferenceAssemblies.props
@@ -4,19 +4,19 @@
     <IsReferenceAssembly Condition="'$(IsReferenceAssembly)'=='' AND ($(MSBuildProjectFullPath.Contains('\ref\')) OR $(MSBuildProjectFullPath.Contains('/ref/')))">true</IsReferenceAssembly>
 
     <!-- Create a common root output directory for all reference assemblies -->
-    <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$(BaseOutputPath)ref/</ReferenceAssemblyOutputPath>
+    <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$(ArtifactsBinDir)ref/</ReferenceAssemblyOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
-    <OutputPath>$(ReferenceAssemblyOutputPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</OutputPath>
-    <IntermediateOutputPath>$(RootIntermediateOutputPath)ref/$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
+    <OutputPath>$(ReferenceAssemblyOutputPath)$(MSBuildProjectName)/$(Configuration)</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)ref/$(MSBuildProjectName)/$(Configuration)</IntermediateOutputPath>
 
     <!-- disable warnings about unused fields -->
     <NoWarn>$(NoWarn);0169;0649</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsReferenceAssembly)'=='true'">
-    <!-- All reference assemblies should have the 0x70 flag which prevents them from loading 
+    <!-- All reference assemblies should have the 0x70 flag which prevents them from loading
          and the ReferenceAssemblyAttribute. -->
     <AssemblyInfoLines Include="[assembly:System.Runtime.CompilerServices.ReferenceAssembly]" />
     <AssemblyInfoLines Include="[assembly:System.Reflection.AssemblyFlags((System.Reflection.AssemblyNameFlags)0x70)]" />

--- a/external/Directory.Build.targets
+++ b/external/Directory.Build.targets
@@ -4,6 +4,12 @@
   <PropertyGroup>
     <RestorePackages>true</RestorePackages>
     <PrereleaseResolveNuGetPackages>true</PrereleaseResolveNuGetPackages>
+
+    <!--
+       We need to pass Configuration to our independent restore step to ensure the output paths are constructed the same.
+       This can go away once we move away from our own custom exec call to restore.
+    -->
+    <AdditionalRestoreArgs Condition="'$(Configuration)' != ''">$(AdditionalRestoreArgs) /p:Configuration=$(Configuration)</AdditionalRestoreArgs>
   </PropertyGroup>
 
   <!-- Override build and GetTargetPath to return all items deployed -->

--- a/netci.groovy
+++ b/netci.groovy
@@ -71,7 +71,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
         // Set the machine affinity to windows machines
         Utilities.setMachineAffinity(newJob, 'Windows_NT', 'latest-or-auto')
         // Publish reports
-        Utilities.addHtmlPublisher(newJob, 'bin/tests/coverage', 'Code Coverage Report', 'index.htm')
+        Utilities.addHtmlPublisher(newJob, 'artifacts/bin/tests/coverage', 'Code Coverage Report', 'index.htm')
         // Archive results.
         Utilities.addArchival(newJob, '**/coverage/*,msbuild.log')
         // Timeout. Code coverage runs take longer, so we set the timeout to be longer.
@@ -137,23 +137,23 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                     steps {
                         if (osName == 'Windows 7' || osName == 'Windows_NT') {
                             batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -ci -includetests -framework:${targetGroup} -${configurationGroup} -outerloop ")
-                            batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin\\runtime\\${targetGroup}-${osGroup}-${configurationGroup}-${archGroup}")
+                            batchFile("C:\\Packer\\Packer.exe .\\artifacts\\bin\\build.pack .\\artifacts\\bin\\runtime\\${targetGroup}-${osGroup}-${configurationGroup}-${archGroup}")
                         }
                         else if (osName == 'OSX10.12') {
                             shell("HOME=\$WORKSPACE/tempHome ./build.sh --ci -includetests -${configurationGroup.toLowerCase()} -outerloop")
-                            shell("tar -czf bin/build.tar.gz --directory=\"bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-${archGroup}\" .")
+                            shell("tar -czf artifacts/bin/build.tar.gz --directory=\"artifacts/bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-${archGroup}\" .")
                         }
                         else if (osName == 'CentOS7.1') {
                             // On Centos7.1, the cmake toolset is currently installed in /usr/local/bin (it was built manually).  When
                             // running sudo, that will be typically eliminated from the PATH, so let's add it back in.
                             shell("sudo PATH=\$PATH:/usr/local/bin HOME=\$WORKSPACE/tempHome ./build.sh --ci -includetests -${configurationGroup.toLowerCase()} -outerloop")
-                            shell("sudo tar -czf bin/build.tar.gz --directory=\"bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-${archGroup}\" .")
+                            shell("sudo tar -czf artifacts/bin/build.tar.gz --directory=\"artifacts/bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-${archGroup}\" .")
                         }
                         else {
                             def portableLinux = (osName == 'PortableLinux') ? '-portable' : ''
                             shell("sudo HOME=\$WORKSPACE/tempHome ./build.sh --ci -includetests -${configurationGroup.toLowerCase()} ${portableLinux} -outerloop")
                             // Tar up the appropriate bits.
-                            shell("sudo tar -czf bin/build.tar.gz --directory=\"bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-${archGroup}\" .")
+                            shell("sudo tar -czf artifacts/bin/build.tar.gz --directory=\"artifacts/bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-${archGroup}\" .")
 
                         }
                     }
@@ -172,14 +172,14 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                 // Set up standard options.
                 Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
                 // Add the unit test results
-                Utilities.addXUnitDotNETResults(newJob, 'bin/**/testResults.xml')
+                Utilities.addXUnitDotNETResults(newJob, 'artifacts/bin/**/testResults.xml')
                 def archiveContents = "msbuild.log"
                 if (osName.contains('Windows')) {
                     // Packer.exe is a .NET Framework application. When we can use it from the tool-runtime, we can archive the ".pack" file here.
-                    archiveContents += ",bin/build.pack"
+                    archiveContents += ",artifacts/bin/build.pack"
                 }
                 else {
-                    archiveContents += ",bin/build.tar.gz"
+                    archiveContents += ",artifacts/bin/build.tar.gz"
                 }
                 // Add archival for the built data.
                 Utilities.addArchival(newJob, archiveContents, '', doNotFailIfNothingArchived=true, archiveOnlyIfSuccessful=false)
@@ -227,7 +227,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                     steps {
                         if (osName == 'Windows 7' || osName == 'Windows_NT') {
                             batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -ci -includetests -${configurationGroup} -os:${osGroup} /p:ArchGroup:${archGroup} -framework:${targetGroup}")
-                            batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
+                            batchFile("C:\\Packer\\Packer.exe .\\artifacts\\bin\\build.pack .\\artifacts\\bin")
                         }
                         else {
                             // Use Server GC for Ubuntu/OSX Debug PR build & test
@@ -235,7 +235,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                             def portableLinux = (osName == 'PortableLinux') ? '-portable' : ''
                             shell("HOME=\$WORKSPACE/tempHome ./build.sh --ci -includetests -${configurationGroup.toLowerCase()} -framework:${targetGroup} -os:${osGroup} /p:ArchGroup:${archGroup} ${useServerGC}")
                             // Tar up the appropriate bits.
-                            shell("tar -czf bin/build.tar.gz --directory=\"bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-x64\" .")
+                            shell("tar -czf artifacts/bin/build.tar.gz --directory=\"artifacts/bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-x64\" .")
                         }
                     }
                 }
@@ -245,14 +245,14 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                 // Set up standard options.
                 Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
                 // Add the unit test results
-                Utilities.addXUnitDotNETResults(newJob, 'bin/**/testResults.xml')
+                Utilities.addXUnitDotNETResults(newJob, 'artifacts/bin/**/testResults.xml')
                 def archiveContents = "msbuild.log"
                 if (osName.contains('Windows')) {
                     // Packer.exe is a .NET Framework application. When we can use it from the tool-runtime, we can archive the ".pack" file here.
-                    archiveContents += ",bin/build.pack"
+                    archiveContents += ",artifacts/bin/build.pack"
                 }
                 else {
-                    archiveContents += ",bin/build.tar.gz"
+                    archiveContents += ",artifacts/bin/build.tar.gz"
                 }
                 // Add archival for the built data.
                 Utilities.addArchival(newJob, archiveContents, '', doNotFailIfNothingArchived=true, archiveOnlyIfSuccessful=false)
@@ -297,7 +297,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                         shell(script)
 
                         // Tar up the appropriate bits.
-                        shell("tar -czf bin/build.tar.gz --directory=\"bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-${abi}\" .")
+                        shell("tar -czf artifacts/bin/build.tar.gz --directory=\"artifacts/bin/runtime/${targetGroup}-${osGroup}-${configurationGroup}-${abi}\" .")
                     }
                 }
 
@@ -309,7 +309,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                 Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
 
                 // Add archival for the built binaries
-                def archiveContents = "bin/build.tar.gz"
+                def archiveContents = "artifacts/bin/build.tar.gz"
                 Utilities.addArchival(newJob, archiveContents)
 
                 newJob.with {
@@ -355,7 +355,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
             shell(script)
 
             // Tar up the appropriate bits
-            shell("tar -czf bin/build.tar.gz --directory=\"bin/Linux.${archGroup}.${configurationGroup}/native\" .")
+            shell("tar -czf artifacts/bin/build.tar.gz --directory=\"artifacts/bin/Linux.${archGroup}.${configurationGroup}/native\" .")
         }
     }
 
@@ -367,7 +367,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
     Utilities.standardJobSetup(newJob, project, false, "*/${branch}")
 
     // Add archival for the built binaries
-    def archiveContents = "bin/build.tar.gz"
+    def archiveContents = "artifacts/bin/build.tar.gz"
     Utilities.addArchival(newJob, archiveContents)
 
     // Set a push trigger as a daily work

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -17,7 +17,7 @@
     <LibFileTargetPath Condition="'$(LibFileTargetPath)' == '' AND '$(PackageTargetRuntime)' != ''">runtimes/$(PackageTargetRuntime)/lib/$(TargetFramework)</LibFileTargetPath>
 
     <NativeFileTargetPath Condition="'$(NativeFileTargetPath)' == '' AND '$(PackageTargetRuntime)' != ''">runtimes/$(PackageTargetRuntime)/native</NativeFileTargetPath>
-    <NativeBinDir Condition="'$(PackageTargetRuntimeSuffix)' == 'aot'">$(NativeBinDir)_aot</NativeBinDir>
+    <NativeBinDir Condition="'$(PackageTargetRuntimeSuffix)' == 'aot'">$(NativeBinDir)-aot</NativeBinDir>
   </PropertyGroup>
 
   <!-- Bring in ref content from binplaced ref props -->

--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_INSTALL_PREFIX $ENV{__CMakeBinDir})
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
-set(VERSION_FILE_PATH "${CMAKE_BINARY_DIR}/../../../../artifacts/obj/_version.c")
+set(VERSION_FILE_PATH "${CMAKE_BINARY_DIR}/../../_version.c")
 
 # We mark the function which needs exporting with DLLEXPORT
 add_compile_options(-fvisibility=hidden)

--- a/src/Native/Windows/clrcompression/CMakeLists.txt
+++ b/src/Native/Windows/clrcompression/CMakeLists.txt
@@ -81,9 +81,6 @@ if ($ENV{__VSVersion} STREQUAL vs2015)
     add_definitions(-DHAVE_VSNPRINTF)
 endif ()
 
-# Include the dir that contains the generated _version.h
-include_directories("${CMAKE_BINARY_DIR}/../../../../artifacts/obj")
-
 #Include Brotli include files
 include_directories("../../AnyOS/brotli/include")
 

--- a/src/Native/build-native.proj
+++ b/src/Native/build-native.proj
@@ -5,7 +5,7 @@
   <Target Name="Build" DependsOnTargets="GenerateNativeVersionFile;BuildNativeUnix;BuildNativeWindows" />
 
   <PropertyGroup>
-    <_BuildNativeArgs>$(ArchGroup) $(ConfigurationGroup) $(OSGroup)</_BuildNativeArgs>
+    <_BuildNativeArgs>$(ArchGroup) $(ConfigurationGroup) $(OSGroup) outconfig $(Configuration)</_BuildNativeArgs>
   </PropertyGroup>
 
   <Target Name="BuildNativeUnix"

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -109,7 +109,7 @@ prepare_native_build()
     fi
 
     # Generate version.c if specified, else have an empty one.
-    __versionSourceFile=$__rootRepo/artifacts/obj/_version.c
+    __versionSourceFile=$__artifactsDir/obj/_version.c
     if [ ! -e "${__versionSourceFile}" ]; then
         __versionSourceLine="static char sccsid[] __attribute__((used)) = \"@(#)No version information produced\";"
         echo "${__versionSourceLine}" > ${__versionSourceFile}
@@ -148,7 +148,7 @@ build_native()
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __nativeroot=$__scriptpath/Unix
 __rootRepo="$__scriptpath/../.."
-__rootbinpath="$__scriptpath/../../bin"
+__artifactsDir="$__rootRepo/artifacts"
 
 # Set the various build properties here so that CMake and MSBuild can pick them up
 __CMakeExtraArgs=""
@@ -244,6 +244,10 @@ while :; do
         release|-release)
             __BuildType=Release
             __CMakeArgs=RELEASE
+            ;;
+        outconfig|-outconfig)
+            __outConfig=$2
+            shift
             ;;
         freebsd|FreeBSD|-freebsd|-FreeBSD)
             __BuildOS=FreeBSD
@@ -363,8 +367,9 @@ if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
 fi
 
 # Set the remaining variables based upon the determined build configuration
-__IntermediatesDir="$__rootbinpath/obj/$__BuildOS.$__BuildArch.$__BuildType/native"
-__BinDir="$__rootbinpath/$__BuildOS.$__BuildArch.$__BuildType/native"
+__outConfig=${__outConfig:-"$__BuildOS-$__BuildArch-$__BuildType"}
+__IntermediatesDir="$__artifactsDir/obj/native/$__outConfig"
+__BinDir="$__artifactsDir/bin/native/$__outConfig"
 
 # Make the directories necessary for build if they don't exist
 setup_dirs

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -7,7 +7,7 @@
   <Import Project="$(PackagesDir)/$(PublishSymbolsPackage.ToLower())/$(PublishSymbolsPackageVersion)/build/PublishSymbols.targets" />
 
   <PropertyGroup>
-    <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)\**\*.nupkg</PublishPattern>
+    <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputPath)\**\*.nupkg</PublishPattern>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/shims/Directory.Build.props
+++ b/src/shims/Directory.Build.props
@@ -20,6 +20,6 @@
 
   <PropertyGroup>
     <!-- shared folder for ApiCompat.proj and shims.proj -->
-    <GenFacadesOutputPath>$(RootIntermediateOutputPath)shims/$(TargetGroup)/</GenFacadesOutputPath>
+    <GenFacadesOutputPath>$(ArtifactsObjDir)shims/$(TargetGroup)/</GenFacadesOutputPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This updates corefx to move all the outputs under artifacts and
use the properties defined in the arcade sdk. For directory output
structure see https://github.com/dotnet/arcade/blob/master/Documentation/ArcadeSdk.md#single-build-output

cc @ericstj @safern @ViktorHofer 