### PR TITLE
Move ObsoleteAttribute to correct property

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -618,7 +618,6 @@ namespace System.Diagnostics
 
         partial void EnsureHandleCountPopulated();
 
-        [ObsoleteAttribute("This property has been deprecated.  Please use System.Diagnostics.Process.VirtualMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
         public long VirtualMemorySize64
         {
             get
@@ -628,6 +627,7 @@ namespace System.Diagnostics
             }
         }
 
+        [ObsoleteAttribute("This property has been deprecated.  Please use System.Diagnostics.Process.VirtualMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
         public int VirtualMemorySize
         {
             get


### PR DESCRIPTION
The ObsoleteAttribute for System.Diagnostics.Process.VirtualMemorySize was on the wrong property.