### PR TITLE
Fix SourceLink URL to be GitHub one

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
     <RepositoryEngineeringDir>$(RepoRoot)eng\</RepositoryEngineeringDir>
+    <RepositoryUrl>git://github.com/dotnet/corefx</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Currently our sourcelink URL's point to a private server which hosts a clone of the public server. We want them to point to the public locations as they did before the Arcade conversion.

I suspect this is the fix but I cannot get my local repo to build in such a way it reproes the problem like the official build.

This prevents Arcade using $(PrivateRepositoryUrl)
https://github.com/dotnet/arcade/blob/a991a1d46cf6e5ed7dde93309217306f6a42c136/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets#L122-L123

CLI sets this property: https://github.com/dotnet/cli/blob/e08f56b7e4f67be64f3084fb91ac0e995c32e75e/build/BuildDefaults.props#L25


