### PR TITLE
Condition Test SDK right, ci fixes and code cleanup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -180,8 +180,6 @@
       https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json;
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://api.nuget.org/v3/index.json;
-      <!-- Temporary until the Microsoft.Net.Test.Sdk 16.0.0-preview is published on nuget. -->
-      https://dotnet.myget.org/F/vstest/api/v3/index.json;
       $(OverridePackageSource);
       $(RestoreSources)
     </RestoreSources>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,12 +30,12 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>04ee3b77a39302513ece3a950554d6c0ee6d0951</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.18605.15">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>52e1e2b87d2ea0c7a30b2d34eb98c5a441888fd3</Sha>
-    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.18605.7">
+    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.18607.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>04ee3b77a39302513ece3a950554d6c0ee6d0951</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.18605.15">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>52e1e2b87d2ea0c7a30b2d34eb98c5a441888fd3</Sha>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
     <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.18578.2</MicrosoftDotNetGenFacadesPackageVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.18578.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.18578.2</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.18605.7</MicrosoftDotNetCoreFxTestingPackageVersion>
+    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.18607.2</MicrosoftDotNetCoreFxTestingPackageVersion>
     <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.18605.15</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -47,7 +47,7 @@
     <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
 
     <!-- xunit test dependency version  -->
-    <MicrosoftNetTestSdkPackageVersion>16.0.0-preview-20181204-03</MicrosoftNetTestSdkPackageVersion>
+    <MicrosoftNetTestSdkPackageVersion>16.0.0-preview-20181205-02</MicrosoftNetTestSdkPackageVersion>
     <XUnitPackageVersion>2.4.1-pre.build.4059</XUnitPackageVersion>
     <XUnitPerformancePackageVersion>1.0.0-beta-build0020</XUnitPerformancePackageVersion>
     <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>

--- a/external/Directory.Build.props
+++ b/external/Directory.Build.props
@@ -2,7 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <ContainsPackageReferences>true</ContainsPackageReferences>
-    <EnableVSTestReferences Condition="'$(EnableVSTestReferences)' == ''">true</EnableVSTestReferences>
     <!-- We need configuration-specific assets files. -->
     <RestoreOutputPath>$(IntermediateOutputPath)</RestoreOutputPath>
     <ProjectAssetsFile>$(RestoreOutputPath)/project.assets.json</ProjectAssetsFile>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -185,7 +185,9 @@
 
   </Target>
 
-  <Target Name="AddTestPlatformDependencies" BeforeTargets="ResolveReferences">
+  <Target Name="AddTestPlatformDependencies"
+          Condition="'$(EnableVSTestReferences)' == 'true'"
+          BeforeTargets="ResolveReferences">
 
     <PropertyGroup>
       <TestSdkTFM Condition="'$(TargetsNetFx)' == 'true'">net45</TestSdkTFM>

--- a/perf.groovy
+++ b/perf.groovy
@@ -88,7 +88,7 @@ def osShortName = ['Windows 10': 'win10',
                     def benchViewName = isPR ? 'corefx private %BenchviewCommitName%' : 'corefx rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
                     steps {
                         //We need to specify the max cpu count to be one as we do not want to be executing performance tests in parallel
-                        batchFile("build.cmd -release")
+                        batchFile("build.cmd -ci -release")
                         batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory \"%WORKSPACE%\\Tools\" -Prerelease -ExcludeVersion")
                         //Do this here to remove the origin but at the front of the branch name as this is a problem for BenchView
                         //we have to do it all as one statement because cmd is called each time and we lose the set environment variable
@@ -97,15 +97,15 @@ def osShortName = ['Windows 10': 'win10',
                         "${python} \"%WORKSPACE%\\Tools\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type " + runType)
                         batchFile("${python} \"%WORKSPACE%\\Tools\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
 
-                        batchFile("build.cmd -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
-                        batchFile("build.cmd -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Diagnostic")
+                        batchFile("build.cmd -ci -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
+                        batchFile("build.cmd -ci -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Diagnostic")
                     }
                 }
                 else {
                     def benchViewName = isPR ? 'corefx private \$BenchviewCommitName' : 'corefx rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
                     steps {
                         //We need to specify the max cpu count to be one as we do not want to be executing performance tests in parallel
-                        shell("./build.sh -release")
+                        shell("./build.sh --ci -release")
                         shell("find . -type f -name dotnet | xargs chmod u+x")
                         shell("curl \"http://benchviewtestfeed.azurewebsites.net/nuget/FindPackagesById()?id='Microsoft.BenchView.JSONFormat'\" | grep \"content type\" | sed \"\$ s/.*src=\\\"\\([^\\\"]*\\)\\\".*/\\1/;tx;d;:x\" | xargs curl -o benchview.zip")
                         shell("unzip -q -o benchview.zip -d \"\${WORKSPACE}/Tools/Microsoft.BenchView.JSONFormat\"")
@@ -117,7 +117,7 @@ def osShortName = ['Windows 10': 'win10',
                         "python3.5 \"\${WORKSPACE}/Tools/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type " + runType)
                         shell("python3.5 \"\${WORKSPACE}/Tools/Microsoft.BenchView.JSONFormat/tools/machinedata.py\"")
 
-                        shell("bash ./build.sh -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
+                        shell("bash ./build.sh --ci -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
                     }
                 }
             }


### PR DESCRIPTION
- Condition Test SDK target in xunit depproj correct and code cleanup
- Remove microsoft/vstest myget feed and update Microsoft.Net.Test.Sdk version
- Add ci argument to perf legs
- Update Microsoft.DotNet.CoreFxTesting package manually