### PR TITLE
Optimize performance of SecurityIdentifier.ToString()

### DIFF
--- a/src/System.Security.Principal.Windows/src/Configurations.props
+++ b/src/System.Security.Principal.Windows/src/Configurations.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-  <PackageConfigurations>
+    <PackageConfigurations>
       netstandard;
       netcoreapp2.0-Windows_NT;
       netcoreapp2.0-Unix;

--- a/src/System.Security.Principal.Windows/src/Configurations.props
+++ b/src/System.Security.Principal.Windows/src/Configurations.props
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageConfigurations>
+  <PackageConfigurations>
       netstandard;
       netcoreapp2.0-Windows_NT;
       netcoreapp2.0-Unix;
+      netcoreapp2.1-Windows_NT;
+      netcoreapp2.1-Unix;
       net461-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>

--- a/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.netcoreapp2.1
+++ b/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.netcoreapp2.1
@@ -1,0 +1,1 @@
+advapi32.dll!LsaNtStatusToWinError

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -6,7 +6,7 @@
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(TargetsNetFx)' == 'true'">true</OmitResources>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_Principal</GeneratePlatformNotSupportedAssemblyMessage>
-    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Unix-Debug;netcoreapp2.0-Unix-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Unix-Debug;netcoreapp2.0-Unix-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netcoreapp2.1-Unix-Debug;netcoreapp2.1-Unix-Release;netcoreapp2.1-Windows_NT-Debug;netcoreapp2.1-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="($(TargetGroup.StartsWith('netcoreapp')) or '$(TargetGroup)' == 'uap') AND '$(TargetsWindows)' == 'true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeAccessTokenHandle.cs" />

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -797,7 +797,7 @@ nameof(binaryForm));
                 // otherwise you would see this: "S-1-NTAuthority-32-544"
                 //
 
-#if netcoreapp20 || netstandard
+#if netcoreapp20
                 StringBuilder result = new StringBuilder();
                 result.Append("S-1-").Append((ulong)_identifierAuthority);
                 for (int i = 0; i < SubAuthorityCount; i++)

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -798,21 +798,21 @@ nameof(binaryForm));
                 //
                 // length of buffer calculation
                 // prefix = "S-1-".Length: 4;
-                // authority: long.MaxValue.ToString("D") + '-'.Length : 18+1: 20;
+                // authority: long.MaxValue.ToString("D") : 19;
                 // subauth = MaxSubAuthorities * ( uint.MaxValue.ToString("D").Length + '-'.Length ): 15 * (10+1): 165;
-                // max possible length = 4 + 20 + 165: 189;
-                Span<char> result = stackalloc char[189];
-                int written = 0;
-                int length = 4;
-                ReadOnlySpan<char> prefix = stackalloc char[] { 'S', '-', '1', '-' };
-                int count = _subAuthorities.Length;
+                // max possible length = 4 + 19 + 165: 188
+                Span<char> result = stackalloc char[188];
+                int written;
                 int[] values = _subAuthorities;
-
-                prefix.CopyTo(result);
+                result[0] = 'S';
+                result[1] = '-';
+                result[0] = '1';
+                result[1] = '-';
+                int length = 4;
                 ((long)_identifierAuthority).TryFormat(result.Slice(4), out written);
                 length += written;
 
