### PR TITLE
Test PipeStream.DisposeAsync

### DIFF
--- a/src/System.IO.Pipes/tests/PipeTest.Write.netcoreapp.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Write.netcoreapp.cs
@@ -80,5 +80,17 @@ namespace System.IO.Pipes.Tests
                 Assert.Throws<IOException>(() => { pair.writeablePipe.WriteAsync(new Memory<byte>(buffer)); });
             }
         }
+
+        [Fact]
+        public void DisposeAsync_NothingWrittenNeedsToBeFlushed_CompletesSynchronously()
+        {
+            ServerClientPair pair = CreateServerClientPair();
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.True(pair.readablePipe.DisposeAsync().IsCompletedSuccessfully);
+                Assert.True(pair.writeablePipe.DisposeAsync().IsCompletedSuccessfully);
+            }
+            Assert.Throws<ObjectDisposedException>(() => pair.writeablePipe.Write(new Span<byte>(new byte[1])));
+        }
     }
 }


### PR DESCRIPTION
This doesn't need to override the base implementation, as it doesn't have anything to flush and can just perform the disposal synchronously. But still have a basic test to ensure it behaves as expected.

cc: @JeremyKuhne
Contributes to #32665 