### PR TITLE
Allow specifying the required clang version for the native build

### DIFF
--- a/src/Native/build-native.proj
+++ b/src/Native/build-native.proj
@@ -19,8 +19,9 @@
       <_ProcessorCountArg> --numproc $(MSBuildNodeCount)</_ProcessorCountArg>
       <_StripSymbolsArg Condition="'$(BuildNativeStripSymbols)' == 'true'"> stripsymbols</_StripSymbolsArg>
       <_PortableBuildArg Condition="'$(PortableBuild)' == 'true'"> -portable</_PortableBuildArg>
+      <_ClangBuildArg Condition="'$(Clang)' != ''"> $(Clang)</_ClangBuildArg>
 
-      <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessCountArg)$(_StripSymbolsArg)$(_PortableBuildArg)</_BuildNativeUnixArgs>
+      <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessCountArg)$(_StripSymbolsArg)$(_PortableBuildArg)$(_ClangBuildArg)</_BuildNativeUnixArgs>
     </PropertyGroup>
 
     <Message Text="$(MSBuildProjectDirectory)/build-native.sh $(_BuildNativeUnixArgs)" Importance="High"/>

--- a/src/Native/build-native.proj
+++ b/src/Native/build-native.proj
@@ -22,7 +22,7 @@
 
       <!--
         BuildNativeClang is a pass-through argument, to pass an argument to build-native.sh. It is intended to be
-        used to force a specific clang toolset. E.g., pass to msbuild "/p:BuildNativeClang=--clang5.0"
+        used to force a specific clang toolset.
       -->
       <_BuildNativeClangArg Condition="'$(BuildNativeClang)' != ''"> $(BuildNativeClang)</_BuildNativeClangArg>
 

--- a/src/Native/build-native.proj
+++ b/src/Native/build-native.proj
@@ -19,9 +19,14 @@
       <_ProcessorCountArg> --numproc $(MSBuildNodeCount)</_ProcessorCountArg>
       <_StripSymbolsArg Condition="'$(BuildNativeStripSymbols)' == 'true'"> stripsymbols</_StripSymbolsArg>
       <_PortableBuildArg Condition="'$(PortableBuild)' == 'true'"> -portable</_PortableBuildArg>
-      <_ClangBuildArg Condition="'$(Clang)' != ''"> $(Clang)</_ClangBuildArg>
 
-      <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessCountArg)$(_StripSymbolsArg)$(_PortableBuildArg)$(_ClangBuildArg)</_BuildNativeUnixArgs>
+      <!--
+        BuildNativeClang is a pass-through argument, to pass an argument to build-native.sh. It is intended to be
+        used to force a specific clang toolset. E.g., pass to msbuild "/p:BuildNativeClang=--clang5.0"
+      -->
+      <_BuildNativeClangArg Condition="'$(BuildNativeClang)' != ''"> $(BuildNativeClang)</_BuildNativeClangArg>
+
+      <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessCountArg)$(_StripSymbolsArg)$(_PortableBuildArg)$(_BuildNativeClangArg)</_BuildNativeUnixArgs>
     </PropertyGroup>
 
     <Message Text="$(MSBuildProjectDirectory)/build-native.sh $(_BuildNativeUnixArgs)" Importance="High"/>


### PR DESCRIPTION
E.g.,
```
./build.sh -Release /p:OSGroup=Linux /p:ArchGroup=arm /p:Clang=--clang5.0
```

The "Clang" property is actually just a pass-through argument used when invoking
Linux build-native.sh.