### PR TITLE
HTTP2: rework SendHeader logic

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -631,7 +631,7 @@ namespace System.Net.Http
             }
 
             WriteHeader(":authority", authority);
-            WriteHeader(":path", request.RequestUri.GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.UriEscaped));
+            WriteHeader(":path", request.RequestUri.PathAndQuery);
 
             if (request.HasHeaders)
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -670,15 +670,15 @@ namespace System.Net.Http
             // We also serialize usage of the header encoder and the header buffer this way.
             await _writerLock.WaitAsync().ConfigureAwait(false);
 
-            // Generate the entire header block, without framing, into the connection header buffer.
-            WriteHeaders(request);
-
-            ReadOnlyMemory<byte> remaining = _headerBuffer.ActiveMemory;
-            Debug.Assert(remaining.Length > 0);
-
-            // Split into frames and send.
             try
             {
+                // Generate the entire header block, without framing, into the connection header buffer.
+                WriteHeaders(request);
+
+                ReadOnlyMemory<byte> remaining = _headerBuffer.ActiveMemory;
+                Debug.Assert(remaining.Length > 0);
+
+                // Split into frames and send.
                 ReadOnlyMemory<byte> current;
                 (current, remaining) = SplitBufferForFraming(remaining);
 


### PR DESCRIPTION
Rework the SendHeader logic a bit to do a couple things: align better with other send logic, ensure correctness of encoded headers across multiple requests, move header buffer management to Http2Connection so there is only one header buffer, and generally simplify the logic a bit.

@dotnet/ncl @stephentoub 