### PR TITLE
HTTP2: Respect SETTINGS_INITIAL_WINDOW_SIZE and rework SendAsync code structure

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2Frames.cs
+++ b/src/Common/tests/System/Net/Http/Http2Frames.cs
@@ -253,15 +253,15 @@ namespace System.Net.Test.Common
         public int ErrorCode = 0;
 
         public RstStreamFrame(FrameFlags flags, int errorCode, int streamId) :
-            base(Frame.FrameHeaderLength + 4, FrameType.RstStream, flags, streamId)
+            base(4, FrameType.RstStream, flags, streamId)
         {
             ErrorCode = errorCode;
         }
 
         public static RstStreamFrame ReadFrom(Frame header, ReadOnlySpan<byte> buffer)
         {
-            int idx = Frame.FrameHeaderLength;
-            int errorCode = (int)((uint)((buffer[idx++] << 24) | (buffer[idx++] << 16) | (buffer[idx++] << idx++) | buffer[idx++]) & 0x7FFFFFFF);
+            int idx = 0;
+            int errorCode = (int)((uint)((buffer[idx++] << 24) | (buffer[idx++] << 16) | (buffer[idx++] << 8) | buffer[idx++]) & 0x7FFFFFFF);
 
             return new RstStreamFrame(header.Flags, errorCode, header.StreamId);
         }

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -21,6 +21,7 @@ namespace System.Net.Test.Common
         private Http2Options _options;
         private Uri _uri;
         private bool _ignoreSettingsAck;
+        private bool _ignoreWindowUpdates;
 
         public Uri Address
         {
@@ -120,6 +121,11 @@ namespace System.Net.Test.Common
                 return await ReadFrameAsync(timeout);
             }
 
+            if (_ignoreWindowUpdates && header.Type == FrameType.WindowUpdate)
+            {
+                return await ReadFrameAsync(timeout);
+            }
+
             // Construct the correct frame type and return it.
             switch (header.Type)
             {
@@ -190,6 +196,11 @@ namespace System.Net.Test.Common
 
             Assert.False(_ignoreSettingsAck);
             _ignoreSettingsAck = true;
+        }
+
+        public void IngoreWindowUpdates()
+        {
+            _ignoreWindowUpdates = true;
         }
 
         // Accept connection and handle connection setup

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -198,7 +198,7 @@ namespace System.Net.Test.Common
             _ignoreSettingsAck = true;
         }
 
