### PR TITLE
Allows Debug.Fail to go through Trace Listeners

### DIFF
--- a/src/System.Diagnostics.Debug/tests/DebugTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebugTests.cs
@@ -65,9 +65,9 @@ namespace System.Diagnostics.Tests
             var originalWriteCoreHook = writeCoreHook.GetValue(null);
             writeCoreHook.SetValue(null, new Action<string>(WriteLogger.s_instance.WriteCore));
             
-            FieldInfo showDialogHook = typeof(DebugProvider).GetField("s_ShowDialog", BindingFlags.Static | BindingFlags.Public);
-            var originalShowDialogHook = showDialogHook.GetValue(null);
-            showDialogHook.SetValue(null, new Action<string, string, string, string>(WriteLogger.s_instance.ShowDialog));
+            FieldInfo failCoreHook = typeof(DebugProvider).GetField("s_FailCore", BindingFlags.Static | BindingFlags.NonPublic);
+            var originalFailCoreHook = failCoreHook.GetValue(null);
+            failCoreHook.SetValue(null, new Action<string, string, string, string>(WriteLogger.s_instance.FailCore));
 
             try
             {
@@ -83,7 +83,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 writeCoreHook.SetValue(null, originalWriteCoreHook);
-                showDialogHook.SetValue(null, originalShowDialogHook);
+                failCoreHook.SetValue(null, originalFailCoreHook);
             }
         }
 
@@ -103,7 +103,7 @@ namespace System.Diagnostics.Tests
                 AssertUIOutput = string.Empty;
             }
 
-            public void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
+            public void FailCore(string stackTrace, string message, string detailMessage, string errorSource)
             {
                 AssertUIOutput += stackTrace + message + detailMessage + errorSource;
             }

--- a/src/System.Diagnostics.Debug/tests/DebugTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebugTests.cs
@@ -41,7 +41,7 @@ namespace System.Diagnostics.Tests
 
             // First use our test logger to verify the output
             var originalWriteCoreHook = writeCoreHook.GetValue(null);
