### PR TITLE
Add ImmutableInterlocked.GetOrAdd for sets

### DIFF
--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -494,6 +494,8 @@ namespace System.Collections.Immutable
         public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
         public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
         public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+        public static T GetOrAdd<T>(ref System.Collections.Immutable.ImmutableHashSet<T> location, T value) { throw null; }
+        public static T GetOrAdd<T>(ref System.Collections.Immutable.ImmutableSortedSet<T> location, T value) { throw null; }
         public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
         public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
         public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }

--- a/src/System.Collections.Immutable/tests/ImmutableInterlockedTests.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableInterlockedTests.cs
@@ -287,6 +287,26 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void GetOrAddHashSet()
+        {
+            var set = ImmutableHashSet.Create<string>();
+            string value = "a";
+            string valueClone = new string(value.ToCharArray());
+            Assert.Same(value, ImmutableInterlocked.GetOrAdd(ref set, value));
+            Assert.Same(value, ImmutableInterlocked.GetOrAdd(ref set, valueClone));
+        }
+
+        [Fact]
+        public void GetOrAddSortedSet()
+        {
+            var set = ImmutableSortedSet.Create<string>();
+            string value = "a";
+            string valueClone = new string(value.ToCharArray());
+            Assert.Same(value, ImmutableInterlocked.GetOrAdd(ref set, value));
+            Assert.Same(value, ImmutableInterlocked.GetOrAdd(ref set, valueClone));
+        }
+
+        [Fact]
         public void AddOrUpdateDictionaryAddValue()
         {
             var dictionary = ImmutableDictionary.Create<int, string>();


### PR DESCRIPTION
This brings support for interlocked updates to `ImmutableHashSet<T>` and `ImmutableOrderedSet<T>`.

Such a pattern is particularly useful for object pools/caches. We use something similar in `dotnet/project-system` to consolidate object references and reduce retained memory.

Should thes new methods have type constraint `where T : class`? I don't think they makes much sense for value types.