### PR TITLE
Add publish symbols to new official builds

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -48,3 +48,12 @@ jobs:
 
     # Publish step
     - template: /eng/pipelines/publish.yml
+      parameters:
+        dependsOn:
+          - WindowsTest
+          - WindowsNoTest
+          - AllConfigurations
+          - LinuxTest
+          - LinuxNoTest
+          - MacOS
+          - RedHat6

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -1,18 +1,14 @@
 parameters:
   buildConfiguration: Release
+  dependsOn: ''
 
 jobs:
-  - job: Publish
+  - job: PublishPackages
     displayName: Publish Packages
     timeoutInMinutes: 120
-    dependsOn:
-      - WindowsTest
-      - WindowsNoTest
-      - AllConfigurations
-      - LinuxTest
-      - LinuxNoTest
-      - MacOS
-      - RedHat6
+
+    ${{ if ne(parameters.dependsOn, '') }}:
+      dependsOn: ${{ parameters.dependsOn }}
 
     pool:
       name: dotnet-internal-temp
@@ -72,3 +68,49 @@ jobs:
                 /p:NuGetSource=$(_mygetFeedUrl)
                 /p:NuGetApiKey=$(dotnet-myget-org-api-key)
         displayName: Push to myget.org
+
+  - job: PublishSymbols
+    displayName: Publish Symbols
+    timeoutInMinutes: 120
+
+    ${{ if ne(parameters.dependsOn, '') }}:
+      dependsOn: ${{ parameters.dependsOn }}
+
+    pool:
+      name: dotnet-internal-temp
+
+    workspace:
+      clean: all
+
+    variables:
+      - group: DotNet-Symbol-Server-Pats
+      - name: _msdlSymbolServerUrl
+        value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
+      - name: _symwebSymbolServerUrl
+        value: https://microsoft.artifacts.visualstudio.com/DefaultCollection
+      - name: _symbolExpirationInDays
+        value: 30
+
+    steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download symbols to publish
+        inputs:
+          artifactName: packages
+          downloadPath: $(Build.SourcesDirectory)/artifacts
+
+      - script: build.cmd -InitTools
+        displayName: Restore Tools
+
+      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+                -warnaserror:0 -ci
+                /t:PublishSymbols
+                /p:SymbolServerPath=$(_msdlSymbolServerUrl)
+                /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
+        displayName: Publish symbols to msdl
+
+      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+                -warnaserror:0 -ci
+                /t:PublishSymbols
+                /p:SymbolServerPath=$(_symwebSymbolServerUrl)
+                /p:SymbolServerPAT=$(symweb-symbol-server-pat)
+        displayName: Publish symbols to symweb

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -1,5 +1,9 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
+  <Import Project="$(PackagesDir)/$(PublishSymbolsPackage.ToLower())/$(PublishSymbolsPackageVersion)/build/PublishSymbols.targets" />
+
+  <!-- We need to import Directory.Build.targets at the beginning because there is where we import the restored tools targets, in 
+  this case we need Microsoft.DotNet.Build.Tasks.Feed targets to be imported. -->
   <Import Project="..\Directory.Build.targets" />
 
   <PropertyGroup>
@@ -10,6 +14,9 @@
     <FinalPublishPattern>$(PackageOutputRoot)*.nupkg</FinalPublishPattern>
     <FinalPublishPrivatePattern>$(PackageOutputRoot)*Private*.nupkg</FinalPublishPrivatePattern>
     <FinalPublishExperimentalPattern>$(PackageOutputRoot)*Experimental*.nupkg</FinalPublishExperimentalPattern>
+
+    <SymbolsOutputRoot Condition="'$(SymbolsOutputRoot)' == ''">$(PackageOutputRoot)/symbols/</SymbolsOutputRoot>
+    <SymbolsPublishPattern>$(SymbolsOutputRoot)*.nupkg</SymbolsPublishPattern>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PackagesGlob)' != ''">
@@ -23,8 +30,22 @@
     <PackagesToPublish Include="$(FinalPublishPattern)" Exclude="@(PackagesToPublish)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <SymbolPackagesToPublish  Include="$(SymbolsPublishPattern)">
+      <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
+    </SymbolPackagesToPublish>
+
+    <PublishSymbolsDependsOn Include="SetupPublishSymbols" />
+  </ItemGroup>
+
   <Target Name="PublishToAzureBlobFeed">
     <Error Condition="'@(PackagesToPublish)'==''" Text="PackagesToPublish for packages is empty." />
+
+    <!-- Include Symbols when publishing to blob feed so that the manifest contains symbols and we send all the assets to BAR -->
+    <ItemGroup>
+      <PackagesToPublish Include="@(SymbolPackagesToPublish)" />
+    </ItemGroup>
+
     <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
                     AccountKey="$(AccountKey)"
                     ItemsToPush="@(PackagesToPublish)"
@@ -82,8 +103,16 @@
       IgnoredErrorMessagesWithConditional="@(IgnorableErrorMessages)"
       PackageFile="%(NuGetPushCommand.PackageToPush)"
       PassIfIdenticalV2Feed="$(PassIfIdenticalV2Feed)" />
-
   </Target>
 
-  <Target Name="CheckForBuildTools" />
+  <Target Name="SetupPublishSymbols">
+    <PropertyGroup>
+      <ConvertPortablePdbsToWindowsPdbs Condition="'$(ConvertPortablePdbsToWindowsPdbs)'==''">true</ConvertPortablePdbsToWindowsPdbs>
+    </PropertyGroup>
+
+    <Error Condition="'$(SymbolServerPath)'==''" Text="Missing property SymbolServerPath" />
+    <Error Condition="'$(SymbolServerPAT)'==''" Text="Missing property SymbolServerPAT" />
+
+    <Message Importance="High" Text="Publishing %(SymbolPackagesToPublish.Identity) to $(SymbolServerPath)"/>
+  </Target>
 </Project>


### PR DESCRIPTION
With this the only thing left to remove the old builds is add FreeBSD which is next, and we should be getting agents soon and also update the versions repo 😄 

cc: @danmosemsft