### PR TITLE
Add span-based TextEncoder APIs and remove use of unsafe code in implementations by using Span.

### DIFF
--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{B7EDBF00-765A-48E8-B593-CD668288E274}</ProjectGuid>
     <RootNamespace>System.Text.Encodings.Web</RootNamespace>
@@ -33,5 +33,8 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+    <Reference Include="System.Memory" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/AllowedCharactersBitmap.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/AllowedCharactersBitmap.cs
@@ -15,17 +15,11 @@ namespace System.Text.Internal
 
         // should be called in place of the default ctor
         public static AllowedCharactersBitmap CreateNew()
-        {
-            return new AllowedCharactersBitmap(new uint[ALLOWED_CHARS_BITMAP_LENGTH]);
-        }
+            => new AllowedCharactersBitmap(new uint[ALLOWED_CHARS_BITMAP_LENGTH]);
 
         private AllowedCharactersBitmap(uint[] allowedCharacters)
         {
-            if(allowedCharacters == null)
-            {
-                throw new ArgumentNullException(nameof(allowedCharacters));
-            }
-            _allowedCharacters = allowedCharacters;
+            _allowedCharacters = allowedCharacters ?? throw new ArgumentNullException(nameof(allowedCharacters));
         }
 
         // Marks a character as allowed (can be returned unencoded)
@@ -52,23 +46,17 @@ namespace System.Text.Internal
         {
             uint[] definedCharactersBitmap = UnicodeHelpers.GetDefinedCharacterBitmap();
             Debug.Assert(definedCharactersBitmap.Length == _allowedCharacters.Length);
+
             for (int i = 0; i < _allowedCharacters.Length; i++)
-            {
                 _allowedCharacters[i] &= definedCharactersBitmap[i];
-            }
         }
 
         // Marks all characters as forbidden (must be returned encoded)
-        public void Clear()
-        {
-            Array.Clear(_allowedCharacters, 0, _allowedCharacters.Length);
-        }
+        public void Clear() => Array.Clear(_allowedCharacters, 0, _allowedCharacters.Length);
 
         // Creates a deep copy of this bitmap
         public AllowedCharactersBitmap Clone()
-        {
-            return new AllowedCharactersBitmap((uint[])_allowedCharacters.Clone());
-        }
+            => new AllowedCharactersBitmap((uint[])_allowedCharacters.Clone());
 
         // Determines whether the given character can be returned unencoded.
         public bool IsCharacterAllowed(char character)
@@ -89,11 +77,14 @@ namespace System.Text.Internal
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe int FindFirstCharacterToEncode(char* text, int textLength)
+        public int FindFirstCharacterToEncode(ReadOnlySpan<char> text)
         {
-            for (int i = 0; i < textLength; i++)
+            for (int i = 0; i < text.Length; i++)
             {
-                if (!IsCharacterAllowed(text[i])) { return i; }
+                if (!IsCharacterAllowed(text[i]))
+                {
+                    return i;
+                }
             }
             return -1;
         }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Internal;
@@ -18,10 +17,7 @@ namespace System.Text.Encodings.Web
         /// <summary>
         /// Returns a default built-in instance of <see cref="JavaScriptEncoder"/>.
         /// </summary>
-        public static JavaScriptEncoder Default
-        {
-            get { return DefaultJavaScriptEncoder.Singleton; }
-        }
+        public static JavaScriptEncoder Default => DefaultJavaScriptEncoder.s_singleton;
 
         /// <summary>
         /// Creates a new instance of JavaScriptEncoder with provided settings.
@@ -29,9 +25,7 @@ namespace System.Text.Encodings.Web
         /// <param name="settings">Settings used to control how the created <see cref="JavaScriptEncoder"/> encodes, primarily which characters to encode.</param>
         /// <returns>A new instance of the <see cref="JavaScriptEncoder"/>.</returns>
         public static JavaScriptEncoder Create(TextEncoderSettings settings)
-        {
-            return new DefaultJavaScriptEncoder(settings);
-        }
+            => new DefaultJavaScriptEncoder(settings);
 
         /// <summary>
         /// Creates a new instance of JavaScriptEncoder specifying character to be encoded.
