### PR TITLE
avoid processing incorrect ICMP message on Unix

### DIFF
--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -88,8 +88,10 @@ namespace System.Net.NetworkInformation
 
         private Socket GetRawSocket(SocketConfig socketConfig)
         {
+            IPEndPoint ep = socketConfig.EndPoint as IPEndPoint;
+
             // Setting Socket.DontFragment and .Ttl is not supported on Unix, so socketConfig.Options is ignored.
-            AddressFamily addrFamily = ((IPEndPoint)socketConfig.EndPoint).Address.AddressFamily;
+            AddressFamily addrFamily = ep.Address.AddressFamily;
             Socket socket = new Socket(addrFamily, SocketType.Raw, socketConfig.ProtocolType);
             socket.ReceiveTimeout = socketConfig.Timeout;
             socket.SendTimeout = socketConfig.Timeout;
@@ -97,6 +99,16 @@ namespace System.Net.NetworkInformation
             {
                 socket.Ttl = (short)socketConfig.Options.Ttl;
             }
+
+#pragma warning disable 618
+            // Disable warning about obsolete property. We could use GetAddressBytes but that allocates.
+            if (!ep.Address.IsIPv6Multicast && !(addrFamily == AddressFamily.InterNetwork && (ep.Address.Address & 0xf0) == 0xe0))
+            {
+                // If it is not multicast, use Connect to scope responses only tho target address.
+                socket.Connect(socketConfig.EndPoint);
+            }
+#pragma warning restore 618
+
             return socket;
         }
 
@@ -129,7 +141,7 @@ namespace System.Net.NetworkInformation
             {
                 return false;
             }
-            
+
             sw.Stop();
             long roundTripTime = sw.ElapsedMilliseconds;
             int dataOffset = ipHeaderLength + IcmpHeaderLengthInBytes;


### PR DESCRIPTION
fixes #33699 Ping.Unix falsely returns successful pings

When we use RAW socket implementation we simply create socket to get all ICMP.
When there are multiple pings going (even from different process)  the raw socket would receive all ICMP responses and than it can incorrectly report success even for non existing host. 

This change effectively implements address filtering. Instead of doing it explicitly as discussed in issue, it uses Connect() to ping socket to only that address for Unicast. (similar behavior to UDP)

I don't know if there is better way to determine multicast (leading 1110) IP for IPv4.

Aside from running tests, I did verify that ping to multicast (224.0.0.1 all nodes) still works as it used to. There is currently not good API to know what nodes responded to the query. So successful response means that there is at least one responding node.

I also did tests with broadcast and directed broadcast (xx.xx.xx.255) 
It fails with even for root:

> Unhandled Exception: System.Net.Sockets.SocketException: Permission denied
>    at System.Net.Sockets.Socket.DoBeginSendTo(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags, EndPoint endPointSnapshot, SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
> 

this is because we would need to do ioctl to enable broadcast functions on socket. 
This behavior remains same with this change. 




 

