### PR TITLE
Regenerating the System.Runtime.Intrinsics ref assembly via /t:GenerateReferenceSource

### DIFF
--- a/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -5,1117 +5,1109 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-using System.Runtime.InteropServices;
-
 namespace System.Runtime.Intrinsics
 {
-    public static class Vector64
+    public static partial class Vector128
     {
-        public static Vector64<byte> Create(byte value) { throw null; }
-        public static Vector64<double> Create(double value) { throw null; }
-        public static Vector64<short> Create(short value) { throw null; }
-        public static Vector64<int> Create(int value) { throw null; }
-        public static Vector64<long> Create(long value) { throw null; }
-        public static Vector64<sbyte> Create(sbyte value) { throw null; }
-        public static Vector64<float> Create(float value) { throw null; }
-        public static Vector64<ushort> Create(ushort value) { throw null; }
-        public static Vector64<uint> Create(uint value) { throw null; }
-        public static Vector64<ulong> Create(ulong value) { throw null; }
-        public static Vector64<byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7) { throw null; }
-        public static Vector64<short> Create(short e0, short e1, short e2, short e3) { throw null; }
-        public static Vector64<int> Create(int e0, int e1) { throw null; }
-        public static Vector64<sbyte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7) { throw null; }
-        public static Vector64<float> Create(float e0, float e1) { throw null; }
-        public static Vector64<ushort> Create(ushort e0, ushort e1, ushort e2, ushort e3) { throw null; }
-        public static Vector64<uint> Create(uint e0, uint e1) { throw null; }
-        public static Vector64<byte> CreateScalar(byte value) { throw null; }
-        public static Vector64<short> CreateScalar(short value) { throw null; }
-        public static Vector64<int> CreateScalar(int value) { throw null; }
-        public static Vector64<sbyte> CreateScalar(sbyte value) { throw null; }
-        public static Vector64<float> CreateScalar(float value) { throw null; }
-        public static Vector64<ushort> CreateScalar(ushort value) { throw null; }
-        public static Vector64<uint> CreateScalar(uint value) { throw null; }
-        public static Vector64<byte> CreateScalarUnsafe(byte value) { throw null; }
-        public static Vector64<short> CreateScalarUnsafe(short value) { throw null; }
-        public static Vector64<int> CreateScalarUnsafe(int value) { throw null; }
-        public static Vector64<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
-        public static Vector64<float> CreateScalarUnsafe(float value) { throw null; }
-        public static Vector64<ushort> CreateScalarUnsafe(ushort value) { throw null; }
-        public static Vector64<uint> CreateScalarUnsafe(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Byte> Create(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Double> Create(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Double> Create(double e0, double e1) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int16> Create(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int16> Create(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int32> Create(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int32> Create(int e0, int e1, int e2, int e3) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int64> Create(long value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int64> Create(long e0, long e1) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Byte> Create(System.Runtime.Intrinsics.Vector64<byte> lower, System.Runtime.Intrinsics.Vector64<byte> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Double> Create(System.Runtime.Intrinsics.Vector64<double> lower, System.Runtime.Intrinsics.Vector64<double> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int16> Create(System.Runtime.Intrinsics.Vector64<short> lower, System.Runtime.Intrinsics.Vector64<short> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int32> Create(System.Runtime.Intrinsics.Vector64<int> lower, System.Runtime.Intrinsics.Vector64<int> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int64> Create(System.Runtime.Intrinsics.Vector64<long> lower, System.Runtime.Intrinsics.Vector64<long> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.SByte> Create(System.Runtime.Intrinsics.Vector64<sbyte> lower, System.Runtime.Intrinsics.Vector64<sbyte> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Single> Create(System.Runtime.Intrinsics.Vector64<float> lower, System.Runtime.Intrinsics.Vector64<float> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt16> Create(System.Runtime.Intrinsics.Vector64<ushort> lower, System.Runtime.Intrinsics.Vector64<ushort> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt32> Create(System.Runtime.Intrinsics.Vector64<uint> lower, System.Runtime.Intrinsics.Vector64<uint> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt64> Create(System.Runtime.Intrinsics.Vector64<ulong> lower, System.Runtime.Intrinsics.Vector64<ulong> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.SByte> Create(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.SByte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7, sbyte e8, sbyte e9, sbyte e10, sbyte e11, sbyte e12, sbyte e13, sbyte e14, sbyte e15) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Single> Create(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Single> Create(float e0, float e1, float e2, float e3) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt16> Create(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt16> Create(ushort e0, ushort e1, ushort e2, ushort e3, ushort e4, ushort e5, ushort e6, ushort e7) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt32> Create(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt32> Create(uint e0, uint e1, uint e2, uint e3) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt64> Create(ulong value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt64> Create(ulong e0, ulong e1) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Byte> CreateScalar(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Double> CreateScalar(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int16> CreateScalar(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int32> CreateScalar(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int64> CreateScalar(long value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.SByte> CreateScalar(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Single> CreateScalar(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt16> CreateScalar(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt32> CreateScalar(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt64> CreateScalar(ulong value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Byte> CreateScalarUnsafe(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Double> CreateScalarUnsafe(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int16> CreateScalarUnsafe(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int32> CreateScalarUnsafe(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Int64> CreateScalarUnsafe(long value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.SByte> CreateScalarUnsafe(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.Single> CreateScalarUnsafe(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt16> CreateScalarUnsafe(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt32> CreateScalarUnsafe(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<System.UInt64> CreateScalarUnsafe(ulong value) { throw null; }
     }
-    [StructLayout(LayoutKind.Sequential, Size = 8)]
-    public readonly struct Vector64<T> : IEquatable<Vector64<T>>, IFormattable
-        where T : struct
+    public readonly partial struct Vector128<T> : System.IEquatable<System.Runtime.Intrinsics.Vector128<T>>, System.IFormattable where T : struct
     {
-        private readonly int _dummy;
+        private readonly int _dummyPrimitive;
         public static int Count { get { throw null; } }
-        public static Vector64<T> Zero { get { throw null; } }
-        public Vector64<U> As<U>() where U : struct { throw null; }
-        public Vector64<byte> AsByte() { throw null; }
-        public Vector64<double> AsDouble() { throw null; }
-        public Vector64<short> AsInt16() { throw null; }
-        public Vector64<int> AsInt32() { throw null; }
-        public Vector64<long> AsInt64() { throw null; }
-        public Vector64<sbyte> AsSByte() { throw null; }
-        public Vector64<float> AsSingle() { throw null; }
-        public Vector64<ushort> AsUInt16() { throw null; }
-        public Vector64<uint> AsUInt32() { throw null; }
-        public Vector64<ulong> AsUInt64() { throw null; }
-        public bool Equals(Vector64<T> other) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> Zero { get { throw null; } }
+        public System.Runtime.Intrinsics.Vector128<System.Byte> AsByte() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.Double> AsDouble() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.Int16> AsInt16() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.Int32> AsInt32() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.Int64> AsInt64() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.SByte> AsSByte() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.Single> AsSingle() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.UInt16> AsUInt16() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.UInt32> AsUInt32() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<System.UInt64> AsUInt64() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<U> As<U>() where U : struct { throw null; }
         public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Runtime.Intrinsics.Vector128<T> other) { throw null; }
         public T GetElement(int index) { throw null; }
-        public Vector64<T> WithElement(int index, T value) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<T> GetLower() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<T> GetUpper() { throw null; }
+        public T ToScalar() { throw null; }
+        public override string ToString() { throw null; }
+        public string ToString(string format) { throw null; }
+        public string ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+        public System.Runtime.Intrinsics.Vector256<T> ToVector256() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<T> ToVector256Unsafe() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<T> WithElement(int index, T value) { throw null; }
+        public System.Runtime.Intrinsics.Vector128<T> WithLower(System.Runtime.Intrinsics.Vector64<T> value) { throw null; }
+        public System.Runtime.Intrinsics.Vector128<T> WithUpper(System.Runtime.Intrinsics.Vector64<T> value) { throw null; }
+    }
+    public static partial class Vector256
+    {
+        public static System.Runtime.Intrinsics.Vector256<System.Byte> Create(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15, byte e16, byte e17, byte e18, byte e19, byte e20, byte e21, byte e22, byte e23, byte e24, byte e25, byte e26, byte e27, byte e28, byte e29, byte e30, byte e31) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Double> Create(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Double> Create(double e0, double e1, double e2, double e3) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int16> Create(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int16> Create(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7, short e8, short e9, short e10, short e11, short e12, short e13, short e14, short e15) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int32> Create(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int32> Create(int e0, int e1, int e2, int e3, int e4, int e5, int e6, int e7) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int64> Create(long value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int64> Create(long e0, long e1, long e2, long e3) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Byte> Create(System.Runtime.Intrinsics.Vector128<byte> lower, System.Runtime.Intrinsics.Vector128<byte> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Double> Create(System.Runtime.Intrinsics.Vector128<double> lower, System.Runtime.Intrinsics.Vector128<double> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int16> Create(System.Runtime.Intrinsics.Vector128<short> lower, System.Runtime.Intrinsics.Vector128<short> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int32> Create(System.Runtime.Intrinsics.Vector128<int> lower, System.Runtime.Intrinsics.Vector128<int> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int64> Create(System.Runtime.Intrinsics.Vector128<long> lower, System.Runtime.Intrinsics.Vector128<long> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.SByte> Create(System.Runtime.Intrinsics.Vector128<sbyte> lower, System.Runtime.Intrinsics.Vector128<sbyte> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Single> Create(System.Runtime.Intrinsics.Vector128<float> lower, System.Runtime.Intrinsics.Vector128<float> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt16> Create(System.Runtime.Intrinsics.Vector128<ushort> lower, System.Runtime.Intrinsics.Vector128<ushort> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt32> Create(System.Runtime.Intrinsics.Vector128<uint> lower, System.Runtime.Intrinsics.Vector128<uint> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt64> Create(System.Runtime.Intrinsics.Vector128<ulong> lower, System.Runtime.Intrinsics.Vector128<ulong> upper) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.SByte> Create(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.SByte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7, sbyte e8, sbyte e9, sbyte e10, sbyte e11, sbyte e12, sbyte e13, sbyte e14, sbyte e15, sbyte e16, sbyte e17, sbyte e18, sbyte e19, sbyte e20, sbyte e21, sbyte e22, sbyte e23, sbyte e24, sbyte e25, sbyte e26, sbyte e27, sbyte e28, sbyte e29, sbyte e30, sbyte e31) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Single> Create(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Single> Create(float e0, float e1, float e2, float e3, float e4, float e5, float e6, float e7) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt16> Create(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt16> Create(ushort e0, ushort e1, ushort e2, ushort e3, ushort e4, ushort e5, ushort e6, ushort e7, ushort e8, ushort e9, ushort e10, ushort e11, ushort e12, ushort e13, ushort e14, ushort e15) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt32> Create(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt32> Create(uint e0, uint e1, uint e2, uint e3, uint e4, uint e5, uint e6, uint e7) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt64> Create(ulong value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt64> Create(ulong e0, ulong e1, ulong e2, ulong e3) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Byte> CreateScalar(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Double> CreateScalar(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int16> CreateScalar(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int32> CreateScalar(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int64> CreateScalar(long value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.SByte> CreateScalar(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Single> CreateScalar(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt16> CreateScalar(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt32> CreateScalar(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt64> CreateScalar(ulong value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Byte> CreateScalarUnsafe(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Double> CreateScalarUnsafe(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int16> CreateScalarUnsafe(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int32> CreateScalarUnsafe(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Int64> CreateScalarUnsafe(long value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.SByte> CreateScalarUnsafe(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.Single> CreateScalarUnsafe(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt16> CreateScalarUnsafe(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt32> CreateScalarUnsafe(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<System.UInt64> CreateScalarUnsafe(ulong value) { throw null; }
+    }
+    public readonly partial struct Vector256<T> : System.IEquatable<System.Runtime.Intrinsics.Vector256<T>>, System.IFormattable where T : struct
+    {
+        private readonly int _dummyPrimitive;
+        public static int Count { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector256<T> Zero { get { throw null; } }
+        public System.Runtime.Intrinsics.Vector256<System.Byte> AsByte() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.Double> AsDouble() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.Int16> AsInt16() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.Int32> AsInt32() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.Int64> AsInt64() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.SByte> AsSByte() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.Single> AsSingle() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.UInt16> AsUInt16() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.UInt32> AsUInt32() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<System.UInt64> AsUInt64() { throw null; }
+        public System.Runtime.Intrinsics.Vector256<U> As<U>() where U : struct { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Runtime.Intrinsics.Vector256<T> other) { throw null; }
+        public T GetElement(int index) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<T> GetLower() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<T> GetUpper() { throw null; }
+        public T ToScalar() { throw null; }
+        public override string ToString() { throw null; }
+        public string ToString(string format) { throw null; }
+        public string ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+        public System.Runtime.Intrinsics.Vector256<T> WithElement(int index, T value) { throw null; }
+        public System.Runtime.Intrinsics.Vector256<T> WithLower(System.Runtime.Intrinsics.Vector128<T> value) { throw null; }
+        public System.Runtime.Intrinsics.Vector256<T> WithUpper(System.Runtime.Intrinsics.Vector128<T> value) { throw null; }
+    }
+    public static partial class Vector64
+    {
+        public static System.Runtime.Intrinsics.Vector64<System.Byte> Create(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Double> Create(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int16> Create(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int16> Create(short e0, short e1, short e2, short e3) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int32> Create(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int32> Create(int e0, int e1) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int64> Create(long value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.SByte> Create(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.SByte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Single> Create(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Single> Create(float e0, float e1) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt16> Create(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt16> Create(ushort e0, ushort e1, ushort e2, ushort e3) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt32> Create(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt32> Create(uint e0, uint e1) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt64> Create(ulong value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Byte> CreateScalar(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int16> CreateScalar(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int32> CreateScalar(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.SByte> CreateScalar(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Single> CreateScalar(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt16> CreateScalar(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt32> CreateScalar(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Byte> CreateScalarUnsafe(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int16> CreateScalarUnsafe(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Int32> CreateScalarUnsafe(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.SByte> CreateScalarUnsafe(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.Single> CreateScalarUnsafe(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt16> CreateScalarUnsafe(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<System.UInt32> CreateScalarUnsafe(uint value) { throw null; }
+    }
+    public readonly partial struct Vector64<T> : System.IEquatable<System.Runtime.Intrinsics.Vector64<T>>, System.IFormattable where T : struct
+    {
+        private readonly int _dummyPrimitive;
+        public static int Count { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector64<T> Zero { get { throw null; } }
+        public System.Runtime.Intrinsics.Vector64<System.Byte> AsByte() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.Double> AsDouble() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.Int16> AsInt16() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.Int32> AsInt32() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.Int64> AsInt64() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.SByte> AsSByte() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.Single> AsSingle() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.UInt16> AsUInt16() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.UInt32> AsUInt32() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<System.UInt64> AsUInt64() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<U> As<U>() where U : struct { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Runtime.Intrinsics.Vector64<T> other) { throw null; }
+        public T GetElement(int index) { throw null; }
         public override int GetHashCode() { throw null; }
         public T ToScalar() { throw null; }
         public override string ToString() { throw null; }
         public string ToString(string format) { throw null; }
-        public string ToString(string format, IFormatProvider formatProvider) { throw null; }
-        public Vector128<T> ToVector128() { throw null; }
-        public unsafe Vector128<T> ToVector128Unsafe() { throw null; }
-    }
-    public static class Vector128
-    {
-        public static Vector128<byte> Create(byte value) { throw null; }
-        public static Vector128<double> Create(double value) { throw null; }
-        public static Vector128<short> Create(short value) { throw null; }
-        public static Vector128<int> Create(int value) { throw null; }
-        public static Vector128<long> Create(long value) { throw null; }
-        public static Vector128<sbyte> Create(sbyte value) { throw null; }
-        public static Vector128<float> Create(float value) { throw null; }
-        public static Vector128<ushort> Create(ushort value) { throw null; }
-        public static Vector128<uint> Create(uint value) { throw null; }
-        public static Vector128<ulong> Create(ulong value) { throw null; }
-        public static Vector128<byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15) { throw null; }
-        public static Vector128<double> Create(double e0, double e1) { throw null; }
-        public static Vector128<short> Create(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7) { throw null; }
-        public static Vector128<int> Create(int e0, int e1, int e2, int e3) { throw null; }
-        public static Vector128<long> Create(long e0, long e1) { throw null; }
-        public static Vector128<sbyte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7, sbyte e8, sbyte e9, sbyte e10, sbyte e11, sbyte e12, sbyte e13, sbyte e14, sbyte e15) { throw null; }
-        public static Vector128<float> Create(float e0, float e1, float e2, float e3) { throw null; }
-        public static Vector128<ushort> Create(ushort e0, ushort e1, ushort e2, ushort e3, ushort e4, ushort e5, ushort e6, ushort e7) { throw null; }
-        public static Vector128<uint> Create(uint e0, uint e1, uint e2, uint e3) { throw null; }
-        public static Vector128<ulong> Create(ulong e0, ulong e1) { throw null; }
-        public static Vector128<byte> Create(Vector64<byte> lower, Vector64<byte> upper) { throw null; }
-        public static Vector128<double> Create(Vector64<double> lower, Vector64<double> upper) { throw null; }
-        public static Vector128<short> Create(Vector64<short> lower, Vector64<short> upper) { throw null; }
-        public static Vector128<int> Create(Vector64<int> lower, Vector64<int> upper) { throw null; }
-        public static Vector128<long> Create(Vector64<long> lower, Vector64<long> upper) { throw null; }
-        public static Vector128<sbyte> Create(Vector64<sbyte> lower, Vector64<sbyte> upper) { throw null; }
-        public static Vector128<float> Create(Vector64<float> lower, Vector64<float> upper) { throw null; }
-        public static Vector128<ushort> Create(Vector64<ushort> lower, Vector64<ushort> upper) { throw null; }
-        public static Vector128<uint> Create(Vector64<uint> lower, Vector64<uint> upper) { throw null; }
-        public static Vector128<ulong> Create(Vector64<ulong> lower, Vector64<ulong> upper) { throw null; }
-        public static Vector128<byte> CreateScalar(byte value) { throw null; }
-        public static Vector128<double> CreateScalar(double value) { throw null; }
-        public static Vector128<short> CreateScalar(short value) { throw null; }
-        public static Vector128<int> CreateScalar(int value) { throw null; }
-        public static Vector128<long> CreateScalar(long value) { throw null; }
-        public static Vector128<sbyte> CreateScalar(sbyte value) { throw null; }
-        public static Vector128<float> CreateScalar(float value) { throw null; }
-        public static Vector128<ushort> CreateScalar(ushort value) { throw null; }
-        public static Vector128<uint> CreateScalar(uint value) { throw null; }
-        public static Vector128<ulong> CreateScalar(ulong value) { throw null; }
-        public static Vector128<byte> CreateScalarUnsafe(byte value) { throw null; }
-        public static Vector128<double> CreateScalarUnsafe(double value) { throw null; }
-        public static Vector128<short> CreateScalarUnsafe(short value) { throw null; }
-        public static Vector128<int> CreateScalarUnsafe(int value) { throw null; }
-        public static Vector128<long> CreateScalarUnsafe(long value) { throw null; }
-        public static Vector128<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
-        public static Vector128<float> CreateScalarUnsafe(float value) { throw null; }
-        public static Vector128<ushort> CreateScalarUnsafe(ushort value) { throw null; }
-        public static Vector128<uint> CreateScalarUnsafe(uint value) { throw null; }
-        public static Vector128<ulong> CreateScalarUnsafe(ulong value) { throw null; }
-    }
-    [StructLayout(LayoutKind.Sequential, Size = 16)]
-    public readonly struct Vector128<T> : IEquatable<Vector128<T>>, IFormattable
-        where T : struct
-    {
-        private readonly int _dummy;
-        public static int Count { get { throw null; } }
-        public static Vector128<T> Zero { get { throw null; } }
-        public Vector128<U> As<U>() where U : struct { throw null; }
-        public Vector128<byte> AsByte() { throw null; }
-        public Vector128<double> AsDouble() { throw null; }
-        public Vector128<short> AsInt16() { throw null; }
-        public Vector128<int> AsInt32() { throw null; }
-        public Vector128<long> AsInt64() { throw null; }
-        public Vector128<sbyte> AsSByte() { throw null; }
-        public Vector128<float> AsSingle() { throw null; }
-        public Vector128<ushort> AsUInt16() { throw null; }
-        public Vector128<uint> AsUInt32() { throw null; }
-        public Vector128<ulong> AsUInt64() { throw null; }
-        public bool Equals(Vector128<T> other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public T GetElement(int index) { throw null; }
-        public Vector128<T> WithElement(int index, T value) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public Vector64<T> GetLower() { throw null; }
-        public Vector128<T> WithLower(Vector64<T> value) { throw null; }
-        public Vector64<T> GetUpper() { throw null; }
-        public Vector128<T> WithUpper(Vector64<T> value) { throw null; }
-        public T ToScalar() { throw null; }
-        public override string ToString() { throw null; }
-        public string ToString(string format) { throw null; }
-        public string ToString(string format, IFormatProvider formatProvider) { throw null; }
-        public Vector256<T> ToVector256() { throw null; }
-        public unsafe Vector256<T> ToVector256Unsafe() { throw null; }
-    }
-    public static class Vector256
-    {
-        public static Vector256<byte> Create(byte value) { throw null; }
-        public static Vector256<double> Create(double value) { throw null; }
-        public static Vector256<short> Create(short value) { throw null; }
-        public static Vector256<int> Create(int value) { throw null; }
-        public static Vector256<long> Create(long value) { throw null; }
-        public static Vector256<sbyte> Create(sbyte value) { throw null; }
-        public static Vector256<float> Create(float value) { throw null; }
-        public static Vector256<ushort> Create(ushort value) { throw null; }
-        public static Vector256<uint> Create(uint value) { throw null; }
-        public static Vector256<ulong> Create(ulong value) { throw null; }
-        public static Vector256<byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15, byte e16, byte e17, byte e18, byte e19, byte e20, byte e21, byte e22, byte e23, byte e24, byte e25, byte e26, byte e27, byte e28, byte e29, byte e30, byte e31) { throw null; }
-        public static Vector256<double> Create(double e0, double e1, double e2, double e3) { throw null; }
-        public static Vector256<short> Create(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7, short e8, short e9, short e10, short e11, short e12, short e13, short e14, short e15) { throw null; }
-        public static Vector256<int> Create(int e0, int e1, int e2, int e3, int e4, int e5, int e6, int e7) { throw null; }
-        public static Vector256<long> Create(long e0, long e1, long e2, long e3) { throw null; }
-        public static Vector256<sbyte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7, sbyte e8, sbyte e9, sbyte e10, sbyte e11, sbyte e12, sbyte e13, sbyte e14, sbyte e15, sbyte e16, sbyte e17, sbyte e18, sbyte e19, sbyte e20, sbyte e21, sbyte e22, sbyte e23, sbyte e24, sbyte e25, sbyte e26, sbyte e27, sbyte e28, sbyte e29, sbyte e30, sbyte e31) { throw null; }
-        public static Vector256<float> Create(float e0, float e1, float e2, float e3, float e4, float e5, float e6, float e7) { throw null; }
-        public static Vector256<ushort> Create(ushort e0, ushort e1, ushort e2, ushort e3, ushort e4, ushort e5, ushort e6, ushort e7, ushort e8, ushort e9, ushort e10, ushort e11, ushort e12, ushort e13, ushort e14, ushort e15) { throw null; }
-        public static Vector256<uint> Create(uint e0, uint e1, uint e2, uint e3, uint e4, uint e5, uint e6, uint e7) { throw null; }
-        public static Vector256<ulong> Create(ulong e0, ulong e1, ulong e2, ulong e3) { throw null; }
-        public static Vector256<byte> Create(Vector128<byte> lower, Vector128<byte> upper) { throw null; }
-        public static Vector256<double> Create(Vector128<double> lower, Vector128<double> upper) { throw null; }
-        public static Vector256<short> Create(Vector128<short> lower, Vector128<short> upper) { throw null; }
-        public static Vector256<int> Create(Vector128<int> lower, Vector128<int> upper) { throw null; }
-        public static Vector256<long> Create(Vector128<long> lower, Vector128<long> upper) { throw null; }
-        public static Vector256<sbyte> Create(Vector128<sbyte> lower, Vector128<sbyte> upper) { throw null; }
-        public static Vector256<float> Create(Vector128<float> lower, Vector128<float> upper) { throw null; }
-        public static Vector256<ushort> Create(Vector128<ushort> lower, Vector128<ushort> upper) { throw null; }
-        public static Vector256<uint> Create(Vector128<uint> lower, Vector128<uint> upper) { throw null; }
-        public static Vector256<ulong> Create(Vector128<ulong> lower, Vector128<ulong> upper) { throw null; }
-        public static Vector256<byte> CreateScalar(byte value) { throw null; }
-        public static Vector256<double> CreateScalar(double value) { throw null; }
-        public static Vector256<short> CreateScalar(short value) { throw null; }
-        public static Vector256<int> CreateScalar(int value) { throw null; }
-        public static Vector256<long> CreateScalar(long value) { throw null; }
-        public static Vector256<sbyte> CreateScalar(sbyte value) { throw null; }
-        public static Vector256<float> CreateScalar(float value) { throw null; }
-        public static Vector256<ushort> CreateScalar(ushort value) { throw null; }
-        public static Vector256<uint> CreateScalar(uint value) { throw null; }
-        public static Vector256<ulong> CreateScalar(ulong value) { throw null; }
-        public static Vector256<byte> CreateScalarUnsafe(byte value) { throw null; }
-        public static Vector256<double> CreateScalarUnsafe(double value) { throw null; }
-        public static Vector256<short> CreateScalarUnsafe(short value) { throw null; }
-        public static Vector256<int> CreateScalarUnsafe(int value) { throw null; }
-        public static Vector256<long> CreateScalarUnsafe(long value) { throw null; }
-        public static Vector256<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
-        public static Vector256<float> CreateScalarUnsafe(float value) { throw null; }
-        public static Vector256<ushort> CreateScalarUnsafe(ushort value) { throw null; }
-        public static Vector256<uint> CreateScalarUnsafe(uint value) { throw null; }
-        public static Vector256<ulong> CreateScalarUnsafe(ulong value) { throw null; }
-    }
-    [StructLayout(LayoutKind.Sequential, Size = 32)]
-    public readonly struct Vector256<T> : IEquatable<Vector256<T>>, IFormattable
-        where T : struct
-    {
-        private readonly int _dummy;
-        public static int Count { get { throw null; } }
-        public static Vector256<T> Zero { get { throw null; } }
-        public Vector256<U> As<U>() where U : struct { throw null; }
-        public Vector256<byte> AsByte() { throw null; }
-        public Vector256<double> AsDouble() { throw null; }
-        public Vector256<short> AsInt16() { throw null; }
-        public Vector256<int> AsInt32() { throw null; }
-        public Vector256<long> AsInt64() { throw null; }
-        public Vector256<sbyte> AsSByte() { throw null; }
-        public Vector256<float> AsSingle() { throw null; }
-        public Vector256<ushort> AsUInt16() { throw null; }
-        public Vector256<uint> AsUInt32() { throw null; }
-        public Vector256<ulong> AsUInt64() { throw null; }
-        public bool Equals(Vector256<T> other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public T GetElement(int index) { throw null; }
-        public Vector256<T> WithElement(int index, T value) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public Vector128<T> GetLower() { throw null; }
-        public Vector256<T> WithLower(Vector128<T> value) { throw null; }
-        public Vector128<T> GetUpper() { throw null; }
-        public Vector256<T> WithUpper(Vector128<T> value) { throw null; }
-        public T ToScalar() { throw null; }
-        public override string ToString() { throw null; }
-        public string ToString(string format) { throw null; }
-        public string ToString(string format, IFormatProvider formatProvider) { throw null; }
+        public string ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+        public System.Runtime.Intrinsics.Vector128<T> ToVector128() { throw null; }
+        public System.Runtime.Intrinsics.Vector128<T> ToVector128Unsafe() { throw null; }
+        public System.Runtime.Intrinsics.Vector64<T> WithElement(int index, T value) { throw null; }
     }
 }
 namespace System.Runtime.Intrinsics.Arm.Arm64
 {
-    public static class Aes
+    public static partial class Aes
     {
         public static bool IsSupported { get { throw null; } }
-        public static Vector128<byte> Decrypt(Vector128<byte> value, Vector128<byte> roundKey) { throw null; }
-        public static Vector128<byte> Encrypt(Vector128<byte> value, Vector128<byte> roundKey) { throw null; }
-        public static Vector128<byte> MixColumns(Vector128<byte> value) { throw null; }
-        public static Vector128<byte> InverseMixColumns(Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Decrypt(System.Runtime.Intrinsics.Vector128<byte> value, System.Runtime.Intrinsics.Vector128<byte> roundKey) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Encrypt(System.Runtime.Intrinsics.Vector128<byte> value, System.Runtime.Intrinsics.Vector128<byte> roundKey) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> InverseMixColumns(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> MixColumns(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
     }
-    public static class Base
+    public static partial class Base
     {
         public static bool IsSupported { get { throw null; } }
         public static int LeadingSignCount(int value) { throw null; }
         public static int LeadingSignCount(long value) { throw null; }
         public static int LeadingZeroCount(int value) { throw null; }
-        public static int LeadingZeroCount(uint value) { throw null; }
         public static int LeadingZeroCount(long value) { throw null; }
+        public static int LeadingZeroCount(uint value) { throw null; }
         public static int LeadingZeroCount(ulong value) { throw null; }
     }
-    public static class Sha1
+    public static partial class Sha1
     {
         public static bool IsSupported { get { throw null; } }
-        public static Vector128<uint> HashChoose(Vector128<uint> hash_abcd, uint hash_e, Vector128<uint>wk) { throw null; }
-        public static Vector128<uint> HashMajority(Vector128<uint> hash_abcd, uint hash_e, Vector128<uint>wk) { throw null; }
-        public static Vector128<uint> HashParity(Vector128<uint> hash_abcd, uint hash_e, Vector128<uint>wk) { throw null; }
         public static uint FixedRotate(uint hash_e) { throw null; }
-        public static Vector128<uint> SchedulePart1(Vector128<uint> w0_3, Vector128<uint> w4_7, Vector128<uint> w8_11) { throw null; }
-        public static Vector128<uint> SchedulePart2(Vector128<uint> tw0_3, Vector128<uint> w12_15) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> HashChoose(System.Runtime.Intrinsics.Vector128<uint> hash_abcd, uint hash_e, System.Runtime.Intrinsics.Vector128<uint> wk) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> HashMajority(System.Runtime.Intrinsics.Vector128<uint> hash_abcd, uint hash_e, System.Runtime.Intrinsics.Vector128<uint> wk) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> HashParity(System.Runtime.Intrinsics.Vector128<uint> hash_abcd, uint hash_e, System.Runtime.Intrinsics.Vector128<uint> wk) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> SchedulePart1(System.Runtime.Intrinsics.Vector128<uint> w0_3, System.Runtime.Intrinsics.Vector128<uint> w4_7, System.Runtime.Intrinsics.Vector128<uint> w8_11) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> SchedulePart2(System.Runtime.Intrinsics.Vector128<uint> tw0_3, System.Runtime.Intrinsics.Vector128<uint> w12_15) { throw null; }
     }
-    public static class Sha256
+    public static partial class Sha256
     {
         public static bool IsSupported { get { throw null; } }
-        public static Vector128<uint> HashLower(Vector128<uint> hash_abcd, Vector128<uint> hash_efgh, Vector128<uint> wk) { throw null; }
-        public static Vector128<uint> HashUpper(Vector128<uint> hash_efgh, Vector128<uint> hash_abcd, Vector128<uint> wk) { throw null; }
-        public static Vector128<uint> SchedulePart1(Vector128<uint> w0_3, Vector128<uint> w4_7) { throw null; }
-        public static Vector128<uint> SchedulePart2(Vector128<uint> w0_3, Vector128<uint> w8_11, Vector128<uint> w12_15) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> HashLower(System.Runtime.Intrinsics.Vector128<uint> hash_abcd, System.Runtime.Intrinsics.Vector128<uint> hash_efgh, System.Runtime.Intrinsics.Vector128<uint> wk) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> HashUpper(System.Runtime.Intrinsics.Vector128<uint> hash_efgh, System.Runtime.Intrinsics.Vector128<uint> hash_abcd, System.Runtime.Intrinsics.Vector128<uint> wk) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> SchedulePart1(System.Runtime.Intrinsics.Vector128<uint> w0_3, System.Runtime.Intrinsics.Vector128<uint> w4_7) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> SchedulePart2(System.Runtime.Intrinsics.Vector128<uint> w0_3, System.Runtime.Intrinsics.Vector128<uint> w8_11, System.Runtime.Intrinsics.Vector128<uint> w12_15) { throw null; }
     }
-    public static class Simd
+    public static partial class Simd
     {
         public static bool IsSupported { get { throw null; } }
-        public static Vector64<byte> Abs(Vector64<sbyte> value) { throw null; }
-        public static Vector64<ushort> Abs(Vector64<short> value) { throw null; }
-        public static Vector64<uint> Abs(Vector64<int> value) { throw null; }
-        public static Vector64<float> Abs(Vector64<float> value) { throw null; }
-        public static Vector128<byte> Abs(Vector128<sbyte> value) { throw null; }
-        public static Vector128<ushort> Abs(Vector128<short> value) { throw null; }
-        public static Vector128<uint> Abs(Vector128<int> value) { throw null; }
-        public static Vector128<ulong> Abs(Vector128<long> value) { throw null; }
-        public static Vector128<float> Abs(Vector128<float> value) { throw null; }
-        public static Vector128<double> Abs(Vector128<double> value) { throw null; }
-        public static Vector64<T> Add<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> Add<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> And<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> And<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> AndNot<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> AndNot<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> BitwiseSelect<T>(Vector64<T> sel, Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> BitwiseSelect<T>(Vector128<T> sel, Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> CompareEqual<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> CompareEqual<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> CompareEqualZero<T>(Vector64<T> value) where T : struct { throw null; }
-        public static Vector128<T> CompareEqualZero<T>(Vector128<T> value) where T : struct { throw null; }
-        public static Vector64<T> CompareGreaterThan<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> CompareGreaterThan<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> CompareGreaterThanZero<T>(Vector64<T> value) where T : struct { throw null; }
-        public static Vector128<T> CompareGreaterThanZero<T>(Vector128<T> value) where T : struct { throw null; }
-        public static Vector64<T> CompareGreaterThanOrEqual<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> CompareGreaterThanOrEqual<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> CompareGreaterThanOrEqualZero<T>(Vector64<T> value) where T : struct { throw null; }
-        public static Vector128<T> CompareGreaterThanOrEqualZero<T>(Vector128<T> value) where T : struct { throw null; }
-        public static Vector64<T> CompareLessThanZero<T>(Vector64<T> value) where T : struct { throw null; }
-        public static Vector128<T> CompareLessThanZero<T>(Vector128<T> value) where T : struct { throw null; }
-        public static Vector64<T> CompareLessThanOrEqualZero<T>(Vector64<T> value) where T : struct { throw null; }
-        public static Vector128<T> CompareLessThanOrEqualZero<T>(Vector128<T> value) where T : struct { throw null; }
-        public static Vector64<T> CompareTest<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> CompareTest<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<float> Divide(Vector64<float> left, Vector64<float> right) { throw null; }
-        public static Vector128<float> Divide(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<double> Divide(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static T Extract<T>(Vector64<T> vector, byte index) where T : struct { throw null; }
-        public static T Extract<T>(Vector128<T> vector, byte index) where T : struct { throw null; }
-        public static Vector64<T> Insert<T>(Vector64<T> vector, byte index, T data) where T : struct { throw null; }
-        public static Vector128<T> Insert<T>(Vector128<T> vector, byte index, T data) where T : struct { throw null; }
-        public static Vector64<sbyte> LeadingSignCount(Vector64<sbyte> value) { throw null; }
-        public static Vector64<short> LeadingSignCount(Vector64<short> value) { throw null; }
-        public static Vector64<int> LeadingSignCount(Vector64<int> value) { throw null; }
-        public static Vector128<sbyte> LeadingSignCount(Vector128<sbyte> value) { throw null; }
-        public static Vector128<short> LeadingSignCount(Vector128<short> value) { throw null; }
-        public static Vector128<int> LeadingSignCount(Vector128<int> value) { throw null; }
-        public static Vector64<byte> LeadingZeroCount(Vector64<byte> value) { throw null; }
-        public static Vector64<sbyte> LeadingZeroCount(Vector64<sbyte> value) { throw null; }
-        public static Vector64<ushort> LeadingZeroCount(Vector64<ushort> value) { throw null; }
-        public static Vector64<short> LeadingZeroCount(Vector64<short> value) { throw null; }
-        public static Vector64<uint> LeadingZeroCount(Vector64<uint> value) { throw null; }
-        public static Vector64<int> LeadingZeroCount(Vector64<int> value) { throw null; }
-        public static Vector128<byte> LeadingZeroCount(Vector128<byte> value) { throw null; }
-        public static Vector128<sbyte> LeadingZeroCount(Vector128<sbyte> value) { throw null; }
-        public static Vector128<ushort> LeadingZeroCount(Vector128<ushort> value) { throw null; }
-        public static Vector128<short> LeadingZeroCount(Vector128<short> value) { throw null; }
-        public static Vector128<uint> LeadingZeroCount(Vector128<uint> value) { throw null; }
-        public static Vector128<int> LeadingZeroCount(Vector128<int> value) { throw null; }
-        public static Vector64<byte> Max(Vector64<byte> left, Vector64<byte> right) { throw null; }
-        public static Vector64<sbyte> Max(Vector64<sbyte> left, Vector64<sbyte> right) { throw null; }
-        public static Vector64<ushort> Max(Vector64<ushort> left, Vector64<ushort> right) { throw null; }
-        public static Vector64<short> Max(Vector64<short> left, Vector64<short> right) { throw null; }
-        public static Vector64<uint> Max(Vector64<uint> left, Vector64<uint> right) { throw null; }
-        public static Vector64<int> Max(Vector64<int> left, Vector64<int> right) { throw null; }
-        public static Vector64<float> Max(Vector64<float> left, Vector64<float> right) { throw null; }
-        public static Vector128<byte> Max(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> Max(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<ushort> Max(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<short> Max(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<uint> Max(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<int> Max(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<float> Max(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<double> Max(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector64<byte> Min(Vector64<byte> left, Vector64<byte> right) { throw null; }
-        public static Vector64<sbyte> Min(Vector64<sbyte> left, Vector64<sbyte> right) { throw null; }
-        public static Vector64<ushort> Min(Vector64<ushort> left, Vector64<ushort> right) { throw null; }
-        public static Vector64<short> Min(Vector64<short> left, Vector64<short> right) { throw null; }
-        public static Vector64<uint> Min(Vector64<uint> left, Vector64<uint> right) { throw null; }
-        public static Vector64<int> Min(Vector64<int> left, Vector64<int> right) { throw null; }
-        public static Vector64<float> Min(Vector64<float> left, Vector64<float> right) { throw null; }
-        public static Vector128<byte> Min(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> Min(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<ushort> Min(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<short> Min(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<uint> Min(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<int> Min(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<float> Min(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<double> Min(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector64<byte> Multiply(Vector64<byte> left, Vector64<byte> right) { throw null; }
-        public static Vector64<sbyte> Multiply(Vector64<sbyte> left, Vector64<sbyte> right) { throw null; }
-        public static Vector64<ushort> Multiply(Vector64<ushort> left, Vector64<ushort> right) { throw null; }
-        public static Vector64<short> Multiply(Vector64<short> left, Vector64<short> right) { throw null; }
-        public static Vector64<uint> Multiply(Vector64<uint> left, Vector64<uint> right) { throw null; }
-        public static Vector64<int> Multiply(Vector64<int> left, Vector64<int> right) { throw null; }
-        public static Vector64<float> Multiply(Vector64<float> left, Vector64<float> right) { throw null; }
-        public static Vector128<byte> Multiply(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> Multiply(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<ushort> Multiply(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<short> Multiply(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<uint> Multiply(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<int> Multiply(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<float> Multiply(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<double> Multiply(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector64<sbyte> Negate(Vector64<sbyte> value) { throw null; }
-        public static Vector64<short> Negate(Vector64<short> value) { throw null; }
-        public static Vector64<int> Negate(Vector64<int> value) { throw null; }
-        public static Vector64<float> Negate(Vector64<float> value) { throw null; }
-        public static Vector128<sbyte> Negate(Vector128<sbyte> value) { throw null; }
-        public static Vector128<short> Negate(Vector128<short> value) { throw null; }
-        public static Vector128<int> Negate(Vector128<int> value) { throw null; }
-        public static Vector128<long> Negate(Vector128<long> value) { throw null; }
-        public static Vector128<float> Negate(Vector128<float> value) { throw null; }
-        public static Vector128<double> Negate(Vector128<double> value) { throw null; }
-        public static Vector64<T> Not<T>(Vector64<T> value) where T : struct { throw null; }
-        public static Vector128<T> Not<T>(Vector128<T> value) where T : struct { throw null; }
-        public static Vector64<T> Or<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> Or<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> OrNot<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> OrNot<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<byte> PopCount(Vector64<byte> value) { throw null; }
-        public static Vector64<sbyte> PopCount(Vector64<sbyte> value) { throw null; }
-        public static Vector128<byte> PopCount(Vector128<byte> value) { throw null; }
-        public static Vector128<sbyte> PopCount(Vector128<sbyte> value) { throw null; }
-        public static Vector64<T> SetAllVector64<T>(T value) where T : struct { throw null; }
-        public static Vector128<T> SetAllVector128<T>(T value) where T : struct { throw null; }
-        public static Vector64<float> Sqrt(Vector64<float> value) { throw null; }
-        public static Vector128<float> Sqrt(Vector128<float> value) { throw null; }
-        public static Vector128<double> Sqrt(Vector128<double> value) { throw null; }
-        public static Vector64<T> Subtract<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> Subtract<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
-        public static Vector64<T> Xor<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw null; }
-        public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Abs(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Abs(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Abs(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> Abs(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Abs(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Abs(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<ushort> Abs(System.Runtime.Intrinsics.Vector64<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<uint> Abs(System.Runtime.Intrinsics.Vector64<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<byte> Abs(System.Runtime.Intrinsics.Vector64<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Abs(System.Runtime.Intrinsics.Vector64<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> Add<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> Add<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> AndNot<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> AndNot<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> And<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> And<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> BitwiseSelect<T>(System.Runtime.Intrinsics.Vector128<T> sel, System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> BitwiseSelect<T>(System.Runtime.Intrinsics.Vector64<T> sel, System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareEqualZero<T>(System.Runtime.Intrinsics.Vector128<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareEqualZero<T>(System.Runtime.Intrinsics.Vector64<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareEqual<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareEqual<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareGreaterThanOrEqualZero<T>(System.Runtime.Intrinsics.Vector128<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareGreaterThanOrEqualZero<T>(System.Runtime.Intrinsics.Vector64<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareGreaterThanOrEqual<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareGreaterThanOrEqual<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareGreaterThanZero<T>(System.Runtime.Intrinsics.Vector128<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareGreaterThanZero<T>(System.Runtime.Intrinsics.Vector64<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareGreaterThan<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareGreaterThan<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareLessThanOrEqualZero<T>(System.Runtime.Intrinsics.Vector128<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareLessThanOrEqualZero<T>(System.Runtime.Intrinsics.Vector64<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareLessThanZero<T>(System.Runtime.Intrinsics.Vector128<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareLessThanZero<T>(System.Runtime.Intrinsics.Vector64<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> CompareTest<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> CompareTest<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Divide(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Divide(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Divide(System.Runtime.Intrinsics.Vector64<float> left, System.Runtime.Intrinsics.Vector64<float> right) { throw null; }
+        public static T Extract<T>(System.Runtime.Intrinsics.Vector128<T> vector, byte index) where T : struct { throw null; }
+        public static T Extract<T>(System.Runtime.Intrinsics.Vector64<T> vector, byte index) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> Insert<T>(System.Runtime.Intrinsics.Vector128<T> vector, byte index, T data) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> Insert<T>(System.Runtime.Intrinsics.Vector64<T> vector, byte index, T data) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> LeadingSignCount(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> LeadingSignCount(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> LeadingSignCount(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<short> LeadingSignCount(System.Runtime.Intrinsics.Vector64<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<int> LeadingSignCount(System.Runtime.Intrinsics.Vector64<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<sbyte> LeadingSignCount(System.Runtime.Intrinsics.Vector64<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> LeadingZeroCount(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> LeadingZeroCount(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> LeadingZeroCount(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> LeadingZeroCount(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> LeadingZeroCount(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> LeadingZeroCount(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<byte> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<short> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<int> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<sbyte> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<ushort> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<uint> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<uint> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Max(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Max(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Max(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Max(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Max(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Max(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Max(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Max(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<byte> Max(System.Runtime.Intrinsics.Vector64<byte> left, System.Runtime.Intrinsics.Vector64<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<short> Max(System.Runtime.Intrinsics.Vector64<short> left, System.Runtime.Intrinsics.Vector64<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<int> Max(System.Runtime.Intrinsics.Vector64<int> left, System.Runtime.Intrinsics.Vector64<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<sbyte> Max(System.Runtime.Intrinsics.Vector64<sbyte> left, System.Runtime.Intrinsics.Vector64<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Max(System.Runtime.Intrinsics.Vector64<float> left, System.Runtime.Intrinsics.Vector64<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<ushort> Max(System.Runtime.Intrinsics.Vector64<ushort> left, System.Runtime.Intrinsics.Vector64<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<uint> Max(System.Runtime.Intrinsics.Vector64<uint> left, System.Runtime.Intrinsics.Vector64<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Min(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Min(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Min(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Min(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Min(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Min(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Min(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Min(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<byte> Min(System.Runtime.Intrinsics.Vector64<byte> left, System.Runtime.Intrinsics.Vector64<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<short> Min(System.Runtime.Intrinsics.Vector64<short> left, System.Runtime.Intrinsics.Vector64<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<int> Min(System.Runtime.Intrinsics.Vector64<int> left, System.Runtime.Intrinsics.Vector64<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<sbyte> Min(System.Runtime.Intrinsics.Vector64<sbyte> left, System.Runtime.Intrinsics.Vector64<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Min(System.Runtime.Intrinsics.Vector64<float> left, System.Runtime.Intrinsics.Vector64<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<ushort> Min(System.Runtime.Intrinsics.Vector64<ushort> left, System.Runtime.Intrinsics.Vector64<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<uint> Min(System.Runtime.Intrinsics.Vector64<uint> left, System.Runtime.Intrinsics.Vector64<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Multiply(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Multiply(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Multiply(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Multiply(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Multiply(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Multiply(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Multiply(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Multiply(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<byte> Multiply(System.Runtime.Intrinsics.Vector64<byte> left, System.Runtime.Intrinsics.Vector64<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<short> Multiply(System.Runtime.Intrinsics.Vector64<short> left, System.Runtime.Intrinsics.Vector64<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<int> Multiply(System.Runtime.Intrinsics.Vector64<int> left, System.Runtime.Intrinsics.Vector64<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<sbyte> Multiply(System.Runtime.Intrinsics.Vector64<sbyte> left, System.Runtime.Intrinsics.Vector64<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Multiply(System.Runtime.Intrinsics.Vector64<float> left, System.Runtime.Intrinsics.Vector64<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<ushort> Multiply(System.Runtime.Intrinsics.Vector64<ushort> left, System.Runtime.Intrinsics.Vector64<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<uint> Multiply(System.Runtime.Intrinsics.Vector64<uint> left, System.Runtime.Intrinsics.Vector64<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Negate(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Negate(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Negate(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> Negate(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Negate(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Negate(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<short> Negate(System.Runtime.Intrinsics.Vector64<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<int> Negate(System.Runtime.Intrinsics.Vector64<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<sbyte> Negate(System.Runtime.Intrinsics.Vector64<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Negate(System.Runtime.Intrinsics.Vector64<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> Not<T>(System.Runtime.Intrinsics.Vector128<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> Not<T>(System.Runtime.Intrinsics.Vector64<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> OrNot<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> OrNot<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> Or<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> Or<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> PopCount(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> PopCount(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<byte> PopCount(System.Runtime.Intrinsics.Vector64<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<sbyte> PopCount(System.Runtime.Intrinsics.Vector64<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> SetAllVector128<T>(T value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> SetAllVector64<T>(T value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Sqrt(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Sqrt(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Sqrt(System.Runtime.Intrinsics.Vector64<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> Subtract<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> Subtract<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> Xor<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<T> Xor<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) where T : struct { throw null; }
     }
 }
 namespace System.Runtime.Intrinsics.X86
 {
-    public abstract class Aes : Sse2
+    public abstract partial class Aes : System.Runtime.Intrinsics.X86.Sse2
     {
         internal Aes() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector128<byte> Decrypt(Vector128<byte> value, Vector128<byte> roundKey) { throw null; }
-        public static Vector128<byte> DecryptLast(Vector128<byte> value, Vector128<byte> roundKey) { throw null; }
-        public static Vector128<byte> Encrypt(Vector128<byte> value, Vector128<byte> roundKey) { throw null; }
-        public static Vector128<byte> EncryptLast(Vector128<byte> value, Vector128<byte> roundKey) { throw null; }
-        public static Vector128<byte> InverseMixColumns(Vector128<byte> value) { throw null; }
-        public static Vector128<byte> KeygenAssist(Vector128<byte> value, byte control) { throw null; }
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector128<byte> Decrypt(System.Runtime.Intrinsics.Vector128<byte> value, System.Runtime.Intrinsics.Vector128<byte> roundKey) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> DecryptLast(System.Runtime.Intrinsics.Vector128<byte> value, System.Runtime.Intrinsics.Vector128<byte> roundKey) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Encrypt(System.Runtime.Intrinsics.Vector128<byte> value, System.Runtime.Intrinsics.Vector128<byte> roundKey) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> EncryptLast(System.Runtime.Intrinsics.Vector128<byte> value, System.Runtime.Intrinsics.Vector128<byte> roundKey) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> InverseMixColumns(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> KeygenAssist(System.Runtime.Intrinsics.Vector128<byte> value, byte control) { throw null; }
     }
-    public abstract class Avx : Sse42
+    public abstract partial class Avx : System.Runtime.Intrinsics.X86.Sse42
     {
         internal Avx() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector256<float> Add(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> Add(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> AddSubtract(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> AddSubtract(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> And(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> And(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> AndNot(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> AndNot(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> Blend(Vector256<float> left, Vector256<float> right, byte control) { throw null; }
-        public static Vector256<double> Blend(Vector256<double> left, Vector256<double> right, byte control) { throw null; }
-        public static Vector256<float> BlendVariable(Vector256<float> left, Vector256<float> right, Vector256<float> mask) { throw null; }
-        public static Vector256<double> BlendVariable(Vector256<double> left, Vector256<double> right, Vector256<double> mask) { throw null; }
-        public static unsafe Vector128<float> BroadcastScalarToVector128(float* source) { throw null; }
-        public static unsafe Vector256<float> BroadcastVector128ToVector256(float* address) { throw null; }
-        public static unsafe Vector256<float> BroadcastScalarToVector256(float* source) { throw null; }
-        public static unsafe Vector256<double> BroadcastVector128ToVector256(double* address) { throw null; }
-        public static unsafe Vector256<double> BroadcastScalarToVector256(double* source) { throw null; }
-        public static Vector256<float> Ceiling(Vector256<float> value) { throw null; }
-        public static Vector256<double> Ceiling(Vector256<double> value) { throw null; }
-        public static Vector128<float> Compare(Vector128<float> left, Vector128<float> right, FloatComparisonMode mode) { throw null; }
-        public static Vector128<double> Compare(Vector128<double> left, Vector128<double> right, FloatComparisonMode mode) { throw null; }
-        public static Vector256<float> Compare(Vector256<float> left, Vector256<float> right, FloatComparisonMode mode) { throw null; }
-        public static Vector256<double> Compare(Vector256<double> left, Vector256<double> right, FloatComparisonMode mode) { throw null; }
-        public static Vector128<double> CompareScalar(Vector128<double> left, Vector128<double> right, FloatComparisonMode mode) { throw null; }
-        public static Vector128<float> CompareScalar(Vector128<float> left, Vector128<float> right, FloatComparisonMode mode) { throw null; }
-        public static float ConvertToSingle(Vector256<float> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32(Vector256<double> value) { throw null; }
-        public static Vector128<float> ConvertToVector128Single(Vector256<double> value) { throw null; }
-        public static Vector256<int> ConvertToVector256Int32(Vector256<float> value) { throw null; }
-        public static Vector256<float> ConvertToVector256Single(Vector256<int> value) { throw null; }
-        public static Vector256<double> ConvertToVector256Double(Vector128<float> value) { throw null; }
-        public static Vector256<double> ConvertToVector256Double(Vector128<int> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector256<double> value) { throw null; }
-        public static Vector256<int> ConvertToVector256Int32WithTruncation(Vector256<float> value) { throw null; }
-        public static Vector256<float> Divide(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> Divide(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> DotProduct(Vector256<float> left, Vector256<float> right, byte control) { throw null; }
-        public static Vector256<float> DuplicateEvenIndexed(Vector256<float> value) { throw null; }
-        public static Vector256<double> DuplicateEvenIndexed(Vector256<double> value) { throw null; }
-        public static Vector256<float> DuplicateOddIndexed(Vector256<float> value) { throw null; }
-        public static byte Extract(Vector256<byte> value, byte index) { throw null; }
-        public static ushort Extract(Vector256<ushort> value, byte index) { throw null; }
-        public static int Extract(Vector256<int> value, byte index) { throw null; }
-        public static uint Extract(Vector256<uint> value, byte index) { throw null; }
-        public static long Extract(Vector256<long> value, byte index) { throw null; }
-        public static ulong Extract(Vector256<ulong> value, byte index) { throw null; }
-        public static Vector128<byte> ExtractVector128(Vector256<byte> value, byte index) { throw null; }
-        public static Vector128<sbyte> ExtractVector128(Vector256<sbyte> value, byte index) { throw null; }
-        public static Vector128<short> ExtractVector128(Vector256<short> value, byte index) { throw null; }
-        public static Vector128<ushort> ExtractVector128(Vector256<ushort> value, byte index) { throw null; }
-        public static Vector128<int> ExtractVector128(Vector256<int> value, byte index) { throw null; }
-        public static Vector128<uint> ExtractVector128(Vector256<uint> value, byte index) { throw null; }
-        public static Vector128<long> ExtractVector128(Vector256<long> value, byte index) { throw null; }
-        public static Vector128<ulong> ExtractVector128(Vector256<ulong> value, byte index) { throw null; }
-        public static Vector128<float> ExtractVector128(Vector256<float> value, byte index) { throw null; }
-        public static Vector128<double> ExtractVector128(Vector256<double> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(byte* address, Vector256<byte> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(sbyte* address, Vector256<sbyte> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(short* address, Vector256<short> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(ushort* address, Vector256<ushort> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(int* address, Vector256<int> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(uint* address, Vector256<uint> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(long* address, Vector256<long> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(ulong* address, Vector256<ulong> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(float* address, Vector256<float> value, byte index) { throw null; }
-        public static unsafe void ExtractVector128(double* address, Vector256<double> value, byte index) { throw null; }
-        public static Vector256<T> ExtendToVector256<T>(Vector128<T> value) where T : struct { throw null; }
-        public static Vector256<float> Floor(Vector256<float> value) { throw null; }
-        public static Vector256<double> Floor(Vector256<double> value) { throw null; }
-        public static Vector128<T> GetLowerHalf<T>(Vector256<T> value) where T : struct { throw null; }
-        public static Vector256<float> HorizontalAdd(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> HorizontalAdd(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> HorizontalSubtract(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> HorizontalSubtract(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<sbyte> Insert(Vector256<sbyte> value, sbyte data, byte index) { throw null; }
-        public static Vector256<byte> Insert(Vector256<byte> value, byte data, byte index) { throw null; }
-        public static Vector256<short> Insert(Vector256<short> value, short data, byte index) { throw null; }
-        public static Vector256<ushort> Insert(Vector256<ushort> value, ushort data, byte index) { throw null; }
-        public static Vector256<int> Insert(Vector256<int> value, int data, byte index) { throw null; }
-        public static Vector256<uint> Insert(Vector256<uint> value, uint data, byte index) { throw null; }
-        public static Vector256<long> Insert(Vector256<long> value, long data, byte index) { throw null; }
-        public static Vector256<ulong> Insert(Vector256<ulong> value, ulong data, byte index) { throw null; }
-        public static Vector256<byte> InsertVector128(Vector256<byte> value, Vector128<byte> data, byte index) { throw null; }
-        public static Vector256<sbyte> InsertVector128(Vector256<sbyte> value, Vector128<sbyte> data, byte index) { throw null; }
-        public static Vector256<short> InsertVector128(Vector256<short> value, Vector128<short> data, byte index) { throw null; }
-        public static Vector256<ushort> InsertVector128(Vector256<ushort> value, Vector128<ushort> data, byte index) { throw null; }
-        public static Vector256<int> InsertVector128(Vector256<int> value, Vector128<int> data, byte index) { throw null; }
-        public static Vector256<uint> InsertVector128(Vector256<uint> value, Vector128<uint> data, byte index) { throw null; }
-        public static Vector256<long> InsertVector128(Vector256<long> value, Vector128<long> data, byte index) { throw null; }
-        public static Vector256<ulong> InsertVector128(Vector256<ulong> value, Vector128<ulong> data, byte index) { throw null; }
-        public static Vector256<float> InsertVector128(Vector256<float> value, Vector128<float> data, byte index) { throw null; }
-        public static Vector256<double> InsertVector128(Vector256<double> value, Vector128<double> data, byte index) { throw null; }
-        public static unsafe Vector256<sbyte> InsertVector128(Vector256<sbyte> value, sbyte* address, byte index) { throw null; }
-        public static unsafe Vector256<byte> InsertVector128(Vector256<byte> value, byte* address, byte index) { throw null; }
-        public static unsafe Vector256<short> InsertVector128(Vector256<short> value, short* address, byte index) { throw null; }
-        public static unsafe Vector256<ushort> InsertVector128(Vector256<ushort> value, ushort* address, byte index) { throw null; }
-        public static unsafe Vector256<int> InsertVector128(Vector256<int> value, int* address, byte index) { throw null; }
-        public static unsafe Vector256<uint> InsertVector128(Vector256<uint> value, uint* address, byte index) { throw null; }
-        public static unsafe Vector256<long> InsertVector128(Vector256<long> value, long* address, byte index) { throw null; }
-        public static unsafe Vector256<ulong> InsertVector128(Vector256<ulong> value, ulong* address, byte index) { throw null; }
-        public static unsafe Vector256<float> InsertVector128(Vector256<float> value, float* address, byte index) { throw null; }
-        public static unsafe Vector256<double> InsertVector128(Vector256<double> value, double* address, byte index) { throw null; }
-        public static unsafe Vector256<sbyte> LoadVector256(sbyte* address) { throw null; }
-        public static unsafe Vector256<byte> LoadVector256(byte* address) { throw null; }
-        public static unsafe Vector256<short> LoadVector256(short* address) { throw null; }
-        public static unsafe Vector256<ushort> LoadVector256(ushort* address) { throw null; }
-        public static unsafe Vector256<int> LoadVector256(int* address) { throw null; }
-        public static unsafe Vector256<uint> LoadVector256(uint* address) { throw null; }
-        public static unsafe Vector256<long> LoadVector256(long* address) { throw null; }
-        public static unsafe Vector256<ulong> LoadVector256(ulong* address) { throw null; }
-        public static unsafe Vector256<float> LoadVector256(float* address) { throw null; }
-        public static unsafe Vector256<double> LoadVector256(double* address) { throw null; }
-        public static unsafe Vector256<sbyte> LoadAlignedVector256(sbyte* address) { throw null; }
-        public static unsafe Vector256<byte> LoadAlignedVector256(byte* address) { throw null; }
-        public static unsafe Vector256<short> LoadAlignedVector256(short* address) { throw null; }
-        public static unsafe Vector256<ushort> LoadAlignedVector256(ushort* address) { throw null; }
-        public static unsafe Vector256<int> LoadAlignedVector256(int* address) { throw null; }
-        public static unsafe Vector256<uint> LoadAlignedVector256(uint* address) { throw null; }
-        public static unsafe Vector256<long> LoadAlignedVector256(long* address) { throw null; }
-        public static unsafe Vector256<ulong> LoadAlignedVector256(ulong* address) { throw null; }
-        public static unsafe Vector256<float> LoadAlignedVector256(float* address) { throw null; }
-        public static unsafe Vector256<double> LoadAlignedVector256(double* address) { throw null; }
-        public static unsafe Vector256<sbyte> LoadDquVector256(sbyte* address) { throw null; }
-        public static unsafe Vector256<byte> LoadDquVector256(byte* address) { throw null; }
-        public static unsafe Vector256<short> LoadDquVector256(short* address) { throw null; }
-        public static unsafe Vector256<ushort> LoadDquVector256(ushort* address) { throw null; }
-        public static unsafe Vector256<int> LoadDquVector256(int* address) { throw null; }
-        public static unsafe Vector256<uint> LoadDquVector256(uint* address) { throw null; }
-        public static unsafe Vector256<long> LoadDquVector256(long* address) { throw null; }
-        public static unsafe Vector256<ulong> LoadDquVector256(ulong* address) { throw null; }
-        public static unsafe Vector128<float> MaskLoad(float* address, Vector128<float> mask) { throw null; }
-        public static unsafe Vector128<double> MaskLoad(double* address, Vector128<double> mask) { throw null; }
-        public static unsafe Vector256<float> MaskLoad(float* address, Vector256<float> mask) { throw null; }
-        public static unsafe Vector256<double> MaskLoad(double* address, Vector256<double> mask) { throw null; }
-        public static unsafe void MaskStore(float* address, Vector128<float> mask, Vector128<float> source) { throw null; }
-        public static unsafe void MaskStore(double* address, Vector128<double> mask, Vector128<double> source) { throw null; }
-        public static unsafe void MaskStore(float* address, Vector256<float> mask, Vector256<float> source) { throw null; }
-        public static unsafe void MaskStore(double* address, Vector256<double> mask, Vector256<double> source) { throw null; }
-        public static Vector256<float> Max(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> Max(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> Min(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> Min(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static int MoveMask(Vector256<float> value) { throw null; }
-        public static int MoveMask(Vector256<double> value) { throw null; }
-        public static Vector256<float> Multiply(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> Multiply(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> Or(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> Or(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector128<float> Permute(Vector128<float> value, byte control) { throw null; }
-        public static Vector128<double> Permute(Vector128<double> value, byte control) { throw null; }
-        public static Vector256<float> Permute(Vector256<float> value, byte control) { throw null; }
-        public static Vector256<double> Permute(Vector256<double> value, byte control) { throw null; }
-        public static Vector256<byte> Permute2x128(Vector256<byte> left, Vector256<byte> right, byte control) { throw null; }
-        public static Vector256<sbyte> Permute2x128(Vector256<sbyte> left, Vector256<sbyte> right, byte control) { throw null; }
-        public static Vector256<short> Permute2x128(Vector256<short> left, Vector256<short> right, byte control) { throw null; }
-        public static Vector256<ushort> Permute2x128(Vector256<ushort> left, Vector256<ushort> right, byte control) { throw null; }
-        public static Vector256<int> Permute2x128(Vector256<int> left, Vector256<int> right, byte control) { throw null; }
-        public static Vector256<uint> Permute2x128(Vector256<uint> left, Vector256<uint> right, byte control) { throw null; }
-        public static Vector256<long> Permute2x128(Vector256<long> left, Vector256<long> right, byte control) { throw null; }
-        public static Vector256<ulong> Permute2x128(Vector256<ulong> left, Vector256<ulong> right, byte control) { throw null; }
-        public static Vector256<float> Permute2x128(Vector256<float> left, Vector256<float> right, byte control) { throw null; }
-        public static Vector256<double> Permute2x128(Vector256<double> left, Vector256<double> right, byte control) { throw null; }
-        public static Vector128<float> PermuteVar(Vector128<float> left, Vector128<int> control) { throw null; }
-        public static Vector128<double> PermuteVar(Vector128<double> left, Vector128<long> control) { throw null; }
-        public static Vector256<float> PermuteVar(Vector256<float> left, Vector256<int> control) { throw null; }
-        public static Vector256<double> PermuteVar(Vector256<double> left, Vector256<long> control) { throw null; }
-        public static Vector256<float> Reciprocal(Vector256<float> value) { throw null; }
-        public static Vector256<float> ReciprocalSqrt(Vector256<float> value) { throw null; }
-        public static Vector256<float> RoundToNearestInteger(Vector256<float> value) { throw null; }
-        public static Vector256<float> RoundToNegativeInfinity(Vector256<float> value) { throw null; }
-        public static Vector256<float> RoundToPositiveInfinity(Vector256<float> value) { throw null; }
-        public static Vector256<float> RoundToZero(Vector256<float> value) { throw null; }
-        public static Vector256<float> RoundCurrentDirection(Vector256<float> value) { throw null; }
-        public static Vector256<double> RoundToNearestInteger(Vector256<double> value) { throw null; }
-        public static Vector256<double> RoundToNegativeInfinity(Vector256<double> value) { throw null; }
-        public static Vector256<double> RoundToPositiveInfinity(Vector256<double> value) { throw null; }
-        public static Vector256<double> RoundToZero(Vector256<double> value) { throw null; }
-        public static Vector256<double> RoundCurrentDirection(Vector256<double> value) { throw null; }
-        public static Vector256<sbyte> SetVector256(sbyte e31, sbyte e30, sbyte e29, sbyte e28, sbyte e27, sbyte e26, sbyte e25, sbyte e24, sbyte e23, sbyte e22, sbyte e21, sbyte e20, sbyte e19, sbyte e18, sbyte e17, sbyte e16, sbyte e15, sbyte e14, sbyte e13, sbyte e12, sbyte e11, sbyte e10, sbyte e9, sbyte e8, sbyte e7, sbyte e6, sbyte e5, sbyte e4, sbyte e3, sbyte e2, sbyte e1, sbyte e0) { throw null; }
-        public static Vector256<byte> SetVector256(byte e31, byte e30, byte e29, byte e28, byte e27, byte e26, byte e25, byte e24, byte e23, byte e22, byte e21, byte e20, byte e19, byte e18, byte e17, byte e16, byte e15, byte e14, byte e13, byte e12, byte e11, byte e10, byte e9, byte e8, byte e7, byte e6, byte e5, byte e4, byte e3, byte e2, byte e1, byte e0) { throw null; }
-        public static Vector256<short> SetVector256(short e15, short e14, short e13, short e12, short e11, short e10, short e9, short e8, short e7, short e6, short e5, short e4, short e3, short e2, short e1, short e0) { throw null; }
-        public static Vector256<ushort> SetVector256(ushort e15, ushort e14, ushort e13, ushort e12, ushort e11, ushort e10, ushort e9, ushort e8, ushort e7, ushort e6, ushort e5, ushort e4, ushort e3, ushort e2, ushort e1, ushort e0) { throw null; }
-        public static Vector256<int> SetVector256(int e7, int e6, int e5, int e4, int e3, int e2, int e1, int e0) { throw null; }
-        public static Vector256<uint> SetVector256(uint e7, uint e6, uint e5, uint e4, uint e3, uint e2, uint e1, uint e0) { throw null; }
-        public static Vector256<long> SetVector256(long e3, long e2, long e1, long e0) { throw null; }
-        public static Vector256<ulong> SetVector256(ulong e3, ulong e2, ulong e1, ulong e0) { throw null; }
-        public static Vector256<float> SetVector256(float e7, float e6, float e5, float e4, float e3, float e2, float e1, float e0) { throw null; }
-        public static Vector256<double> SetVector256(double e3, double e2, double e1, double e0) { throw null; }
-        public static Vector256<T> SetAllVector256<T>(T value) where T : struct { throw null; }
-        public static Vector256<T> SetHighLow<T>(Vector128<T> hi, Vector128<T> lo) where T : struct { throw null; }
-        public static Vector256<T> SetZeroVector256<T>() where T : struct { throw null; }
-        public static Vector256<float> Shuffle(Vector256<float> value, Vector256<float> right, byte control) { throw null; }
-        public static Vector256<double> Shuffle(Vector256<double> value, Vector256<double> right, byte control) { throw null; }
-        public static Vector256<float> Sqrt(Vector256<float> value) { throw null; }
-        public static Vector256<double> Sqrt(Vector256<double> value) { throw null; }
-        public static Vector256<U> StaticCast<T, U>(Vector256<T> value) where T : struct where U : struct { throw null; }
-        public static unsafe void StoreAligned(sbyte* address, Vector256<sbyte> source) { throw null; }
-        public static unsafe void StoreAligned(byte* address, Vector256<byte> source) { throw null; }
-        public static unsafe void StoreAligned(short* address, Vector256<short> source) { throw null; }
-        public static unsafe void StoreAligned(ushort* address, Vector256<ushort> source) { throw null; }
-        public static unsafe void StoreAligned(int* address, Vector256<int> source) { throw null; }
-        public static unsafe void StoreAligned(uint* address, Vector256<uint> source) { throw null; }
-        public static unsafe void StoreAligned(long* address, Vector256<long> source) { throw null; }
-        public static unsafe void StoreAligned(ulong* address, Vector256<ulong> source) { throw null; }
-        public static unsafe void StoreAligned(float* address, Vector256<float> source) { throw null; }
-        public static unsafe void StoreAligned(double* address, Vector256<double> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(sbyte* address, Vector256<sbyte> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(byte* address, Vector256<byte> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(short* address, Vector256<short> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(ushort* address, Vector256<ushort> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(int* address, Vector256<int> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(uint* address, Vector256<uint> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(long* address, Vector256<long> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(ulong* address, Vector256<ulong> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(float* address, Vector256<float> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(double* address, Vector256<double> source) { throw null; }
-        public static unsafe void Store(sbyte* address, Vector256<sbyte> source) { throw null; }
-        public static unsafe void Store(byte* address, Vector256<byte> source) { throw null; }
-        public static unsafe void Store(short* address, Vector256<short> source) { throw null; }
-        public static unsafe void Store(ushort* address, Vector256<ushort> source) { throw null; }
-        public static unsafe void Store(int* address, Vector256<int> source) { throw null; }
-        public static unsafe void Store(uint* address, Vector256<uint> source) { throw null; }
-        public static unsafe void Store(long* address, Vector256<long> source) { throw null; }
-        public static unsafe void Store(ulong* address, Vector256<ulong> source) { throw null; }
-        public static unsafe void Store(float* address, Vector256<float> source) { throw null; }
-        public static unsafe void Store(double* address, Vector256<double> source) { throw null; }
-        public static Vector256<float> Subtract(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> Subtract(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static bool TestC(Vector128<float> left, Vector128<float> right) { throw null; } 
-        public static bool TestC(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool TestC(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static bool TestC(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static bool TestC(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static bool TestC(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static bool TestC(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static bool TestC(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static bool TestC(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static bool TestC(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static bool TestC(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static bool TestC(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<float> left, Vector128<float> right) { throw null; } 
-        public static bool TestNotZAndNotC(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static bool TestZ(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool TestZ(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool TestZ(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static bool TestZ(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static bool TestZ(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static bool TestZ(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static bool TestZ(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static bool TestZ(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static bool TestZ(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static bool TestZ(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static bool TestZ(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static bool TestZ(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> UnpackHigh(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> UnpackHigh(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> UnpackLow(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> UnpackLow(Vector256<double> left, Vector256<double> right) { throw null; }
-        public static Vector256<float> Xor(Vector256<float> left, Vector256<float> right) { throw null; }
-        public static Vector256<double> Xor(Vector256<double> left, Vector256<double> right) { throw null; }
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector256<double> Add(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Add(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> AddSubtract(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> AddSubtract(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> And(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> And(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> AndNot(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> AndNot(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Blend(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Blend(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> BlendVariable(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right, System.Runtime.Intrinsics.Vector256<double> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> BlendVariable(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right, System.Runtime.Intrinsics.Vector256<float> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> BroadcastScalarToVector128(float* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> BroadcastScalarToVector256(double* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> BroadcastScalarToVector256(float* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> BroadcastVector128ToVector256(double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> BroadcastVector128ToVector256(float* address) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Ceiling(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Ceiling(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Compare(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, System.Runtime.Intrinsics.X86.FloatComparisonMode mode) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Compare(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, System.Runtime.Intrinsics.X86.FloatComparisonMode mode) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Compare(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right, System.Runtime.Intrinsics.X86.FloatComparisonMode mode) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Compare(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right, System.Runtime.Intrinsics.X86.FloatComparisonMode mode) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, System.Runtime.Intrinsics.X86.FloatComparisonMode mode) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, System.Runtime.Intrinsics.X86.FloatComparisonMode mode) { throw null; }
+        public static float ConvertToSingle(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32WithTruncation(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ConvertToVector128Single(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> ConvertToVector256Double(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> ConvertToVector256Double(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32WithTruncation(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> ConvertToVector256Single(System.Runtime.Intrinsics.Vector256<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Divide(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Divide(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> DotProduct(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> DuplicateEvenIndexed(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> DuplicateEvenIndexed(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> DuplicateOddIndexed(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<T> ExtendToVector256<T>(System.Runtime.Intrinsics.Vector128<T> value) where T : struct { throw null; }
+        public static byte Extract(System.Runtime.Intrinsics.Vector256<byte> value, byte index) { throw null; }
+        public static int Extract(System.Runtime.Intrinsics.Vector256<int> value, byte index) { throw null; }
+        public static long Extract(System.Runtime.Intrinsics.Vector256<long> value, byte index) { throw null; }
+        public static ushort Extract(System.Runtime.Intrinsics.Vector256<ushort> value, byte index) { throw null; }
+        public static uint Extract(System.Runtime.Intrinsics.Vector256<uint> value, byte index) { throw null; }
+        public static ulong Extract(System.Runtime.Intrinsics.Vector256<ulong> value, byte index) { throw null; }
+        public unsafe static void ExtractVector128(byte* address, System.Runtime.Intrinsics.Vector256<byte> value, byte index) { }
+        public unsafe static void ExtractVector128(double* address, System.Runtime.Intrinsics.Vector256<double> value, byte index) { }
+        public unsafe static void ExtractVector128(short* address, System.Runtime.Intrinsics.Vector256<short> value, byte index) { }
+        public unsafe static void ExtractVector128(int* address, System.Runtime.Intrinsics.Vector256<int> value, byte index) { }
+        public unsafe static void ExtractVector128(long* address, System.Runtime.Intrinsics.Vector256<long> value, byte index) { }
+        public static System.Runtime.Intrinsics.Vector128<byte> ExtractVector128(System.Runtime.Intrinsics.Vector256<byte> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> ExtractVector128(System.Runtime.Intrinsics.Vector256<double> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ExtractVector128(System.Runtime.Intrinsics.Vector256<short> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ExtractVector128(System.Runtime.Intrinsics.Vector256<int> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ExtractVector128(System.Runtime.Intrinsics.Vector256<long> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> ExtractVector128(System.Runtime.Intrinsics.Vector256<sbyte> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ExtractVector128(System.Runtime.Intrinsics.Vector256<float> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ExtractVector128(System.Runtime.Intrinsics.Vector256<ushort> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ExtractVector128(System.Runtime.Intrinsics.Vector256<uint> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ExtractVector128(System.Runtime.Intrinsics.Vector256<ulong> value, byte index) { throw null; }
+        public unsafe static void ExtractVector128(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> value, byte index) { }
+        public unsafe static void ExtractVector128(float* address, System.Runtime.Intrinsics.Vector256<float> value, byte index) { }
+        public unsafe static void ExtractVector128(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> value, byte index) { }
+        public unsafe static void ExtractVector128(uint* address, System.Runtime.Intrinsics.Vector256<uint> value, byte index) { }
+        public unsafe static void ExtractVector128(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> value, byte index) { }
+        public static System.Runtime.Intrinsics.Vector256<double> Floor(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Floor(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> GetLowerHalf<T>(System.Runtime.Intrinsics.Vector256<T> value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> HorizontalAdd(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> HorizontalAdd(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> HorizontalSubtract(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> HorizontalSubtract(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Insert(System.Runtime.Intrinsics.Vector256<byte> value, byte data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Insert(System.Runtime.Intrinsics.Vector256<short> value, short data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Insert(System.Runtime.Intrinsics.Vector256<int> value, int data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> Insert(System.Runtime.Intrinsics.Vector256<long> value, long data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Insert(System.Runtime.Intrinsics.Vector256<sbyte> value, sbyte data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Insert(System.Runtime.Intrinsics.Vector256<ushort> value, ushort data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Insert(System.Runtime.Intrinsics.Vector256<uint> value, uint data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> Insert(System.Runtime.Intrinsics.Vector256<ulong> value, ulong data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<byte> InsertVector128(System.Runtime.Intrinsics.Vector256<byte> value, byte* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> InsertVector128(System.Runtime.Intrinsics.Vector256<byte> value, System.Runtime.Intrinsics.Vector128<byte> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> InsertVector128(System.Runtime.Intrinsics.Vector256<double> value, double* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> InsertVector128(System.Runtime.Intrinsics.Vector256<double> value, System.Runtime.Intrinsics.Vector128<double> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<short> InsertVector128(System.Runtime.Intrinsics.Vector256<short> value, short* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> InsertVector128(System.Runtime.Intrinsics.Vector256<short> value, System.Runtime.Intrinsics.Vector128<short> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> InsertVector128(System.Runtime.Intrinsics.Vector256<int> value, int* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> InsertVector128(System.Runtime.Intrinsics.Vector256<int> value, System.Runtime.Intrinsics.Vector128<int> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> InsertVector128(System.Runtime.Intrinsics.Vector256<long> value, long* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> InsertVector128(System.Runtime.Intrinsics.Vector256<long> value, System.Runtime.Intrinsics.Vector128<long> data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> InsertVector128(System.Runtime.Intrinsics.Vector256<sbyte> value, System.Runtime.Intrinsics.Vector128<sbyte> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<sbyte> InsertVector128(System.Runtime.Intrinsics.Vector256<sbyte> value, sbyte* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> InsertVector128(System.Runtime.Intrinsics.Vector256<float> value, System.Runtime.Intrinsics.Vector128<float> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> InsertVector128(System.Runtime.Intrinsics.Vector256<float> value, float* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> InsertVector128(System.Runtime.Intrinsics.Vector256<ushort> value, System.Runtime.Intrinsics.Vector128<ushort> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ushort> InsertVector128(System.Runtime.Intrinsics.Vector256<ushort> value, ushort* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> InsertVector128(System.Runtime.Intrinsics.Vector256<uint> value, System.Runtime.Intrinsics.Vector128<uint> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> InsertVector128(System.Runtime.Intrinsics.Vector256<uint> value, uint* address, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> InsertVector128(System.Runtime.Intrinsics.Vector256<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> InsertVector128(System.Runtime.Intrinsics.Vector256<ulong> value, ulong* address, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<byte> LoadAlignedVector256(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> LoadAlignedVector256(double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<short> LoadAlignedVector256(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> LoadAlignedVector256(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> LoadAlignedVector256(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<sbyte> LoadAlignedVector256(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> LoadAlignedVector256(float* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ushort> LoadAlignedVector256(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> LoadAlignedVector256(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> LoadAlignedVector256(ulong* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<byte> LoadDquVector256(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<short> LoadDquVector256(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> LoadDquVector256(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> LoadDquVector256(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<sbyte> LoadDquVector256(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ushort> LoadDquVector256(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> LoadDquVector256(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> LoadDquVector256(ulong* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<byte> LoadVector256(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> LoadVector256(double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<short> LoadVector256(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> LoadVector256(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> LoadVector256(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<sbyte> LoadVector256(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> LoadVector256(float* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ushort> LoadVector256(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> LoadVector256(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> LoadVector256(ulong* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector128<double> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector256<double> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector128<float> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector256<float> mask) { throw null; }
+        public unsafe static void MaskStore(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> source) { }
+        public unsafe static void MaskStore(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> source) { }
+        public unsafe static void MaskStore(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> source) { }
+        public unsafe static void MaskStore(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> source) { }
+        public static System.Runtime.Intrinsics.Vector256<double> Max(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Max(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Min(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Min(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static int MoveMask(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static int MoveMask(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Multiply(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Multiply(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Or(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Or(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Permute(System.Runtime.Intrinsics.Vector128<double> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Permute(System.Runtime.Intrinsics.Vector128<float> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Permute(System.Runtime.Intrinsics.Vector256<double> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Permute(System.Runtime.Intrinsics.Vector256<float> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Permute2x128(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Permute2x128(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Permute2x128(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Permute2x128(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> Permute2x128(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Permute2x128(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Permute2x128(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Permute2x128(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Permute2x128(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> Permute2x128(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> PermuteVar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<long> control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> PermuteVar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<int> control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> PermuteVar(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<long> control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> PermuteVar(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<int> control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Reciprocal(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> ReciprocalSqrt(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> RoundCurrentDirection(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> RoundCurrentDirection(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> RoundToNearestInteger(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> RoundToNearestInteger(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> RoundToNegativeInfinity(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> RoundToNegativeInfinity(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> RoundToPositiveInfinity(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> RoundToPositiveInfinity(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> RoundToZero(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> RoundToZero(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<T> SetAllVector256<T>(T value) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<T> SetHighLow<T>(System.Runtime.Intrinsics.Vector128<T> hi, System.Runtime.Intrinsics.Vector128<T> lo) where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> SetVector256(byte e31, byte e30, byte e29, byte e28, byte e27, byte e26, byte e25, byte e24, byte e23, byte e22, byte e21, byte e20, byte e19, byte e18, byte e17, byte e16, byte e15, byte e14, byte e13, byte e12, byte e11, byte e10, byte e9, byte e8, byte e7, byte e6, byte e5, byte e4, byte e3, byte e2, byte e1, byte e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> SetVector256(double e3, double e2, double e1, double e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> SetVector256(short e15, short e14, short e13, short e12, short e11, short e10, short e9, short e8, short e7, short e6, short e5, short e4, short e3, short e2, short e1, short e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> SetVector256(int e7, int e6, int e5, int e4, int e3, int e2, int e1, int e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> SetVector256(long e3, long e2, long e1, long e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> SetVector256(sbyte e31, sbyte e30, sbyte e29, sbyte e28, sbyte e27, sbyte e26, sbyte e25, sbyte e24, sbyte e23, sbyte e22, sbyte e21, sbyte e20, sbyte e19, sbyte e18, sbyte e17, sbyte e16, sbyte e15, sbyte e14, sbyte e13, sbyte e12, sbyte e11, sbyte e10, sbyte e9, sbyte e8, sbyte e7, sbyte e6, sbyte e5, sbyte e4, sbyte e3, sbyte e2, sbyte e1, sbyte e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> SetVector256(float e7, float e6, float e5, float e4, float e3, float e2, float e1, float e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> SetVector256(ushort e15, ushort e14, ushort e13, ushort e12, ushort e11, ushort e10, ushort e9, ushort e8, ushort e7, ushort e6, ushort e5, ushort e4, ushort e3, ushort e2, ushort e1, ushort e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> SetVector256(uint e7, uint e6, uint e5, uint e4, uint e3, uint e2, uint e1, uint e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> SetVector256(ulong e3, ulong e2, ulong e1, ulong e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<T> SetZeroVector256<T>() where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Shuffle(System.Runtime.Intrinsics.Vector256<double> value, System.Runtime.Intrinsics.Vector256<double> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Shuffle(System.Runtime.Intrinsics.Vector256<float> value, System.Runtime.Intrinsics.Vector256<float> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Sqrt(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Sqrt(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<U> StaticCast<T, U>(System.Runtime.Intrinsics.Vector256<T> value) where T : struct where U : struct { throw null; }
+        public unsafe static void Store(byte* address, System.Runtime.Intrinsics.Vector256<byte> source) { }
+        public unsafe static void Store(double* address, System.Runtime.Intrinsics.Vector256<double> source) { }
+        public unsafe static void Store(short* address, System.Runtime.Intrinsics.Vector256<short> source) { }
+        public unsafe static void Store(int* address, System.Runtime.Intrinsics.Vector256<int> source) { }
+        public unsafe static void Store(long* address, System.Runtime.Intrinsics.Vector256<long> source) { }
+        public unsafe static void Store(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> source) { }
+        public unsafe static void Store(float* address, System.Runtime.Intrinsics.Vector256<float> source) { }
+        public unsafe static void Store(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> source) { }
+        public unsafe static void Store(uint* address, System.Runtime.Intrinsics.Vector256<uint> source) { }
+        public unsafe static void Store(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> source) { }
+        public unsafe static void StoreAligned(byte* address, System.Runtime.Intrinsics.Vector256<byte> source) { }
+        public unsafe static void StoreAligned(double* address, System.Runtime.Intrinsics.Vector256<double> source) { }
+        public unsafe static void StoreAligned(short* address, System.Runtime.Intrinsics.Vector256<short> source) { }
+        public unsafe static void StoreAligned(int* address, System.Runtime.Intrinsics.Vector256<int> source) { }
+        public unsafe static void StoreAligned(long* address, System.Runtime.Intrinsics.Vector256<long> source) { }
+        public unsafe static void StoreAligned(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> source) { }
+        public unsafe static void StoreAligned(float* address, System.Runtime.Intrinsics.Vector256<float> source) { }
+        public unsafe static void StoreAligned(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> source) { }
+        public unsafe static void StoreAligned(uint* address, System.Runtime.Intrinsics.Vector256<uint> source) { }
+        public unsafe static void StoreAligned(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> source) { }
+        public unsafe static void StoreAlignedNonTemporal(byte* address, System.Runtime.Intrinsics.Vector256<byte> source) { }
+        public unsafe static void StoreAlignedNonTemporal(double* address, System.Runtime.Intrinsics.Vector256<double> source) { }
+        public unsafe static void StoreAlignedNonTemporal(short* address, System.Runtime.Intrinsics.Vector256<short> source) { }
+        public unsafe static void StoreAlignedNonTemporal(int* address, System.Runtime.Intrinsics.Vector256<int> source) { }
+        public unsafe static void StoreAlignedNonTemporal(long* address, System.Runtime.Intrinsics.Vector256<long> source) { }
+        public unsafe static void StoreAlignedNonTemporal(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> source) { }
+        public unsafe static void StoreAlignedNonTemporal(float* address, System.Runtime.Intrinsics.Vector256<float> source) { }
+        public unsafe static void StoreAlignedNonTemporal(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> source) { }
+        public unsafe static void StoreAlignedNonTemporal(uint* address, System.Runtime.Intrinsics.Vector256<uint> source) { }
+        public unsafe static void StoreAlignedNonTemporal(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> source) { }
+        public static System.Runtime.Intrinsics.Vector256<double> Subtract(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Subtract(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> UnpackHigh(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> UnpackHigh(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> UnpackLow(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> UnpackLow(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Xor(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Xor(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
     }
-    public abstract class Avx2 : Avx
+    public abstract partial class Avx2 : System.Runtime.Intrinsics.X86.Avx
     {
         internal Avx2() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector256<byte> Abs(Vector256<sbyte> value) { throw null; }
-        public static Vector256<ushort> Abs(Vector256<short> value) { throw null; }
-        public static Vector256<uint> Abs(Vector256<int> value) { throw null; }
-        public static Vector256<sbyte> Add(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> Add(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> Add(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> Add(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> Add(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> Add(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> Add(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> Add(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static Vector256<sbyte> AddSaturate(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> AddSaturate(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> AddSaturate(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> AddSaturate(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<sbyte> AlignRight(Vector256<sbyte> left, Vector256<sbyte> right, byte mask) { throw null; }
-        public static Vector256<byte> AlignRight(Vector256<byte> left, Vector256<byte> right, byte mask) { throw null; }
-        public static Vector256<short> AlignRight(Vector256<short> left, Vector256<short> right, byte mask) { throw null; }
-        public static Vector256<ushort> AlignRight(Vector256<ushort> left, Vector256<ushort> right, byte mask) { throw null; }
-        public static Vector256<int> AlignRight(Vector256<int> left, Vector256<int> right, byte mask) { throw null; }
-        public static Vector256<uint> AlignRight(Vector256<uint> left, Vector256<uint> right, byte mask) { throw null; }
-        public static Vector256<long> AlignRight(Vector256<long> left, Vector256<long> right, byte mask) { throw null; }
-        public static Vector256<ulong> AlignRight(Vector256<ulong> left, Vector256<ulong> right, byte mask) { throw null; }
-        public static Vector256<sbyte> And(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> And(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> And(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> And(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> And(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> And(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> And(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> And(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static Vector256<sbyte> AndNot(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> AndNot(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> AndNot(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> AndNot(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> AndNot(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> AndNot(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> AndNot(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> AndNot(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static Vector256<byte> Average(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<ushort> Average(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector128<int> Blend(Vector128<int> left, Vector128<int> right, byte control) { throw null; }
-        public static Vector128<uint> Blend(Vector128<uint> left, Vector128<uint> right, byte control) { throw null; }
-        public static Vector256<short> Blend(Vector256<short> left, Vector256<short> right, byte control) { throw null; }
-        public static Vector256<ushort> Blend(Vector256<ushort> left, Vector256<ushort> right, byte control) { throw null; }
-        public static Vector256<int> Blend(Vector256<int> left, Vector256<int> right, byte control) { throw null; }
-        public static Vector256<uint> Blend(Vector256<uint> left, Vector256<uint> right, byte control) { throw null; }
-        public static Vector256<sbyte> BlendVariable(Vector256<sbyte> left, Vector256<sbyte> right, Vector256<sbyte> mask) { throw null; }
-        public static Vector256<byte> BlendVariable(Vector256<byte> left, Vector256<byte> right, Vector256<byte> mask) { throw null; }
-        public static Vector256<short> BlendVariable(Vector256<short> left, Vector256<short> right, Vector256<short> mask) { throw null; }
-        public static Vector256<ushort> BlendVariable(Vector256<ushort> left, Vector256<ushort> right, Vector256<ushort> mask) { throw null; }
-        public static Vector256<int> BlendVariable(Vector256<int> left, Vector256<int> right, Vector256<int> mask) { throw null; }
-        public static Vector256<uint> BlendVariable(Vector256<uint> left, Vector256<uint> right, Vector256<uint> mask) { throw null; }
-        public static Vector256<long> BlendVariable(Vector256<long> left, Vector256<long> right, Vector256<long> mask) { throw null; }
-        public static Vector256<ulong> BlendVariable(Vector256<ulong> left, Vector256<ulong> right, Vector256<ulong> mask) { throw null; }
-        public static Vector128<byte> BroadcastScalarToVector128(Vector128<byte> value) { throw null; }
-        public static Vector128<sbyte> BroadcastScalarToVector128(Vector128<sbyte> value) { throw null; }
-        public static Vector128<short> BroadcastScalarToVector128(Vector128<short> value) { throw null; }
-        public static Vector128<ushort> BroadcastScalarToVector128(Vector128<ushort> value) { throw null; }
-        public static Vector128<int> BroadcastScalarToVector128(Vector128<int> value) { throw null; }
-        public static Vector128<uint> BroadcastScalarToVector128(Vector128<uint> value) { throw null; }
-        public static Vector128<long> BroadcastScalarToVector128(Vector128<long> value) { throw null; }
-        public static Vector128<ulong> BroadcastScalarToVector128(Vector128<ulong> value) { throw null; }
-        public static Vector128<float> BroadcastScalarToVector128(Vector128<float> value) { throw null; }
-        public static Vector128<double> BroadcastScalarToVector128(Vector128<double> value) { throw null; }
-        public static unsafe Vector128<byte> BroadcastScalarToVector128(byte* source) { throw null; }
-        public static unsafe Vector128<sbyte> BroadcastScalarToVector128(sbyte* source) { throw null; }
-        public static unsafe Vector128<short> BroadcastScalarToVector128(short* source) { throw null; }
-        public static unsafe Vector128<ushort> BroadcastScalarToVector128(ushort* source) { throw null; }
-        public static unsafe Vector128<int> BroadcastScalarToVector128(int* source) { throw null; }
-        public static unsafe Vector128<uint> BroadcastScalarToVector128(uint* source) { throw null; }
-        public static unsafe Vector128<long> BroadcastScalarToVector128(long* source) { throw null; }
-        public static unsafe Vector128<ulong> BroadcastScalarToVector128(ulong* source) { throw null; }
-        public static Vector256<byte> BroadcastScalarToVector256(Vector128<byte> value) { throw null; }
-        public static Vector256<sbyte> BroadcastScalarToVector256(Vector128<sbyte> value) { throw null; }
-        public static Vector256<short> BroadcastScalarToVector256(Vector128<short> value) { throw null; }
-        public static Vector256<ushort> BroadcastScalarToVector256(Vector128<ushort> value) { throw null; }
-        public static Vector256<int> BroadcastScalarToVector256(Vector128<int> value) { throw null; }
-        public static Vector256<uint> BroadcastScalarToVector256(Vector128<uint> value) { throw null; }
-        public static Vector256<long> BroadcastScalarToVector256(Vector128<long> value) { throw null; }
-        public static Vector256<ulong> BroadcastScalarToVector256(Vector128<ulong> value) { throw null; }
-        public static Vector256<float> BroadcastScalarToVector256(Vector128<float> value) { throw null; }
-        public static Vector256<double> BroadcastScalarToVector256(Vector128<double> value) { throw null; }
-        public static unsafe Vector256<byte> BroadcastScalarToVector256(byte* source) { throw null; }
-        public static unsafe Vector256<sbyte> BroadcastScalarToVector256(sbyte* source) { throw null; }
-        public static unsafe Vector256<short> BroadcastScalarToVector256(short* source) { throw null; }
-        public static unsafe Vector256<ushort> BroadcastScalarToVector256(ushort* source) { throw null; }
-        public static unsafe Vector256<int> BroadcastScalarToVector256(int* source) { throw null; }
-        public static unsafe Vector256<uint> BroadcastScalarToVector256(uint* source) { throw null; }
-        public static unsafe Vector256<long> BroadcastScalarToVector256(long* source) { throw null; }
-        public static unsafe Vector256<ulong> BroadcastScalarToVector256(ulong* source) { throw null; }
-        public static unsafe Vector256<sbyte> BroadcastVector128ToVector256(sbyte* address) { throw null; }
-        public static unsafe Vector256<byte> BroadcastVector128ToVector256(byte* address) { throw null; }
-        public static unsafe Vector256<short> BroadcastVector128ToVector256(short* address) { throw null; }
-        public static unsafe Vector256<ushort> BroadcastVector128ToVector256(ushort* address) { throw null; }
-        public static unsafe Vector256<int> BroadcastVector128ToVector256(int* address) { throw null; }
-        public static unsafe Vector256<uint> BroadcastVector128ToVector256(uint* address) { throw null; }
-        public static unsafe Vector256<long> BroadcastVector128ToVector256(long* address) { throw null; }
-        public static unsafe Vector256<ulong> BroadcastVector128ToVector256(ulong* address) { throw null; }
-        public static Vector256<sbyte> CompareEqual(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> CompareEqual(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> CompareEqual(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> CompareEqual(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> CompareEqual(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> CompareEqual(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> CompareEqual(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> CompareEqual(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static Vector256<sbyte> CompareGreaterThan(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<short> CompareGreaterThan(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<int> CompareGreaterThan(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<long> CompareGreaterThan(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static double ConvertToDouble(Vector256<double> value) { throw null; }
-        public static int ConvertToInt32(Vector256<int> value) { throw null; }
-        public static uint ConvertToUInt32(Vector256<uint> value) { throw null; }
-        public static Vector256<short> ConvertToVector256Int16(Vector128<sbyte> value) { throw null; }
-        public static Vector256<ushort> ConvertToVector256UInt16(Vector128<byte> value) { throw null; }
-        public static Vector256<int> ConvertToVector256Int32(Vector128<sbyte> value) { throw null; }
-        public static Vector256<int> ConvertToVector256Int32(Vector128<short> value) { throw null; }
-        public static Vector256<uint> ConvertToVector256UInt32(Vector128<byte> value) { throw null; }
-        public static Vector256<uint> ConvertToVector256UInt32(Vector128<ushort> value) { throw null; }
-        public static Vector256<long> ConvertToVector256Int64(Vector128<sbyte> value) { throw null; }
-        public static Vector256<long> ConvertToVector256Int64(Vector128<short> value) { throw null; }
-        public static Vector256<long> ConvertToVector256Int64(Vector128<int> value) { throw null; }
-        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<byte> value) { throw null; }
-        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<ushort> value) { throw null; }
-        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<uint> value) { throw null; }
-        public new static Vector128<sbyte> ExtractVector128(Vector256<sbyte> value, byte index) { throw null; }
-        public new static unsafe void ExtractVector128(sbyte* address, Vector256<sbyte> value, byte index) { throw null; }
-        public new static Vector128<byte> ExtractVector128(Vector256<byte> value, byte index) { throw null; }
-        public new static unsafe void ExtractVector128(byte* address, Vector256<byte> value, byte index) { throw null; }
-        public new static Vector128<short> ExtractVector128(Vector256<short> value, byte index) { throw null; }
-        public new static unsafe void ExtractVector128(short* address, Vector256<short> value, byte index) { throw null; }
-        public new static Vector128<ushort> ExtractVector128(Vector256<ushort> value, byte index) { throw null; }
-        public new static unsafe void ExtractVector128(ushort* address, Vector256<ushort> value, byte index) { throw null; }
-        public new static Vector128<int> ExtractVector128(Vector256<int> value, byte index) { throw null; }
-        public new static unsafe void ExtractVector128(int* address, Vector256<int> value, byte index) { throw null; }
-        public new static Vector128<uint> ExtractVector128(Vector256<uint> value, byte index) { throw null; }
-        public new static unsafe void ExtractVector128(uint* address, Vector256<uint> value, byte index) { throw null; }
-        public new static Vector128<long> ExtractVector128(Vector256<long> value, byte index) { throw null; }
-        public new static unsafe void ExtractVector128(long* address, Vector256<long> value, byte index) { throw null; }
-        public new static Vector128<ulong> ExtractVector128(Vector256<ulong> value, byte index) { throw null; }
-        public new static unsafe void ExtractVector128(ulong* address, Vector256<ulong> value, byte index) { throw null; }
-        public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector128<long> GatherVector128(long* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector128<ulong> GatherVector128(ulong* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector128<double> GatherVector128(double* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector128<long> index, byte scale) { throw null; }
-        public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector128<long> index, byte scale) { throw null; }
-        public static unsafe Vector128<long> GatherVector128(long* baseAddress, Vector128<long> index, byte scale) { throw null; }
-        public static unsafe Vector128<ulong> GatherVector128(ulong* baseAddress, Vector128<long> index, byte scale) { throw null; }
-        public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector128<long> index, byte scale) { throw null; }
-        public static unsafe Vector128<double> GatherVector128(double* baseAddress, Vector128<long> index, byte scale) { throw null; }
-        public static unsafe Vector256<int> GatherVector256(int* baseAddress, Vector256<int> index, byte scale) { throw null; }
-        public static unsafe Vector256<uint> GatherVector256(uint* baseAddress, Vector256<int> index, byte scale) { throw null; }
-        public static unsafe Vector256<long> GatherVector256(long* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector256<ulong> GatherVector256(ulong* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector256<float> GatherVector256(float* baseAddress, Vector256<int> index, byte scale) { throw null; }
-        public static unsafe Vector256<double> GatherVector256(double* baseAddress, Vector128<int> index, byte scale) { throw null; }
-        public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector256<long> index, byte scale) { throw null; }
-        public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector256<long> index, byte scale) { throw null; }
-        public static unsafe Vector256<long> GatherVector256(long* baseAddress, Vector256<long> index, byte scale) { throw null; }
-        public static unsafe Vector256<ulong> GatherVector256(ulong* baseAddress, Vector256<long> index, byte scale) { throw null; }
-        public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector256<long> index, byte scale) { throw null; }
-        public static unsafe Vector256<double> GatherVector256(double* baseAddress, Vector256<long> index, byte scale) { throw null; }
-        public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector128<int> index, Vector128<int> mask, byte scale) { throw null; }
-        public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector128<int> index, Vector128<uint> mask, byte scale) { throw null; }
-        public static unsafe Vector128<long> GatherMaskVector128(Vector128<long> source, long* baseAddress, Vector128<int> index, Vector128<long> mask, byte scale) { throw null; }
-        public static unsafe Vector128<ulong> GatherMaskVector128(Vector128<ulong> source, ulong* baseAddress, Vector128<int> index, Vector128<ulong> mask, byte scale) { throw null; }
-        public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector128<int> index, Vector128<float> mask, byte scale) { throw null; }
-        public static unsafe Vector128<double> GatherMaskVector128(Vector128<double> source, double* baseAddress, Vector128<int> index, Vector128<double> mask, byte scale) { throw null; }
-        public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector128<long> index, Vector128<int> mask, byte scale) { throw null; }
-        public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector128<long> index, Vector128<uint> mask, byte scale) { throw null; }
-        public static unsafe Vector128<long> GatherMaskVector128(Vector128<long> source, long* baseAddress, Vector128<long> index, Vector128<long> mask, byte scale) { throw null; }
-        public static unsafe Vector128<ulong> GatherMaskVector128(Vector128<ulong> source, ulong* baseAddress, Vector128<long> index, Vector128<ulong> mask, byte scale) { throw null; }
-        public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector128<long> index, Vector128<float> mask, byte scale) { throw null; }
-        public static unsafe Vector128<double> GatherMaskVector128(Vector128<double> source, double* baseAddress, Vector128<long> index, Vector128<double> mask, byte scale) { throw null; }
-        public static unsafe Vector256<int> GatherMaskVector256(Vector256<int> source, int* baseAddress, Vector256<int> index, Vector256<int> mask, byte scale) { throw null; }
-        public static unsafe Vector256<uint> GatherMaskVector256(Vector256<uint> source, uint* baseAddress, Vector256<int> index, Vector256<uint> mask, byte scale) { throw null; }
-        public static unsafe Vector256<long> GatherMaskVector256(Vector256<long> source, long* baseAddress, Vector128<int> index, Vector256<long> mask, byte scale) { throw null; }
-        public static unsafe Vector256<ulong> GatherMaskVector256(Vector256<ulong> source, ulong* baseAddress, Vector128<int> index, Vector256<ulong> mask, byte scale) { throw null; }
-        public static unsafe Vector256<float> GatherMaskVector256(Vector256<float> source, float* baseAddress, Vector256<int> index, Vector256<float> mask, byte scale) { throw null; }
-        public static unsafe Vector256<double> GatherMaskVector256(Vector256<double> source, double* baseAddress, Vector128<int> index, Vector256<double> mask, byte scale) { throw null; }
-        public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector256<long> index, Vector128<int> mask, byte scale) { throw null; }
-        public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector256<long> index, Vector128<uint> mask, byte scale) { throw null; }
-        public static unsafe Vector256<long> GatherMaskVector256(Vector256<long> source, long* baseAddress, Vector256<long> index, Vector256<long> mask, byte scale) { throw null; }
-        public static unsafe Vector256<ulong> GatherMaskVector256(Vector256<ulong> source, ulong* baseAddress, Vector256<long> index, Vector256<ulong> mask, byte scale) { throw null; }
-        public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector256<long> index, Vector128<float> mask, byte scale) { throw null; }
-        public static unsafe Vector256<double> GatherMaskVector256(Vector256<double> source, double* baseAddress, Vector256<long> index, Vector256<double> mask, byte scale) { throw null; }
-        public static Vector256<short> HorizontalAdd(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<int> HorizontalAdd(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<short> HorizontalAddSaturate(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<short> HorizontalSubtract(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<int> HorizontalSubtract(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<short> HorizontalSubtractSaturate(Vector256<short> left, Vector256<short> right) { throw null; }
-        public new static Vector256<sbyte> InsertVector128(Vector256<sbyte> value, Vector128<sbyte> data, byte index) { throw null; }
-        public new static unsafe Vector256<sbyte> InsertVector128(Vector256<sbyte> value, sbyte* address, byte index) { throw null; }
-        public new static Vector256<byte> InsertVector128(Vector256<byte> value, Vector128<byte> data, byte index) { throw null; }
-        public new static unsafe Vector256<byte> InsertVector128(Vector256<byte> value, byte* address, byte index) { throw null; }
-        public new static Vector256<short> InsertVector128(Vector256<short> value, Vector128<short> data, byte index) { throw null; }
-        public new static unsafe Vector256<short> InsertVector128(Vector256<short> value, short* address, byte index) { throw null; }
-        public new static Vector256<ushort> InsertVector128(Vector256<ushort> value, Vector128<ushort> data, byte index) { throw null; }
-        public new static unsafe Vector256<ushort> InsertVector128(Vector256<ushort> value, ushort* address, byte index) { throw null; }
-        public new static Vector256<int> InsertVector128(Vector256<int> value, Vector128<int> data, byte index) { throw null; }
-        public new static unsafe Vector256<int> InsertVector128(Vector256<int> value, int* address, byte index) { throw null; }
-        public new static Vector256<uint> InsertVector128(Vector256<uint> value, Vector128<uint> data, byte index) { throw null; }
-        public new static unsafe Vector256<uint> InsertVector128(Vector256<uint> value, uint* address, byte index) { throw null; }
-        public new static Vector256<long> InsertVector128(Vector256<long> value, Vector128<long> data, byte index) { throw null; }
-        public new static unsafe Vector256<long> InsertVector128(Vector256<long> value, long* address, byte index) { throw null; }
-        public new static Vector256<ulong> InsertVector128(Vector256<ulong> value, Vector128<ulong> data, byte index) { throw null; }
-        public new static unsafe Vector256<ulong> InsertVector128(Vector256<ulong> value, ulong* address, byte index) { throw null; }
-        public static unsafe Vector128<int> MaskLoad(int* address, Vector128<int> mask) { throw null; }
-        public static unsafe Vector256<sbyte> LoadAlignedVector256NonTemporal(sbyte* address) { throw null; }
-        public static unsafe Vector256<byte> LoadAlignedVector256NonTemporal(byte* address) { throw null; }
-        public static unsafe Vector256<short> LoadAlignedVector256NonTemporal(short* address) { throw null; }
-        public static unsafe Vector256<ushort> LoadAlignedVector256NonTemporal(ushort* address) { throw null; }
-        public static unsafe Vector256<int> LoadAlignedVector256NonTemporal(int* address) { throw null; }
-        public static unsafe Vector256<uint> LoadAlignedVector256NonTemporal(uint* address) { throw null; }
-        public static unsafe Vector256<long> LoadAlignedVector256NonTemporal(long* address) { throw null; }
-        public static unsafe Vector256<ulong> LoadAlignedVector256NonTemporal(ulong* address) { throw null; }
-        public static unsafe Vector128<uint> MaskLoad(uint* address, Vector128<uint> mask) { throw null; }
-        public static unsafe Vector128<long> MaskLoad(long* address, Vector128<long> mask) { throw null; }
-        public static unsafe Vector128<ulong> MaskLoad(ulong* address, Vector128<ulong> mask) { throw null; }
-        public static unsafe Vector256<int> MaskLoad(int* address, Vector256<int> mask) { throw null; }
-        public static unsafe Vector256<uint> MaskLoad(uint* address, Vector256<uint> mask) { throw null; }
-        public static unsafe Vector256<long> MaskLoad(long* address, Vector256<long> mask) { throw null; }
-        public static unsafe Vector256<ulong> MaskLoad(ulong* address, Vector256<ulong> mask) { throw null; }
-        public static unsafe void MaskStore(int* address, Vector128<int> mask, Vector128<int> source) { throw null; }
-        public static unsafe void MaskStore(uint* address, Vector128<uint> mask, Vector128<uint> source) { throw null; }
-        public static unsafe void MaskStore(long* address, Vector128<long> mask, Vector128<long> source) { throw null; }
-        public static unsafe void MaskStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) { throw null; }
-        public static unsafe void MaskStore(int* address, Vector256<int> mask, Vector256<int> source) { throw null; }
-        public static unsafe void MaskStore(uint* address, Vector256<uint> mask, Vector256<uint> source) { throw null; }
-        public static unsafe void MaskStore(long* address, Vector256<long> mask, Vector256<long> source) { throw null; }
-        public static unsafe void MaskStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) { throw null; }
-        public static Vector256<int> MultiplyAddAdjacent(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<short> MultiplyAddAdjacent(Vector256<byte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<sbyte> Max(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> Max(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> Max(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> Max(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> Max(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> Max(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<sbyte> Min(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> Min(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> Min(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> Min(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> Min(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> Min(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static int MoveMask(Vector256<sbyte> value) { throw null; }
-        public static int MoveMask(Vector256<byte> value) { throw null; }
-        public static Vector256<ushort> MultipleSumAbsoluteDifferences(Vector256<byte> left, Vector256<byte> right, byte mask) { throw null; }
-        public static Vector256<long> Multiply(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<ulong> Multiply(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<short> MultiplyHigh(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> MultiplyHigh(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<short> MultiplyHighRoundScale(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<short> MultiplyLow(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> MultiplyLow(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> MultiplyLow(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> MultiplyLow(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<sbyte> Or(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> Or(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> Or(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> Or(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> Or(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> Or(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> Or(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> Or(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static Vector256<sbyte> PackSignedSaturate(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<short> PackSignedSaturate(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<byte> PackUnsignedSaturate(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> PackUnsignedSaturate(Vector256<int> left, Vector256<int> right) { throw null; }
-        public new static Vector256<sbyte> Permute2x128(Vector256<sbyte> left, Vector256<sbyte> right, byte control) { throw null; }
-        public new static Vector256<byte> Permute2x128(Vector256<byte> left, Vector256<byte> right, byte control) { throw null; }
-        public new static Vector256<short> Permute2x128(Vector256<short> left, Vector256<short> right, byte control) { throw null; }
-        public new static Vector256<ushort> Permute2x128(Vector256<ushort> left, Vector256<ushort> right, byte control) { throw null; }
-        public new static Vector256<int> Permute2x128(Vector256<int> left, Vector256<int> right, byte control) { throw null; }
-        public new static Vector256<uint> Permute2x128(Vector256<uint> left, Vector256<uint> right, byte control) { throw null; }
-        public new static Vector256<long> Permute2x128(Vector256<long> left, Vector256<long> right, byte control) { throw null; }
-        public new static Vector256<ulong> Permute2x128(Vector256<ulong> left, Vector256<ulong> right, byte control) { throw null; }
-        public static Vector256<long> Permute4x64(Vector256<long> value, byte control) { throw null; }
-        public static Vector256<ulong> Permute4x64(Vector256<ulong> value, byte control) { throw null; }
-        public static Vector256<double> Permute4x64(Vector256<double> value, byte control) { throw null; }
-        public static Vector256<int> PermuteVar8x32(Vector256<int> left, Vector256<int> control) { throw null; }
-        public static Vector256<uint> PermuteVar8x32(Vector256<uint> left, Vector256<uint> control) { throw null; }
-        public static Vector256<float> PermuteVar8x32(Vector256<float> left, Vector256<int> control) { throw null; }
-        public static Vector256<short> ShiftLeftLogical(Vector256<short> value, Vector128<short> count) { throw null; }
-        public static Vector256<ushort> ShiftLeftLogical(Vector256<ushort> value, Vector128<ushort> count) { throw null; }
-        public static Vector256<int> ShiftLeftLogical(Vector256<int> value, Vector128<int> count) { throw null; }
-        public static Vector256<uint> ShiftLeftLogical(Vector256<uint> value, Vector128<uint> count) { throw null; }
-        public static Vector256<long> ShiftLeftLogical(Vector256<long> value, Vector128<long> count) { throw null; }
-        public static Vector256<ulong> ShiftLeftLogical(Vector256<ulong> value, Vector128<ulong> count) { throw null; }
-        public static Vector256<short> ShiftLeftLogical(Vector256<short> value, byte count) { throw null; }
-        public static Vector256<ushort> ShiftLeftLogical(Vector256<ushort> value, byte count) { throw null; }
-        public static Vector256<int> ShiftLeftLogical(Vector256<int> value, byte count) { throw null; }
-        public static Vector256<uint> ShiftLeftLogical(Vector256<uint> value, byte count) { throw null; }
-        public static Vector256<long> ShiftLeftLogical(Vector256<long> value, byte count) { throw null; }
-        public static Vector256<ulong> ShiftLeftLogical(Vector256<ulong> value, byte count) { throw null; }
-        public static Vector256<sbyte> ShiftLeftLogical128BitLane(Vector256<sbyte> value, byte numBytes) { throw null; }
-        public static Vector256<byte> ShiftLeftLogical128BitLane(Vector256<byte> value, byte numBytes) { throw null; }
-        public static Vector256<short> ShiftLeftLogical128BitLane(Vector256<short> value, byte numBytes) { throw null; }
-        public static Vector256<ushort> ShiftLeftLogical128BitLane(Vector256<ushort> value, byte numBytes) { throw null; }
-        public static Vector256<int> ShiftLeftLogical128BitLane(Vector256<int> value, byte numBytes) { throw null; }
-        public static Vector256<uint> ShiftLeftLogical128BitLane(Vector256<uint> value, byte numBytes) { throw null; }
-        public static Vector256<long> ShiftLeftLogical128BitLane(Vector256<long> value, byte numBytes) { throw null; }
-        public static Vector256<ulong> ShiftLeftLogical128BitLane(Vector256<ulong> value, byte numBytes) { throw null; }
-        public static Vector256<int> ShiftLeftLogicalVariable(Vector256<int> value, Vector256<uint> count) { throw null; }
-        public static Vector256<uint> ShiftLeftLogicalVariable(Vector256<uint> value, Vector256<uint> count) { throw null; }
-        public static Vector256<long> ShiftLeftLogicalVariable(Vector256<long> value, Vector256<ulong> count) { throw null; }
-        public static Vector256<ulong> ShiftLeftLogicalVariable(Vector256<ulong> value, Vector256<ulong> count) { throw null; }
-        public static Vector128<int> ShiftLeftLogicalVariable(Vector128<int> value, Vector128<uint> count) { throw null; }
-        public static Vector128<uint> ShiftLeftLogicalVariable(Vector128<uint> value, Vector128<uint> count) { throw null; }
-        public static Vector128<long> ShiftLeftLogicalVariable(Vector128<long> value, Vector128<ulong> count) { throw null; }
-        public static Vector128<ulong> ShiftLeftLogicalVariable(Vector128<ulong> value, Vector128<ulong> count) { throw null; }
-        public static Vector256<short> ShiftRightArithmetic(Vector256<short> value, Vector128<short> count) { throw null; }
-        public static Vector256<int> ShiftRightArithmetic(Vector256<int> value, Vector128<int> count) { throw null; }
-        public static Vector256<short> ShiftRightArithmetic(Vector256<short> value, byte count) { throw null; }
-        public static Vector256<int> ShiftRightArithmetic(Vector256<int> value, byte count) { throw null; }
-        public static Vector256<int> ShiftRightArithmeticVariable(Vector256<int> value, Vector256<uint> count) { throw null; }
-        public static Vector128<int> ShiftRightArithmeticVariable(Vector128<int> value, Vector128<uint> count) { throw null; }
-        public static Vector256<short> ShiftRightLogical(Vector256<short> value, Vector128<short> count) { throw null; }
-        public static Vector256<ushort> ShiftRightLogical(Vector256<ushort> value, Vector128<ushort> count) { throw null; }
-        public static Vector256<int> ShiftRightLogical(Vector256<int> value, Vector128<int> count) { throw null; }
-        public static Vector256<uint> ShiftRightLogical(Vector256<uint> value, Vector128<uint> count) { throw null; }
-        public static Vector256<long> ShiftRightLogical(Vector256<long> value, Vector128<long> count) { throw null; }
-        public static Vector256<ulong> ShiftRightLogical(Vector256<ulong> value, Vector128<ulong> count) { throw null; }
-        public static Vector256<short> ShiftRightLogical(Vector256<short> value, byte count) { throw null; }
-        public static Vector256<ushort> ShiftRightLogical(Vector256<ushort> value, byte count) { throw null; }
-        public static Vector256<int> ShiftRightLogical(Vector256<int> value, byte count) { throw null; }
-        public static Vector256<uint> ShiftRightLogical(Vector256<uint> value, byte count) { throw null; }
-        public static Vector256<long> ShiftRightLogical(Vector256<long> value, byte count) { throw null; }
-        public static Vector256<ulong> ShiftRightLogical(Vector256<ulong> value, byte count) { throw null; }
-        public static Vector256<sbyte> ShiftRightLogical128BitLane(Vector256<sbyte> value, byte numBytes) { throw null; }
-        public static Vector256<byte> ShiftRightLogical128BitLane(Vector256<byte> value, byte numBytes) { throw null; }
-        public static Vector256<short> ShiftRightLogical128BitLane(Vector256<short> value, byte numBytes) { throw null; }
-        public static Vector256<ushort> ShiftRightLogical128BitLane(Vector256<ushort> value, byte numBytes) { throw null; }
-        public static Vector256<int> ShiftRightLogical128BitLane(Vector256<int> value, byte numBytes) { throw null; }
-        public static Vector256<uint> ShiftRightLogical128BitLane(Vector256<uint> value, byte numBytes) { throw null; }
-        public static Vector256<long> ShiftRightLogical128BitLane(Vector256<long> value, byte numBytes) { throw null; }
-        public static Vector256<ulong> ShiftRightLogical128BitLane(Vector256<ulong> value, byte numBytes) { throw null; }
-        public static Vector256<int> ShiftRightLogicalVariable(Vector256<int> value, Vector256<uint> count) { throw null; }
-        public static Vector256<uint> ShiftRightLogicalVariable(Vector256<uint> value, Vector256<uint> count) { throw null; }
-        public static Vector256<long> ShiftRightLogicalVariable(Vector256<long> value, Vector256<ulong> count) { throw null; }
-        public static Vector256<ulong> ShiftRightLogicalVariable(Vector256<ulong> value, Vector256<ulong> count) { throw null; }
-        public static Vector128<int> ShiftRightLogicalVariable(Vector128<int> value, Vector128<uint> count) { throw null; }
-        public static Vector128<uint> ShiftRightLogicalVariable(Vector128<uint> value, Vector128<uint> count) { throw null; }
-        public static Vector128<long> ShiftRightLogicalVariable(Vector128<long> value, Vector128<ulong> count) { throw null; }
-        public static Vector128<ulong> ShiftRightLogicalVariable(Vector128<ulong> value, Vector128<ulong> count) { throw null; }
-        public static Vector256<sbyte> Shuffle(Vector256<sbyte> value, Vector256<sbyte> mask) { throw null; }
-        public static Vector256<byte> Shuffle(Vector256<byte> value, Vector256<byte> mask) { throw null; }
-        public static Vector256<int> Shuffle(Vector256<int> value, byte control) { throw null; }
-        public static Vector256<uint> Shuffle(Vector256<uint> value, byte control) { throw null; }
-        public static Vector256<short> ShuffleHigh(Vector256<short> value, byte control) { throw null; }
-        public static Vector256<ushort> ShuffleHigh(Vector256<ushort> value, byte control) { throw null; }
-        public static Vector256<short> ShuffleLow(Vector256<short> value, byte control) { throw null; }
-        public static Vector256<ushort> ShuffleLow(Vector256<ushort> value, byte control) { throw null; }
-        public static Vector256<sbyte> Sign(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<short> Sign(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<int> Sign(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<sbyte> Subtract(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> Subtract(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> Subtract(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> Subtract(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> Subtract(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> Subtract(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> Subtract(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> Subtract(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static Vector256<sbyte> SubtractSaturate(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<short> SubtractSaturate(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<byte> SubtractSaturate(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<ushort> SubtractSaturate(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<ushort> SumAbsoluteDifferences(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<sbyte> UnpackHigh(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> UnpackHigh(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> UnpackHigh(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> UnpackHigh(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> UnpackHigh(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> UnpackHigh(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> UnpackHigh(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> UnpackHigh(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static Vector256<sbyte> UnpackLow(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> UnpackLow(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> UnpackLow(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> UnpackLow(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> UnpackLow(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> UnpackLow(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> UnpackLow(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> UnpackLow(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
-        public static Vector256<sbyte> Xor(Vector256<sbyte> left, Vector256<sbyte> right) { throw null; }
-        public static Vector256<byte> Xor(Vector256<byte> left, Vector256<byte> right) { throw null; }
-        public static Vector256<short> Xor(Vector256<short> left, Vector256<short> right) { throw null; }
-        public static Vector256<ushort> Xor(Vector256<ushort> left, Vector256<ushort> right) { throw null; }
-        public static Vector256<int> Xor(Vector256<int> left, Vector256<int> right) { throw null; }
-        public static Vector256<uint> Xor(Vector256<uint> left, Vector256<uint> right) { throw null; }
-        public static Vector256<long> Xor(Vector256<long> left, Vector256<long> right) { throw null; }
-        public static Vector256<ulong> Xor(Vector256<ulong> left, Vector256<ulong> right) { throw null; }
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Abs(System.Runtime.Intrinsics.Vector256<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Abs(System.Runtime.Intrinsics.Vector256<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Abs(System.Runtime.Intrinsics.Vector256<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Add(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Add(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Add(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> Add(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Add(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Add(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Add(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> Add(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> AddSaturate(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> AddSaturate(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> AddSaturate(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> AddSaturate(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> AlignRight(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> AlignRight(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> AlignRight(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> AlignRight(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> AlignRight(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> AlignRight(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> AlignRight(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> AlignRight(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> And(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> And(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> And(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> And(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> And(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> And(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> And(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> And(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> AndNot(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> AndNot(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> AndNot(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> AndNot(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> AndNot(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> AndNot(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> AndNot(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> AndNot(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Average(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Average(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Blend(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Blend(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Blend(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Blend(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Blend(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Blend(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> BlendVariable(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right, System.Runtime.Intrinsics.Vector256<byte> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> BlendVariable(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right, System.Runtime.Intrinsics.Vector256<short> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> BlendVariable(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right, System.Runtime.Intrinsics.Vector256<int> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> BlendVariable(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right, System.Runtime.Intrinsics.Vector256<long> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> BlendVariable(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right, System.Runtime.Intrinsics.Vector256<sbyte> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> BlendVariable(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right, System.Runtime.Intrinsics.Vector256<ushort> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> BlendVariable(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right, System.Runtime.Intrinsics.Vector256<uint> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> BlendVariable(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right, System.Runtime.Intrinsics.Vector256<ulong> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<byte> BroadcastScalarToVector128(byte* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<short> BroadcastScalarToVector128(short* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> BroadcastScalarToVector128(int* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> BroadcastScalarToVector128(long* source) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<sbyte> BroadcastScalarToVector128(sbyte* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ushort> BroadcastScalarToVector128(ushort* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> BroadcastScalarToVector128(uint* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> BroadcastScalarToVector128(ulong* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<byte> BroadcastScalarToVector256(byte* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<short> BroadcastScalarToVector256(short* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> BroadcastScalarToVector256(int* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> BroadcastScalarToVector256(long* source) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<sbyte> BroadcastScalarToVector256(sbyte* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ushort> BroadcastScalarToVector256(ushort* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> BroadcastScalarToVector256(uint* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> BroadcastScalarToVector256(ulong* source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<byte> BroadcastVector128ToVector256(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<short> BroadcastVector128ToVector256(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> BroadcastVector128ToVector256(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> BroadcastVector128ToVector256(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<sbyte> BroadcastVector128ToVector256(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ushort> BroadcastVector128ToVector256(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> BroadcastVector128ToVector256(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> BroadcastVector128ToVector256(ulong* address) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> CompareEqual(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> CompareEqual(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> CompareEqual(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> CompareEqual(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> CompareEqual(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> CompareEqual(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> CompareEqual(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> CompareEqual(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> CompareGreaterThan(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> CompareGreaterThan(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> CompareGreaterThan(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> CompareGreaterThan(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static double ConvertToDouble(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
+        public static int ConvertToInt32(System.Runtime.Intrinsics.Vector256<int> value) { throw null; }
+        public static uint ConvertToUInt32(System.Runtime.Intrinsics.Vector256<uint> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ConvertToVector256Int16(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ConvertToVector256UInt16(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ConvertToVector256UInt32(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ConvertToVector256UInt32(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ConvertToVector256UInt64(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ConvertToVector256UInt64(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ConvertToVector256UInt64(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
+        public unsafe static new void ExtractVector128(byte* address, System.Runtime.Intrinsics.Vector256<byte> value, byte index) { }
+        public unsafe static new void ExtractVector128(short* address, System.Runtime.Intrinsics.Vector256<short> value, byte index) { }
+        public unsafe static new void ExtractVector128(int* address, System.Runtime.Intrinsics.Vector256<int> value, byte index) { }
+        public unsafe static new void ExtractVector128(long* address, System.Runtime.Intrinsics.Vector256<long> value, byte index) { }
+        public static new System.Runtime.Intrinsics.Vector128<byte> ExtractVector128(System.Runtime.Intrinsics.Vector256<byte> value, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector128<short> ExtractVector128(System.Runtime.Intrinsics.Vector256<short> value, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector128<int> ExtractVector128(System.Runtime.Intrinsics.Vector256<int> value, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector128<long> ExtractVector128(System.Runtime.Intrinsics.Vector256<long> value, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector128<sbyte> ExtractVector128(System.Runtime.Intrinsics.Vector256<sbyte> value, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector128<ushort> ExtractVector128(System.Runtime.Intrinsics.Vector256<ushort> value, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector128<uint> ExtractVector128(System.Runtime.Intrinsics.Vector256<uint> value, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector128<ulong> ExtractVector128(System.Runtime.Intrinsics.Vector256<ulong> value, byte index) { throw null; }
+        public unsafe static new void ExtractVector128(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> value, byte index) { }
+        public unsafe static new void ExtractVector128(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> value, byte index) { }
+        public unsafe static new void ExtractVector128(uint* address, System.Runtime.Intrinsics.Vector256<uint> value, byte index) { }
+        public unsafe static new void ExtractVector128(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> value, byte index) { }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<double> source, double* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<double> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<double> source, double* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<double> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<int> source, int* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<int> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<int> source, int* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<int> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<int> source, int* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector128<int> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<long> source, long* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<long> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<long> source, long* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<long> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<float> source, float* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<float> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<float> source, float* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<float> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<float> source, float* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector128<float> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<uint> source, uint* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<uint> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<uint> source, uint* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<uint> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<uint> source, uint* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector128<uint> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<ulong> source, ulong* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<ulong> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<ulong> source, ulong* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<ulong> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<double> source, double* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector256<double> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<double> source, double* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector256<double> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<int> source, int* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, System.Runtime.Intrinsics.Vector256<int> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<long> source, long* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector256<long> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<long> source, long* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector256<long> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<float> source, float* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, System.Runtime.Intrinsics.Vector256<float> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<uint> source, uint* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, System.Runtime.Intrinsics.Vector256<uint> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<ulong> source, ulong* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector256<ulong> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<ulong> source, ulong* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector256<ulong> mask, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> GatherVector128(double* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> GatherVector128(double* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> GatherVector128(int* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> GatherVector128(int* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> GatherVector128(int* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> GatherVector128(long* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> GatherVector128(long* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> GatherVector128(float* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> GatherVector128(float* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> GatherVector128(float* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> GatherVector128(uint* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> GatherVector128(uint* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> GatherVector128(uint* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> GatherVector128(ulong* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> GatherVector128(ulong* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> GatherVector256(double* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> GatherVector256(double* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> GatherVector256(int* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> GatherVector256(long* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> GatherVector256(long* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> GatherVector256(float* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> GatherVector256(uint* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> GatherVector256(ulong* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, byte scale) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> GatherVector256(ulong* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, byte scale) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> HorizontalAdd(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> HorizontalAdd(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> HorizontalAddSaturate(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> HorizontalSubtract(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> HorizontalSubtract(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> HorizontalSubtractSaturate(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public unsafe static new System.Runtime.Intrinsics.Vector256<byte> InsertVector128(System.Runtime.Intrinsics.Vector256<byte> value, byte* address, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<byte> InsertVector128(System.Runtime.Intrinsics.Vector256<byte> value, System.Runtime.Intrinsics.Vector128<byte> data, byte index) { throw null; }
+        public unsafe static new System.Runtime.Intrinsics.Vector256<short> InsertVector128(System.Runtime.Intrinsics.Vector256<short> value, short* address, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<short> InsertVector128(System.Runtime.Intrinsics.Vector256<short> value, System.Runtime.Intrinsics.Vector128<short> data, byte index) { throw null; }
+        public unsafe static new System.Runtime.Intrinsics.Vector256<int> InsertVector128(System.Runtime.Intrinsics.Vector256<int> value, int* address, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<int> InsertVector128(System.Runtime.Intrinsics.Vector256<int> value, System.Runtime.Intrinsics.Vector128<int> data, byte index) { throw null; }
+        public unsafe static new System.Runtime.Intrinsics.Vector256<long> InsertVector128(System.Runtime.Intrinsics.Vector256<long> value, long* address, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<long> InsertVector128(System.Runtime.Intrinsics.Vector256<long> value, System.Runtime.Intrinsics.Vector128<long> data, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<sbyte> InsertVector128(System.Runtime.Intrinsics.Vector256<sbyte> value, System.Runtime.Intrinsics.Vector128<sbyte> data, byte index) { throw null; }
+        public unsafe static new System.Runtime.Intrinsics.Vector256<sbyte> InsertVector128(System.Runtime.Intrinsics.Vector256<sbyte> value, sbyte* address, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<ushort> InsertVector128(System.Runtime.Intrinsics.Vector256<ushort> value, System.Runtime.Intrinsics.Vector128<ushort> data, byte index) { throw null; }
+        public unsafe static new System.Runtime.Intrinsics.Vector256<ushort> InsertVector128(System.Runtime.Intrinsics.Vector256<ushort> value, ushort* address, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<uint> InsertVector128(System.Runtime.Intrinsics.Vector256<uint> value, System.Runtime.Intrinsics.Vector128<uint> data, byte index) { throw null; }
+        public unsafe static new System.Runtime.Intrinsics.Vector256<uint> InsertVector128(System.Runtime.Intrinsics.Vector256<uint> value, uint* address, byte index) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<ulong> InsertVector128(System.Runtime.Intrinsics.Vector256<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> data, byte index) { throw null; }
+        public unsafe static new System.Runtime.Intrinsics.Vector256<ulong> InsertVector128(System.Runtime.Intrinsics.Vector256<ulong> value, ulong* address, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<byte> LoadAlignedVector256NonTemporal(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<short> LoadAlignedVector256NonTemporal(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> LoadAlignedVector256NonTemporal(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> LoadAlignedVector256NonTemporal(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<sbyte> LoadAlignedVector256NonTemporal(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ushort> LoadAlignedVector256NonTemporal(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> LoadAlignedVector256NonTemporal(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> LoadAlignedVector256NonTemporal(ulong* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector128<int> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector256<int> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector128<long> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector256<long> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask) { throw null; }
+        public unsafe static void MaskStore(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> source) { }
+        public unsafe static void MaskStore(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> source) { }
+        public unsafe static void MaskStore(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> source) { }
+        public unsafe static void MaskStore(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> source) { }
+        public unsafe static void MaskStore(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> source) { }
+        public unsafe static void MaskStore(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> source) { }
+        public unsafe static void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> source) { }
+        public unsafe static void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> source) { }
+        public static System.Runtime.Intrinsics.Vector256<byte> Max(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Max(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Max(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Max(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Max(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Max(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Min(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Min(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Min(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Min(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Min(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Min(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static int MoveMask(System.Runtime.Intrinsics.Vector256<byte> value) { throw null; }
+        public static int MoveMask(System.Runtime.Intrinsics.Vector256<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> MultipleSumAbsoluteDifferences(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> Multiply(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> Multiply(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> MultiplyAddAdjacent(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> MultiplyAddAdjacent(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> MultiplyHigh(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> MultiplyHigh(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> MultiplyHighRoundScale(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> MultiplyLow(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> MultiplyLow(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> MultiplyLow(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> MultiplyLow(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Or(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Or(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Or(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> Or(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Or(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Or(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Or(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> Or(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> PackSignedSaturate(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> PackSignedSaturate(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> PackUnsignedSaturate(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> PackUnsignedSaturate(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<byte> Permute2x128(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right, byte control) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<short> Permute2x128(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right, byte control) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<int> Permute2x128(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right, byte control) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<long> Permute2x128(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right, byte control) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<sbyte> Permute2x128(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right, byte control) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<ushort> Permute2x128(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right, byte control) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<uint> Permute2x128(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right, byte control) { throw null; }
+        public static new System.Runtime.Intrinsics.Vector256<ulong> Permute2x128(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Permute4x64(System.Runtime.Intrinsics.Vector256<double> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> Permute4x64(System.Runtime.Intrinsics.Vector256<long> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> Permute4x64(System.Runtime.Intrinsics.Vector256<ulong> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> PermuteVar8x32(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> PermuteVar8x32(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<int> control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> PermuteVar8x32(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<short> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<short> value, System.Runtime.Intrinsics.Vector128<short> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<int> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<int> value, System.Runtime.Intrinsics.Vector128<int> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<long> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<long> value, System.Runtime.Intrinsics.Vector128<long> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<ushort> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<ushort> value, System.Runtime.Intrinsics.Vector128<ushort> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<uint> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<uint> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<ulong> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ShiftLeftLogical(System.Runtime.Intrinsics.Vector256<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector256<byte> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector256<short> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector256<int> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector256<long> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector256<sbyte> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector256<ushort> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector256<uint> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector256<ulong> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftLeftLogicalVariable(System.Runtime.Intrinsics.Vector128<int> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ShiftLeftLogicalVariable(System.Runtime.Intrinsics.Vector128<long> value, System.Runtime.Intrinsics.Vector128<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ShiftLeftLogicalVariable(System.Runtime.Intrinsics.Vector128<uint> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ShiftLeftLogicalVariable(System.Runtime.Intrinsics.Vector128<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftLeftLogicalVariable(System.Runtime.Intrinsics.Vector256<int> value, System.Runtime.Intrinsics.Vector256<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ShiftLeftLogicalVariable(System.Runtime.Intrinsics.Vector256<long> value, System.Runtime.Intrinsics.Vector256<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ShiftLeftLogicalVariable(System.Runtime.Intrinsics.Vector256<uint> value, System.Runtime.Intrinsics.Vector256<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ShiftLeftLogicalVariable(System.Runtime.Intrinsics.Vector256<ulong> value, System.Runtime.Intrinsics.Vector256<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShiftRightArithmetic(System.Runtime.Intrinsics.Vector256<short> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShiftRightArithmetic(System.Runtime.Intrinsics.Vector256<short> value, System.Runtime.Intrinsics.Vector128<short> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftRightArithmetic(System.Runtime.Intrinsics.Vector256<int> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftRightArithmetic(System.Runtime.Intrinsics.Vector256<int> value, System.Runtime.Intrinsics.Vector128<int> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftRightArithmeticVariable(System.Runtime.Intrinsics.Vector128<int> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftRightArithmeticVariable(System.Runtime.Intrinsics.Vector256<int> value, System.Runtime.Intrinsics.Vector256<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<short> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<short> value, System.Runtime.Intrinsics.Vector128<short> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<int> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<int> value, System.Runtime.Intrinsics.Vector128<int> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<long> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<long> value, System.Runtime.Intrinsics.Vector128<long> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<ushort> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<ushort> value, System.Runtime.Intrinsics.Vector128<ushort> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<uint> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<uint> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<ulong> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ShiftRightLogical(System.Runtime.Intrinsics.Vector256<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector256<byte> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector256<short> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector256<int> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector256<long> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector256<sbyte> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector256<ushort> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector256<uint> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector256<ulong> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftRightLogicalVariable(System.Runtime.Intrinsics.Vector128<int> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ShiftRightLogicalVariable(System.Runtime.Intrinsics.Vector128<long> value, System.Runtime.Intrinsics.Vector128<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ShiftRightLogicalVariable(System.Runtime.Intrinsics.Vector128<uint> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ShiftRightLogicalVariable(System.Runtime.Intrinsics.Vector128<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> ShiftRightLogicalVariable(System.Runtime.Intrinsics.Vector256<int> value, System.Runtime.Intrinsics.Vector256<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> ShiftRightLogicalVariable(System.Runtime.Intrinsics.Vector256<long> value, System.Runtime.Intrinsics.Vector256<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> ShiftRightLogicalVariable(System.Runtime.Intrinsics.Vector256<uint> value, System.Runtime.Intrinsics.Vector256<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> ShiftRightLogicalVariable(System.Runtime.Intrinsics.Vector256<ulong> value, System.Runtime.Intrinsics.Vector256<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Shuffle(System.Runtime.Intrinsics.Vector256<byte> value, System.Runtime.Intrinsics.Vector256<byte> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Shuffle(System.Runtime.Intrinsics.Vector256<int> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Shuffle(System.Runtime.Intrinsics.Vector256<sbyte> value, System.Runtime.Intrinsics.Vector256<sbyte> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Shuffle(System.Runtime.Intrinsics.Vector256<uint> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShuffleHigh(System.Runtime.Intrinsics.Vector256<short> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ShuffleHigh(System.Runtime.Intrinsics.Vector256<ushort> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> ShuffleLow(System.Runtime.Intrinsics.Vector256<short> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> ShuffleLow(System.Runtime.Intrinsics.Vector256<ushort> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Sign(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Sign(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Sign(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Subtract(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Subtract(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Subtract(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> Subtract(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Subtract(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Subtract(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Subtract(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> Subtract(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> SubtractSaturate(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> SubtractSaturate(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> SubtractSaturate(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> SubtractSaturate(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> SumAbsoluteDifferences(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> UnpackHigh(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> UnpackHigh(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> UnpackHigh(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> UnpackHigh(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> UnpackHigh(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> UnpackHigh(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> UnpackHigh(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> UnpackHigh(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> UnpackLow(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> UnpackLow(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> UnpackLow(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> UnpackLow(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> UnpackLow(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> UnpackLow(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> UnpackLow(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> UnpackLow(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<byte> Xor(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<short> Xor(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<int> Xor(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<long> Xor(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<sbyte> Xor(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ushort> Xor(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<uint> Xor(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<ulong> Xor(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right) { throw null; }
     }
-    public abstract class Bmi1
+    public abstract partial class Bmi1
     {
         internal Bmi1() { }
         public static bool IsSupported { get { throw null; } }
@@ -1126,7 +1118,7 @@ namespace System.Runtime.Intrinsics.X86
         public static uint GetMaskUpToLowestSetBit(uint value) { throw null; }
         public static uint ResetLowestSetBit(uint value) { throw null; }
         public static uint TrailingZeroCount(uint value) { throw null; }
-        public abstract class X64
+        public abstract partial class X64
         {
             internal X64() { }
             public static bool IsSupported { get { throw null; } }
@@ -1139,802 +1131,802 @@ namespace System.Runtime.Intrinsics.X86
             public static ulong TrailingZeroCount(ulong value) { throw null; }
         }
     }
-    public abstract class Bmi2
+    public abstract partial class Bmi2
     {
         internal Bmi2() { }
         public static bool IsSupported { get { throw null; } }
-        public static uint ZeroHighBits(uint value, uint index) { throw null; }
         public static uint MultiplyNoFlags(uint left, uint right) { throw null; }
-        public static unsafe uint MultiplyNoFlags(uint left, uint right, uint* low) { throw null; }
+        public unsafe static uint MultiplyNoFlags(uint left, uint right, uint* low) { throw null; }
         public static uint ParallelBitDeposit(uint value, uint mask) { throw null; }
         public static uint ParallelBitExtract(uint value, uint mask) { throw null; }
-        public abstract class X64
+        public static uint ZeroHighBits(uint value, uint index) { throw null; }
+        public abstract partial class X64
         {
             internal X64() { }
             public static bool IsSupported { get { throw null; } }
-            public static ulong ZeroHighBits(ulong value, ulong index) { throw null; }
             public static ulong MultiplyNoFlags(ulong left, ulong right) { throw null; }
-            public static unsafe ulong MultiplyNoFlags(ulong left, ulong right, ulong* low) { throw null; }
+            public unsafe static ulong MultiplyNoFlags(ulong left, ulong right, ulong* low) { throw null; }
             public static ulong ParallelBitDeposit(ulong value, ulong mask) { throw null; }
-            public static ulong ParallelBitExtract(ulong value, ulong mask) { throw null; } 
+            public static ulong ParallelBitExtract(ulong value, ulong mask) { throw null; }
+            public static ulong ZeroHighBits(ulong value, ulong index) { throw null; }
         }
     }
     public enum FloatComparisonMode : byte
     {
-        EqualOrderedNonSignaling = 0,
-        LessThanOrderedSignaling = 1,
-        LessThanOrEqualOrderedSignaling = 2,
-        UnorderedNonSignaling = 3,
-        NotEqualUnorderedNonSignaling = 4,
-        NotLessThanUnorderedSignaling = 5,
-        NotLessThanOrEqualUnorderedSignaling = 6,
-        OrderedNonSignaling = 7,
-        EqualUnorderedNonSignaling = 8,
-        NotGreaterThanOrEqualUnorderedSignaling = 9,
-        NotGreaterThanUnorderedSignaling = 10,
-        FalseOrderedNonSignaling = 11,
-        NotEqualOrderedNonSignaling = 12,
-        GreaterThanOrEqualOrderedSignaling = 13,
-        GreaterThanOrderedSignaling = 14,
-        TrueUnorderedNonSignaling = 15,
-        EqualOrderedSignaling = 16,
-        LessThanOrderedNonSignaling = 17,
-        LessThanOrEqualOrderedNonSignaling = 18,
-        UnorderedSignaling = 19,
-        NotEqualUnorderedSignaling = 20,
-        NotLessThanUnorderedNonSignaling = 21,
-        NotLessThanOrEqualUnorderedNonSignaling = 22,
-        OrderedSignaling = 23,
-        EqualUnorderedSignaling = 24,
-        NotGreaterThanOrEqualUnorderedNonSignaling = 25,
-        NotGreaterThanUnorderedNonSignaling = 26,
-        FalseOrderedSignaling = 27,
-        NotEqualOrderedSignaling = 28,
-        GreaterThanOrEqualOrderedNonSignaling = 29,
-        GreaterThanOrderedNonSignaling = 30,
-        TrueUnorderedSignaling = 31,
+        EqualOrderedNonSignaling = (byte)0,
+        EqualOrderedSignaling = (byte)16,
+        EqualUnorderedNonSignaling = (byte)8,
+        EqualUnorderedSignaling = (byte)24,
+        FalseOrderedNonSignaling = (byte)11,
+        FalseOrderedSignaling = (byte)27,
+        GreaterThanOrderedNonSignaling = (byte)30,
+        GreaterThanOrderedSignaling = (byte)14,
+        GreaterThanOrEqualOrderedNonSignaling = (byte)29,
+        GreaterThanOrEqualOrderedSignaling = (byte)13,
+        LessThanOrderedNonSignaling = (byte)17,
+        LessThanOrderedSignaling = (byte)1,
+        LessThanOrEqualOrderedNonSignaling = (byte)18,
+        LessThanOrEqualOrderedSignaling = (byte)2,
+        NotEqualOrderedNonSignaling = (byte)12,
+        NotEqualOrderedSignaling = (byte)28,
+        NotEqualUnorderedNonSignaling = (byte)4,
+        NotEqualUnorderedSignaling = (byte)20,
+        NotGreaterThanOrEqualUnorderedNonSignaling = (byte)25,
+        NotGreaterThanOrEqualUnorderedSignaling = (byte)9,
+        NotGreaterThanUnorderedNonSignaling = (byte)26,
+        NotGreaterThanUnorderedSignaling = (byte)10,
+        NotLessThanOrEqualUnorderedNonSignaling = (byte)22,
+        NotLessThanOrEqualUnorderedSignaling = (byte)6,
+        NotLessThanUnorderedNonSignaling = (byte)21,
+        NotLessThanUnorderedSignaling = (byte)5,
+        OrderedNonSignaling = (byte)7,
+        OrderedSignaling = (byte)23,
+        TrueUnorderedNonSignaling = (byte)15,
+        TrueUnorderedSignaling = (byte)31,
+        UnorderedNonSignaling = (byte)3,
+        UnorderedSignaling = (byte)19,
     }
-    public abstract class Fma : Avx
+    public abstract partial class Fma : System.Runtime.Intrinsics.X86.Avx
     {
         internal Fma() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector128<float> MultiplyAdd(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<double> MultiplyAdd(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector256<float> MultiplyAdd(Vector256<float> a, Vector256<float> b, Vector256<float> c) { throw null; }
-        public static Vector256<double> MultiplyAdd(Vector256<double> a, Vector256<double> b, Vector256<double> c) { throw null; }
-        public static Vector128<double> MultiplyAddScalar(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector128<float> MultiplyAddScalar(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<float> MultiplyAddSubtract(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<double> MultiplyAddSubtract(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector256<float> MultiplyAddSubtract(Vector256<float> a, Vector256<float> b, Vector256<float> c) { throw null; }
-        public static Vector256<double> MultiplyAddSubtract(Vector256<double> a, Vector256<double> b, Vector256<double> c) { throw null; }
-        public static Vector128<float> MultiplySubtract(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<double> MultiplySubtract(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector256<float> MultiplySubtract(Vector256<float> a, Vector256<float> b, Vector256<float> c) { throw null; }
-        public static Vector256<double> MultiplySubtract(Vector256<double> a, Vector256<double> b, Vector256<double> c) { throw null; }
-        public static Vector128<float> MultiplySubtractAdd(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<double> MultiplySubtractAdd(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector256<float> MultiplySubtractAdd(Vector256<float> a, Vector256<float> b, Vector256<float> c) { throw null; }
-        public static Vector256<double> MultiplySubtractAdd(Vector256<double> a, Vector256<double> b, Vector256<double> c) { throw null; }
-        public static Vector128<double> MultiplySubtractScalar(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector128<float> MultiplySubtractScalar(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<float> MultiplyAddNegated(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<double> MultiplyAddNegated(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector256<float> MultiplyAddNegated(Vector256<float> a, Vector256<float> b, Vector256<float> c) { throw null; }
-        public static Vector256<double> MultiplyAddNegated(Vector256<double> a, Vector256<double> b, Vector256<double> c) { throw null; }
-        public static Vector128<double> MultiplyAddNegatedScalar(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector128<float> MultiplyAddNegatedScalar(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<float> MultiplySubtractNegated(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
-        public static Vector128<double> MultiplySubtractNegated(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector256<float> MultiplySubtractNegated(Vector256<float> a, Vector256<float> b, Vector256<float> c) { throw null; }
-        public static Vector256<double> MultiplySubtractNegated(Vector256<double> a, Vector256<double> b, Vector256<double> c) { throw null; }
-        public static Vector128<double> MultiplySubtractNegatedScalar(Vector128<double> a, Vector128<double> b, Vector128<double> c) { throw null; }
-        public static Vector128<float> MultiplySubtractNegatedScalar(Vector128<float> a, Vector128<float> b, Vector128<float> c) { throw null; }
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplyAdd(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplyAdd(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> MultiplyAdd(System.Runtime.Intrinsics.Vector256<double> a, System.Runtime.Intrinsics.Vector256<double> b, System.Runtime.Intrinsics.Vector256<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> MultiplyAdd(System.Runtime.Intrinsics.Vector256<float> a, System.Runtime.Intrinsics.Vector256<float> b, System.Runtime.Intrinsics.Vector256<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplyAddNegated(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplyAddNegated(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> MultiplyAddNegated(System.Runtime.Intrinsics.Vector256<double> a, System.Runtime.Intrinsics.Vector256<double> b, System.Runtime.Intrinsics.Vector256<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> MultiplyAddNegated(System.Runtime.Intrinsics.Vector256<float> a, System.Runtime.Intrinsics.Vector256<float> b, System.Runtime.Intrinsics.Vector256<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplyAddNegatedScalar(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplyAddNegatedScalar(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplyAddScalar(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplyAddScalar(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplyAddSubtract(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplyAddSubtract(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> MultiplyAddSubtract(System.Runtime.Intrinsics.Vector256<double> a, System.Runtime.Intrinsics.Vector256<double> b, System.Runtime.Intrinsics.Vector256<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> MultiplyAddSubtract(System.Runtime.Intrinsics.Vector256<float> a, System.Runtime.Intrinsics.Vector256<float> b, System.Runtime.Intrinsics.Vector256<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplySubtract(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplySubtract(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> MultiplySubtract(System.Runtime.Intrinsics.Vector256<double> a, System.Runtime.Intrinsics.Vector256<double> b, System.Runtime.Intrinsics.Vector256<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> MultiplySubtract(System.Runtime.Intrinsics.Vector256<float> a, System.Runtime.Intrinsics.Vector256<float> b, System.Runtime.Intrinsics.Vector256<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplySubtractAdd(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplySubtractAdd(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> MultiplySubtractAdd(System.Runtime.Intrinsics.Vector256<double> a, System.Runtime.Intrinsics.Vector256<double> b, System.Runtime.Intrinsics.Vector256<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> MultiplySubtractAdd(System.Runtime.Intrinsics.Vector256<float> a, System.Runtime.Intrinsics.Vector256<float> b, System.Runtime.Intrinsics.Vector256<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplySubtractNegated(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplySubtractNegated(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> MultiplySubtractNegated(System.Runtime.Intrinsics.Vector256<double> a, System.Runtime.Intrinsics.Vector256<double> b, System.Runtime.Intrinsics.Vector256<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> MultiplySubtractNegated(System.Runtime.Intrinsics.Vector256<float> a, System.Runtime.Intrinsics.Vector256<float> b, System.Runtime.Intrinsics.Vector256<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplySubtractNegatedScalar(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplySubtractNegatedScalar(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplySubtractScalar(System.Runtime.Intrinsics.Vector128<double> a, System.Runtime.Intrinsics.Vector128<double> b, System.Runtime.Intrinsics.Vector128<double> c) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplySubtractScalar(System.Runtime.Intrinsics.Vector128<float> a, System.Runtime.Intrinsics.Vector128<float> b, System.Runtime.Intrinsics.Vector128<float> c) { throw null; }
     }
-    public abstract class Lzcnt
+    public abstract partial class Lzcnt
     {
         internal Lzcnt() { }
         public static bool IsSupported { get { throw null; } }
         public static uint LeadingZeroCount(uint value) { throw null; }
-        public abstract class X64
+        public abstract partial class X64
         {
             internal X64() { }
             public static bool IsSupported { get { throw null; } }
             public static ulong LeadingZeroCount(ulong value) { throw null; }
         }
     }
-    public abstract class Pclmulqdq : Sse2
+    public abstract partial class Pclmulqdq : System.Runtime.Intrinsics.X86.Sse2
     {
         internal Pclmulqdq() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector128<long> CarrylessMultiply(Vector128<long> left, Vector128<long> right, byte control) { throw null; }
-        public static Vector128<ulong> CarrylessMultiply(Vector128<ulong> left, Vector128<ulong> right, byte control) { throw null; }
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector128<long> CarrylessMultiply(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> CarrylessMultiply(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right, byte control) { throw null; }
     }
-    public abstract class Popcnt : Sse42
+    public abstract partial class Popcnt : System.Runtime.Intrinsics.X86.Sse42
     {
         internal Popcnt() { }
-        public new static bool IsSupported { get { throw null; } }
+        public static new bool IsSupported { get { throw null; } }
         public static uint PopCount(uint value) { throw null; }
-        public new abstract class X64 : Sse41.X64
+        public abstract partial class X64 : System.Runtime.Intrinsics.X86.Sse41.X64
         {
             internal X64() { }
-            public new static bool IsSupported { get { throw null; } }
+            public static new bool IsSupported { get { throw null; } }
             public static ulong PopCount(ulong value) { throw null; }
         }
     }
-    public abstract class Sse
+    public abstract partial class Sse
     {
         internal Sse() { }
         public static bool IsSupported { get { throw null; } }
-        public static Vector128<float> Add(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> AddScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> And(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> AndNot(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareEqual(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareEqualOrderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareEqualScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareGreaterThan(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareGreaterThanOrderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareGreaterThanScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareGreaterThanUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareGreaterThanOrEqualOrderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareGreaterThanOrEqualScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareGreaterThanOrEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareLessThan(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareLessThanOrderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareLessThanScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareLessThanUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareLessThanOrEqual(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareLessThanOrEqualOrderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareLessThanOrEqualScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareLessThanOrEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotEqual(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareNotEqualOrderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotEqualScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static bool CompareNotEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotGreaterThan(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotGreaterThanScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotGreaterThanOrEqualScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotLessThan(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotLessThanScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotLessThanOrEqual(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareNotLessThanOrEqualScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareOrdered(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareOrderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareUnordered(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> CompareUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static int ConvertToInt32(Vector128<float> value) { throw null; }
-        public static int ConvertToInt32WithTruncation(Vector128<float> value) { throw null; }
-        public static float ConvertToSingle(Vector128<float> value) { throw null; }
-        public static Vector128<float> ConvertScalarToVector128Single(Vector128<float> upper, int value) { throw null; }
-        public static Vector128<float> Divide(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> DivideScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static unsafe Vector128<float> LoadVector128(float* address) { throw null; }
-        public static unsafe Vector128<float> LoadAlignedVector128(float* address) { throw null; }
-        public static unsafe Vector128<float> LoadHigh(Vector128<float> lower, float* address) { throw null; }
-        public static unsafe Vector128<float> LoadLow(Vector128<float> upper, float* address) { throw null; }
-        public static unsafe Vector128<float> LoadScalarVector128(float* address) { throw null; }
-        public static Vector128<float> Max(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> MaxScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> Min(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> MinScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> MoveHighToLow(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> MoveLowToHigh(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> MoveScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static int MoveMask(Vector128<float> value) { throw null; }
-        public static Vector128<float> Multiply(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> MultiplyScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> Or(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static unsafe void Prefetch0(void* address) { throw null; }
-        public static unsafe void Prefetch1(void* address) { throw null; }
-        public static unsafe void Prefetch2(void* address) { throw null; }
-        public static unsafe void PrefetchNonTemporal(void* address) { throw null; }
-        public static Vector128<float> Reciprocal(Vector128<float> value) { throw null; }
-        public static Vector128<float> ReciprocalScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> ReciprocalScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<float> ReciprocalSqrt(Vector128<float> value) { throw null; }
-        public static Vector128<float> ReciprocalSqrtScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> ReciprocalSqrtScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<float> SetVector128(float e3, float e2, float e1, float e0) { throw null; }
-        public static Vector128<float> SetAllVector128(float value) { throw null; }
-        public static Vector128<float> SetScalarVector128(float value) { throw null; }
-        public static Vector128<float> SetZeroVector128() { throw null; }
-        public static Vector128<U> StaticCast<T, U>(Vector128<T> value) where T : struct where U : struct { throw null; }
-        public static Vector128<float> Shuffle(Vector128<float> left, Vector128<float> right, byte control) { throw null; }
-        public static Vector128<float> Sqrt(Vector128<float> value) { throw null; }
-        public static Vector128<float> SqrtScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> SqrtScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static unsafe void StoreAligned(float* address, Vector128<float> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(float* address, Vector128<float> source) { throw null; }
-        public static unsafe void Store(float* address, Vector128<float> source) { throw null; }
-        public static void StoreFence() { throw null; }
-        public static unsafe void StoreHigh(float* address, Vector128<float> source) { throw null; }
-        public static unsafe void StoreLow(float* address, Vector128<float> source) { throw null; } 
-        public static unsafe void StoreScalar(float* address, Vector128<float> source) { throw null; }
-        public static Vector128<float> Subtract(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> SubtractScalar(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> UnpackHigh(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> UnpackLow(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<float> Xor(Vector128<float> left, Vector128<float> right) { throw null; }
-        public abstract class X64
+        public static System.Runtime.Intrinsics.Vector128<float> Add(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> AddScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> And(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> AndNot(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareEqual(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareEqualOrderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareEqualScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareEqualUnorderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareGreaterThan(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareGreaterThanOrderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareGreaterThanOrEqual(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareGreaterThanOrEqualOrderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareGreaterThanOrEqualScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareGreaterThanOrEqualUnorderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareGreaterThanScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareGreaterThanUnorderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareLessThan(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareLessThanOrderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareLessThanOrEqual(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareLessThanOrEqualOrderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareLessThanOrEqualScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareLessThanOrEqualUnorderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareLessThanScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareLessThanUnorderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotEqual(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareNotEqualOrderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotEqualScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static bool CompareNotEqualUnorderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotGreaterThan(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotGreaterThanOrEqual(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotGreaterThanOrEqualScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotGreaterThanScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotLessThan(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotLessThanOrEqual(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotLessThanOrEqualScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareNotLessThanScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareOrdered(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareOrderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareUnordered(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CompareUnorderedScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ConvertScalarToVector128Single(System.Runtime.Intrinsics.Vector128<float> upper, int value) { throw null; }
+        public static int ConvertToInt32(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static int ConvertToInt32WithTruncation(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static float ConvertToSingle(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Divide(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> DivideScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> LoadAlignedVector128(float* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> LoadHigh(System.Runtime.Intrinsics.Vector128<float> lower, float* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> LoadLow(System.Runtime.Intrinsics.Vector128<float> upper, float* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> LoadScalarVector128(float* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> LoadVector128(float* address) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Max(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MaxScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Min(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MinScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MoveHighToLow(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MoveLowToHigh(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static int MoveMask(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MoveScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Multiply(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MultiplyScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Or(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public unsafe static void Prefetch0(void* address) { }
+        public unsafe static void Prefetch1(void* address) { }
+        public unsafe static void Prefetch2(void* address) { }
+        public unsafe static void PrefetchNonTemporal(void* address) { }
+        public static System.Runtime.Intrinsics.Vector128<float> Reciprocal(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ReciprocalScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ReciprocalScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ReciprocalSqrt(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ReciprocalSqrtScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ReciprocalSqrtScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> SetAllVector128(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> SetScalarVector128(float value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> SetVector128(float e3, float e2, float e1, float e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> SetZeroVector128() { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Shuffle(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Sqrt(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> SqrtScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> SqrtScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<U> StaticCast<T, U>(System.Runtime.Intrinsics.Vector128<T> value) where T : struct where U : struct { throw null; }
+        public unsafe static void Store(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
+        public unsafe static void StoreAligned(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
+        public unsafe static void StoreAlignedNonTemporal(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
+        public static void StoreFence() { }
+        public unsafe static void StoreHigh(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
+        public unsafe static void StoreLow(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
+        public unsafe static void StoreScalar(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
+        public static System.Runtime.Intrinsics.Vector128<float> Subtract(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> SubtractScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> UnpackHigh(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> UnpackLow(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Xor(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public abstract partial class X64
         {
             internal X64() { }
             public static bool IsSupported { get { throw null; } }
-            public static long ConvertToInt64(Vector128<float> value) { throw null; }
-            public static Vector128<float> ConvertScalarToVector128Single(Vector128<float> upper, long value) { throw null; }
-            public static long ConvertToInt64WithTruncation(Vector128<float> value) { throw null; }
+            public static System.Runtime.Intrinsics.Vector128<float> ConvertScalarToVector128Single(System.Runtime.Intrinsics.Vector128<float> upper, long value) { throw null; }
+            public static long ConvertToInt64(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+            public static long ConvertToInt64WithTruncation(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
         }
     }
-    public abstract class Sse2 : Sse
+    public abstract partial class Sse2 : System.Runtime.Intrinsics.X86.Sse
     {
         internal Sse2() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector128<byte> Add(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> Add(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> Add(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> Add(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> Add(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> Add(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<long> Add(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> Add(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<double> Add(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> AddScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<sbyte> AddSaturate(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<byte> AddSaturate(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<short> AddSaturate(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> AddSaturate(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<byte> And(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> And(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> And(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> And(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> And(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> And(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<long> And(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> And(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<double> And(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<byte> AndNot(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> AndNot(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> AndNot(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> AndNot(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> AndNot(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> AndNot(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<long> AndNot(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> AndNot(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<double> AndNot(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<byte> Average(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<ushort> Average(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<sbyte> CompareEqual(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<byte> CompareEqual(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<short> CompareEqual(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> CompareEqual(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> CompareEqual(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> CompareEqual(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<double> CompareEqual(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareEqualOrderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareEqualScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<sbyte> CompareGreaterThan(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> CompareGreaterThan(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<int> CompareGreaterThan(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<double> CompareGreaterThan(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareGreaterThanOrderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareGreaterThanScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareGreaterThanUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareGreaterThanOrEqualOrderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareGreaterThanOrEqualScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareGreaterThanOrEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<sbyte> CompareLessThan(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> CompareLessThan(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<int> CompareLessThan(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<double> CompareLessThan(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareLessThanOrderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareLessThanScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareLessThanUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareLessThanOrEqual(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareLessThanOrEqualOrderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareLessThanOrEqualScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareLessThanOrEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotEqual(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareNotEqualOrderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotEqualScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static bool CompareNotEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotGreaterThan(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotGreaterThanScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotGreaterThanOrEqualScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotLessThan(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotLessThanScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotLessThanOrEqual(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareNotLessThanOrEqualScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareOrdered(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareOrderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareUnordered(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> CompareUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static double ConvertToDouble(Vector128<double> value) { throw null; }
-        public static int ConvertToInt32(Vector128<double> value) { throw null; }
-        public static int ConvertToInt32(Vector128<int> value) { throw null; }
-        public static int ConvertToInt32WithTruncation(Vector128<double> value) { throw null; }
-        public static uint ConvertToUInt32(Vector128<uint> value) { throw null; }
-        public static Vector128<double> ConvertScalarToVector128Double(Vector128<double> upper, int value) { throw null; }
-        public static Vector128<double> ConvertScalarToVector128Double(Vector128<double> upper, Vector128<float> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32(Vector128<float> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32(Vector128<double> value) { throw null; }
-        public static Vector128<int> ConvertScalarToVector128Int32(int value) { throw null; }
-        public static Vector128<float> ConvertToVector128Single(Vector128<int> value) { throw null; }
-        public static Vector128<float> ConvertToVector128Single(Vector128<double> value) { throw null; }
-        public static Vector128<float> ConvertScalarToVector128Single(Vector128<float> upper, Vector128<double> value) { throw null; }
-        public static Vector128<double> ConvertToVector128Double(Vector128<int> value) { throw null; }
-        public static Vector128<double> ConvertToVector128Double(Vector128<float> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector128<float> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector128<double> value) { throw null; }
-        public static Vector128<uint> ConvertScalarToVector128UInt32(uint value) { throw null; }
-        public static Vector128<double> Divide(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> DivideScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static ushort Extract(Vector128<ushort> value, byte index) { throw null; }
-        public static Vector128<short> Insert(Vector128<short> value, short data, byte index) { throw null; }
-        public static Vector128<ushort> Insert(Vector128<ushort> value, ushort data, byte index) { throw null; }
-        public static unsafe Vector128<sbyte> LoadVector128(sbyte* address) { throw null; }
-        public static unsafe Vector128<byte> LoadVector128(byte* address) { throw null; }
-        public static unsafe Vector128<short> LoadVector128(short* address) { throw null; }
-        public static unsafe Vector128<ushort> LoadVector128(ushort* address) { throw null; }
-        public static unsafe Vector128<int> LoadVector128(int* address) { throw null; }
-        public static unsafe Vector128<uint> LoadVector128(uint* address) { throw null; }
-        public static unsafe Vector128<long> LoadVector128(long* address) { throw null; }
-        public static unsafe Vector128<ulong> LoadVector128(ulong* address) { throw null; }
-        public static unsafe Vector128<double> LoadVector128(double* address) { throw null; }
-        public static unsafe Vector128<sbyte> LoadAlignedVector128(sbyte* address) { throw null; }
-        public static unsafe Vector128<byte> LoadAlignedVector128(byte* address) { throw null; }
-        public static unsafe Vector128<short> LoadAlignedVector128(short* address) { throw null; }
-        public static unsafe Vector128<ushort> LoadAlignedVector128(ushort* address) { throw null; }
-        public static unsafe Vector128<int> LoadAlignedVector128(int* address) { throw null; }
-        public static unsafe Vector128<uint> LoadAlignedVector128(uint* address) { throw null; }
-        public static unsafe Vector128<long> LoadAlignedVector128(long* address) { throw null; }
-        public static unsafe Vector128<ulong> LoadAlignedVector128(ulong* address) { throw null; }
-        public static unsafe Vector128<double> LoadAlignedVector128(double* address) { throw null; }
-        public static void LoadFence() { throw null; }
-        public static unsafe Vector128<double> LoadHigh(Vector128<double> lower, double* address) { throw null; }
-        public static unsafe Vector128<double> LoadLow(Vector128<double> upper, double* address) { throw null; }
-        public static unsafe Vector128<int> LoadScalarVector128(int* address) { throw null; }
-        public static unsafe Vector128<uint> LoadScalarVector128(uint* address) { throw null; }
-        public static unsafe Vector128<long> LoadScalarVector128(long* address) { throw null; }
-        public static unsafe Vector128<ulong> LoadScalarVector128(ulong* address) { throw null; }
-        public static unsafe Vector128<double> LoadScalarVector128(double* address) { throw null; }
-        public static unsafe void MaskMove(Vector128<sbyte> source, Vector128<sbyte> mask, sbyte* address) { throw null; }
-        public static unsafe void MaskMove(Vector128<byte> source, Vector128<byte> mask, byte* address) { throw null; }
-        public static Vector128<byte> Max(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<short> Max(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<double> Max(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> MaxScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static void MemoryFence() { throw null; }
-        public static Vector128<byte> Min(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<short> Min(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<double> Min(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> MinScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static int MoveMask(Vector128<byte> value) { throw null; }
-        public static int MoveMask(Vector128<sbyte> value) { throw null; }
-        public static int MoveMask(Vector128<double> value) { throw null; }
-        public static Vector128<long> MoveScalar(Vector128<long> value) { throw null; }
-        public static Vector128<ulong> MoveScalar(Vector128<ulong> value) { throw null; }
-        public static Vector128<double> MoveScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static Vector128<ulong> Multiply(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<double> Multiply(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<double> MultiplyScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<short> MultiplyHigh(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> MultiplyHigh(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> MultiplyAddAdjacent(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<short> MultiplyLow(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> MultiplyLow(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<byte> Or(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> Or(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> Or(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> Or(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> Or(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> Or(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<long> Or(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> Or(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<double> Or(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<sbyte> PackSignedSaturate(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<short> PackSignedSaturate(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<byte> PackUnsignedSaturate(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<sbyte> SetVector128(sbyte e15, sbyte e14, sbyte e13, sbyte e12, sbyte e11, sbyte e10, sbyte e9, sbyte e8, sbyte e7, sbyte e6, sbyte e5, sbyte e4, sbyte e3, sbyte e2, sbyte e1, sbyte e0) { throw null; }
-        public static Vector128<byte> SetVector128(byte e15, byte e14, byte e13, byte e12, byte e11, byte e10, byte e9, byte e8, byte e7, byte e6, byte e5, byte e4, byte e3, byte e2, byte e1, byte e0) { throw null; }
-        public static Vector128<short> SetVector128(short e7, short e6, short e5, short e4, short e3, short e2, short e1, short e0) { throw null; }
-        public static Vector128<ushort> SetVector128(ushort e7, ushort e6, ushort e5, ushort e4, ushort e3, ushort e2, ushort e1, ushort e0) { throw null; }
-        public static Vector128<int> SetVector128(int e3, int e2, int e1, int e0) { throw null; }
-        public static Vector128<uint> SetVector128(uint e3, uint e2, uint e1, uint e0) { throw null; }
-        public static Vector128<long> SetVector128(long e1, long e0) { throw null; }
-        public static Vector128<ulong> SetVector128(ulong e1, ulong e0) { throw null; }
-        public static Vector128<double> SetVector128(double e1, double e0) { throw null; }
-        public static Vector128<byte> SetAllVector128(byte value) { throw null; }
-        public static Vector128<sbyte> SetAllVector128(sbyte value) { throw null; }
-        public static Vector128<short> SetAllVector128(short value) { throw null; }
-        public static Vector128<ushort> SetAllVector128(ushort value) { throw null; }
-        public static Vector128<int> SetAllVector128(int value) { throw null; }
-        public static Vector128<uint> SetAllVector128(uint value) { throw null; }
-        public static Vector128<long> SetAllVector128(long value) { throw null; }
-        public static Vector128<ulong> SetAllVector128(ulong value) { throw null; }
-        public static Vector128<double> SetAllVector128(double value) { throw null; }
-        public static Vector128<double> SetScalarVector128(double value) { throw null; }
-        public static Vector128<T> SetZeroVector128<T>() where T : struct { throw null; }
-        public static Vector128<ushort> SumAbsoluteDifferences(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<int> Shuffle(Vector128<int> value, byte control) { throw null; }
-        public static Vector128<uint> Shuffle(Vector128<uint> value, byte control) { throw null; }
-        public static Vector128<double> Shuffle(Vector128<double> left, Vector128<double> right, byte control) { throw null; }
-        public static Vector128<short> ShuffleHigh(Vector128<short> value, byte control) { throw null; }
-        public static Vector128<ushort> ShuffleHigh(Vector128<ushort> value, byte control) { throw null; }
-        public static Vector128<short> ShuffleLow(Vector128<short> value, byte control) { throw null; }
-        public static Vector128<ushort> ShuffleLow(Vector128<ushort> value, byte control) { throw null; }
-        public static Vector128<short> ShiftLeftLogical(Vector128<short> value, Vector128<short> count) { throw null; }
-        public static Vector128<ushort> ShiftLeftLogical(Vector128<ushort> value, Vector128<ushort> count) { throw null; }
-        public static Vector128<int> ShiftLeftLogical(Vector128<int> value, Vector128<int> count) { throw null; }
-        public static Vector128<uint> ShiftLeftLogical(Vector128<uint> value, Vector128<uint> count) { throw null; }
-        public static Vector128<long> ShiftLeftLogical(Vector128<long> value, Vector128<long> count) { throw null; }
-        public static Vector128<ulong> ShiftLeftLogical(Vector128<ulong> value, Vector128<ulong> count) { throw null; }
-        public static Vector128<short> ShiftLeftLogical(Vector128<short> value, byte count) { throw null; }
-        public static Vector128<ushort> ShiftLeftLogical(Vector128<ushort> value, byte count) { throw null; }
-        public static Vector128<int> ShiftLeftLogical(Vector128<int> value, byte count) { throw null; }
-        public static Vector128<uint> ShiftLeftLogical(Vector128<uint> value, byte count) { throw null; }
-        public static Vector128<long> ShiftLeftLogical(Vector128<long> value, byte count) { throw null; }
-        public static Vector128<ulong> ShiftLeftLogical(Vector128<ulong> value, byte count) { throw null; }
-        public static Vector128<sbyte> ShiftLeftLogical128BitLane(Vector128<sbyte> value, byte numBytes) { throw null; }
-        public static Vector128<byte> ShiftLeftLogical128BitLane(Vector128<byte> value, byte numBytes) { throw null; }
-        public static Vector128<short> ShiftLeftLogical128BitLane(Vector128<short> value, byte numBytes) { throw null; }
-        public static Vector128<ushort> ShiftLeftLogical128BitLane(Vector128<ushort> value, byte numBytes) { throw null; }
-        public static Vector128<int> ShiftLeftLogical128BitLane(Vector128<int> value, byte numBytes) { throw null; }
-        public static Vector128<uint> ShiftLeftLogical128BitLane(Vector128<uint> value, byte numBytes) { throw null; }
-        public static Vector128<long> ShiftLeftLogical128BitLane(Vector128<long> value, byte numBytes) { throw null; }
-        public static Vector128<ulong> ShiftLeftLogical128BitLane(Vector128<ulong> value, byte numBytes) { throw null; }
-        public static Vector128<short> ShiftRightArithmetic(Vector128<short> value, Vector128<short> count) { throw null; }
-        public static Vector128<int> ShiftRightArithmetic(Vector128<int> value, Vector128<int> count) { throw null; }
-        public static Vector128<short> ShiftRightArithmetic(Vector128<short> value, byte count) { throw null; }
-        public static Vector128<int> ShiftRightArithmetic(Vector128<int> value, byte count) { throw null; }
-        public static Vector128<short> ShiftRightLogical(Vector128<short> value, Vector128<short> count) { throw null; }
-        public static Vector128<ushort> ShiftRightLogical(Vector128<ushort> value, Vector128<ushort> count) { throw null; }
-        public static Vector128<int> ShiftRightLogical(Vector128<int> value, Vector128<int> count) { throw null; }
-        public static Vector128<uint> ShiftRightLogical(Vector128<uint> value, Vector128<uint> count) { throw null; }
-        public static Vector128<long> ShiftRightLogical(Vector128<long> value, Vector128<long> count) { throw null; }
-        public static Vector128<ulong> ShiftRightLogical(Vector128<ulong> value, Vector128<ulong> count) { throw null; }
-        public static Vector128<short> ShiftRightLogical(Vector128<short> value, byte count) { throw null; }
-        public static Vector128<ushort> ShiftRightLogical(Vector128<ushort> value, byte count) { throw null; }
-        public static Vector128<int> ShiftRightLogical(Vector128<int> value, byte count) { throw null; }
-        public static Vector128<uint> ShiftRightLogical(Vector128<uint> value, byte count) { throw null; }
-        public static Vector128<long> ShiftRightLogical(Vector128<long> value, byte count) { throw null; }
-        public static Vector128<ulong> ShiftRightLogical(Vector128<ulong> value, byte count) { throw null; }
-        public static Vector128<sbyte> ShiftRightLogical128BitLane(Vector128<sbyte> value, byte numBytes) { throw null; }
-        public static Vector128<byte> ShiftRightLogical128BitLane(Vector128<byte> value, byte numBytes) { throw null; }
-        public static Vector128<short> ShiftRightLogical128BitLane(Vector128<short> value, byte numBytes) { throw null; }
-        public static Vector128<ushort> ShiftRightLogical128BitLane(Vector128<ushort> value, byte numBytes) { throw null; }
-        public static Vector128<int> ShiftRightLogical128BitLane(Vector128<int> value, byte numBytes) { throw null; }
-        public static Vector128<uint> ShiftRightLogical128BitLane(Vector128<uint> value, byte numBytes) { throw null; }
-        public static Vector128<long> ShiftRightLogical128BitLane(Vector128<long> value, byte numBytes) { throw null; }
-        public static Vector128<ulong> ShiftRightLogical128BitLane(Vector128<ulong> value, byte numBytes) { throw null; }
-        public static Vector128<double> Sqrt(Vector128<double> value) { throw null; }
-        public static Vector128<double> SqrtScalar(Vector128<double> value) { throw null; }
-        public static Vector128<double> SqrtScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static unsafe void StoreAligned(sbyte* address, Vector128<sbyte> source) { throw null; }
-        public static unsafe void StoreAligned(byte* address, Vector128<byte> source) { throw null; }
-        public static unsafe void StoreAligned(short* address, Vector128<short> source) { throw null; }
-        public static unsafe void StoreAligned(ushort* address, Vector128<ushort> source) { throw null; }
-        public static unsafe void StoreAligned(int* address, Vector128<int> source) { throw null; }
-        public static unsafe void StoreAligned(uint* address, Vector128<uint> source) { throw null; }
-        public static unsafe void StoreAligned(long* address, Vector128<long> source) { throw null; }
-        public static unsafe void StoreAligned(ulong* address, Vector128<ulong> source) { throw null; }
-        public static unsafe void StoreAligned(double* address, Vector128<double> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(sbyte* address, Vector128<sbyte> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(byte* address, Vector128<byte> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(short* address, Vector128<short> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(ushort* address, Vector128<ushort> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(int* address, Vector128<int> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(uint* address, Vector128<uint> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(long* address, Vector128<long> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(ulong* address, Vector128<ulong> source) { throw null; }
-        public static unsafe void StoreAlignedNonTemporal(double* address, Vector128<double> source) { throw null; }
-        public static unsafe void StoreScalar(double* address, Vector128<double> source) { throw null; }
-        public static unsafe void Store(sbyte* address, Vector128<sbyte> source) { throw null; }
-        public static unsafe void Store(byte* address, Vector128<byte> source) { throw null; }
-        public static unsafe void Store(short* address, Vector128<short> source) { throw null; }
-        public static unsafe void Store(ushort* address, Vector128<ushort> source) { throw null; }
-        public static unsafe void Store(int* address, Vector128<int> source) { throw null; }
-        public static unsafe void Store(uint* address, Vector128<uint> source) { throw null; }
-        public static unsafe void Store(long* address, Vector128<long> source) { throw null; }
-        public static unsafe void Store(ulong* address, Vector128<ulong> source) { throw null; }
-        public static unsafe void Store(double* address, Vector128<double> source) { throw null; }
-        public static unsafe void StoreNonTemporal(int* address, int value) { throw null; }
-        public static unsafe void StoreNonTemporal(uint* address, uint value) { throw null; }
-        public static unsafe void StoreHigh(double* address, Vector128<double> source) { throw null; }
-        public static unsafe void StoreLow(long* address, Vector128<long> source) { throw null; }
-        public static unsafe void StoreLow(ulong* address, Vector128<ulong> source) { throw null; }
-        public static unsafe void StoreLow(double* address, Vector128<double> source) { throw null; }
-        public static Vector128<byte> Subtract(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> Subtract(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> Subtract(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> Subtract(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> Subtract(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> Subtract(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<long> Subtract(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> Subtract(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<double> Subtract(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<sbyte> SubtractSaturate(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> SubtractSaturate(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<byte> SubtractSaturate(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<ushort> SubtractSaturate(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<double> SubtractScalar(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<byte> UnpackHigh(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> UnpackHigh(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> UnpackHigh(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> UnpackHigh(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> UnpackHigh(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> UnpackHigh(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<long> UnpackHigh(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> UnpackHigh(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<double> UnpackHigh(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<byte> UnpackLow(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> UnpackLow(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> UnpackLow(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> UnpackLow(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> UnpackLow(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> UnpackLow(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<long> UnpackLow(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> UnpackLow(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<double> UnpackLow(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<byte> Xor(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static Vector128<sbyte> Xor(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> Xor(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<ushort> Xor(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> Xor(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> Xor(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<long> Xor(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> Xor(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<double> Xor(Vector128<double> left, Vector128<double> right) { throw null; }
-        public new abstract class X64 : Sse.X64
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector128<byte> Add(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Add(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Add(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Add(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> Add(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Add(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Add(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Add(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> Add(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> AddSaturate(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> AddSaturate(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> AddSaturate(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> AddSaturate(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> AddScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> And(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> And(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> And(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> And(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> And(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> And(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> And(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> And(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> And(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> AndNot(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> AndNot(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> AndNot(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> AndNot(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> AndNot(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> AndNot(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> AndNot(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> AndNot(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> AndNot(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Average(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Average(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> CompareEqual(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareEqual(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> CompareEqual(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> CompareEqual(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> CompareEqual(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> CompareEqual(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> CompareEqual(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static bool CompareEqualOrderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareEqualScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareEqualUnorderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareGreaterThan(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> CompareGreaterThan(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> CompareGreaterThan(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> CompareGreaterThan(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static bool CompareGreaterThanOrderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareGreaterThanOrEqual(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareGreaterThanOrEqualOrderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareGreaterThanOrEqualScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareGreaterThanOrEqualUnorderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareGreaterThanScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareGreaterThanUnorderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareLessThan(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> CompareLessThan(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> CompareLessThan(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> CompareLessThan(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static bool CompareLessThanOrderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareLessThanOrEqual(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareLessThanOrEqualOrderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareLessThanOrEqualScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareLessThanOrEqualUnorderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareLessThanScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareLessThanUnorderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotEqual(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareNotEqualOrderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotEqualScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static bool CompareNotEqualUnorderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotGreaterThan(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotGreaterThanOrEqual(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotGreaterThanOrEqualScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotGreaterThanScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotLessThan(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotLessThanOrEqual(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotLessThanOrEqualScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareNotLessThanScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareOrdered(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareOrderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareUnordered(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CompareUnorderedScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> ConvertScalarToVector128Double(System.Runtime.Intrinsics.Vector128<double> upper, int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> ConvertScalarToVector128Double(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertScalarToVector128Int32(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ConvertScalarToVector128Single(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ConvertScalarToVector128UInt32(uint value) { throw null; }
+        public static double ConvertToDouble(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static int ConvertToInt32(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static int ConvertToInt32(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static int ConvertToInt32WithTruncation(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static uint ConvertToUInt32(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> ConvertToVector128Double(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> ConvertToVector128Double(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32WithTruncation(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32WithTruncation(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ConvertToVector128Single(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> ConvertToVector128Single(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Divide(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> DivideScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static ushort Extract(System.Runtime.Intrinsics.Vector128<ushort> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Insert(System.Runtime.Intrinsics.Vector128<short> value, short data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Insert(System.Runtime.Intrinsics.Vector128<ushort> value, ushort data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<byte> LoadAlignedVector128(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> LoadAlignedVector128(double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<short> LoadAlignedVector128(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> LoadAlignedVector128(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> LoadAlignedVector128(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<sbyte> LoadAlignedVector128(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ushort> LoadAlignedVector128(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> LoadAlignedVector128(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> LoadAlignedVector128(ulong* address) { throw null; }
+        public static void LoadFence() { }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> LoadHigh(System.Runtime.Intrinsics.Vector128<double> lower, double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> LoadLow(System.Runtime.Intrinsics.Vector128<double> upper, double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> LoadScalarVector128(double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> LoadScalarVector128(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> LoadScalarVector128(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> LoadScalarVector128(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> LoadScalarVector128(ulong* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<byte> LoadVector128(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> LoadVector128(double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<short> LoadVector128(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> LoadVector128(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> LoadVector128(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<sbyte> LoadVector128(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ushort> LoadVector128(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> LoadVector128(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> LoadVector128(ulong* address) { throw null; }
+        public unsafe static void MaskMove(System.Runtime.Intrinsics.Vector128<byte> source, System.Runtime.Intrinsics.Vector128<byte> mask, byte* address) { }
+        public unsafe static void MaskMove(System.Runtime.Intrinsics.Vector128<sbyte> source, System.Runtime.Intrinsics.Vector128<sbyte> mask, sbyte* address) { }
+        public static System.Runtime.Intrinsics.Vector128<byte> Max(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Max(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Max(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MaxScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static void MemoryFence() { }
+        public static System.Runtime.Intrinsics.Vector128<byte> Min(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Min(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Min(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MinScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static int MoveMask(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static int MoveMask(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static int MoveMask(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MoveScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> MoveScalar(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> MoveScalar(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Multiply(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> Multiply(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> MultiplyAddAdjacent(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> MultiplyHigh(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> MultiplyHigh(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> MultiplyLow(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> MultiplyLow(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MultiplyScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Or(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Or(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Or(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Or(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> Or(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Or(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Or(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Or(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> Or(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> PackSignedSaturate(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> PackSignedSaturate(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> PackUnsignedSaturate(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> SetAllVector128(byte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> SetAllVector128(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> SetAllVector128(short value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> SetAllVector128(int value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> SetAllVector128(long value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> SetAllVector128(sbyte value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> SetAllVector128(ushort value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> SetAllVector128(uint value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> SetAllVector128(ulong value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> SetScalarVector128(double value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> SetVector128(byte e15, byte e14, byte e13, byte e12, byte e11, byte e10, byte e9, byte e8, byte e7, byte e6, byte e5, byte e4, byte e3, byte e2, byte e1, byte e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> SetVector128(double e1, double e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> SetVector128(short e7, short e6, short e5, short e4, short e3, short e2, short e1, short e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> SetVector128(int e3, int e2, int e1, int e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> SetVector128(long e1, long e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> SetVector128(sbyte e15, sbyte e14, sbyte e13, sbyte e12, sbyte e11, sbyte e10, sbyte e9, sbyte e8, sbyte e7, sbyte e6, sbyte e5, sbyte e4, sbyte e3, sbyte e2, sbyte e1, sbyte e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> SetVector128(ushort e7, ushort e6, ushort e5, ushort e4, ushort e3, ushort e2, ushort e1, ushort e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> SetVector128(uint e3, uint e2, uint e1, uint e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> SetVector128(ulong e1, ulong e0) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<T> SetZeroVector128<T>() where T : struct { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<short> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<short> value, System.Runtime.Intrinsics.Vector128<short> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<int> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<int> value, System.Runtime.Intrinsics.Vector128<int> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<long> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<long> value, System.Runtime.Intrinsics.Vector128<long> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<ushort> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<ushort> value, System.Runtime.Intrinsics.Vector128<ushort> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<uint> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<uint> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<ulong> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ShiftLeftLogical(System.Runtime.Intrinsics.Vector128<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector128<byte> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector128<short> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector128<int> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector128<long> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector128<sbyte> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector128<ushort> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector128<uint> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ShiftLeftLogical128BitLane(System.Runtime.Intrinsics.Vector128<ulong> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShiftRightArithmetic(System.Runtime.Intrinsics.Vector128<short> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShiftRightArithmetic(System.Runtime.Intrinsics.Vector128<short> value, System.Runtime.Intrinsics.Vector128<short> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftRightArithmetic(System.Runtime.Intrinsics.Vector128<int> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftRightArithmetic(System.Runtime.Intrinsics.Vector128<int> value, System.Runtime.Intrinsics.Vector128<int> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<short> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<short> value, System.Runtime.Intrinsics.Vector128<short> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<int> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<int> value, System.Runtime.Intrinsics.Vector128<int> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<long> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<long> value, System.Runtime.Intrinsics.Vector128<long> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<ushort> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<ushort> value, System.Runtime.Intrinsics.Vector128<ushort> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<uint> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<uint> value, System.Runtime.Intrinsics.Vector128<uint> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<ulong> value, byte count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ShiftRightLogical(System.Runtime.Intrinsics.Vector128<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> count) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector128<byte> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector128<short> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector128<int> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector128<long> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector128<sbyte> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector128<ushort> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector128<uint> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> ShiftRightLogical128BitLane(System.Runtime.Intrinsics.Vector128<ulong> value, byte numBytes) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Shuffle(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Shuffle(System.Runtime.Intrinsics.Vector128<int> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Shuffle(System.Runtime.Intrinsics.Vector128<uint> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShuffleHigh(System.Runtime.Intrinsics.Vector128<short> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ShuffleHigh(System.Runtime.Intrinsics.Vector128<ushort> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ShuffleLow(System.Runtime.Intrinsics.Vector128<short> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> ShuffleLow(System.Runtime.Intrinsics.Vector128<ushort> value, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Sqrt(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> SqrtScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> SqrtScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public unsafe static void Store(byte* address, System.Runtime.Intrinsics.Vector128<byte> source) { }
+        public unsafe static void Store(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
+        public unsafe static void Store(short* address, System.Runtime.Intrinsics.Vector128<short> source) { }
+        public unsafe static void Store(int* address, System.Runtime.Intrinsics.Vector128<int> source) { }
+        public unsafe static void Store(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
+        public unsafe static void Store(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> source) { }
+        public unsafe static void Store(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source) { }
+        public unsafe static void Store(uint* address, System.Runtime.Intrinsics.Vector128<uint> source) { }
+        public unsafe static void Store(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
+        public unsafe static void StoreAligned(byte* address, System.Runtime.Intrinsics.Vector128<byte> source) { }
+        public unsafe static void StoreAligned(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
+        public unsafe static void StoreAligned(short* address, System.Runtime.Intrinsics.Vector128<short> source) { }
+        public unsafe static void StoreAligned(int* address, System.Runtime.Intrinsics.Vector128<int> source) { }
+        public unsafe static void StoreAligned(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
+        public unsafe static void StoreAligned(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> source) { }
+        public unsafe static void StoreAligned(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source) { }
+        public unsafe static void StoreAligned(uint* address, System.Runtime.Intrinsics.Vector128<uint> source) { }
+        public unsafe static void StoreAligned(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
+        public unsafe static void StoreAlignedNonTemporal(byte* address, System.Runtime.Intrinsics.Vector128<byte> source) { }
+        public unsafe static void StoreAlignedNonTemporal(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
+        public unsafe static void StoreAlignedNonTemporal(short* address, System.Runtime.Intrinsics.Vector128<short> source) { }
+        public unsafe static void StoreAlignedNonTemporal(int* address, System.Runtime.Intrinsics.Vector128<int> source) { }
+        public unsafe static void StoreAlignedNonTemporal(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
+        public unsafe static void StoreAlignedNonTemporal(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> source) { }
+        public unsafe static void StoreAlignedNonTemporal(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source) { }
+        public unsafe static void StoreAlignedNonTemporal(uint* address, System.Runtime.Intrinsics.Vector128<uint> source) { }
+        public unsafe static void StoreAlignedNonTemporal(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
+        public unsafe static void StoreHigh(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
+        public unsafe static void StoreLow(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
+        public unsafe static void StoreLow(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
+        public unsafe static void StoreLow(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
+        public unsafe static void StoreNonTemporal(int* address, int value) { }
+        public unsafe static void StoreNonTemporal(uint* address, uint value) { }
+        public unsafe static void StoreScalar(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
+        public static System.Runtime.Intrinsics.Vector128<byte> Subtract(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Subtract(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Subtract(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Subtract(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> Subtract(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Subtract(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Subtract(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Subtract(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> Subtract(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> SubtractSaturate(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> SubtractSaturate(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> SubtractSaturate(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> SubtractSaturate(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> SubtractScalar(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> SumAbsoluteDifferences(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> UnpackHigh(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> UnpackHigh(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> UnpackHigh(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> UnpackHigh(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> UnpackHigh(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> UnpackHigh(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> UnpackHigh(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> UnpackHigh(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> UnpackHigh(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> UnpackLow(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> UnpackLow(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> UnpackLow(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> UnpackLow(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> UnpackLow(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> UnpackLow(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> UnpackLow(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> UnpackLow(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> UnpackLow(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Xor(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Xor(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Xor(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Xor(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> Xor(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Xor(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Xor(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Xor(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> Xor(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public abstract partial class X64 : System.Runtime.Intrinsics.X86.Sse.X64
         {
             internal X64() { }
-            public new static bool IsSupported { get { throw null; } }
-            public static long ConvertToInt64(Vector128<double> value) { throw null; }
-            public static long ConvertToInt64(Vector128<long> value) { throw null; }
-            public static ulong ConvertToUInt64(Vector128<ulong> value) { throw null; }
-            public static Vector128<double> ConvertScalarToVector128Double(Vector128<double> upper, long value) { throw null; }
-            public static Vector128<long> ConvertScalarToVector128Int64(long value) { throw null; }
-            public static Vector128<ulong> ConvertScalarToVector128UInt64(ulong value) { throw null; }
-            public static long ConvertToInt64WithTruncation(Vector128<double> value) { throw null; }
-            public static unsafe void StoreNonTemporal(long* address, long value) { throw null; }
-            public static unsafe void StoreNonTemporal(ulong* address, ulong value) { throw null; }
+            public static new bool IsSupported { get { throw null; } }
+            public static System.Runtime.Intrinsics.Vector128<double> ConvertScalarToVector128Double(System.Runtime.Intrinsics.Vector128<double> upper, long value) { throw null; }
+            public static System.Runtime.Intrinsics.Vector128<long> ConvertScalarToVector128Int64(long value) { throw null; }
+            public static System.Runtime.Intrinsics.Vector128<ulong> ConvertScalarToVector128UInt64(ulong value) { throw null; }
+            public static long ConvertToInt64(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+            public static long ConvertToInt64(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
+            public static long ConvertToInt64WithTruncation(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+            public static ulong ConvertToUInt64(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
+            public unsafe static void StoreNonTemporal(long* address, long value) { }
+            public unsafe static void StoreNonTemporal(ulong* address, ulong value) { }
         }
     }
-    public abstract class Sse3 : Sse2
+    public abstract partial class Sse3 : System.Runtime.Intrinsics.X86.Sse2
     {
         internal Sse3() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector128<float> AddSubtract(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<double> AddSubtract(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<float> HorizontalAdd(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<double> HorizontalAdd(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static Vector128<float> HorizontalSubtract(Vector128<float> left, Vector128<float> right) { throw null; }
-        public static Vector128<double> HorizontalSubtract(Vector128<double> left, Vector128<double> right) { throw null; }
-        public static unsafe Vector128<double> LoadAndDuplicateToVector128(double* address) { throw null; }
-        public static unsafe Vector128<sbyte> LoadDquVector128(sbyte* address) { throw null; }
-        public static unsafe Vector128<byte> LoadDquVector128(byte* address) { throw null; }
-        public static unsafe Vector128<short> LoadDquVector128(short* address) { throw null; }
-        public static unsafe Vector128<ushort> LoadDquVector128(ushort* address) { throw null; }
-        public static unsafe Vector128<int> LoadDquVector128(int* address) { throw null; }
-        public static unsafe Vector128<uint> LoadDquVector128(uint* address) { throw null; }
-        public static unsafe Vector128<long> LoadDquVector128(long* address) { throw null; }
-        public static unsafe Vector128<ulong> LoadDquVector128(ulong* address) { throw null; }
-        public static Vector128<double> MoveAndDuplicate(Vector128<double> source) { throw null; }
-        public static Vector128<float> MoveHighAndDuplicate(Vector128<float> source) { throw null; }
-        public static Vector128<float> MoveLowAndDuplicate(Vector128<float> source) { throw null; }
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector128<double> AddSubtract(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> AddSubtract(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> HorizontalAdd(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> HorizontalAdd(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> HorizontalSubtract(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> HorizontalSubtract(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> LoadAndDuplicateToVector128(double* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<byte> LoadDquVector128(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<short> LoadDquVector128(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> LoadDquVector128(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> LoadDquVector128(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<sbyte> LoadDquVector128(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ushort> LoadDquVector128(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> LoadDquVector128(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> LoadDquVector128(ulong* address) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> MoveAndDuplicate(System.Runtime.Intrinsics.Vector128<double> source) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MoveHighAndDuplicate(System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> MoveLowAndDuplicate(System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
     }
-    public abstract class Sse41 : Ssse3
+    public abstract partial class Sse41 : System.Runtime.Intrinsics.X86.Ssse3
     {
         internal Sse41() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector128<short> Blend(Vector128<short> left, Vector128<short> right, byte control) { throw null; }
-        public static Vector128<ushort> Blend(Vector128<ushort> left, Vector128<ushort> right, byte control) { throw null; }
-        public static Vector128<float> Blend(Vector128<float> left, Vector128<float> right, byte control) { throw null; }
-        public static Vector128<double> Blend(Vector128<double> left, Vector128<double> right, byte control) { throw null; }
-        public static Vector128<sbyte> BlendVariable(Vector128<sbyte> left, Vector128<sbyte> right, Vector128<sbyte> mask) { throw null; }
-        public static Vector128<byte> BlendVariable(Vector128<byte> left, Vector128<byte> right, Vector128<byte> mask) { throw null; }
-        public static Vector128<short> BlendVariable(Vector128<short> left, Vector128<short> right, Vector128<short> mask) { throw null; }
-        public static Vector128<ushort> BlendVariable(Vector128<ushort> left, Vector128<ushort> right, Vector128<ushort> mask) { throw null; }
-        public static Vector128<int> BlendVariable(Vector128<int> left, Vector128<int> right, Vector128<int> mask) { throw null; }
-        public static Vector128<uint> BlendVariable(Vector128<uint> left, Vector128<uint> right, Vector128<uint> mask) { throw null; }
-        public static Vector128<long> BlendVariable(Vector128<long> left, Vector128<long> right, Vector128<long> mask) { throw null; }
-        public static Vector128<ulong> BlendVariable(Vector128<ulong> left, Vector128<ulong> right, Vector128<ulong> mask) { throw null; }
-        public static Vector128<float> BlendVariable(Vector128<float> left, Vector128<float> right, Vector128<float> mask) { throw null; }
-        public static Vector128<double> BlendVariable(Vector128<double> left, Vector128<double> right, Vector128<double> mask) { throw null; }
-        public static Vector128<float> Ceiling(Vector128<float> value) { throw null; }
-        public static Vector128<double> Ceiling(Vector128<double> value) { throw null; }
-        public static Vector128<double> CeilingScalar(Vector128<double> value) { throw null; }
-        public static Vector128<double> CeilingScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static Vector128<float> CeilingScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> CeilingScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<long> CompareEqual(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static Vector128<ulong> CompareEqual(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static Vector128<short> ConvertToVector128Int16(Vector128<sbyte> value) { throw null; }
-        public static Vector128<short> ConvertToVector128Int16(Vector128<byte> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32(Vector128<sbyte> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32(Vector128<byte> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32(Vector128<short> value) { throw null; }
-        public static Vector128<int> ConvertToVector128Int32(Vector128<ushort> value) { throw null; }
-        public static Vector128<long> ConvertToVector128Int64(Vector128<sbyte> value) { throw null; }
-        public static Vector128<long> ConvertToVector128Int64(Vector128<byte> value) { throw null; }
-        public static Vector128<long> ConvertToVector128Int64(Vector128<short> value) { throw null; }
-        public static Vector128<long> ConvertToVector128Int64(Vector128<ushort> value) { throw null; }
-        public static Vector128<long> ConvertToVector128Int64(Vector128<int> value) { throw null; }
-        public static Vector128<long> ConvertToVector128Int64(Vector128<uint> value) { throw null; }
-        public static Vector128<float> DotProduct(Vector128<float> left, Vector128<float> right, byte control) { throw null; }
-        public static Vector128<double> DotProduct(Vector128<double> left, Vector128<double> right, byte control) { throw null; }
-        public static byte Extract(Vector128<byte> value, byte index) { throw null; }
-        public static int Extract(Vector128<int> value, byte index) { throw null; }
-        public static uint Extract(Vector128<uint> value, byte index) { throw null; }
-        public static float Extract(Vector128<float> value, byte index) { throw null; }
-        public static Vector128<float> Floor(Vector128<float> value) { throw null; }
-        public static Vector128<double> Floor(Vector128<double> value) { throw null; }
-        public static Vector128<double> FloorScalar(Vector128<double> value) { throw null; }
-        public static Vector128<double> FloorScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static Vector128<float> FloorScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> FloorScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<sbyte> Insert(Vector128<sbyte> value, sbyte data, byte index) { throw null; }
-        public static Vector128<byte> Insert(Vector128<byte> value, byte data, byte index) { throw null; }
-        public static Vector128<int> Insert(Vector128<int> value, int data, byte index) { throw null; }
-        public static Vector128<uint> Insert(Vector128<uint> value, uint data, byte index) { throw null; }
-        public static Vector128<float> Insert(Vector128<float> value, Vector128<float> data, byte index) { throw null; }
-        public static Vector128<sbyte> Max(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<ushort> Max(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> Max(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> Max(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<sbyte> Min(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<ushort> Min(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static Vector128<int> Min(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> Min(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<ushort> MinHorizontal(Vector128<ushort> value) { throw null; }
-        public static Vector128<ushort> MultipleSumAbsoluteDifferences(Vector128<byte> left, Vector128<byte> right, byte mask) { throw null; }
-        public static Vector128<long> Multiply(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<int> MultiplyLow(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<uint> MultiplyLow(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static Vector128<ushort> PackUnsignedSaturate(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<double> RoundCurrentDirectionScalar(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundCurrentDirectionScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static Vector128<float> RoundCurrentDirectionScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundCurrentDirectionScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundToNearestInteger(Vector128<float> value) { throw null; }
-        public static Vector128<double> RoundToNearestIntegerScalar(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundToNearestIntegerScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static Vector128<float> RoundToNearestIntegerScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundToNearestIntegerScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundToNegativeInfinity(Vector128<float> value) { throw null; }
-        public static Vector128<double> RoundToNegativeInfinityScalar(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundToNegativeInfinityScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static Vector128<float> RoundToNegativeInfinityScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundToNegativeInfinityScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundToPositiveInfinity(Vector128<float> value) { throw null; }
-        public static Vector128<double> RoundToPositiveInfinityScalar(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundToPositiveInfinityScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static Vector128<float> RoundToPositiveInfinityScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundToPositiveInfinityScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundToZero(Vector128<float> value) { throw null; }
-        public static Vector128<double> RoundToZeroScalar(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundToZeroScalar(Vector128<double> upper, Vector128<double> value) { throw null; }
-        public static Vector128<float> RoundToZeroScalar(Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundToZeroScalar(Vector128<float> upper, Vector128<float> value) { throw null; }
-        public static Vector128<float> RoundCurrentDirection(Vector128<float> value) { throw null; }
-        public static Vector128<double> RoundToNearestInteger(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundToNegativeInfinity(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundToPositiveInfinity(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundToZero(Vector128<double> value) { throw null; }
-        public static Vector128<double> RoundCurrentDirection(Vector128<double> value) { throw null; }
-        public static unsafe Vector128<sbyte> LoadAlignedVector128NonTemporal(sbyte* address) { throw null; }
-        public static unsafe Vector128<byte> LoadAlignedVector128NonTemporal(byte* address) { throw null; }
-        public static unsafe Vector128<short> LoadAlignedVector128NonTemporal(short* address) { throw null; }
-        public static unsafe Vector128<ushort> LoadAlignedVector128NonTemporal(ushort* address) { throw null; }
-        public static unsafe Vector128<int> LoadAlignedVector128NonTemporal(int* address) { throw null; }
-        public static unsafe Vector128<uint> LoadAlignedVector128NonTemporal(uint* address) { throw null; }
-        public static unsafe Vector128<long> LoadAlignedVector128NonTemporal(long* address) { throw null; }
-        public static unsafe Vector128<ulong> LoadAlignedVector128NonTemporal(ulong* address) { throw null; }
-        public static bool TestAllOnes(Vector128<sbyte> value) { throw null; }
-        public static bool TestAllOnes(Vector128<byte> value) { throw null; }
-        public static bool TestAllOnes(Vector128<short> value) { throw null; }
-        public static bool TestAllOnes(Vector128<ushort> value) { throw null; }
-        public static bool TestAllOnes(Vector128<int> value) { throw null; }
-        public static bool TestAllOnes(Vector128<uint> value) { throw null; }
-        public static bool TestAllOnes(Vector128<long> value) { throw null; }
-        public static bool TestAllOnes(Vector128<ulong> value) { throw null; }
-        public static bool TestAllZeros(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static bool TestAllZeros(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static bool TestAllZeros(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static bool TestAllZeros(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static bool TestAllZeros(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static bool TestAllZeros(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static bool TestAllZeros(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static bool TestAllZeros(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static bool TestC(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static bool TestC(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static bool TestC(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static bool TestC(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static bool TestC(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static bool TestC(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static bool TestC(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static bool TestC(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static bool TestMixOnesZeros(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static bool TestMixOnesZeros(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static bool TestMixOnesZeros(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static bool TestMixOnesZeros(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static bool TestMixOnesZeros(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static bool TestMixOnesZeros(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static bool TestMixOnesZeros(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static bool TestMixOnesZeros(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static bool TestNotZAndNotC(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public static bool TestZ(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static bool TestZ(Vector128<byte> left, Vector128<byte> right) { throw null; }
-        public static bool TestZ(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static bool TestZ(Vector128<ushort> left, Vector128<ushort> right) { throw null; }
-        public static bool TestZ(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static bool TestZ(Vector128<uint> left, Vector128<uint> right) { throw null; }
-        public static bool TestZ(Vector128<long> left, Vector128<long> right) { throw null; }
-        public static bool TestZ(Vector128<ulong> left, Vector128<ulong> right) { throw null; }
-        public new abstract class X64 : Sse2.X64
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector128<double> Blend(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Blend(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Blend(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Blend(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> BlendVariable(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right, System.Runtime.Intrinsics.Vector128<byte> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> BlendVariable(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, System.Runtime.Intrinsics.Vector128<double> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> BlendVariable(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right, System.Runtime.Intrinsics.Vector128<short> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> BlendVariable(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right, System.Runtime.Intrinsics.Vector128<int> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> BlendVariable(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right, System.Runtime.Intrinsics.Vector128<long> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> BlendVariable(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right, System.Runtime.Intrinsics.Vector128<sbyte> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> BlendVariable(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, System.Runtime.Intrinsics.Vector128<float> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> BlendVariable(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right, System.Runtime.Intrinsics.Vector128<ushort> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> BlendVariable(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right, System.Runtime.Intrinsics.Vector128<uint> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> BlendVariable(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right, System.Runtime.Intrinsics.Vector128<ulong> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Ceiling(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Ceiling(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CeilingScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> CeilingScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CeilingScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> CeilingScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> CompareEqual(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> CompareEqual(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ConvertToVector128Int16(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> ConvertToVector128Int16(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> DotProduct(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, byte control) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> DotProduct(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, byte control) { throw null; }
+        public static byte Extract(System.Runtime.Intrinsics.Vector128<byte> value, byte index) { throw null; }
+        public static int Extract(System.Runtime.Intrinsics.Vector128<int> value, byte index) { throw null; }
+        public static float Extract(System.Runtime.Intrinsics.Vector128<float> value, byte index) { throw null; }
+        public static uint Extract(System.Runtime.Intrinsics.Vector128<uint> value, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Floor(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Floor(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> FloorScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> FloorScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> FloorScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> FloorScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Insert(System.Runtime.Intrinsics.Vector128<byte> value, byte data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Insert(System.Runtime.Intrinsics.Vector128<int> value, int data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Insert(System.Runtime.Intrinsics.Vector128<sbyte> value, sbyte data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Insert(System.Runtime.Intrinsics.Vector128<float> value, System.Runtime.Intrinsics.Vector128<float> data, byte index) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Insert(System.Runtime.Intrinsics.Vector128<uint> value, uint data, byte index) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<byte> LoadAlignedVector128NonTemporal(byte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<short> LoadAlignedVector128NonTemporal(short* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> LoadAlignedVector128NonTemporal(int* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> LoadAlignedVector128NonTemporal(long* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<sbyte> LoadAlignedVector128NonTemporal(sbyte* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ushort> LoadAlignedVector128NonTemporal(ushort* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> LoadAlignedVector128NonTemporal(uint* address) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> LoadAlignedVector128NonTemporal(ulong* address) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Max(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Max(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Max(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Max(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Min(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Min(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Min(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Min(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> MinHorizontal(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> MultipleSumAbsoluteDifferences(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> Multiply(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> MultiplyLow(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> MultiplyLow(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> PackUnsignedSaturate(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundCurrentDirection(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundCurrentDirection(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundCurrentDirectionScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundCurrentDirectionScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundCurrentDirectionScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundCurrentDirectionScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToNearestInteger(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToNearestInteger(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToNearestIntegerScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToNearestIntegerScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToNearestIntegerScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToNearestIntegerScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToNegativeInfinity(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToNegativeInfinity(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToNegativeInfinityScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToNegativeInfinityScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToNegativeInfinityScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToNegativeInfinityScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToPositiveInfinity(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToPositiveInfinity(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToPositiveInfinityScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToPositiveInfinityScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToPositiveInfinityScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToPositiveInfinityScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToZero(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToZero(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToZeroScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> RoundToZeroScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToZeroScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> RoundToZeroScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
+        public static bool TestAllOnes(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
+        public static bool TestAllOnes(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static bool TestAllOnes(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static bool TestAllOnes(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
+        public static bool TestAllOnes(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static bool TestAllOnes(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
+        public static bool TestAllOnes(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
+        public static bool TestAllOnes(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
+        public static bool TestAllZeros(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static bool TestAllZeros(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static bool TestAllZeros(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static bool TestAllZeros(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static bool TestAllZeros(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static bool TestAllZeros(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static bool TestAllZeros(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static bool TestAllZeros(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static bool TestC(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static bool TestMixOnesZeros(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static bool TestMixOnesZeros(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static bool TestMixOnesZeros(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static bool TestMixOnesZeros(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static bool TestMixOnesZeros(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static bool TestMixOnesZeros(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static bool TestMixOnesZeros(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static bool TestMixOnesZeros(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static bool TestNotZAndNotC(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right) { throw null; }
+        public static bool TestZ(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
+        public abstract partial class X64 : System.Runtime.Intrinsics.X86.Sse2.X64
         {
             internal X64() { }
-            public new static bool IsSupported { get { throw null; } }
-            public static long Extract(Vector128<long> value, byte index) { throw null; }
-            public static ulong Extract(Vector128<ulong> value, byte index) { throw null; }
-            public static Vector128<long> Insert(Vector128<long> value, long data, byte index) { throw null; }
-            public static Vector128<ulong> Insert(Vector128<ulong> value, ulong data, byte index) { throw null; }
+            public static new bool IsSupported { get { throw null; } }
+            public static long Extract(System.Runtime.Intrinsics.Vector128<long> value, byte index) { throw null; }
+            public static ulong Extract(System.Runtime.Intrinsics.Vector128<ulong> value, byte index) { throw null; }
+            public static System.Runtime.Intrinsics.Vector128<long> Insert(System.Runtime.Intrinsics.Vector128<long> value, long data, byte index) { throw null; }
+            public static System.Runtime.Intrinsics.Vector128<ulong> Insert(System.Runtime.Intrinsics.Vector128<ulong> value, ulong data, byte index) { throw null; }
         }
     }
-    public abstract class Sse42 : Sse41
+    public abstract partial class Sse42 : System.Runtime.Intrinsics.X86.Sse41
     {
         internal Sse42() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector128<long> CompareGreaterThan(Vector128<long> left, Vector128<long> right) { throw null; }
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector128<long> CompareGreaterThan(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
         public static uint Crc32(uint crc, byte data) { throw null; }
         public static uint Crc32(uint crc, ushort data) { throw null; }
         public static uint Crc32(uint crc, uint data) { throw null; }
-        public new abstract class X64 : Sse41.X64
+        public abstract partial class X64 : System.Runtime.Intrinsics.X86.Sse41.X64
         {
             internal X64() { }
-            public new static bool IsSupported { get { throw null; } }
+            public static new bool IsSupported { get { throw null; } }
             public static ulong Crc32(ulong crc, ulong data) { throw null; }
         }
     }
-    public abstract class Ssse3 : Sse3
+    public abstract partial class Ssse3 : System.Runtime.Intrinsics.X86.Sse3
     {
         internal Ssse3() { }
-        public new static bool IsSupported { get { throw null; } }
-        public static Vector128<byte> Abs(Vector128<sbyte> value) { throw null; }
-        public static Vector128<ushort> Abs(Vector128<short> value) { throw null; }
-        public static Vector128<uint> Abs(Vector128<int> value) { throw null; }
-        public static Vector128<sbyte> AlignRight(Vector128<sbyte> left, Vector128<sbyte> right, byte mask) { throw null; }
-        public static Vector128<byte> AlignRight(Vector128<byte> left, Vector128<byte> right, byte mask) { throw null; }
-        public static Vector128<short> AlignRight(Vector128<short> left, Vector128<short> right, byte mask) { throw null; }
-        public static Vector128<ushort> AlignRight(Vector128<ushort> left, Vector128<ushort> right, byte mask) { throw null; }
-        public static Vector128<int> AlignRight(Vector128<int> left, Vector128<int> right, byte mask) { throw null; }
-        public static Vector128<uint> AlignRight(Vector128<uint> left, Vector128<uint> right, byte mask) { throw null; }
-        public static Vector128<long> AlignRight(Vector128<long> left, Vector128<long> right, byte mask) { throw null; }
-        public static Vector128<ulong> AlignRight(Vector128<ulong> left, Vector128<ulong> right, byte mask) { throw null; }
-        public static Vector128<short> HorizontalAdd(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<int> HorizontalAdd(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<short> HorizontalAddSaturate(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<short> HorizontalSubtract(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<int> HorizontalSubtract(Vector128<int> left, Vector128<int> right) { throw null; }
-        public static Vector128<short> HorizontalSubtractSaturate(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<short> MultiplyAddAdjacent(Vector128<byte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> MultiplyHighRoundScale(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<sbyte> Shuffle(Vector128<sbyte> value, Vector128<sbyte> mask) { throw null; }
-        public static Vector128<byte> Shuffle(Vector128<byte> value, Vector128<byte> mask) { throw null; }
-        public static Vector128<sbyte> Sign(Vector128<sbyte> left, Vector128<sbyte> right) { throw null; }
-        public static Vector128<short> Sign(Vector128<short> left, Vector128<short> right) { throw null; }
-        public static Vector128<int> Sign(Vector128<int> left, Vector128<int> right) { throw null; }
+        public static new bool IsSupported { get { throw null; } }
+        public static System.Runtime.Intrinsics.Vector128<ushort> Abs(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> Abs(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Abs(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> AlignRight(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> AlignRight(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> AlignRight(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<long> AlignRight(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> AlignRight(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ushort> AlignRight(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<uint> AlignRight(System.Runtime.Intrinsics.Vector128<uint> left, System.Runtime.Intrinsics.Vector128<uint> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<ulong> AlignRight(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right, byte mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> HorizontalAdd(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> HorizontalAdd(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> HorizontalAddSaturate(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> HorizontalSubtract(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> HorizontalSubtract(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> HorizontalSubtractSaturate(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> MultiplyAddAdjacent(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> MultiplyHighRoundScale(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<byte> Shuffle(System.Runtime.Intrinsics.Vector128<byte> value, System.Runtime.Intrinsics.Vector128<byte> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Shuffle(System.Runtime.Intrinsics.Vector128<sbyte> value, System.Runtime.Intrinsics.Vector128<sbyte> mask) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<short> Sign(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<int> Sign(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<sbyte> Sign(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
     }
 }

--- a/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.csproj
+++ b/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Intrinsics.cs" />
+    <Compile Include="System.Runtime.Intrinsics.manual.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />

--- a/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.manual.cs
+++ b/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.manual.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.MidpointRounding))]
+
+namespace System.Runtime.Intrinsics.X86
+{
+    public abstract partial class Popcnt
+    {
+        public new abstract partial class X64 { }
+    }
+    public abstract partial class Sse2
+    {
+        public new abstract partial class X64 { }
+    }
+    public abstract partial class Sse41
+    {
+        public new abstract partial class X64 { }
+    }
+    public abstract partial class Sse42
+    {
+        public new abstract partial class X64 { }
+    }
+}


### PR DESCRIPTION
As recommended by @ahsonkhan, this regenerates the `System.Runtime.Intrinsics` ref assembly by running `msbuild /t:GenerateReferenceSource`