-                for (int index = 0; index < count; index++)
+                for (int index = 0; index < _subAuthorities.Length; index++)
                 {
                     uint value = (uint)values[index];
                     result[length] = '-';

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -792,21 +792,36 @@ nameof(binaryForm));
         {
             if (_sddlForm == null)
             {
-                StringBuilder result = new StringBuilder();
-
                 //
                 // Typecasting of _IdentifierAuthority to a long below is important, since
                 // otherwise you would see this: "S-1-NTAuthority-32-544"
                 //
+                // length of buffer calculation
+                // prefix = "S-1-".Length: 4;
+                // authority: long.MaxValue.ToString("D") + '-'.Length : 18+1: 20;
+                // subauth = MaxSubAuthorities * ( uint.MaxValue.ToString("D").Length + '-'.Length ): 15 * (10+1): 165;
+                // max possible length = 4 + 20 + 165: 189;
+                Span<char> result = stackalloc char[189];
+                int written = 0;
+                int length = 4;
+                ReadOnlySpan<char> prefix = stackalloc char[] { 'S', '-', '1', '-' };
+                int count = _subAuthorities.Length;
+                int[] values = _subAuthorities;
 
-                result.Append("S-1-").Append((long)_identifierAuthority);
+                prefix.CopyTo(result);
+                ((long)_identifierAuthority).TryFormat(result.Slice(4), out written);
+                length += written;
 
-                for (int i = 0; i < SubAuthorityCount; i++)
+                for (int index = 0; index < count; index++)
                 {
-                    result.Append('-').Append((uint)(_subAuthorities[i]));
+                    uint value = (uint)values[index];
+                    result[length] = '-';
+                    length += 1;
+                    value.TryFormat(result.Slice(length), out written);
+                    length += written;
                 }
+                _sddlForm = result.Slice(0, length).ToString();
 
-                _sddlForm = result.ToString();
             }
 
             return _sddlForm;

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -802,17 +802,16 @@ nameof(binaryForm));
                 // subauth = MaxSubAuthorities * ( uint.MaxValue.ToString("D").Length + '-'.Length ): 15 * (10+1): 165;
                 // max possible length = 4 + 19 + 165: 188
                 Span<char> result = stackalloc char[188];
-                int written;
-                int[] values = _subAuthorities;
                 result[0] = 'S';
                 result[1] = '-';
-                result[0] = '1';
-                result[1] = '-';
+                result[2] = '1';
+                result[3] = '-';
+                int written;
                 int length = 4;
-                ((long)_identifierAuthority).TryFormat(result.Slice(4), out written);
+                ((ulong)_identifierAuthority).TryFormat(result.Slice(4), out written);
                 length += written;
-
-                for (int index = 0; index < _subAuthorities.Length; index++)
+                int[] values = _subAuthorities;
+                for (int index = 0; index < values.Length; index++)
                 {
                     uint value = (uint)values[index];
                     result[length] = '-';

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -793,34 +793,43 @@ nameof(binaryForm));
             if (_sddlForm == null)
             {
                 //
-                // Typecasting of _IdentifierAuthority to a long below is important, since
+                // Typecasting of _IdentifierAuthority to a ulong below is important, since
                 // otherwise you would see this: "S-1-NTAuthority-32-544"
                 //
+
+#if netcoreapp20 || netstandard
+                StringBuilder result = new StringBuilder();
+                result.Append("S-1-").Append((ulong)_identifierAuthority);
+                for (int i = 0; i < SubAuthorityCount; i++)
+                {
+                    result.Append('-').Append((uint)(_subAuthorities[i]));
+                }
+                _sddlForm = result.ToString();
+#else
                 // length of buffer calculation
                 // prefix = "S-1-".Length: 4;
-                // authority: long.MaxValue.ToString("D") : 19;
+                // authority: ulong.MaxValue.ToString("D") : 20;
                 // subauth = MaxSubAuthorities * ( uint.MaxValue.ToString("D").Length + '-'.Length ): 15 * (10+1): 165;
-                // max possible length = 4 + 19 + 165: 188
-                Span<char> result = stackalloc char[188];
+                // max possible length = 4 + 20 + 165: 189
+                Span<char> result = stackalloc char[189];
                 result[0] = 'S';
                 result[1] = '-';
                 result[2] = '1';
                 result[3] = '-';
                 int written;
                 int length = 4;
-                ((ulong)_identifierAuthority).TryFormat(result.Slice(4), out written);
+                ((ulong)_identifierAuthority).TryFormat(result.Slice(length), out written);
                 length += written;
                 int[] values = _subAuthorities;
                 for (int index = 0; index < values.Length; index++)
                 {
-                    uint value = (uint)values[index];
                     result[length] = '-';
                     length += 1;
-                    value.TryFormat(result.Slice(length), out written);
+                    ((uint)values[index]).TryFormat(result.Slice(length), out written);
                     length += written;
                 }
                 _sddlForm = result.Slice(0, length).ToString();
-
+#endif
             }
 
             return _sddlForm;
