### PR TITLE
Linux NetworkInterface.GetIPStatistics - handle values > uint.MaxValue

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.IO;
 
 namespace System.Net.NetworkInformation
@@ -445,7 +446,7 @@ namespace System.Net.NetworkInformation
 
         private static long ParseUInt64AndClampToInt64(string value) 
         {
-            return (long)Math.Min((ulong)long.MaxValue, ulong.Parse(value)); 
+            return (long)Math.Min((ulong)long.MaxValue, ulong.Parse(value, CultureInfo.InvariantCulture));
         }
     }
 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -417,23 +417,23 @@ namespace System.Net.NetworkInformation
 
                         return new IPInterfaceStatisticsTable()
                         {
-                            BytesReceived = long.Parse(pieces[1]),
-                            PacketsReceived = long.Parse(pieces[2]),
-                            ErrorsReceived = long.Parse(pieces[3]),
-                            IncomingPacketsDropped = long.Parse(pieces[4]),
-                            FifoBufferErrorsReceived = long.Parse(pieces[5]),
-                            PacketFramingErrorsReceived = long.Parse(pieces[6]),
-                            CompressedPacketsReceived = long.Parse(pieces[7]),
-                            MulticastFramesReceived = long.Parse(pieces[8]),
+                            BytesReceived = ParseUInt64AndClampToInt64(pieces[1]),
+                            PacketsReceived = ParseUInt64AndClampToInt64(pieces[2]),
+                            ErrorsReceived = ParseUInt64AndClampToInt64(pieces[3]),
+                            IncomingPacketsDropped = ParseUInt64AndClampToInt64(pieces[4]),
+                            FifoBufferErrorsReceived = ParseUInt64AndClampToInt64(pieces[5]),
+                            PacketFramingErrorsReceived = ParseUInt64AndClampToInt64(pieces[6]),
+                            CompressedPacketsReceived = ParseUInt64AndClampToInt64(pieces[7]),
+                            MulticastFramesReceived = ParseUInt64AndClampToInt64(pieces[8]),
 
-                            BytesTransmitted = long.Parse(pieces[9]),
-                            PacketsTransmitted = long.Parse(pieces[10]),
-                            ErrorsTransmitted = long.Parse(pieces[11]),
-                            OutgoingPacketsDropped = long.Parse(pieces[12]),
-                            FifoBufferErrorsTransmitted = long.Parse(pieces[13]),
-                            CollisionsDetected = long.Parse(pieces[14]),
-                            CarrierLosses = long.Parse(pieces[15]),
-                            CompressedPacketsTransmitted = long.Parse(pieces[16]),
+                            BytesTransmitted = ParseUInt64AndClampToInt64(pieces[9]),
+                            PacketsTransmitted = ParseUInt64AndClampToInt64(pieces[10]),
+                            ErrorsTransmitted = ParseUInt64AndClampToInt64(pieces[11]),
+                            OutgoingPacketsDropped = ParseUInt64AndClampToInt64(pieces[12]),
+                            FifoBufferErrorsTransmitted = ParseUInt64AndClampToInt64(pieces[13]),
+                            CollisionsDetected = ParseUInt64AndClampToInt64(pieces[14]),
+                            CarrierLosses = ParseUInt64AndClampToInt64(pieces[15]),
+                            CompressedPacketsTransmitted = ParseUInt64AndClampToInt64(pieces[16]),
                         };
                     }
                     index += 1;
@@ -441,6 +441,11 @@ namespace System.Net.NetworkInformation
 
                 throw ExceptionHelper.CreateForParseFailure();
             }
