### PR TITLE
Test {Unmanaged}MemoryStream.DisposeAsync

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
@@ -15,6 +15,7 @@
     <Compile Include="UmaTests.cs" />
     <Compile Include="UmsCtorTests.cs" />
     <Compile Include="HGlobalSafeBuffer.cs" />
+    <Compile Include="UmsDisposeAsync.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="UmsReadWrite.cs" />
     <Compile Include="UmsReadWrite.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="UmsSafeBuffer.cs" />

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsDisposeAsync.netcoreapp.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsDisposeAsync.netcoreapp.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public sealed class UmsDisposeAsync
+    {
+        [Fact]
+        public void DisposeAsync_ClosesStream()
+        {
+            using (var manager = new UmsManager(FileAccess.Write, 1000))
+            {
+                UnmanagedMemoryStream stream = manager.Stream;
+                Assert.True(stream.CanWrite);
+                Assert.True(stream.DisposeAsync().IsCompletedSuccessfully);
+                Assert.False(stream.CanWrite);
+            }
+        }
+    }
+}

--- a/src/System.IO/tests/MemoryStream/MemoryStreamTests.netcoreapp.cs
+++ b/src/System.IO/tests/MemoryStream/MemoryStreamTests.netcoreapp.cs
@@ -147,6 +147,15 @@ namespace System.IO.Tests
             Assert.True(s.ReadArrayInvoked);
         }
 
+        [Fact]
+        public void DisposeAsync_ClosesStream()
+        {
+            var ms = new MemoryStream();
+            Assert.True(ms.DisposeAsync().IsCompletedSuccessfully);
+            Assert.True(ms.DisposeAsync().IsCompletedSuccessfully);
+            Assert.Throws<ObjectDisposedException>(() => ms.Position);
+        }
+
         private class ReadWriteOverridingMemoryStream : MemoryStream
         {
             public bool ReadArrayInvoked, WriteArrayInvoked;


### PR DESCRIPTION
These types don't need to override the base implementation, as they just perform the disposal synchronously.  But still have basic tests to ensure they behave as expected.

cc: @JeremyKuhne
Contributes to #32665