### PR TITLE
Remove unnecessary using directive

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
-using System.Linq;
 
 #if MS_IO_REDIST
 using Microsoft.IO.Enumeration;


### PR DESCRIPTION
Mono does not have LINQ in its corlib so the change is helpful for integration