### PR TITLE
Undoing the ref removal on two packages that didn't need this change

### DIFF
--- a/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
+++ b/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
@@ -9,8 +9,14 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Data.SqlClient.csproj" />
-    <HarvestIncludePaths Include="lib/net451;runtimes/win/lib/net451" />
-    <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
+    <HarvestIncludePaths Include="ref/net451;lib/net451;runtimes/win/lib/net451" />
+    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
+    <HarvestIncludePaths Include="ref/netstandard1.2">
+      <SupportedFramework>net451;win81;wpa81</SupportedFramework>
+    </HarvestIncludePaths>
+    <HarvestIncludePaths Include="ref/netstandard1.3">
+      <SupportedFramework>net46;netcoreapp1.0</SupportedFramework>
+    </HarvestIncludePaths>
     <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.3;runtimes/win/lib/netstandard1.3" />
 
     <!-- Since UAP and .NETCoreApp are package based we still want to enable
@@ -25,10 +31,5 @@
   <ItemGroup>
     <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
-    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
-    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -13,18 +13,14 @@
     <InboxOnTargetFramework Include="uap10.0.16299" />
     <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <!-- All elements from previous packages that will be included in the newly built package -->
-    <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.4" />
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.6;lib/netstandard1.6" />
-    <HarvestIncludePaths Include="runtimes/win/lib/netcoreapp2.0" />
+    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
+    <HarvestIncludePaths Include="ref/netstandard1.3" />
+    <HarvestIncludePaths Include="ref/netstandard1.4;runtimes/win/lib/netstandard1.4" />
+    <HarvestIncludePaths Include="ref/netstandard1.6;runtimes/win/lib/netstandard1.6;lib/netstandard1.6" />
+    <HarvestIncludePaths Include="ref/netcoreapp2.0;runtimes/win/lib/netcoreapp2.0" />
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
-    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
-    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -20,11 +20,14 @@
   </Target>
 
   <!-- This target will be moved into buildtools. Checked in here for now to add validationand in order not to block buildtools ingestion. -->
-  <Target Name="ValidateExcludeCompileDesktop" AfterTargets="GetPackageDependencies">
+  <Target Name="ValidateExcludeCompileDesktop" AfterTargets="GetPackageDependencies" Inputs="%(Dependency.Identity);%(Dependency.TargetFramework)" Outputs="unused">
+    <PropertyGroup>
+      <_excludeCompile Condition="@(Dependency->WithMetadataValue('Exclude', 'Compile')->Count()) == @(Dependency->Count())">true</_excludeCompile>
+    </PropertyGroup>
     <Error Text="Cannot have Exclude=Compile dependencies when targeting a desktop TFM. @(Dependency). You can exclude the reference asset in the package by setting the ExcludeReferenceAssets property to true in your project." 
            Condition="$([System.String]::Copy('%(Dependency.TargetFramework)').StartsWith('net4')) AND 
-                      '%(Dependency.Exclude)' == 'Compile' AND
+                      '$(_excludeCompile)' == 'true' AND
                       '%(Dependency.Identity)' != '_._'" />
-  </Target>
+  </Target> 
 
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -27,9 +27,6 @@
     <Project Include="*\pkg\**\CoreFx.Private.TestUtilities.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="*\pkg\**\System.Data.SqlClient.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-    </Project>
     <Project Include="*\pkg\**\System.IO.Pipelines.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
@@ -37,9 +34,6 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <Project Include="*\pkg\**\System.Net.Http.WinHttpHandler.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-    </Project>
-    <Project Include="*\pkg\**\System.Security.Cryptography.Cng.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <Project Include="*\pkg\**\System.Text.Encoding.CodePages.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">


### PR DESCRIPTION
Undoing part of #33254 since there were two packages that didn't require the change. Also fixing the validation target we used to spot packages that needed these changes.

cc: @ericstj

#### Description
When doing #33254 we created a target to validate which packages would need this fix, which was to remove the reference assemblies from them. This validation target had a bug, which caused us to apply the fix to two packages that didn't require it. This change will undo the fixes that were applied to those two packages, and it will fix the validation target so that we catch future packages that will need the fix applied.

#### Customer Impact
We haven't yet shipped anything after merging #33254, which means that this will have no impact on customers

#### Regression?
Yes. This is fixing a couple packages that were regressed by #33254.

#### Risk
None. These two packages will simply not be produced, which was the case for 2.1.6. This means that it won't impact at all our customers.