### PR TITLE
Invoke eng/common/build scripts from perf.groovy instead of root build scripts

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -97,8 +97,8 @@ def osShortName = ['Windows 10': 'win10',
                         "${python} \"%WORKSPACE%\\artifacts\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type " + runType)
                         batchFile("${python} \"%WORKSPACE%\\artifacts\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
 
-                        batchFile("build.cmd -ci -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
-                        batchFile("build.cmd -ci -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Diagnostic")
+                        batchFile("powershell -ExecutionPolicy ByPass -NoProfile ./eng/common/build.ps1 -ci -configuration Release -includetests /p:ConfigurationGroup=Release /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
+                        batchFile("powershell -ExecutionPolicy ByPass -NoProfile ./eng/common/build.ps1 -ci -configuration Release -includetests /p:ConfigurationGroup=Release /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Diagnostic")
                     }
                 }
                 else {
@@ -117,7 +117,7 @@ def osShortName = ['Windows 10': 'win10',
                         "python3.5 \"\${WORKSPACE}/artifacts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type " + runType)
                         shell("python3.5 \"\${WORKSPACE}/artifacts/Microsoft.BenchView.JSONFormat/tools/machinedata.py\"")
 
-                        shell("bash ./build.sh --ci -release -includetests /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
+                        shell("bash .eng/common/build.sh --ci --configuration Release /p:ConfigurationGroup=Release /p:BuildTests=true /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
                     }
                 }
             }

--- a/perf.groovy
+++ b/perf.groovy
@@ -117,7 +117,7 @@ def osShortName = ['Windows 10': 'win10',
                         "python3.5 \"\${WORKSPACE}/artifacts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type " + runType)
                         shell("python3.5 \"\${WORKSPACE}/artifacts/Microsoft.BenchView.JSONFormat/tools/machinedata.py\"")
 
-                        shell("bash .eng/common/build.sh --ci --configuration Release /p:ConfigurationGroup=Release /p:BuildTests=true /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
+                        shell("bash ./eng/common/build.sh --ci --configuration Release /p:ConfigurationGroup=Release /p:BuildTests=true /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
                     }
                 }
             }

--- a/perf.groovy
+++ b/perf.groovy
@@ -97,8 +97,8 @@ def osShortName = ['Windows 10': 'win10',
                         "${python} \"%WORKSPACE%\\artifacts\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type " + runType)
                         batchFile("${python} \"%WORKSPACE%\\artifacts\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
 
-                        batchFile("powershell -ExecutionPolicy ByPass -NoProfile ./eng/common/build.ps1 -ci -configuration Release -includetests /p:ConfigurationGroup=Release /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
-                        batchFile("powershell -ExecutionPolicy ByPass -NoProfile ./eng/common/build.ps1 -ci -configuration Release -includetests /p:ConfigurationGroup=Release /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Diagnostic")
+                        batchFile("powershell -ExecutionPolicy ByPass -NoProfile eng/common/build.ps1 -ci -configuration Release -includetests /p:ConfigurationGroup=Release /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Profile")
+                        batchFile("powershell -ExecutionPolicy ByPass -NoProfile eng/common/build.ps1 -ci -configuration Release -includetests /p:ConfigurationGroup=Release /p:BuildNative=false /p:Performance=true /p:TargetOS=${osGroup} /m:1 /p:LogToBenchview=true /p:BenchviewRunType=${runType} /p:PerformanceType=Diagnostic")
                     }
                 }
                 else {


### PR DESCRIPTION
For https://github.com/dotnet/corefx/issues/34065

We should be directly invoking the common build scripts from `perf.groovy`, rather than relying on the root build scripts. This will allow us to pass msbuild arguments that don't start with `/p`

@tmat @ViktorHofer @v-haren PTAL

