### PR TITLE
Disable CurrentInfo_CustomCulture tests failing on UWP

### DIFF
--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
@@ -17,6 +17,7 @@ namespace System.Globalization.Tests
             yield return new object[] { CultureInfo.InvariantCulture };
         }
 
+        [ActiveIssue(33904, TargetFrameworkMonikers.Uap)]
         [Theory]
         [MemberData(nameof(CurrentInfo_CustomCulture_TestData))]
         public void CurrentInfo_CustomCulture(CultureInfo newCurrentCulture)


### PR DESCRIPTION
#33904

cc: @tarekgh, @krwq 