### PR TITLE
Expose `Iscollectible` property on Assembly and MemberInfo

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -5856,6 +5856,7 @@ namespace System.Reflection
         public virtual System.Reflection.Module Module { get { throw null; } }
         public abstract string Name { get; }
         public abstract System.Type ReflectedType { get; }
+        public virtual bool IsCollectible { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public abstract object[] GetCustomAttributes(bool inherit);
         public abstract object[] GetCustomAttributes(System.Type attributeType, bool inherit);

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -5273,6 +5273,7 @@ namespace System.Reflection
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.Module> Modules { get { throw null; } }
         public virtual bool ReflectionOnly { get { throw null; } }
         public virtual System.Security.SecurityRuleSet SecurityRuleSet { get { throw null; } }
+        public virtual bool IsCollectible { get { throw null; } }
         public virtual event System.Reflection.ModuleResolveEventHandler ModuleResolve { add { } remove { } }
         public object CreateInstance(string typeName) { throw null; }
         public object CreateInstance(string typeName, bool ignoreCase) { throw null; }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -175,6 +175,7 @@
     <Compile Include="System\Reflection\CustomAttributesTestData.cs" />
     <Compile Include="System\Reflection\CustomAttribute_Named_Typed_ArgumentTests.cs" />
     <Compile Include="System\Reflection\DefaultMemberAttributeTests.cs" />
+    <Compile Include="System\Reflection\IsCollectibleTests.cs" />
     <Compile Include="System\Reflection\MethodBaseTests.cs" />
     <Compile Include="System\Reflection\MethodBodyTests.cs" />
     <Compile Include="System\Reflection\ModuleTests.cs" />
@@ -296,6 +297,9 @@
     <ProjectReference Include="TestLoadAssembly\TestLoadAssembly.csproj">
       <Project>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</Project>
       <Name>TestLoadAssembly</Name>
+    </ProjectReference>
+    <ProjectReference Include="TestCollectibleAssembly\TestCollectibleAssembly.csproj">
+      <Name>TestCollectibleAssembly</Name>
     </ProjectReference>
     <Reference Include="TestModule\System.Reflection.TestModule.dll">
     </Reference>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -175,7 +175,6 @@
     <Compile Include="System\Reflection\CustomAttributesTestData.cs" />
     <Compile Include="System\Reflection\CustomAttribute_Named_Typed_ArgumentTests.cs" />
     <Compile Include="System\Reflection\DefaultMemberAttributeTests.cs" />
-    <Compile Include="System\Reflection\IsCollectibleTests.cs" />
     <Compile Include="System\Reflection\MethodBaseTests.cs" />
     <Compile Include="System\Reflection\MethodBodyTests.cs" />
     <Compile Include="System\Reflection\ModuleTests.cs" />
@@ -245,6 +244,7 @@
     <Compile Include="System\ComponentModel\DefaultValueAttributeTests.netcoreapp.cs" />
     <Compile Include="System\Reflection\BindingFlagsDoNotWrap.netcoreapp.cs" />
     <Compile Include="System\Reflection\InvokeRefReturn.netcoreapp.cs" />
+    <Compile Include="System\Reflection\IsCollectibleTests.cs" />
     <Compile Include="System\Reflection\MethodBaseTests.netcoreapp.cs" />
     <Compile Include="System\Reflection\SignatureTypes.netcoreapp.cs" />
     <Compile Include="System\Reflection\TypeDelegatorTests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using Xunit;
+
+namespace System.Reflection.Tests
+{
+    public class TestAssemblyLoadContext : AssemblyLoadContext
+    {
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    // These types are recreated in TestCollectibleAssembly.cs
+    public class MyTestClass
+    {
+        public bool MyField = false;
+        public int MyProperty => 1;
+        public int MyMethod() { return 1 * 1; }
+    }
+
+    public class MyGenericTestClass<T>
+    {
+        public T MyGenericField;
+        public T MyGenericProperty { get; set; }
+        public T MyMethod(T arg1) { return arg1; }
+        public T MyGenericMethod<V>(T arg1, V arg2) { return arg1; }
+    }
+
+    public class MemberInfoIsCollectibleTests : RemoteExecutorTestBase
+    {
+        static public string asmNameString = "TestCollectibleAssembly";
+        static public string asmPath = Path.Combine(Environment.CurrentDirectory, "TestCollectibleAssembly.dll");
+
+        static public Func<AssemblyName, Assembly> assemblyResolver = (asmName) => 
+            asmName.Name == asmNameString ? Assembly.LoadFrom(asmPath) : null;
+
+        static public Func<Assembly, string, bool, Type> typeResolver(bool shouldThrowIfNotFound) => 
+            (asm, simpleTypeName, isCaseSensitive) => asm == null ? 
+                Type.GetType(simpleTypeName, shouldThrowIfNotFound, isCaseSensitive) : 
+                asm.GetType(simpleTypeName, shouldThrowIfNotFound, isCaseSensitive);
+
+        [Theory]
+        [InlineData("MyField")]
+        [InlineData("MyProperty")]
+        [InlineData("MyMethod")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
+        public void MemberInfo_IsCollectibleFalse_WhenUsingAssemblyLoad(string memberName)
+        {
+            RemoteInvoke((marshalledName) => 
+            {
+                Type t1 = Type.GetType(
+                    "TestCollectibleAssembly.MyTestClass, TestCollectibleAssembly, Version=1.0.0.0", 
+                    assemblyResolver, 
+                    typeResolver(false), 
+                    true
+                );
+
+                Assert.NotNull(t1);
+
+                var member = t1.GetMember(marshalledName).FirstOrDefault();
+
+                Assert.NotNull(member);
+
+                Assert.False(member.IsCollectible);
+
+                return SuccessExitCode;
+            }, memberName).Dispose();
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
@@ -26,6 +26,8 @@ namespace System.Reflection.Tests
             assemblyName.Name == _assemblyName ? LoadFromAssemblyPath(_assemblyPath) : null;
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "AssemblyLoadContext not available in NetFx")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
     public class IsCollectibleTests : RemoteExecutorTestBase
     {
         static public string asmNameString = "TestCollectibleAssembly";
@@ -34,9 +36,9 @@ namespace System.Reflection.Tests
         static public Func<AssemblyName, Assembly> assemblyResolver = (asmName) => 
             asmName.Name == asmNameString ? Assembly.LoadFrom(asmPath) : null;
         
-        static public Func<AssemblyName, Assembly> collectibleAssemblyResolver(AssemblyLoadContext acl) => 
+        static public Func<AssemblyName, Assembly> collectibleAssemblyResolver(AssemblyLoadContext alc) => 
             (asmName) => 
-                asmName.Name == asmNameString ? acl.LoadFromAssemblyPath(asmPath) : null;
+                asmName.Name == asmNameString ? alc.LoadFromAssemblyPath(asmPath) : null;
 
         static public Func<Assembly, string, bool, Type> typeResolver(bool shouldThrowIfNotFound) => 
             (asm, simpleTypeName, isCaseSensitive) => asm == null ? 
@@ -44,7 +46,6 @@ namespace System.Reflection.Tests
                 asm.GetType(simpleTypeName, shouldThrowIfNotFound, isCaseSensitive);
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public void Assembly_IsCollectibleFalse_WhenUsingAssemblyLoad()
         {
             RemoteInvoke(() => {
@@ -59,13 +60,12 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public void Assembly_IsCollectibleTrue_WhenUsingAssemblyLoadContext()
         {
             RemoteInvoke(() => {
-                AssemblyLoadContext acl = new TestAssemblyLoadContext(asmNameString, asmPath);
+                AssemblyLoadContext alc = new TestAssemblyLoadContext(asmNameString, asmPath);
 
-                Assembly asm = acl.LoadFromAssemblyName(new AssemblyName(asmNameString));
+                Assembly asm = alc.LoadFromAssemblyName(new AssemblyName(asmNameString));
 
                 Assert.NotNull(asm);
                 
@@ -79,7 +79,6 @@ namespace System.Reflection.Tests
         [InlineData("MyField")]
         [InlineData("MyProperty")]
         [InlineData("MyMethod")]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public void MemberInfo_IsCollectibleFalse_WhenUsingAssemblyLoad(string memberName)
         {
             RemoteInvoke((marshalledName) => 
@@ -107,7 +106,6 @@ namespace System.Reflection.Tests
         [InlineData("MyGenericField")]
         [InlineData("MyGenericProperty")]
         [InlineData("MyGenericMethod")]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public void MemberInfoGeneric_IsCollectibleFalse_WhenUsingAssemblyLoad(string memberName)
         {
             RemoteInvoke((marshalledName) => 
@@ -135,16 +133,15 @@ namespace System.Reflection.Tests
         [InlineData("MyGenericField")]
         [InlineData("MyGenericProperty")]
         [InlineData("MyGenericMethod")]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public void MemberInfoGeneric_IsCollectibleTrue_WhenUsingAssemblyLoadContext(string memberName)
         {
             RemoteInvoke((marshalledName) => 
             {
-                AssemblyLoadContext acl = new TestAssemblyLoadContext(asmNameString, asmPath);
+                AssemblyLoadContext alc = new TestAssemblyLoadContext(asmNameString, asmPath);
 
                 Type t1 = Type.GetType(
                     "TestCollectibleAssembly.MyGenericTestClass`1[System.Int32], TestCollectibleAssembly, Version=1.0.0.0", 
-                    collectibleAssemblyResolver(acl), 
+                    collectibleAssemblyResolver(alc), 
                     typeResolver(false), 
                     true
                 );
@@ -162,16 +159,15 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public void GenericWithCollectibleTypeParameter_IsCollectibleTrue_WhenUsingAssemblyLoadContext()
         {
             RemoteInvoke(() => 
             {
-                AssemblyLoadContext acl = new TestAssemblyLoadContext(asmNameString, asmPath);
+                AssemblyLoadContext alc = new TestAssemblyLoadContext(asmNameString, asmPath);
 
                 Type t1 = Type.GetType(
                     "System.Collections.Generic.Dictionary`2[[System.Int32],[TestCollectibleAssembly.MyTestClass, TestCollectibleAssembly, Version=1.0.0.0]]", 
-                    collectibleAssemblyResolver(acl), 
+                    collectibleAssemblyResolver(alc), 
                     typeResolver(false), 
                     true
                 );

--- a/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
@@ -44,6 +44,7 @@ namespace System.Reflection.Tests
                 asm.GetType(simpleTypeName, shouldThrowIfNotFound, isCaseSensitive);
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public void Assembly_IsCollectibleFalse_WhenUsingAssemblyLoad()
         {
             RemoteInvoke(() => {
@@ -58,6 +59,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public void Assembly_IsCollectibleTrue_WhenUsingAssemblyLoadContext()
         {
             RemoteInvoke(() => {

--- a/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
@@ -55,7 +55,7 @@ namespace System.Reflection.Tests
                 Assert.False(asm.IsCollectible);
 
                 return SuccessExitCode;
-            });
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
@@ -22,8 +22,7 @@ namespace System.Reflection.Tests
             _assemblyName = assemblyName;
             _assemblyPath = assemblyPath;
         }
-        protected override Assembly Load(AssemblyName assemblyName) =>
-            assemblyName.Name == _assemblyName ? LoadFromAssemblyPath(_assemblyPath) : null;
+        protected override Assembly Load(AssemblyName assemblyName) => null;
     }
 
     [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "AssemblyLoadContext not available in NetFx")]
@@ -65,7 +64,7 @@ namespace System.Reflection.Tests
             RemoteInvoke(() => {
                 AssemblyLoadContext alc = new TestAssemblyLoadContext(asmNameString, asmPath);
 
-                Assembly asm = alc.LoadFromAssemblyName(new AssemblyName(asmNameString));
+                Assembly asm = alc.LoadFromAssemblyPath(asmPath);
 
                 Assert.NotNull(asm);
                 

--- a/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
@@ -26,7 +26,7 @@ namespace System.Reflection.Tests
             assemblyName.Name == _assemblyName ? LoadFromAssemblyPath(_assemblyPath) : null;
     }
 
-    public class MemberInfoIsCollectibleTests : RemoteExecutorTestBase
+    public class IsCollectibleTests : RemoteExecutorTestBase
     {
         static public string asmNameString = "TestCollectibleAssembly";
         static public string asmPath = Path.Combine(Environment.CurrentDirectory, "TestCollectibleAssembly.dll");

--- a/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -16,30 +17,13 @@ namespace System.Reflection.Tests
         private readonly string _assemblyPath;
 
         public TestAssemblyLoadContext(string assemblyName, string assemblyPath)
+            : base(true)
         {
             _assemblyName = assemblyName;
             _assemblyPath = assemblyPath;
         }
-        protected override Assembly Load(AssemblyName assemblyName)
-        {
-            return assemblyName.Name == _assemblyName ? Assembly.LoadFrom(_assemblyPath) : null;
-        }
-    }
-
-    // These types are recreated in TestCollectibleAssembly.cs
-    public class MyTestClass
-    {
-        public bool MyField = false;
-        public int MyProperty => 1;
-        public int MyMethod() { return 1 * 1; }
-    }
-
-    public class MyGenericTestClass<T>
-    {
-        public T MyGenericField;
-        public T MyGenericProperty { get; set; }
-        public T MyMethod(T arg1) { return arg1; }
-        public T MyGenericMethod<V>(T arg1, V arg2) { return arg1; }
+        protected override Assembly Load(AssemblyName assemblyName) =>
+            assemblyName.Name == _assemblyName ? LoadFromAssemblyPath(_assemblyPath) : null;
     }
 
     public class MemberInfoIsCollectibleTests : RemoteExecutorTestBase
@@ -49,11 +33,46 @@ namespace System.Reflection.Tests
 
         static public Func<AssemblyName, Assembly> assemblyResolver = (asmName) => 
             asmName.Name == asmNameString ? Assembly.LoadFrom(asmPath) : null;
+        
+        static public Func<AssemblyName, Assembly> collectibleAssemblyResolver(AssemblyLoadContext acl) => 
+            (asmName) => 
+                asmName.Name == asmNameString ? acl.LoadFromAssemblyPath(asmPath) : null;
 
         static public Func<Assembly, string, bool, Type> typeResolver(bool shouldThrowIfNotFound) => 
             (asm, simpleTypeName, isCaseSensitive) => asm == null ? 
                 Type.GetType(simpleTypeName, shouldThrowIfNotFound, isCaseSensitive) : 
                 asm.GetType(simpleTypeName, shouldThrowIfNotFound, isCaseSensitive);
+
+        [Fact]
+        public void Assembly_IsCollectibleFalse_WhenUsingAssemblyLoad()
+        {
+            RemoteInvoke(() => {
+                Assembly asm = Assembly.LoadFrom(asmPath);
+
+                Assert.NotNull(asm);
+                
+                Assert.False(asm.IsCollectible);
+
+                return SuccessExitCode;
+            });
+        }
+
+        [Fact]
+        // TODO: IsCollectible is returning false... fix it
+        public void Assembly_IsCollectibleTrue_WhenUsingAssemblyLoadContext()
+        {
+            RemoteInvoke(() => {
+                AssemblyLoadContext acl = new TestAssemblyLoadContext(asmNameString, asmPath);
+
+                Assembly asm = acl.LoadFromAssemblyName(new AssemblyName(asmNameString));
+
+                Assert.NotNull(asm);
+                
+                Assert.True(asm.IsCollectible);
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
 
         [Theory]
         [InlineData("MyField")]
@@ -109,6 +128,59 @@ namespace System.Reflection.Tests
 
                 return SuccessExitCode;
             }, memberName).Dispose();
+        }
+
+        [Theory]
+        [InlineData("MyGenericField")]
+        [InlineData("MyGenericProperty")]
+        [InlineData("MyGenericMethod")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
+        public void MemberInfoGeneric_IsCollectibleTrue_WhenUsingAssemblyLoadContext(string memberName)
+        {
+            RemoteInvoke((marshalledName) => 
+            {
+                AssemblyLoadContext acl = new TestAssemblyLoadContext(asmNameString, asmPath);
+
+                Type t1 = Type.GetType(
+                    "TestCollectibleAssembly.MyGenericTestClass`1[System.Int32], TestCollectibleAssembly, Version=1.0.0.0", 
+                    collectibleAssemblyResolver(acl), 
+                    typeResolver(false), 
+                    true
+                );
+
+                Assert.NotNull(t1);
+
+                var member = t1.GetMember(marshalledName).FirstOrDefault();
+
+                Assert.NotNull(member);
+
+                Assert.True(member.IsCollectible);
+
+                return SuccessExitCode;
+            }, memberName).Dispose();
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
+        public void GenericWithCollectibleTypeParameter_IsCollectibleTrue_WhenUsingAssemblyLoadContext()
+        {
+            RemoteInvoke(() => 
+            {
+                AssemblyLoadContext acl = new TestAssemblyLoadContext(asmNameString, asmPath);
+
+                Type t1 = Type.GetType(
+                    "System.Collections.Generic.Dictionary`2[[System.Int32],[TestCollectibleAssembly.MyTestClass, TestCollectibleAssembly, Version=1.0.0.0]]", 
+                    collectibleAssemblyResolver(acl), 
+                    typeResolver(false), 
+                    true
+                );
+
+                Assert.NotNull(t1);
+
+                Assert.True(t1.IsCollectible);
+
+                return SuccessExitCode;
+            }).Dispose();
         }
     }
 }

--- a/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/IsCollectibleTests.cs
@@ -58,7 +58,6 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        // TODO: IsCollectible is returning false... fix it
         public void Assembly_IsCollectibleTrue_WhenUsingAssemblyLoadContext()
         {
             RemoteInvoke(() => {

--- a/src/System.Runtime/tests/TestCollectibleAssembly/Configurations.props
+++ b/src/System.Runtime/tests/TestCollectibleAssembly/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.cs
+++ b/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.cs
@@ -9,6 +9,12 @@ namespace TestCollectibleAssembly
         public bool MyField = false;
         public int MyProperty => 1;
         public int MyMethod() { return 1 * 1; }
+        public T MyGenericMethod<T>(T arg1) { return arg1; }
+
+        public static int MyStaticField = 1;
+        public static int MyStaticMethod() { return 1 * 1; }
+
+        public static T MyStaticGenericMethod<T>(T arg1) { return arg1; }
     }
 
     public class MyGenericTestClass<T>
@@ -16,11 +22,10 @@ namespace TestCollectibleAssembly
         public T MyGenericField;
         public T MyGenericProperty { get; set; }
         public T MyGenericMethod(T arg1) { return arg1; }
-        public T MyGenericMethod<V>(T arg1, V arg2) { return arg1; }
-    }
 
-    public class UseGenerics
-    {
-        public MyGenericTestClass<int> myGenericTest { get; set; }
+        public static T MyStaticGenericField;
+        public static int MyStaticField =1;
+        public static int MyStaticMethod() { return 1 * 1; }
+        public static T MyStaticGenericMethod(T arg1) { return arg1; }
     }
 }

--- a/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.cs
+++ b/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.cs
@@ -18,4 +18,9 @@ namespace TestCollectibleAssembly
         public T MyGenericMethod(T arg1) { return arg1; }
         public T MyGenericMethod<V>(T arg1, V arg2) { return arg1; }
     }
+
+    public class UseGenerics
+    {
+        public MyGenericTestClass<int> myGenericTest { get; set; }
+    }
 }

--- a/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.cs
+++ b/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace TestCollectibleAssembly
+{
+    public class MyTestClass
+    {
+        public bool MyField = false;
+        public int MyProperty => 1;
+        public int MyMethod() { return 1 * 1; }
+    }
+
+    public class MyGenericTestClass<T>
+    {
+        public T MyGenericField;
+        public T MyGenericProperty { get; set; }
+        public T MyGenericMethod(T arg1) { return arg1; }
+        public T MyGenericMethod<V>(T arg1, V arg2) { return arg1; }
+    }
+}

--- a/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.csproj
+++ b/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TestCollectibleAssembly.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Exposes the Boolean property `IsCollectible` on `System.Reflection.Assembly` and `System.Refelction.MemberInfo`.  Also includes test for this property.

CC - @janvorli @sergiy-k 