### PR TITLE
[WIP] Update the way corefx consumes coreclr dependencies once they publish to BAR

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <ProductDependencies></ProductDependencies>
+  <ProductDependencies>
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27218-02">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>6f4c9d6427829807ad1fc4432f6f7d544e982c67</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview-27218-02">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>6f4c9d6427829807ad1fc4432f6f7d544e982c67</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview-27218-02">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>6f4c9d6427829807ad1fc4432f6f7d544e982c67</Sha>
+    </Dependency>
+  </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.18618.3">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,6 +14,7 @@
   <PropertyGroup>
     <MicrosoftDotNetXUnitExtensionsPackage>Microsoft.DotNet.XUnitExtensions</MicrosoftDotNetXUnitExtensionsPackage>
   </PropertyGroup>
+  <!-- Arcade dependencies -->
   <PropertyGroup>
     <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.18618.3</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.18618.3</MicrosoftDotNetCodeAnalysisPackageVersion>
@@ -24,5 +25,10 @@
     <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.18618.3</MicrosoftDotNetCoreFxTestingPackageVersion>
     <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.18618.3</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.18618.3</MicrosoftDotNetBuildTasksFeedPackageVersion>
+  </PropertyGroup>
+  <!-- Coreclr dependencies -->
+  <PropertyGroup>
+    <MicrosoftNetCoreIlasmPackageVersion>3.0.0-preview-27218-02</MicrosoftNetCoreIlasmPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview-27218-02</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -10,7 +10,6 @@
   -->
   <PropertyGroup>
     <CoreFxCurrentRef>4ffdf01885ba0575eb4d8e980315e3e52ff19c0c</CoreFxCurrentRef>
-    <CoreClrCurrentRef>56b60e4ef0879b0423542f32a0b87779b4236453</CoreClrCurrentRef>
     <CoreSetupCurrentRef>56b60e4ef0879b0423542f32a0b87779b4236453</CoreSetupCurrentRef>
     <ExternalCurrentRef>96dc7805f5df4a70a55783964ce69dcd91bfca80</ExternalCurrentRef>
     <ProjectNTfsCurrentRef>259833ca9bc03788c4af55c6df35c5f71c70a660</ProjectNTfsCurrentRef>
@@ -34,8 +33,6 @@
   <PropertyGroup>
     <CoreFxExpectedPrerelease>preview.18613.4</CoreFxExpectedPrerelease>
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview.18613.4</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview-27218-02</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
-    <MicrosoftNetCoreIlasmPackageVersion>3.0.0-preview-27218-02</MicrosoftNetCoreIlasmPackageVersion>
     <ProjectNTfsExpectedPrerelease>beta-27213-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-27213-00</ProjectNTfsTestILCExpectedPrerelease>
     <ProjectNTfsTestILCPackageVersion>1.0.0-beta-27213-00</ProjectNTfsTestILCPackageVersion>
@@ -93,10 +90,6 @@
       <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
-    <RemoteDependencyBuildInfo Include="CoreClr">
-      <BuildInfoPath>$(BaseDotNetBuildInfo)coreclr/$(DependencyBranch)</BuildInfoPath>
-      <CurrentRef>$(CoreClrCurrentRef)</CurrentRef>
-    </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="CoreSetup">
       <BuildInfoPath>$(BaseDotNetBuildInfo)core-setup/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(CoreSetupCurrentRef)</CurrentRef>
@@ -144,22 +137,6 @@
       <ElementName>MicrosoftNETCorePlatformsPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.Platforms</PackageId>
     </XmlUpdateStep>
-    <XmlUpdateStep Include="CoreClr">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>MicrosoftNETCoreRuntimeCoreCLRPackageVersion</ElementName>
-      <PackageId>Microsoft.NETCore.Runtime.CoreCLR</PackageId>
-    </XmlUpdateStep>
-    <XmlUpdateStep Include="CoreClr">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>MicrosoftNetCoreIlasmPackageVersion</ElementName>
-      <PackageId>Microsoft.NETCore.ILAsm</PackageId>
-    </XmlUpdateStep>
-    <UpdateStep Include="CoreCLR">
-      <UpdaterType>MSBuildSdk</UpdaterType>
-      <Path>$(MSBuildThisFileDirectory)../global.json</Path>
-      <PackageId>Microsoft.NET.Sdk.IL</PackageId>
-      <MSBuildSdkName>Microsoft.NET.Sdk.IL</MSBuildSdkName>
-    </UpdateStep>
     <XmlUpdateStep Include="Standard">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>NETStandardLibraryPackageVersion</ElementName>


### PR DESCRIPTION
CoreCLR is close to be done publishing to BAR correctly from master. Once they have a successful build running from master, we should apply this changes with the combination of running a darc update manually, or pointing the versions to the right produced packages. Also, in order for this to work we need to add a subscription from corefx to coreclr in maestro in the 3.0 channel that points to master branch.

- [ ] Add subscription
- [ ] Run first darc update  top of this changes once coreclr publishes to master

cc: @jcagme @sbomer @ViktorHofer @danmosemsft @ericstj