### PR TITLE
AllowEmptySignList for netfx

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -13,9 +13,11 @@
     <ItemsToSign Include="$(ArtifactsDir)packages\**\*.nupkg" Exclude="$(ArtifactsDir)packages\**\*symbols.nupkg" />
   </ItemGroup>
 
-  <Target Name="ValidateSignFileListIsNotEmpty" BeforeTargets="Sign">
-    <!-- we don't sign any files during our netfx build because we don't have any packages we produce there -->
-    <Error Condition="'@(ItemsToSign)' == '' and '$(TargetGroup)' != 'netfx'" Text="List of files to sign is empty. Ensure '$(ArtifactsDir)packages' contains nupkg files to sign." />
-    <Message Importance="High" Text="Attempting to sign %(ItemsToSign.Identity)" />
+  <Target Name="AllowEmptySignListForNetFx" BeforeTargets="Sign">
+    <PropertyGroup>
+      <!-- We do not build packages for NetFx.
+           This must be set in a target since the sign.proj sets this property statically -->
+      <AllowEmptySignList Condition="'$(TargetGroup)' == 'netfx'">true</AllowEmptySignList>
+    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/arcade/commit/de6f4d0197c61cf84eca8c5f9750bcea989ec237#diff-38e82ab9ad7f83dbc2ad37fb5b89c9c7R75 broke our official builds since we have no files to sign on netfx.

We can remove our own check and replace it with the property to disable this check on netfx.