### PR TITLE
AwaitableSocketAsyncEventArgs should use UnsafeQueueUserWorkItem

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -1010,6 +1010,8 @@ namespace System.Net.Sockets
 
             private void InvokeContinuation(Action<object> continuation, object state, bool forceAsync)
             {
+                Debug.Assert(_executionContext == null);
+
                 object scheduler = _scheduler;
                 _scheduler = null;
 
@@ -1031,7 +1033,7 @@ namespace System.Net.Sockets
                 }
                 else if (forceAsync)
                 {
-                    ThreadPool.QueueUserWorkItem(continuation, state, preferLocal: true);
+                    ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: true);
                 }
                 else
                 {


### PR DESCRIPTION
Might even be non-allocating if... https://github.com/dotnet/coreclr/pull/21159 😉 

/cc @stephentoub @davidfowl 