### PR TITLE
Update intellisense files for System.Memory and System.Text.Json based on 11-28-2018 doc build.

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -13,7 +13,7 @@
     <NativePackagePath>$(MSBuildThisFileDirectory)src/Native/pkg</NativePackagePath>
 
     <XmlDocPackage>Microsoft.Private.Intellisense</XmlDocPackage>
-    <XmlDocPackageVersion>2.1.0-rc1-26508-0</XmlDocPackageVersion>
+    <XmlDocPackageVersion>3.0.0-preview1-27128-0</XmlDocPackageVersion>
     <XmlDocFileRoot>$(PackagesDir)$(XmlDocPackage.ToLowerInvariant())/$(XmlDocPackageVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
     <XmlDocDir>$(BinDir)docs</XmlDocDir>
 


### PR DESCRIPTION
Temporary, first attempt to go through the process of updating IntelliSense docs.

- The `System.Memory.xml` comes from the docs drop (11-28-2018) for netcoreapp2.2.
- The `System.Text.Json.xml` is auto-generated from source (using `<GenerateDocumentationFile>true</GenerateDocumentationFile>`) and will likely have to be overwritten with a future docs drop (which contains more detailed documentation that has been reviewed).
- Holding off on replacing the other xml files that came from the netcoreapp2.2 doc drop, for now (waiting for 3.0 drop and other fixes).