### PR TITLE
Temporarily disable Tizen leg on PRs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -323,7 +323,8 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                 // Set up triggers
                 if (isPR) {
                     // We run Tizen Debug and Linux Release as default PR builds
-                    if ((osName == "Tizen" && configurationGroup == "Debug") || (osName == "Linux" && configurationGroup == "Release")) {
+                    if (//(osName == "Tizen" && configurationGroup == "Debug") || 
+                        (osName == "Linux" && configurationGroup == "Release")) {
                         Utilities.addGithubPRTriggerForBranch(newJob, branch, "${osName} ${abi} ${configurationGroup} Build")
                     }
                     else {


### PR DESCRIPTION
In order to be able to update the coreclr corefx uses.  We can re-enable this once there's an updated Tizen package.
cc: @gbalykov, @danmosemsft 