### PR TITLE
change ALPN detection from Linux to !OSX on Unix

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -62,7 +62,7 @@ namespace System
 
         public static Version OSXVersion { get; } = ToVersion(Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystemVersion);
 
-        public static Version OpenSslVersion => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? GetOpenSslVersion() : throw new PlatformNotSupportedException();
+        public static Version OpenSslVersion => !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? GetOpenSslVersion() : throw new PlatformNotSupportedException();
 
         public static string GetDistroVersionString()
         {

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -53,7 +53,7 @@ namespace System
         // Linux - OpenSsl supports alpn from openssl 1.0.2 and higher.
         // OSX - SecureTransport doesn't expose alpn APIs. #30492
         public static bool SupportsAlpn => (IsWindows && !IsWindows7) ||
-            (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+            ((!IsOSX && !IsWindows) &&
             (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
         public static bool SupportsClientAlpn => SupportsAlpn ||
             (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && PlatformDetection.OSXVersion > new Version(10, 12));


### PR DESCRIPTION
For now, assume OSX is special and all other Unixes will use OpenSSL. 
System.Net.Security tests do pass now. 

```
  === TEST EXECUTION SUMMARY ===
     System.Net.Security.Tests  Total: 4233, Errors: 0, Failed: 0, Skipped: 5, Time: 16.908s
  /mnt/resource/corefx/src/System.Net.Security/tests/FunctionalTests
```