### PR TITLE
improve detection and portability of pal_networkstatistics.c

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -57,6 +57,8 @@
 #cmakedefine01 HAVE_IP_MREQN
 #cmakedefine01 HAVE_TCP_VAR_H
 #cmakedefine01 HAVE_RT_MSGHDR
+#cmakedefine01 HAVE_RT_MSGHDR2
+#cmakedefine01 HAVE_IF_MSGHDR2
 #cmakedefine01 HAVE_SYS_SYSCTL_H
 #cmakedefine01 HAVE_NET_IFMEDIA_H
 #cmakedefine01 HAVE_LINUX_RTNETLINK_H

--- a/src/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/Native/Unix/System.Native/pal_networkstatistics.c
@@ -171,28 +171,31 @@ int32_t SystemNative_GetIcmpv4GlobalStatistics(Icmpv4GlobalStatistics* retStats)
         return -1;
     }
 
-    retStats->AddressMaskRepliesReceived = systemStats.icps_inhist[ICMP_MASKREPLY];
-    retStats->AddressMaskRepliesSent = systemStats.icps_outhist[ICMP_MASKREPLY];
-    retStats->AddressMaskRequestsReceived = systemStats.icps_inhist[ICMP_MASKREQ];
-    retStats->AddressMaskRequestsSent = systemStats.icps_outhist[ICMP_MASKREQ];
-    retStats->DestinationUnreachableMessagesReceived = systemStats.icps_inhist[ICMP_UNREACH];
-    retStats->DestinationUnreachableMessagesSent = systemStats.icps_outhist[ICMP_UNREACH];
-    retStats->EchoRepliesReceived = systemStats.icps_inhist[ICMP_ECHOREPLY];
-    retStats->EchoRepliesSent = systemStats.icps_outhist[ICMP_ECHOREPLY];
-    retStats->EchoRequestsReceived = systemStats.icps_inhist[ICMP_ECHO];
-    retStats->EchoRequestsSent = systemStats.icps_outhist[ICMP_ECHO];
-    retStats->ParameterProblemsReceived = systemStats.icps_inhist[ICMP_PARAMPROB];
-    retStats->ParameterProblemsSent = systemStats.icps_outhist[ICMP_PARAMPROB];
-    retStats->RedirectsReceived = systemStats.icps_inhist[ICMP_REDIRECT];
-    retStats->RedirectsSent = systemStats.icps_outhist[ICMP_REDIRECT];
-    retStats->SourceQuenchesReceived = systemStats.icps_inhist[ICMP_SOURCEQUENCH];
-    retStats->SourceQuenchesSent = systemStats.icps_outhist[ICMP_SOURCEQUENCH];
-    retStats->TimeExceededMessagesReceived = systemStats.icps_inhist[ICMP_TIMXCEED];
-    retStats->TimeExceededMessagesSent = systemStats.icps_outhist[ICMP_TIMXCEED];
-    retStats->TimestampRepliesReceived = systemStats.icps_inhist[ICMP_TSTAMPREPLY];
-    retStats->TimestampRepliesSent = systemStats.icps_outhist[ICMP_TSTAMPREPLY];
-    retStats->TimestampRequestsReceived = systemStats.icps_inhist[ICMP_TSTAMP];
-    retStats->TimestampRequestsSent = systemStats.icps_outhist[ICMP_TSTAMP];
+    __typeof(systemStats.icps_inhist[0])* inHist = systemStats.icps_inhist;
+    __typeof(systemStats.icps_outhist[0])* outHist = systemStats.icps_outhist;
+
+    retStats->AddressMaskRepliesReceived = inHist[ICMP_MASKREPLY];
+    retStats->AddressMaskRepliesSent = outHist[ICMP_MASKREPLY];
+    retStats->AddressMaskRequestsReceived = inHist[ICMP_MASKREQ];
+    retStats->AddressMaskRequestsSent = outHist[ICMP_MASKREQ];
+    retStats->DestinationUnreachableMessagesReceived = inHist[ICMP_UNREACH];
+    retStats->DestinationUnreachableMessagesSent = outHist[ICMP_UNREACH];
+    retStats->EchoRepliesReceived = inHist[ICMP_ECHOREPLY];
+    retStats->EchoRepliesSent = outHist[ICMP_ECHOREPLY];
+    retStats->EchoRequestsReceived = inHist[ICMP_ECHO];
+    retStats->EchoRequestsSent = outHist[ICMP_ECHO];
+    retStats->ParameterProblemsReceived = inHist[ICMP_PARAMPROB];
+    retStats->ParameterProblemsSent = outHist[ICMP_PARAMPROB];
+    retStats->RedirectsReceived = inHist[ICMP_REDIRECT];
+    retStats->RedirectsSent = outHist[ICMP_REDIRECT];
+    retStats->SourceQuenchesReceived = inHist[ICMP_SOURCEQUENCH];
+    retStats->SourceQuenchesSent = outHist[ICMP_SOURCEQUENCH];
+    retStats->TimeExceededMessagesReceived = inHist[ICMP_TIMXCEED];
+    retStats->TimeExceededMessagesSent = outHist[ICMP_TIMXCEED];
+    retStats->TimestampRepliesReceived = inHist[ICMP_TSTAMPREPLY];
+    retStats->TimestampRepliesSent = outHist[ICMP_TSTAMPREPLY];
+    retStats->TimestampRequestsReceived = inHist[ICMP_TSTAMP];
+    retStats->TimestampRequestsSent = outHist[ICMP_TSTAMP];
 
     return 0;
 }

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -564,6 +564,7 @@ check_c_source_compiles(
     "
     #include <sys/types.h>
     #include <sys/socketvar.h>
+    #include <netinet/in.h>
     #include <netinet/ip.h>
     #include <netinet/tcp.h>
     #include <netinet/tcp_var.h>
@@ -601,10 +602,19 @@ check_symbol_exists(
     HAVE_TCP_FSM_H
 )
 
-set(CMAKE_EXTRA_INCLUDE_FILES sys/types.h net/route.h)
+set(CMAKE_EXTRA_INCLUDE_FILES sys/types.h sys/socket.h net/route.h)
 check_type_size(
     "struct rt_msghdr"
      HAVE_RT_MSGHDR
+     BUILTIN_TYPES_ONLY)
+check_type_size(
+    "struct rt_msghdr2"
+     HAVE_RT_MSGHDR2
+     BUILTIN_TYPES_ONLY)
+set(CMAKE_EXTRA_INCLUDE_FILES) # reset CMAKE_EXTRA_INCLUDE_FILES
+check_type_size(
+    "struct if_msghdr2"
+     HAVE_IF_MSGHDR2
      BUILTIN_TYPES_ONLY)
 set(CMAKE_EXTRA_INCLUDE_FILES) # reset CMAKE_EXTRA_INCLUDE_FILES
 
@@ -613,7 +623,7 @@ check_include_files(
     HAVE_SYS_SYSCTL_H)
 
 check_include_files(
-    "net/if_media.h"
+    "stdint.h;net/if_media.h"
     HAVE_NET_IFMEDIA_H)
 
 check_include_files(


### PR DESCRIPTION
related to #24386

This improves detection of HAVE_NET_IFMEDIA_H and HAVE_TCP_FSM_H.
Furthermore we were detecting presence of rt_msghdr but than we used rt_msghdr2 in the code. 

Aside from that this adds fee special cases for freebsd. Some fields OSX has do not exist. 
icps_[in|out]hist has different size (long vs int) 
 