### PR TITLE
add __HostDistroRid calculation for OSX

### DIFF
--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -40,8 +40,11 @@ initHostDistroRid()
                __HostDistroRid="rhel.6-$__HostArch"
             fi
         fi
+    elif  [ "$__HostOS" == "OSX" ]; then
+        _osx_version=`sw_vers -productVersion | cut -f1-2 -d'.'`
+        __HostDistroRid="osx.$_osx_version-x64"
     elif [ "$__HostOS" == "FreeBSD" ]; then
-      __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
+      __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'-'`
       __HostDistroRid="freebsd.$__freebsd_version-x64"
     fi
 


### PR DESCRIPTION
This fixes build warning on OSX in native build. 
Since we build OSX as portable (new) , this has no real impact. 
Now the HostDistroRid set to `osx.10.13-x64` on 10.13, `osx.10.13-x64` on Mojave and to `freebsd.11.2-x64` on FreeBSD. 


fixes #33390


 