@@ -40,16 +34,14 @@ namespace System.Text.Encodings.Web
         /// <returns>A new instance of the <see cref="JavaScriptEncoder"/>.</returns>
         /// <remarks>Some characters in <paramref name="allowedRanges"/> might still get encoded, i.e. this parameter is just telling the encoder what ranges it is allowed to not encode, not what characters it must not encode.</remarks> 
         public static JavaScriptEncoder Create(params UnicodeRange[] allowedRanges)
-        {
-            return new DefaultJavaScriptEncoder(allowedRanges);
-        }
+            => new DefaultJavaScriptEncoder(allowedRanges);
     }
 
     internal sealed class DefaultJavaScriptEncoder : JavaScriptEncoder
     {
         private AllowedCharactersBitmap _allowedCharacters;
 
-        internal static readonly DefaultJavaScriptEncoder Singleton = new DefaultJavaScriptEncoder(new TextEncoderSettings(UnicodeRanges.BasicLatin));
+        internal static readonly DefaultJavaScriptEncoder s_singleton = new DefaultJavaScriptEncoder(new TextEncoderSettings(UnicodeRanges.BasicLatin));
 
         public DefaultJavaScriptEncoder(TextEncoderSettings filter)
         {
@@ -73,9 +65,9 @@ namespace System.Text.Encodings.Web
 
             _allowedCharacters.ForbidCharacter('\\');
             _allowedCharacters.ForbidCharacter('/');
-            
+
             // Forbid GRAVE ACCENT \u0060 character.
-            _allowedCharacters.ForbidCharacter('`'); 
+            _allowedCharacters.ForbidCharacter('`');
         }
 
         public DefaultJavaScriptEncoder(params UnicodeRange[] allowedRanges) : this(new TextEncoderSettings(allowedRanges))
@@ -84,7 +76,8 @@ namespace System.Text.Encodings.Web
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool WillEncode(int unicodeScalar)
         {
-            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar)) return true;
+            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
+                return true;
             return !_allowedCharacters.IsUnicodeScalarAllowed(unicodeScalar);
         }
 
@@ -92,27 +85,22 @@ namespace System.Text.Encodings.Web
         public unsafe override int FindFirstCharacterToEncode(char* text, int textLength)
         {
             if (text == null)
-            {
                 throw new ArgumentNullException(nameof(text));
-            }
-            return _allowedCharacters.FindFirstCharacterToEncode(text, textLength);
+            return FindFirstCharacterToEncode(new ReadOnlySpan<char>(text, textLength));
         }
 
         // The worst case encoding is 6 output chars per input char: [input] U+FFFF -> [output] "\uFFFF"
         // We don't need to worry about astral code points since they're represented as encoded
         // surrogate pairs in the output.
-        public override int MaxOutputCharactersPerInputCharacter
-        {
-            get { return 12; } // "\uFFFF\uFFFF" is the longest encoded form 
-        }
+        public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form 
 
