### PR TITLE
Unix: change SetCreationTime to match better with GetCreationTime

### DIFF
--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -48,8 +48,8 @@ namespace System.IO.Tests
 
             // Set CreationTime to some time in the past, after the file was created.
             // This causes us to set mtime to a value past ctime.
-            await Task.Delay(300);
-            DateTime newCreationTimeUTC = System.DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(600));
+            await Task.Delay(600);
+            DateTime newCreationTimeUTC = System.DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(300));
             File.SetCreationTimeUtc(path, newCreationTimeUTC);
 
             Assert.Equal(newCreationTimeUTC, File.GetLastWriteTimeUtc(path));

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -46,8 +46,7 @@ namespace System.IO.Tests
             string path = GetTestFilePath();
             File.WriteAllText(path, "");
 
-            // Set CreationTime to some time in the past, after the file was created.
-            // This causes us to set mtime to a value past ctime.
+            // Set the creation time to a value in the past that is between ctime and now.
             await Task.Delay(600);
             DateTime newCreationTimeUTC = System.DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(300));
             File.SetCreationTimeUtc(path, newCreationTimeUTC);

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -46,10 +46,11 @@ namespace System.IO.Tests
             File.WriteAllText(fileName, "");
 
             FileInfo fileInfo = new System.IO.FileInfo(fileName);
-            DateTime newCreationTimeUTC = System.DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(1));
+            DateTime newCreationTimeUTC = System.DateTime.UtcNow.Subtract(TimeSpan.FromDays(1));
             fileInfo.CreationTimeUtc = newCreationTimeUTC;
 
             Assert.Equal(newCreationTimeUTC, fileInfo.LastWriteTimeUtc);
+
             Assert.Equal(newCreationTimeUTC, fileInfo.CreationTimeUtc);
         }
 

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -49,7 +49,8 @@ namespace System.IO.Tests
             DateTime newCreationTimeUTC = System.DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(1));
             fileInfo.CreationTimeUtc = newCreationTimeUTC;
 
-            Assert.True(fileInfo.CreationTimeUtc == newCreationTimeUTC);
+            Assert.Equal(newCreationTimeUTC, fileInfo.LastWriteTimeUtc);
+            Assert.Equal(newCreationTimeUTC, fileInfo.CreationTimeUtc);
         }
 
         public override IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false)

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -21,7 +21,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Linux)]
         public void BirthTimeIsNotNewerThanLowestOfAccessModifiedTimes()
         {
-            // On Linux, we synthesize CreationTime from the oldest of statuc changed time and write time
+            // On Linux, we synthesize CreationTime from the oldest of status changed time and write time
             //  if birth time is not available. So WriteTime should never be earlier.
 
             // Set different values for all three
@@ -32,6 +32,24 @@ namespace System.IO.Tests
 
             // Assert.InRange is inclusive.
             Assert.InRange(File.GetCreationTimeUtc(path), DateTime.MinValue, File.GetLastWriteTimeUtc(path));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        public void CreationTimeSet_GetReturnsExpected_WhenNotInFuture()
+        {
+            // On Linux, we synthesize CreationTime from the oldest of status changed time (ctime) and write time (mtime).
+            // Changing the CreationTime, updates mtime and causes ctime to change to the current time.
+            // When setting CreationTime to a value that isn't in the future, getting the CreationTime should return the same value.
+
+            string fileName = Path.GetTempFileName();
+            File.WriteAllText(fileName, "");
+
+            FileInfo fileInfo = new System.IO.FileInfo(fileName);
+            DateTime newCreationTimeUTC = System.DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(1));
+            fileInfo.CreationTimeUtc = newCreationTimeUTC;
+
+            Assert.True(fileInfo.CreationTimeUtc == newCreationTimeUTC);
         }
 
         public override IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/33601

CC @danmosemsft @WernerMairl