### PR TITLE
Remove buildtools imports from Directory.Build.*

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -103,6 +103,10 @@
     <!-- Properties to remove with buildtools removal -->
     <ProjectDir>$(RepoRoot)</ProjectDir>
     <BinDir>$(ProjectDir)artifacts\bin\</BinDir>
+    <ToolsDir Condition="'$(ToolsDir)'==''">$(ProjectDir)Tools/</ToolsDir>
+    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(ToolsDir)net46/</BuildToolsTaskDir>
+    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolsDir)</BuildToolsTaskDir>
+    
     <!-- Need to try and keep the same logic as the native builds as we need this for packaging -->
     <NativeBinDir>$(BinDir)native/$(BuildConfiguration)</NativeBinDir>
 
@@ -113,8 +117,6 @@
     <PackagesDir>$(DotNetRestorePackagesPath)</PackagesDir>
     <PackagesDir Condition="'$(PackagesDir)'=='' AND '$(NuGetPackageRoot)' != ''">$([MSBuild]::EnsureTrailingSlash('$(NuGetPackageRoot)'))</PackagesDir>
     <PackagesDir Condition="'$(PackagesDir)'==''">$(ProjectDir).packages/</PackagesDir>
-    <ToolsDir Condition="'$(ToolsDir)'==''">$(ProjectDir)Tools/</ToolsDir>
-    <IlasmToolPath>$(ToolsDir)ilasm/ilasm</IlasmToolPath>
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleset>
     <!-- Respect environment variable for the .NET install directory if set; otherwise, use the current default location -->
     <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(DOTNET_INSTALL_DIR)</DotNetRoot>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,7 @@
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Unix' AND $([MSBuild]::IsOSPlatform('NETBSD'))">NetBSD</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Unix'">Linux</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'==''">$(OS)</DefaultOSGroup>
+    <RunningOnUnix Condition="'$(OS)'!='Windows_NT'">true</RunningOnUnix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -343,7 +343,6 @@
     <TargetOutputRelPath Condition="'$(TargetGroup)'!=''">$(TargetGroup)/</TargetOutputRelPath>
 
     <RuntimePath Condition="'$(RuntimePath)' == ''">$(BinDir)runtime/$(BuildConfiguration)/</RuntimePath>
-    <ResourcesFolderPath Condition="'$(ResourcesFolderPath)' == ''">$(RuntimePath)resw</ResourcesFolderPath>
     <ShimsTargetRuntimeRoot>$(BinDir)shimsTargetRuntime/</ShimsTargetRuntimeRoot>
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(ArtifactsBinDir)tests/</TestWorkingDir>
     <TestPath Condition="'$(TestPath)' == ''">$(TestWorkingDir)$(MSBuildProjectName)/$(BuildConfiguration)/</TestPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -125,34 +125,11 @@
     <DotNetCmd Condition="'$(OS)' == 'Windows_NT'">$(DotNetCmd).exe</DotNetCmd>
   </PropertyGroup>
 
-  <!-- Choose .targets files that come from Arcade rather than from buildtools -->
-  <!-- TODO: Remove when buildtools dependency removed. -->
-  <PropertyGroup>
-    <ExcludeNotSupportedImport>true</ExcludeNotSupportedImport>
-    <ExcludePartialFacadesImport>true</ExcludePartialFacadesImport>
-    <ExcludeApiCompatImport>true</ExcludeApiCompatImport>
-    <ExcludeReferenceAssembliesImport>true</ExcludeReferenceAssembliesImport>
-    <ExcludePackagingImport>true</ExcludePackagingImport>
-    <ExcludePackageLibsImport>true</ExcludePackageLibsImport>
-    <ExcludeCodeAnalysisImport>true</ExcludeCodeAnalysisImport>
-    <ExcludeResourcesImport>true</ExcludeResourcesImport>
-    <ExcludeVersioningImport>true</ExcludeVersioningImport>
-    <ExcludeSigningImport>true</ExcludeSigningImport>
-    <ExcludeDepProjImport>true</ExcludeDepProjImport>
-    <ExcludeResolveContractImport>true</ExcludeResolveContractImport>
-    <ExcludePackageResolveImport>true</ExcludePackageResolveImport>
-    <ExcludeTestsImport>true</ExcludeTestsImport>
-    <ExcludeBinPlaceImport>true</ExcludeBinPlaceImport>
-  </PropertyGroup>
-
   <!-- workaround https://github.com/dotnet/sdk/issues/2288
        remove once we have a new CLI -->
   <PropertyGroup>
     <LanguageTargets Condition="'$(LanguageTargets)' == '' AND '$(MSBuildProjectExtension)' != '.csproj' AND '$(MSBuildProjectExtension)' != '.vbproj' AND '$(MSBuildProjectExtension)' != '.fsproj'">$(MSBuildToolsPath)\Microsoft.Common.targets</LanguageTargets>
   </PropertyGroup>
-
-  <!-- Import Build tools common props file where repo-independent properties are found -->
-  <Import Project="$(ToolsDir)Build.Common.props" Condition="Exists('$(ToolsDir)Build.Common.props')" />
 
   <!-- Enable the analyzers for this repo -->
   <PropertyGroup>
@@ -341,6 +318,10 @@
 
     <!-- Suppress preview message as we are usually using preview SDK versions. -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    
