### PR TITLE
Removing workaround now that System.Memory 4.2.0.0 version is consumed

### DIFF
--- a/pkg/test/project.csproj.template
+++ b/pkg/test/project.csproj.template
@@ -8,8 +8,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <!-- System.Memory version has been bumped so we expect validation to fail until we ingest the new core-setup which contains that change -->
-    <IgnoredReference Include="System.Memory" Version="4.2.0.0" />
     <PackageReference Include="{PackageId}" Version="{PackageVersion}" />
   </ItemGroup>
 


### PR DESCRIPTION
cc: @ericstj 

Undoing #33400 now that a new version of core-setup has been ingested into corefx.