### PR TITLE
Make well-known IPv4 addresses readonly

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -17,9 +17,9 @@ namespace System.Net
     /// </devdoc>
     public class IPAddress
     {
-        public static readonly IPAddress Any = new IPAddress(0x0000000000000000);
-        public static readonly IPAddress Loopback = new IPAddress(0x000000000100007F);
-        public static readonly IPAddress Broadcast = new IPAddress(0x00000000FFFFFFFF);
+        public static readonly IPAddress Any = new ReadOnlyIPAddress(0x0000000000000000);
+        public static readonly IPAddress Loopback = new ReadOnlyIPAddress(0x000000000100007F);
+        public static readonly IPAddress Broadcast = new ReadOnlyIPAddress(0x00000000FFFFFFFF);
         public static readonly IPAddress None = Broadcast;
 
         internal const long LoopbackMask = 0x00000000000000FF;
@@ -532,6 +532,10 @@ namespace System.Net
                 {
                     if (PrivateAddress != value)
                     {
+                        if (this is ReadOnlyIPAddress)
+                        {
+                            throw new SocketException(SocketError.OperationNotSupported);
+                        }
                         PrivateAddress = unchecked((uint)value);
                     }
                 }
@@ -658,5 +662,11 @@ namespace System.Net
         }
 
         private static byte[] ThrowAddressNullException() => throw new ArgumentNullException("address");
+
+        private sealed class ReadOnlyIPAddress : IPAddress
+        {
+            public ReadOnlyIPAddress(long newAddress) : base(newAddress)
+            { }
+        }
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -313,6 +313,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // IPAddress.Value can be set on full framework
         public static void Address_ReadOnlyStatics_Set_Failure()
         {
             Assert.Throws<SocketException>(() => IPAddress.Any.Address = MaxAddress - 1);

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -311,6 +311,15 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(ip1, ip2);
             Assert.Equal(ip1.GetHashCode(), ip2.GetHashCode());
         }
+
+        [Fact]
+        public static void Address_ReadOnlyStatics_Set_Failure()
+        {
+            Assert.Throws<SocketException>(() => IPAddress.Any.Address = MaxAddress - 1);
+            Assert.Throws<SocketException>(() => IPAddress.Broadcast.Address = MaxAddress - 1);
+            Assert.Throws<SocketException>(() => IPAddress.Loopback.Address = MaxAddress - 1);
+            Assert.Throws<SocketException>(() => IPAddress.None.Address = MaxAddress - 1);
+        }
 #pragma warning restore 618
     }
 }


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/33373 using the approach suggested in PR https://github.com/dotnet/corefx/pull/33476 

/cc @alfredmyers @stephentoub 