+    <CLSCompliant Condition="'$(CLSCompliant)'=='' and '$(IsTestProject)'=='true'">false</CLSCompliant>
+    <CLSCompliant Condition="'$(CLSCompliant)'==''">true</CLSCompliant>
+    <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
   </PropertyGroup>
 
   <!-- Set up some common paths -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,6 @@
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Unix' AND $([MSBuild]::IsOSPlatform('NETBSD'))">NetBSD</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Unix'">Linux</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'==''">$(OS)</DefaultOSGroup>
-    <RunningOnUnix Condition="'$(OS)'!='Windows_NT'">true</RunningOnUnix>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -143,7 +142,7 @@
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' and '$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuildId)' == ''">
     <WithoutCategories>IgnoreForCI</WithoutCategories>
     <EnableDumpling>false</EnableDumpling>
-    <CrashDumpFolder Condition="'$(RunningOnUnix)' != 'true'">%TMP%\CoreRunCrashDumps</CrashDumpFolder>
+    <CrashDumpFolder Condition="'$(OS)' == 'Windows_NT'">%TMP%\CoreRunCrashDumps</CrashDumpFolder>
   </PropertyGroup>
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuildId)' == ''">
     <!-- Disable F5 and test explorer support for CI builds. -->
@@ -265,7 +264,7 @@
     <DebugType>portable</DebugType>
 
     <!-- Empty DebugType when building for netfx and in windows so that it is set to full or pdbonly later -->
-    <DebugType Condition="'$(TargetsNetFx)' == 'true' AND '$(RunningOnUnix)' != 'true'"></DebugType>
+    <DebugType Condition="'$(TargetsNetFx)' == 'true' AND '$(OS)' == 'Windows_NT'"></DebugType>
 
     <!-- Rhel 6 and FreeBSD doesn't support the source control git package so disable SourceLink -->
     <EnableSourceLink Condition="$(RuntimeOS.StartsWith('rhel.6')) OR '$(_runtimeOSFamily)' == 'FreeBSD'">false</EnableSourceLink>
@@ -465,16 +464,12 @@
   </ItemDefinitionGroup>
 
   <!-- Import it at the end of the props file to override the OutputPath for reference assemblies and use common directory props -->
-  <Import Project="$(MSBuildThisFileDirectory)eng\ReferenceAssemblies.props" />
+  <Import Project="$(RepositoryEngineeringDir)ReferenceAssemblies.props" />
 
   <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
     <!-- Set the documentation output file globally. -->
     <DocumentationFile Condition="'$(DocumentationFile)' == ''">$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
   </PropertyGroup>
-
-  <!-- Use Roslyn Compilers to build -->
-  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false' and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
-  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)') and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
 
   <!-- Additional optimizations -->
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -342,6 +342,7 @@
     <TargetOutputRelPath Condition="'$(TargetGroup)'!=''">$(TargetGroup)/</TargetOutputRelPath>
 
     <RuntimePath Condition="'$(RuntimePath)' == ''">$(BinDir)runtime/$(BuildConfiguration)/</RuntimePath>
+    <ResourcesFolderPath Condition="'$(ResourcesFolderPath)' == ''">$(RuntimePath)resw</ResourcesFolderPath>
     <ShimsTargetRuntimeRoot>$(BinDir)shimsTargetRuntime/</ShimsTargetRuntimeRoot>
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(ArtifactsBinDir)tests/</TestWorkingDir>
     <TestPath Condition="'$(TestPath)' == ''">$(TestWorkingDir)$(MSBuildProjectName)/$(BuildConfiguration)/</TestPath>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -141,10 +141,21 @@
     <BinPlaceConfiguration Include="@(AdditionalBinPlaceConfiguration)" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)eng/depProj.targets" Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
-  <Import Project="$(ToolsDir)/Build.Common.targets" Condition="Exists('$(ToolsDir)/Build.Common.targets')" />
+  <Import Project="$(RepositoryEngineeringDir)/blockReflectionAttribute.targets" />
+  <Import Project="$(RepositoryEngineeringDir)/depProj.targets" Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
   <Import Project="$(RepositoryEngineeringDir)Resources.targets" />
+  <Import Project="$(RepositoryEngineeringDir)references.targets" />
   <Import Project="$(RepositoryEngineeringDir)resolveContract.targets" />
+  
+  <!-- TODO: remove remaining functionality from buildtools -->
+  <PropertyGroup>
+     <!-- codeOptimization uses DnuRestoreCommand -->
+    <DnuRestoreCommand>$(DotnetTool) restore</DnuRestoreCommand>
+     <!-- optionalTooling uses DotnetToolCommand -->
+    <DotnetToolCommand>$(DotnetTool)</DotnetToolCommand>
+  </PropertyGroup>
+  <Import Project="$(ToolsDir)/codeOptimization.targets" />
+  <Import Project="$(ToolsDir)/optionalTooling.targets" />
 
   <Import Project="$(ToolSetCommonDirectory)Tools.proj.nuget.g.targets" Condition="Exists('$(ToolSetCommonDirectory)Tools.proj.nuget.g.targets')" />
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -141,8 +141,8 @@
     <BinPlaceConfiguration Include="@(AdditionalBinPlaceConfiguration)" />
   </ItemGroup>
 
-  <Import Project="$(RepositoryEngineeringDir)/blockReflectionAttribute.targets" />
-  <Import Project="$(RepositoryEngineeringDir)/depProj.targets" Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
+  <Import Project="$(RepositoryEngineeringDir)blockReflectionAttribute.targets" />
+  <Import Project="$(RepositoryEngineeringDir)depProj.targets" Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
   <Import Project="$(RepositoryEngineeringDir)Resources.targets" />
   <Import Project="$(RepositoryEngineeringDir)references.targets" />
   <Import Project="$(RepositoryEngineeringDir)resolveContract.targets" />
