### PR TITLE
[WIP] Move CI validation legs to yml using Azure Dev Ops

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -1,0 +1,42 @@
+# Disable triggers for now. TODO: add right merge triggers.
+trigger: none
+
+# TODO: add paths to exclude CI when modifying docs or stuff not affecting the build
+pr:
+- master
+
+resources:
+  containers:
+  - container: RhelContainer
+    image: microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2
+  - container: AlpineContainer
+    # Use this image once updated: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/66
+    # image: microsoft/dotnet-buildtools-prereqs:alpine-3.6-e2521f8-20180716231200
+    image: santifdezm/alpine:latest
+  - container: UbuntuArmContainer
+    image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921
+
+variables:
+  # Helix target queues need to be separated by +
+
+  # Windows queues
+  netcoreappWindowsQueues: Windows.7.Amd64.Open+Windows.81.Amd64.Open+Windows.10.Amd64.ClientRS4.ES.Open
+  nanoQueues: Windows.10.Nano.Amd64.Open
+  uapNetfxQueues: Windows.10.Amd64.ClientRS4.Open
+
+  # Linux queues
+  linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open+Fedora.27.Amd64.Open
+  linuxArmQueues: Ubuntu.1604.Arm64.Open
+
+  # MacOS queues:
+  macOSQueues: OSX.1013.Amd64.Open # TODO: add OSX.1012 queue once we get available agents
+
+jobs:
+  # Include Windows legs
+  - template: /eng/pipelines/windows.yml
+  
+  # Linux legs
+  - template: /eng/pipelines/linux.yml
+
+  # MacOS legs
+  - template: /eng/pipelines/macos.yml

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,0 +1,5 @@
+# We depend on a local cli for a number of our buildtool
+# commands like init-tools so for now we need to disable
+# using the globally installed dotnet
+
+useInstalledDotNetCli=false

