### PR TITLE
Marking S.Numerics.Tensors as "stable" for v0.1.0

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -3098,6 +3098,9 @@
       }
     },
     "System.Numerics.Tensors": {
+      "StableVersions": [
+        "0.1.0",
+      ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "0.1.0.0": "0.1.0"


### PR DESCRIPTION
CC. @danmosemsft, @ericstj, @eerhardt 