### PR TITLE
WIP: Move memory slicing to the read side

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -13,6 +13,7 @@ namespace System.IO.Pipelines
         private IMemoryOwner<byte> _memoryOwner;
         private BufferSegment _next;
         private int _end;
+        private bool _dirty;
 
         /// <summary>
         /// The End represents the offset into AvailableMemory where the range of "active" bytes ends. At the point when the block is leased
@@ -27,7 +28,7 @@ namespace System.IO.Pipelines
                 Debug.Assert(value <= AvailableMemory.Length);
 
                 _end = value;
-                Memory = AvailableMemory.Slice(0, _end);
+                _dirty = true;
             }
         }
 
@@ -69,6 +70,15 @@ namespace System.IO.Pipelines
         public Memory<byte> AvailableMemory { get; private set; }
 
         public int Length => End;
+
+        public void UpdateMemory()
+        {
+            if (_dirty)
+            {
+                Memory = AvailableMemory.Slice(0, _end);
+                _dirty = false;
+            }
+        }
 
         /// <summary>
         /// The amount of writable bytes in this segment. It is the amount of bytes between Length and End

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -94,6 +94,10 @@ namespace System.IO.Pipelines
             Debug.Assert(segment != null);
             Debug.Assert(Next == null);
 
+            // Update the memory of the current segment since it's full and we're 
+            // adding another segment as the NextSegment
+            UpdateMemory();
+
             NextSegment = segment;
 
             segment = this;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -789,7 +789,10 @@ namespace System.IO.Pipelines
             BufferSegment head = _readHead;
             if (head != null)
             {
-                SetMemory();
+                Debug.Assert(_readTail != null);
+
+                // Update the current _readTail if it isn't been updated as yet
+                _readTail.UpdateMemory();
 
                 // Reading commit head shared with writer
                 var readOnlySequence = new ReadOnlySequence<byte>(head, _readHeadIndex, _readTail, _readTailIndex);
@@ -807,23 +810,6 @@ namespace System.IO.Pipelines
             else
             {
                 _operationState.BeginRead();
-            }
-        }
-
-        private void SetMemory()
-        {
-            // REVIEW: Optimize the single block case?
-            BufferSegment node = _readHead;
-
-            while (true)
-            {
-                node.UpdateMemory();
-
-                if (node == null || node == _readTail)
-                {
-                    break;
-                }
-                node = node.NextSegment;
             }
         }
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -789,6 +789,8 @@ namespace System.IO.Pipelines
             BufferSegment head = _readHead;
             if (head != null)
             {
+                SetMemory();
+
                 // Reading commit head shared with writer
                 var readOnlySequence = new ReadOnlySequence<byte>(head, _readHeadIndex, _readTail, _readTailIndex);
                 result = new ReadResult(readOnlySequence, isCanceled, isCompleted);
@@ -805,6 +807,23 @@ namespace System.IO.Pipelines
             else
             {
                 _operationState.BeginRead();
+            }
+        }
+
+        private void SetMemory()
+        {
+            // REVIEW: Optimize the single block case?
+            BufferSegment node = _readHead;
+
+            while (true)
+            {
+                node.UpdateMemory();
+
+                if (node == null || node == _readTail)
+                {
+                    break;
+                }
+                node = node.NextSegment;
             }
         }
 


### PR DESCRIPTION
Only slice the memory when we're about to read.

TODO: new benchmark numbers