### PR TITLE
Rename Outside and Inside dummy classes in test fixtures

### DIFF
--- a/src/System.Reflection/tests/ModuleTests.cs
+++ b/src/System.Reflection/tests/ModuleTests.cs
@@ -64,11 +64,11 @@ namespace System.Reflection.Tests
         [InlineData("System.Nullable`1[System.Int32]", typeof(int?))]
         [InlineData("System.Int32*", typeof(int*))]
         [InlineData("System.Int32**", typeof(int**))]
-        [InlineData("Outside`1", typeof(Outside<>))]
-        [InlineData("Outside`1+Inside`1", typeof(Outside<>.Inside<>))]
-        [InlineData("Outside[]", typeof(Outside[]))]
-        [InlineData("Outside[,,]", typeof(Outside[,,]))]
-        [InlineData("Outside[][]", typeof(Outside[][]))]        
+        [InlineData("OutsideModuleTest`1", typeof(OutsideModuleTest<>))]
+        [InlineData("OutsideModuleTest`1+InsideModuleTest`1", typeof(OutsideModuleTest<>.InsideModuleTest<>))]
+        [InlineData("OutsideModuleTest[]", typeof(OutsideModuleTest[]))]
+        [InlineData("OutsideModuleTest[,,]", typeof(OutsideModuleTest[,,]))]
+        [InlineData("OutsideModuleTest[][]", typeof(OutsideModuleTest[][]))]        
         public void GetType(string className, Type expectedType)
         {
             Module module = expectedType.GetTypeInfo().Module;
@@ -91,10 +91,10 @@ namespace System.Reflection.Tests
             Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), new object()));
 
             Assert.Empty(typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "out*"));
-            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "Out*").Length);
-            Assert.Empty(typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "outside"));
-            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "Outside").Length);
-            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "Inside").Length);
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "OutsideMod*").Length);
+            Assert.Empty(typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "outsidemoduletest"));
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "OutsideModuleTest").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "InsideModuleTest").Length);
 
             Assert.True(Module.FilterTypeName(typeof(string), "String"));
             Assert.True(Module.FilterTypeName(typeof(string), "*"));
@@ -120,11 +120,11 @@ namespace System.Reflection.Tests
             Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), null));
             Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), new object()));
 
-            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "out*").Length);
-            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "Out*").Length);
-            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "oUtside").Length);
-            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "Outside").Length);
-            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "inSIDE").Length);
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "outsidemod*").Length);
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "Outsidemod*").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "ouTsidemoduLeTest").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "OutsideModuleTest").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "insiDemoduLeTest").Length);
 
             Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "string"));
             Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "*"));
@@ -142,12 +142,12 @@ namespace System.Reflection.Tests
     }
 }
 
-public class Outside
+public class OutsideModuleTest
 {
-    public class Inside { }
+    public class InsideModuleTest { }
 }
 
-public class Outside<T>
+public class OutsideModuleTest<T>
 {
-    public class Inside<U> { }
+    public class InsideModuleTest<U> { }
 }

--- a/src/System.Reflection/tests/TypeInfoTests.netcoreapp.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.netcoreapp.cs
@@ -32,12 +32,12 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(int).MakeArrayType(1), false };
             yield return new object[] { typeof(int).MakeArrayType().MakeArrayType(), true };
             yield return new object[] { typeof(int).MakeArrayType(2), false };
-            yield return new object[] { typeof(Outside<int>.Inside<string>), false };
-            yield return new object[] { typeof(Outside<int>.Inside<string>[]), true };
-            yield return new object[] { typeof(Outside<int>.Inside<string>[,]), false };
+            yield return new object[] { typeof(OutsideTypeInfoNetcoreTests<int>.InsideTypeInfoNetcoreTests<string>), false };
+            yield return new object[] { typeof(OutsideTypeInfoNetcoreTests<int>.InsideTypeInfoNetcoreTests<string>[]), true };
+            yield return new object[] { typeof(OutsideTypeInfoNetcoreTests<int>.InsideTypeInfoNetcoreTests<string>[,]), false };
             if (PlatformDetection.IsNonZeroLowerBoundArraySupported)
             {
-                yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
+                yield return new object[] { Array.CreateInstance(typeof(OutsideTypeInfoNetcoreTests<int>.InsideTypeInfoNetcoreTests<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
             }
         }
 
@@ -47,4 +47,14 @@ namespace System.Reflection.Tests
             Assert.Equal(expected, type.GetTypeInfo().IsSZArray);
         }
     }
+
+    public class OutsideTypeInfoNetcoreTests
+    {
+        public class InsideTypeInfoNetcoreTests { }
+    }
+
+    public class OutsideTypeInfoNetcoreTests<T>
+    {
+        public class InsideTypeInfoNetcoreTests<U> { }
+    }    
 }


### PR DESCRIPTION
Test class files in System.Reflection and System.Runtime locations ([src/System.Reflection/tests/ModuleTests.cs](https://github.com/dotnet/corefx/blob/a10890f4ffe0fadf090c922578ba0e606ebdd16c/src/System.Reflection/tests/ModuleTests.cs#L145-L153) and [src/System.Runtime/tests/System/TypeTests.cs](https://github.com/dotnet/corefx/blob/ace87f7cae870b1c2ffe4f47e11209a5cd7c2f79/src/System.Runtime/tests/System/Type/TypeTests.cs#L11-L33)) contain `Outside` and `Inside` dummy classes. So they can have a conflict within single corlib test assembly on Mono.
Renaming allows to avoid this issue.

Relates to https://github.com/mono/mono/pull/11665