### PR TITLE
Decrease Pipe lock held time to reduce contention

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -59,9 +59,10 @@ namespace System.IO.Pipelines
 
         public void ResetMemory()
         {
-            _memoryOwner.Dispose();
+            IMemoryOwner<byte> memoryOwner = _memoryOwner;
             _memoryOwner = null;
             AvailableMemory = default;
+            memoryOwner.Dispose();
         }
 
         internal IMemoryOwner<byte> MemoryOwner => _memoryOwner;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -909,11 +909,12 @@ namespace System.IO.Pipelines
             private static int s_activePipes;
             private static int s_maxSegmentsPerThread;
 
+            private readonly ThreadLocal<BufferSegmentPool> _owningPool;
+
             private int _count;
             private BufferSegment _firstSegment;
             private BufferSegment _lastSegment;
 
-            private ThreadLocal<BufferSegmentPool> _owningPool;
 
             private BufferSegmentPool(ThreadLocal<BufferSegmentPool> owningPool)
             {
@@ -986,7 +987,7 @@ namespace System.IO.Pipelines
 
             public static void ReturnSegments(BufferSegment returnStart, BufferSegment returnEndExclusive)
             {
-                BufferSegmentPool pool = s_pools.Value;
+                BufferSegmentPool pool = s_pools?.Value;
 
                 if (pool == null || pool._count >= s_maxSegmentsPerThread)
                 {

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -5,7 +5,6 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
@@ -44,6 +43,8 @@ namespace System.IO.Pipelines
         private readonly PipeScheduler _readerScheduler;
         private readonly PipeScheduler _writerScheduler;
 
+        private readonly BufferSegment[] _bufferSegmentPool;
+
         private readonly DefaultPipeReader _reader;
         private readonly DefaultPipeWriter _writer;
 
@@ -51,6 +52,8 @@ namespace System.IO.Pipelines
 
         private long _length;
         private long _currentWriteLength;
+
+        private int _pooledSegmentCount;
 
         private PipeAwaitable _readerAwaitable;
         private PipeAwaitable _writerAwaitable;
@@ -92,6 +95,8 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.options);
             }
 
+            _bufferSegmentPool = new BufferSegment[SegmentPoolSize];
+
             _operationState = default;
             _readerCompletion = default;
             _writerCompletion = default;
@@ -107,8 +112,6 @@ namespace System.IO.Pipelines
             _writerAwaitable = new PipeAwaitable(completed: true, _useSynchronizationContext);
             _reader = new DefaultPipeReader(this);
             _writer = new DefaultPipeWriter(this);
-
-            BufferSegmentPool.IncrementActivePipes();
         }
 
         private void ResetState()
