### PR TITLE
Temporarily disable dumpling since it runs a python 2 script.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -110,7 +110,7 @@
   <!-- Default properties for CI builds -->
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' and '$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuildId)' == ''">
     <WithoutCategories>IgnoreForCI</WithoutCategories>
-    <EnableDumpling>true</EnableDumpling>
+    <EnableDumpling>false</EnableDumpling>
     <CrashDumpFolder Condition="'$(RunningOnUnix)' != 'true'">%TMP%\CoreRunCrashDumps</CrashDumpFolder>
   </PropertyGroup>
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuildId)' == ''">

--- a/buildpipeline/centos.6.groovy
+++ b/buildpipeline/centos.6.groovy
@@ -24,7 +24,7 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-201743110
         if (params.TestOuter) {
             additionalArgs = ' /p:OuterLoop=true'
         }
-        sh "LD_LIBRARY_PATH=/usr/local/lib ./build.sh -test ${commonprops} /p:SkipTests=true /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false${additionalArgs}"
+        sh "LD_LIBRARY_PATH=/usr/local/lib ./build.sh -test ${commonprops} /p:SkipTests=true /p:ArchiveTests=true /p:EnableDumpling=false /p:PortableBuild=false${additionalArgs}"
     }
     stage ('Submit To Helix For Testing') {
         // Bind the credentials

--- a/buildpipeline/linux-musl.groovy
+++ b/buildpipeline/linux-musl.groovy
@@ -20,7 +20,7 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-2017111
         if (params.TestOuter) {
             additionalArgs = ' /p:OuterLoop=true'
         }
-        sh "./build.sh -test ${commonprops} /p:SkipTests=true /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false${additionalArgs}"
+        sh "./build.sh -test ${commonprops} /p:SkipTests=true /p:ArchiveTests=true /p:EnableDumpling=false /p:PortableBuild=false${additionalArgs}"
     }
 
     // TODO: Add submission for Helix testing once we have queue for Alpine Linux working

--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -24,7 +24,7 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
         if (params.TestOuter) {
             additionalArgs = '/p:Outerloop=true'
         }
-        sh "./build.sh -test ${commonprops} /p:SkipTests=true ${additionalArgs} /p:ArchiveTests=true /p:EnableDumpling=true"
+        sh "./build.sh -test ${commonprops} /p:SkipTests=true ${additionalArgs} /p:ArchiveTests=true /p:EnableDumpling=false"
     }
     stage ('Submit To Helix For Testing') {
         // Bind the credentials

--- a/buildpipeline/osx.groovy
+++ b/buildpipeline/osx.groovy
@@ -24,7 +24,7 @@ simpleNode('OSX10.12','latest') {
         if (params.TestOuter) {
             additionalArgs = ' /p:Outerloop=true'
         }
-        sh "HOME=\$WORKSPACE/tempHome ./build.sh -test ${commonprops} /p:SkipTests=true /p:ArchiveTests=true /p:EnableDumpling=true${additionalArgs}"
+        sh "HOME=\$WORKSPACE/tempHome ./build.sh -test ${commonprops} /p:SkipTests=true /p:ArchiveTests=true /p:EnableDumpling=false${additionalArgs}"
     }
     stage ('Submit To Helix For Testing') {
         // Bind the credentials

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -21,7 +21,7 @@
           "Parameters": {
             "PB_DockerTag": "centos-7-d485f41-20173404063424",
             "PB_BuildArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -stripSymbols /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop /p:ArchiveTests=true /p:EnableDumpling=true",
+            "PB_BuildTestsArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop /p:ArchiveTests=true /p:EnableDumpling=false",
             "PB_SyncArguments": "/p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
             "PB_TargetQueue": "Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+OpenSuse.42.Amd64+SLES.12.Amd64+SLES.15.Amd64+Fedora.27.Amd64+Fedora.28.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
@@ -37,7 +37,7 @@
           "Parameters": {
             "PB_DockerTag": "centos-6-376e1a3-20174311014331",
             "PB_BuildArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -stripSymbols /p:RuntimeOS=rhel.6 /p:PortableBuild=false /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop /p:RuntimeOS=rhel.6 /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false",
+            "PB_BuildTestsArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop /p:RuntimeOS=rhel.6 /p:ArchiveTests=true /p:EnableDumpling=false /p:PortableBuild=false",
             "PB_SyncArguments": "/p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
             "PB_TargetQueue": "RedHat.6.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
@@ -53,7 +53,7 @@
           "Parameters": {
             "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
             "PB_BuildArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -stripSymbols /p:RuntimeOS=linux-musl /p:PortableBuild=false /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
-            "PB_BuildTestsArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop /p:RuntimeOS=linux-musl /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false",
+            "PB_BuildTestsArguments": "/p:ArchGroup=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop /p:RuntimeOS=linux-musl /p:ArchiveTests=true /p:EnableDumpling=false /p:PortableBuild=false",
             "PB_SyncArguments": "/p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
             "PB_TargetQueue": "Alpine.36.Amd64+Alpine.38.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"

--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -42,7 +42,7 @@ simpleNode('windows.10.amd64.clientrs4.devex.open') {
             additionalArgs += ' -SkipTests'
         }
         if (params.TGroup != 'all') {
-            bat ".\\build.cmd -test ${commonprops} /p:RuntimeOS=win10 /p:ArchiveTests=${archiveTests} /p:EnableDumpling=true${additionalArgs}"
+            bat ".\\build.cmd -test ${commonprops} /p:RuntimeOS=win10 /p:ArchiveTests=${archiveTests} /p:EnableDumpling=false${additionalArgs}"
         }
         else {
             bat ".\\build.cmd -test -ci /p:TargetGroup=netstandard /p:ArchGroup=${params.AGroup} /p:ConfigurationGroup=${params.CGroup} /p:SkipTests=true"

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -78,7 +78,8 @@
   </Target>
 
   <!-- Dumpling.targets needs to install dumpling.py before running tests. -->
-  <Import Project="$(ToolsDir)Dumpling.targets" Condition="Exists('$(ToolsDir)Dumpling.targets') AND ('$(EnableDumpling)' == 'true' OR '$(EnableCloudTest)' == 'true')" />
+  <!-- Disabling dumpling for the time being since the script only runs on python 2: https://github.com/dotnet/core-eng/issues/4753 -->
+  <!-- <Import Project="$(ToolsDir)Dumpling.targets" Condition="Exists('$(ToolsDir)Dumpling.targets') AND ('$(EnableDumpling)' == 'true' OR '$(EnableCloudTest)' == 'true')" /> -->
 
   <Target Name="GetFilesToPackage"
           DependsOnTargets="FilterProjects"


### PR DESCRIPTION
Temporary work-around for https://github.com/dotnet/core-eng/issues/4753 to unblock CI.

Long term, we should either re-write the scrip to run on python 3 OR change the build machines to have python 2 still installed.
