### PR TITLE
Fix Content-Type parsing of quoted charsets

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -196,22 +196,24 @@ namespace System.Net.Http
             Encoding encoding = null;
             int bomLength = -1;
 
+            string charset = headers.ContentType?.CharSet;
+
             // If we do have encoding information in the 'Content-Type' header, use that information to convert
             // the content to a string.
-            if ((headers.ContentType != null) && (headers.ContentType.CharSet != null))
+            if (charset != null)
             {
                 try
                 {
                     // Remove at most a single set of quotes.
-                    if (headers.ContentType.CharSet.Length > 2 &&
-                        headers.ContentType.CharSet[0] == '\"' &&
-                        headers.ContentType.CharSet[headers.ContentType.CharSet.Length - 1] == '\"')
+                    if (charset.Length > 2 &&
+                        charset[0] == '\"' &&
+                        charset[charset.Length - 1] == '\"')
                     {
-                        encoding = Encoding.GetEncoding(headers.ContentType.CharSet.Substring(1, headers.ContentType.CharSet.Length - 2));
+                        encoding = Encoding.GetEncoding(charset.Substring(1, charset.Length - 2));
                     }
                     else
                     {
-                        encoding = Encoding.GetEncoding(headers.ContentType.CharSet);
+                        encoding = Encoding.GetEncoding(charset);
                     }
 
                     // Byte-order-mark (BOM) characters may be present even if a charset was specified.

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -202,7 +202,8 @@ namespace System.Net.Http
             {
                 try
                 {
-                    /*if (headers.ContentType.CharSet.Length > 2 &&
+                    // Remove at most a single set of quotes.
+                    if (headers.ContentType.CharSet.Length > 2 &&
                         headers.ContentType.CharSet[0] == '\"' &&
                         headers.ContentType.CharSet[headers.ContentType.CharSet.Length - 1] == '\"')
                     {
@@ -211,10 +212,7 @@ namespace System.Net.Http
                     else
                     {
                         encoding = Encoding.GetEncoding(headers.ContentType.CharSet);
-                    }*/
-
-                    encoding = Encoding.GetEncoding(headers.ContentType.CharSet);
-
+                    }
 
                     // Byte-order-mark (BOM) characters may be present even if a charset was specified.
                     bomLength = GetPreambleLength(buffer, encoding);

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -202,7 +202,19 @@ namespace System.Net.Http
             {
                 try
                 {
+                    /*if (headers.ContentType.CharSet.Length > 2 &&
+                        headers.ContentType.CharSet[0] == '\"' &&
+                        headers.ContentType.CharSet[headers.ContentType.CharSet.Length - 1] == '\"')
+                    {
+                        encoding = Encoding.GetEncoding(headers.ContentType.CharSet.Substring(1, headers.ContentType.CharSet.Length - 2));
+                    }
+                    else
+                    {
+                        encoding = Encoding.GetEncoding(headers.ContentType.CharSet);
+                    }*/
+
                     encoding = Encoding.GetEncoding(headers.ContentType.CharSet);
+
 
                     // Byte-order-mark (BOM) characters may be present even if a charset was specified.
                     bomLength = GetPreambleLength(buffer, encoding);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
@@ -421,8 +421,8 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task ReadAsStringAsync_SetNoCharset_DefaultCharsetUsed()
         {
-            // Use content with umlaut characters.
-            string sourceString = "ÄäüÜ"; // c4 e4 fc dc
+            // Assorted latin letters with diaeresis
+            string sourceString = "\u00C4\u00E4\u00FC\u00DC";
             Encoding defaultEncoding = Encoding.GetEncoding("utf-8");
             byte[] contentBytes = defaultEncoding.GetBytes(sourceString);
 
@@ -435,6 +435,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public async Task ReadAsStringAsync_SetQuotedCharset_ParsesContent()
         {
             string sourceString = "some string";
@@ -457,7 +458,8 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("invalid\"")]
         public async Task ReadAsStringAsync_SetInvalidContentTypeHeader_DefaultCharsetUsed(string charset)
         {
-            string sourceString = "some string";
+            // Assorted latin letters with diaeresis
+            string sourceString = "\u00C4\u00E4\u00FC\u00DC";
 
             // Because the Content-Type header is invalid, we expect to default to UTF-8.
             byte[] contentBytes = Encoding.UTF8.GetBytes(sourceString);


### PR DESCRIPTION
Based on the HTTP 1.1 spec, all of the following are legal ([RFC 7231](https://tools.ietf.org/html/rfc7231#section-3.1.1.1))

```
     text/html;charset=utf-8
     text/html;charset=UTF-8
     Text/HTML;Charset="utf-8"
     text/html; charset="utf-8"
```

This fix adds support for quoted string tokens in the charset parameter, fixing our behavior for the third and fourth cases above.

Not a huge fix, but it bothered me how long this had been open :)

Fixes: #5014