### PR TITLE
Optimize SqlClient connection pool performance

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
@@ -22,8 +22,9 @@ namespace System.Data.ProviderBase
             using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
             {
                 IntPtr token = identity.AccessToken.DangerousGetHandle();
-                bool isNetwork = identity.User.IsWellKnown(WellKnownSidType.NetworkSid);
-                string sidString = identity.User.Value;
+                SecurityIdentifier user = identity.User;
+                bool isNetwork = user.IsWellKnown(WellKnownSidType.NetworkSid);
+                string sidString = user.ToString();
 
                 // Win32NativeMethods.IsTokenRestricted will raise exception if the native call fails
                 bool isRestricted = Win32NativeMethods.IsTokenRestrictedWrapper(token);

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
@@ -24,7 +24,7 @@ namespace System.Data.ProviderBase
                 IntPtr token = identity.AccessToken.DangerousGetHandle();
                 SecurityIdentifier user = identity.User;
                 bool isNetwork = user.IsWellKnown(WellKnownSidType.NetworkSid);
-                string sidString = user.ToString();
+                string sidString = user.Value;
 
                 // Win32NativeMethods.IsTokenRestricted will raise exception if the native call fails
                 bool isRestricted = Win32NativeMethods.IsTokenRestrictedWrapper(token);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Buffers;
 using System.Data.Common;
 using System.Data.Sql;
 using System.Data.SqlTypes;
@@ -6207,7 +6208,7 @@ namespace System.Data.SqlClient
                 if (rec.useSSPI)
                 {
                     // now allocate proper length of buffer, and set length
-                    outSSPIBuff = new byte[s_maxSSPILength];
+                    outSSPIBuff = ArrayPool<byte>.Shared.Rent((int)s_maxSSPILength);
                     outSSPILength = s_maxSSPILength;
 
                     // Call helper function for SSPI data and actual length.
@@ -6515,6 +6516,11 @@ namespace System.Data.SqlClient
                 throw;
             }
 
+            if (outSSPIBuff != null)
+            {
+                ArrayPool<byte>.Shared.Return(outSSPIBuff, clearArray: true);
+            }
+
             _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
             _physicalStateObj.ResetSecurePasswordsInformation();
             _physicalStateObj._pendingData = true;
@@ -6569,7 +6575,7 @@ namespace System.Data.SqlClient
             if (!result) { throw SQL.SynchronousCallMayNotPend(); }
 
             // allocate send buffer and initialize length
-            byte[] sendBuff = new byte[s_maxSSPILength];
+            byte[] sendBuff = ArrayPool<byte>.Shared.Rent((int)s_maxSSPILength);
             uint sendLength = s_maxSSPILength;
 
             // make call for SSPI data
@@ -6578,6 +6584,8 @@ namespace System.Data.SqlClient
 
             // DO NOT SEND LENGTH - TDS DOC INCORRECT!  JUST SEND SSPI DATA!
             _physicalStateObj.WriteByteArray(sendBuff, (int)sendLength, 0);
+
+            ArrayPool<byte>.Shared.Return(sendBuff, clearArray: true);
 
             // set message type so server knows its a SSPI response
             _physicalStateObj._outputMessageType = TdsEnums.MT_SSPI;


### PR DESCRIPTION
When using trusted authentication with connection pooling profiling has shown that getting the connection from the pool and getting the security information from the unmanaged library are hot paths. 

This PR slightly rearranges the code in the connection pool key identification code to be more efficient about use of the user SecurityIdentifier object fetching it only once because it is expensive and calling ToString() directly instead of using Value because Value will make an unneeded ToUpperInvariant() call.
It also changes the allocation of SSPI buffers to use the ArrayPool, in testing the sspi buffers were being requested at 55K each time which caused a lot of memory churn.

Combined with the changes in https://github.com/dotnet/corefx/pull/33579 this should allow connections to be retrieved ~20% faster allowing better short frequent query throughput. I'm still having trouble with benching but the profile run output is reasonable, all tests pass and the changes are very small.

![after](https://user-images.githubusercontent.com/13322696/48678782-b54e9480-eb7f-11e8-8a5b-b7870bda44af.PNG)

/CC @keeratsingh, @AfsanehR, @saurabh500, @divega 