### PR TITLE
Remove minor code duplication and use `is` better for Indexes and Ranges

### DIFF
--- a/src/Common/src/CoreLib/System/Index.cs
+++ b/src/Common/src/CoreLib/System/Index.cs
@@ -20,7 +20,7 @@ namespace System
 
         public int Value => _value < 0 ? ~_value : _value;
         public bool FromEnd => _value < 0;
-        public override bool Equals(object value) => value is Index && _value == ((Index)value)._value;
+        public override bool Equals(object value) => value is Index index && _value == index._value;
         public bool Equals (Index other) => _value == other._value;
 
         public override int GetHashCode()

--- a/src/Common/src/CoreLib/System/Range.cs
+++ b/src/Common/src/CoreLib/System/Range.cs
@@ -17,10 +17,9 @@ namespace System
 
         public override bool Equals(object value)
         {
-            if (value is Range)
+            if (value is Range range)
             {
-                Range r = (Range)value;
-                return r.Start.Equals(Start) && r.End.Equals(End);
+                return Equals(range);
             }
 
             return false;

--- a/src/Common/src/CoreLib/System/Range.cs
+++ b/src/Common/src/CoreLib/System/Range.cs
@@ -15,16 +15,7 @@ namespace System
             End = end;
         }
 
-        public override bool Equals(object value)
-        {
-            if (value is Range range)
-            {
-                return Equals(range);
-            }
-
-            return false;
-        }
-
+        public override bool Equals(object value) => value is Range range && Equals(range);
         public bool Equals (Range other) => other.Start.Equals(Start) && other.End.Equals(End);
 
         public override int GetHashCode()


### PR DESCRIPTION
- Modify the Range.Equals(object other) to use the Range.Equals(Range other) if the `other is range` passes 
- Remove casting and use the feature of the `is`

