### PR TITLE
Make System.ComponentModel.Composition and System.Security.Permissions in-box for uap10.0.16299 

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -4386,7 +4386,9 @@
         "4.5.0"
       ],
       "BaselineVersion": "4.4.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.16299": "4.0.1.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
         "4.0.1.0": "4.5.0"

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -4387,7 +4387,7 @@
       ],
       "BaselineVersion": "4.4.0",
       "InboxOn": {
-        "uap10.0.16299": "4.0.1.0"
+        "uap10.0.16300": "4.0.1.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",

--- a/src/System.ComponentModel.Composition/dir.props
+++ b/src/System.ComponentModel.Composition/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>ECMA</AssemblyKey>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Permissions/dir.props
+++ b/src/System.Security.Permissions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #33434: System.ComponentModel.Composition doesn't work on UWP

Include System.ComponentModel.Composition and System.Security.Permissions
in-box for uap10.0.16299 to be shipped with the UWP 6.2.x metapackage.
System.ComponentModel.Composition previously shipped in-box as a facade but
once the facade was removed we didn't replace it with a full implementation,
which caused a regression.