### PR TITLE
Added AssociatedMetadataTypeTypeDescriptionProvider & MetadataTypeAttribute to S.CM.DA

### DIFF
--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 // ------------------------------------------------------------------------------
@@ -8,6 +8,12 @@
 
 namespace System.ComponentModel.DataAnnotations
 {
+    public partial class AssociatedMetadataTypeTypeDescriptionProvider : System.ComponentModel.TypeDescriptionProvider
+    {
+        public AssociatedMetadataTypeTypeDescriptionProvider(System.Type type) { }
+        public AssociatedMetadataTypeTypeDescriptionProvider(System.Type type, System.Type associatedMetadataType) { }
+        public override System.ComponentModel.ICustomTypeDescriptor GetTypeDescriptor(System.Type objectType, object instance) { throw null; }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), AllowMultiple = false, Inherited = true)]
     [System.ObsoleteAttribute("This attribute is no longer in use and will be ignored if applied.")]
     public sealed partial class AssociationAttribute : System.Attribute
@@ -183,6 +189,12 @@ namespace System.ComponentModel.DataAnnotations
         public int Length { get { throw null; } }
         public override string FormatErrorMessage(string name) { throw null; }
         public override bool IsValid(object value) { throw null; }
+    }
+    [System.AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed partial class MetadataTypeAttribute : System.Attribute
+    {
+        public System.Type MetadataClassType { get { throw null; } }
+        public MetadataTypeAttribute(System.Type metadataClassType) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(2432), AllowMultiple = false)]
     public partial class MinLengthAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute

--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{C4D6F1F4-DC7E-4756-9A88-171A8B1F1E26}</ProjectGuid>
     <!-- Must match version supported by frameworks which support 4.2.* inbox.
@@ -12,6 +12,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Reference Include="mscorlib" />
+    <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'netcoreapp2.0'">
+    <Reference Include="System.ComponentModel.TypeConverter" />
   </ItemGroup>
 </Project>

--- a/src/System.ComponentModel.Annotations/src/Resources/Strings.resx
+++ b/src/System.ComponentModel.Annotations/src/Resources/Strings.resx
@@ -61,6 +61,9 @@
   <data name="ArgumentIsNullOrWhitespace" xml:space="preserve">
     <value>The argument '{0}' cannot be null, empty or contain only whitespace.</value>
   </data>
+  <data name="AssociatedMetadataTypeTypeDescriptor_MetadataTypeContainsUnknownProperties" xml:space="preserve">
+    <value>The associated metadata type for type '{0}' contains the following unknown properties or fields: {1}. Please make sure that the names of these members match the names of the properties on the main type.</value>
+  </data>
   <data name="AttributeStore_Unknown_Property" xml:space="preserve">
     <value>The type '{0}' does not contain a public property named '{1}'.</value>
   </data>
@@ -126,6 +129,9 @@
   </data>
   <data name="MaxLengthAttribute_ValidationError" xml:space="preserve">
     <value>The field {0} must be a string or array type with a maximum length of '{1}'.</value>
+  </data>
+  <data name="MetadataTypeAttribute_TypeCannotBeNull" xml:space="preserve">
+    <value>MetadataClassType cannot be null.</value>
   </data>
   <data name="MinLengthAttribute_InvalidMinLength" xml:space="preserve">
     <value>MinLengthAttribute must have a Length value that is zero or greater.</value>

