### PR TITLE
Update publish symbols task to fix freebsd symbols publishing

### DIFF
--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -78,7 +78,7 @@
   <!-- Publish symbol build task package -->
   <PropertyGroup>
     <PublishSymbolsPackage>Microsoft.SymbolUploader.Build.Task</PublishSymbolsPackage>
-    <PublishSymbolsPackageVersion>1.0.0-beta-63412-03</PublishSymbolsPackageVersion>
+    <PublishSymbolsPackageVersion>1.0.0-beta-63604-05</PublishSymbolsPackageVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->


### PR DESCRIPTION
Update publish symbols package that contains fix for freebsd symbols publishing. 