### PR TITLE
Fix SslStream_StreamToStream_Alpn_NonMatchingProtocols

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -199,7 +199,7 @@ internal static partial class Interop
         {
             sendBuf = null;
             sendCount = 0;
-            
+
             if ((recvBuf != null) && (recvCount > 0))
             {
                 if (BioWrite(context.InputBio, recvBuf, recvOffset, recvCount) <= 0)
@@ -403,7 +403,7 @@ internal static partial class Interop
             GCHandle protocolHandle = GCHandle.FromIntPtr(arg);
             if (!(protocolHandle.Target is List<SslApplicationProtocol> protocolList))
             {
-                return Ssl.SSL_TLSEXT_ERR_NOACK;
+                return Ssl.SSL_TLSEXT_ERR_ALERT_FATAL;
             }
 
             try
@@ -432,14 +432,14 @@ internal static partial class Interop
                 // It is ok to clear the handle value here, this results in handshake failure, so the SslStream object is disposed.
                 protocolHandle.Target = null;
 
-                return Ssl.SSL_TLSEXT_ERR_NOACK;
+                return Ssl.SSL_TLSEXT_ERR_ALERT_FATAL;
             }
 
             // No common application protocol was negotiated, set the target on the alpnHandle to null.
             // It is ok to clear the handle value here, this results in handshake failure, so the SslStream object is disposed.
             protocolHandle.Target = null;
 
-            return Ssl.SSL_TLSEXT_ERR_NOACK;
+            return Ssl.SSL_TLSEXT_ERR_ALERT_FATAL;
         }
 
         private static int BioRead(SafeBioHandle bio, byte[] buffer, int count)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
     {
         internal const int SSL_TLSEXT_ERR_OK = 0;
         internal const int OPENSSL_NPN_NEGOTIATED = 1;
+        internal const int SSL_TLSEXT_ERR_ALERT_FATAL = 2;
         internal const int SSL_TLSEXT_ERR_NOACK = 3;
 
         internal delegate int SslCtxSetVerifyCallback(int preverify_ok, IntPtr x509_ctx);


### PR DESCRIPTION
Fixes: #33514
Fixes: #32946

I thought I broke it when working on other changes but the issue happened when I updated OpenSsl to latest and the issue was unrelated. The problem is that we used wrong error code to say "no application protocols match"