### PR TITLE
Disable TryGetAddrInfo_HostName_TryGetNameInfo on Arm64.

### DIFF
--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -92,7 +92,6 @@ namespace System.Net.NameResolution.PalTests
             Assert.NotNull(name);
         }
 
-        [Fact]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
         public void TryGetAddrInfo_HostName_TryGetNameInfo()
         {

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -93,6 +93,7 @@ namespace System.Net.NameResolution.PalTests
         }
 
         [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
         public void TryGetAddrInfo_HostName_TryGetNameInfo()
         {
             string hostName = NameResolutionPal.GetHostName();


### PR DESCRIPTION
The test is failing very frequently in CI runs, and is generating a lot of noise in PRs.

Disabling it for now on Arm64 until we can track down the issue.

Related: #32797