### PR TITLE
Stabilize System.Net.NameResolution.Pal.Tests on FreeBSD

### DIFF
--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -105,7 +105,7 @@ namespace System.Net.NameResolution.PalTests
             {
                 // On Unix, getaddrinfo returns host not found, if all the machine discovery settings on the local network
                 // is turned off. Hence dns lookup for it's own hostname fails.
-                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD));
+                Assert.Equal(PlatformID.Unix, Environment.OSVersion.Platform);
                 return;
             }
 
@@ -117,7 +117,7 @@ namespace System.Net.NameResolution.PalTests
             {
                 // On Unix, getaddrinfo returns private ipv4 address for hostname. If the OS doesn't have the
                 // reverse dns lookup entry for this address, getnameinfo returns host not found.
-                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD));
+                Assert.Equal(PlatformID.Unix, Environment.OSVersion.Platform);
                 return;
             }
 

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -105,7 +105,7 @@ namespace System.Net.NameResolution.PalTests
             {
                 // On Unix, getaddrinfo returns host not found, if all the machine discovery settings on the local network
                 // is turned off. Hence dns lookup for it's own hostname fails.
-                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD));
                 return;
             }
 
@@ -117,7 +117,7 @@ namespace System.Net.NameResolution.PalTests
             {
                 // On Unix, getaddrinfo returns private ipv4 address for hostname. If the OS doesn't have the
                 // reverse dns lookup entry for this address, getnameinfo returns host not found.
-                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD));
                 return;
             }
 


### PR DESCRIPTION
use same Linux & OSX strategy on FreeBSD for lookup failures
```
  === TEST EXECUTION SUMMARY ===
     System.Net.NameResolution.Pal.Tests  Total: 11, Errors: 0, Failed: 0, Skipped: 0, Time: 0.204s
  /mnt/resource/corefx/src/System.Net.NameResolution/tests/PalTests
  ----- end 16:13:33 ----- exit code 0 ----------------------------------------------------------
```
