### PR TITLE
Fix SendAsync/SendMailAsync fails with DeliveryFormat=SmtpDeliveryFormat.SevenBit

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -964,7 +964,7 @@ namespace System.Net.Mail
                 else
                 {
                     _message.BeginSend(_writer, DeliveryMethod != SmtpDeliveryMethod.Network,
-                        ServerSupportsEai, new AsyncCallback(SendMessageCallback), result.AsyncState);
+                        IsUnicodeSupported(), new AsyncCallback(SendMessageCallback), result.AsyncState);
                 }
             }
             catch (Exception e)

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -367,14 +367,14 @@ namespace System.Net.Mail.Tests
 
         [Theory]
         [InlineData(false, false, false)]
-        [InlineData(false, false, true)] // Received text.
+        [InlineData(false, false, true)] // Received subjectText.
         [InlineData(false, true, false)]
         [InlineData(false, true, true)]
         [InlineData(true, false, false)]
-        [InlineData(true, false, true)] // Received text.
+        [InlineData(true, false, true)] // Received subjectText.
         [InlineData(true, true, false)]
-        [InlineData(true, true, true)]
-        public void SendMail_DeliveryFormatSevenBit_SubjectEncoded(bool useAsyncSend, bool useSevenBit, bool useSmtpUTF8)
+        [InlineData(true, true, true)] // Received subjectBase64. If subjectText is received, the test fails, and the results are inconsistent with those of synchronous methods.
+        public void SendMail_DeliveryFormat_SubjectEncoded(bool useAsyncSend, bool useSevenBit, bool useSmtpUTF8)
         {
             // If the server support `SMTPUTF8` and use `SmtpDeliveryFormat.International`, the server should received this subject.
             const string subjectText = "Test \u6d4b\u8bd5 Contain \u5305\u542b UTF8";

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -378,7 +378,7 @@ namespace System.Net.Mail.Tests
                 SmtpClient client = new SmtpClient("localhost", server.EndPoint.Port);
                 client.DeliveryFormat = SmtpDeliveryFormat.SevenBit;
 
-                MailMessage msg = new MailMessage("foo@example.com", "bar@example.com", "Test \u6d4b\u8bd5 Contain \u5305\u542b UTF8", "howdydoo");
+                MailMessage msg = new MailMessage("foo@example.com", "bar@example.com", "Test \u6d4b\u8bd5 Contain \u5305\u542b UTF8", "hello \u9ad8\u575a\u679c");
                 msg.HeadersEncoding = msg.BodyEncoding = msg.SubjectEncoding = System.Text.Encoding.UTF8;
 
                 try

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -377,10 +377,10 @@ namespace System.Net.Mail.Tests
         public void SendMail_DeliveryFormat_SubjectEncoded(bool useAsyncSend, bool useSevenBit, bool useSmtpUTF8)
         {
             // If the server support `SMTPUTF8` and use `SmtpDeliveryFormat.International`, the server should received this subject.
-            const string subjectText = "Test \u251C Contain \u251C UTF8";
+            const string subjectText = "Test \u6d4b\u8bd5 Contain \u5305\u542b UTF8";
 
             // If the server does not support `SMTPUTF8` or use `SmtpDeliveryFormat.SevenBit`, the server should received this subject.
-            const string subjectBase64 = "=?utf-8?B?VGVzdCDilJwgQ29udGFpbiDilJwgVVRGOA==?=";
+            const string subjectBase64 = "=?utf-8?B?VGVzdCDmtYvor5UgQ29udGFpbiDljIXlkKsgVVRGOA==?=";
 
             SmtpServer server = new SmtpServer();
 

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -403,8 +403,8 @@ namespace System.Net.Mail.Tests
                 }
             }
 
-            //Comparing the results of synchronous and asynchronous methods
-            Assert.Equal(sendSubject, sendAsyncSubject);
+            //Comparing the results of synchronous and asynchronous methods. Prefixes are used to distinguish the next test.
+            Assert.Equal("subject:" + sendSubject, "subject:" + sendAsyncSubject);
 
             //Most important inspection
             Assert.Equal("=?utf-8?B?VGVzdCDmtYvor5UgQ29udGFpbiDljIXlkKsgVVRGOA==?=", sendAsyncSubject);

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -403,11 +403,11 @@ namespace System.Net.Mail.Tests
                 }
             }
 
-            //Most important inspection
-            Assert.Equal("=?utf-8?B?VGVzdCDmtYvor5UgQ29udGFpbiDljIXlkKsgVVRGOA==?=", sendAsyncSubject);
-
             //Comparing the results of synchronous and asynchronous methods
             Assert.Equal(sendSubject, sendAsyncSubject);
