### PR TITLE
修复SmtpClient，使用异步方法发送邮件（SendAsync、SendMailAsync）DeliveryFormat=SmtpDeliveryFormat.SevenBit配置失效

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -964,7 +964,7 @@ namespace System.Net.Mail
                 else
                 {
                     _message.BeginSend(_writer, DeliveryMethod != SmtpDeliveryMethod.Network,
-                        ServerSupportsEai, new AsyncCallback(SendMessageCallback), result.AsyncState);
+                        IsUnicodeSupported(), new AsyncCallback(SendMessageCallback), result.AsyncState);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
## 问题

使用异步方法（`SendAsync`、`SendMailAsync`）发送邮件时，设置`DeliveryFormat` `=` `SmtpDeliveryFormat.SevenBit`，如果邮件服务器支持`SMTPUTF8`，那么配置将会失效。`Subject`、`附件文件名`等里面的UTF-8内容（如中文）将直接以`UTF-8编码`纯文本形式发送，并不会进行`Base64`转码。同步方法(`Send`)不受此影响。

具体细节参考提问：[https://developercommunity.visualstudio.com/content/problem/381046/smtpclient%E4%B8%80%E5%A4%84%E4%BB%A3%E7%A0%81%E7%BC%96%E5%86%99%E9%94%99%E8%AF%AF%E5%AF%BC%E8%87%B4%E5%BC%82%E6%AD%A5%E5%8F%91%E9%80%81%E9%82%AE%E4%BB%B6%E6%97%B6deliveryformat%E9%85%8D%E7%BD%AE%E9%A1%B9%E6%97%A0%E6%B3%95%E6%AD%A3%E7%A1%AE%E5%B7%A5%E4%BD%9C.html]()

## 复现代码

注：我使用.NET Framework 4.5测试的代码，因为受影响部分.NET Framework和.NET Core是一致的，并不影响复现，但我并未测试.NET Core。
``` C#
var yourOutlookMailAddr = "xiangyuecn@outlook.com";//此处改为你的outlook邮箱，outlook支持SMTPUTF8

var msg = new MailMessage("test@localhost", yourOutlookMailAddr);
msg.HeadersEncoding = msg.BodyEncoding = msg.SubjectEncoding = Encoding.UTF8;

var smtp = new SmtpClient("outlook-com.olc.protection.outlook.com", 25);
smtp.DeliveryFormat = SmtpDeliveryFormat.SevenBit;

try {
	//受影响的发送方式
	msg.Subject = "SendMailAsync 中文 Test 测试";
	var task = smtp.SendMailAsync(msg);
	task.Wait();
	Console.WriteLine("SendMailAsync OK");

	//不受影响的发送方式
	msg.Subject = "Send 中文 Test 测试";
	smtp.Send(msg);
	Console.WriteLine("Send OK");
} catch (AggregateException e) {
	Console.WriteLine("Send Fail：");
	Console.WriteLine(e.InnerException.ToString());
}
Console.ReadLine();
```

### 检查
你可以用wireshark抓包发现`SendMailAsync`方式发送的`Subject Header`内容未进行任何编码；`Send`方式发送的为Base64编码。

另外可以去outlook邮箱（**垃圾箱**）查看邮件源码，会发现：

`SendMailAsync`方法发送的：
```
Subject: SendMailAsync ä¸­æ Test æµè¯
```

`Send`方法发送的：
```
Subject: =?utf-8?B?U2VuZCDkuK3mlocgVGVzdCDmtYvor5U=?=
```

## 原因和解决办法

根源在`SmtpClient.SendMailCallback`方法中`message.BeginSend` `allowUnicode`参数直接传入了`ServerSupportsEai`，而不是统一的`IsUnicodeSupported()`。

把`ServerSupportsEai`，改成`IsUnicodeSupported()`问题解决。


## 发现受影响版本

- .NET Framework 4.5 - 4.7.2
- .NET Core 最新版本