### PR TITLE
Expose\test {Stream}TextWriter.DisposeAsync

### DIFF
--- a/src/System.IO/tests/StreamWriter/StreamWriter.DisposeAsync.netcoreapp.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.DisposeAsync.netcoreapp.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class StreamWriterTests
+    {
+
+        [Fact]
+        public void DisposeAsync_CanInvokeMultipleTimes()
+        {
+            var ms = new MemoryStream();
+            var sw = new StreamWriter(ms);
+            Assert.True(sw.DisposeAsync().IsCompletedSuccessfully);
+            Assert.True(sw.DisposeAsync().IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void DisposeAsync_CanDisposeAsyncAfterDispose()
+        {
+            var ms = new MemoryStream();
+            var sw = new StreamWriter(ms);
+            sw.Dispose();
+            Assert.True(sw.DisposeAsync().IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_FlushesStream()
+        {
+            var ms = new MemoryStream();
+            var sw = new StreamWriter(ms);
+            try
+            {
+                sw.Write("hello");
+                Assert.Equal(0, ms.Position);
+            }
+            finally
+            {
+                await sw.DisposeAsync();
+            }
+            Assert.Throws<ObjectDisposedException>(() => ms.Position);
+            Assert.Equal(5, ms.ToArray().Length);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_LeaveOpenTrue_LeftOpen()
+        {
+            var ms = new MemoryStream();
+            var sw = new StreamWriter(ms, Encoding.ASCII, 0x1000, leaveOpen: true);
+            try
+            {
+                sw.Write("hello");
+            }
+            finally
+            {
+                await sw.DisposeAsync();
+            }
+            Assert.Equal(5, ms.Position); // doesn't throw
+        }
+
+        [Fact]
+        public async Task DisposeAsync_DerivedTypeForcesDisposeToBeUsedUnlessOverridden()
+        {
+            var ms = new MemoryStream();
+            var sw = new OverrideDisposeStreamWriter(ms);
+            try
+            {
+                sw.Write("hello");
+            }
+            finally
+            {
+                Assert.False(sw.DisposeInvoked);
+                await sw.DisposeAsync();
+                Assert.True(sw.DisposeInvoked);
+            }
+        }
+
+        [Fact]
+        public async Task DisposeAsync_DerivedTypeDisposeAsyncInvoked()
+        {
+            var ms = new MemoryStream();
+            var sw = new OverrideDisposeAndDisposeAsyncStreamWriter(ms);
+            try
+            {
+                sw.Write("hello");
+            }
+            finally
+            {
+                Assert.False(sw.DisposeInvoked);
+                Assert.False(sw.DisposeAsyncInvoked);
+                await sw.DisposeAsync();
+                Assert.False(sw.DisposeInvoked);
+                Assert.True(sw.DisposeAsyncInvoked);
+            }
+        }
+
+        private sealed class OverrideDisposeStreamWriter : StreamWriter
+        {
+            public bool DisposeInvoked;
+            public OverrideDisposeStreamWriter(Stream output) : base(output) { }
+            protected override void Dispose(bool disposing) => DisposeInvoked = true;
+        }
+
+        private sealed class OverrideDisposeAndDisposeAsyncStreamWriter : StreamWriter
+        {
+            public bool DisposeInvoked, DisposeAsyncInvoked;
+            public OverrideDisposeAndDisposeAsyncStreamWriter(Stream output) : base(output) { }
+            protected override void Dispose(bool disposing) => DisposeInvoked = true;
+            public override ValueTask DisposeAsync() { DisposeAsyncInvoked = true; return default; }
+        }
+    }
+}

--- a/src/System.IO/tests/StringWriter/StringWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.netcoreapp.cs
@@ -93,5 +93,17 @@ namespace System.IO.Tests
             cts.Cancel();
             Assert.Equal(TaskStatus.Canceled, sw.WriteLineAsync(sb, cts.Token).Status);
         }
+
+        [Fact]
+        public void DisposeAsync_ClosesWriterAndLeavesBuilderAvailable()
+        {
+            var sb = new StringBuilder();
+            var sw = new StringWriter(sb);
+            sw.Write("hello");
+            Assert.True(sw.DisposeAsync().IsCompletedSuccessfully);
+            Assert.True(sw.DisposeAsync().IsCompletedSuccessfully);
+            Assert.Throws<ObjectDisposedException>(() => sw.Write(42));
+            Assert.Equal("hello", sb.ToString());
+        }
     }
 }

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="StreamWriter\StreamWriter.BaseStream.cs" />
     <Compile Include="StreamWriter\StreamWriter.CloseTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.CtorTests.cs" />
+    <Compile Include="StreamWriter\StreamWriter.DisposeAsync.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="StreamWriter\StreamWriter.FlushTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.WriteTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.WriteTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />

--- a/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -105,6 +106,33 @@ namespace System.IO.Tests
                 tw.Flush();
                 Assert.Equal(testData + tw.NewLine, ctw.Text);
             }
+        }
+
+        [Fact]
+        public void DisposeAsync_InvokesDisposeSynchronously()
+        {
+            bool disposeInvoked = false;
+            var tw = new InvokeActionOnDisposeTextWriter() { DisposeAction = () => disposeInvoked = true };
+            Assert.False(disposeInvoked);
+            Assert.True(tw.DisposeAsync().IsCompletedSuccessfully);
+            Assert.True(disposeInvoked);
+        }
+
+        [Fact]
+        public void DisposeAsync_ExceptionReturnedInTask()
+        {
+            Exception e = new FormatException();
+            var tw = new InvokeActionOnDisposeTextWriter() { DisposeAction = () => { throw e; } };
+            ValueTask vt = tw.DisposeAsync();
+            Assert.True(vt.IsFaulted);
+            Assert.Same(e, vt.AsTask().Exception.InnerException);
+        }
+
+        private sealed class InvokeActionOnDisposeTextWriter : TextWriter
+        {
+            public Action DisposeAction;
+            public override Encoding Encoding => Encoding.UTF8;
+            protected override void Dispose(bool disposing) => DisposeAction?.Invoke();
         }
 
         // Generate data for TextWriter.Write* methods that take a stringBuilder.  

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1464,6 +1464,7 @@ namespace System.IO
         public override System.Text.Encoding Encoding { get { throw null; } }
         public override void Close() { }
         protected override void Dispose(bool disposing) { }
+        public override System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync() { throw null; }
         public override void Write(char value) { }

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1563,6 +1563,7 @@ namespace System.IO
         public virtual void Close() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public virtual void Flush() { }
         public virtual System.Threading.Tasks.Task FlushAsync() { throw null; }
         public static System.IO.TextWriter Synchronized(System.IO.TextWriter writer) { throw null; }


### PR DESCRIPTION
Also adds a test for StringWriter.DisposeAsync, which is fine with the base behavior and thus doesn't actually need/get an override.

cc: @JeremyKuhne
Contributes to #32665