### PR TITLE
improve test filter for bogus VPN IPv6 link local addresses

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -110,7 +110,7 @@ namespace System.Net.Http.Functional.Tests
         public static IPAddress GetIPv6LinkLocalAddress() =>
             NetworkInterface
                 .GetAllNetworkInterfaces()
-                .Where(i => i.Description != "PANGP Virtual Ethernet Adapter")      // This is a VPN adapter, but is reported as a regular Ethernet interface with
+                .Where(i => !i.Description.StartsWith("PANGP Virtual Ethernet"))    // This is a VPN adapter, but is reported as a regular Ethernet interface with
                                                                                     // a valid link-local address, but the link-local address doesn't actually work.
                                                                                     // So just manually filter it out.
                 .SelectMany(i => i.GetIPProperties().UnicastAddresses)


### PR DESCRIPTION
We already filter these out. Make the logic catch more cases, e.g. "PANGP Virtual Ethernet Adapter #3" (which is what I'm seeing on my machine now).

Fixes #32493 

@dotnet/ncl @stephentoub 