### PR TITLE
Add support for TLS 1.3 to .NET Core

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
@@ -166,6 +166,7 @@ internal static partial class Interop
             CURL_SSLVERSION_TLSv1_0 = 4, /* TLS 1.0 */
             CURL_SSLVERSION_TLSv1_1 = 5, /* TLS 1.1 */
             CURL_SSLVERSION_TLSv1_2 = 6, /* TLS 1.2 */
+            CURL_SSLVERSION_TLSv1_3 = 7, /* TLS 1.3 */
         };
 
         // Enum for constants defined for the enum CURLINFO in curl.h

--- a/src/Common/src/Interop/Windows/SChannel/Interop.SchProtocols.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SchProtocols.cs
@@ -29,10 +29,14 @@ internal static partial class Interop
         public const int SP_PROT_TLS1_2_CLIENT = 0x00000800;
         public const int SP_PROT_TLS1_2 = (SP_PROT_TLS1_2_SERVER | SP_PROT_TLS1_2_CLIENT);
 
+        public const int SP_PROT_TLS1_3_SERVER = 0x00001000;
+        public const int SP_PROT_TLS1_3_CLIENT = 0x00002000;
+        public const int SP_PROT_TLS1_3 = (SP_PROT_TLS1_3_SERVER | SP_PROT_TLS1_3_CLIENT);
+
         public const int SP_PROT_NONE = 0;
 
         // These two constants are not taken from schannel.h. 
-        public const int ClientProtocolMask = (SP_PROT_SSL2_CLIENT | SP_PROT_SSL3_CLIENT | SP_PROT_TLS1_0_CLIENT | SP_PROT_TLS1_1_CLIENT | SP_PROT_TLS1_2_CLIENT);
-        public const int ServerProtocolMask = (SP_PROT_SSL2_SERVER | SP_PROT_SSL3_SERVER | SP_PROT_TLS1_0_SERVER | SP_PROT_TLS1_1_SERVER | SP_PROT_TLS1_2_SERVER);
+        public const int ClientProtocolMask = (SP_PROT_SSL2_CLIENT | SP_PROT_SSL3_CLIENT | SP_PROT_TLS1_0_CLIENT | SP_PROT_TLS1_1_CLIENT | SP_PROT_TLS1_2_CLIENT | SP_PROT_TLS1_3_CLIENT);
+        public const int ServerProtocolMask = (SP_PROT_SSL2_SERVER | SP_PROT_SSL3_SERVER | SP_PROT_TLS1_0_SERVER | SP_PROT_TLS1_1_SERVER | SP_PROT_TLS1_2_SERVER | SP_PROT_TLS1_3_SERVER);
     }
 }

--- a/src/Common/src/System/Net/SecurityProtocol.cs
+++ b/src/Common/src/System/Net/SecurityProtocol.cs
@@ -8,7 +8,11 @@ namespace System.Net
 {
     internal static class SecurityProtocol
     {
-        public const SslProtocols DefaultSecurityProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+        public const SslProtocols DefaultSecurityProtocols =
+#if !netstandard
+            SslProtocols.Tls13 |
+#endif
+            SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
 
         public const SslProtocols SystemDefaultSecurityProtocols = SslProtocols.None;
     }

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -350,7 +350,11 @@ namespace System.Net.Test.Common
             public IPAddress Address { get; set; } = IPAddress.Loopback;
             public int ListenBacklog { get; set; } = 1;
             public bool UseSsl { get; set; } = false;
-            public SslProtocols SslProtocols { get; set; } = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+            public SslProtocols SslProtocols { get; set; } =
+#if !netstandard
+                SslProtocols.Tls13 |
+#endif
+                SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
             public bool WebSocketEndpoint { get; set; } = false;
             public Func<Stream, Stream> StreamWrapper { get; set; }
             public string Username { get; set; }

--- a/src/Common/tests/System/Net/SslProtocolSupport.cs
+++ b/src/Common/tests/System/Net/SslProtocolSupport.cs
@@ -11,7 +11,11 @@ namespace System.Net.Test.Common
 {
     public class SslProtocolSupport
     {
-        public const SslProtocols DefaultSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
+        public const SslProtocols DefaultSslProtocols =
+#if !netstandard
+            SslProtocols.Tls13 |
+#endif
+            SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
 
         public static SslProtocols SupportedSslProtocols
         {
@@ -26,6 +30,13 @@ namespace System.Net.Test.Common
                     supported |= SslProtocols.Ssl3;
                 }
 #pragma warning restore 0618
+#if !netstandard
+                // TLS 1.3 is new
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PlatformDetection.OpenSslVersion >= new Version(1, 1, 1))
+                {
+                    supported |= SslProtocols.Tls13;
+                }
+#endif
                 return supported;
             }
         }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -100,6 +100,7 @@ namespace System
         public static bool IsUbuntu1710 { get { throw null; } }
         public static bool IsUbuntu1710OrHigher { get { throw null; } }
         public static bool IsUbuntu1804 { get { throw null; } }
