### PR TITLE
[WIP] Tests for RFC 6265 behavior in #29651

### DIFF
--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -68,5 +68,43 @@ namespace NetPrimitivesUnitTests
             int expectedCookieCount = expectedStrings.Length >> 1;
             Assert.Equal(expectedCookieCount, cookieCount);
         }
+
+        // This assumes that the default cookie behavior is RFC 6265, which it
+        // is not ("Default = Rfc2109" in Cookie.cs:20)
+        // TODO: Will the Default behavior change to RFC 6265? If not, specify appropriate CookieVariant
+        [Theory]
+        [InlineData("https://contoso.com/", "/")]
+        [InlineData("https://contoso.com", "/")]
+        [InlineData("https://contoso.com/path", "/")]
+        [InlineData("https://contoso.com/path/subpath", "/path")]
+        [InlineData("https://contoso.com/path/subpath/", "/path/subpath")]
+        [InlineData("https://contoso.com/path/subpath?query=queryString", "/path")]
+        public void SetCookies_Sets_Rfc6265_Default_Path_From_Url(string url, string expectedPath)
+        {
+            var uri = new Uri(url);
+            var cc = new CookieContainer();
+            cc.SetCookies(uri, "name=value");
+
+            Assert.Equal(expectedPath, cc.GetCookies(uri)["name"].Path);
+        }
+
+        // This assumes that the default cookie behavior is RFC 6265, which it
+        // is not ("Default = Rfc2109" in Cookie.cs:20)
+        // TODO: Will the Default behavior change to RFC 6265? If not, specify appropriate CookieVariant
+        [Theory]
+        [InlineData("/", "/")]
+        [InlineData("", "/")]
+        [InlineData("Path=path", "/")]
+        [InlineData("Path=/path/subpath", "/path/subpath")]
+        [InlineData("Path=/path", "/path")]
+        [InlineData("Path=/path/", "/path/")]
+        public void SetCookies_Sets_Rfc6265_Path_From_Header_Path(string path, string expectedPath)
+        {
+            var uri = new Uri("https://contoso.com/");
+            var cc = new CookieContainer();
+            cc.SetCookies(uri, $"name=value; Path={path}");
+
+            Assert.Equal(expectedPath, cc.GetCookies(uri)["name"].Path);
+        }
     }
 }

--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -106,5 +106,18 @@ namespace NetPrimitivesUnitTests
 
             Assert.Equal(expectedPath, cc.GetCookies(uri)["name"].Path);
         }
+
+        // This assumes that the default cookie behavior is RFC 6265, which it
+        // is not ("Default = Rfc2109" in Cookie.cs:20)
+        // TODO: Will the Default behavior change to RFC 6265? If not, specify appropriate CookieVariant
+        [Fact]
+        public void Rfc6265_DoesNotThrow_When_Header_Path_Differs_From_Url()
+        {
+            var uri = new Uri("https://contoso.com/some/path");
+            var cc = new CookieContainer();
+
+            // Assert.DoesNotThrow
+            cc.SetCookies(uri, "name=value; Path=/another/path");
+        }
     }
 }

--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -119,5 +119,20 @@ namespace NetPrimitivesUnitTests
             // Assert.DoesNotThrow
             cc.SetCookies(uri, "name=value; Path=/another/path");
         }
+
+        // This assumes that the default cookie behavior is RFC 6265, which it
+        // is not ("Default = Rfc2109" in Cookie.cs:20)
+        // TODO: Will the Default behavior change to RFC 6265? If not, specify appropriate CookieVariant
+        [Fact]
+        public void Rfc6265_Sends_Appropriate_Cookies_For_Different_Path()
+        {
+            var uri1 = new Uri("https://contoso.com/some/path");
+            var cc = new CookieContainer();
+            cc.SetCookies(uri1, "name=value; Path=/another/path");
+
+            var uri2 = new Uri("https://contoso.com/another/path");
+
+            Assert.NotEmpty(cc.GetCookies(uri2));
+        }
     }
 }

--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -134,5 +134,28 @@ namespace NetPrimitivesUnitTests
 
             Assert.NotEmpty(cc.GetCookies(uri2));
         }
+
+        // This assumes that the default cookie behavior is RFC 6265, which it
+        // is not ("Default = Rfc2109" in Cookie.cs:20)
+        // TODO: Will the Default behavior change to RFC 6265? If not, specify appropriate CookieVariant
+        [Theory]
+        [InlineData("name=value; Domain=contoso.com", "contoso.com")]
+        [InlineData("name=value; Domain=.contoso.com", "contoso.com")]
+        [InlineData("name=value; Domain=.CONTOSO.COM", "contoso.com")]
+        [InlineData("name=value; Domain=subdomain.contoso.com", "subdomain.contoso.com")]
+        [InlineData("name=value; Domain=.subdomain.contoso.com", "subdomain.contoso.com")]
+        public void Rfc6265_Domain(string cookieHeader, string expectedDomain)
+        {
+            var uri = new Uri("https://contoso.com/");
+            var cc = new CookieContainer();
+
+            // Assert.DoesNotThrow
+            cc.SetCookies(uri, cookieHeader);
+
+            var cookie = cc.GetCookies(uri);
+            Assert.NotEmpty(cookie);
+            Assert.Equal(expectedDomain, cookie["name"].Domain);
+
+        }
     }
 }


### PR DESCRIPTION
# Step 1 -- Add tests to demonstrate correct behavior

Do not merge. This PR serves to show tests for #29651. Some of the tests are failing. 

These tests cover behavior defined in `Cookie.VerifySetDefaults` via calls through `CookieContainer.SetCookie` 


# Step 2 -- Verify browser behavior (pending...)
## #19166

| User Agent | First request GET `/cookie/set` with no cookies | Second Request GET `/cookie/set` | GET `/cookie/index` |
| --------- | ---------------------------------- | ------------------------------- | ------------------- |
| Chrome 70.0.3538.77 | stored path: `/cookie` | Sent cookie "p=not_overwritten" | Sent cookie "p=not_overwritten" |
| Edge 42.17134.1.0 | stored path: `/cookie/` | Sent cookie "p=not_overwritten" | Sent cookie "p=not_overwritten" |
| Firefox 63.0.1 | stored path: `/cookie/` | Sent cookie "p=not_overwritten" | Sent cookie "p=not_overwritten" |
| .NET Core master | stored path: `/cookie/set` | Sent cookie "p=not_overwritten" | **Does not send cookie** |

Edge and Firefox appear to include the last `/`, but the value should really be `/cookie` according to the RFC

RFC6265 Section 5.1.4:
>    4.  Output the characters of the uri-path from the first character up
       to, but not including, the right-most %x2F ("/").

## #21250

Pending...

## #27520

Pending...

## #14674

Pending...

## #18013

Pending...