@@ -154,8 +154,8 @@
      <!-- optionalTooling uses DotnetToolCommand -->
     <DotnetToolCommand>$(DotnetTool)</DotnetToolCommand>
   </PropertyGroup>
-  <Import Project="$(ToolsDir)/codeOptimization.targets" />
-  <Import Project="$(ToolsDir)/optionalTooling.targets" />
+  <Import Project="$(ToolsDir)codeOptimization.targets" />
+  <Import Project="$(ToolsDir)OptionalTooling.targets" />
 
   <Import Project="$(ToolSetCommonDirectory)Tools.proj.nuget.g.targets" Condition="Exists('$(ToolSetCommonDirectory)Tools.proj.nuget.g.targets')" />
 

--- a/build.proj
+++ b/build.proj
@@ -23,6 +23,7 @@
     <ProjectProperties>Configuration=$(BuildConfiguration)</ProjectProperties>
   </PropertyGroup>
 
+  <!-- remove once we no longer use maestro v1 updating -->
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
 
   <Import Project="Directory.Build.targets" />

--- a/build.proj
+++ b/build.proj
@@ -76,8 +76,6 @@
     <MSBuild Projects="@(_PackProjects)" Properties="$(ProjectProperties)" />
   </Target>
 
-  <Import Project="$(ToolsDir)clean.targets" />
-
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
 
   <Target Name="Clean">

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -76,10 +76,6 @@
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
 
-  <!-- Dumpling.targets needs to install dumpling.py before running tests. -->
-  <!-- Disabling dumpling for the time being since the script only runs on python 2: https://github.com/dotnet/core-eng/issues/4753 -->
-  <!-- <Import Project="$(ToolsDir)Dumpling.targets" Condition="Exists('$(ToolsDir)Dumpling.targets') AND ('$(EnableDumpling)' == 'true' OR '$(EnableCloudTest)' == 'true')" /> -->
-
   <Target Name="GetFilesToPackage"
           DependsOnTargets="FilterProjects"
           Returns="@(FilesToPackage)">

--- a/eng/BlockReflectionAttribute.cs
+++ b/eng/BlockReflectionAttribute.cs
@@ -1,0 +1,14 @@
+/*
+  Providing a definition for __BlockReflectionAttribute in an assembly is a signal to the .NET Native toolchain 
+  to remove the metadata for all non-public APIs. This both reduces size and disables private reflection on those 
+  APIs in libraries that include this. The attribute can also be applied to individual public APIs to similarly block them.
+  This file is consumed by Build.Common.Targets.
+*/
+
+using System;
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.All)]
+    internal class __BlockReflectionAttribute : Attribute { }
+}

--- a/eng/BlockReflectionAttribute.cs
+++ b/eng/BlockReflectionAttribute.cs
@@ -1,9 +1,10 @@
-/*
-  Providing a definition for __BlockReflectionAttribute in an assembly is a signal to the .NET Native toolchain 
-  to remove the metadata for all non-public APIs. This both reduces size and disables private reflection on those 
-  APIs in libraries that include this. The attribute can also be applied to individual public APIs to similarly block them.
-  This file is consumed by Build.Common.Targets.
-*/
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Defining __BlockReflectionAttribute indicates that the .NET Native toolchain should remove metadata for all non-public APIs.
+// This reduces size and disables private reflection on those APIs. 
+// The attribute can also be applied to individual public APIs to similarly block them.
 
 using System;
 

--- a/eng/blockReflectionAttribute.targets
+++ b/eng/blockReflectionAttribute.targets
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!--
-    Providing a definition for __BlockReflectionAttribute in an assembly is a signal to the .NET Native toolchain
-    to remove the metadata for all non-public APIs. This both reduces size and disables private reflection on those
-    APIs in libraries that include this. The attribute can also be applied to individual public APIs to similarly block them.
-  -->
+      Defining __BlockReflectionAttribute indicates that the .NET Native toolchain should remove the metadata for all non-public APIs.
+      This reduces size and disables private reflection on those APIs.
+      The attribute can also be applied to individual public APIs to similarly block them.
+   -->
   <PropertyGroup>
     <BlockReflectionAttribute Condition="'$(BlockReflectionAttribute)' == '' and '$(UWPCompatible)' == 'true' and '$(IsTestProject)' != 'true'">true</BlockReflectionAttribute>
     <BlockReflectionAttribute Condition="'$(MSBuildProjectExtension)' != '.csproj'">false</BlockReflectionAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(BlockReflectionAttribute)'=='true'">
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);AddBlockReflectionAttribute</CoreCompileDependsOn>
-    <BlockReflectionAtributeFile>$(MSBuildThisFileDirectory)/BlockReflectionAttribute.cs</BlockReflectionAtributeFile>
-  </PropertyGroup>
-  <Target Name="AddBlockReflectionAttribute">
-    <ItemGroup>
-      <Compile Include="$(BlockReflectionAtributeFile)" />
-    </ItemGroup>
-  </Target>
+
+  <ItemGroup Condition="'$(BlockReflectionAttribute)'=='true'">
+    <Compile Include="$(MSBuildThisFileDirectory)/BlockReflectionAttribute.cs" />
+  </ItemGroup>
 </Project>