@@ -924,9 +933,9 @@ nameof(binaryForm));
             }
         }
 
-        #endregion
+#endregion
 
-        #region Operators
+#region Operators
 
         public static bool operator ==(SecurityIdentifier left, SecurityIdentifier right)
         {
@@ -952,9 +961,9 @@ nameof(binaryForm));
             return !(left == right);
         }
 
-        #endregion
+#endregion
 
-        #region IComparable implementation
+#region IComparable implementation
 
         public int CompareTo(SecurityIdentifier sid)
         {
@@ -996,9 +1005,9 @@ nameof(binaryForm));
             return 0;
         }
 
-        #endregion
+#endregion
 
-        #region Public Methods
+#region Public Methods
 
         internal int GetSubAuthority(int index)
         {
@@ -1234,6 +1243,6 @@ nameof(binaryForm));
 
             throw new ArgumentException(SR.IdentityReference_MustBeIdentityReference, nameof(targetType));
         }
-        #endregion
+#endregion
     }
 }

--- a/src/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
+++ b/src/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
@@ -68,16 +68,12 @@ public class SecurityIdentifierTests
             int endSid = 0;
             if (startSid >= 0)
             {
-                int index = startSid + 6;
-                while (index < output.Length)
+                int length = Math.Min(output.Length - startSid, librarySid.Length);
+                windowsSid = output.Substring(startSid, length);
+
+                if (output.Length > startSid + length)
                 {
-                    char value = output[index];
-                    if (value != '-' && !char.IsNumber(value))
-                    {
-                        endSid = index;
-                        break;
-                    }
-                    index++;
+                    Assert.True(char.IsWhiteSpace(output[startSid + length]));
                 }
             }
             if (endSid > startSid)

--- a/src/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
+++ b/src/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
@@ -40,7 +40,7 @@ public class SecurityIdentifierTests
         Assert.All(parts, part => uint.TryParse(part, out uint _));
     }
 
