### PR TITLE
Pipelines perf tweaks

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -59,9 +59,11 @@ namespace System.IO.Pipelines
 
         public void ResetMemory()
         {
-            _memoryOwner.Dispose();
+            IMemoryOwner<byte> memoryOwner = _memoryOwner;
             _memoryOwner = null;
             AvailableMemory = default;
+
+            memoryOwner.Dispose();
         }
 
         internal IMemoryOwner<byte> MemoryOwner => _memoryOwner;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -54,7 +54,6 @@ namespace System.IO.Pipelines
             AvailableMemory = _memoryOwner.Memory;
             RunningIndex = 0;
             End = 0;
-            NextSegment = null;
         }
 
         public void ResetMemory()
@@ -62,6 +61,7 @@ namespace System.IO.Pipelines
             IMemoryOwner<byte> memoryOwner = _memoryOwner;
             _memoryOwner = null;
             AvailableMemory = default;
+            NextSegment = null;
 
             memoryOwner.Dispose();
         }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -459,11 +459,11 @@ namespace System.IO.Pipelines
                 }
 
                 // Reset and try to pool any used blocks
-                if (returnStart != null)
+                if (returnStart != returnEnd)
                 {
                     int index = _pooledSegmentCount;
                     BufferSegment[] pool = _bufferSegmentPool;
-                    while (returnStart != returnEnd)
+                    while (returnStart != null)
                     {
                         BufferSegment next = returnStart.NextSegment;
                         returnStart.ResetMemory();
@@ -474,10 +474,11 @@ namespace System.IO.Pipelines
                             index++;
                         }
 
-                        if (next is null)
+                        if (next == returnEnd)
                         {
                             break;
                         }
+
                         returnStart = next;
                     }
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -211,10 +211,12 @@ namespace System.IO.Pipelines
 
         private BufferSegment CreateSegmentUnsynchronized()
         {
-            if (_pooledSegmentCount > 0)
+            int index = _pooledSegmentCount - 1;
+            BufferSegment[] pool = _bufferSegmentPool;
+            if ((uint)index < (uint)pool.Length)
             {
-                _pooledSegmentCount--;
-                return _bufferSegmentPool[_pooledSegmentCount];
+                _pooledSegmentCount = index;
+                return pool[index];
             }
 
             return new BufferSegment();


### PR DESCRIPTION
Added separate commits for each one (from https://github.com/dotnet/corefx/pull/33851)

- Elide bounds check in CreateSegmentUnsynchronized https://github.com/dotnet/corefx/pull/33917/commits/fa14af861289f5568a30fc964980872ccee80ed5
- Tailcall Dispose (call it last) https://github.com/dotnet/corefx/pull/33917/commits/60a3ad844b62972d98cc10c81bef71fa9c70d9d5
- Drop trailing segments in ResetMemory (otherwise chain of segments if larger than pool held until reuse disconnects them) https://github.com/dotnet/corefx/pull/33917/commits/94520d50a7d038c2ea9900a1d049c50a9ed58ff6

/cc @ahsonkhan @pakrym @davidfowl 