--- a/eng/blockReflectionAttribute.targets
+++ b/eng/blockReflectionAttribute.targets
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    Providing a definition for __BlockReflectionAttribute in an assembly is a signal to the .NET Native toolchain
+    to remove the metadata for all non-public APIs. This both reduces size and disables private reflection on those
+    APIs in libraries that include this. The attribute can also be applied to individual public APIs to similarly block them.
+  -->
+  <PropertyGroup>
+    <BlockReflectionAttribute Condition="'$(BlockReflectionAttribute)' == '' and '$(UWPCompatible)' == 'true' and '$(IsTestProject)' != 'true'">true</BlockReflectionAttribute>
+    <BlockReflectionAttribute Condition="'$(MSBuildProjectExtension)' != '.csproj'">false</BlockReflectionAttribute>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BlockReflectionAttribute)'=='true'">
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);AddBlockReflectionAttribute</CoreCompileDependsOn>
+    <BlockReflectionAtributeFile>$(MSBuildThisFileDirectory)/BlockReflectionAttribute.cs</BlockReflectionAtributeFile>
+  </PropertyGroup>
+  <Target Name="AddBlockReflectionAttribute">
+    <ItemGroup>
+      <Compile Include="$(BlockReflectionAtributeFile)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -10,8 +10,8 @@
 
   <!-- Inputs and outputs of ILLinkTrimAssembly -->
   <PropertyGroup>
-    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(RunningOnCore)' == 'true'">$(ToolsDir)ILLink/netcoreapp2.0/ILLink.Tasks.dll</ILLinkTasksPath>
-    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(RunningOnCore)' != 'true'">$(ToolsDir)ILLink/net46/ILLink.Tasks.dll</ILLinkTasksPath>
+    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(MSBuildRuntimeType)' == 'core'">$(ToolsDir)ILLink/netcoreapp2.0/ILLink.Tasks.dll</ILLinkTasksPath>
+    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(MSBuildRuntimeType)' != 'core'">$(ToolsDir)ILLink/net46/ILLink.Tasks.dll</ILLinkTasksPath>
     <ILLinkTrimAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ILLinkTrimAssemblyPath>
     <ILLinkTrimAssemblySymbols>$(IntermediateOutputPath)$(TargetName).pdb</ILLinkTrimAssemblySymbols>
     <ILLinkTrimInputPath>$(IntermediateOutputPath)PreTrim/</ILLinkTrimInputPath>
@@ -63,7 +63,7 @@
        rewriting the assembly to an "output assembly"
   -->
   <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksPath)" />
-  <Target Name="ILLinkTrimAssembly" Condition="'$(ILLinkTrimAssembly)' == 'true'" DependsOnTargets="EnsureBuildToolsRuntime">
+  <Target Name="ILLinkTrimAssembly" Condition="'$(ILLinkTrimAssembly)' == 'true'">
     <PropertyGroup>
       <ILLinkArgs>$(ILLinkArgs)-r $(TargetName)</ILLinkArgs>
       <!-- default action for core assemblies -->

--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -11,7 +11,7 @@
   </Target>
 
   <Target Name="AddRuntimeProjectReference"
-          BeforeTargets="AddProjectReferencesDynamically"
+          BeforeTargets="AddReferencesDynamically"
           Condition="'$(IsTestProject)'!='true' AND '@(ReferenceFromRuntime)' != ''">
     <Error Condition="('$(IsReferenceAssembly)' != 'true' OR '$(AllowReferenceFromRuntime)' == 'true') AND '$(RuntimeProjectFile)' == ''" Text="RuntimeProjectFile must be specified when using ReferenceFromRuntime from source projects." />
     <Error Condition="'$(IsReferenceAssembly)' == 'true' AND '$(AllowReferenceFromRuntime)' != 'true'" Text="ReferenceFromRuntime may not be used from reference assemblies." />

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -5,6 +5,13 @@
     <AssemblySearchPaths>$(AssemblySearchPaths);$(ContractOutputPath);{RawFileName}</AssemblySearchPaths>
     <!-- Disable RAR from transitively discovering dependencies for References -->
     <_FindDependencies>false</_FindDependencies>
+    <!--
+      We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder
+      that exists to skip the GenerateReferenceAssemblyPaths task (not target) and to prevent it from outputting a warning (MSB3644).
+      Need to set these after the common targets import.
+      -->
+    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)</_TargetFrameworkDirectories>
+    <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)</_FullFrameworkReferenceAssemblyPaths>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IncludeDefaultReferences)' == ''">
     <IncludeDefaultReferences Condition="'$(MSBuildProjectExtension)' == '.csproj'">true</IncludeDefaultReferences>

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -1,0 +1,31 @@
+<Project>
+  <PropertyGroup>
+    <ContractOutputPath>$(RefPath)</ContractOutputPath>
+    <FrameworkPathOverride>$(ContractOutputPath)</FrameworkPathOverride>
+    <AssemblySearchPaths>$(AssemblySearchPaths);$(ContractOutputPath);{RawFileName}</AssemblySearchPaths>
+    <!-- Disable RAR from transitively discovering dependencies for References -->
+    <_FindDependencies>false</_FindDependencies>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IncludeDefaultReferences)' == ''">
+    <IncludeDefaultReferences Condition="'$(MSBuildProjectExtension)' == '.csproj'">true</IncludeDefaultReferences>
+    <IncludeDefaultReferences Condition="'$(MSBuildProjectExtension)' == '.vbproj'">true</IncludeDefaultReferences>
+  </PropertyGroup>
+  <Target Name="SetupDefaultReferences">
+    <ItemGroup Condition="'$(IncludeDefaultReferences)' =='true'">
+      <!-- netstandard is a default reference whenever building for NETStandard or building an implementation assembly -->
+      <DefaultReference Condition="($(NuGetTargetMoniker.StartsWith('.NETStandard')) OR '$(IsReferenceAssembly)' != 'true') AND Exists('$(RefPath)netstandard.dll')" Include="netstandard" />
+    </ItemGroup>
+  </Target>
+  <Target Name="UpdateReferenceItems" DependsOnTargets="SetupDefaultReferences" BeforeTargets="AddReferencesDynamically">
+    <ItemGroup>
+      <Reference Include="@(DefaultReference)" />
+    </ItemGroup>
+    <ItemGroup>
+      <!-- Simple name references will be resolved from the targeting pack folders and should never be copied to output -->
+      <Reference Condition="'%(Reference.Extension)' != '.dll'">
+        <Private>false</Private>
+      </Reference>
+    </ItemGroup>
+  </Target>
+  <Target Name="AddReferencesDynamically" BeforeTargets="BeforeResolveReferences;ResolveAssemblyReferences" />
+</Project>

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -8,6 +8,19 @@
     <AssemblyInfoFile Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(IntermediateOutputPath)_AssemblyInfo.vb</AssemblyInfoFile>
   </PropertyGroup>
 
