### PR TITLE
Use !IsEmpty instead of TryPeek

### DIFF
--- a/src/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbConnectionPool.cs
@@ -673,7 +673,7 @@ namespace System.Data.ProviderBase
                         Interlocked.Exchange(ref _pendingOpensWaiting, 0);
                     }
                 }
-            } while (_pendingOpens.TryPeek(out next));
+            } while (!_pendingOpens.IsEmpty);
         }
 
         internal bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions, out DbConnectionInternal connection)

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -1021,7 +1021,7 @@ namespace System.Data.ProviderBase
                         Interlocked.Exchange(ref _pendingOpensWaiting, 0);
                     }
                 }
-            } while (_pendingOpens.TryPeek(out next));
+            } while (!_pendingOpens.IsEmpty);
         }
 
         internal bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions, out DbConnectionInternal connection)


### PR DESCRIPTION
Use `!IsEmpty` instead of `TryPeek` to check if the concurrent queue is empty. Using TryPeek is inefficient since it will mark the segment with `_preservedForObservation` and prevent it from being reused.