### PR TITLE
Remove test that sets static readonly field after type initialization

### DIFF
--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -224,21 +224,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
-        public void StaticReadonlyField(bool useInterpreter)
-        {
-            MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StaticReadonlyStringField))[0];
-            Expression<Func<PropertyAndFields>> assignToReadonly = Expression.Lambda<Func<PropertyAndFields>>(
-                Expression.MemberInit(
-                    Expression.New(typeof(PropertyAndFields)),
-                    Expression.Bind(member, Expression.Constant("ABC" + useInterpreter))
-                    )
-                );
-            Func<PropertyAndFields> func = assignToReadonly.Compile(useInterpreter);
-            func();
-            Assert.Equal("ABC" + useInterpreter, PropertyAndFields.StaticReadonlyStringField);
-        }
-
-        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticProperty(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StaticStringProperty))[0];


### PR DESCRIPTION
dotnet/coreclr#20866 extends the jit to incorporate the type of readonly ref
class typed static fields into jitted code when jitting happens after class
initialization. For instance, the jit may optimize type tests or devirtualize
calls.

With the advent of type based jit optimizations we are also blocking reflection
based updates to all readonly static fields after class initialization.