+  <!-- Assembly metadata indicating that an assembly is a framework (as opposed to user) assembly:
+       Test projects need to not have this because of the way "IsFrameworkAssembly" APIs work to check this. -->
+  <ItemGroup Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' AND '$(IsTestProject)' != 'true'" >
+    <AssemblyMetadata Include=".NETFrameworkAssembly">
+      <Value></Value>
+    </AssemblyMetadata>
+    <AssemblyMetadata Include="Serviceable">
+      <Value>True</Value>
+    </AssemblyMetadata>
+    <AssemblyMetadata Include="PreferInbox">
+      <Value>True</Value>
+    </AssemblyMetadata>
+  </ItemGroup>
 
   <Target Name="DecideIfWeNeedToIncludeDllSafeSearchPathAttribute"
     Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' AND '$(IsTestProject)' != 'true'">

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -109,14 +109,22 @@
       <SymbolPackagesToDownload Include="@(_CoreCLRSymbolPackagesToDownload)" Condition="!Exists('%(UnzipDestinationDir)')" />
     </ItemGroup>
   </Target>
+  
+  <Target Name="DownloadAndUnzipSymbolPackage"
+          Condition="'@(SymbolPackagesToDownload)' != ''">
+      <DownloadFile SourceUrl="%(SymbolPackagesToDownload.Url)"
+                    DestinationFolder="$(SymbolPackagesDir)"
+                    DestinationFileName="%(SymbolPackagesToDownload.DestinationFile)" />
+      <Unzip SourceFiles="$(SymbolPackagesDir)\%(SymbolPackagesToDownload.DestinationFile)"
+             DestinationFolder="%(SymbolPackagesToDownload.UnzipDestinationDir)"
+             OverwriteReadOnlyFiles="true"  />
+  </Target>
+          
 
   <Target Name="BinPlaceCoreCLRSymbols"
           AfterTargets="AfterResolveReferences"
           DependsOnTargets="CalculateCoreCLRSymbolPackageProperties;DownloadAndUnzipSymbolPackage"
           Condition="'$(CoreCLROverridePath)' == '' AND '$(DownloadCoreCLRSymbols)' != 'false'">
-
-      <Warning Text="Failed to download CoreCLR symbols" Condition="'@(SymbolPackagesDownloaded)' == '' AND '@(SymbolPackagesToDownload)' != ''" />
-
       <ItemGroup>
         <_CoreCLRSymbolFiles Include="%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(RuntimeIdentifier)/native/*.pdb" />
         <_CoreCLRSymbolFiles Include="%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(RuntimeIdentifier)/native/*.dbg" />

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -114,10 +114,12 @@
           Condition="'@(SymbolPackagesToDownload)' != ''">
       <DownloadFile SourceUrl="%(SymbolPackagesToDownload.Url)"
                     DestinationFolder="$(SymbolPackagesDir)"
-                    DestinationFileName="%(SymbolPackagesToDownload.DestinationFile)" />
+                    DestinationFileName="%(SymbolPackagesToDownload.DestinationFile)"
+                    ContinueOnError="WarnAndContinue" />
       <Unzip SourceFiles="$(SymbolPackagesDir)\%(SymbolPackagesToDownload.DestinationFile)"
              DestinationFolder="%(SymbolPackagesToDownload.UnzipDestinationDir)"
-             OverwriteReadOnlyFiles="true"  />
+             OverwriteReadOnlyFiles="true"
+             Condition="Exists('$(SymbolPackagesDir)\%(SymbolPackagesToDownload.DestinationFile)')" />
   </Target>
           
 

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -85,7 +85,7 @@
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="$(UseHardlink)" />
 
-    <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(RunningOnUnix)' == 'true'"/>
+    <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(OS)' != 'Windows_NT'"/>
   </Target>
 
   <PropertyGroup>

--- a/pkg/test/packageTest.targets
+++ b/pkg/test/packageTest.targets
@@ -14,7 +14,7 @@
     </RestoreSources>
   </PropertyGroup>
 
-  <Import Project="tools\Packaging.common.targets" />
+  <Import Project="tools\build\Packaging.common.targets" />
   <Import Project="tools\dependencies.props" />
   <Import Project="tools\eng\versions.props" />
   <Import Project="frameworkSettings\$(_targetFrameworkIdentifier)\*.targets" />

--- a/pkg/test/testPackages.proj
+++ b/pkg/test/testPackages.proj
@@ -53,17 +53,8 @@
     <TestSupportFiles Include="$(RepositoryEngineeringDir)versions.props">
       <DestinationFolder>$(TestToolsDir)eng/</DestinationFolder>
     </TestSupportFiles>
