### PR TITLE
Improve port parsing to reject non-digit characters

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2422,8 +2422,7 @@ namespace System
                                 for (++idx; idx < info.Offset.End; ++idx)
                                 {
                                     ushort val = unchecked((ushort)((ushort)userString[idx] - (ushort)'0'));
-                                    if (val == unchecked((ushort)('/' - '0')) || val == (ushort)('?' - '0') ||
-                                        val == unchecked((ushort)('#' - '0')))
+                                    if (val > unchecked((ushort)('9' - '0')))
                                     {
                                         break;
                                     }

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2411,8 +2411,7 @@ namespace System
                         if (++idx < info.Offset.End)
                         {
                             port = unchecked((ushort)(userString[idx] - '0'));
-                            if (!(port == unchecked((ushort)('/' - '0')) || port == (ushort)('?' - '0') ||
-                                port == unchecked((ushort)('#' - '0'))))
+                            if (port <= unchecked((ushort)('9' - '0')))
                             {
                                 notEmpty = true;
                                 if (port == 0)

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -913,6 +913,8 @@ namespace System.PrivateUri.Tests
         [InlineData("90")]
         [InlineData("0")]
         [InlineData("000")]
+        [InlineData("65535")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Uri_PortTrailingSpaces_SpacesTrimmed(string portString)
         {
             Uri u = new Uri($"http://www.contoso.com:{portString}     ");
@@ -923,7 +925,8 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
-        public static void Uri_EmptyPortTrailingSpaces_SpacesTrimmed()
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void Uri_EmptyPortTrailingSpaces_UsesDefaultPortSpacesTrimmed()
         {
             Uri u = new Uri($"http://www.contoso.com:     ");
 
@@ -949,6 +952,30 @@ namespace System.PrivateUri.Tests
 
             Assert.Equal($"http://www.contoso.com/{query}", u.AbsoluteUri);
             Assert.Equal(query, u.Query);
+        }
+
+        [Theory]
+        [InlineData(" 80")]
+        [InlineData("8 0")]
+        [InlineData("80a")]
+        [InlineData("65536")]
+        [InlineData("100000")]
+        [InlineData("10000000000")]
+        public static void Uri_InvalidPort_ThrowsUriFormatException(string portString)
+        {
+            Assert.Throws<UriFormatException>( () =>
+            {
+                Uri u = new Uri($"http://www.contoso.com:{portString}");
+            });
+        }
+
+        [Fact]
+        public static void Uri_EmptyPort_UsesDefaultPort()
+        {
+            Uri u = new Uri($"http://www.contoso.com:");
+
+            Assert.Equal($"http://www.contoso.com/", u.AbsoluteUri);
+            Assert.Equal(80, u.Port);
         }
     }
 }

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -903,14 +903,32 @@ namespace System.PrivateUri.Tests
             Assert.Equal(host, u.Host);
         }
 
-        [Fact]
-        public static void Uri_PortTrailingSpaces_SpacesTrimmed()
+        [Theory]
+        [InlineData("1234")]
+        [InlineData("01234")]
+        [InlineData("12340")]
+        [InlineData("012340")]
+        [InlineData("99")]
+        [InlineData("09")]
+        [InlineData("90")]
+        [InlineData("0")]
+        [InlineData("000")]
+        public static void Uri_PortTrailingSpaces_SpacesTrimmed(string portString)
         {
-            int port = 1234;
-            Uri u = new Uri($"http://www.contoso.com:{port}     ");
+            Uri u = new Uri($"http://www.contoso.com:{portString}     ");
 
+            int port = Int32.Parse(portString);
             Assert.Equal($"http://www.contoso.com:{port}/", u.AbsoluteUri);
             Assert.Equal(port, u.Port);
+        }
+
+        [Fact]
+        public static void Uri_EmptyPortTrailingSpaces_SpacesTrimmed()
+        {
+            Uri u = new Uri($"http://www.contoso.com:     ");
+
+            Assert.Equal($"http://www.contoso.com/", u.AbsoluteUri);
+            Assert.Equal(80, u.Port);
         }
 
         [Fact]

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -892,5 +892,45 @@ namespace System.PrivateUri.Tests
             string largeString = new string('a', 1_000_000) + ":"; // 2MB is large enough to cause a stack overflow if we stackalloc the scheme buffer.
             Assert.Throws<UriFormatException>(() => new Uri(largeString));
         }
+
+        [Fact]
+        public static void Uri_HostTrailingSpaces_SpacesTrimmed()
+        {
+            string host = "www.contoso.com";
+            Uri u = new Uri($"http://{host}     ");
+
+            Assert.Equal($"http://{host}/", u.AbsoluteUri);
+            Assert.Equal(host, u.Host);
+        }
+
+        [Fact]
+        public static void Uri_PortTrailingSpaces_SpacesTrimmed()
+        {
+            int port = 1234;
+            Uri u = new Uri($"http://www.contoso.com:{port}     ");
+
+            Assert.Equal($"http://www.contoso.com:{port}/", u.AbsoluteUri);
+            Assert.Equal(port, u.Port);
+        }
+
+        [Fact]
+        public static void Uri_PathTrailingSpaces_SpacesTrimmed()
+        {
+            string path = "/path/";
+            Uri u = new Uri($"http://www.contoso.com{path}     ");
+
+            Assert.Equal($"http://www.contoso.com{path}", u.AbsoluteUri);
+            Assert.Equal(path, u.AbsolutePath);
+        }
+
+        [Fact]
+        public static void Uri_QueryTrailingSpaces_SpacesTrimmed()
+        {
+            string query = "?query";
+            Uri u = new Uri($"http://www.contoso.com/{query}     ");
+
+            Assert.Equal($"http://www.contoso.com/{query}", u.AbsoluteUri);
+            Assert.Equal(query, u.Query);
+        }
     }
 }


### PR DESCRIPTION
The current port parsing code is doing string -> int conversion with no validation that the characters it's operating on are actually in the range of '0' to '9'. Previous validation will prevent most characters from getting through, but our rules on trailing whitespace allow spaces, tabs, and newlines.

While I think it would be great to rip out all this code and replace it, that change would have a significant potential to regress current users. It may be worth doing at some point, but for now I'm taking a more targeted approach.

The fix here expands the set of characters that will terminate the port to include all non-digit characters, rather than just URI separators.

Fixes: #33199