### PR TITLE
[release/2.1] Skip CoreFx.Private.TestUtilities in source-build

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -306,6 +306,14 @@
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
   </PropertyGroup>
 
+  <!--
+    Remove test-only dependencies during source-build: disable project that brings in XUnit.Runtime
+    dependencies through 'ReferenceFromRuntime' property.
+  -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' and '$(BuildTests)' != 'true'">
+    <ProjectExclusions Include="$(SourceDir)CoreFx.Private.TestUtilities/**/*.csproj" />
+  </ItemGroup>
+
   <!-- Properties related to multi-file mode for ILC tests -->
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <!-- Only enable multi-file for Release-x64 and Debug-x86 for now -->

--- a/dir.props
+++ b/dir.props
@@ -306,14 +306,6 @@
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
   </PropertyGroup>
 
-  <!--
-    Remove test-only dependencies during source-build: disable project that brings in XUnit.Runtime
-    dependencies through 'ReferenceFromRuntime' property.
-  -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' and '$(BuildTests)' != 'true'">
-    <ProjectExclusions Include="$(SourceDir)CoreFx.Private.TestUtilities/**/*.csproj" />
-  </ItemGroup>
-
   <!-- Properties related to multi-file mode for ILC tests -->
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <!-- Only enable multi-file for Release-x64 and Debug-x86 for now -->

--- a/src/dir.props
+++ b/src/dir.props
@@ -1,3 +1,11 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
+
+  <!--
+    Remove test-only dependencies during source-build: disable project that brings in XUnit.Runtime
+    dependencies through 'ReferenceFromRuntime' property.
+  -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' and '$(BuildTests)' != 'true'">
+    <ProjectExclusions Include="$(SourceDir)CoreFx.Private.TestUtilities/**/*.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/ref.builds
+++ b/src/ref.builds
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)*\ref\*.*proj" />
+    <Project Include="$(MSBuildThisFileDirectory)*\ref\*.*proj" Exclude="@(ProjectExclusions)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
This project referenced the XUnit.Runtime dependency project, causing test-only prebuilt dependencies.

Even though source-build always passes BuildTests=false, include a condition to handle "true" to make intent clear.

---

This is a patch for removing test dependencies from source-build: https://github.com/dotnet/source-build/pull/847.

From what I can tell, `ProjectExclusions` is a vestigial itemgroup from the `dev/eng` branch. I don't see any usages, but we can start using it for this.

I've got a port of this on `master` that I submitted as https://github.com/dotnet/corefx/pull/33218, since `dir.props` => `Directory.Build.props`.

(If this doesn't seem like the right way to do this, let me know a better fix and I can update the patch.)