### PR TITLE
Add StringBuilder.Append(ROM<char>) ref, test, comparative perf tests

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7588,8 +7588,8 @@ namespace System.Text
         public System.Text.StringBuilder Append(int value) { throw null; }
         public System.Text.StringBuilder Append(long value) { throw null; }
         public System.Text.StringBuilder Append(object value) { throw null; }
-        public System.Text.StringBuilder Append(System.ReadOnlySpan<char> value) { throw null; }
         public System.Text.StringBuilder Append(System.ReadOnlyMemory<char> value) { throw null; }
+        public System.Text.StringBuilder Append(System.ReadOnlySpan<char> value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public System.Text.StringBuilder Append(sbyte value) { throw null; }
         public System.Text.StringBuilder Append(float value) { throw null; }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7589,7 +7589,6 @@ namespace System.Text
         public System.Text.StringBuilder Append(long value) { throw null; }
         public System.Text.StringBuilder Append(object value) { throw null; }
         public System.Text.StringBuilder Append(System.ReadOnlySpan<char> value) { throw null; }
-
         public System.Text.StringBuilder Append(System.ReadOnlyMemory<char> value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public System.Text.StringBuilder Append(sbyte value) { throw null; }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7589,6 +7589,8 @@ namespace System.Text
         public System.Text.StringBuilder Append(long value) { throw null; }
         public System.Text.StringBuilder Append(object value) { throw null; }
         public System.Text.StringBuilder Append(System.ReadOnlySpan<char> value) { throw null; }
+
+        public System.Text.StringBuilder Append(System.ReadOnlyMemory<char> value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public System.Text.StringBuilder Append(sbyte value) { throw null; }
         public System.Text.StringBuilder Append(float value) { throw null; }

--- a/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
+++ b/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
@@ -161,7 +161,7 @@ namespace System.Tests
 
                 // Actual perf testing
                 using (iteration.StartMeasurement())
-                    for (int i = 0; i < 10000; i++)
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                         empty.Append(memory); // Appends a string of length "length" to an increasingly large StringBuilder
             }
         }
@@ -177,13 +177,13 @@ namespace System.Tests
             {
                 // Setup - Create a string of the specified length
                 string builtString = utils.CreateString(length);
-                ReadOnlyMemory<char> memory = builtString.AsMemory();
+                object memoryObject = builtString.AsMemory(); // deliberately forces memory.ToString() to be called so this can be compared to AppendAsReadOnlyMemory
                 StringBuilder empty = new StringBuilder();
 
                 // Actual perf testing
                 using (iteration.StartMeasurement())
-                    for (int i = 0; i < 10000; i++)
-                        empty.Append((object)memory); // cast to object deliberately forces memory.ToString() to be called so this can be compared to AppendAsReadOnlyMemory
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        empty.Append(memoryObject); 
             }
         }
     }

--- a/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
+++ b/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
@@ -145,7 +145,7 @@ namespace System.Tests
             }
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = 1000)]
         [InlineData(20)]
         [InlineData(200)]
         [InlineData(1000)]
@@ -166,7 +166,7 @@ namespace System.Tests
             }
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = 1000)]
         [InlineData(20)]
         [InlineData(200)]
         [InlineData(1000)]
@@ -177,7 +177,7 @@ namespace System.Tests
             {
                 // Setup - Create a string of the specified length
                 string builtString = utils.CreateString(length);
-                object memoryObject = builtString.AsMemory(); // deliberately forces memory.ToString() to be called so this can be compared to AppendAsReadOnlyMemory
+                object memoryObject = builtString.AsMemory(); // deliberately uses object to force use of memory.ToString() for comparison to AppendAsReadOnlyMemory
                 StringBuilder empty = new StringBuilder();
 
                 // Actual perf testing

--- a/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
+++ b/src/System.Runtime/tests/Performance/Perf.StringBuilder.cs
@@ -144,5 +144,47 @@ namespace System.Tests
                 }
             }
         }
+
+        [Benchmark]
+        [InlineData(20)]
+        [InlineData(200)]
+        [InlineData(1000)]
+        public void AppendMemoryAsMemory(int length)
+        {
+            PerfUtils utils = new PerfUtils();
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup - Create a string of the specified length
+                string builtString = utils.CreateString(length);
+                ReadOnlyMemory<char> memory = builtString.AsMemory();
+                StringBuilder empty = new StringBuilder();
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < 10000; i++)
+                        empty.Append(memory); // Appends a string of length "length" to an increasingly large StringBuilder
+            }
+        }
+
+        [Benchmark]
+        [InlineData(20)]
+        [InlineData(200)]
+        [InlineData(1000)]
+        public void AppendMemoryAsObject(int length)
+        {
+            PerfUtils utils = new PerfUtils();
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                // Setup - Create a string of the specified length
+                string builtString = utils.CreateString(length);
+                ReadOnlyMemory<char> memory = builtString.AsMemory();
+                StringBuilder empty = new StringBuilder();
+
+                // Actual perf testing
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < 10000; i++)
+                        empty.Append((object)memory); // cast to object deliberately forces memory.ToString() to be called so this can be compared to AppendAsReadOnlyMemory
+            }
+        }
     }
 }

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -142,6 +142,19 @@ namespace System.Text.Tests
         }
 
         [Theory]
+        [InlineData("Hello", new char[] { 'a' }, "Helloa")]
+        [InlineData("Hello", new char[] { 'b', 'c', 'd' }, "Hellobcd")]
+        [InlineData("Hello", new char[] { 'b', '\0', 'd' }, "Hellob\0d")]
+        [InlineData("", new char[] { 'e', 'f', 'g' }, "efg")]
+        [InlineData("Hello", new char[0], "Hello")]
+        public static void Append_CharMemory(string original, char[] value, string expected)
+        {
+            var builder = new StringBuilder(original);
+            builder.Append(new ReadOnlyMemory<char>(value));
+            Assert.Equal(expected, builder.ToString());
+        }
+
+        [Theory]
         [InlineData(1)]
         [InlineData(10000)]
         public static void Clear_AppendAndInsertBeforeClearManyTimes_CapacityStaysWithinRange(int times)

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -150,7 +150,7 @@ namespace System.Text.Tests
         public static void Append_CharMemory(string original, char[] value, string expected)
         {
             var builder = new StringBuilder(original);
-            builder.Append(new ReadOnlyMemory<char>(value));
+            builder.Append(value.AsMemory());
             Assert.Equal(expected, builder.ToString());
         }
 


### PR DESCRIPTION
Addresses #32348
implementation is in Coreclr PR https://github.com/dotnet/coreclr/pull/20773

Adds a StringBuilder.Append(ReadOnlyMemory<char> value) method to avoid the situation where a user assumes memory will work just as well as span but has it use the object parameter overload which causes boxing and a ToString() call on the memory instance which allocates.

Ref is added. basic test is added. Two perf tests are added, one using memory overload and the other forced down the object overload, these two can be compared to make sure memory is better than object.