-        public void IngoreWindowUpdates()
+        public void IgnoreWindowUpdates()
         {
             _ignoreWindowUpdates = true;
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -22,6 +22,7 @@ namespace System.Net.Http
             private readonly int _streamId;
             private readonly object _syncObject;
 
+            private readonly TaskCompletionSource<bool> _responseHeadersAvailable;
             private ArrayBuffer _responseBuffer;
             private TaskCompletionSource<bool> _responseDataAvailable;
             private bool _responseComplete;
@@ -29,114 +30,75 @@ namespace System.Net.Http
 
             private readonly CreditManager _streamWindow;
 
-            private HttpResponseMessage _response;
+            private readonly HttpRequestMessage _request;
+            private readonly HttpResponseMessage _response;
+            private readonly HttpConnectionResponseContent _responseContent;
             private bool _disposed;
 
-            public Http2Stream(Http2Connection connection)
+            public Http2Stream(HttpRequestMessage request, Http2Connection connection, int streamId, int initialWindowSize)
             {
                 _connection = connection;
+                _streamId = streamId;
 
-                _streamId = connection.AddStream(this);
+                _request = request;
+                _responseContent = new HttpConnectionResponseContent();
+                _response = new HttpResponseMessage() { Version = HttpVersion.Version20, RequestMessage = request, Content = _responseContent };
 
                 _syncObject = new object();
                 _disposed = false;
 
                 _responseBuffer = new ArrayBuffer(InitialBufferSize);
 
-                _streamWindow = new CreditManager(InitialWindowSize);
+                _streamWindow = new CreditManager(initialWindowSize);
+
+                _responseHeadersAvailable = new TaskCompletionSource<bool>();
+
+                // TODO: ISSUE 31313: Avoid allocating a TaskCompletionSource repeatedly by using a resettable ValueTaskSource.
+                // See: https://github.com/dotnet/corefx/blob/master/src/Common/tests/System/Threading/Tasks/Sources/ManualResetValueTaskSource.cs
+                _responseDataAvailable = null;
             }
 
             public int StreamId => _streamId;
+            public HttpRequestMessage Request => _request;
+            public HttpResponseMessage Response => _response;
 
-            public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            public async Task SendRequestBodyAsync()
             {
-                // TODO: ISSUE 31310: Cancellation support
+                // TODO: ISSUE 31312: Expect: 100-continue and early response handling
+                // Note that in an "early response" scenario, where we get a response before we've finished sending the request body
+                // (either with a 100-continue that timed out, or without 100-continue),
+                // we can stop send a RST_STREAM on the request stream and stop sending the request without tearing down the entire connection.
 
-                try
+                // Send request body, if any
+                if (_request.Content != null)
                 {
-                    HttpConnectionResponseContent responseContent = new HttpConnectionResponseContent();
-                    _response = new HttpResponseMessage() { Version = HttpVersion.Version20, RequestMessage = request, Content = responseContent };
-
-                    // TODO: ISSUE 31312: Expect: 100-continue and early response handling
-                    // Note that in an "early response" scenario, where we get a response before we've finished sending the request body
-                    // (either with a 100-continue that timed out, or without 100-continue),
-                    // we can stop send a RST_STREAM on the request stream and stop sending the request without tearing down the entire connection.
-
-                    // TODO: ISSUE 31313: Avoid allocating a TaskCompletionSource repeatedly by using a resettable ValueTaskSource.
-                    // See: https://github.com/dotnet/corefx/blob/master/src/Common/tests/System/Threading/Tasks/Sources/ManualResetValueTaskSource.cs
-                    Debug.Assert(_responseDataAvailable == null);
-                    _responseDataAvailable = new TaskCompletionSource<bool>();
-                    Task readDataAvailableTask = _responseDataAvailable.Task;
-
-                    // Send headers
-                    await _connection.SendHeadersAsync(_streamId, request).ConfigureAwait(false);
-
-                    // Send request body, if any
-                    if (request.Content != null)
+                    using (Http2WriteStream writeStream = new Http2WriteStream(this))
                     {
-                        using (Http2WriteStream writeStream = new Http2WriteStream(this))
-                        {
-                            await request.Content.CopyToAsync(writeStream).ConfigureAwait(false);
-                        }
-                    }
-
-                    // Wait for response headers to be read.
-                    await readDataAvailableTask.ConfigureAwait(false);
-
-                    // Start to process the response body.
-                    bool emptyResponse = false;
-                    lock (_syncObject)
-                    {
-                        if (_responseComplete && _responseBuffer.ActiveSpan.Length == 0)
-                        {
-                            if (_responseAborted)
-                            {
-                                throw new IOException(SR.net_http_invalid_response);
-                            }
-
-                            emptyResponse = true;
-                        }
-                    }
-
-                    if (emptyResponse)
-                    {
-                        responseContent.SetStream(EmptyReadStream.Instance);
-                    }
-                    else
-                    {
-                        responseContent.SetStream(new Http2ReadStream(this));
-                    }
-
-                    // Process Set-Cookie headers.
-                    if (_connection._pool.Settings._useCookies)
-                    {
-                        CookieHelper.ProcessReceivedCookies(_response, _connection._pool.Settings._cookieContainer);
+                        await _request.Content.CopyToAsync(writeStream).ConfigureAwait(false);
                     }
                 }
-                catch (Exception e)
-                {
-                    Dispose();
+            }
 
-                    if (e is IOException ioe)
-                    {
-                        throw new HttpRequestException(SR.net_http_client_execution_error, ioe);
-                    }
-                    else if (e is ObjectDisposedException)
-                    {
-                        throw new HttpRequestException(SR.net_http_client_execution_error);
-                    }
-                    else if (e is Http2ProtocolException)
-                    {
-                        // ISSUE 31315: Determine if/how to expose HTTP2 error codes
-                        throw new HttpRequestException(SR.net_http_client_execution_error);
-                    }
-                    else
-                    {
-                        throw;
-                    }
+            public async Task ReadResponseHeadersAsync()
+            {
+                // Wait for response headers to be read.
+                bool emptyResponse = await _responseHeadersAvailable.Task.ConfigureAwait(false);
+
+                // Start to process the response body.
+                if (emptyResponse)
+                {
+                    _responseContent.SetStream(EmptyReadStream.Instance);
+                }
+                else
+                {
+                    _responseContent.SetStream(new Http2ReadStream(this));
                 }
 
-                return _response;
+                // Process Set-Cookie headers.
+                if (_connection._pool.Settings._useCookies)
+                {
+                    CookieHelper.ProcessReceivedCookies(_response, _connection._pool.Settings._cookieContainer);
+                }
             }
 
             public void OnWindowUpdate(int amount)
@@ -193,14 +155,7 @@ namespace System.Net.Http
 
             public void OnResponseHeadersComplete(bool endStream)
             {
-                if (endStream)
-                {
-                    _responseComplete = true;
-                }
-
-                TaskCompletionSource<bool> readDataAvailable = _responseDataAvailable;
-                _responseDataAvailable = null;
-                readDataAvailable.SetResult(true);
+                _responseHeadersAvailable.SetResult(endStream);
             }
 
             public void OnResponseData(ReadOnlySpan<byte> buffer, bool endStream)
@@ -216,7 +171,7 @@ namespace System.Net.Http
 
                     Debug.Assert(!_responseComplete);
 
-                    if (_responseBuffer.ActiveSpan.Length + buffer.Length > InitialWindowSize)
+                    if (_responseBuffer.ActiveSpan.Length + buffer.Length > DefaultInitialWindowSize)
                     {
                         // Window size exceeded.
                         throw new Http2ProtocolException(Http2ProtocolErrorCode.FlowControlError);
@@ -260,10 +215,21 @@ namespace System.Net.Http
                     _responseComplete = true;
                     _responseAborted = true;
 
-                    if (_responseDataAvailable != null)
+                    if (!_responseHeadersAvailable.Task.IsCompleted)
                     {
-                        readDataAvailable = _responseDataAvailable;
-                        _responseDataAvailable = null;
+                        // We are still waiting for response headers, so fail that task
+                        _responseHeadersAvailable.SetException(new IOException(SR.net_http_invalid_response));
+
+                        // We shouldn't be waiting on data, since we haven't processed headers yet
+                        Debug.Assert(_responseDataAvailable == null);
+                    }
+                    else
+                    {
+                        if (_responseDataAvailable != null)
+                        {
+                            readDataAvailable = _responseDataAvailable;
+                            _responseDataAvailable = null;
+                        }
                     }
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http
 
                 _streamWindow = new CreditManager(initialWindowSize);
 
-                _responseHeadersAvailable = new TaskCompletionSource<bool>();
+                _responseHeadersAvailable = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // TODO: ISSUE 31313: Avoid allocating a TaskCompletionSource repeatedly by using a resettable ValueTaskSource.
                 // See: https://github.com/dotnet/corefx/blob/master/src/Common/tests/System/Threading/Tasks/Sources/ManualResetValueTaskSource.cs
@@ -201,8 +201,6 @@ namespace System.Net.Http
 
             public void OnResponseAbort()
             {
-                TaskCompletionSource<bool> readDataAvailable = null;
-
                 lock (_syncObject)
                 {
                     if (_disposed)
@@ -227,15 +225,10 @@ namespace System.Net.Http
                     {
                         if (_responseDataAvailable != null)
                         {
-                            readDataAvailable = _responseDataAvailable;
+                            _responseDataAvailable.SetResult(true);
                             _responseDataAvailable = null;
                         }
                     }
-                }
-
-                if (readDataAvailable != null)
-                {
-                    readDataAvailable.SetResult(true);
                 }
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
@@ -275,7 +275,7 @@ namespace System.Net.Http.Functional.Tests
                 Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
 
                 await server.EstablishConnectionAsync();
-                server.IngoreWindowUpdates();
+                server.IgnoreWindowUpdates();
                 int streamId = await server.ReadRequestHeaderAsync();
 
                 // Send response and end stream.
@@ -666,7 +666,7 @@ namespace System.Net.Http.Functional.Tests
                 Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
 
                 await server.EstablishConnectionAsync();
-                server.IngoreWindowUpdates();
+                server.IgnoreWindowUpdates();
 
                 // Process first request and send response.
                 int streamId = await server.ReadRequestHeaderAsync();

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
@@ -380,6 +380,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop("Uses Task.Delay")]
         [ConditionalFact(nameof(SupportsAlpn))]
         public async Task Http2_FlowControl_ClientDoesNotExceedWindows()
         {
@@ -507,6 +508,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop("Uses Task.Delay")]
         [ConditionalFact(nameof(SupportsAlpn))]
         public async Task Http2_InitialWindowSize_ClientDoesNotExceedWindows()
         {
@@ -654,6 +656,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop("Uses Task.Delay")]
         [ConditionalFact(nameof(SupportsAlpn))]
         public async Task Http2_MaxConcurrentStreams_LimitEnforced()
         {


### PR DESCRIPTION
Fixes #34059 

Update: I pushed another commit that also implements SETTINGS_MAX_CONCURRENT_STREAMS.

Fixes #31296 
Fixes #31514 
Fixes #31812
Fixes #31813

@dotnet/ncl 