### PR TITLE
CI is failing after my last checkin, trying to revert the version

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2543,10 +2543,8 @@
       ],
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0",
-        "netcoreapp3.0": "4.2.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
-        "uap10.0.16300": "4.2.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",

--- a/src/System.Memory/Directory.Build.props
+++ b/src/System.Memory/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- System.Memory has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.0.* -->
-    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>


### PR DESCRIPTION
…change for System.Memory to try and repair.

```
19:30:06     Testing System.Windows.Extensions TFM=netcoreapp3.0 RID=win7-x64
19:30:06     Testing System.Windows.Extensions TFM=netcoreapp3.0 RID=debian.8-x64
19:30:07 D:\j\workspace\windows-TGrou---0d2c9ac4\artifacts\bin\testPkg\packageTest.targets(69,5): error : Assembly 'System.Drawing.Common' has insufficient version for dependency 'System.Memory' : 4.1.0.0 < 4.2.0.0. [D:\j\workspace\windows-TGrou---0d2c9ac4\artifacts\bin\testPkg\projects\System.Windows.Extensions\netcoreapp3.0\project.csproj] [D:\j\workspace\windows-TGrou---0d2c9ac4\pkg\test\testPackages.proj]
```