+        }
+
+        private static long ParseUInt64AndClampToInt64(string value) 
+        {
+            return (long)Math.Min((ulong)long.MaxValue, ulong.Parse(value)); 
         }
     }
 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -150,24 +150,24 @@ namespace System.Net.NetworkInformation
     internal struct IPInterfaceStatisticsTable
     {
         // Receive section
-        public uint BytesReceived;
-        public uint PacketsReceived;
-        public uint ErrorsReceived;
-        public uint IncomingPacketsDropped;
-        public uint FifoBufferErrorsReceived;
-        public uint PacketFramingErrorsReceived;
-        public uint CompressedPacketsReceived;
-        public uint MulticastFramesReceived;
+        public long BytesReceived;
+        public long PacketsReceived;
+        public long ErrorsReceived;
+        public long IncomingPacketsDropped;
+        public long FifoBufferErrorsReceived;
+        public long PacketFramingErrorsReceived;
+        public long CompressedPacketsReceived;
+        public long MulticastFramesReceived;
 
         // Transmit section
-        public uint BytesTransmitted;
-        public uint PacketsTransmitted;
-        public uint ErrorsTransmitted;
-        public uint OutgoingPacketsDropped;
-        public uint FifoBufferErrorsTransmitted;
-        public uint CollisionsDetected;
-        public uint CarrierLosses;
-        public uint CompressedPacketsTransmitted;
+        public long BytesTransmitted;
+        public long PacketsTransmitted;
+        public long ErrorsTransmitted;
+        public long OutgoingPacketsDropped;
+        public long FifoBufferErrorsTransmitted;
+        public long CollisionsDetected;
+        public long CarrierLosses;
+        public long CompressedPacketsTransmitted;
     }
 
     internal static partial class StringParsingHelpers
@@ -417,23 +417,23 @@ namespace System.Net.NetworkInformation
 
                         return new IPInterfaceStatisticsTable()
                         {
-                            BytesReceived = ParseUInt64AndClampToUInt32(pieces[1]),
-                            PacketsReceived = ParseUInt64AndClampToUInt32(pieces[2]),
-                            ErrorsReceived = ParseUInt64AndClampToUInt32(pieces[3]),
-                            IncomingPacketsDropped = ParseUInt64AndClampToUInt32(pieces[4]),
-                            FifoBufferErrorsReceived = ParseUInt64AndClampToUInt32(pieces[5]),
-                            PacketFramingErrorsReceived = ParseUInt64AndClampToUInt32(pieces[6]),
-                            CompressedPacketsReceived = ParseUInt64AndClampToUInt32(pieces[7]),
-                            MulticastFramesReceived = ParseUInt64AndClampToUInt32(pieces[8]),
+                            BytesReceived = long.Parse(pieces[1]),
+                            PacketsReceived = long.Parse(pieces[2]),
+                            ErrorsReceived = long.Parse(pieces[3]),
+                            IncomingPacketsDropped = long.Parse(pieces[4]),
+                            FifoBufferErrorsReceived = long.Parse(pieces[5]),
+                            PacketFramingErrorsReceived = long.Parse(pieces[6]),
+                            CompressedPacketsReceived = long.Parse(pieces[7]),
+                            MulticastFramesReceived = long.Parse(pieces[8]),
 
-                            BytesTransmitted = ParseUInt64AndClampToUInt32(pieces[9]),
-                            PacketsTransmitted = ParseUInt64AndClampToUInt32(pieces[10]),
-                            ErrorsTransmitted = ParseUInt64AndClampToUInt32(pieces[11]),
-                            OutgoingPacketsDropped = ParseUInt64AndClampToUInt32(pieces[12]),
-                            FifoBufferErrorsTransmitted = ParseUInt64AndClampToUInt32(pieces[13]),
-                            CollisionsDetected = ParseUInt64AndClampToUInt32(pieces[14]),
-                            CarrierLosses = ParseUInt64AndClampToUInt32(pieces[15]),
-                            CompressedPacketsTransmitted = ParseUInt64AndClampToUInt32(pieces[16]),
+                            BytesTransmitted = long.Parse(pieces[9]),
+                            PacketsTransmitted = long.Parse(pieces[10]),
+                            ErrorsTransmitted = long.Parse(pieces[11]),
+                            OutgoingPacketsDropped = long.Parse(pieces[12]),
+                            FifoBufferErrorsTransmitted = long.Parse(pieces[13]),
+                            CollisionsDetected = long.Parse(pieces[14]),
+                            CarrierLosses = long.Parse(pieces[15]),
+                            CompressedPacketsTransmitted = long.Parse(pieces[16]),
                         };
                     }
                     index += 1;
