### PR TITLE
HTTP2: Rework send logic and support request body send

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -503,6 +503,7 @@ namespace System.Net.Http
             {
                 WriteFrameHeader(new FrameHeader(FrameHeader.RstStreamLength, FrameType.RstStream, FrameFlags.None, streamId));
 
+                _outgoingBuffer.EnsureAvailableSpace(FrameHeader.RstStreamLength);
                 _outgoingBuffer.AvailableSpan[0] = (byte)(((int)errorCode & 0xFF000000) >> 24);
                 _outgoingBuffer.AvailableSpan[1] = (byte)(((int)errorCode & 0x00FF0000) >> 16);
                 _outgoingBuffer.AvailableSpan[2] = (byte)(((int)errorCode & 0x0000FF00) >> 8);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -86,7 +86,7 @@ namespace System.Net.Http
             }
 
             // Process the SETTINGS frame.  This will send an ACK.
-            await ProcessSettingsFrame(frameHeader).ConfigureAwait(false);
+            ProcessSettingsFrame(frameHeader);
 
             ProcessIncomingFrames();
         }
@@ -108,7 +108,7 @@ namespace System.Net.Http
         {
             Debug.Assert(_outgoingBuffer.ActiveSpan.Length > 0);
 
-            await SendFramesAsync(_outgoingBuffer.ActiveMemory).ConfigureAwait(false);
+            await _stream.WriteAsync(_outgoingBuffer.ActiveMemory).ConfigureAwait(false);
             _outgoingBuffer.Discard(_outgoingBuffer.ActiveMemory.Length);
         }
 
@@ -145,11 +145,11 @@ namespace System.Net.Http
                             break;
 
                         case FrameType.Data:
-                            await ProcessDataFrame(frameHeader).ConfigureAwait(false);
+                            ProcessDataFrame(frameHeader);
                             break;
 
                         case FrameType.Settings:
-                            await ProcessSettingsFrame(frameHeader).ConfigureAwait(false);
+                            ProcessSettingsFrame(frameHeader);
                             break;
 
                         case FrameType.Priority:
@@ -157,7 +157,7 @@ namespace System.Net.Http
                             break;
 
                         case FrameType.Ping:
-                            await ProcessPingFrame(frameHeader).ConfigureAwait(false);
+                            ProcessPingFrame(frameHeader);
                             break;
 
                         case FrameType.WindowUpdate:
@@ -205,19 +205,6 @@ namespace System.Net.Http
             }
         }
 
-        private async Task SendRstStreamFrameAsync(int streamId, Http2ProtocolErrorCode errorCode)
-        {
-            WriteFrameHeader(new FrameHeader(FrameHeader.RstStreamLength, FrameType.RstStream, FrameFlags.None, streamId));
-
-            _outgoingBuffer.AvailableSpan[0] = (byte)(((int)errorCode & 0xFF000000) >> 24);
-            _outgoingBuffer.AvailableSpan[1] = (byte)(((int)errorCode & 0x00FF0000) >> 16);
-            _outgoingBuffer.AvailableSpan[2] = (byte)(((int)errorCode & 0x0000FF00) >> 8);
-            _outgoingBuffer.AvailableSpan[3] = (byte)((int)errorCode & 0x000000FF);
-            _outgoingBuffer.Commit(FrameHeader.RstStreamLength);
-
-            await FlushOutgoingBytesAsync().ConfigureAwait(false);
-        }
-
         private async Task ProcessHeadersFrame(FrameHeader frameHeader)
         {
             Debug.Assert(frameHeader.Type == FrameType.Headers);
@@ -229,7 +216,7 @@ namespace System.Net.Http
             if (http2Stream == null)
             {
                 _incomingBuffer.Discard(frameHeader.Length);
-                await SendRstStreamFrameAsync(streamId, Http2ProtocolErrorCode.StreamClosed);
+                SendRstStream(streamId, Http2ProtocolErrorCode.StreamClosed);
                 return;
             }
 
@@ -297,7 +284,7 @@ namespace System.Net.Http
             return frameData;
         }
 
