### PR TITLE
Add nuget restore source and set WorkingDirectory to RepoRoot for global tools install

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -349,7 +349,7 @@
     <RefPath Condition="$(TargetGroup.EndsWith('aot'))">$(RefRootPath)$(TargetGroup.TrimEnd('t').TrimEnd('o').TrimEnd('a'))/</RefPath>
     <NetStandardRefPath>$(RefRootPath)netstandard/</NetStandardRefPath>
     <NetFxRefPath>$(RefRootPath)netfx/</NetFxRefPath>
-    <GlobalToolsDir>$(ArtifactsDir)tools/</GlobalToolsDir>
+    <GlobalToolsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'tools'))</GlobalToolsDir>
 
     <!-- Helix properties -->
     <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -73,6 +73,7 @@
     <!-- List all global tools and save the output. -->
     <Exec Condition="Exists($(GlobalToolsDir))"
           Command="$(DotNetCmd) tool list --tool-path $(GlobalToolsDir)"
+          WorkingDirectory="$(RepoRoot)"
           ConsoleToMsBuild="true"
           ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ConsoleOutput" PropertyName="DotNetListToolsOutput" />
@@ -81,6 +82,7 @@
     <!-- Uninstall the global tool if it exists with a different version. -->
     <Exec Condition="Exists($(GlobalToolsDir)) AND $(DotNetListToolsOutput.Contains('%(RepoTool.Identity)')) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(DotNetListToolsOutput)', '$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Identity)'))\s+$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Version)'))'))"
           Command="$(DotNetCmd) tool uninstall --tool-path $(GlobalToolsDir) %(RepoTool.Identity)"
+          WorkingDirectory="$(RepoRoot)"
           ContinueOnError="WarnAndContinue" />
 
     <!--
@@ -88,7 +90,8 @@
       Creates the global tools folder automatically if it doesn't exist.
     -->
     <Exec Condition="!Exists($(GlobalToolsDir)) OR !$([System.Text.RegularExpressions.Regex]::IsMatch('$(DotNetListToolsOutput)', '$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Identity)'))\s+$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Version)'))'))"
-          Command="$(DotNetCmd) tool install --tool-path $(GlobalToolsDir) %(RepoTool.Identity) --version %(RepoTool.Version)"
+          Command="$(DotNetCmd) tool install --tool-path $(GlobalToolsDir) %(RepoTool.Identity) --version %(RepoTool.Version) --add-source https:%2F%2Fapi.nuget.org/v3/index.json"
+          WorkingDirectory="$(RepoRoot)"
           ContinueOnError="WarnAndContinue" />
     
   </Target>


### PR DESCRIPTION
- Adding nuget restore source to `dotnet tool install` command as the sources are cleared in the root NuGet.config (I have no idea why it worked on Windows!)
- Changing working directory of dotnet tool commands because of the error discussed here: dotnet/cli#4808.
- Escaping slashes because of the error discussed here: https://github.com/Microsoft/msbuild/issues/1622

It seems working with nuget cross-platform is still fragile.

cc @ericstj @safern 