--- a/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+    <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptor.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptionProvider.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\AssociationAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\CompareAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\ConcurrencyCheckAttribute.cs" />
@@ -27,6 +29,8 @@
     <Compile Include="System\ComponentModel\DataAnnotations\KeyAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\LocalizableString.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\MaxLengthAttribute.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\MetadataPropertyDescriptorWrapper.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\MetadataTypeAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\MinLengthAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\PhoneAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\RangeAttribute.cs" />

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptionProvider.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.DataAnnotations
+{
+    /// <summary>
+    /// Extends the metadata information for a class by adding attributes and property
+    /// information that is defined in an associated class.
+    /// </summary>
+    public class AssociatedMetadataTypeTypeDescriptionProvider : TypeDescriptionProvider
+    {
+        private Type _associatedMetadataType;
+
+        /// <summary>
+        /// Initializes a new instance of the System.ComponentModel.DataAnnotations.AssociatedMetadataTypeTypeDescriptionProvider
+        /// class by using the specified type.
+        /// </summary>
+        /// <param name="type">The type for which the metadata provider is created.</param>
+        public AssociatedMetadataTypeTypeDescriptionProvider(Type type)
+            : base(TypeDescriptor.GetProvider(type))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the System.ComponentModel.DataAnnotations.AssociatedMetadataTypeTypeDescriptionProvider
+        /// class by using the specified metadata provider type and associated type.
+        /// </summary>
+        /// <param name="type">The type for which the metadata provider is created.</param>
+        /// <param name="associatedMetadataType">The associated type that contains the metadata.</param>
+        /// <exception cref="System.ArgumentNullException">The value of associatedMetadataType is null.</exception>
+        public AssociatedMetadataTypeTypeDescriptionProvider(Type type, Type associatedMetadataType)
+            : this(type)
+        {
+            if (associatedMetadataType == null)
+            {
+                throw new ArgumentNullException(nameof(associatedMetadataType));
+            }
+
+            _associatedMetadataType = associatedMetadataType;
+        }
+
+        /// <summary>
+        /// Gets a type descriptor for the specified type and object.
+        /// </summary>
+        /// <param name="objectType">The type of object to retrieve the type descriptor for.</param>
+        /// <param name="instance">An instance of the type.</param>
+        /// <returns>The descriptor that provides metadata for the type.</returns>
+        public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
+        {
+            ICustomTypeDescriptor baseDescriptor = base.GetTypeDescriptor(objectType, instance);
+            return new AssociatedMetadataTypeTypeDescriptor(baseDescriptor, objectType, _associatedMetadataType);
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptor.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptor.cs
@@ -1,0 +1,187 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    internal class AssociatedMetadataTypeTypeDescriptor : CustomTypeDescriptor
+    {
+        private Type AssociatedMetadataType
+        {
+            get;
+            set;
+        }
+
+        private bool IsSelfAssociated
+        {
+            get;
+            set;
+        }
+
+        public AssociatedMetadataTypeTypeDescriptor(ICustomTypeDescriptor parent, Type type, Type associatedMetadataType)
+            : base(parent)
+        {
+            AssociatedMetadataType = associatedMetadataType ?? TypeDescriptorCache.GetAssociatedMetadataType(type);
+            IsSelfAssociated = (type == AssociatedMetadataType);
+            if (AssociatedMetadataType != null)
+            {
+                TypeDescriptorCache.ValidateMetadataType(type, AssociatedMetadataType);
+            }
+        }
+
+        public override PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+        {
+            return GetPropertiesWithMetadata(base.GetProperties(attributes));
+        }
+
+        public override PropertyDescriptorCollection GetProperties()
+        {
+            return GetPropertiesWithMetadata(base.GetProperties());
+        }
+
+        private PropertyDescriptorCollection GetPropertiesWithMetadata(PropertyDescriptorCollection originalCollection)
+        {
+            if (AssociatedMetadataType == null)
+            {
+                return originalCollection;
+            }
+
+            bool customDescriptorsCreated = false;
+            List<PropertyDescriptor> tempPropertyDescriptors = new List<PropertyDescriptor>();
+            foreach (PropertyDescriptor propDescriptor in originalCollection)
+            {
+                Attribute[] newMetadata = TypeDescriptorCache.GetAssociatedMetadata(AssociatedMetadataType, propDescriptor.Name);
+                PropertyDescriptor descriptor = propDescriptor;
+                if (newMetadata.Length > 0)
+                {
+                    // Create a metadata descriptor that wraps the property descriptor
+                    descriptor = new MetadataPropertyDescriptorWrapper(propDescriptor, newMetadata);
+                    customDescriptorsCreated = true;
+                }
+
+                tempPropertyDescriptors.Add(descriptor);
+            }
+
+            if (customDescriptorsCreated)
+            {
+                return new PropertyDescriptorCollection(tempPropertyDescriptors.ToArray(), true);
+            }
+            return originalCollection;
+        }
+
+        public override AttributeCollection GetAttributes()
+        {
+            // Since normal TD behavior is to return cached attribute instances on subsequent
+            // calls to GetAttributes, we must be sure below to use the TD APIs to get both
+            // the base and associated attributes
+            AttributeCollection attributes = base.GetAttributes();
+            if (AssociatedMetadataType != null && !IsSelfAssociated)
+            {
+                // Note that the use of TypeDescriptor.GetAttributes here opens up the possibility of
+                // infinite recursion, in the corner case of two Types referencing each other as
+                // metadata types (or a longer cycle), though the second condition above saves an immediate such
+                // case where a Type refers to itself.
+                Attribute[] newAttributes = TypeDescriptor.GetAttributes(AssociatedMetadataType).OfType<Attribute>().ToArray();
+                attributes = AttributeCollection.FromExisting(attributes, newAttributes);
+            }
+            return attributes;
+        }
+
+        private static class TypeDescriptorCache
+        {
+            private static readonly Attribute[] emptyAttributes = new Attribute[0];
+            // Stores the associated metadata type for a type
+            private static readonly ConcurrentDictionary<Type, Type> _metadataTypeCache = new ConcurrentDictionary<Type, Type>();
+
+            // Stores the attributes for a member info
+            private static readonly ConcurrentDictionary<Tuple<Type, string>, Attribute[]> _typeMemberCache = new ConcurrentDictionary<Tuple<Type, string>, Attribute[]>();
+
+            // Stores whether or not a type and associated metadata type has been checked for validity
+            private static readonly ConcurrentDictionary<Tuple<Type, Type>, bool> _validatedMetadataTypeCache = new ConcurrentDictionary<Tuple<Type, Type>, bool>();
+
+            public static void ValidateMetadataType(Type type, Type associatedType)
+            {
+                Tuple<Type, Type> typeTuple = new Tuple<Type, Type>(type, associatedType);
+                if (!_validatedMetadataTypeCache.ContainsKey(typeTuple))
+                {
+                    CheckAssociatedMetadataType(type, associatedType);
+                    _validatedMetadataTypeCache.TryAdd(typeTuple, true);
+                }
+            }
+
+            public static Type GetAssociatedMetadataType(Type type)
+            {
+                Type associatedMetadataType = null;
+                if (_metadataTypeCache.TryGetValue(type, out associatedMetadataType))
+                {
+                    return associatedMetadataType;
+                }
+
+                // Try association attribute
+                MetadataTypeAttribute attribute = (MetadataTypeAttribute)Attribute.GetCustomAttribute(type, typeof(MetadataTypeAttribute));
+                if (attribute != null)
+                {
+                    associatedMetadataType = attribute.MetadataClassType;
+                }
+                _metadataTypeCache.TryAdd(type, associatedMetadataType);
+                return associatedMetadataType;
+            }
+
+            private static void CheckAssociatedMetadataType(Type mainType, Type associatedMetadataType)
+            {
+                // Only properties from main type
+                HashSet<string> mainTypeMemberNames = new HashSet<string>(mainType.GetProperties().Select(p => p.Name));
+
+                // Properties and fields from buddy type
+                var buddyFields = associatedMetadataType.GetFields().Select(f => f.Name);
+                var buddyProperties = associatedMetadataType.GetProperties().Select(p => p.Name);
+                HashSet<string> buddyTypeMembers = new HashSet<string>(buddyFields.Concat(buddyProperties), StringComparer.Ordinal);
+
+                // Buddy members should be a subset of the main type's members
+                if (!buddyTypeMembers.IsSubsetOf(mainTypeMemberNames))
+                {
+                    // Reduce the buddy members to the set not contained in the main members
+                    buddyTypeMembers.ExceptWith(mainTypeMemberNames);
+
+                    throw new InvalidOperationException(SR.Format(SR.AssociatedMetadataTypeTypeDescriptor_MetadataTypeContainsUnknownProperties,
+                        mainType.FullName,
+                        String.Join(", ", buddyTypeMembers.ToArray())));
+                }
+            }
+
+            public static Attribute[] GetAssociatedMetadata(Type type, string memberName)
+            {
+                var memberTuple = new Tuple<Type, string>(type, memberName);
+                Attribute[] attributes;
+                if (_typeMemberCache.TryGetValue(memberTuple, out attributes))
+                {
+                    return attributes;
+                }
+
+                // Allow fields and properties
+                MemberTypes allowedMemberTypes = MemberTypes.Property | MemberTypes.Field;
+                // Only public static/instance members
+                BindingFlags searchFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
+                // Try to find a matching member on type
+                MemberInfo matchingMember = type.GetMember(memberName, allowedMemberTypes, searchFlags).FirstOrDefault();
+                if (matchingMember != null)
+                {
+                    attributes = Attribute.GetCustomAttributes(matchingMember, true /* inherit */);
+                }
+                else
+                {
+                    attributes = emptyAttributes;
+                }
+
+                _typeMemberCache.TryAdd(memberTuple, attributes);
+                return attributes;
+            }
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MetadataPropertyDescriptorWrapper.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MetadataPropertyDescriptorWrapper.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    internal class MetadataPropertyDescriptorWrapper : PropertyDescriptor
+    {
+        private PropertyDescriptor _descriptor;
+        private bool _isReadOnly;
+
+        public MetadataPropertyDescriptorWrapper(PropertyDescriptor descriptor, Attribute[] newAttributes)
+            : base(descriptor, newAttributes)
+        {
+            _descriptor = descriptor;
+            var readOnlyAttribute = newAttributes.OfType<ReadOnlyAttribute>().FirstOrDefault();
+            _isReadOnly = (readOnlyAttribute != null ? readOnlyAttribute.IsReadOnly : false);
+        }
+
+        public override void AddValueChanged(object component, EventHandler handler) { _descriptor.AddValueChanged(component, handler); }
+
+        public override bool CanResetValue(object component) { return _descriptor.CanResetValue(component); }
+
+        public override Type ComponentType { get { return _descriptor.ComponentType; } }
+
+        public override object GetValue(object component) { return _descriptor.GetValue(component); }
+
+        public override bool IsReadOnly
+        {
+            get
+            {
+                // Dev10 Bug 594083
+                // It's not enough to call the wrapped _descriptor because it does not know anything about
+                // new attributes passed into the constructor of this class.
+                return _isReadOnly || _descriptor.IsReadOnly;
+            }
+        }
+
+        public override Type PropertyType { get { return _descriptor.PropertyType; } }
+
+        public override void RemoveValueChanged(object component, EventHandler handler) { _descriptor.RemoveValueChanged(component, handler); }
+
+        public override void ResetValue(object component) { _descriptor.ResetValue(component); }
+
+        public override void SetValue(object component, object value) { _descriptor.SetValue(component, value); }
+
+        public override bool ShouldSerializeValue(object component) { return _descriptor.ShouldSerializeValue(component); }
+
+        public override bool SupportsChangeEvents { get { return _descriptor.SupportsChangeEvents; } }
+    }
+}

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MetadataTypeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MetadataTypeAttribute.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    /// <summary>
+    /// Specifies the metadata class to associate with a data model class.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class MetadataTypeAttribute : Attribute
+    {
+        private Type _metadataClassType;
+
+        /// <summary>
+        /// Initializes a new instance of the System.ComponentModel.DataAnnotations.MetadataTypeAttribute
+        /// class.
+        /// </summary>
+        /// <param name="metadataClassType">The metadata class to reference.</param>
+        /// <exception cref="System.ArgumentNullException">metadataClassType is null.</exception>
+        public MetadataTypeAttribute(Type metadataClassType)
+        {
+            _metadataClassType = metadataClassType;
+        }
+
+        /// <summary>
+        /// Gets the metadata class that is associated with a data-model partial class.
+        /// </summary>
+        public Type MetadataClassType
+        {
+            get
+            {
+                if (_metadataClassType == null)
+                {
+                    throw new InvalidOperationException(SR.MetadataTypeAttribute_TypeCannotBeNull);
+                }
+
+                return _metadataClassType;
+            }
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -4,6 +4,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptionProviderTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\UIHintAttributeTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\FilterUIHintAttributeTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\DisplayAttributeTests.cs" />
@@ -21,6 +22,7 @@
     <Compile Include="System\ComponentModel\DataAnnotations\EnumDataTypeAttributeTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\FileExtensionsAttributeTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\MaxLengthAttributeTests.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\MetadataTypeAttributeTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\MinLengthAttributeTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\PhoneAttributeTests.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\RangeAttributeTests.cs" />
@@ -45,5 +47,5 @@
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptionProviderTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptionProviderTests.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.ComponentModel.DataAnnotations.Tests
+{
+    public class AssociatedMetadataTypeTypeDescriptionProviderTests
+    {
+        [Fact]
+        public static void Constructor_NullType_ThrowsArgumentNullException()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("type", () => new AssociatedMetadataTypeTypeDescriptionProvider(null));
+        }
+
+        [Fact]
+        public static void Constructor_NullAssociatedMetadataType_ThrowsArgumentNullException()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("associatedMetadataType", () => new AssociatedMetadataTypeTypeDescriptionProvider(typeof(string), null));
+        }
+
+        [Fact]
+        public static void Validate_GetTypeDescriptor_ReturnsTypeDescriptor_ForTypeWithCustomDescription()
+        {
+            var provider = new AssociatedMetadataTypeTypeDescriptionProvider(typeof(SomeClassWithMetadata));
+            ICustomTypeDescriptor typeDescriptor = provider.GetTypeDescriptor(typeof(SomeClassWithMetadata), null);
+            PropertyDescriptorCollection props = typeDescriptor.GetProperties();
+            PropertyDescriptor firstNameProp = props[nameof(SomeClassWithMetadata.FirstName)];
+            string displayName = firstNameProp.DisplayName;
+
+            Assert.Equal("First name", displayName);
+        }
+
+        class SomeClassWithMetadata
+        {
+            [DisplayName("First name")]
+            public string FirstName { get; set; }
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/MetadataTypeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/MetadataTypeAttributeTests.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.ComponentModel.DataAnnotations.Tests
+{
+    public class MetadataTypeAttributeTests
+    {
+        [Fact]
+        public static void Validate_GetTypeDescriptor_ReturnsMetadataType()
+        {
+            var provider = new AssociatedMetadataTypeTypeDescriptionProvider(typeof(SomeClassWithMetadataOnAnotherClass));
+            ICustomTypeDescriptor typeDescriptor = provider.GetTypeDescriptor(typeof(SomeClassWithMetadataOnAnotherClass), null);
+            PropertyDescriptorCollection props = typeDescriptor.GetProperties();
+            PropertyDescriptor firstNameProp = props[nameof(SomeClassWithMetadataOnAnotherClass.FirstName)];
+            string displayName = firstNameProp.DisplayName;
+            Assert.Equal("First name", displayName);
+        }
+
+        class MetadataForAnotherClass
+        {
+            [DisplayName("First name")]
+            public string FirstName { get; set; }
+        }
+
+        [MetadataType(typeof(MetadataForAnotherClass))]
+        class SomeClassWithMetadataOnAnotherClass
+        {
+            public string FirstName { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
This PR brings remaining types under System.ComponentModel.DataAnnotations namespace of .net framework to .net core.

Fixes #22469 - .NET Core 2 type load exception for "AssociatedMetadataTypeTypeDescriptionProvider" when using full .net framework dll in web api owin 
Fixes #16101 - Port more of System.ComponentModel.DataAnnotations types

These files are being used in ASP.NET Web API | ASP.NET Web API OData | Entity Framework 6 and some UI libraries which are interested in metadata reading. [MetadataTypeAttributeTests](https://github.com/dotnet/corefx/blob/7878f3ed95ce8036980817f290daff5eaf9282aa/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/MetadataTypeAttributeTests.cs) shows how nice are these types (:

#29121 & #33312 were my attempts to achieve the same goal too. But for some reasons which are described, I closed them.

Let me know if any change is required.
Thanks in advance.