### PR TITLE
Remove StringBuilder marshaling from GetNameInfoW

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.GetNameInfoW.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.GetNameInfoW.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal static partial class Interop
 {
@@ -22,13 +21,13 @@ internal static partial class Interop
         }
 
         [DllImport(Interop.Libraries.Ws2_32, CharSet = CharSet.Unicode, BestFitMapping = false, ThrowOnUnmappableChar = true, SetLastError = true)]
-        internal static extern SocketError GetNameInfoW(
-            [In]         byte[] sa,
-            [In]         int salen,
-            [Out]        StringBuilder host,
-            [In]         int hostlen,
-            [Out]        StringBuilder serv,
-            [In]         int servlen,
-            [In]         int flags);
+        internal static extern unsafe SocketError GetNameInfoW(
+            byte* pSockaddr,
+            int SockaddrLength,
+            char* pNodeBuffer,
+            int NodeBufferSize,
+            char* pServiceBuffer,
+            int ServiceBufferSize,
+            int Flags);
     }
 }

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -243,42 +243,32 @@ namespace System.Net
             return SocketError.Success;
         }
 
-        public static string TryGetNameInfo(IPAddress addr, out SocketError errorCode, out int nativeErrorCode)
+        public static unsafe string TryGetNameInfo(IPAddress addr, out SocketError errorCode, out int nativeErrorCode)
         {
-            //
-            // Use SocketException here to show operation not supported
-            // if, by some nefarious means, this method is called on an
-            // unsupported platform.
-            //
-            SocketAddress address = (new IPEndPoint(addr, 0)).Serialize();
-            StringBuilder hostname = new StringBuilder(1025); // NI_MAXHOST
-
-            int flags = (int)Interop.Winsock.NameInfoFlags.NI_NAMEREQD;
-
-            nativeErrorCode = 0;
-
-            byte[] addressBuffer = new byte[address.Size];
+            SocketAddress address = new IPEndPoint(addr, 0).Serialize();
+            Span<byte> addressBuffer = address.Size <= 64 ? stackalloc byte[64] : new byte[address.Size];
             for (int i = 0; i < address.Size; i++)
             {
                 addressBuffer[i] = address[i];
             }
 
-            errorCode =
-                Interop.Winsock.GetNameInfoW(
-                    addressBuffer,
+            const int NI_MAXHOST = 1025;
+            char* hostname = stackalloc char[NI_MAXHOST];
+
+            nativeErrorCode = 0;
+            fixed (byte* addressBufferPtr = addressBuffer)
+            {
+                errorCode = Interop.Winsock.GetNameInfoW(
+                    addressBufferPtr,
                     address.Size,
                     hostname,
-                    hostname.Capacity,
+                    NI_MAXHOST,
                     null, // We don't want a service name
                     0, // so no need for buffer or length
-                    flags);
-
-            if (errorCode != SocketError.Success)
-            {
-                return null;
+                    (int)Interop.Winsock.NameInfoFlags.NI_NAMEREQD);
             }
 
-            return hostname.ToString();
+            return errorCode == SocketError.Success ? new string(hostname) : null;
         }
 
         public static unsafe string GetHostName()


### PR DESCRIPTION
cc: @JeremyKuhne, @davidsh, @jkotas 

```C#
[Benchmark] public IPHostEntry GetHostEntry() => Dns.GetHostEntry("34.206.253.53");
```

Before:
```
       Method |     Mean |    Error |   StdDev | Allocated |
------------- |---------:|---------:|---------:|----------:|
 GetHostEntry | 717.8 us | 14.20 us | 41.21 us |   2.73 KB |
```

After:
```
       Method |     Mean |    Error |   StdDev | Allocated |
------------- |---------:|---------:|---------:|----------:|
 GetHostEntry | 708.1 us | 14.02 us | 34.12 us |     624 B |
```