### PR TITLE
Support for Sampling based on Activity 

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -575,7 +575,7 @@ namespace System.Diagnostics
 
         /* Activity Sampling Support */
         /// <summary>
-        /// If true (set by StartWithSampling) 
+        /// True if something has called SetRecordingDesired in this Activity or a parent activity.  
         /// </summary>
         public bool Recording { get; private set; }
 
@@ -650,9 +650,24 @@ namespace System.Diagnostics
         public static bool IsActivitySamplingEnabled { get { return s_sampling.IsActivitySamplingEnabled; } }
 
         /// <summary>
-        /// Activities support sampling.   Logging systems are strongly encouraged to support sampling 
-        /// by adding the following check before they actually log (the logging system gets to decide 
-        /// what verbosity level does this (we recommend info or more verbose).
+        /// Returns true if the current Activity has the Recording flag set.   
+        /// Note that this also returns true if ActivitySampling is off. 
+        /// </summary>
+        public static bool CurrentActivityIsRecording {
+            get
+            {
+                if (Activity.IsActivitySamplingEnabled)
+                {
+                    var cur = Activity.Current;
+                    if (cur == null || !cur.Recording)
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Activities support sampling.  
         /// 
         /// To turn on logging you create a ActivityConfig class (which specifies the degree of filtering)
         /// and call RegisterActivityConfig.  Once registered this config is active until the config object

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -219,7 +219,7 @@ namespace System.Diagnostics
         /// to ensure somebody listens to the DiagnosticListener at all.</remarks>
         public bool IsEnabled()
         {
-            return _subscriptions != null && IsSamplingOn();
+            return _subscriptions != null && Activity.CurrentActivityIsRecording;
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace System.Diagnostics
             for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
             {
                 if (curSubscription.IsEnabled1Arg == null || curSubscription.IsEnabled1Arg(name))
-                    return IsSamplingOn();
+                    return Activity.CurrentActivityIsRecording;
             }
             return false;
         }
@@ -244,7 +244,7 @@ namespace System.Diagnostics
             for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
             {
                 if (curSubscription.IsEnabled3Arg == null || curSubscription.IsEnabled3Arg(name, arg1, arg2))
-                    return IsSamplingOn();
+                    return Activity.CurrentActivityIsRecording;
             }
             return false;
         }
@@ -259,16 +259,6 @@ namespace System.Diagnostics
         }
 
         #region private
-        private bool IsSamplingOn()
-        {
-            if (Activity.IsActivitySamplingEnabled)
-            {
-                var cur = Activity.Current;
-                if (cur == null || !cur.Recording)
-                    return false;
-            }
-            return true;
-        }
 
         // Note that Subscriptions are READ ONLY.   This means you never update any fields (even on removal!)
         private class DiagnosticSubscription : IDisposable


### PR DESCRIPTION
The PR is for discussion purposes at the moment.  It is a strawman.  

It is likely a companion to other Activity changes, most notably the change to support W3C IDs. 
See https://github.com/dotnet/corefx/pull/33207

The basic idea behind Activity Sampling is that an Activity can be marked as being 'Recording' and from then on all DiagnosticSource logging from that activity will be logged.  In addition, this Recording bit is propagated to any children, so the whole transitive closure of the Activity is logged.   Thus you get 'complete' information for a 'Recording' activity, but hopefully only a small percentage (e.g. 1%) actually have this bit set, so both overhead and data volume is low enough to leave on 'all the time'.  

## Goal - Performance. 

Note that the KEY goal of ActivitySampling is PERFORMANCE.   The fundamental issue is that logging every event for every request is simply too expensive.  The goal is to have SOMETHING on all the time.    We do this by allowing users to specify a 'SamplingPercent'.     If this is set to say 1 (that is 1%) than only 1 out of every 100 requests are logged, and logging overhead is 1/100 what it was before.   My setting this low enough you can reduce the overhead to something you can leave on all the time.  

Because the goal is performance, it is important that for the 99% of requests that are NOT sampled, that overhead is as close to 'logging off' as possible.   It is critical that path to filtering things out be VERY FAST.   

While more sophisticated sampling (which is triggered by some user-defined criteria) is possible, we do NOT suggest that here.   The only configuration we currently support is the 'SamplingPercent' and the sampling is random.    Note that this is still very powerful, especially in high scale scenarios.   If you set a SamplingPercent to 1%, then it will  have to wait 100 X longer than you would otherwise but you will ultimately get every interesting repeating behavior (and the user has the option of turning up the SamplingPercent if he is impatient).    The most important aspect is that some amount of logging can be left on all time time (which allows you to get all the rapidly repeating issues quickly).   

##  Sampling is a service of Activity, not the logging system.   

The performance goal, along with the fact we have more than one logging system (DiagnosticSource, EventSource, ILogger, and many 3rd parties) has pushed us to a design where ActivitySampling is a service from ACTIVITY, NOT the logging system.    Thus there is a single PROCESS GLOBAL decision on whether we are doing sampling or not (and what the SamplingPercent configuration value is).  

This is not to say that logging systems don't participate.  Indeed by default each logging system will IGNORE ActivitySampling and always log if they don't participate at all.   We strongly encourage every logging system to add the following code to the 'Write' APIs.  
```
    if (Activity.CurrentActivityIsRecording) {   // Static method.  
        // Normal Writing logic
    }
```
The logic in Activity.CurrentActivityIsRecording is very cheap.    We have made this change to DiagnosticSource's  logic, but it needs to go into every other logging system as well.   

The logging system is also likely to want to 'wrap' the configuration of the 'SamplingPercent' value.   This is completely expected (more details below).  

##  You can only REQUEST that an activity starts recording

In order for the PERFORMANCE GOAL to be achieved, it is important the if the client asked for a samplingPercent = 1%, that on average only 1% of the activities are logged.    Thus code is not allowed to actually set the Recording bit on an activity, it can only set a REQUEST to do so.   Ultimately the Activity class insures that the requested SamplingPercent is honored.    If too many activities ask for the recording bit to be set, then some of them will not be honored.  

##  Boundary activities need to 'Start' the sampling.  

Most Activities have parents that are in the same process.  These Activities get their 'Recording' state from their parent.   But what about the others?   There are two cases 

1. 'Top level' activities that have no logical parent
2. Activities whose parent is 'outside' the process (e.g. on incoming HTTP request).  

We have created two overloads 
```
    static Activity CreateActivityIfRecording(string operationName);  // For top level 
    static Activity CreateActivityIfRecording(string operationName, string parentW3CId) // For incoming requests.  
```
Both of these APIs will 
1.  Return an activity (with Recording==false) if Sampling is completely turned off (thus no filtering)
2.  Returns NULL if Sampling is on and this Activity was NOT chosen for recording
3. Returns an activity (with Recording==true) if if Sampling is on, AND the Activity was chosen for Recording.  

The first API was meant for 'top level' (no parent) activities.   It will simply randomly decide to log or not log trying to honor the SamplingPercent desired.   The second API is meant to be used for incoming HTTP requests.   It was already the case that you needed to set the Activity with the W3C ID from the HTTP request, but in addition this API checks if the W3C ID indicates if it should Record, and tries to honor that request (but its first priority is to not exceed the SamplingPercent value the user specified).  

## Activity Sampling plays nice with multiple loggers.   

Because Activity sampling is 'process  global' state, there is a strong potential for conflict between more than one logging system.   For example one logging system might set the SamplingPercent to 10 and another at 1%.   Which should win?   How can we insure a level of 'sanity' where after the second logging system 'detaches, the global state goes back to what it was before it entered?   

We solve this by making Activity Sampling configuration a bit more complex than you might expect.  Instead of having a read-write global static variable 'SamplingPercent' which clients could 'fight over', instead we have an API
```
        public static void RegisterActivityConfig(ActivityConfig config);
```
Where ActivityConfig is simply a class with a settable 'SamplingPercent' property and a 'Dispose' method.   Thus each logging system only requests what value of SamplingPercent it wants, and the ActivityClass makes a decision (it decides on the maximum value).   When clients wish to 'detach' they simply call 'Dispose' on their config and the system reacts as you would expect (the new value will be the maxium of the (Now smaller set) of active configurations.   

Note that if there is NO registrations for a SamplingPercent, then Activity sampling is 'off' and no filtering happens (this is also the behavior if event one client asks for a SamplingPercent=100),   Thus by default, you get what you get today (no sampling, that is 100% of all events logged).   

## Putting it all together. 

These are all the APIs we are adding.  
```
public partial class Activity {
	// Testing if we are sampling
    public bool Recording { get; private set; }

	// Asks to set 'Recording' but may not happen if it would log too many activities. 
    public void SetRecordingDesired()

	// This is Activity.Current.Recording, but deals with a null Activity.Current.
    public static bool CurrentActivityIsRecording { get }

	// Use these to create activities when you don't have a (local parent)
    static Activity CreateActivityIfRecording(string operationName);                     // For top level Activties
    static Activity CreateActivityIfRecording(string operationName, string parentW3CId)  // For incomming HTTP req with W3CIds

	// The way clients ask that sampling be turned on. 
    public static void RegisterActivityConfig(ActivityConfig config);
}

// Remembers the configuration for Sampling (Dispose() allows you to remove this configuration)
public sealed class ActivityConfig : IDisposable
{
	// Used to create a config and set the values you care about (currently only SamplingPercent
    public ActivityConfig(double samplingPercent)
    public double SamplingPercent { get; set; }

	// If you call this it removes the config so that it is like you never called RegisterActivityConfig
    public void Dispose()
}
```
## What has to happen
After this sampling support goes in, things that have to happen include
1. Logging Systems need to add a call to CurrentActivityIsRecording to their write logic so that they too filter out events if ActivitySampling is turned on.
2. Something (e.g. a logging system) has to get a 'SampingPercent' from the 'user' and call RegisterActivityConfig.  
3. Any 'top level' activities, should use CreateActivityIfRecording(string operationName);
4. Any incomming HTTP requests should look for the W3C Id and call CreateActivityIfRecording(string operationName, string parentW3CId) as needed. 

## Changes for Additional Perf
Currently  CreateActivityIfRecording takes its W3CId as a string.   This forces this string to be created, and afterward it is no longer needed.    The good news is that this overhead only happens when the HTTP request has a W3CId in its header.     Thus if you DON'T create even IDs for most requests, it can be efficient, but if you do, then you incur this extra cost.

Note that this can be mitigated a bit by instead of having the HTTP header parser return a string, you instead either have it some convenient Span, or even have the parser be thing that calls 'CreateActivityIfReording (thus you can have the parser have 'ReturnActivityBasedOnHeaderFields').   This can be done later.  