### PR TITLE
Fix PlatformPackageVersion property

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -27,6 +27,9 @@
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">4.6.0</PackageVersion>
+    <!-- this must represent the major.minor.release version of the platforms package we're currently building 
+         pre-release will be appended during build -->
+    <PlatformPackageVersion>3.0.0</PlatformPackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>

--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -261,13 +261,4 @@
   <!-- Override isolated build dependency versions with versions from Repo API. -->
   <Import Project="$(DotNetPackageVersionPropsPath)"
           Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
-
-  <!--
-    Map PackageVersion properties that don't match the Repo API naming conventions. This must be
-    defined after the DotNetPackageVersionPropsPath Import so overrides apply correctly.
-  -->
-  <PropertyGroup>
-    <!-- Backward compatibility for BuildTools usage. -->
-    <PlatformPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</PlatformPackageVersion>
-  </PropertyGroup>
 </Project>

--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>3.0.0</PackageVersion>
+    <PackageVersion>$(PlatformPackageVersion)</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>


### PR DESCRIPTION
This property was meant to indicate the major.minor.release
version of the *currently building* package, but was changed
to represent ingested version here: https://github.com/dotnet/corefx/commit/444ea73cdd596059f2ef5ed4ba4a46ae6819d95e#r23359117

That change resulted in folks occasionally hitting a parsing
error with unusual package shapes: https://github.com/dotnet/arcade/issues/1355

This reintroduces the separation between
 - PlatformPackageVersion : version w/o prerelease that will be built
 - MicrosoftNETCorePlatformsPackageVersion : last built version available for restore