### PR TITLE
Fix CookieContainer memory leak

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -514,7 +514,7 @@ namespace System.Net
 
         private void DomainTableCleanup()
         {
-            var removePathList = new List<Object>();
+            var removePathList = new List<object>();
             var removeDomainList = new List<string>();
 
             string currentDomain;
@@ -522,10 +522,12 @@ namespace System.Net
 
             lock (m_domainTable.SyncRoot)
             {
-                foreach (DictionaryEntry entry in m_domainTable)
+                // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                IDictionaryEnumerator enumerator = m_domainTable.GetEnumerator();
+                while (enumerator.MoveNext())
                 {
-                    currentDomain = (string)entry.Key;
-                    pathList = (PathList)entry.Value;
+                    currentDomain = (string)enumerator.Key;
+                    pathList = (PathList)enumerator.Value;
 
                     lock (pathList.SyncRoot)
                     {
@@ -1082,7 +1084,7 @@ namespace System.Net
             }
         }
 
-        internal void Remove(Object key)
+        internal void Remove(object key)
         {
             lock (SyncRoot)
             {

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.NetworkInformation;
@@ -332,11 +333,17 @@ namespace System.Net
                         return; // Cannot age: reject new cookie
                     }
 
-                    // About to change the collection
+                    // About to change the collection.
                     lock (cookies)
                     {
                         m_count += cookies.InternalAdd(cookie, true);
                     }
+                }
+
+                // We don't want to cleanup m_domaintable/m_list too often. Add check to avoid overhead.
+                if (m_domainTable.Count > m_count || pathList.Count > m_maxCookiesPerDomain)
+                {
+                    DomainTableCleanup();
                 }
             }
             catch (OutOfMemoryException)
@@ -503,6 +510,50 @@ namespace System.Net
                 }
             }
             return true;
+        }
+
+        private void DomainTableCleanup()
+        {
+            var removePathList = new List<Object>();
+            var removeDomainList = new List<string>();
+
+            string currentDomain;
+            PathList pathList;
+
+            lock (m_domainTable.SyncRoot)
+            {
+                foreach (DictionaryEntry entry in m_domainTable)
+                {
+                    currentDomain = (string)entry.Key;
+                    pathList = (PathList)entry.Value;
+
+                    lock (pathList.SyncRoot)
+                    {
+                        IDictionaryEnumerator e = pathList.GetEnumerator();
+                        while (e.MoveNext())
+                        {
+                            CookieCollection cc = (CookieCollection)e.Value;
+                            if (cc.Count == 0)
+                            {
+                                removePathList.Add(e.Key);
+                            }
+                        }
+
+                        foreach (var key in removePathList)
+                        {
+                            pathList.Remove(key);
+                        }
+
+                        removePathList.Clear();
+                        if (pathList.Count == 0) removeDomainList.Add(currentDomain);
+                    }
+                }
+
+                foreach (var key in removeDomainList)
+                {
+                    m_domainTable.Remove(key);
+                }
+            }
         }
 
         // Return number of cookies removed from the collection.
@@ -841,8 +892,7 @@ namespace System.Net
                     }
                 }
 
