### PR TITLE
updating the test queues

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -487,7 +487,7 @@
       "allowOverride": true
     },
     "PB_TargetQueue": {
-      "value": "Centos.73.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Debian.9.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+opensuse.423.amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64"
+      "value": "Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+opensuse.42.amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64"
     },
     "PB_VsoAccountName": {
       "value": "dn-bot"

--- a/buildpipeline/centos.6.groovy
+++ b/buildpipeline/centos.6.groovy
@@ -47,7 +47,7 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-201743110
             // Get the user that should be associated with the submission
             def helixCreator = getUser()
             // Target queues
-            def targetHelixQueues = ['RedHat.69.Amd64.Open']
+            def targetHelixQueues = ['RedHat.6.Amd64.Open']
             
             sh "LD_LIBRARY_PATH=/usr/local/lib ./Tools/msbuild.sh src/upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${params.CGroup} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=\$CloudDropAccessToken /p:CloudResultsAccessToken=\$OutputCloudResultsAccessToken /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=${targetHelixQueues.join('+')} /p:HelixLogFolder=${WORKSPACE}/${logFolder}/ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
 

--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -47,17 +47,17 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
             // Get the user that should be associated with the submission
             def helixCreator = getUser()
             // Target queues
-            def targetHelixQueues = ['Centos.74.Amd64.Open',
-                                     'RedHat.74.Amd64.Open',
-                                     'Debian.87.Amd64.Open',
-                                     'Ubuntu.1404.Amd64.Open',
+            def targetHelixQueues = ['Centos.7.Amd64.Open',
+                                     'RedHat.7.Amd64.Open',
+                                     'Debian.8.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
                                      'Ubuntu.1804.Amd64.Open',
-                                     'OpenSuse.423.Amd64.Open',
+                                     'OpenSuse.42.Amd64.Open',
                                      'Fedora.27.Amd64.Open',]
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.9.Amd64.Open',
                                       'Fedora.28.Amd64.Open',
+                                      'Ubuntu.1810.Amd64.Open',
                                       'SLES.12.Amd64.Open',]
             }
 

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -23,7 +23,7 @@
             "PB_BuildArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -stripSymbols -- /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_BuildTestsArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Centos.73.Amd64+Centos.74.Amd64+RedHat.73.Amd64+RedHat.74.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+OpenSuse.423.Amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64",
+            "PB_TargetQueue": "Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+OpenSuse.42.Amd64+SLES.12.Amd64+Fedora.27.Amd64+Fedora.28.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {
@@ -39,7 +39,7 @@
             "PB_BuildArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -stripSymbols -RuntimeOS=rhel.6 -- /p:PortableBuild=false /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_BuildTestsArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -RuntimeOS=rhel.6 -- /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false",
             "PB_SyncArguments": "-p -RuntimeOS=rhel.6 -- /p:ArchGroup=x64 /p:PortableBuild=false /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "RedHat.69.Amd64",
+            "PB_TargetQueue": "RedHat.6.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {


### PR DESCRIPTION
Related Changes 
https://github.com/dotnet/corefx/commit/96572c1544c5fd681ea9558bd735ed5228fff2f8#diff-710d99e87996e45abbc6ea5e780cdc61
https://github.com/dotnet/corefx/commit/778fea75a78e7fed1155ef68cac84ba1dd65946f#diff-710d99e87996e45abbc6ea5e780cdc61

Queue changes include 
Centos.73.Amd64 => Centos.7.Amd64
Centos.74.Amd64 => (delete, redundant to 7)
RedHat.69.Amd64 => RedHat.6.Amd64
RedHat.73.Amd64 => RedHat.7.Amd64
RedHat.74.Amd64 => (delete, redundant to 7)
Debian.87.Amd64 => Debian.8.Amd64
Debian.90.Amd64  => Debian.9.Amd64
OpenSuse.423.Amd64 => OpenSuse.42.Amd64
-Ubuntu.1404.Amd64 (OS near End of Life)
+Ubuntu.1810.Amd64