### PR TITLE
Remove dead code from System.Security.Cryptography.Xml

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
@@ -185,7 +185,6 @@ namespace System.Security.Cryptography.Xml
             if (cipherData == null)
                 throw new ArgumentNullException(nameof(cipherData));
 
-            WebResponse response = null;
             Stream inputStream = null;
 
             if (cipherData.CipherValue != null)
@@ -242,8 +241,6 @@ namespace System.Security.Cryptography.Xml
                     Utils.Pump(decInputStream, ms);
                     cipherValue = ms.ToArray();
                     // Close the stream and return
-                    if (response != null)
-                        response.Close();
                     if (inputStream != null)
                         inputStream.Close();
                     decInputStream.Close();

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -513,9 +513,6 @@ namespace System.Security.Cryptography.Xml
 
             CanonicalXmlNodeList namespaces = new CanonicalXmlNodeList();
             XmlNode ancestorNode = elem;
-
-            if (ancestorNode == null) return null;
-
             bool bDefNamespaceToAdd = true;
 
             while (ancestorNode != null)

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigEnvelopedSignatureTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigEnvelopedSignatureTransform.cs
@@ -155,7 +155,7 @@ namespace System.Security.Cryptography.Xml
                                 position++;
                                 if (node1 == result) break;
                             }
-                            if (result == null || (result != null && position != _signaturePosition))
+                            if (result == null || position != _signaturePosition)
                             {
                                 resultNodeList.Add(node);
                             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/33542

@dhcgn, I cherry-picked https://github.com/dhcgn/corefx/commit/00356d51a57b875608eb024446139eaba64e90ca, but undid two of the changes I wasn't convinced were actually dead, specifically:
https://github.com/dhcgn/corefx/commit/00356d51a57b875608eb024446139eaba64e90ca#diff-491938a58f7f94f42b301a71b0623862R280
and
https://github.com/dhcgn/corefx/commit/00356d51a57b875608eb024446139eaba64e90ca#diff-e0de85e0e5dbc04b589a7ac9c41694dfR72
My hesitancy for those is that they're abstract/virtual, and it's not clear from a local analysis that some derived type may not be returning null.  Why are these guaranteed to never return null in this case?

cc: @bartonjs, @krwq 