### PR TITLE
Add RHEL 8 runtime ids

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -1948,6 +1948,49 @@
     "any",
     "base"
   ],
+  "rhel.8": [
+    "rhel.8",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "rhel.8-x64": [
+    "rhel.8-x64",
+    "rhel.8",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "rhel.8.0": [
+    "rhel.8.0",
+    "rhel.8",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "rhel.8.0-x64": [
+    "rhel.8.0-x64",
+    "rhel.8.0",
+    "rhel.8-x64",
+    "rhel.8",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "sles": [
     "sles",
     "linux",

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -889,6 +889,28 @@
         "rhel.7.5-x64"
       ]
     },
+    "rhel.8": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "rhel.8-x64": {
+      "#import": [
+        "rhel.8",
+        "rhel-x64"
+      ]
+    },
+    "rhel.8.0": {
+      "#import": [
+        "rhel.8"
+      ]
+    },
+    "rhel.8.0-x64": {
+      "#import": [
+        "rhel.8.0",
+        "rhel.8-x64"
+      ]
+    },
     "sles": {
       "#import": [
         "linux"

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -109,6 +109,12 @@
       <Versions>7;7.0;7.1;7.2;7.3;7.4;7.5;7.6</Versions>
     </RuntimeGroup>
 
+    <RuntimeGroup Include="rhel">
+      <Parent>linux</Parent>
+      <Architectures>x64</Architectures>
+      <Versions>8;8.0</Versions>
+    </RuntimeGroup>
+
     <RuntimeGroup Include="sles">
       <Parent>linux</Parent>
       <Architectures>x64</Architectures>


### PR DESCRIPTION
RHEL 8 beta was announced today: https://developers.redhat.com/rhel8/. This adds a new set of runtime IDs for that. This adds it as a separate set of versions from the RHEL 6 and RHEL 7 set.

```
$ cat /etc/os-release 
NAME="Red Hat Enterprise Linux"
VERSION="8.0 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.0"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Red Hat Enterprise Linux 8.0 Beta (Ootpa)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:8.0:beta"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_BUGZILLA_PRODUCT_VERSION=8.0
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.0 Beta"
```
