### PR TITLE
Disable TimeZoneInfo_DisplayNameStartsWithOffset on Win 7

### DIFF
--- a/src/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2221,7 +2221,9 @@ namespace System.Tests
                 {
                     Assert.False(string.IsNullOrWhiteSpace(tzi.StandardName));
                     Assert.Matches(@"^\(UTC(\+|-)[0-9]{2}:[0-9]{2}\) \S.*", tzi.DisplayName);
-                    if (PlatformDetection.IsNotWindowsNanoServer) // see https://github.com/dotnet/corefx/pull/33204#issuecomment-438782500
+                    
+                    // see https://github.com/dotnet/corefx/pull/33204#issuecomment-438782500
+                    if (PlatformDetection.IsNotWindowsNanoServer && !PlatformDetection.IsWindows7)
                     {
                         string offset = Regex.Match(tzi.DisplayName, @"(-|)[0-9]{2}:[0-9]{2}").Value;
                         Assert.True(tzi.BaseUtcOffset == TimeSpan.Parse(offset), $"{offset} != {tzi.BaseUtcOffset}, dn:{tzi.DisplayName}, sn:{tzi.DisplayName}");


### PR DESCRIPTION
Fixes #34106 

I do not see this test doing anything which could be improved. Win7 likely contains some invalid data in the registry since we don't do much in TZI code except for reading from registry