### PR TITLE
Use vfork() improve performance when starting processes.

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -11,8 +11,8 @@
 #cmakedefine01 HAVE_GETIFADDRS
 #cmakedefine01 HAVE_UTSNAME_DOMAINNAME
 #cmakedefine01 HAVE_STAT64
+#cmakedefine01 HAVE_VFORK
 #cmakedefine01 HAVE_PIPE2
-#cmakedefine01 HAVE_VFORK_SHM
 #cmakedefine01 HAVE_STAT_BIRTHTIME
 #cmakedefine01 HAVE_STAT_TIMESPEC
 #cmakedefine01 HAVE_STAT_TIM

--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -12,6 +12,7 @@
 #cmakedefine01 HAVE_UTSNAME_DOMAINNAME
 #cmakedefine01 HAVE_STAT64
 #cmakedefine01 HAVE_PIPE2
+#cmakedefine01 HAVE_VFORK_SHM
 #cmakedefine01 HAVE_STAT_BIRTHTIME
 #cmakedefine01 HAVE_STAT_TIMESPEC
 #cmakedefine01 HAVE_STAT_TIM

--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -258,7 +258,7 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     //   + process exit by any means unblocks the parent
     //   + ptrace() makes a security demand against the parent process
     //   + accessing the terminal with read() or write() fail in system-dependent ways
-    // Due to lack of documentation, changing signals in the vfork() child is a bad idea. We don't
+    // Due to lack of documentation, setting signal handlers in the vfork() child is a bad idea. We don't
     // do this, but it's worth pointing out.
 
     // All platforms that provide shared memory vfork() check the parent process's context when
@@ -295,9 +295,8 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
             {
                 break; // No more signals
             }
-            if ((sa_old.sa_flags & SA_SIGINFO)
-                ? ((void (*)(int))sa_old.sa_sigaction != SIG_IGN && (void (*)(int))sa_old.sa_sigaction != SIG_DFL)
-                : (sa_old.sa_handler != SIG_IGN && sa_old.sa_handler != SIG_DFL))
+	    void (*oldhandler)(int) = (sa_old.sa_flags & SA_SIGINFO) ? (void (*)(int))sa_old.sa_sigaction : sa_old.sa_handler;
+	    if (oldhandler != SIG_IGN && oldhandler != SIG_DFL)
             {
                 // It has a custom handler, put the default handler back.
 		// We check first th preserve flags on default handlers.

--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -272,7 +272,7 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     if ((processId = fork()) == 0) // processId == 0 if this is child process
 #endif
     {
-	// It turns out that child processes depend on their sigmask being set to something sane rather than mask all.
+        // It turns out that child processes depend on their sigmask being set to something sane rather than mask all.
         // On the other hand, we have to mask all to avoid our own signal handlers running in the child process, writing
         // to the pipe, and waking up the handling thread in the parent process. This also avoids third-party code getting
         // equally confused.
@@ -295,11 +295,11 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
             {
                 break; // No more signals
             }
-	    void (*oldhandler)(int) = (sa_old.sa_flags & SA_SIGINFO) ? (void (*)(int))sa_old.sa_sigaction : sa_old.sa_handler;
-	    if (oldhandler != SIG_IGN && oldhandler != SIG_DFL)
+            void (*oldhandler)(int) = (sa_old.sa_flags & SA_SIGINFO) ? (void (*)(int))sa_old.sa_sigaction : sa_old.sa_handler;
+            if (oldhandler != SIG_IGN && oldhandler != SIG_DFL)
             {
                 // It has a custom handler, put the default handler back.
-		// We check first th preserve flags on default handlers.
+                // We check first th preserve flags on default handlers.
                 sigaction(sig, &sa_default, NULL);
             }
         }

--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -163,13 +163,13 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     bool haveProcessCreateLock = false;
 #endif
     bool success = true;
-    int stdinFds[2] = {-1, -1}, stdoutFds[2] = {-1, -1}, stderrFds[2] = {-1, -1}, waitForChildToExecPipe[2] = {-1, 1};
+    int stdinFds[2] = {-1, -1}, stdoutFds[2] = {-1, -1}, stderrFds[2] = {-1, -1}, waitForChildToExecPipe[2] = {-1, -1};
     pid_t processId = -1;
     int thread_cancel_state;
     sigset_t signal_set;
     sigset_t old_signal_set;
 
-    // None of this code can be cancelled without leaking handles, so just don't allow it
+    // None of this code can be canceled without leaking handles, so just don't allow it
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &thread_cancel_state);
 
     // Validate arguments
@@ -297,7 +297,7 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
                 if (oldhandler != SIG_IGN && oldhandler != SIG_DFL)
                 {
                     // It has a custom handler, put the default handler back.
-                    // We check first th preserve flags on default handlers.
+                    // We check first to preserve flags on default handlers.
                     sigaction(sig, &sa_default, NULL);
                 }
             }

--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -242,9 +242,9 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     sigfillset(&signal_set);
     pthread_sigmask(SIG_SETMASK, &signal_set, &old_signal_set);
 
-#if HAVE_VFORK
+#if HAVE_VFORK && !(defined(__APPLE__)) // We don't trust vfork on OS X right now.
     // This platform has vfork(). vfork() is either a synonym for fork or provides shared memory
-    // semantics. For a one gigabyte process/ the expected performance gain of using shared memory
+    // semantics. For a one gigabyte process, the expected performance gain of using shared memory
     // vfork() rather than fork() is 99.5% merely due to avoiding page faults as the kernel does not
     // need to set all writable pages in the parent process to copy-on-write because the child process
     // is allowed to write to the parent process memory pages.

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -119,6 +119,11 @@ check_symbol_exists(
     HAVE_STAT64)
 
 check_symbol_exists(
+    vfork
+    unistd.h
+    HAVE_VFORK)
+
+check_symbol_exists(
     pipe2
     unistd.h
     HAVE_PIPE2)
@@ -326,15 +331,6 @@ check_c_source_compiles(
     int main(void) { int i = sendfile(0, 0, 0, NULL, NULL, 0); return 0; }
     "
     HAVE_SENDFILE_6)
-
-check_c_source_runs(
-    "
-    #include <sys/types.h>
-    #include <sys/wait.h>
-    #include <unistd.h>
-    int main(void) { volatile int shm = 1; int status; pid_t pid; if ((pid = vfork()) == 0) { shm = 0; _exit(0); } if (pid > 0) waitpid(pid, &status, 0); return shm; }
-    "
-    HAVE_VFORK_SHM)
 
 check_symbol_exists(
     fcopyfile

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -327,6 +327,15 @@ check_c_source_compiles(
     "
     HAVE_SENDFILE_6)
 
+check_c_source_runs(
+    "
+    #include <sys/types.h>
+    #include <sys/wait.h>
+    #include <unistd.h>
+    int main(void) { volatile int shm = 1; int status; pid_t pid; if ((pid = vfork()) == 0) { shm = 0; _exit(0); } if (pid > 0) waitpid(pid, &status, 0); return shm; }
+    "
+    HAVE_VFORK_SHM)
+
 check_symbol_exists(
     fcopyfile
     copyfile.h


### PR DESCRIPTION
Use `vfork()` to start child processes where this yields a performance improvement due to getting rid of page faults.

The larger the host process, the bigger the improvement. For a one gigabyte process, `vfork()` is literally 150 times faster than `fork()`; however most of the performance penalty is incorrectly being charged to the garbage collector.