### PR TITLE
Added TryParse to StandardFormat

### DIFF
--- a/src/Common/src/CoreLib/System/Buffers/StandardFormat.cs
+++ b/src/Common/src/CoreLib/System/Buffers/StandardFormat.cs
@@ -79,7 +79,7 @@ namespace System.Buffers
         /// <summary>
         /// Converts a classic .NET format string into a StandardFormat
         /// </summary>
-        [System.Obsolete]public static StandardFormat Parse(string format) => format == null ? default : Parse(format.AsSpan());
+        public static StandardFormat Parse(string format) => format == null ? default : Parse(format.AsSpan());
 
         /// <summary>
         /// Tries to convert a classic .NET format string into a StandardFormat. A return value indicates whether the conversion succeeded or failed.

--- a/src/Common/src/CoreLib/System/Buffers/StandardFormat.cs
+++ b/src/Common/src/CoreLib/System/Buffers/StandardFormat.cs
@@ -71,30 +71,8 @@ namespace System.Buffers
         /// </summary>
         public static StandardFormat Parse(ReadOnlySpan<char> format)
         {
-            ParseHelper(format, out StandardFormat standardFormat, true);
-
-            return standardFormat;
-        }
-
-        /// <summary>
-        /// Converts a classic .NET format string into a StandardFormat
-        /// </summary>
-        public static StandardFormat Parse(string format) => format == null ? default : Parse(format.AsSpan());
-
-        /// <summary>
-        /// Tries to convert a classic .NET format string into a StandardFormat. A return value indicates whether the conversion succeeded or failed.
-        /// </summary>
-        public static bool TryParse(ReadOnlySpan<char> format, out StandardFormat result)
-        {
-            return ParseHelper(format, out standardFormat, false);
-        }
-
-        private static bool ParseHelper(ReadOnlySpan<char> format, out StandardFormat standardFormat, bool throws)
-        {
-            standardFormat = default;
-
             if (format.Length == 0)
-                return true;
+                return default;
 
             char symbol = format[0];
             byte precision;
@@ -109,19 +87,23 @@ namespace System.Buffers
                 {
                     uint digit = format[srcIndex] - 48u; // '0'
                     if (digit > 9)
-                        return throws ? throw new FormatException(SR.Format(SR.Argument_CannotParsePrecision, MaxPrecision)) : false;
+                        throw new FormatException(SR.Format(SR.Argument_CannotParsePrecision, MaxPrecision));
 
                     parsedPrecision = parsedPrecision * 10 + digit;
                     if (parsedPrecision > MaxPrecision)
-                        return throws ? throw new FormatException(SR.Format(SR.Argument_PrecisionTooLarge, MaxPrecision)) : false;
+                        throw new FormatException(SR.Format(SR.Argument_PrecisionTooLarge, MaxPrecision));
                 }
 
                 precision = (byte)parsedPrecision;
             }
 
-            standardFormat = new StandardFormat(symbol, precision);
-            return true;
+            return new StandardFormat(symbol, precision);
         }
+
+        /// <summary>
+        /// Converts a classic .NET format string into a StandardFormat
+        /// </summary>
+        public static StandardFormat Parse(string format) => format == null ? default : Parse(format.AsSpan());
 
         /// <summary>
         /// Returns true if both the Symbol and Precision are equal.

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -246,7 +246,7 @@ namespace System.Buffers
         public static implicit operator System.Buffers.StandardFormat (char symbol) { throw null; }
         public static bool operator !=(System.Buffers.StandardFormat left, System.Buffers.StandardFormat right) { throw null; }
         public static System.Buffers.StandardFormat Parse(System.ReadOnlySpan<char> format) { throw null; }
-        public static System.Buffers.StandardFormat Parse(string format) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> format, out StandardFormat result) { throw null; }
         public override string ToString() { throw null; }
     }
 }

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -246,6 +246,7 @@ namespace System.Buffers
         public static implicit operator System.Buffers.StandardFormat (char symbol) { throw null; }
         public static bool operator !=(System.Buffers.StandardFormat left, System.Buffers.StandardFormat right) { throw null; }
         public static System.Buffers.StandardFormat Parse(System.ReadOnlySpan<char> format) { throw null; }
+        public static System.Buffers.StandardFormat Parse(string format) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> format, out StandardFormat result) { throw null; }
         public override string ToString() { throw null; }
     }

--- a/src/System.Memory/tests/Configurations.props
+++ b/src/System.Memory/tests/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
-      netstandard;
       uap;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs
@@ -64,12 +64,12 @@ namespace System.Buffers.Text.Tests
         [InlineData("G$", default(char), default(byte), false)]
         [InlineData("Ga", default(char), default(byte), false)]
         [InlineData("G100", default(char), default(byte), false)]
-        public static void StandardFormatTryParse(string formatString, char expectedSymbol, byte expectedPrecision, bool expectedSuccess)
+        public static void StandardFormatTryParse(string formatString, char expectedSymbol, byte expectedPrecision, bool expectedResult)
         {
-            bool success = StandardFormat.TryParse(formatString, out StandardFormat format);
+            bool result = StandardFormat.TryParse(formatString, out StandardFormat format);
             Assert.Equal(expectedSymbol, format.Symbol);
             Assert.Equal(expectedPrecision, format.Precision);
-            Assert.Equal(expectedSuccess, success);
+            Assert.Equal(expectedResult, result);
         }
 
         [Theory]

--- a/src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs
@@ -55,6 +55,24 @@ namespace System.Buffers.Text.Tests
         }
 
         [Theory]
+        [InlineData("G4", 'G', 4, true)]
+        [InlineData("n0", 'n', 0, true)]
+        [InlineData("d", 'd', StandardFormat.NoPrecision, true)]
+        [InlineData("x99", 'x', StandardFormat.MaxPrecision, true)]
+        [InlineData(null, default(char), default(byte), true)]
+        [InlineData("", default(char), default(byte), true)]
+        [InlineData("G$", default(char), default(byte), false)]
+        [InlineData("Ga", default(char), default(byte), false)]
+        [InlineData("G100", default(char), default(byte), false)]
+        public static void StandardFormatTryParse(string formatString, char expectedSymbol, byte expectedPrecision, bool expectedSuccess)
+        {
+            bool success = StandardFormat.TryParse(formatString, out StandardFormat format);
+            Assert.Equal(expectedSymbol, format.Symbol);
+            Assert.Equal(expectedPrecision, format.Precision);
+            Assert.Equal(expectedSuccess, success);
+        }
+
+        [Theory]
         [InlineData('a')]
         [InlineData('B')]
         public static void StandardFormatOpImplicitFromChar(char c)


### PR DESCRIPTION
Fixes issue #32950 

1. Removed StandardFormat.Parse(string) overload in src/System.Memory/ref/System.Memory.cs
2. Added StandardFormat.TryParse in src/System.Memory/ref/System.Memory.cs
3. Marked Obsolete StandardFormat.Parse(string) overload in src/Common/src/CoreLib/System/Buffers/StandardFormat.cs
4. Added TryParse in src/Common/src/CoreLib/System/Buffers/StandardFormat.cs
5. Added UnitTests for TryParse in src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs

Need help for this. I didn't get it exactly how all these parts work together.
Like I see, there is [src/System.Memory/ref/System.Memory.cs](https://github.com/dotnet/corefx/blob/master/src/System.Memory/ref/System.Memory.cs), where the "abstraction" is defined and the [src/Common/src/CoreLib/System/Buffers/StandardFormat.cs](https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/Buffers/StandardFormat.cs), but this file has no *.sln or *.csproj. But as you can see regardless of the changes I made the build fails.