-    <TestSupportFiles Include="$(ToolsDir)Packaging.common.targets">
-      <DestinationFolder>$(TestToolsDir)</DestinationFolder>
-    </TestSupportFiles>
-    <TestSupportFiles Include="$(ToolsDir)Microsoft.DotNet.Build.Tasks.Packaging.dll">
-      <DestinationFolder>$(TestToolsDir)</DestinationFolder>
-    </TestSupportFiles>
-    <TestSupportFiles Include="$(ToolsDir)Newtonsoft.Json.dll">
-      <DestinationFolder>$(TestToolsDir)</DestinationFolder>
-    </TestSupportFiles>
-    <TestSupportFiles Include="$(ToolsDir)NuGet.*.dll">
-      <DestinationFolder>$(TestToolsDir)</DestinationFolder>
+    <TestSupportFiles Include="$(PackagingTaskDir)..\..\**\*.*">
+      <DestinationFolder>$(TestToolsDir)%(RecursiveDir)</DestinationFolder>
     </TestSupportFiles>
     <TestSupportFiles Include="props\Directory.Build.props">
       <DestinationFolder>$(TestDir)</DestinationFolder>
@@ -196,6 +187,7 @@
       <TestRestoreCommand>$(TestRestoreCommand) restore</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) --packages "$(TestPackageDir)"</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) /p:LocalPackagesPath=$(PackageOutputPath)</TestRestoreCommand>
+      <TestRestoreCommand>$(TestRestoreCommand) /nr:false</TestRestoreCommand>
       <TestRestoreCommand  Condition="'$(TestPackages)' != ''">$(TestRestoreCommand) /p:TestPackages=$(TestPackages)</TestRestoreCommand>
     </PropertyGroup>
 
@@ -211,6 +203,7 @@
       <TestBuildCommand>$(TestDotNetPath)</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) msbuild</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /t:Test</TestBuildCommand>
+      <TestBuildCommand>$(TestBuildCommand) /nr:false</TestBuildCommand>
       <TestBuildCommand  Condition="'$(TestPackages)' != ''">$(TestBuildCommand) /p:TestPackages=$(TestPackages)</TestBuildCommand>
     </PropertyGroup>
 
@@ -220,6 +213,9 @@
   </Target>
 
   <Target Name="Build" DependsOnTargets="BuildProjects;ArchiveHelixItems" />
+
+  <!-- define test to do nothing, for this project Build does all the testing -->
+  <Target Name="Test" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -21,7 +21,7 @@
       XmlInputPaths="@(AsnXml)"
       OutputPaths="@(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs')" />
 
-    <Exec Condition="'$(RunningOnUnix)' != 'true'"
+    <Exec Condition="'$(OS)'=='Windows_NT'"
       IgnoreExitCode="true"
       StandardOutputImportance="Low"
       Command="$(SystemRoot)\System32\fc.exe /a @(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs') @(AsnXml -> '%(Identity).cs')">
@@ -29,7 +29,7 @@
     </Exec>
 
     <!-- TODO: Call diff on Unix -->
-    <ItemGroup Condition="'$(RunningOnUnix)' == 'true'">
+    <ItemGroup Condition="'$(OS)'!='Windows_NT'">
       <_AsnXmlDiffCode Include="1" />
     </ItemGroup>
 

--- a/src/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -10,7 +10,7 @@
 
   <!-- MSBuild for .NET Core doesn't support XslTransform at this time -->
   <Target Name="CompileAsn" BeforeTargets="CoreCompile"
-    Condition="'$(RunningOnCore)' != 'true'"
+    Condition="'$(MSBuildRuntimeType)' != 'core'"
     Inputs="@(AsnXml);$(MSBuildThisFileDirectory)asn.xslt"
     Outputs="%(Identity).cs">
 

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' != 'netcoreapp'">
     <!-- We're building some non-netcoreapp target, run on the Tools CLI.
-         Reuse the same runtimeconfig used by CSC. -->
-    <GeneratorRuntimeConfig>$(ToolsDir)csc.runtimeconfig.json</GeneratorRuntimeConfig>
+         Reuse the same runtimeconfig used by MSBuild. -->
+    <GeneratorRuntimeConfig>$(MSBuildToolsPath)msbuild.runtimeconfig.json</GeneratorRuntimeConfig>
     <GeneratorCliPath>$(ToolsDir)dotnetcli/</GeneratorCliPath>
   </PropertyGroup>
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true' ">

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -17,8 +17,8 @@
   <PropertyGroup Condition="'$(TargetGroup)' != 'netcoreapp'">
     <!-- We're building some non-netcoreapp target, run on the Tools CLI.
          Reuse the same runtimeconfig used by MSBuild. -->
-    <GeneratorRuntimeConfig>$(MSBuildToolsPath)msbuild.runtimeconfig.json</GeneratorRuntimeConfig>
-    <GeneratorCliPath>$(ToolsDir)dotnetcli/</GeneratorCliPath>
+    <GeneratorRuntimeConfig>$(MSBuildToolsPath)\msbuild.runtimeconfig.json</GeneratorRuntimeConfig>
+    <GeneratorCliPath>$(DotNetRoot)</GeneratorCliPath>
   </PropertyGroup>
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <Compile Include=".\SGenTests.cs" />

--- a/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
+++ b/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
@@ -8,21 +8,21 @@
     <_LKGSharedFrameworkVersion>1.1.2</_LKGSharedFrameworkVersion>
     <SharedFrameworkExtractPath>$(RefRootPath)sharedFrameworkZip/shared/Microsoft.NETCore.App/$(MicrosoftNETCoreAppPackageVersion)</SharedFrameworkExtractPath>
     <LKGSharedFrameworkExtractPath>$(RefRootPath)sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/$(_LKGSharedFrameworkVersion)</LKGSharedFrameworkExtractPath>