-    [Fact]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection.IsNotWindowsServerCore))]
     public void ValidateToStringUsingWhoami()
     {
         string librarySid = null;

--- a/src/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
+++ b/src/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
@@ -12,9 +12,10 @@ public class SecurityIdentifierTests
     [Fact]
     public void ValidateGetCurrentUser()
     {
-        WindowsIdentity identity = WindowsIdentity.GetCurrent(false);
-        Assert.NotNull(identity.User);
-        identity?.Dispose();
+        using (WindowsIdentity identity = WindowsIdentity.GetCurrent(false))
+        {
+            Assert.NotNull(identity.User);
+        }
     }
 
     [Fact]

--- a/src/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
+++ b/src/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Principal;
+using Xunit;
+
+public class SecurityIdentifierTests
+{
+    [Fact]
+    public void ValidateGetCurrentUser()
+    {
+        WindowsIdentity identity = WindowsIdentity.GetCurrent(false);
+        Assert.NotNull(identity.User);
+        identity?.Dispose();
+    }
+
+    [Fact]
+    public void ValidateToString()
+    {
+        string sddl = null;
+        using (WindowsIdentity me = WindowsIdentity.GetCurrent(false))
+        {
+            sddl = me.User.ToString();
+        }
+
+        Assert.NotNull(sddl);
+        Assert.NotEmpty(sddl);
+        Assert.StartsWith("S-1-5-", sddl); // sid prefix, version 1, user account type
+        Assert.NotEqual('-', sddl[sddl.Length - 1]);
+
+        string[] parts = sddl.Substring(6).Split('-');
+
+        Assert.NotNull(parts);
+        Assert.NotEmpty(parts);
+
+        Assert.All(parts, part => uint.TryParse(part, out uint _));
+    }
+
+    [Fact]
+    public void ValidateToStringUsingWhoami()
+    {
+        string librarySid = null;
+        using (WindowsIdentity me = WindowsIdentity.GetCurrent(false))
+        {
+            librarySid = me.User.ToString();
+        }
+
+        string windowsSid = null;
+        string processArguments = " /user";
+        // Call whois to get current sid
+        Process whoamiProcess = new Process();
+        whoamiProcess.StartInfo.FileName = "whoami.exe"; // whoami.exe is in system32, should already be on path
+        whoamiProcess.StartInfo.Arguments = " " + processArguments;
+        whoamiProcess.StartInfo.CreateNoWindow = true;
+        whoamiProcess.StartInfo.UseShellExecute = false;
+        whoamiProcess.StartInfo.RedirectStandardOutput = true;
+        whoamiProcess.Start();
+        string output = whoamiProcess.StandardOutput.ReadToEnd();
+        whoamiProcess.WaitForExit();
+
+        if (whoamiProcess.ExitCode == 0)
+        {
+            int startSid = output.IndexOf("S-1-5-");
+            int endSid = 0;
+            if (startSid >= 0)
+            {
+                int index = startSid + 6;
+                while (index < output.Length)
+                {
+                    char value = output[index];
+                    if (value != '-' && !char.IsNumber(value))
+                    {
+                        endSid = index;
+                        break;
+                    }
+                    index++;
+                }
+            }
+            if (endSid > startSid)
+            {
+                windowsSid = output.Substring(startSid, (endSid - startSid));
+            }
+        }
+        Assert.NotNull(windowsSid);
+        Assert.NotEmpty(windowsSid);
+        Assert.NotNull(librarySid);
+        Assert.NotEmpty(librarySid);
+
+        Assert.Equal(windowsSid, librarySid);
+    }
+}
+

--- a/src/System.Security.Principal.Windows/tests/System.Security.Principal.Windows.Tests.csproj
+++ b/src/System.Security.Principal.Windows/tests/System.Security.Principal.Windows.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NTAccount.cs" />
+    <Compile Include="SecurityIdentifierTests.cs" />
     <Compile Include="WindowsIdentityTests.cs" />
     <Compile Include="WindowsPrincipalTests.cs" />
     <Compile Include="WellKnownSidTypeTests.cs" />


### PR DESCRIPTION
in SqlClient when using trusted authentication the windows user identity is used as part of the pool key. Profiling has shown that getting the user sid is on the hot path for this and that optimizing the retrieval of the SecurityIdentifier string form will improve connection throughput. 

This change avoids the use of a StringBuilder, it's expansion and formatting intermediate strings by using a stackalloc span of the maximum possible length for a v1 string form sid and formatting directly into that buffer. The size calculation is included in the comments so the next person to look at this code doesn't have to work it out for themselves. 

The stackalloc buffer is 189 chars in length which looks odd but remember that chars are 16bit so this buffer is still 16bit aligned on the stack. It could be increased up to the closest power of 2 (192) if this is desirable, I know there are rules about this which @GrabYourPitchforks will need to review.

Performance changes make it almost 50% faster and change the memory allocation from using StringBuilder expansion and intermediate formatting representation strings to a flat allocation at the end of the method to return the string.

|      Method |     Mean |    Error |   StdDev | Ratio | Gen 0/1k Op |  Allocated Memory/Op |
------------ |---------:|---------:|--:|------:|-------:|--:|
   Reference | 829.0 ns | 9.954 ns | 8.824 ns |  1.00 |      0.4339 |  1368 B |
 Development | 431.9 ns | 3.390 ns | 3.171 ns |  0.52 |      0.1140 | 360 B |


/CC @GrabYourPitchforks , @bartonjs 
Contributes to https://github.com/dotnet/corefx/issues/30430 @saurabh500 