### PR TITLE
Optimize SqlClient query memory allocation

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -947,7 +947,10 @@ namespace System.Data.SqlClient
                 // Add callback after work is done to avoid overlapping Begin\End methods
                 if (callback != null)
                 {
-                    completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
+                    completion.Task.ContinueWith(
+                        (task,state) => ((AsyncCallback)state)(task),
+                        state: callback
+                    );
                 }
 
                 return completion.Task;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -911,7 +911,8 @@ namespace System.Data.SqlClient
                                             catch (SqlException)
                                             {
                                             }
-                                            runningReconnect = Task.Run(() => ReconnectAsync(timeout));
+                                            // use Task.Factory.StartNew with state overload instead of Task.Run to avoid anonymous closure context capture in method scope and avoid the unneeded allocation
+                                            runningReconnect = Task.Factory.StartNew(state => ReconnectAsync((int)state), timeout,CancellationToken.None, TaskCreationOptions.DenyChildAttach,TaskScheduler.Default);
                                             // if current reconnect is not null, somebody already started reconnection task - some kind of race condition
                                             Debug.Assert(_currentReconnectionTask == null, "Duplicate reconnection tasks detected");
                                             _currentReconnectionTask = runningReconnect;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -912,7 +912,7 @@ namespace System.Data.SqlClient
                                             {
                                             }
                                             // use Task.Factory.StartNew with state overload instead of Task.Run to avoid anonymous closure context capture in method scope and avoid the unneeded allocation
-                                            runningReconnect = Task.Factory.StartNew(state => ReconnectAsync((int)state), timeout,CancellationToken.None, TaskCreationOptions.DenyChildAttach,TaskScheduler.Default);
+                                            runningReconnect = Task.Factory.StartNew(state => ReconnectAsync((int)state), timeout, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
                                             // if current reconnect is not null, somebody already started reconnection task - some kind of race condition
                                             Debug.Assert(_currentReconnectionTask == null, "Duplicate reconnection tasks detected");
                                             _currentReconnectionTask = runningReconnect;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -2418,37 +2418,23 @@ namespace System.Data.SqlClient
                 else
                 {
                     uint error;
+                    SniContext = SniContext.Snix_Connect;
 
-                    object readPacket = EmptyReadPacket;
-
-                    try
+                    error = CheckConnection();
+                    if ((error != TdsEnums.SNI_SUCCESS) && (error != TdsEnums.SNI_WAIT_TIMEOUT))
                     {
-                        SniContext = SniContext.Snix_Connect;
-
-                        error = CheckConnection();
-
-                        if ((error != TdsEnums.SNI_SUCCESS) && (error != TdsEnums.SNI_WAIT_TIMEOUT))
+                        // Connection is dead
+                        isAlive = false;
+                        if (throwOnException)
                         {
-                            // Connection is dead
-                            isAlive = false;
-                            if (throwOnException)
-                            {
-                                // Get the error from SNI so that we can throw the correct exception
-                                AddError(_parser.ProcessSNIError(this));
-                                ThrowExceptionAndWarning();
-                            }
-                        }
-                        else
-                        {
-                            _lastSuccessfulIOTimer._value = DateTime.UtcNow.Ticks;
+                            // Get the error from SNI so that we can throw the correct exception
+                            AddError(_parser.ProcessSNIError(this));
+                            ThrowExceptionAndWarning();
                         }
                     }
-                    finally
+                    else
                     {
-                        if (!IsPacketEmpty(readPacket))
-                        {
-                            ReleasePacket(readPacket);
-                        }
+                        _lastSuccessfulIOTimer._value = DateTime.UtcNow.Ticks;
                     }
                 }
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -12,6 +12,8 @@ namespace System.Data.SqlClient
 {
     internal class TdsParserStateObjectNative : TdsParserStateObject
     {
+        private static readonly object s_cachedEmptyReadPacketObjectPointer = (object)IntPtr.Zero;
+
         private SNIHandle _sessionHandle = null;              // the SNI handle we're to work on
 
         private SNIPacket _sniPacket = null;                // Will have to re-vamp this for MARS
@@ -35,7 +37,7 @@ namespace System.Data.SqlClient
 
         internal override object SessionHandle => _sessionHandle;
 
-        protected override object EmptyReadPacket => IntPtr.Zero;
+        protected override object EmptyReadPacket => s_cachedEmptyReadPacketObjectPointer;
 
         protected override void CreateSessionHandle(TdsParserStateObject physicalConnection, bool async)
         {


### PR DESCRIPTION
Many synchronous code paths contain lambda allocations for async usage which capture variables in function scope which cause the allocation and use of closure types to contain them. This set of changes attempts to prevent allocation of a closure by using a state tuple or by breaking the closure machinery into a separate method only called in the async case.

The CachedAsyncState field was being allocated in the sync code path, I have refined the logic slightly to avoid this unless it is needed.

I have introduced a couple of pre-boxed integer constants which prevent the repeated boxing of the default value, these are bof the invalid prepared handle value and the empty read packet.

I have added an `AsyncHelper.ContinueTaskWithState` function which uses the same logic as the existing `ContinueTask` and adds the ability to pass a state object to each of the delegate parameters, this helps to avoid closures in calling code.

This PR was split from https://github.com/dotnet/corefx/pull/32811 and into smaller commits for easier review. It has passed the manual and efcore tests in native mode, the tests cannot be successfully run in managed mode due to https://github.com/dotnet/corefx/issues/33930 . Performance improvements for this and related PR's are in the original discussion.
/cc @keeratsingh @AfsanehR @saurabh500 @David-Engel