### PR TITLE
Always use ElementAtOrDefault in ElementAtOrDefaultTests

### DIFF
--- a/src/System.Linq/tests/ElementAtOrDefaultTests.cs
+++ b/src/System.Linq/tests/ElementAtOrDefaultTests.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Tests
                     where x > int.MinValue
                     select x;
 
-            Assert.Equal(q.ElementAt(3), q.ElementAt(3));
+            Assert.Equal(q.ElementAtOrDefault(3), q.ElementAtOrDefault(3));
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace System.Linq.Tests
                     where !string.IsNullOrEmpty(x)
                     select x;
 
-            Assert.Equal(q.ElementAt(4), q.ElementAt(4));
+            Assert.Equal(q.ElementAtOrDefault(4), q.ElementAtOrDefault(4));
         }
 
         public static IEnumerable<object[]> TestData()


### PR DESCRIPTION
It looks like ElementAtOrDefaultTests were copied from ElementAtTests, and not all the usages of ElementAt were changed to ElementAtOrDefault. This commit fixes that.