-        private Task ProcessDataFrame(FrameHeader frameHeader)
+        private void ProcessDataFrame(FrameHeader frameHeader)
         {
             Debug.Assert(frameHeader.Type == FrameType.Data);
 
@@ -305,7 +292,8 @@ namespace System.Net.Http
             if (http2Stream == null)
             {
                 _incomingBuffer.Discard(frameHeader.Length);
-                return SendRstStreamFrameAsync(frameHeader.StreamId, Http2ProtocolErrorCode.StreamClosed);
+                SendRstStream(frameHeader.StreamId, Http2ProtocolErrorCode.StreamClosed);
+                return;
             }
 
             ReadOnlySpan<byte> frameData = GetFrameData(_incomingBuffer.ActiveSpan.Slice(0, frameHeader.Length), hasPad: frameHeader.PaddedFlag, hasPriority: false);
@@ -320,11 +308,9 @@ namespace System.Net.Http
             {
                 RemoveStream(http2Stream);
             }
-
-            return Task.CompletedTask;
         }
 
-        private async Task ProcessSettingsFrame(FrameHeader frameHeader)
+        private void ProcessSettingsFrame(FrameHeader frameHeader)
         {
             Debug.Assert(frameHeader.Type == FrameType.Settings);
 
@@ -363,8 +349,7 @@ namespace System.Net.Http
                 _incomingBuffer.Discard(frameHeader.Length);
 
                 // Send acknowledgement
-                WriteFrameHeader(new FrameHeader(0, FrameType.Settings, FrameFlags.Ack, 0));
-                await FlushOutgoingBytesAsync().ConfigureAwait(false);
+                SendSettingsAck();
             }
         }
 
@@ -382,7 +367,7 @@ namespace System.Net.Http
             _incomingBuffer.Discard(frameHeader.Length);
         }
 
-        private async Task ProcessPingFrame(FrameHeader frameHeader)
+        private void ProcessPingFrame(FrameHeader frameHeader)
         {
             Debug.Assert(frameHeader.Type == FrameType.Ping);
 
@@ -403,11 +388,7 @@ namespace System.Net.Http
             }
 
             // Send PING ACK
-            WriteFrameHeader(new FrameHeader(FrameHeader.PingLength, FrameType.Ping, FrameFlags.Ack, 0));
-            _outgoingBuffer.EnsureAvailableSpace(FrameHeader.PingLength);
-            _incomingBuffer.ActiveSpan.Slice(0, FrameHeader.PingLength).CopyTo(_outgoingBuffer.AvailableSpan);
-            _outgoingBuffer.Commit(FrameHeader.PingLength);
-            await FlushOutgoingBytesAsync().ConfigureAwait(false);
+            SendPingAck(_incomingBuffer.ActiveMemory.Slice(0, FrameHeader.PingLength));
 
             _incomingBuffer.Discard(frameHeader.Length);
         }
@@ -478,6 +459,108 @@ namespace System.Net.Http
             AbortStreams(lastValidStream);
 
             _incomingBuffer.Discard(frameHeader.Length);
+        }
+
+        private async void SendSettingsAck()
+        {
+            await _writerLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                WriteFrameHeader(new FrameHeader(0, FrameType.Settings, FrameFlags.Ack, 0));
+
+                await FlushOutgoingBytesAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _writerLock.Release();
+            }
+        }
+
+        private async void SendPingAck(ReadOnlyMemory<byte> pingContent)
+        {
+            Debug.Assert(pingContent.Length == FrameHeader.PingLength);
+
+            await _writerLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                WriteFrameHeader(new FrameHeader(FrameHeader.PingLength, FrameType.Ping, FrameFlags.Ack, 0));
+                _outgoingBuffer.EnsureAvailableSpace(FrameHeader.PingLength);
+                pingContent.CopyTo(_outgoingBuffer.AvailableMemory);
+                _outgoingBuffer.Commit(FrameHeader.PingLength);
+
+                await FlushOutgoingBytesAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _writerLock.Release();
+            }
+        }
+
+        private async void SendRstStream(int streamId, Http2ProtocolErrorCode errorCode)
+        {
+            await _writerLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                WriteFrameHeader(new FrameHeader(FrameHeader.RstStreamLength, FrameType.RstStream, FrameFlags.None, streamId));
+
+                _outgoingBuffer.AvailableSpan[0] = (byte)(((int)errorCode & 0xFF000000) >> 24);
+                _outgoingBuffer.AvailableSpan[1] = (byte)(((int)errorCode & 0x00FF0000) >> 16);
+                _outgoingBuffer.AvailableSpan[2] = (byte)(((int)errorCode & 0x0000FF00) >> 8);
+                _outgoingBuffer.AvailableSpan[3] = (byte)((int)errorCode & 0x000000FF);
+                _outgoingBuffer.Commit(FrameHeader.RstStreamLength);
+
+                await FlushOutgoingBytesAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _writerLock.Release();
+            }
+        }
+
+        private (ReadOnlyMemory<byte> first, ReadOnlyMemory<byte> rest) SplitBufferForFraming(ReadOnlyMemory<byte> buffer) =>
+            buffer.Length > FrameHeader.MaxLength ?
+                (buffer.Slice(0, FrameHeader.MaxLength), buffer.Slice(FrameHeader.MaxLength)) :
+                (buffer, Memory<byte>.Empty);
+
+        private async ValueTask SendStreamDataAsync(int streamId, ReadOnlyMemory<byte> buffer)
+        {
+            ReadOnlyMemory<byte> remaining = buffer;
+
+            while (remaining.Length > 0)
+            {
+                ReadOnlyMemory<byte> current;
+                (current, remaining) = SplitBufferForFraming(remaining);
+
+                await _writerLock.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    _outgoingBuffer.EnsureAvailableSpace(FrameHeader.Size + current.Length);
+                    WriteFrameHeader(new FrameHeader(current.Length, FrameType.Data, FrameFlags.None, streamId));
+                    current.CopyTo(_outgoingBuffer.AvailableMemory);
+                    _outgoingBuffer.Commit(current.Length);
+
+                    await FlushOutgoingBytesAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    _writerLock.Release();
+                }
+            }
+        }
+
+        private async void SendEndStream(int streamId)
+        {
+            await _writerLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                _outgoingBuffer.EnsureAvailableSpace(FrameHeader.Size);
+                WriteFrameHeader(new FrameHeader(0, FrameType.Data, FrameFlags.EndStream, streamId));
+                await FlushOutgoingBytesAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _writerLock.Release();
+            }
         }
 
         private void WriteFrameHeader(FrameHeader frameHeader)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -484,7 +484,7 @@ namespace System.Net.Http
                 }
             }
 