@@ -177,7 +180,7 @@ namespace System.IO.Pipelines
             if (_writingHead == null)
             {
                 // We need to allocate memory to write since nobody has written before
-                BufferSegment newSegment = BufferSegmentPool.GetSegment();
+                BufferSegment newSegment = CreateSegmentUnsynchronized();
                 newSegment.SetMemory(_pool.Rent(GetSegmentSize(sizeHint)));
 
                 // Set all the pointers
@@ -189,7 +192,7 @@ namespace System.IO.Pipelines
 
                 if (bytesLeftInBuffer == 0 || bytesLeftInBuffer < sizeHint)
                 {
-                    BufferSegment newSegment = BufferSegmentPool.GetSegment();
+                    BufferSegment newSegment = CreateSegmentUnsynchronized();
                     newSegment.SetMemory(_pool.Rent(GetSegmentSize(sizeHint)));
 
                     _writingHead.SetNext(newSegment);
@@ -205,6 +208,29 @@ namespace System.IO.Pipelines
             // After that adjust it to fit into pools max buffer size
             var adjustedToMaximumSize = Math.Min(_pool.MaxBufferSize, sizeHint);
             return adjustedToMaximumSize;
+        }
+
+        private BufferSegment CreateSegmentUnsynchronized()
+        {
+            if (_pooledSegmentCount > 0)
+            {
+                _pooledSegmentCount--;
+                return _bufferSegmentPool[_pooledSegmentCount];
+            }
+
+            return new BufferSegment();
+        }
+
+        private bool TryReturnSegmentUnsynchronized(BufferSegment segment)
+        {
+            if (_pooledSegmentCount < _bufferSegmentPool.Length)
+            {
+                _bufferSegmentPool[_pooledSegmentCount] = segment;
+                _pooledSegmentCount++;
+                return true;
+            }
+
+            return false;
         }
 
         internal bool CommitUnsynchronized()
@@ -361,9 +387,9 @@ namespace System.IO.Pipelines
         {
             BufferSegment returnStart = null;
             BufferSegment returnEnd = null;
-            bool readCompleted;
 
             CompletionData completionData = default;
+            bool readCompleted;
 
             lock (_sync)
             {
@@ -446,12 +472,38 @@ namespace System.IO.Pipelines
 
             if (readCompleted)
             {
-                // If read completed sucessfully, scehudle next early, prior to clean up
+                // Scehudle early, prior to clean up
                 TrySchedule(_writerScheduler, completionData);
             }
 
-            // Always reset and return the segments prior to any read exception
-            BufferSegmentPool.ReturnSegments(returnStart, returnEndExclusive: returnEnd);
+            // Reset the segments outside lock
+            BufferSegment returnCurrent = returnStart;
+            while (returnCurrent != null && returnCurrent != returnEnd)
+            {
+                returnCurrent.ResetMemory();
+                returnCurrent = returnCurrent.NextSegment;
+            }
+
+            // Return the segments to the pipe pool inside lock
+            returnCurrent = returnStart;
+            lock (_sync)
+            {
+                BufferSegment lastSegment = null;
+                while (returnCurrent != null && returnCurrent != returnEnd)
+                {
+                    if (!TryReturnSegmentUnsynchronized(returnCurrent))
+                    {
+                        // Pool full, drop and stop processing the rest of the chain
+                        if (lastSegment != null)
+                        {
+                            lastSegment.NextSegment = null;
+                        }
+                        break;
+                    }
+
+                    returnCurrent = returnCurrent.NextSegment;
+                }
+            }
 
             if (!readCompleted)
             {
@@ -673,7 +725,7 @@ namespace System.IO.Pipelines
 
         private void CompletePipe()
         {
-            BufferSegment segment = null;
+            BufferSegment returnStart = null;
             lock (_sync)
             {
                 if (_disposed)
@@ -685,7 +737,7 @@ namespace System.IO.Pipelines
                 // Return all segments
                 // if _readHead is null we need to try return _commitHead
                 // because there might be a block allocated for writing
-                segment = _readHead ?? _readTail;
+                returnStart = _readHead ?? _readTail;
 
                 _writingHead = null;
                 _readHead = null;
@@ -693,8 +745,11 @@ namespace System.IO.Pipelines
             }
 
             // Reset the segments outside lock
-            BufferSegmentPool.DecrementActivePipes();
-            BufferSegmentPool.ReturnSegments(segment, returnEndExclusive: null);
+            while (returnStart != null)
+            {
+                returnStart.ResetMemory();
+                returnStart = returnStart.NextSegment;
+            }
         }
 
         internal ValueTaskSourceStatus GetReadAsyncStatus()
@@ -896,195 +951,6 @@ namespace System.IO.Pipelines
 
                 _disposed = false;
                 ResetState();
-            }
-        }
-
-        private class BufferSegmentPool
-        {
-            private static ThreadLocal<BufferSegmentPool> s_pools = null;
-
-            private static readonly Func<BufferSegmentPool> s_poolFactory = new Func<BufferSegmentPool>(PoolFactory);
-            private static int s_activePools;
-            private static readonly object s_sync = new object();
-            private static int s_activePipes;
-            private static int s_maxSegmentsPerThread;
-
-            private readonly ThreadLocal<BufferSegmentPool> _owningPool;
-
-            private int _count;
-            private BufferSegment _firstSegment;
-            private BufferSegment _lastSegment;
-
-
-            private BufferSegmentPool(ThreadLocal<BufferSegmentPool> owningPool)
-            {
-                _owningPool = owningPool;
-            }
-
-            public static void DecrementActivePipes()
-            {
-                lock (s_sync)
-                {
-                    int activePipes = s_activePipes - 1;
-                    if (activePipes == 0)
-                    {
-                        // No active pipes, discard the pool
-                        s_pools = null;
-                        s_maxSegmentsPerThread = 0;
-                        s_activePools = 0;
-                    }
-
-                    s_activePipes = activePipes;
-
-                    CalculateSegmentsPerThread();
-                }
-            }
-
-            public static void IncrementActivePipes()
-            {
-                lock (s_sync)
-                {
-                    int activePipes = s_activePipes + 1;
-                    if (activePipes == 1)
-                    {
-                        // First active pipe, create the pool
-                        s_pools = new ThreadLocal<BufferSegmentPool>(s_poolFactory);
-                    }
-
-                    s_activePipes = activePipes;
-
-                    CalculateSegmentsPerThread();
-                }
-            }
-
-            public static BufferSegment GetSegment()
-            {
-                Debug.Assert(s_pools != null);
-
-                return s_pools.Value.GetOrCreateSegment();
-            }
-
-            private BufferSegment GetOrCreateSegment()
-            {
-                BufferSegmentPool pool = s_pools.Value;
-
-                BufferSegment segment = _firstSegment;
-                if (segment != null)
-                {
-                    BufferSegment nextSegment = segment.NextSegment;
-                    _firstSegment = nextSegment;
-                    if (nextSegment == null)
-                    {
-                        _lastSegment = null;
-                    }
-
-                    segment.NextSegment = null;
-                    return segment;
-                }
-
-                return new BufferSegment();
-            }
-
-            public static void ReturnSegments(BufferSegment returnStart, BufferSegment returnEndExclusive)
-            {
-                BufferSegmentPool pool = s_pools?.Value;
-
-                if (pool == null || pool._count >= s_maxSegmentsPerThread)
-                {
-                    // Pool full or no pool; just reset, don't return
-                    while (returnStart != null && returnStart != returnEndExclusive)
-                    {
-                        BufferSegment nextSegment = returnStart.NextSegment;
-                        returnStart.ResetMemory();
-                        returnStart = nextSegment;
-                    }
-                }
-                else if (returnStart != returnEndExclusive)
-                {
-                    pool.ResetAndReturnSegments(returnStart, returnEndExclusive);
-                }
-            }
-
-            private void ResetAndReturnSegments(BufferSegment returnStart, BufferSegment returnEndExclusive)
-            {
-                Debug.Assert(_count < s_maxSegmentsPerThread);
-                Debug.Assert(returnStart != returnEndExclusive);
-
-                int count = _count;
-                int maxSegments = s_maxSegmentsPerThread;
-
-                BufferSegment lastSegment = _lastSegment;
-                BufferSegment currentSegment = returnStart;
-
-                if (_firstSegment == null)
-                {
-                    _firstSegment = currentSegment;
-                }
-                else
-                {
-                    lastSegment.NextSegment = currentSegment;
-                }
-
-                while (currentSegment != null && currentSegment != returnEndExclusive)
-                {
-                    BufferSegment nextSegment = currentSegment.NextSegment;
-                    currentSegment.ResetMemory();
-
-                    if (count < maxSegments)
-                    {
-                        count++;
-                        lastSegment = currentSegment;
-                    }
-
-                    if (count >= maxSegments)
-                    {
-                        currentSegment.NextSegment = null;
-                    }
-
-                    currentSegment = nextSegment;
-                }
-
-                _count = count;
-                _lastSegment = lastSegment;
-            }
-
-            private static void CalculateSegmentsPerThread()
-            {
-                if (s_activePools > 0)
-                {
-                    s_maxSegmentsPerThread = Math.Max(SegmentPoolSize, (s_activePipes * SegmentPoolSize) / s_activePools);
-                }
-                else
-                {
-                    s_maxSegmentsPerThread = 0;
-                }
-            }
-
-            private static BufferSegmentPool PoolFactory()
-            {
-                lock (s_sync)
-                {
-                    BufferSegmentPool pool = new BufferSegmentPool(s_pools);
-                    s_activePools++;
-                    CalculateSegmentsPerThread();
-                    return pool;
-                }
-            }
-
-            ~BufferSegmentPool()
-            {
-                if (_owningPool == s_pools)
-                {
-                    lock (s_sync)
-                    {
-                        if (_owningPool == s_pools)
-                        {
-                            s_activePools--;
-
-                            CalculateSegmentsPerThread();
-                        }
-                    }
-                }
             }
         }
     }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
@@ -43,6 +43,7 @@ namespace System.IO.Pipelines
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryEndRead()
         {
             if ((_state & State.Reading) != State.Reading &&

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
@@ -37,13 +37,22 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void EndRead()
         {
-            if ((_state & State.Reading) != State.Reading && 
-                (_state & State.ReadingTentative) != State.ReadingTentative)
+            if (!TryEndRead())
             {
                 ThrowHelper.ThrowInvalidOperationException_NoReadToComplete();
             }
+        }
+
+        public bool TryEndRead()
+        {
+            if ((_state & State.Reading) != State.Reading &&
+                (_state & State.ReadingTentative) != State.ReadingTentative)
+            {
+                return false;
+            }
 
             _state &= ~(State.Reading | State.ReadingTentative);
+            return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
50% of `AdvanceReader` is `ResetMemory()` and there is also lock contention

![image](https://user-images.githubusercontent.com/1142958/49553231-a9d4ca80-f8ee-11e8-94b2-841dcbfe5faf.png)

Schedule the next step prior to returning the memory so its ready to run earlier and reset the memory outside the lock (so its held for less time); then return to the pipe pool under lock again.

/cc @davidfowl @halter73 @pakrym @sebastienros 