### PR TITLE
filter out MSG_PEEK so it does not loop back

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1194,7 +1194,7 @@ static int8_t ConvertSocketFlagsPalToPlatform(int32_t palFlags, int* platformFla
 
 static int32_t ConvertSocketFlagsPlatformToPal(int platformFlags)
 {
-    const int SupportedFlagsMask = MSG_OOB | MSG_PEEK | MSG_DONTROUTE | MSG_TRUNC | MSG_CTRUNC;
+    const int SupportedFlagsMask = MSG_OOB | MSG_DONTROUTE | MSG_TRUNC | MSG_CTRUNC;
 
     platformFlags &= SupportedFlagsMask;
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1136,7 +1136,6 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ActiveIssue(31766, TestPlatforms.OSX)]
         public async Task Socket_ReceiveFlags_Success()
         {
             using (var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))


### PR DESCRIPTION
fixes  #31766

The problem is that if ReceiveAsync() is called with 0 size buffer we add MSG_PEEK and wait for data to arrive. (caller has nothing to do with it) This works ok on Linux & Windows. However on OSX the MSG_PEEK get also set in msg_control flags. That get pushed  to SocketFlags in EventArgs.
When that is reused to make the call with real buffer the MSG_PEEK is still set and we will never finish reading and draining the socket buffer. 

Since this is platform difference I decided to fix it in PAL layer. I did testing on Linux and MSG_PEEK would never be set by os as far as I know. 