-            sealed class Http2ReadStream : BaseAsyncStream
+            private sealed class Http2ReadStream : BaseAsyncStream
             {
                 private readonly Http2Stream _http2Stream;
                 private int _disposed; // 0==no, 1==yes
@@ -525,7 +525,7 @@ namespace System.Net.Http
             }
 
 
-            sealed class Http2WriteStream : BaseAsyncStream
+            private sealed class Http2WriteStream : BaseAsyncStream
             {
                 private readonly Http2Stream _http2Stream;
                 private int _disposed; // 0==no, 1==yes

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -543,7 +543,8 @@ namespace System.Net.Http
                         return;
                     }
 
-                    _http2Stream._connection.SendEndStream(_http2Stream.StreamId);
+                    // Don't wait for completion, which could happen asynchronously.
+                    ValueTask ignored = _http2Stream._connection.SendEndStreamAsync(_http2Stream.StreamId);
 
                     base.Dispose(disposing);
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -3149,7 +3149,6 @@ namespace System.Net.Http.Functional.Tests
             HttpClientHandler handler = CreateHttpClientHandler();
             using (var client = new HttpClient(handler))
             {
-                TestHelper.EnsureHttp2Feature(handler);
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -172,7 +172,6 @@ namespace System.Net.Http.Functional.Tests
                 if (IsWinHttpHandler && !PlatformDetection.IsWindows10Version1607OrGreater) return;
 
                 expectedVersion = new Version(2,0);
-                TestHelper.EnsureHttp2Feature(handler);
             }
 
             using (HttpClient client = new HttpClient(handler))

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
@@ -21,7 +21,6 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-            TestHelper.EnsureHttp2Feature(handler);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(handler))
@@ -39,7 +38,6 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-            TestHelper.EnsureHttp2Feature(handler);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(handler))
@@ -69,7 +67,6 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-            TestHelper.EnsureHttp2Feature(handler);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(handler))
@@ -93,7 +90,6 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-            TestHelper.EnsureHttp2Feature(handler);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(handler))
@@ -121,7 +117,6 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-            TestHelper.EnsureHttp2Feature(handler);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(handler))
@@ -153,7 +148,6 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-            TestHelper.EnsureHttp2Feature(handler);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(handler))
@@ -185,7 +179,6 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-            TestHelper.EnsureHttp2Feature(handler);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(handler))
@@ -216,7 +209,6 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
-            TestHelper.EnsureHttp2Feature(handler);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(handler))


### PR DESCRIPTION
This change adds support for sending request bodies in HTTP2 requests, and reworks how sending frames works for HTTP2 connections overall. In particular, the _writerLock semaphore is now used to synchronize all access to the connection's write buffer.

@stephentoub @dotnet/ncl 