### PR TITLE
Change value CERT_DELETE_KEYSET_PROP_ID to 125 as defined in wincrypt.h in RS2

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -38,7 +38,7 @@ namespace Internal.Cryptography.Pal
 
             CRYPTOAPI_BLOB dataBlob;
             int cbData = 0;
-            bool deleteKeyContainer = Interop.crypt32.CertGetCertificateContextProperty(safeCertContextHandle, CertContextPropId.CERT_DELETE_KEYSET_PROP_ID, out dataBlob, ref cbData);
+            bool deleteKeyContainer = Interop.crypt32.CertGetCertificateContextProperty(safeCertContextHandle, CertContextPropId.CERT_CLR_DELETE_KEY_PROP_ID, out dataBlob, ref cbData);
             return new CertificatePal(safeCertContextHandle, deleteKeyContainer);
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
@@ -173,7 +173,7 @@ namespace Internal.Cryptography.Pal.Native
         // CERT_DELETE_KEYSET_PROP_ID is not defined by Windows. It's a custom property set by the framework
         // as a backchannel message from the portion of X509Certificate2Collection.Import() that loads up the PFX
         // to the X509Certificate2..ctor(IntPtr) call that creates the managed wrapper.
-        CERT_DELETE_KEYSET_PROP_ID = 101,
+        CERT_DELETE_KEYSET_PROP_ID = 125,
     }
 
     [Flags]

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
@@ -169,7 +169,7 @@ namespace Internal.Cryptography.Pal.Native
         CERT_KEY_IDENTIFIER_PROP_ID  = 20,
         CERT_PUBKEY_ALG_PARA_PROP_ID = 22,
         CERT_NCRYPT_KEY_HANDLE_PROP_ID = 78,
-        CERT_DELETE_KEYSET_PROP_ID = 125,
+        CERT_CLR_DELETE_KEY_PROP_ID = 125,
     }
 
     [Flags]

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
@@ -169,10 +169,6 @@ namespace Internal.Cryptography.Pal.Native
         CERT_KEY_IDENTIFIER_PROP_ID  = 20,
         CERT_PUBKEY_ALG_PARA_PROP_ID = 22,
         CERT_NCRYPT_KEY_HANDLE_PROP_ID = 78,
-
-        // CERT_DELETE_KEYSET_PROP_ID is not defined by Windows. It's a custom property set by the framework
-        // as a backchannel message from the portion of X509Certificate2Collection.Import() that loads up the PFX
-        // to the X509Certificate2..ctor(IntPtr) call that creates the managed wrapper.
         CERT_DELETE_KEYSET_PROP_ID = 125,
     }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Import.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Import.cs
@@ -81,14 +81,14 @@ namespace Internal.Cryptography.Pal
                             {
                                 //
                                 // If the user did not want us to persist private keys, then we should loop through all
-                                // the certificates in the collection and set our custom CERT_DELETE_KEYSET_PROP_ID property
+                                // the certificates in the collection and set our custom CERT_CLR_DELETE_KEY_PROP_ID property
                                 // so the key container will be deleted when the cert contexts will go away.
                                 //
                                 SafeCertContextHandle pCertContext = null;
                                 while (Interop.crypt32.CertEnumCertificatesInStore(certStore, ref pCertContext))
                                 {
                                     CRYPTOAPI_BLOB nullBlob = new CRYPTOAPI_BLOB(0, null);
-                                    if (!Interop.crypt32.CertSetCertificateContextProperty(pCertContext, CertContextPropId.CERT_DELETE_KEYSET_PROP_ID, CertSetPropertyFlags.CERT_SET_PROPERTY_INHIBIT_PERSIST_FLAG, &nullBlob))
+                                    if (!Interop.crypt32.CertSetCertificateContextProperty(pCertContext, CertContextPropId.CERT_CLR_DELETE_KEY_PROP_ID, CertSetPropertyFlags.CERT_SET_PROPERTY_INHIBIT_PERSIST_FLAG, &nullBlob))
                                         throw Marshal.GetLastWin32Error().ToCryptographicException();
                                 }
                             }


### PR DESCRIPTION
Tracked by internal bug - the previous value was originally defined before wincrypt.h had a correct value for it.

This was tested manually with:

```csharp
            using (var c = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
            {
                Console.WriteLine("Key should disappear in 5s");
                Thread.Sleep(5000);
            }
```

And inspecting directory if key appears for 5s and disappears on dispose.
`%appdata%\Microsoft\Crypto\RSA\S-1-5-21-2127521184-1604012920-1887927527-15622336\`