-    <_RunTestsScriptName Condition="'$(RunningOnUnix)' != 'true'">CloneAndRunTests.cmd</_RunTestsScriptName>
-    <_RunTestsScriptName Condition="'$(RunningOnUnix)' == 'true'">CloneAndRunTests.sh</_RunTestsScriptName>
+    <_RunTestsScriptName Condition="'$(OS)' == 'Windows_NT'">CloneAndRunTests.cmd</_RunTestsScriptName>
+    <_RunTestsScriptName Condition="'$(OS)' != 'Windows_NT'">CloneAndRunTests.sh</_RunTestsScriptName>
   </PropertyGroup>
 
   <Target Name="CreateScriptToDownloadSharedFrameworkZip">
 
-    <ItemGroup Condition="'$(RunningOnUnix)' != 'true'">
+    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
       <_DownloadSharedFrameworkScriptLines Include="Invoke-WebRequest %22https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1%22 -OutFile $(ToolsDir.Replace('/', '\'))bootstrap.ps1" />
       <_DownloadSharedFrameworkScriptLines Include="%26 %22$(ToolsDir.Replace('/', '\'))bootstrap.ps1%22 -Channel %22master%22 -SharedRuntime -Version %22$(MicrosoftNETCoreAppPackageVersion)%22 -InstallDir %22$(RefRootPath.Replace('/', '\'))sharedFrameworkZip%22 | Out-File %22$(BinDir.Replace('/', '\'))bootstrap.log%22" />
       <_DownloadSharedFrameworkScriptLines Include="%26 %22$(ToolsDir.Replace('/', '\'))bootstrap.ps1%22 -Channel %22rel-1.1.0%22 -InstallDir %22$(RefRootPath.Replace('/', '\'))sharedFrameworkZip.LKG%22 | Out-File %22$(BinDir.Replace('/', '\'))bootstrap.LKG.log%22" />
     </ItemGroup>
 
     <PropertyGroup>
-      <_ScriptName Condition="'$(RunningOnUnix)' != 'true'">$(BinDir)DownloadSharedFramework.ps1</_ScriptName>
-      <_ScriptName Condition="'$(RunningOnUnix)' == 'true'">$(BinDir)DownloadSharedFramework.sh</_ScriptName>
+      <_ScriptName Condition="'$(OS)' == 'Windows_NT'">$(BinDir)DownloadSharedFramework.ps1</_ScriptName>
+      <_ScriptName Condition="'$(OS)' != 'Windows_NT'">$(BinDir)DownloadSharedFramework.sh</_ScriptName>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(RunningOnUnix)' == 'true'">
@@ -168,7 +168,7 @@
     </PropertyGroup>
 
     <!-- Windows script -->
-    <ItemGroup Condition="'$(RunningOnUnix)'!='true'">
+    <ItemGroup Condition="'$(OS)'=='Windows_NT'">
       <_CloneRepoLines Include="@echo off" />
       <_CloneRepoLines Include="pushd $(CoreFxCopyLocation.Replace('/', '\'))" />
       <_CloneRepoLines Include="git clone $(_RepoURL)" />
@@ -180,7 +180,7 @@
     </ItemGroup>
 
     <!-- Unix script -->
-    <ItemGroup Condition="'$(RunningOnUnix)'=='true'">
+    <ItemGroup Condition="'$(OS)'!='Windows_NT'">
       <_CloneRepoLines Include="#!/usr/bin/env bash" />
       <_CloneRepoLines Include="__scriptpath=%24(cd %22%24(dirname %22%240%22)%22%3B pwd -P)" />
       <_CloneRepoLines Include="cd $(CorefxCopyLocation.Replace('\', '/'))" />

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -16,8 +16,7 @@
   </ItemGroup>
   
   <PropertyGroup>
-    <GenerateDepsJsonTaskDll Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll</GenerateDepsJsonTaskDll>
-    <GenerateDepsJsonTaskDll Condition="'$(MSBuildRuntimeType)' != 'core'">$(ToolsDir)net46/Microsoft.DotNet.Build.Tasks.dll</GenerateDepsJsonTaskDll>
+    <GenerateDepsJsonTaskDll>$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll</GenerateDepsJsonTaskDll>
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateDepsJson" AssemblyFile="$(GenerateDepsJsonTaskDll)"/>
@@ -49,8 +48,6 @@
   </ItemGroup>
 
   <Import Project="..\dir.traversal.targets" />
-
-  <Import Project="$(ToolsDir)UpdateBuildValues.targets" Condition="Exists('$(ToolsDir)UpdateBuildValues.targets')" />
 
   <!-- Generate the shared library for running ILC tests for configuration Release-x64 -->
   <Target Name="GenerateSharedLibraryForILC" AfterTargets="BuildAllProjects" Condition="'$(EnableMultiFileILCTests)' == 'true'">

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <Import Project="Directory.Build.props" />
 
   <!-- required to build the projects in their specified order -->

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Directory.Build.props" />
 
   <!-- required to build the projects in their specified order -->
@@ -14,8 +14,13 @@
     <Project Include="shims\manual\*.csproj" />
     <Project Include="shims\ApiCompat.proj" />
   </ItemGroup>
