### PR TITLE
Force CoreFX to use source-build's BuildTools

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -52,10 +52,10 @@
   <Target Name="InitTools" AfterTargets="Restore">
 
     <PropertyGroup>
-      <ToolsDir>$(RepoRoot)Tools</ToolsDir>
+      <ToolsDir Condition="'$(ToolsDir)' == ''">$(RepoRoot)Tools</ToolsDir>
       <BuildToolsSemaphore>$(ToolsDir)/$(BuildToolsPackageVersion).init-tools.completed</BuildToolsSemaphore>
       <PackagesDir>$(NuGetPackageRoot)/</PackagesDir>
-      <BuildToolsPackageDir>$(PackagesDir)$(BuildToolsPackage)/$(BuildToolsPackageVersion)/lib/</BuildToolsPackageDir>
+      <BuildToolsPackageDir Condition="'$(BuildToolsPackageDir)' == ''">$(PackagesDir)$(BuildToolsPackage)/$(BuildToolsPackageVersion)/lib/</BuildToolsPackageDir>
       <CmdExt>cmd</CmdExt>
       <CmdExt Condition="'$(OS)' != 'Windows_NT'">sh</CmdExt>
       <InitToolsCmdLine>$(BuildToolsPackageDir)init-tools.$(CmdExt) $(RepoRoot) $(DotNETCmd) $(ToolsDir) $(PackagesDir)</InitToolsCmdLine>


### PR DESCRIPTION
We used this patch to get CoreFX on Arcade to use source-build's copy of buildtools: https://github.com/dotnet/source-build/pull/916.

@bartonjs can you make sure this (or some better approach) gets merged in to reduce maintenance burden as CoreFX moves along?