+        public static bool IsUbuntu1810OrHigher { get { throw null; } }
         public static bool IsWindows { get { throw null; } }
         public static bool IsWindows10Version1607OrGreater { get { throw null; } } // >= Windows 10 Anniversary Update
         public static bool IsWindows10Version1703OrGreater { get { throw null; } } // >= Windows 10 Creators Update

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -38,6 +38,7 @@ namespace System
         public static bool IsUbuntu1710 => IsDistroAndVersion("ubuntu", 17, 10);
         public static bool IsUbuntu1710OrHigher => IsDistroAndVersionOrHigher("ubuntu", 17, 10);
         public static bool IsUbuntu1804 => IsDistroAndVersion("ubuntu", 18, 04);
+        public static bool IsUbuntu1810OrHigher => IsDistroAndVersionOrHigher("ubuntu", 18, 10);
         public static bool IsTizen => IsDistroAndVersion("tizen");
         public static bool IsFedora => IsDistroAndVersion("fedora");
         public static bool IsWindowsNanoServer => false;

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -29,6 +29,7 @@ namespace System
         public static bool IsUbuntu1710 => false;
         public static bool IsUbuntu1710OrHigher => false;
         public static bool IsUbuntu1804 => false;
+        public static bool IsUbuntu1810OrHigher => false;
         public static bool IsTizen => false;
         public static bool IsNotFedoraOrRedHatFamily => true;
         public static bool IsFedora => false;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -31,6 +31,8 @@ static SSLProtocol PalSslProtocolToSslProtocol(PAL_SslProtocol palProtocolId)
 {
     switch (palProtocolId)
     {
+        case PAL_SslProtocol_Tls13:
+            return kTLSProtocol13;
         case PAL_SslProtocol_Tls12:
             return kTLSProtocol12;
         case PAL_SslProtocol_Tls11:
@@ -419,7 +421,9 @@ int32_t AppleCryptoNative_SslGetProtocolVersion(SSLContextRef sslContext, PAL_Ss
     {
         PAL_SslProtocol matchedProtocol = PAL_SslProtocol_None;
 
-        if (protocol == kTLSProtocol12)
+        if (protocol == kTLSProtocol13)
+            matchedProtocol = PAL_SslProtocol_Tls13;
+        else if (protocol == kTLSProtocol12)
             matchedProtocol = PAL_SslProtocol_Tls12;
         else if (protocol == kTLSProtocol11)
             matchedProtocol = PAL_SslProtocol_Tls11;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
@@ -35,6 +35,7 @@ enum
     PAL_SslProtocol_Tls10 = 192,
     PAL_SslProtocol_Tls11 = 768,
     PAL_SslProtocol_Tls12 = 3072,
+    PAL_SslProtocol_Tls13 = 12288,
 };
 typedef int32_t PAL_SslProtocol;
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -147,7 +147,10 @@ void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
 #ifndef SSL_OP_NO_TLSv1_3
 #define SSL_OP_NO_TLSv1_3 0x20000000U
 #endif
-    protocolOptions |= SSL_OP_NO_TLSv1_3;
+    if ((protocols & PAL_SSL_TLS13) != PAL_SSL_TLS13)
+    {
+        protocolOptions |= SSL_OP_NO_TLSv1_3;
+    }
 
     // OpenSSL 1.0 calls this long, OpenSSL 1.1 calls it unsigned long.
 #pragma clang diagnostic push

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -16,7 +16,8 @@ typedef enum
     PAL_SSL_SSL3 = 48,
     PAL_SSL_TLS = 192,
     PAL_SSL_TLS11 = 768,
-    PAL_SSL_TLS12 = 3072
+    PAL_SSL_TLS12 = 3072,
+    PAL_SSL_TLS13 = 12288,
 } SslProtocols;
 
 /*

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -979,6 +979,17 @@ namespace System.Net.Http
                 optionData |= Interop.WinHttp.WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
             }
 
+            // As of Win10RS5 there's no public constant for WinHTTP + TLS 1.3
+            // This library builds against netstandard, which doesn't define the Tls13 enum field.
+
+            // If only unknown values (e.g. TLS 1.3) were asked for, report ERROR_INVALID_PARAMETER.
+            if (optionData == 0)
+            {
+                throw WinHttpException.CreateExceptionUsingError(
+                    unchecked((int)Interop.WinHttp.ERROR_INVALID_PARAMETER),
+                    nameof(SetSessionHandleTlsOptions));
+            }
+
             SetWinHttpOption(sessionHandle, Interop.WinHttp.WINHTTP_OPTION_SECURE_PROTOCOLS, ref optionData);
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
@@ -233,8 +233,12 @@ namespace System.Net.Http
                     case SslProtocols.Tls12:
                         curlSslVersion = Interop.Http.CurlSslVersion.CURL_SSLVERSION_TLSv1_2;
                         break;
+                    case SslProtocols.Tls13:
+                        curlSslVersion = Interop.Http.CurlSslVersion.CURL_SSLVERSION_TLSv1_3;
+                        break;
 
                     case SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12:
+                    case SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13:
                         curlSslVersion = Interop.Http.CurlSslVersion.CURL_SSLVERSION_TLSv1;
                         break;
 

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.OSX.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.OSX.cs
@@ -125,8 +125,12 @@ namespace System.Net.Http
                     case SslProtocols.Tls12:
                         curlSslVersion = Interop.Http.CurlSslVersion.CURL_SSLVERSION_TLSv1_2;
                         break;
+                    case SslProtocols.Tls13:
+                        curlSslVersion = Interop.Http.CurlSslVersion.CURL_SSLVERSION_TLSv1_3;
+                        break;
 
                     case SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12:
+                    case SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13:
                         curlSslVersion = Interop.Http.CurlSslVersion.CURL_SSLVERSION_TLSv1;
                         break;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -29,6 +29,8 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(SslProtocols.Tls, true)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, false)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, true)]
+        [InlineData(SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, false)]
+        [InlineData(SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, true)]
         [InlineData(SslProtocols.None, false)]
         [InlineData(SslProtocols.None, true)]
         public async Task SetDelegate_ConnectionSucceeds(SslProtocols acceptedProtocol, bool requestOnlyThisProtocol)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -33,10 +33,15 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(SslProtocols.Tls)]
         [InlineData(SslProtocols.Tls11)]
         [InlineData(SslProtocols.Tls12)]
+        [InlineData(SslProtocols.Tls13)]
         [InlineData(SslProtocols.Tls | SslProtocols.Tls11)]
         [InlineData(SslProtocols.Tls11 | SslProtocols.Tls12)]
+        [InlineData(SslProtocols.Tls11 | SslProtocols.Tls13)]
+        [InlineData(SslProtocols.Tls12 | SslProtocols.Tls13)]
         [InlineData(SslProtocols.Tls | SslProtocols.Tls12)]
+        [InlineData(SslProtocols.Tls | SslProtocols.Tls13)]
         [InlineData(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12)]
+        [InlineData(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13)]
         public void SetGetProtocols_Roundtrips(SslProtocols protocols)
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())
@@ -97,6 +102,12 @@ namespace System.Net.Http.Functional.Tests
                 yield return new object[] { SslProtocols.Ssl2, true };
             }
 #pragma warning restore 0618
+            // These protocols are new, and might not be enabled everywhere yet
+            if (PlatformDetection.IsUbuntu1810OrHigher)
+            {
+                yield return new object[] { SslProtocols.Tls13, false };
+                yield return new object[] { SslProtocols.Tls13, true };
+            }
         }
 
         [Theory]

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -508,6 +508,7 @@ namespace System.Security.Authentication
         Tls = 192,
         Tls11 = 768,
         Tls12 = 3072,
+        Tls13 = 12288,
         [Obsolete("This value has been deprecated.  It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
         Default = Ssl3 | Tls
     }

--- a/src/System.Net.Primitives/src/System/Net/SecureProtocols/SslEnumTypes.cs
+++ b/src/System.Net.Primitives/src/System/Net/SecureProtocols/SslEnumTypes.cs
@@ -16,6 +16,7 @@ namespace System.Security.Authentication
         Tls = Interop.SChannel.SP_PROT_TLS1_0,
         Tls11 = Interop.SChannel.SP_PROT_TLS1_1,
         Tls12 = Interop.SChannel.SP_PROT_TLS1_2,
+        Tls13 = Interop.SChannel.SP_PROT_TLS1_3,
         Default = Ssl3 | Tls
     }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.Unix.cs
@@ -59,6 +59,8 @@ namespace System.Net.Security
                     return SslProtocols.Tls11;
                 case "TLSv1.2":
                     return SslProtocols.Tls12;
+                case "TLSv1.3":
+                    return SslProtocols.Tls13;
                 default:
                     return SslProtocols.None;
             }

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -376,6 +376,11 @@ namespace System.Net.Security
                     ret |= SslProtocols.Tls12;
                 }
 
+                if ((proto & SslProtocols.Tls13) != 0)
+                {
+                    ret |= SslProtocols.Tls13;
+                }
+
                 return ret;
             }
         }

--- a/src/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
+++ b/src/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
@@ -62,5 +62,6 @@ namespace System.Net
         Tls = System.Security.Authentication.SslProtocols.Tls,
         Tls11 = System.Security.Authentication.SslProtocols.Tls11,
         Tls12 = System.Security.Authentication.SslProtocols.Tls12,
+        Tls13 = System.Security.Authentication.SslProtocols.Tls13,
     }
 }

--- a/src/System.Net.ServicePoint/src/System/Net/SecurityProtocolType.cs
+++ b/src/System.Net.ServicePoint/src/System/Net/SecurityProtocolType.cs
@@ -16,5 +16,6 @@ namespace System.Net
         Tls = SslProtocols.Tls,
         Tls11 = SslProtocols.Tls11,
         Tls12 = SslProtocols.Tls12,
+        Tls13 = SslProtocols.Tls13,
     }
 }

--- a/src/System.Net.ServicePoint/src/System/Net/ServicePointManager.cs
+++ b/src/System.Net.ServicePoint/src/System/Net/ServicePointManager.cs
@@ -36,7 +36,7 @@ namespace System.Net
 
         private static void ValidateSecurityProtocol(SecurityProtocolType value)
         {
-            SecurityProtocolType allowed = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            SecurityProtocolType allowed = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
             if ((value & ~allowed) != 0)
             {
                 throw new NotSupportedException(SR.net_securityprotocolnotsupported);


### PR DESCRIPTION
* TLS 1.3 connections have been tested on Ubuntu 18.10 (OpenSSL 1.1.1).
* There's no public version of Windows with TLS 1.3 enabled.
* There's no public version of macOS with TLS 1.3 enabled out of the box.

When making use of SslProtocols.None (system default) TLS 1.3 is already working on Ubuntu 18.10, this change mainly makes it so that EncryptionPolicy.None is better handled, and that we can restrict-to and report TLS 1.3.