### PR TITLE
improve sysctl error reporting

### DIFF
--- a/src/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -45,7 +45,7 @@ internal static partial class Interop
                 ret = Sysctl(name,  name_len, pBuffer, &bytesLength);
                 if (ret != 0)
                 {
-                    throw new InvalidOperationException(string.Format("sysctl {0} returned {1} ({2})", *name, ret, Marshal.GetLastWin32Error()));
+                    throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastWin32Error()));
                 }
                 pBuffer = (byte*)Marshal.AllocHGlobal((int)bytesLength);
             }
@@ -57,7 +57,7 @@ internal static partial class Interop
                     // This is case we allocated memory for caller
                     Marshal.FreeHGlobal((IntPtr)pBuffer);
                 }
-                throw new InvalidOperationException(string.Format("sysctl {0} returned {1} ({2})", *name, ret, Marshal.GetLastWin32Error()));
+                throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastWin32Error()));
             }
 
             value = pBuffer;

--- a/src/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -45,7 +45,7 @@ internal static partial class Interop
                 ret = Sysctl(name,  name_len, pBuffer, &bytesLength);
                 if (ret != 0)
                 {
-                    throw new InvalidOperationException(string.Format("sysctl returned {0}", ret));
+                    throw new InvalidOperationException(string.Format("sysctl {0} returned {1} ({2})", *name, ret, Marshal.GetLastWin32Error()));
                 }
                 pBuffer = (byte*)Marshal.AllocHGlobal((int)bytesLength);
             }
@@ -57,7 +57,7 @@ internal static partial class Interop
                     // This is case we allocated memory for caller
                     Marshal.FreeHGlobal((IntPtr)pBuffer);
                 }
-                throw new InvalidOperationException(string.Format("sysctl returned {0}", ret));
+                throw new InvalidOperationException(string.Format("sysctl {0} returned {1} ({2})", *name, ret, Marshal.GetLastWin32Error()));
             }
 
             value = pBuffer;

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -318,4 +318,7 @@
   <data name="ArgumentAndArgumentListInitialized" xml:space="preserve">
     <value>Only one of Arguments or ArgumentList may be used.</value>
   </data>
+  <data name="InvalidSysctl" xml:space="preserve">
+    <value>sysctl {0} failed with {1} error.</value>
+  </data>
 </root>


### PR DESCRIPTION
I bump to some "sysctl returned -1" messages in build logs. 
That does not help at all with figuring out what was wrong and why. 

This is attempt to make the exception somewhat more useful. 
With this change we will print sysctl id (int) and errno instead of just returning code.   