+  
+  <PropertyGroup>
+    <GenerateDepsJsonTaskDll Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll</GenerateDepsJsonTaskDll>
+    <GenerateDepsJsonTaskDll Condition="'$(MSBuildRuntimeType)' != 'core'">$(ToolsDir)net46/Microsoft.DotNet.Build.Tasks.dll</GenerateDepsJsonTaskDll>
+  </PropertyGroup>
 
-  <UsingTask TaskName="GenerateDepsJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="GenerateDepsJson" AssemblyFile="$(GenerateDepsJsonTaskDll)"/>
   <!-- After we build all the source libraries we need to generate a deps.json file for the shared test framework -->
   <Target Name="GenerateTestSharedFrameworkDepsFile" AfterTargets="BuildAllProjects" Condition="'$(BinplaceTestSharedFramework)' == 'true'">
 
@@ -45,22 +50,7 @@
 
   <Import Project="..\dir.traversal.targets" />
 
-  <Import Project="$(ToolsDir)packages.targets" Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'" />
   <Import Project="$(ToolsDir)UpdateBuildValues.targets" Condition="Exists('$(ToolsDir)UpdateBuildValues.targets')" />
-
-  <PropertyGroup Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'">
-    <TraversalBuildDependsOn>
-      $(TraversalBuildDependsOn);
-      BuildPackages;
-    </TraversalBuildDependsOn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="Exists('$(ToolsDir)toolruntime.targets')">
-    <TraversalBuildDependsOn>
-      EnsureBuildToolsRuntime;
-      $(TraversalBuildDependsOn)
-    </TraversalBuildDependsOn>
-  </PropertyGroup>
 
   <!-- Generate the shared library for running ILC tests for configuration Release-x64 -->
   <Target Name="GenerateSharedLibraryForILC" AfterTargets="BuildAllProjects" Condition="'$(EnableMultiFileILCTests)' == 'true'">

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>

--- a/src/shims/Directory.Build.props
+++ b/src/shims/Directory.Build.props
@@ -16,6 +16,7 @@
   <PropertyGroup>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">$(TargetFramework)</NuGetTargetMoniker>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <PackageConfigurations>
+      netcoreapp2.0
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations)
+    </BuildConfigurations>
+  </PropertyGroup>
+
   <Import Project="Directory.Build.props" />
 
   <PropertyGroup>
-    <PackageConfigurations>
-      netcoreapp2.0;
-    </PackageConfigurations>
-    <BuildConfigurations>
-      $(BuildConfigurations);
-      $(PackageConfigurations);
-    </BuildConfigurations>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">$(TargetFramework)</NuGetTargetMoniker>
   </PropertyGroup>
 
   <Target Name="GetGenFacadesInputs">

--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -11,10 +11,6 @@
 
   <Import Project="Directory.Build.props" />
 
-  <PropertyGroup>
-    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">$(TargetFramework)</NuGetTargetMoniker>
-  </PropertyGroup>
-
   <Target Name="GetGenFacadesInputs">
     <ItemGroup>
       <NetFxContracts Include="@(NetFxReference->'$(NetFxRefPath)%(Identity).dll')" Condition="'$(TargetGroup)' != 'netfx'">

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -49,8 +49,6 @@
     <Project Include="$(ProjectDir)pkg\test\testPackages.proj" />
   </ItemGroup>
 
-  <Import Project="$(ToolsDir)Build.Post.targets" Condition="Exists('$(ToolsDir)Build.Post.targets')" />
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 
   <PropertyGroup Condition="'$(BuildingUAPVertical)' == 'true'">

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -26,8 +26,6 @@
     <SerializeProjects>true</SerializeProjects>
   </PropertyGroup>
 
-  <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
-
   <Target Name="BinPlaceXUnitRuntimeForNetstandardSuite" Condition="'$(TargetGroup)' == 'netstandard'" BeforeTargets="BuildAllProjects">
     <!-- Ensure that we binplace all of the xunit assemblies on the netstandard runtime path in order to be able to build netstandard test suite -->
     <MSBuild Projects="$(MSBuildThisFileDirectory)../external/test-runtime/XUnit.Runtime.depproj"
@@ -61,21 +59,4 @@
       $(TraversalBuildDependsOn)
     </TraversalBuildDependsOn>
   </PropertyGroup>
-
-    <!-- TODO: Can we move this archive test build to BuildTools -->
-  <UsingTask TaskName="ZipFileCreateFromDependencyLists" Condition="'$(Platform)' == 'ARM64' and '$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <Target Name="ArchiveTestBuild" Condition="'$(Platform)' == 'ARM64' and '$(ArchiveTests)' == 'true'" AfterTargets="Build" >
-    <ItemGroup>
-      <ExcludeFromArchive Include="nupkg$" />
-      <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
-      <ExcludeFromArchive Include="TestData" />
-      <TestDependencyListFile Include="$(BinDir)/TestDependencies/*.dependencylist.txt" />
-    </ItemGroup>
-
-    <ZipFileCreateFromDependencyLists
-      DependencyListFiles="@(TestDependencyListFile)"
-      DestinationArchive="$(TestWorkingDir)$(OSPlatformConfig)/archive/Packages.zip"
-      RelativePathBaseDirectory="$(PackagesDir)"
-      OverwriteDestination="true" />
-  </Target>
 </Project>


### PR DESCRIPTION
Remove buildtools imports and implement remaining functionality in CoreFx.

I was able to do most of what BuildTools was doing with 3 exceptions, which will be split into separate issues.
1. Test shared framework deps file: GenerateDepsJson.  We need to port this task to arcade or change how we test to not need it.
2. codeOptimization.targets -> should be moved to arcade, work is pending.
3. optionalTooling.targets -> move to a CSProj that is restored by the official build workflow.