### PR TITLE
Ignoring System.Memory packaging failures due to System.Memory version bump

### DIFF
--- a/pkg/test/project.csproj.template
+++ b/pkg/test/project.csproj.template
@@ -8,6 +8,8 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <!-- System.Memory version has been bumped so we expect validation to fail until we ingest the new core-setup which contains that change -->
+    <IgnoredReference Include="System.Memory" Version="4.2.0.0" />
     <PackageReference Include="{PackageId}" Version="{PackageVersion}" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #33389

FYI: @stephentoub @JeremyKuhne 

CC: @ericstj 

This change should get removed right after we consume a new version of core-setup. I was waiting for that to happen, but looks like because of the free-bsd change core-setup pipebuild might be broken. That's why I'm checking this in in order to unblock corefx PRs.

@ericstj I know that I could have added individual settings to the packages/TFMs that needed this, but given it is only a temporary change and should be removed very soon I decided to do this on the template so there is only one thing to remove.