### PR TITLE
Format Reference assembly to GenerateReferenceSource conventions

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -5,26 +5,28 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-namespace System.Diagnostics {
-  public partial class DiagnosticListener : System.Diagnostics.DiagnosticSource, System.IDisposable, System.IObservable<System.Collections.Generic.KeyValuePair<string, object>> {
-    public DiagnosticListener(string name) { }
-    public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-    public static IObservable<DiagnosticListener> AllListeners { get { throw null; } } 
-    public virtual void Dispose() { }
-    public bool IsEnabled() { throw null; }
-    public override bool IsEnabled(string name) { throw null; }
-    public override bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
-    public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { throw null; }
-    public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { throw null; }
-    public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Func<string, object, object, bool> isEnabled) { throw null; }
-    public override string ToString() { throw null; }
-    public override void Write(string name, object parameters) { }
+namespace System.Diagnostics
+{
+    public partial class DiagnosticListener : System.Diagnostics.DiagnosticSource, System.IDisposable, System.IObservable<System.Collections.Generic.KeyValuePair<string, object>>
+    {
+        public DiagnosticListener(string name) { }
+        public static System.IObservable<System.Diagnostics.DiagnosticListener> AllListeners { get { throw null; } }
+        public string Name { get { throw null; } }
+        public virtual void Dispose() { }
+        public bool IsEnabled() { throw null; }
+        public override bool IsEnabled(string name) { throw null; }
+        public override bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
+        public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { throw null; }
+        public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Func<string, object, object, bool> isEnabled) { throw null; }
+        public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { throw null; }
+        public override string ToString() { throw null; }
+        public override void Write(string name, object value) { }
     }
-  public abstract partial class DiagnosticSource {
-    protected DiagnosticSource() { }
-    public abstract bool IsEnabled(string name);
-    public virtual bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
-    public abstract void Write(string name, object value);
-  }
+    public abstract partial class DiagnosticSource
+    {
+        protected DiagnosticSource() { }
+        public abstract bool IsEnabled(string name);
+        public virtual bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
+        public abstract void Write(string name, object value);
+    }
 }
-

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics
     public partial class DiagnosticListener : System.Diagnostics.DiagnosticSource, System.IDisposable, System.IObservable<System.Collections.Generic.KeyValuePair<string, object>>
     {
         public DiagnosticListener(string name) { }
-        public static System.IObservable<System.Diagnostics.DiagnosticListener> AllListeners { get { throw null; } }
+        public static System.IObservable<System.Diagnostics.DiagnosticListener> AllListeners { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public string Name { get { throw null; } }
         public virtual void Dispose() { }
         public bool IsEnabled() { throw null; }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics
     public partial class DiagnosticListener : System.Diagnostics.DiagnosticSource, System.IDisposable, System.IObservable<System.Collections.Generic.KeyValuePair<string, object>>
     {
         public DiagnosticListener(string name) { }
-        public static System.IObservable<System.Diagnostics.DiagnosticListener> AllListeners { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public static System.IObservable<System.Diagnostics.DiagnosticListener> AllListeners { get { throw null; } }
         public string Name { get { throw null; } }
         public virtual void Dispose() { }
         public bool IsEnabled() { throw null; }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -5,41 +5,43 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-namespace System.Diagnostics {
-  public partial class Activity {
-    public Activity(string operationName) {}      
-    public string OperationName { get { throw null; } }
-    public string Id {get { throw null; } private set {} }
-    public DateTime StartTimeUtc {get { throw null; } private set {} }
-    public Activity Parent {get { throw null; } private set {} }
-    public string ParentId {get { throw null; } private set {} }
-    public string RootId {get { throw null; } private set {} }    
-    public TimeSpan Duration {get { throw null; } private set {} }    
-    public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Tags { get { throw null; } }    
-    public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Baggage { get { throw null; } }
-    public string GetBaggageItem(string key) {throw null;}
-    public Activity AddTag(string key, string value) {throw null;}
-    public Activity AddBaggage(string key, string value) {throw null;}
-    public Activity SetParentId(string parentId) {throw null;}
-    public Activity SetStartTime(DateTime startTimeUtc) {throw null;}
-    public Activity SetEndTime(DateTime endTimeUtc) {throw null;}
-    public Activity Start() {throw null;}
-    public void Stop() {}
-    public static Activity Current 
-    {
+namespace System.Diagnostics 
+{
+   public partial class Activity
+   {
+        public Activity(string operationName) { }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Baggage { get { throw null; } }
+        public static Activity Current
+        {
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
         [System.Security.SecuritySafeCriticalAttribute]
 #endif
-        get { throw null; } 
+            get { throw null; }
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
        [System.Security.SecuritySafeCriticalAttribute]
 #endif
-        set {}
-    }
+            set { }
+        }
+        public System.TimeSpan Duration { get { throw null; } }
+        public string Id { get { throw null; } }
+        public string OperationName { get { throw null; } }
+        public System.Diagnostics.Activity Parent { get { throw null; } }
+        public string ParentId { get { throw null; } }
+        public string RootId { get { throw null; } }
+        public System.DateTime StartTimeUtc { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Tags { get { throw null; } }
+        public System.Diagnostics.Activity AddBaggage(string key, string value) { throw null; }
+        public System.Diagnostics.Activity AddTag(string key, string value) { throw null; }
+        public string GetBaggageItem(string key) { throw null; }
+        public System.Diagnostics.Activity SetEndTime(System.DateTime endTimeUtc) { throw null; }
+        public System.Diagnostics.Activity SetParentId(string parentId) { throw null; }
+        public System.Diagnostics.Activity SetStartTime(System.DateTime startTimeUtc) { throw null; }
+        public System.Diagnostics.Activity Start() { throw null; }
+        public void Stop() { }
   }
-  public abstract partial class DiagnosticSource {
+  public abstract partial class DiagnosticSource 
+  {
     public Activity StartActivity(Activity activity, object args) {throw null;}
     public void StopActivity(Activity activity, object args) {}
   }
 }
-


### PR DESCRIPTION
This change is a semantic nop.
It updates the reference assembly source to be more like what the following build target would generate.

msbuild System.Diagnostics.DiagnosticSource.csproj /t:GenerateReferenceSource

It is not perfect because There are some #Ifdefs and file factoring (DiagnosticSourceActivity.cs), which
are used to produce various reference assemblies for older versions.  I did not disturb that.

What I did do is
1. Alphabetize
2. Remove private setters (not interesting in reference assemblies).
3. Fixed whitespace.
4. Added namespaces to some times (this is what the script does).

This allows the script to be rerun usefully (you probably need to cut and past afterward, but the rest should be clear).

This is in preparation of adding new APIs and I would like to use the GenerateReferenceSource tool to do it and this smooths over that change.  

I did do a careful diff (fixing things by hand until the diff matched perfectly, to insure I only changed the attributes listed above

@ericstj  @weshaggard 