### PR TITLE
Raise the minimum RSA generation size to 512 for OpenSSL-based RSA.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -71,15 +71,12 @@ namespace System.Security.Cryptography
         {
             get
             {
-                // OpenSSL seems to accept answers of all sizes.
-                // Choosing a non-multiple of 8 would make some calculations misalign
-                // (like assertions of (output.Length * 8) == KeySize).
-                // Choosing a number too small is insecure.
-                // Choosing a number too large will cause GenerateKey to take much
-                // longer than anyone would be willing to wait.
+                // While OpenSSL 1.0.x and 1.1.0 will generate RSA-384 keys,
+                // OpenSSL 1.1.1 has lifted the minimum to RSA-512.
                 //
-                // So, copying the values from RSACryptoServiceProvider
-                return new[] { new KeySizes(384, 16384, 8) };
+                // Rather than make the matrix even more complicated,
+                // the low limit now is 512 on all OpenSSL-based RSA.
+                return new[] { new KeySizes(512, 16384, 8) };
             }
         }
 

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -159,8 +159,9 @@ namespace System.Security.Cryptography
             set { _impl.KeySize = value; }
         }
 
-        public override KeySizes[] LegalKeySizes => 
-            _impl.LegalKeySizes; // Csp Windows and RSAOpenSsl are the same (384, 16384, 8)
+        // RSAOpenSsl is (512, 16384, 8), RSASecurityTransforms is (1024, 16384, 8)
+        // Either way the minimum is lifted off of CAPI's 384, due to platform constraints.
+        public override KeySizes[] LegalKeySizes => _impl.LegalKeySizes;
 
         // PersistKeyInCsp has no effect in Unix
         public bool PersistKeyInCsp { get; set; }


### PR DESCRIPTION
RSA-512 is still considered too small/insecure, so this should not have
any tangible impact.

Fixes #33350.