-        static readonly char[] s_b = new char[] { '\\', 'b' };
-        static readonly char[] s_t = new char[] { '\\', 't' };
-        static readonly char[] s_n = new char[] { '\\', 'n' };
-        static readonly char[] s_f = new char[] { '\\', 'f' };
-        static readonly char[] s_r = new char[] { '\\', 'r' };
-        static readonly char[] s_forward = new char[] { '\\', '/' };
-        static readonly char[] s_back = new char[] { '\\', '\\' };
+        private static readonly char[] s_b = new char[] { '\\', 'b' };
+        private static readonly char[] s_t = new char[] { '\\', 't' };
+        private static readonly char[] s_n = new char[] { '\\', 'n' };
+        private static readonly char[] s_f = new char[] { '\\', 'f' };
+        private static readonly char[] s_r = new char[] { '\\', 'r' };
+        private static readonly char[] s_forward = new char[] { '\\', '/' };
+        private static readonly char[] s_back = new char[] { '\\', '\\' };
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -121,9 +109,17 @@ namespace System.Text.Encodings.Web
         public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
         {
             if (buffer == null)
-            {
                 throw new ArgumentNullException(nameof(buffer));
-            }
+
+            return TryEncodeUnicodeScalar(unicodeScalar, new Span<char>(buffer, bufferLength), out numberOfCharactersWritten);
+        }
+
+        // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
+        // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
+        // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
+        // http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
+        public override bool TryEncodeUnicodeScalar(int unicodeScalar, Span<char> buffer, out int numberOfCharactersWritten)
+        {
             // ECMA-262 allows encoding U+000B as "\v", but ECMA-404 does not.
             // Both ECMA-262 and ECMA-404 allow encoding U+002F SOLIDUS as "\/".
             // (In ECMA-262 this character is a NonEscape character.)
@@ -131,36 +127,55 @@ namespace System.Text.Encodings.Web
             // be written out as numeric entities for defense-in-depth.
             // See UnicodeEncoderBase ctor comments for more info.
 
-            if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
+            if (!WillEncode(unicodeScalar))
+                return TryWriteScalarAsChar(unicodeScalar, buffer, out numberOfCharactersWritten);
 
-            char[] toCopy = null;
+            ReadOnlySpan<char> toCopy;
             switch (unicodeScalar)
             {
-                case '\b': toCopy = s_b; break;
-                case '\t': toCopy = s_t; break;
-                case '\n': toCopy = s_n; break;
-                case '\f': toCopy = s_f; break;
-                case '\r': toCopy = s_r; break;
-                case '/': toCopy = s_forward; break;
-                case '\\': toCopy = s_back; break;
-                default: return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); 
+                case '\b':
+                    toCopy = s_b;
+                    break;
+                case '\t':
+                    toCopy = s_t;
+                    break;
+                case '\n':
+                    toCopy = s_n;
+                    break;
+                case '\f':
+                    toCopy = s_f;
+                    break;
+                case '\r':
+                    toCopy = s_r;
+                    break;
+                case '/':
+                    toCopy = s_forward;
+                    break;
+                case '\\':
+                    toCopy = s_back;
+                    break;
+                default:
+                    return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, out numberOfCharactersWritten);
             }
-            return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
+
+            if (!toCopy.TryCopyTo(buffer))
+            {
+                numberOfCharactersWritten = 0;
+                return false;
+            }
+            numberOfCharactersWritten = toCopy.Length;
+            return true;
         }
 
-        private static unsafe bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
+        private static bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, Span<char> buffer, out int numberOfCharactersWritten)
         {
-            Debug.Assert(buffer != null && length >= 0);
-
             if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
             {
                 // Convert this back to UTF-16 and write out both characters.
-                char leadingSurrogate, trailingSurrogate;
-                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out leadingSurrogate, out trailingSurrogate);
-                int leadingSurrogateCharactersWritten;
-                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, length, out leadingSurrogateCharactersWritten) &&
-                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer + leadingSurrogateCharactersWritten, length - leadingSurrogateCharactersWritten, out numberOfCharactersWritten)
-                )
+                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out char leadingSurrogate, out char trailingSurrogate);
+
+                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, out int leadingSurrogateCharactersWritten) &&
+                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer.Slice(leadingSurrogateCharactersWritten), out numberOfCharactersWritten))
                 {
                     numberOfCharactersWritten += leadingSurrogateCharactersWritten;
                     return true;
@@ -174,32 +189,35 @@ namespace System.Text.Encodings.Web
             else
             {
                 // This is only a single character.
-                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, length, out numberOfCharactersWritten);
+                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, out numberOfCharactersWritten);
             }
         }
 
         // Writes an encoded scalar value (in the BMP) as a JavaScript-escaped character.
