### PR TITLE
Fix non-deterministic test failures caused by accessing uninitialized memory

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
@@ -263,7 +263,7 @@ namespace System.Runtime.InteropServices.Tests
 
                 Variant result = Marshal.PtrToStructure<Variant>(pNative);
                 Assert.Equal(VarEnum.VT_R8, (VarEnum)result.vt);
-                Assert.Equal(*((IntPtr*)&obj), result.bstrVal);
+                Assert.Equal(*((ulong*)&obj), *((ulong*)&result.bstrVal));
 
                 object o = Marshal.GetObjectForNativeVariant(pNative);
                 Assert.Equal(obj, o);
@@ -287,7 +287,7 @@ namespace System.Runtime.InteropServices.Tests
 
                 Variant result = Marshal.PtrToStructure<Variant>(pNative);
                 Assert.Equal(VarEnum.VT_R4, (VarEnum)result.vt);
-                Assert.Equal(*((IntPtr*)&obj), result.bstrVal);
+                Assert.Equal(*((uint*)&obj), *((uint*)&result.bstrVal));
 
                 object o = Marshal.GetObjectForNativeVariant(pNative);
                 Assert.Equal(obj, o);


### PR DESCRIPTION
Fixes dotnet/coreclr#21238