### PR TITLE
pull in more recent version of platform detection

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -48,7 +48,7 @@
       <Version>1.5.0</Version>
     </PackageReference>
     <PackageReference Condition="'$(TargetGroup)' != 'uapaot'" Include="Microsoft.DotNet.PlatformAbstractions">
-      <Version>2.0.4</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>


### PR DESCRIPTION
pull in newer version of platform detection. 
This fixes issues when executing tests on FreeBSD.

