### PR TITLE
System.Collections.Generic.SortedSet: Format black-red tree comment

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -17,10 +17,11 @@ namespace System.Collections.Generic
     //
     // The basic idea of a red-black tree is to represent 2-3-4 trees as standard BSTs but to add one extra bit of information
     // per node to encode 3-nodes and 4-nodes.
-    // 4-nodes will be represented as:          B
-    //                                                              R            R
-    // 3 -node will be represented as:           B             or         B
-    //                                                              R          B               B       R
+    // 4-nodes will be represented as:   B
+    //                                 R   R
+    //
+    // 3 -node will be represented as:   B     or     B
+    //                                 R   B        B   R
     //
     // For a detailed description of the algorithm, take a look at "Algorithms" by Robert Sedgewick.
 


### PR DESCRIPTION
I think this comment has been lost in a monospace font transition in IDEs used by the project. :)

I didn't study it in-depth, but it looks congruent with https://en.wikipedia.org/wiki/Red%E2%80%93black_tree.