### PR TITLE
Pipelines to use UnsafeQueueUserWorkItem

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/InlineScheduler.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/InlineScheduler.cs
@@ -10,5 +10,10 @@ namespace System.IO.Pipelines
         {
             action(state);
         }
+
+        internal override void UnsafeSchedule(Action<object> action, object state)
+        {
+            action(state);
+        }
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/InlineScheduler.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/InlineScheduler.cs
@@ -10,5 +10,8 @@ namespace System.IO.Pipelines
         {
             action(state);
         }
+
+        internal override void ScheduleInternal(Action<object> action, object state)
+            => action(state);
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/InlineScheduler.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/InlineScheduler.cs
@@ -10,8 +10,5 @@ namespace System.IO.Pipelines
         {
             action(state);
         }
-
-        internal override void ScheduleInternal(Action<object> action, object state)
-            => action(state);
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -660,7 +660,7 @@ namespace System.IO.Pipelines
         {
             if (action != null)
             {
-                scheduler.ScheduleInternal(action, state);
+                scheduler.UnsafeSchedule(action, state);
             }
         }
 
@@ -684,13 +684,13 @@ namespace System.IO.Pipelines
                 if (completionData.ExecutionContext == null)
                 {
                     // We can run directly, this should be the default fast path
-                    scheduler.ScheduleInternal(completionData.Completion, completionData.CompletionState);
+                    scheduler.UnsafeSchedule(completionData.Completion, completionData.CompletionState);
                     return;
                 }
 
                 // We also have to run on the specified execution context so run the scheduler and execute the
                 // delegate on the execution context
-                scheduler.ScheduleInternal(s_scheduleWithExecutionContextCallback, completionData);
+                scheduler.UnsafeSchedule(s_scheduleWithExecutionContextCallback, completionData);
             }
             else
             {

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -660,7 +660,7 @@ namespace System.IO.Pipelines
         {
             if (action != null)
             {
-                scheduler.Schedule(action, state);
+                scheduler.ScheduleInternal(action, state);
             }
         }
 
@@ -684,13 +684,13 @@ namespace System.IO.Pipelines
                 if (completionData.ExecutionContext == null)
                 {
                     // We can run directly, this should be the default fast path
-                    scheduler.Schedule(completionData.Completion, completionData.CompletionState);
+                    scheduler.ScheduleInternal(completionData.Completion, completionData.CompletionState);
                     return;
                 }
 
                 // We also have to run on the specified execution context so run the scheduler and execute the
                 // delegate on the execution context
-                scheduler.Schedule(s_scheduleWithExecutionContextCallback, completionData);
+                scheduler.ScheduleInternal(s_scheduleWithExecutionContextCallback, completionData);
             }
             else
             {

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeScheduler.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeScheduler.cs
@@ -30,25 +30,6 @@ namespace System.IO.Pipelines
         public abstract void Schedule(Action<object> action, object state);
 
         internal virtual void UnsafeSchedule(Action<object> action, object state)
-        {
-            bool restoreFlow = false;
-            try
-            {
-                if (!ExecutionContext.IsFlowSuppressed())
-                {
-                    ExecutionContext.SuppressFlow();
-                    restoreFlow = true;
-                }
-
-                Schedule(action, state);
-            }
-            finally
-            {
-                if (restoreFlow)
-                {
-                    ExecutionContext.RestoreFlow();
-                }
-            }
-        }
+            => Schedule(action, state);
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeScheduler.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeScheduler.cs
@@ -26,5 +26,8 @@ namespace System.IO.Pipelines
         /// Requests <paramref name="action"/> to be run on scheduler with <paramref name="state"/> being passed in
         /// </summary>
         public abstract void Schedule(Action<object> action, object state);
+
+        internal virtual void ScheduleInternal(Action<object> action, object state)
+            => Schedule(action, state);
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netcoreapp.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netcoreapp.cs
@@ -14,7 +14,7 @@ namespace System.IO.Pipelines
             System.Threading.ThreadPool.QueueUserWorkItem(action, state, preferLocal: false);
         }
 
-        internal override void ScheduleInternal(Action<object> action, object state)
+        internal override void UnsafeSchedule(Action<object> action, object state)
         {
             System.Threading.ThreadPool.UnsafeQueueUserWorkItem(action, state, preferLocal: false);
         }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netcoreapp.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netcoreapp.cs
@@ -11,6 +11,11 @@ namespace System.IO.Pipelines
     {
         public override void Schedule(Action<object> action, object state)
         {
+            System.Threading.ThreadPool.QueueUserWorkItem(action, state, preferLocal: false);
+        }
+
+        internal override void ScheduleInternal(Action<object> action, object state)
+        {
             System.Threading.ThreadPool.UnsafeQueueUserWorkItem(action, state, preferLocal: false);
         }
     }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netcoreapp.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThreadPoolScheduler.netcoreapp.cs
@@ -11,7 +11,7 @@ namespace System.IO.Pipelines
     {
         public override void Schedule(Action<object> action, object state)
         {
-            System.Threading.ThreadPool.QueueUserWorkItem(action, state, preferLocal: false);
+            System.Threading.ThreadPool.UnsafeQueueUserWorkItem(action, state, preferLocal: false);
         }
     }
 }


### PR DESCRIPTION
`ExecutionContext` is handed externally by the scheduler

Fixes #32924

/cc @pakrym @davidfowl @stephentoub 