### PR TITLE
add build-id to FreeBSD native code

### DIFF
--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -119,6 +119,8 @@ endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
     set(CLR_CMAKE_PLATFORM_UNIX 1)
     add_definitions(-D_BSD_SOURCE) # required for getline
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld -Xlinker --build-id=sha1")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  -fuse-ld=lld -Xlinker --build-id=sha1")
 endif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 
 if(CMAKE_SYSTEM_NAME STREQUAL OpenBSD)


### PR DESCRIPTION
This should help with publishing symbols on freebsd

```
[furt@toweinfu-d11 ~/git/wfurt-corefx]$ readelf -Wl artifacts/bin/native/netcoreapp-FreeBSD-Debug-x64/System.Native.so

Elf file type is DYN (Shared object file)
Entry point 0xa000
There are 9 program headers, starting at offset 64

Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  PHDR           0x000040 0x0000000000000040 0x0000000000000040 0x0001f8 0x0001f8 R   0x8
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x0095b0 0x0095b0 R   0x1000
  LOAD           0x00a000 0x000000000000a000 0x000000000000a000 0x00dd00 0x00dd00 R E 0x1000
  LOAD           0x018000 0x0000000000018000 0x0000000000018000 0x0011b8 0x002130 RW  0x1000
  DYNAMIC        0x019028 0x0000000000019028 0x0000000000019028 0x000170 0x000170 RW  0x8
  GNU_RELRO      0x019000 0x0000000000019000 0x0000000000019000 0x0001b8 0x001000 R   0x1
  GNU_EH_FRAME   0x006e48 0x0000000000006e48 0x0000000000006e48 0x0007e4 0x0007e4 R   0x1
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0
  NOTE           0x0020b4 0x00000000000020b4 0x00000000000020b4 0x000024 0x000024 R   0x4

 Section to Segment mapping:
  Segment Sections...
   00
   01     .rodata .note.gnu.build-id .dynsym .gnu.version .gnu.version_r .gnu.hash .hash .dynstr .rela.dyn .rela.plt .eh_frame_hdr .eh_frame
   02     .text .init .fini .plt
   03     .data .got.plt .ctors .dtors .jcr .dynamic .got .bss
   04     .dynamic
   05     .ctors .dtors .jcr .dynamic .got
   06     .eh_frame_hdr
   07
   08     .note.gnu.build-id
```
