### PR TITLE
use copy of dotnet on FreeBSD instead of hardlink

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -71,6 +71,9 @@
     <PropertyGroup>
       <HostFxrFileName Condition="'$(OSGroup)'=='Windows_NT'">hostfxr</HostFxrFileName>
       <HostFxrFileName Condition="'$(OSGroup)'!='Windows_NT'">libhostfxr</HostFxrFileName>
+      <UseHardlink>true</UseHardlink>
+      <!-- workaround core-setup problem for hardlinking dotnet executable to testhost -->
+      <UseHardlink Condition="'$(_runtimeOSFamily)' == 'FreeBSD'">false</UseHardlink>
     </PropertyGroup>
 
     <ItemGroup>
@@ -86,7 +89,7 @@
     <Copy SourceFiles="@(DotnetExe)"
           DestinationFolder="$(TestHostRootPath)"
           SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
+          UseHardlinksIfPossible="$(UseHardlink)" />
 
     <Exec Command="chmod +x $(TestHostRootPath)dotnet" Condition="'$(RunningOnUnix)' == 'true'"/>
   </Target>


### PR DESCRIPTION
This fixes problem when tests are not runnable on FreeBSD

```
[furt@toweinfu-d11 ~/git/wfurt-corefx]$ ./artifacts/bin/testhost/netcoreapp-FreeBSD-Debug-x64/dotnet --info
A fatal error occurred, the folder [/usr/home/furt/git/wfurt-corefx/artifacts/bin/testhost/netcoreapp-FreeBSD-Debug-x64/shared/Microsoft.NETCore.App/9.9.9/host/fxr] does not exist
```

There is problem on FreeBSD with determining self path with hardlink    (https://github.com/dotnet/core-setup/issues/4742)

This change allows tests to run on FreeBSD.

I also verified that on other OSes (OSX) we still use hardlink so that should be no change:

```
macik2:wfurt-corefx furt$ ls -al artifacts/bin/testhost/netcoreapp-OSX-Debug-x64/dotnet
-rwxrwxrwx  4 furt  staff  166268 Nov  9 17:04 artifacts/bin/testhost/netcoreapp-OSX-Debug-x64/dotnet
```
(first number is link count) 