### PR TITLE
Remove char[] allocation in CheckIriUnicodeRange

### DIFF
--- a/src/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/System.Private.Uri/src/System/IriHelper.cs
@@ -36,7 +36,7 @@ namespace System
             if (char.IsSurrogatePair(highSurr, lowSurr))
             {
                 surrogatePair = true;
-                char[] chars = new char[2] { highSurr, lowSurr };
+                ReadOnlySpan<char> chars = stackalloc char[2] { highSurr, lowSurr };
                 string surrPair = new string(chars);
                 if (((string.CompareOrdinal(surrPair, "\U00010000") >= 0)
                         && (string.CompareOrdinal(surrPair, "\U0001FFFD") <= 0)) ||


### PR DESCRIPTION
We can trivially remove a char[2] allocation by replacing it with a stackalloc'd span.  We could likely go further and avoid the subsequent string allocation as well, but we'd want to do perf validation of that, given the sheer number of CompareOrdinal calls that follow.

cc: @davidsh, @GrabYourPitchforks 