### PR TITLE
Remove System.Memory reference from several libraries

### DIFF
--- a/src/Common/src/CoreLib/Interop/Windows/Kernel32/Interop.FormatMessage.cs
+++ b/src/Common/src/CoreLib/Interop/Windows/Kernel32/Interop.FormatMessage.cs
@@ -42,7 +42,7 @@ internal partial class Interop
 
             // First try to format the message into the stack based buffer.  Most error messages willl fit.
             Span<char> stackBuffer = stackalloc char[256]; // arbitrary stack limit
-            fixed (char* bufferPtr = &MemoryMarshal.GetReference(stackBuffer))
+            fixed (char* bufferPtr = stackBuffer)
             {
                 int length = FormatMessage(flags, moduleHandle, unchecked((uint)errorCode), 0, bufferPtr, stackBuffer.Length, IntPtr.Zero);
                 if (length > 0)

--- a/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
+++ b/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
@@ -30,7 +30,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -173,7 +173,6 @@
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.IO.FileSystem" />
-    <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />


### PR DESCRIPTION
Minor cleanup... these projects only have this System.Memory reference in order to support MemoryMarshal.GetReference, and we can just use the default GetPinnableReference instead. (We could also just stackalloc into a pointer instead of using span at all, but using span keeps it tidy and adds a tiny amount of additional safety).

cc: @jkotas