### PR TITLE
Update Restore Target for IBC

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -25,7 +25,7 @@
 
   <UsingTask TaskName="GenerateConfigurationProps" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
-  <Target Name="Restore" DependsOnTargets="RestoreOptionalToolingPackages">
+  <Target Name="Restore" DependsOnTargets="RestoreOptionalToolingPackages;RestoreOptimizationDataPackage">
     <ItemGroup>
       <_RestoreProjects Include="external\dir.proj" />
     </ItemGroup>


### PR DESCRIPTION
When we changed the target of sync we did not move the target that
brings downs the IBC data that we need during build. This change fixes
this.