### PR TITLE
[release/uwp6.2] Port build fixes from uwp6.0

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -542,10 +542,10 @@
       "checkoutNestedSubmodules": "false",
       "labelSourcesFormat": "$(build.buildNumber)"
     },
-    "id": "58fa2458-e392-4373-ba2b-dd3ef0c2d7ce",
+    "id": "0a2b2664-c1be-429c-9b40-8a24dee27a4a",
     "type": "TfsGit",
-    "name": "DotNet-CoreFX-Trusted",
-    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-CoreFX-Trusted",
+    "name": "DotNet-BuildPipeline",
+    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline",
     "defaultBranch": "refs/heads/master",
     "clean": "false",
     "checkoutSubmodules": false

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -41,7 +41,7 @@
         "scriptName": "",
         "arguments": "-path $(build.SourcesDirectory)\\corefx",
         "workingFolder": "",
-        "inlineScript": "param($path)\nif ($path -and (Test-Path $path)){\nStop-Process -processname msbuild -ErrorAction Ignore -Verbose\nStop-Process -processname dotnet -ErrorAction Ignore -Verbose\nStop-Process -processname vbcscompiler -ErrorAction Ignore -Verbose\n$emptyFolder = (New-Item -ItemType Directory (Join-Path -Path $env:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName()))).FullName\nrobocopy $emptyFolder $path /purge\nRemove-Item -Recurse -Force $path,$emptyFolder \nexit 0\n}",
+        "inlineScript": "param($path)\nif ($path -and (Test-Path $path)){\nStop-Process -processname msbuild -ErrorAction Ignore -Verbose\nStop-Process -processname dotnet -ErrorAction Ignore -Verbose\nStop-Process -processname vbcscompiler -ErrorAction Ignore -Verbose\nStop-Process -processname vctip -ErrorAction Ignore -Verbose\n$emptyFolder = (New-Item -ItemType Directory (Join-Path -Path $env:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName()))).FullName\nrobocopy $emptyFolder $path /purge\nRemove-Item -Recurse -Force $path,$emptyFolder \nexit 0\n}",
         "failOnStandardError": "true"
       }
     },


### PR DESCRIPTION
Port build fixes from release/uwp6.0 to release/uwp6.2:
* https://github.com/dotnet/corefx/pull/31741 "Clone DotNet-BuildPipeline, not CoreFX master"
* https://github.com/dotnet/corefx/pull/31747 "Add vctip to list of lingering processes to stop"