@@ -441,11 +441,6 @@ namespace System.Net.NetworkInformation
 
                 throw ExceptionHelper.CreateForParseFailure();
             }
-        }
-
-        private static uint ParseUInt64AndClampToUInt32(string value)
-        {
-            return (uint)Math.Min(uint.MaxValue, ulong.Parse(value));
         }
     }
 }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/dev
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/dev
@@ -1,4 +1,4 @@
 Inter-|   Receive                                                |  Transmit
  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
  wlan0:   26622     394    2    4    6     8         10        12    27465     208    1    2    3     4       5          6
-    lo:   4294967300     302    0    0    0     0          0         0    30008     302    0    0    0     0       0          0
+    lo:   429496730000     302    0    0    0     0          0         0    30008     302    0    0    0     0       0          0

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/dev
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/dev
@@ -1,4 +1,4 @@
 Inter-|   Receive                                                |  Transmit
  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
- wlan0:   26622     394    2    4    6     8         10        12    27465     208    1    2    3     4       5          6
-    lo:   429496730000     302    0    0    0     0          0         0    30008     302    0    0    0     0       0          0
+ wlan0:   26622     394    2    4    6     8         10        12    429496730000     208    1    2    3     4       5          6
+    lo:   18446744073709551615     302    0    0    0     0          0         0    30008     302    0    0    0     0       0          0

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
@@ -198,23 +198,23 @@ namespace System.Net.NetworkInformation.Tests
             FileUtil.NormalizeLineEndings("NetworkFiles/dev", fileName);
             IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(fileName, "wlan0");
 
-            Assert.Equal(26622u, table.BytesReceived);
-            Assert.Equal(394u, table.PacketsReceived);
-            Assert.Equal(2u, table.ErrorsReceived);
-            Assert.Equal(4u, table.IncomingPacketsDropped);
-            Assert.Equal(6u, table.FifoBufferErrorsReceived);
-            Assert.Equal(8u, table.PacketFramingErrorsReceived);
-            Assert.Equal(10u, table.CompressedPacketsReceived);
-            Assert.Equal(12u, table.MulticastFramesReceived);
+            Assert.Equal(26622L, table.BytesReceived);
+            Assert.Equal(394L, table.PacketsReceived);
+            Assert.Equal(2L, table.ErrorsReceived);
+            Assert.Equal(4L, table.IncomingPacketsDropped);
+            Assert.Equal(6L, table.FifoBufferErrorsReceived);
+            Assert.Equal(8L, table.PacketFramingErrorsReceived);
+            Assert.Equal(10L, table.CompressedPacketsReceived);
+            Assert.Equal(12L, table.MulticastFramesReceived);
 
-            Assert.Equal(27465u, table.BytesTransmitted);
-            Assert.Equal(208u, table.PacketsTransmitted);
-            Assert.Equal(1u, table.ErrorsTransmitted);
-            Assert.Equal(2u, table.OutgoingPacketsDropped);
-            Assert.Equal(3u, table.FifoBufferErrorsTransmitted);
-            Assert.Equal(4u, table.CollisionsDetected);
-            Assert.Equal(5u, table.CarrierLosses);
-            Assert.Equal(6u, table.CompressedPacketsTransmitted);
+            Assert.Equal(27465L, table.BytesTransmitted);
+            Assert.Equal(208L, table.PacketsTransmitted);
+            Assert.Equal(1L, table.ErrorsTransmitted);
+            Assert.Equal(2L, table.OutgoingPacketsDropped);
+            Assert.Equal(3L, table.FifoBufferErrorsTransmitted);
+            Assert.Equal(4L, table.CollisionsDetected);
+            Assert.Equal(5L, table.CarrierLosses);
+            Assert.Equal(6L, table.CompressedPacketsTransmitted);
         }
 
         [Fact]