+
+            //Most important inspection
+            Assert.Equal("=?utf-8?B?VGVzdCDmtYvor5UgQ29udGFpbiDljIXlkKsgVVRGOA==?=", sendAsyncSubject);
         }
     }
 }

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -365,6 +365,7 @@ namespace System.Net.Mail.Tests
         }
 
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NETFX doesn't have the fix for encoding")]
         [Theory]
         [InlineData(false, false, false)]
         [InlineData(false, false, true)] // Received subjectText.

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -403,6 +403,9 @@ namespace System.Net.Mail.Tests
                 }
             }
 
+            //Most important inspection
+            Assert.Equal("=?utf-8?B?VGVzdCDmtYvor5UgQ29udGFpbiDljIXlkKsgVVRGOA==?=", sendAsyncSubject);
+
             //Comparing the results of synchronous and asynchronous methods
             Assert.Equal(sendSubject, sendAsyncSubject);
         }

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -377,10 +377,10 @@ namespace System.Net.Mail.Tests
         public void SendMail_DeliveryFormat_SubjectEncoded(bool useAsyncSend, bool useSevenBit, bool useSmtpUTF8)
         {
             // If the server support `SMTPUTF8` and use `SmtpDeliveryFormat.International`, the server should received this subject.
-            const string subjectText = "Test \u0387 Contain \u0387 UTF8";
+            const string subjectText = "Test \u251C Contain \u251C UTF8";
 
             // If the server does not support `SMTPUTF8` or use `SmtpDeliveryFormat.SevenBit`, the server should received this subject.
-            const string subjectBase64 = "=?utf-8?B?VGVzdCDCtyBDb250YWluIMK3IFVURjg=?=";
+            const string subjectBase64 = "=?utf-8?B?VGVzdCDilJwgQ29udGFpbiDilJwgVVRGOA==?=";
 
             SmtpServer server = new SmtpServer();
 

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -333,82 +333,6 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        public void TestSmtpDeliveryFormatSevenBit() {
-            SmtpServer server = null;
-            SmtpClient client = null;
-            var serverList = new System.Collections.Generic.List<SmtpServer>();
-
-            MailMessage msg = new MailMessage("foo@example.com", "bar@example.com");
-            msg.HeadersEncoding = msg.BodyEncoding = msg.SubjectEncoding = System.Text.Encoding.UTF8;
-
-            var subjectTxt = "Test 测试 Contain 包含 UTF8";
-            var subjectEncode = "=?utf-8?B?VGVzdCDmtYvor5UgQ29udGFpbiDljIXlkKsgVVRGOA==?=";
-
-            msg.Subject = subjectTxt;
-
-            Action<SmtpDeliveryFormat, bool, string, string, string> test = (format, utf8, async, sync, tag) => {
-                var retry = 0;
-                while (retry < 3) {
-                    if (client != null) {
-                        server.Stop();
-                        client.Dispose();
-                    }
-                    //New connections are required when parameters change
-                    //How to close cached SmtpConnection !!?? Killing this server is the quickest solution.
-                    server = new SmtpServer();
-                    var running = false;
-                    Thread t = new Thread(() => {
-                        running = true;
-                        server.Run();
-                    });
-                    t.Start();
-                    while (!running) {//wait fist server started
-                        Thread.Sleep(1);
-                    }
-                    Thread.Sleep(100);//wait all server running
-                    server.Support_SMTPUTF8 = utf8;
-
-                    client = new SmtpClient("localhost", server.EndPoint.Port);
-                    client.DeliveryFormat = format;
-
-
-                    var task = client.SendMailAsync(msg);
-                    if (!task.Wait(5000)) {//If the server did not accept the request? Try again.
-                        retry++;
-                        if (retry >= 3) {
-                            throw new Exception("Cannot connect SmtpServer!");
-                        }
-                        continue;
-                    }
-                    Assert.Equal(tag + " Async " + async, tag + " Async " + server.Subject);
-
-                    client.Send(msg);
-                    Assert.Equal(tag + " Sync " + sync, tag + " Sync " + server.Subject);
-                    break;
-                }
-            };
-            try {
-                test(SmtpDeliveryFormat.International, false
-                    , subjectEncode, subjectEncode, "International");
-                
-                test(SmtpDeliveryFormat.International, true
-                    , subjectTxt, subjectTxt, "International+SMTPUTF8");
-
-
-
-                test(SmtpDeliveryFormat.SevenBit, false
-                    , subjectEncode, subjectEncode, "SevenBit");
-
-                //This asynchronous sending of content is wrong before fixing it.
-                test(SmtpDeliveryFormat.SevenBit, true
-                    , subjectEncode, subjectEncode, "SevenBit+SMTPUTF8");
-            } finally {
-                client.Dispose();
-                server.Stop();
-            }
-        }
-
-        [Fact]
         public async Task TestCredentialsCopyInAsyncContext()
         {
             SmtpServer server = new SmtpServer();
@@ -433,6 +357,32 @@ namespace System.Net.Mail.Tests
                 Assert.Equal("hello", server.Subject);
                 Assert.Equal("howdydoo", server.Body);
                 Assert.Equal(clientDomain, server.ClientDomain);
+            }
+            finally
+            {
+                server.Stop();
+            }
+        }
+
+        [Fact]
+        public async Task TestSmtpDeliveryFormatSevenBit()
+        {
+            SmtpServer server = new SmtpServer();
+            server.SupportSmtpUTF8 = true;
+
+            SmtpClient client = new SmtpClient("localhost", server.EndPoint.Port);
+            client.DeliveryFormat = SmtpDeliveryFormat.SevenBit;
+
+            MailMessage msg = new MailMessage("foo@example.com", "bar@example.com", "Test \u6d4b\u8bd5 Contain \u5305\u542b UTF8", "howdydoo");
+            msg.HeadersEncoding = msg.BodyEncoding = msg.SubjectEncoding = System.Text.Encoding.UTF8;
+
+            try
+            {
+                Thread t = new Thread(server.Run);
+                t.Start();
+                await client.SendMailAsync(msg);
+
+                Assert.Equal("=?utf-8?B?VGVzdCDmtYvor5UgQ29udGFpbiDljIXlkKsgVVRGOA==?=", server.Subject);
             }
             finally
             {

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -377,10 +377,10 @@ namespace System.Net.Mail.Tests
         public void SendMail_DeliveryFormat_SubjectEncoded(bool useAsyncSend, bool useSevenBit, bool useSmtpUTF8)
         {
             // If the server support `SMTPUTF8` and use `SmtpDeliveryFormat.International`, the server should received this subject.
-            const string subjectText = "Test \u6d4b\u8bd5 Contain \u5305\u542b UTF8";
+            const string subjectText = "Test \u0387 Contain \u0387 UTF8";
 
             // If the server does not support `SMTPUTF8` or use `SmtpDeliveryFormat.SevenBit`, the server should received this subject.
-            const string subjectBase64 = "=?utf-8?B?VGVzdCDmtYvor5UgQ29udGFpbiDljIXlkKsgVVRGOA==?=";
+            const string subjectBase64 = "=?utf-8?B?VGVzdCDCtyBDb250YWluIMK3IFVURjg=?=";
 
             SmtpServer server = new SmtpServer();
 

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -386,10 +386,13 @@ namespace System.Net.Mail.Tests
                     Thread t = new Thread(server.Run);
                     t.Start();
 
-                    if (i == 0) {
+                    if (i == 0)
+                    {
                         client.Send(msg);
                         sendSubject = server.Subject;
-                    } else {
+                    }
+                    else
+                    {
                         client.SendMailAsync(msg).Wait();
                         sendAsyncSubject = server.Subject;
                     }

--- a/src/System.Net.Mail/tests/Functional/SmtpServer.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpServer.cs
@@ -31,6 +31,8 @@ namespace System.Net.Mail.Tests
             get { return (IPEndPoint)_server.LocalEndpoint; }
         }
 
+        public bool SupportSmtpUTF8 { get; set; }
+
         public SmtpServer()
         {
             IPAddress address = IPAddress.Loopback;
@@ -77,8 +79,7 @@ namespace System.Net.Mail.Tests
             }
         }
 
-        public bool Support_SMTPUTF8 { get; set; }
-		// return false == terminate
+        // return false == terminate
         private bool Dispatch(NetworkStream ns, StreamReader r, string s)
         {
             Trace("command", s);
@@ -98,7 +99,8 @@ namespace System.Net.Mail.Tests
                     _clientdomain = s.Substring(5).Trim().ToLower();
                     WriteNS(ns, "250-localhost Hello" + s.Substring(5, s.Length - 5) + "\r\n");
                     WriteNS(ns, "250-AUTH PLAIN\r\n");
-                    if (Support_SMTPUTF8) {
+                    if (SupportSmtpUTF8)
+                    {
                         WriteNS(ns, "250-SMTPUTF8\r\n");
                     }
                     break;

--- a/src/System.Net.Mail/tests/Functional/SmtpServer.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpServer.cs
@@ -77,7 +77,8 @@ namespace System.Net.Mail.Tests
             }
         }
 
-        // return false == terminate
+        public bool Support_SMTPUTF8 { get; set; }
+		// return false == terminate
         private bool Dispatch(NetworkStream ns, StreamReader r, string s)
         {
             Trace("command", s);
@@ -97,6 +98,9 @@ namespace System.Net.Mail.Tests
                     _clientdomain = s.Substring(5).Trim().ToLower();
                     WriteNS(ns, "250-localhost Hello" + s.Substring(5, s.Length - 5) + "\r\n");
                     WriteNS(ns, "250-AUTH PLAIN\r\n");
+                    if (Support_SMTPUTF8) {
+                        WriteNS(ns, "250-SMTPUTF8\r\n");
+                    }
                     break;
                 case "QUIT":
                     WriteNS(ns, "221 Quit\r\n");


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/27904 (was https://github.com/dotnet/corefx/issues/33480)