### PR TITLE
[master] Skip CoreFx.Private.TestUtilities in source-build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -415,6 +415,14 @@
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>
   </PropertyGroup>
 
+  <!--
+    Remove test-only dependencies during source-build: disable project that brings in XUnit.Runtime
+    dependencies through 'ReferenceFromRuntime' property.
+  -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' and '$(BuildTests)' != 'true'">
+    <ProjectExclusions Include="$(SourceDir)CoreFx.Private.TestUtilities/**/*.csproj" />
+  </ItemGroup>
+
   <!-- Properties related to multi-file mode for ILC tests -->
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <!-- Only enable multi-file for Release-x64 and Debug-x86 for now -->

--- a/src/ref.builds
+++ b/src/ref.builds
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)*\ref\*.*proj" />
+    <Project Include="$(MSBuildThisFileDirectory)*\ref\*.*proj" Exclude="@(ProjectExclusions)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
This project referenced the XUnit.Runtime dependency project, causing test-only prebuilt dependencies.

Even though source-build always passes BuildTests=false, include a condition to handle "true" to make intent clear.

---

Ports https://github.com/dotnet/corefx/pull/33217 to `master` (see that PR for details).