--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -1,0 +1,116 @@
+parameters:
+  # Required: Name to display for this job in the UI
+  displayName: ''
+  
+  # Required: Name for this specific job -- should be unique per each job.
+  name: ''
+
+  # Required: Pool to run the job on.
+  pool: {}
+
+  # Required: TargetOS value to know what script commands to use
+  # Accepted values:
+  # - Windows_NT
+  # - Linux
+  # - OSX
+  # - FreeBSD
+  targetOS: ''
+
+  # Required: Strategy matrix (the matrix that we're going to build for this job)
+  # The following variables should be defined within the matrix:
+  #   matrix:
+  #     matrix_display_name:
+  #      _configuration: Debug | Release
+  #      _architecture: x64 | x86 | arm | arm64
+  #      framework: (netcoreapp, netfx, uap, etc).
+  #      helixQueues: Windows.Amd64 (Only needed if submitToHelix -> true.) -- Queues should be separated by + if multiple.
+  strategy: {}
+
+  # Optional: string to append to Unix build script.
+  #   buildScriptPrefix: 'HOME=/home/ ' -> 'HOME=/home/ ./build.sh ...'
+  buildScriptPrefix: ''
+
+  # Optional: container resource name declared in source template.
+  container: ''
+
+  # Optional: a list of steps to run instead of the common build steps.
+  # If this is specified, useCustomBuildSteps should be set to true.
+  customBuildSteps: []
+  
+  # Optional: steps to be executed before common build steps.
+  # In example, to install build dependencies, or setup an environment.
+  preBuildSteps: []
+
+  # Optional
+  # Default: true
+  # true -- tests are built, but not run.
+  # false -- tests are built and run in the build machine.
+  skipTests: true
+
+  # Optional: Value to know if it should submit tests payloads to helix.
+  # Default: true
+  submitToHelix: true
+
+  # Optional: Value to know if it should test outerloop tests
+  # Default: false
+  testOuterloop: false
+
+  # Optional: Timeout for the job in minutes
+  # Default: 120
+  timeoutInMinutes: 120
+
+  # Optional: Value to specify if the build should run custom steps.
+  # Default: false
+  # When true, customBuildSteps should be populated with the steps to run.
+  useCustomBuildSteps: false
+
+jobs:
+  - job: ${{ parameters.name }}
+    variables:
+      # OS Specific commands
+      ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
+        _buildScript: build.cmd -ci
+        _msbuildCommand: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 -warnaserror:0 -ci
+      ${{ if ne(parameters.targetOS, 'Windows_NT') }}:
+        _buildScript: ${{ parameters.buildScriptPrefix }}./build.sh --ci
+        _msbuildCommand: ${{ parameters.buildScriptPrefix }}./eng/common/msbuild.sh --warnaserror false --ci
+
+    displayName: ${{ parameters.displayName }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    pool:
+      ${{ insert }}: ${{ parameters.pool }}
+
+    ${{ if ne(parameters.strategy, '') }}:
+      strategy:
+        maxParallel: 99
+        ${{ insert }}: ${{ parameters.strategy }}
+
+    container: ${{ parameters.container }}
+
+    steps:
+      - ${{ parameters.preBuildSteps }}
+
+      - ${{ if eq(parameters.useCustomBuildSteps, 'false') }}:
+        - script: $(_buildScript)
+                -includetests
+                -framework $(framework)
+                /p:ArchGroup=$(_architecture)
+                /p:ConfigurationGroup=$(_configuration)
+                /p:SkipTests=${{ parameters.skipTests }}
+                /p:ArchiveTests=${{ parameters.submitToHelix }}
+                /p:Outerloop=${{ parameters.testOuterloop }}
+                ${{ parameters.buildExtraArguments }}
+          displayName: Build Sources and Tests
+
+      - ${{ if eq(parameters.useCustomBuildSteps, 'true') }}:
+        - ${{ parameters.customBuildSteps }}
+
+      - ${{ if eq(parameters.submitToHelix, 'true') }}:
+        - template: /eng/pipelines/helix.yml
+          parameters:
+            targetOS: ${{ parameters.targetOS }}
+            archGroup: $(_architecture)
+            configuration: $(_configuration)
+            helixQueues: $(helixQueues)
+            msbuildScript: $(_msbuildCommand)
+            framework: $(framework)

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -1,0 +1,33 @@
+parameters:
+  targetOS: ''
+  archGroup: ''
+  configuration: ''
+  helixQueues: ''
+  helixToken: $(BotAccount-dotnet-github-anon-kaonashi-bot-helix-token)
+  waitForCompletion: true
+  msbuildScript: ''
+  framework: ''
+
+steps:
+  # TODO: delete calling this target and hook it up to vertical once: https://github.com/dotnet/corefx/pull/33423 is merged
+  - script: ${{ parameters.msbuildScript }}
+            src/upload-tests.proj
+            /t:CompressRuntimeDir
+            /p:TargetGroup=${{ parameters.framework }}
+            /p:ArchGroup=${{ parameters.archGroup }}
+            /p:ConfigurationGroup=${{ parameters.configuration }}
+            /p:TargetOS=${{ parameters.targetOS }}
+    displayName: Compress Runtime Directory
+  - script: ${{ parameters.msbuildScript }}
+            eng/sendtohelix.proj
+            /t:test
+            /p:ArchGroup=${{ parameters.archGroup }}
+            /p:ConfigurationGroup=${{ parameters.configuration }}
+            /p:OSGroup=${{ parameters.targetOS }}
+            /p:TargetGroup=${{ parameters.framework }}
+            /p:HelixTargetQueues=${{ parameters.helixQueues }}
+            /p:HelixBuild=$(Build.BuildNumber)
+            /p:HelixAccessToken=${{ parameters.helixToken }}
+    displayName: Send to Helix
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -1,0 +1,56 @@
+# Linux legs
+jobs:
+
+# Legs with Helix testing
+- template: corefx-base.yml
+  parameters:
+    name: LinHelix
+    displayName: Linux
+    strategy:
+      matrix:
+        # netcoreapp linux x64 release
+        x64_Release:
+          _configuration: Release
+          _architecture: x64
+          framework: netcoreapp
+          helixQueues: $(linuxDefaultQueues)
+          _dockerContainer: RhelContainer
+          _buildScriptPrefix: ''
+
+        # netcoreapp linux arm64 release
+        arm64_Release:
+          _configuration: Release
+          _architecture: arm64
+          framework: netcoreapp
+          helixQueues: $(linuxArmQueues)
+          _dockerContainer: UbuntuArmContainer
+          _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
+
+    pool:
+      name: Hosted Ubuntu 1604
+
+    targetOS: Linux
+    container: $[ variables['_dockerContainer'] ]
+    buildScriptPrefix: $(_buildScriptPrefix)
+
+# Legs without helix
+- template: corefx-base.yml
+  parameters:
+    name: LinNoHelix
+    displayName: Linux
+    strategy:
+      matrix:
+        # linux-musl x64 debug
+        musl_x64_Debug:
+          _configuration: Debug
+          _architecture: x64
+          framework: netcoreapp
+          _dockerContainer: AlpineContainer
+          _buildExtraArguments: /p:RuntimeOs=linux-musl /p:PortableBuild=false
+    pool:
+      name: Default # TODO: update to Hosted Ubuntu 1604 once bring your own node is available
+
+    targetOS: Linux
+    container: $[ variables['_dockerContainer'] ]
+    buildExtraArguments: $(_buildExtraArguments)
+    submitToHelix: false

--- a/eng/pipelines/macos.yml
+++ b/eng/pipelines/macos.yml
@@ -1,0 +1,28 @@
+# Linux legs
+jobs:
+
+# Legs with Helix testing
+- template: corefx-base.yml
+  parameters:
+    name: MacOS
+    displayName: MacOS
+    strategy:
+      matrix:
+        x64_Debug:
+          _configuration: Debug
+          _architecture: x64
+          framework: netcoreapp
+          helixQueues: $(macOSQueues)
+
+    pool:
+      name: Hosted MacOS
+
+    targetOS: OSX
+
+    preBuildSteps:
+      - script: |
+          brew install pkgconfig openssl
+          ln -s /usr/local/opt/openssl/lib/pkgconfig/libcrypto.pc /usr/local/lib/pkgconfig/
+          ln -s /usr/local/opt/openssl/lib/pkgconfig/libssl.pc /usr/local/lib/pkgconfig/
+          ln -s /usr/local/opt/openssl/lib/pkgconfig/openssl.pc /usr/local/lib/pkgconfig/
+        displayName: Install Build Dependencies

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -1,0 +1,95 @@
+# Windows legs
+jobs:
+
+# Legs with Helix testing
+- template: corefx-base.yml
+  parameters:
+    name: WinWithHelix
+    displayName: Windows
+    strategy:
+      matrix:
+        # netcoreapp windows x64 debug
+        x64_Debug:
+          _configuration: Debug
+          _architecture: x64
+          framework: netcoreapp
+          helixQueues: $(netcoreappWindowsQueues)+$(nanoQueues)
+
+        # netcoreapp windows x86 release
+        x86_Release:
+          _configuration: Release
+          _architecture: x86
+          framework: netcoreapp
+          helixQueues: $(netcoreappWindowsQueues)
+
+        NETFX_x86_Release:
+          _configuration: Release
+          _architecture: x86
+          framework: netfx
+          helixQueues: $(uapNetfxQueues)
+
+        UWP_CoreCLR_x64_Debug:
+          _configuration: Debug
+          _architecture: x64
+          framework: uap
+          helixQueues: $(uapNetfxQueues)
+
+    pool:
+      name: Hosted VS2017
+    targetOS: Windows_NT
+
+# # Legs without Helix testing
+- template: /eng/pipelines/corefx-base.yml
+  parameters:
+    name: WinNoHelix
+    displayName: Windows
+    strategy:
+      matrix:
+        UWP_NETNative_x86_Release:
+          _configuration: Release
+          _architecture: x86
+          framework: uapaot
+
+    submitToHelix: false
+    pool:
+      name: Hosted VS2017
+    targetOS: Windows_NT
+
+- template: /eng/pipelines/corefx-base.yml
+  parameters:
+    name: WinAllConfigurations
+    displayName: Packaging All Configurations
+    strategy:
+      matrix:
+        x64_Debug:
+          _configuration: Debug
+          _architecture: x64
+          framework: allConfigurations
+    pool:
+      name: Hosted VS2017
+    submitToHelix: false
+
+    useCustomBuildSteps: true
+    customBuildSteps:
+      - script: build.cmd
+                -ci
+                -$(framework)
+                /p:ArchGroup=$(_architecture)
+                /p:ConfigurationGroup=$(_configuration)
+                /p:RuntimeOS=win10
+        displayName: Build Packages
+      - script: build.cmd
+                -ci
+                -test
+                /p:TargetGroup=netstandard
+                /p:ArchGroup=$(_architecture)
+                /p:ConfigurationGroup=$(_configuration)
+                /p:SkipTests=true
+        displayName: Build Netstandard Test Suite
+      - script: build.cmd
+                -ci
+                -test
+                -$(framework)
+                /p:ArchGroup=$(_architecture)
+                /p:ConfigurationGroup=$(_configuration)
+        displayName: Run Package Tests

--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -1,0 +1,55 @@
+<Project InitialTargets="BuildHelixWorkItem" Sdk="Microsoft.DotNet.Helix.Sdk">
+  <PropertyGroup>
+    <!-- Set helix source -->
+    <HelixSourcePrefix>pr/</HelixSourcePrefix>
+    <HelixSourcePrefix Condition="'$(OfficialBuildId)' != ''">official/</HelixSourcePrefix>
+    <HelixSource Condition="'$(HelixSource)' == ''">$(HelixSourcePrefix)dotnet/corefx</HelixSource>
+    <HelixSource Condition="'$(BUILD_SOURCEBRANCH)' != ''">$(HelixSource)/$(BUILD_SOURCEBRANCH)</HelixSource>
+    
+    <!-- Set helix build to build number if available -->
+    <HelixBuild Condition="'$(HelixBuild)' == ''">$(BUILD_BUILDNUMBER)</HelixBuild>
+    <HelixBuild Condition="'$(HelixBuild)' == ''">default</HelixBuild>
+
+    <HelixType Condition="'$(HelixType)' == ''">test/functional/cli</HelixType>
+    
+    <!-- We need to enable xunit reporter so that it parses test results -->
+    <EnableXunitReporter>true</EnableXunitReporter>
+    
+    <!-- The helix runtime payload and the tests to run -->
+    <HelixCorrelationPayload Condition="'$(HelixCorrelationPayload)' == ''">$(ArtifactsDir)\**\tests\**\archive\test-runtime*.zip</HelixCorrelationPayload>
+    <WorkItemArchiveWildCard Condition="'$(WorkItemArchiveWildCard)' == ''">$(ArtifactsDir)\**\tests\**\archive\tests\**\*.zip</WorkItemArchiveWildCard>
+
+    <HelixConfiguration>$(ConfigurationGroup)</HelixConfiguration>
+    <HelixArchitecture>$(ArchGroup)</HelixArchitecture>
+
+    <!-- This property is used to show the tests results in VSTS. By setting this property the
+    test run name will be displayed as $(TestRunNamePrefix)-$(HelixTargetQueue) -->
+    <TestRunNamePrefix Condition="'$(TargetGroup)' != ''">$(TargetGroup)-</TestRunNamePrefix>
+
+    <!-- TODO: Pass it as argument when adding official build support -->
+    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(HelixCommand)' == ''">
+    <!-- For windows we need to use call, since the command is going to be called from a bat script created by Helix
+    and we exit /b at the end of RunTests.cmd, Helix runs some other commands after ours within the bat script,
+    if we don't use call, then we cause the parent script to exit, and anything after will not be executed. -->
+    <HelixCommand Condition="'$(TargetsWindows)' == 'true'">call RunTests.cmd %HELIX_CORRELATION_PAYLOAD%</HelixCommand>
+    <HelixCommand Condition="'$(TargetsWindows)' != 'true'">./RunTests.sh $HELIX_CORRELATION_PAYLOAD</HelixCommand>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <HelixCorrelationPayload Include="$(HelixCorrelationPayload)" />
+  </ItemGroup>
+
+  <Target Name="BuildHelixWorkItem">
+    <ItemGroup>
+      <_WorkItem Include="$(WorkItemArchiveWildCard)" Exclude="$(HelixCorrelationPayload)" />
+
+      <HelixWorkItem Include="@(_WorkItem -> '%(FileName)')">
+        <PayloadArchive>%(Identity)</PayloadArchive>
+        <Command>$(HelixCommand)</Command>
+      </HelixWorkItem>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/global.json
+++ b/global.json
@@ -4,6 +4,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18578.2",
+    "Microsoft.DotNet.Helix.Sdk": "1.0.0-beta.18578.7",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview-27130-03"
   }
 }


### PR DESCRIPTION
Initial work and structure to move CoreFX CI and official builds to use YAML in Azure DevOps.

Pending work:

- [ ] Linux ARM and Tizen legs
- [ ] MacOS 10.12 support
- [ ] Use officially built alpine6 with Node docker container
- [ ] Use Hosted Ubuntu pool for alpine 6 once bring your own node is available
- [ ] Use job templates from arcade

cc: @danmosemsft @ericstj @ViktorHofer @wtgodbe @chcosta 