### PR TITLE
Add freebsd-x64 to Microsoft.NETCore.App's package graph

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <OfficialBuildRID Include="freebsd-x64" />
     <OfficialBuildRID Include="linux-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>


### PR DESCRIPTION
This seemed to be the only place that tizen showed up, so it seems like the only place that freebsd might be needed.