### PR TITLE
Add update versions repository step to new official builds pipeline

### DIFF
--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -76,10 +76,8 @@ jobs:
       - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 build.proj
                 -warnaserror:0 -ci
                 /t:UpdatePublishedVersions
-                /p:GitHubUser=dotnet-helix-bot
-                /p:GitHubEmail=dotnet-helix-bot@microsoft.com
                 /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
-                /p:VersionsRepoOwner=dagood
+                /p:VersionsRepoOwner=dotnet
                 /p:VersionsRepo=versions
                 /p:VersionsRepoPath=build-info/dotnet/corefx/$(Build.SourceBranchName)
                 /p:ShippedNuGetPackageGlobPath=${{ parameters.artifactsDir }}/packages/*.nupkg

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -1,4 +1,5 @@
 parameters:
+  artifactsDir: $(Build.SourcesDirectory)/artifacts
   buildConfiguration: Release
   dependsOn: ''
 
@@ -20,19 +21,22 @@ jobs:
       - group: Publish-Build-Assets
       - group: DotNet-Blob-Feed
       - group: DotNet-MyGet-Publish
+      - group: DotNet-Versions-Publish
       - name: _dotnetFeedUrl
         value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
       - name: _maestroApiEndpoint
         value: https://maestro-prod.westus2.cloudapp.azure.com
       - name: _mygetFeedUrl
         value: https://dotnet.myget.org/F/dotnet-core/api/v2/package
+      - name: _manifestsDir
+        value: ${{ parameters.artifactsDir }}/AssetManifests
 
     steps:
       - task: DownloadBuildArtifacts@0
         displayName: Download packages to publish
         inputs:
           artifactName: packages
-          downloadPath: $(Build.SourcesDirectory)/artifacts
+          downloadPath: ${{ parameters.artifactsDir }}
 
       - script: build.cmd -InitTools
         displayName: Restore Tools
@@ -51,12 +55,12 @@ jobs:
       - task: PublishBuildArtifacts@1
         displayName: Publish assets manifest to artifacts
         inputs:
-          pathToPublish: $(Build.SourcesDirectory)/artifacts/AssetManifests
+          pathToPublish: $(_manifestsDir)
           artifactName: BuildAssetsManifest
           artifactType: container
 
       - script: eng\common\publishbuildassets.cmd
-                /p:ManifestsPath='$(Build.SourcesDirectory)/artifacts/AssetManifests'
+                /p:ManifestsPath='$(_manifestsDir)'
                 /p:BuildAssetRegistryToken=$(MaestroAccessToken)
                 /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
                 /p:Configuration=${{ parameters.buildConfiguration }}
@@ -68,6 +72,18 @@ jobs:
                 /p:NuGetSource=$(_mygetFeedUrl)
                 /p:NuGetApiKey=$(dotnet-myget-org-api-key)
         displayName: Push to myget.org
+
+      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 build.proj
+                -warnaserror:0 -ci
+                /t:UpdatePublishedVersions
+                /p:GitHubUser=dotnet-helix-bot
+                /p:GitHubEmail=dotnet-helix-bot@microsoft.com
+                /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
+                /p:VersionsRepoOwner=dagood
+                /p:VersionsRepo=versions
+                /p:VersionsRepoPath=build-info/dotnet/corefx/$(Build.SourceBranchName)
+                /p:ShippedNuGetPackageGlobPath=${{ parameters.artifactsDir }}/packages/*.nupkg
+        displayName: Update dotnet/versions
 
   - job: PublishSymbols
     displayName: Publish Symbols
@@ -96,7 +112,7 @@ jobs:
         displayName: Download symbols to publish
         inputs:
           artifactName: packages
-          downloadPath: $(Build.SourcesDirectory)/artifacts
+          downloadPath: ${{ parameters.artifactsDir }}
 
       - script: build.cmd -InitTools
         displayName: Restore Tools

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -8,7 +8,9 @@
 
   <PropertyGroup>
     <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">corefx</GitHubRepositoryName>
-    <AssetManifestFilePath>$(ArtifactsDir)AssetManifests\$(GitHubRepositoryName).xml</AssetManifestFilePath>
+    <AssetManifestFileName Condition="'$(AssetsManifestFileName)' == '' AND '$(ManifestBuildId)' != ''">$(GitHubRepositoryName)-$(ManifestBuildId)</AssetManifestFileName>
+    <AssetManifestFileName Condition="'$(AssetsManifestFileName)' == ''">$(GitHubRepositoryName)</AssetManifestFileName>
+    <AssetManifestFilePath>$(ArtifactsDir)AssetManifests\$(AssetManifestFileName).xml</AssetManifestFilePath>
 
     <PackageOutputRoot Condition="'$(PackagesOutputRoot)' == ''">$(ArtifactsDir)/packages/</PackageOutputRoot>
     <FinalPublishPattern>$(PackageOutputRoot)*.nupkg</FinalPublishPattern>
@@ -18,6 +20,7 @@
     <SymbolsOutputRoot Condition="'$(SymbolsOutputRoot)' == ''">$(PackageOutputRoot)/symbols/</SymbolsOutputRoot>
     <SymbolsPublishPattern>$(SymbolsOutputRoot)*.nupkg</SymbolsPublishPattern>
   </PropertyGroup>
+
 
   <ItemGroup Condition="'$(PackagesGlob)' != ''">
     <PackagesToPublish Include="$(PackagesGlob)" />


### PR DESCRIPTION
Until we stop doing this step once all repos are using the new dependency flow we need buildtools since the update versions task lives in buildtools. If we realize we will need this step longer than expected, we can then move this task to some package coming from arcade.

cc: @danmosemsft 