### PR TITLE
catch exception in ssl handshake so it can be propagated to async caller

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -1381,14 +1381,16 @@ namespace System.Net.Security
                     break;
                 case TaskCompletionSource<int> taskCompletionSource when taskCompletionSource.Task.AsyncState != null:
                     Memory<byte> array = (Memory<byte>)taskCompletionSource.Task.AsyncState;
+                    int oldKeyResult = -1;
                     try
                     {
-                        taskCompletionSource.SetResult(CheckOldKeyDecryptedData(array));
+                        oldKeyResult = CheckOldKeyDecryptedData(array);
                     }
-                    catch (Exception e)
+                    catch (Exception exc)
                     {
-                        taskCompletionSource.SetException(e);
+                        taskCompletionSource.SetException(exc);
                     }
+                    taskCompletionSource.SetResult(oldKeyResult);
                     break;
                 case TaskCompletionSource<int> taskCompletionSource:
                     taskCompletionSource.SetResult(0);

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -1389,6 +1389,7 @@ namespace System.Net.Security
                     catch (Exception exc)
                     {
                         taskCompletionSource.SetException(exc);
+                        break;
                     }
                     taskCompletionSource.SetResult(oldKeyResult);
                     break;

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -1373,7 +1373,7 @@ namespace System.Net.Security
                 return;
             }
             queuedStateRequest = null;
-                        
+
             switch (obj)
             {
                 case LazyAsyncResult lazy:
@@ -1381,7 +1381,14 @@ namespace System.Net.Security
                     break;
                 case TaskCompletionSource<int> taskCompletionSource when taskCompletionSource.Task.AsyncState != null:
                     Memory<byte> array = (Memory<byte>)taskCompletionSource.Task.AsyncState;
-                    taskCompletionSource.SetResult(CheckOldKeyDecryptedData(array));
+                    try
+                    {
+                        taskCompletionSource.SetResult(CheckOldKeyDecryptedData(array));
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
                     break;
                 case TaskCompletionSource<int> taskCompletionSource:
                     taskCompletionSource.SetResult(0);


### PR DESCRIPTION
this is related to #33857 and was recommended by @stephentoub.
This allows to catch IO exception in SSL handshake. 

There is still issue connecting the site but at least it can be handled now. 