### PR TITLE
Update UAP test package

### DIFF
--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -51,7 +51,7 @@
     <XUnitPackageVersion>2.4.1-pre.build.4059</XUnitPackageVersion>
     <XUnitPerformancePackageVersion>1.0.0-beta-build0020</XUnitPerformancePackageVersion>
     <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>
-    <UAPToolsPackageVersion>1.0.23</UAPToolsPackageVersion>
+    <UAPToolsPackageVersion>1.0.24</UAPToolsPackageVersion>
 
     <!-- Code coverage package version -->
     <CoverletConsolePackageVersion>1.3.0</CoverletConsolePackageVersion>


### PR DESCRIPTION
UAP.Tools 1.0.24 is now compiled with the official ARM toolchain which was released with VS 2017.9. Maybe that fixes the not working UWP ARM leg.