### PR TITLE
SerialPort: do not artifically limit baudRate

### DIFF
--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -94,7 +94,7 @@ namespace System.IO.Ports
 
         private static void CheckBaudRate(int baudRate)
         {
-            if (baudRate <= 0 || baudRate > 230400)
+            if (baudRate <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(BaudRate), SR.ArgumentOutOfRange_NeedPosNum);
             }


### PR DESCRIPTION
Linux doesn't have a good way of detecting what baud rates are supported and what are not. I've previously thought that it can't support anything higher than 230400 but that is incorrect as I've found at least one device where that wasn't true and removing the limit allowed me to connect to it.