### PR TITLE
Removing Reference assets from packages which contain runtime-specific dependencies when targeting Desktop.

### DIFF
--- a/external/harvestPackages/harvestPackages.props
+++ b/external/harvestPackages/harvestPackages.props
@@ -68,13 +68,13 @@
   <Version>4.5.0</Version>
 </PackageReference>
 <PackageReference Include="System.IO.Pipelines">
-  <Version>4.5.0</Version>
+  <Version>4.5.2</Version>
 </PackageReference>
 <PackageReference Include="System.Json">
   <Version>4.5.0</Version>
 </PackageReference>
 <PackageReference Include="System.Net.Http.WinHttpHandler">
-  <Version>4.5.0</Version>
+  <Version>4.5.1</Version>
 </PackageReference>
 <PackageReference Include="System.Net.WebSockets.WebSocketProtocol">
   <Version>4.5.1</Version>

--- a/src/CoreFx.Private.TestUtilities/pkg/CoreFx.Private.TestUtilities.pkgproj
+++ b/src/CoreFx.Private.TestUtilities/pkg/CoreFx.Private.TestUtilities.pkgproj
@@ -5,7 +5,14 @@
     <ProjectReference Include="..\ref\CoreFx.Private.TestUtilities.csproj">
       <SupportedFramework>uap10.0.16299;netcoreapp2.0;net461;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\CoreFx.Private.TestUtilities.csproj"/>
+    <ProjectReference Include="..\src\CoreFx.Private.TestUtilities.csproj">
+      <SupportedFramework>uap10.0.16299;netcoreapp2.0;net461;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
+++ b/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
@@ -2,21 +2,15 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageVersion>4.5.1</PackageVersion>
+    <PackageVersion>4.5.2</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Data.SqlClient.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Data.SqlClient.csproj" />
-    <HarvestIncludePaths Include="ref/net451;lib/net451;runtimes/win/lib/net451" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.2">
-      <SupportedFramework>net451;win81;wpa81</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>net46;netcoreapp1.0</SupportedFramework>
-    </HarvestIncludePaths>
+    <HarvestIncludePaths Include="lib/net451;runtimes/win/lib/net451" />
+    <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.3;runtimes/win/lib/netstandard1.3" />
 
     <!-- Since UAP and .NETCoreApp are package based we still want to enable
@@ -31,5 +25,10 @@
   <ItemGroup>
     <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Pipelines/dir.props
+++ b/src/System.IO.Pipelines/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.1</AssemblyVersion>
-    <PackageVersion>4.5.2</PackageVersion>
+    <PackageVersion>4.5.3</PackageVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipelines/pkg/System.IO.Pipelines.pkgproj
+++ b/src/System.IO.Pipelines/pkg/System.IO.Pipelines.pkgproj
@@ -7,5 +7,10 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Pipelines.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Memory/pkg/System.Memory.pkgproj
+++ b/src/System.Memory/pkg/System.Memory.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageVersion>4.5.1</PackageVersion>
+    <PackageVersion>4.5.2</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageIndex Include="$(ProjectDir)\pkg\baseline\packageBaseline.1.1.json" />
@@ -12,5 +12,10 @@
     <ProjectReference Include="..\src\System.Memory.csproj" />
     <InboxOnTargetFramework  Include="netcoreapp2.1" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Http.WinHttpHandler/dir.props
+++ b/src/System.Net.Http.WinHttpHandler/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.3.1</AssemblyVersion>
-    <PackageVersion>4.5.1</PackageVersion>
+    <PackageVersion>4.5.2</PackageVersion>
     <AssemblyKey>MSFT</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
+++ b/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
@@ -5,12 +5,16 @@
     <ProjectReference Include="..\ref\System.Net.Http.WinHttpHandler.csproj">
       <SupportedFramework>net461;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Net.Http.WinHttpHandler.csproj" />
+    <ProjectReference Include="..\src\System.Net.Http.WinHttpHandler.csproj">
+      <SupportedFramework>net461;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
     <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
     <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -3,6 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.3.1.0</AssemblyVersion>
+    <PackageVersion>4.5.1</PackageVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -13,14 +13,18 @@
     <InboxOnTargetFramework Include="uap10.0.16299" />
     <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <!-- All elements from previous packages that will be included in the newly built package -->
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3" />
-    <HarvestIncludePaths Include="ref/netstandard1.4;runtimes/win/lib/netstandard1.4" />
-    <HarvestIncludePaths Include="ref/netstandard1.6;runtimes/win/lib/netstandard1.6;lib/netstandard1.6" />
-    <HarvestIncludePaths Include="ref/netcoreapp2.0;runtimes/win/lib/netcoreapp2.0" />
+    <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
+    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.4" />
+    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.6;lib/netstandard1.6" />
+    <HarvestIncludePaths Include="runtimes/win/lib/netcoreapp2.0" />
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Text.Encoding.CodePages/dir.props
+++ b/src/System.Text.Encoding.CodePages/dir.props
@@ -3,6 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <PackageVersion>4.5.1</PackageVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
+++ b/src/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
@@ -7,7 +7,7 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.Text.Encoding.CodePages.csproj" />
     <HarvestIncludePaths Include="lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3;runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
   </ItemGroup>
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
@@ -26,5 +26,10 @@
       <Value>.NETCoreApp;UAP</Value>
     </ValidatePackageSuppression>
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
+++ b/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
@@ -6,7 +6,7 @@
     <MinClientVersion>2.8.6</MinClientVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageVersion>4.5.1</PackageVersion>
+    <PackageVersion>4.5.2</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Tasks.Extensions.csproj">
@@ -21,5 +21,10 @@
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -19,4 +19,12 @@
     <Message Text="DumpTargets> $(OutputPath), C=[$(Configuration)], CG=[$(ConfigurationGroup)], OG=[$(OSGroup)], TG=[$(TargetGroup)]" Importance="Low" />
   </Target>
 
+  <!-- This target will be moved into buildtools. Checked in here for now to add validationand in order not to block buildtools ingestion. -->
+  <Target Name="ValidateExcludeCompileDesktop" AfterTargets="GetPackageDependencies">
+    <Error Text="Cannot have Exclude=Compile dependencies when targeting a desktop TFM. @(Dependency). You can exclude the reference asset in the package by setting the ExcludeReferenceAssets property to true in your project." 
+           Condition="$([System.String]::Copy('%(Dependency.TargetFramework)').StartsWith('net4')) AND 
+                      '%(Dependency.Exclude)' == 'Compile' AND
+                      '%(Dependency.Identity)' != '_._'" />
+  </Target>
+
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -27,6 +27,30 @@
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="*\pkg\**\CoreFx.Private.TestUtilities.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\**\System.Data.SqlClient.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\**\System.IO.Pipelines.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\**\System.Memory.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\**\System.Net.Http.WinHttpHandler.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\**\System.Security.Cryptography.Cng.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\**\System.Text.Encoding.CodePages.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\**\System.Threading.Tasks.Extensions.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
Fixes #32457 

These changes will remove the reference assets from the packages which have runtime-specific dependencies which are causing RAR to not see a conflict, and won't generate binding redirects to address the conflict. As part of this, we will also add validation that will ensure future packages won't hit the same problem either (that will come in a buildtools PR). Marking it as No Merge since we have to follow the shiproom process to get this in.

cc: @ericstj @natemcmaster 

