### PR TITLE
Fix SystemNative_SchedGetAffinity

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -648,7 +648,7 @@ int32_t SystemNative_SchedGetAffinity(int32_t pid, intptr_t* mask)
         {
             if (CPU_ISSET(cpu, &set))
             {
-                bits |= (1u << cpu);
+                bits |= ((intptr_t)1) << cpu;
             }
         }
 


### PR DESCRIPTION
The function was incorrectly using unsigned int constant 1 as a value
that is shifted as a mask for each processor present or-ed to the final
mask. So on machines with more cores than 32, it was returning max 32
set bits.