### PR TITLE
Change to new test queues, add Ubuntu 18.10, drop 14.04

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -309,7 +309,7 @@
       "allowOverride": true
     },
     "PB_TargetQueue": {
-      "value": "Centos.73.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Debian.9.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+opensuse.423.amd64+SLES.12.Amd64+SLES.15.Amd64+Fedora.27.Amd64+Fedora.28.Amd64"
+      "value": "Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+opensuse.423.amd64+SLES.12.Amd64+SLES.15.Amd64+Fedora.27.Amd64+Fedora.28.Amd64"
     },
     "PB_VsoAccountName": {
       "value": "dn-bot"

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -309,7 +309,7 @@
       "allowOverride": true
     },
     "PB_TargetQueue": {
-      "value": "Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+opensuse.423.amd64+SLES.12.Amd64+SLES.15.Amd64+Fedora.27.Amd64+Fedora.28.Amd64"
+      "value": "Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+opensuse.42.amd64+SLES.12.Amd64+SLES.15.Amd64+Fedora.27.Amd64+Fedora.28.Amd64"
     },
     "PB_VsoAccountName": {
       "value": "dn-bot"

--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -37,10 +37,9 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
             // Get the user that should be associated with the submission
             def helixCreator = getUser()
             // Target queues
-            def targetHelixQueues = ['Centos.74.Amd64.Open',
-                                     'RedHat.74.Amd64.Open',
-                                     'Debian.87.Amd64.Open',
-                                     'Ubuntu.1404.Amd64.Open',
+            def targetHelixQueues = ['Centos.7.Amd64.Open',
+                                     'RedHat.7.Amd64.Open',
+                                     'Debian.8.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
                                      'Ubuntu.1804.Amd64.Open',
                                      'OpenSuse.423.Amd64.Open',
@@ -48,6 +47,7 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.9.Amd64.Open',
                                       'Fedora.28.Amd64.Open',
+                                      'Ubuntu.1810.Amd64.Open',
                                       'SLES.12.Amd64.Open',
                                       'SLES.15.Amd64.Open',]
             }

--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -42,7 +42,7 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      'Debian.8.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
                                      'Ubuntu.1804.Amd64.Open',
-                                     'OpenSuse.423.Amd64.Open',
+                                     'OpenSuse.42.Amd64.Open',
                                      'Fedora.27.Amd64.Open',]
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.9.Amd64.Open',


### PR DESCRIPTION
Centos.73.Amd64 => Centos.7.Amd64
RedHat.73.Amd64 => RedHat.7.Amd64
Debian.87.Amd64 => Debian.8.Amd64
-Debian.90.Amd64 (redundant to Debian.9.Amd64)
-Ubuntu 14.04 (nearing end of life)
+Ubuntu 18.10 (Ubuntu.1810.Amd64)