### PR TITLE
Don't capture the ExecutionContext when registering for the cancellation

### DIFF
--- a/src/System.IO.Pipelines/src/Configurations.props
+++ b/src/System.IO.Pipelines/src/Configurations.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageConfigurations>
       netstandard;
-      netcoreapp2.1;
+      netcoreapp;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{1032D5F6-5AE7-4002-A0E4-FEBEADFEA977}</ProjectGuid>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\InternalsVisibleTo.cs" />
@@ -27,11 +27,12 @@
     <Compile Include="System\IO\Pipelines\ResultFlags.cs" />
     <Compile Include="System\IO\Pipelines\ThrowHelper.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsNETCoreApp)'=='true'">
+  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
     <Compile Include="System\IO\Pipelines\ThreadPoolScheduler.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="System\IO\Pipelines\ThreadPoolScheduler.netstandard.cs" />
+    <Compile Include="System\IO\Pipelines\CancellationTokenExtensions.netstandard.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Buffers" />

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/CancellationTokenExtensions.netstandard.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/CancellationTokenExtensions.netstandard.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace System.Threading
+{
+    internal static class CancellationTokenExtensions
+    {
+        internal static CancellationTokenRegistration UnsafeRegister(this CancellationToken cancellationToken, Action<object> callback, object state)
+        {
+            return cancellationToken.Register(callback, state);
+        }
+    }
+}

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
@@ -51,7 +51,7 @@ namespace System.IO.Pipelines
                 if (_cancellationToken.CanBeCanceled)
                 {
                     _cancellationToken.ThrowIfCancellationRequested();
-                    _cancellationTokenRegistration = _cancellationToken.Register(callback, state);
+                    _cancellationTokenRegistration = _cancellationToken.UnsafeRegister(callback, state);
                 }
             }
             return oldRegistration;


### PR DESCRIPTION
Don't capture the ExecutionContext when registering for cancellation since we're invoking our own callback.