-                // Remove unused domain
-                // (This is the only place that does domain removal)
+                // Remove unused domain.
                 if (pathList.Count == 0)
                 {
                     lock (m_domainTable.SyncRoot)
@@ -1029,6 +1079,14 @@ namespace System.Net
             lock (SyncRoot)
             {
                 return m_list.GetEnumerator();
+            }
+        }
+
+        internal void Remove(Object key)
+        {
+            lock (SyncRoot)
+            {
+                m_list.Remove(key);
             }
         }
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerTest.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -163,6 +165,42 @@ namespace System.Net.Primitives.Functional.Tests
             CookieContainer cc = new CookieContainer();
             Assert.Throws<ArgumentNullException>(() => cc.SetCookies(null, "")); // Null uri
             Assert.Throws<ArgumentNullException>(() => cc.SetCookies(u5, null)); // Null header
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void AddCookies_CapacityReached_OldCookiesRemoved(bool isFromSameDomain)
+        {
+            const int Capacity = 10;
+            const int TotalCookieCount = 100;
+            var cookieContainer = new CookieContainer(Capacity);
+            Cookie cookie;
+
+            for (int i = 0; i < TotalCookieCount; i++)
+            {
+                if (isFromSameDomain)
+                {
+                    cookie = new Cookie("name1", "value1", $"/{i}", "test.com");
+                }
+                else
+                {
+                    cookie = new Cookie("name1", "value1", "/", $"test{i}.com");
+                }
+
+                cookieContainer.Add(cookie);
+            }
+
+            Assert.Equal(Capacity, cookieContainer.Count);
+
+            if (!isFromSameDomain)
+            {
+                FieldInfo domainTableField = typeof(CookieContainer).GetField("m_domainTable", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(domainTableField);
+                Hashtable domainTable = domainTableField.GetValue(cookieContainer) as Hashtable;
+                Assert.NotNull(domainTable);
+                Assert.Equal(Capacity, domainTable.Count);
+            }
         }
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerTest.cs
@@ -170,6 +170,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // .NET Framework will not perform domainTable clean up.
         public static void AddCookies_CapacityReached_OldCookiesRemoved(bool isFromSameDomain)
         {
             const int Capacity = 10;


### PR DESCRIPTION
Cookies are correctly removed based on `Capacity` and `PerDomainCapacity` from `CookieCollection` in each `PathList`, but we forget to clean up the `DomainTable` even when there is no/empty `PathList` associated with a `domainKey`. This can result in memory leak, particularly with these two cases:
1. Add cookies for many distinct domains.
2. Add cookies for the same domain with different paths.

Fix #33712.

Update, post `BenchmarkDotNet` result - the improvement is huge:

Before:

```
// * Summary *

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763, VM=Hyper-V
Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=2.1.500
  [Host]     : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
  Job-ZPUWDY : .NET Core d4939a36-e31f-4770-967a-35a619c12264 (CoreCLR 4.6.27304.02, CoreFX 4.7.19.5701), 64bit RyuJIT

Runtime=Core  Toolchain=CoreRun

                        Method |     Mean |    Error |   StdDev |       Gen 0 |       Gen 1 |     Gen 2 | Allocated |
------------------------------ |---------:|---------:|---------:|------------:|------------:|----------:|----------:|
      AddCookiesFromSameDomain | 38.210 s | 0.6532 s | 0.5791 s | 932000.0000 | 137000.0000 | 2000.0000 |   5.47 GB |
 AddCookiesFromDifferentDomain |  4.610 s | 0.0895 s | 0.0747 s | 189000.0000 |  12000.0000 | 2000.0000 |   1.13 GB |
```

After:

```
// * Summary *

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763, VM=Hyper-V
Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=2.1.500
  [Host]     : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
  Job-DGWAED : .NET Core 90a509e8-00cd-4c3e-bac4-d99eb4e58bfa (CoreCLR 4.6.27304.02, CoreFX 4.7.19.5701), 64bit RyuJIT

Runtime=Core  Toolchain=CoreRun

                        Method |     Mean |     Error |    StdDev |     Gen 0 | Allocated |
------------------------------ |---------:|----------:|----------:|----------:|----------:|
      AddCookiesFromSameDomain | 69.75 ms | 1.5412 ms | 4.1667 ms |         - |  15.91 MB |
 AddCookiesFromDifferentDomain | 44.38 ms | 0.7127 ms | 0.6666 ms | 3083.3333 |  20.23 MB |
```

Here is the test code if you are interested:

```c#

        public void AddCookies_OldCookiesRemoved(bool isFromSameDomain)
        {
            const int Capacity = 10;
            const int TotalCookieCount = 5000;
            var cookieContainer = new CookieContainer(Capacity);
            Cookie cookie;
            for (int i = 0; i < TotalCookieCount; i++)
            {
                if (isFromSameDomain)
                {
                    cookie = new Cookie("name1", "value1", $"/{i}", "test.com");
                }
                else
                {
                    cookie = new Cookie("name1", "value1", "/", $"test{i}.com");
                }
                cookieContainer.Add(cookie);
            }
        }

        [Benchmark] public void AddCookiesFromSameDomain() => AddCookies_OldCookiesRemoved(true);
        [Benchmark] public void AddCookiesFromDifferentDomain() => AddCookies_OldCookiesRemoved(false);

```