### PR TITLE
Remove test for disabled collectible COM interop

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ChangeWrapperHandleStrengthTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ChangeWrapperHandleStrengthTests.cs
@@ -51,21 +51,6 @@ namespace System.Runtime.InteropServices.Tests
             AssertExtensions.Throws<ArgumentNullException>("otp", () => Marshal.ChangeWrapperHandleStrength(null, fIsWeak: false));
         }
 
-#if !netstandard // TODO: Enable for netstandard2.1
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNative))]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void ChangeWrapperHandleStrength_ObjectNotCollectible_ThrowsNotSupportedException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type type = typeBuilder.CreateType();
-
-            object o = Activator.CreateInstance(type);
-            Assert.Throws<NotSupportedException>(() => Marshal.ChangeWrapperHandleStrength(o, fIsWeak: true));
-        }
-#endif
-
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void ChangeWrapperHandleStrength_Unix_ThrowsPlatformNotSupportedException()

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetComInterfaceForObjectTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetComInterfaceForObjectTests.cs
@@ -206,23 +206,6 @@ namespace System.Runtime.InteropServices.Tests
             AssertExtensions.Throws<ArgumentException>("o", () => Marshal.GetComInterfaceForObject<object, NonGenericInterface>(o));
         }
 
-#if !netstandard // TODO: Enable for netstandard2.1
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void GetComInterfaceForObject_ObjectNotCollectible_ThrowsNotSupportedException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type type = typeBuilder.CreateType();
-
-            object o = Activator.CreateInstance(type);
-            Assert.Throws<NotSupportedException>(() => Marshal.GetComInterfaceForObject(o, typeof(NonGenericInterface)));
-            Assert.Throws<NotSupportedException>(() => Marshal.GetComInterfaceForObject(o, typeof(NonGenericInterface), CustomQueryInterfaceMode.Allow));
-            Assert.Throws<NotSupportedException>(() => Marshal.GetComInterfaceForObject<object, NonGenericInterface>(o));
-        }
-#endif
-
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void GetTypedObjectForIUnknown_UncastableType_ThrowsInvalidCastException()

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetIDispatchForObjectTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetIDispatchForObjectTests.cs
@@ -54,22 +54,6 @@ namespace System.Runtime.InteropServices.Tests
             AssertExtensions.Throws<ArgumentNullException>("o", () => Marshal.GetIDispatchForObject(null));
         }
 
-#if !netstandard // TODO: Enable for netstandard2.1
-        [ConditionalFact]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Marshal.GetIDispatchForObject is not implemented in .NET Core.")]
-        public void GetIDispatchForObject_ObjectNotCollectible_ThrowsNotSupportedException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type type = typeBuilder.CreateType();
-
-            object o = Activator.CreateInstance(type);
-            Assert.Throws<NotSupportedException>(() => Marshal.GetIDispatchForObject(o));
-        }
-#endif
-
         [Theory]
         [MemberData(nameof(GetIDispatchForObject_Invalid_TestData))]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Marshal.GetIDispatchForObject is not implemented in .NET Core.")]

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetIUnknownForObjectTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetIUnknownForObjectTests.cs
@@ -23,20 +23,5 @@ namespace System.Runtime.InteropServices.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("o", () => Marshal.GetIUnknownForObject(null));
         }
-
-#if !netstandard // TODO: Enable for netstandard2.1
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNative))]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void GetIUnknownForObject_ObjectNotCollectible_ThrowsNotSupportedException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type type = typeBuilder.CreateType();
-
-            object o = Activator.CreateInstance(type);
-            Assert.Throws<NotSupportedException>(() => Marshal.GetIUnknownForObject(o));
-        }
-#endif
     }
 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
@@ -449,31 +449,6 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-#if !netstandard // TODO: Enable for netstandard2.1
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNative))]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void GetNativeVariantForObject_ObjectNotCollectible_ThrowsNotSupportedException()
-        {
-            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
-            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Module");
-            TypeBuilder typeBuilder = moduleBuilder.DefineType("Type");
-            Type type = typeBuilder.CreateType();
-
-            object o = Activator.CreateInstance(type);
-
-            var v = new Variant();
-            IntPtr pNative = Marshal.AllocHGlobal(Marshal.SizeOf(v));
-            try
-            {
-                Assert.Throws<NotSupportedException>(() => Marshal.GetNativeVariantForObject(o, pNative));
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(pNative);
-            }
-        }
-#endif
-
         public struct StructWithValue
         {
             public int Value;


### PR DESCRIPTION
There were some old tests that I have missed that were testing that COM
interop cannot be used for collectible objects. This is now supported,
so I am removing the tests as obsolete.