### PR TITLE
Disable WebSocket SendReceiveTest on NETFX

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -139,6 +139,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [ActiveIssue(33401, TargetFrameworkMonikers.NetFramework)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_MultipleOutstandingSendOperations_Throws(Uri server)


### PR DESCRIPTION
Disable SendAsync_MultipleOutstandingSendOperations_Throws() test on .NET Framework.  This is likely a .NET Framework bug but possibly a test bug.

Contributes to #33401