-        private static unsafe bool TryWriteEncodedSingleCharacter(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
+        private static bool TryWriteEncodedSingleCharacter(int unicodeScalar, Span<char> buffer, out int numberOfCharactersWritten)
         {
-            Debug.Assert(buffer != null && length >= 0);
             Debug.Assert(!UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar), "The incoming value should've been in the BMP.");
 
-            if (length < 6)
+            if (buffer.Length < 6)
             {
                 numberOfCharactersWritten = 0;
                 return false;
             }
 
             // Encode this as 6 chars "\uFFFF".
-            *buffer = '\\'; buffer++;
-            *buffer = 'u'; buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit(unicodeScalar >> 12); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 8) & 0xFU)); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 4) & 0xFU)); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)(unicodeScalar & 0xFU)); buffer++;
+            buffer[0] = '\\';
+            buffer[1] = 'u';
+            buffer[2] = HexUtil.Int32LsbToHexDigit(unicodeScalar >> 12);
+            buffer[3] = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 8) & 0xFU));
+            buffer[4] = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 4) & 0xFU));
+            buffer[5] = HexUtil.Int32LsbToHexDigit((int)(unicodeScalar & 0xFU));
 
             numberOfCharactersWritten = 6;
             return true;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override int FindFirstCharacterToEncode(ReadOnlySpan<char> text)
+            => _allowedCharacters.FindFirstCharacterToEncode(text);
     }
 }

--- a/src/System.Text.Encodings.Web/tests/ScalarTestEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/ScalarTestEncoder.cs
@@ -53,5 +53,20 @@ namespace Microsoft.Framework.WebEncoders
             numberOfCharactersWritten = Int32Length;
             return true;
         }
+
+        public override unsafe bool TryEncodeUnicodeScalar(int unicodeScalar, Span<char> buffer, out int numberOfCharactersWritten)
+        {
+            fixed (char* chars = unicodeScalar.ToString("X8"))
+                for (int i = 0; i < Int32Length; i++)
+                    buffer[i] = chars[i];
+
+            numberOfCharactersWritten = Int32Length;
+            return true;
+        }
+
+        public override int FindFirstCharacterToEncode(ReadOnlySpan<char> text)
+        {
+            return 0;
+        }
     }
 }

--- a/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public HtmlEncoder()
         {
-            _encoder = System.Text.Encodings.Web.DefaultHtmlEncoder.Singleton;
+            _encoder = System.Text.Encodings.Web.DefaultHtmlEncoder.s_singleton;
         }
         public HtmlEncoder(TextEncoderSettings filter)
         {
@@ -107,7 +107,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public JavaScriptStringEncoder()
         {
-            _encoder = System.Text.Encodings.Web.DefaultJavaScriptEncoder.Singleton;
+            _encoder = System.Text.Encodings.Web.DefaultJavaScriptEncoder.s_singleton;
         }
         public JavaScriptStringEncoder(TextEncoderSettings filter)
         {
@@ -170,7 +170,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public UrlEncoder()
         {
-            _encoder = System.Text.Encodings.Web.DefaultUrlEncoder.Singleton;
+            _encoder = System.Text.Encodings.Web.DefaultUrlEncoder.s_singleton;
         }
         public UrlEncoder(TextEncoderSettings filter)
         {
@@ -190,7 +190,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public string UrlEncode(string value)
         {
-            return _encoder.Encode(value); ;
+            return _encoder.Encode(value);
         }
 
         public void UrlEncode(string value, int startIndex, int characterCount, TextWriter output)


### PR DESCRIPTION
- Added span-based APIs to `TextEncoder` (this has not gone through API review yet which is why I have marked as no merge since it may not be the right approach).
  - **Motivation:** If I am to use the default `JavaScriptEncoder` encode API to escape strings within the `Utf8JsonWriter`, I will need the `ReadOnlySpan<char>` equivalents as well (probably along with `ReadOnlySpan<byte>` for UTF-8 in the future **IF** we plan to add them here rather than try a different approach all together). What are the initial thoughts on adding public APIs to TextEncoder? Are we allowed to or is the type effectively frozen? That is the primary reason for this PR/change.
  - If we are fine with adding such overloads, should we obsolete the unsafe ones (for netstandard1.1+)?
- Replace use of unsafe and pointers with spans (for internal/private at least).
- Fixed formatting and coding style since I was touching the code anyway.
- I couldn't find a ref file here to update. Do we need one?

This change only works for netstandard (and won't work on netstandard1.0), so we will likely need to ifdef the code/API surface for that configuration if we were to accept this change.

**Please let me know if its fine going down this path so I can file an API proposal issue.**