@@ -224,23 +224,23 @@ namespace System.Net.NetworkInformation.Tests
             FileUtil.NormalizeLineEndings("NetworkFiles/dev", fileName);
             IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(fileName, "lo");
 
-            Assert.Equal(uint.MaxValue, table.BytesReceived);
-            Assert.Equal(302u, table.PacketsReceived);
-            Assert.Equal(0u, table.ErrorsReceived);
-            Assert.Equal(0u, table.IncomingPacketsDropped);
-            Assert.Equal(0u, table.FifoBufferErrorsReceived);
-            Assert.Equal(0u, table.PacketFramingErrorsReceived);
-            Assert.Equal(0u, table.CompressedPacketsReceived);
-            Assert.Equal(0u, table.MulticastFramesReceived);
+            Assert.Equal(429496730000L, table.BytesReceived);
+            Assert.Equal(302L, table.PacketsReceived);
+            Assert.Equal(0L, table.ErrorsReceived);
+            Assert.Equal(0L, table.IncomingPacketsDropped);
+            Assert.Equal(0L, table.FifoBufferErrorsReceived);
+            Assert.Equal(0L, table.PacketFramingErrorsReceived);
+            Assert.Equal(0L, table.CompressedPacketsReceived);
+            Assert.Equal(0L, table.MulticastFramesReceived);
 
-            Assert.Equal(30008u, table.BytesTransmitted);
-            Assert.Equal(302u, table.PacketsTransmitted);
-            Assert.Equal(0u, table.ErrorsTransmitted);
-            Assert.Equal(0u, table.OutgoingPacketsDropped);
-            Assert.Equal(0u, table.FifoBufferErrorsTransmitted);
-            Assert.Equal(0u, table.CollisionsDetected);
-            Assert.Equal(0u, table.CarrierLosses);
-            Assert.Equal(0u, table.CompressedPacketsTransmitted);
+            Assert.Equal(30008L, table.BytesTransmitted);
+            Assert.Equal(302L, table.PacketsTransmitted);
+            Assert.Equal(0L, table.ErrorsTransmitted);
+            Assert.Equal(0L, table.OutgoingPacketsDropped);
+            Assert.Equal(0L, table.FifoBufferErrorsTransmitted);
+            Assert.Equal(0L, table.CollisionsDetected);
+            Assert.Equal(0L, table.CarrierLosses);
+            Assert.Equal(0L, table.CompressedPacketsTransmitted);
         }
     }
 }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
@@ -207,7 +207,7 @@ namespace System.Net.NetworkInformation.Tests
             Assert.Equal(10L, table.CompressedPacketsReceived);
             Assert.Equal(12L, table.MulticastFramesReceived);
 
-            Assert.Equal(27465L, table.BytesTransmitted);
+            Assert.Equal(429496730000L, table.BytesTransmitted);
             Assert.Equal(208L, table.PacketsTransmitted);
             Assert.Equal(1L, table.ErrorsTransmitted);
             Assert.Equal(2L, table.OutgoingPacketsDropped);
@@ -224,7 +224,7 @@ namespace System.Net.NetworkInformation.Tests
             FileUtil.NormalizeLineEndings("NetworkFiles/dev", fileName);
             IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(fileName, "lo");
 
-            Assert.Equal(429496730000L, table.BytesReceived);
+            Assert.Equal(long.MaxValue, table.BytesReceived);
             Assert.Equal(302L, table.PacketsReceived);
             Assert.Equal(0L, table.ErrorsReceived);
             Assert.Equal(0L, table.IncomingPacketsDropped);


### PR DESCRIPTION
The story
I was writing a lightweight library to parse /proc/net/dev statistics and verified it against `NetworkInterface.GetIPStatistics` and immediately found that `NetworkInterface.GetIPStatistics` cuts values above `uint.MaxValue` to `uint.MaxValue` since on my Linux VM I have a heavy traffic so receive/transit byte counters are far above 4GB