-            writeCoreHook.SetValue(null, new Action<string>(WriteLogger.s_instance.MockWrite));
+            writeCoreHook.SetValue(null, new Action<string>(WriteLogger.s_instance.WriteCore));
 
             try
             {
@@ -62,11 +62,12 @@ namespace System.Diagnostics.Tests
         protected void VerifyAssert(Action test, params string[] expectedOutputStrings)
         {
             FieldInfo writeCoreHook = typeof(DebugProvider).GetField("s_WriteCore", BindingFlags.Static | BindingFlags.NonPublic);
-            s_defaultProvider = Debug.SetProvider(WriteLogger.s_instance);
-            WriteLogger.s_instance.OriginalProvider = s_defaultProvider;
-            
             var originalWriteCoreHook = writeCoreHook.GetValue(null);
-            writeCoreHook.SetValue(null, new Action<string>(WriteLogger.s_instance.MockWrite));
+            writeCoreHook.SetValue(null, new Action<string>(WriteLogger.s_instance.WriteCore));
+            
+            FieldInfo showDialogHook = typeof(DebugProvider).GetField("s_ShowDialog", BindingFlags.Static | BindingFlags.Public);
+            var originalShowDialogHook = showDialogHook.GetValue(null);
+            showDialogHook.SetValue(null, new Action<string, string, string, string>(WriteLogger.s_instance.ShowDialog));
 
             try
             {
@@ -82,18 +83,15 @@ namespace System.Diagnostics.Tests
             finally
             {
                 writeCoreHook.SetValue(null, originalWriteCoreHook);
-                Debug.SetProvider(s_defaultProvider);
+                showDialogHook.SetValue(null, originalShowDialogHook);
             }
         }
 
-        private static DebugProvider s_defaultProvider;
-        private class WriteLogger : DebugProvider
+        internal class WriteLogger
         {
             public static readonly WriteLogger s_instance = new WriteLogger();
 
             private WriteLogger() { }
-
-            public DebugProvider OriginalProvider { get; set; }
 
             public string LoggedOutput { get; private set; }
 
@@ -105,24 +103,12 @@ namespace System.Diagnostics.Tests
                 AssertUIOutput = string.Empty;
             }
 
-            public override void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
+            public void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
             {
                 AssertUIOutput += stackTrace + message + detailMessage + errorSource;
             }
 
-            public override void OnIndentLevelChanged(int indentLevel)
-            {
-                OriginalProvider.OnIndentLevelChanged(indentLevel);
-            }
-
-            public override void OnIndentSizeChanged(int indentSize)
-            {
-                OriginalProvider.OnIndentLevelChanged(indentSize);
-            }
-            public override void Write(string message) { OriginalProvider.Write(message); }
-            public override void WriteLine(string message) { OriginalProvider.WriteLine(message); }
-
-            public void MockWrite(string message)
+            public void WriteCore(string message)
             {
                 Assert.NotNull(message);
                 LoggedOutput += message;

--- a/src/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
+++ b/src/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
@@ -246,17 +246,17 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        public void Trace_AssertUiEnabledFalse_SkipsShowDialog()
+        public void Trace_AssertUiEnabledFalse_SkipsFail()
         {
             var initialListener = (DefaultTraceListener)Trace.Listeners[0];
             Trace.Listeners.Clear();
-            Trace.Fail("Fail won't show dialog");
-            Debug.Fail("Fail won't show dialog");
+            Trace.Fail("Skips fail fast");
+            Debug.Fail("Skips fail fast");
 
             initialListener.AssertUiEnabled = false;
             Trace.Listeners.Add(initialListener);
-            Debug.Fail("Fail won't show dialog");
-            Trace.Fail("Fail won't show dialog");
+            Debug.Fail("Skips fail fast");
+            Trace.Fail("Skips fail fast");
 
             var myListener = new MyTraceListener();
             string expectedDialog = $"Mock dialog - message: short, detailed message: long";
@@ -286,7 +286,7 @@ namespace System.Diagnostics.Tests
 
         class MyTraceListener : DefaultTraceListener
         {
-            private void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource) 
+            private void FailCore(string stackTrace, string message, string detailMessage, string errorSource) 
             {
                 OutputString += $"Mock dialog - message: {message}, detailed message: {detailMessage}";
             }
@@ -297,7 +297,7 @@ namespace System.Diagnostics.Tests
                 WriteLine(message, detailMessage);
                 if (AssertUiEnabled)
                 {
-                    ShowDialog(string.Empty, message, detailMessage, "Assertion Failed");
+                    FailCore(string.Empty, message, detailMessage, "Assertion Failed");
                 }
             }
         }

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
@@ -92,7 +92,7 @@ namespace System.Diagnostics
             WriteAssert(stackTrace, message, detailMessage);
             if (AssertUiEnabled)
             {
-                DebugProvider.ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
+                DebugProvider.FailCore(stackTrace, message, detailMessage, "Assertion Failed");
             }
         }
 

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
@@ -89,16 +89,10 @@ namespace System.Diagnostics
             {
                 stackTrace = "";
             }
-            // Tracked by #32955: WriteAssert should write "stackTrace" rather than string.Empty. 
-            WriteAssert(string.Empty, message, detailMessage);
+            WriteAssert(stackTrace, message, detailMessage);
             if (AssertUiEnabled)
             {
-                // Tracked by #32955: Currently AssertUiEnabled is true by default but we are not calling Enviroment.FailFast as Debug.Fail does 
-                // s_provider.ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
-            }
-            if (Debugger.IsAttached)
-            {
-                Debugger.Break();
+                DebugProvider.ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
             }
         }
 

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -13,6 +13,7 @@ namespace System.Diagnostics
     {
         private class TraceProvider : DebugProvider
         {
+            public override void Fail(string message, string detailMessage) { TraceInternal.Fail(message, detailMessage); }
             public override void OnIndentLevelChanged(int indentLevel)
             {
                 lock (TraceInternal.critSec)


### PR DESCRIPTION
Allows Debug.Fail to go through Trace Listeners
coreclr PR: dotnet/coreclr#20764

Confirmed in .NET Framework:
- Trace.Fail(..) behavior matches with Debug.Fail(..).
- We only show dialog for DefaultTraceListener when AssertUIEnabled is true.
- DefaultTraceListener.AssertUIEnabled is true by default.

However, although we want behavior consistency between in .NET Core and .NET Framework, we are not planning on Showing UI Dialog in .NET Core by default.

Observation on existing .NET Core behavior:
- DefaultTraceListener.AssertUiEnabled is currently always true by default.
- (ShowDialog by default breaks if debugger is attached and otherwise will exit by invoking Environment.FailFast).
- Debug.Fail calls ShowDialog API but Trace.Fail doesn't. (wrong behavior)
- Trace.Fail only breaks if debugger is attached and otherwise continues execution. (wrong behavior)
- Trace.Fail does not write stack trace. (wrong behavior)

My introduced changes for .NET Core:
- Trace and Debug should behave the same. (I fixed the wrong behaviors to make the match)
- DefaultTraceListener.AssertUiEnabled default value can remain true. When false it skips FailCore (calls Environment.FailFast) which makes it closer to older DefaultTraceListener.Fail behavior

Fixes: #32955 
cc: @jkotas @danmosemsft @eerhardt @stephentoub 