### PR TITLE
Optimize SqlClient SNIPacket async paths

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -265,17 +265,15 @@
     </Compile>
     <Compile Include="System\Data\SqlClient\SqlFileStream.Windows.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
-    <Compile Include="System\Data\SqlClient\SNI\SNIPacket.NetCoreApp.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'false'">
-    <Compile Include="System\Data\SqlClient\SNI\SNIPacket.NetStandard.cs" />
-  </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(OSGroup)' != 'AnyOS' AND '$(TargetsNetCoreApp)' == 'true'">
     <Compile Include="System\Data\Common\DbConnectionStringCommon.NetCoreApp.cs" />
     <Compile Include="System\Data\ProviderBase\DbConnectionPool.NetCoreApp.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionString.NetCoreApp.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionStringBuilder.NetCoreApp.cs" />
+    <Compile Include="System\Data\SqlClient\SNI\SNIPacket.NetCoreApp.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' OR '$(OSGroup)' == 'AnyOS' OR '$(TargetsNetCoreApp)' != 'true'">
+    <Compile Include="System\Data\SqlClient\SNI\SNIPacket.NetStandard.cs" />
   </ItemGroup>
   <!-- Manage the SNI toggle for Windows netstandard and UWP -->
   <ItemGroup Condition="('$(TargetGroup)' == 'netstandard' OR '$(TargetsNetCoreApp)' == 'true') AND '$(TargetsWindows)' == 'true'">

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -272,7 +272,7 @@
     <Compile Include="System\Data\SqlClient\SqlConnectionStringBuilder.NetCoreApp.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNIPacket.NetCoreApp.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' OR '$(OSGroup)' == 'AnyOS' OR '$(TargetsNetCoreApp)' != 'true'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(OSGroup)' != 'AnyOS' AND '$(TargetsNetCoreApp)' != 'true'">
     <Compile Include="System\Data\SqlClient\SNI\SNIPacket.NetStandard.cs" />
   </ItemGroup>
   <!-- Manage the SNI toggle for Windows netstandard and UWP -->

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -265,6 +265,12 @@
     </Compile>
     <Compile Include="System\Data\SqlClient\SqlFileStream.Windows.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
+    <Compile Include="System\Data\SqlClient\SNI\SNIPacket.NetCoreApp.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'false'">
+    <Compile Include="System\Data\SqlClient\SNI\SNIPacket.NetStandard.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(OSGroup)' != 'AnyOS' AND '$(TargetsNetCoreApp)' == 'true'">
     <Compile Include="System\Data\Common\DbConnectionStringCommon.NetCoreApp.cs" />
     <Compile Include="System\Data\ProviderBase\DbConnectionPool.NetCoreApp.cs" />

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.NetCoreApp.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.NetCoreApp.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Data.SqlClient.SNI
+{
+    internal partial class SNIPacket
+    {
+        /// <summary>
+        /// Read data from a stream asynchronously
+        /// </summary>
+        /// <param name="stream">Stream to read from</param>
+        /// <param name="callback">Completion callback</param>
+        public void ReadFromStreamAsync(Stream stream, SNIAsyncCallback callback)
+        {
+            // Treat local function as a static and pass all params otherwise as async will allocate
+            async Task ReadFromStreamAsync(SNIPacket packet, SNIAsyncCallback cb, ValueTask<int> valueTask)
+            {
+                bool error = false;
+                try
+                {
+                    packet._length = await valueTask.ConfigureAwait(false);
+                    if (packet._length == 0)
+                    {
+                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, SNICommon.ConnTerminatedError, string.Empty);
+                        error = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InternalExceptionError, ex);
+                    error = true;
+                }
+
+                if (error)
+                {
+                    packet.Release();
+                }
+
+                cb(packet, error ? TdsEnums.SNI_ERROR : TdsEnums.SNI_SUCCESS);
+            }
+
+            ValueTask<int> vt = stream.ReadAsync(new Memory<byte>(_data, 0, _capacity), CancellationToken.None);
+
+            if (vt.IsCompletedSuccessfully)
+            {
+                _length = vt.Result;
+                // Zero length to go via async local function as is error condition
+                if (_length > 0)
+                {
+                    callback(this, TdsEnums.SNI_SUCCESS);
+
+                    // Completed
+                    return;
+                }
+            }
+
+            // Not complete or error call the async local function to complete
+            _ = ReadFromStreamAsync(this, callback, vt);
+        }
+
+        /// <summary>
+        /// Write data to a stream asynchronously
+        /// </summary>
+        /// <param name="stream">Stream to write to</param>
+        public void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback, SNIProviders provider, bool disposeAfterWriteAsync = false)
+        {
+            // Treat local function as a static and pass all params otherwise as async will allocate
+            async Task WriteToStreamAsync(SNIPacket packet, SNIAsyncCallback cb, SNIProviders providers, bool disposeAfter, ValueTask valueTask)
+            {
+                uint status = TdsEnums.SNI_SUCCESS;
+                try
+                {
+                    await valueTask.ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(providers, SNICommon.InternalExceptionError, e);
+                    status = TdsEnums.SNI_ERROR;
+                }
+
+                cb(packet, status);
+
+                if (disposeAfter)
+                {
+                    packet.Dispose();
+                }
+            }
+
+            ValueTask vt = stream.WriteAsync(new Memory<byte>(_data, 0, _length), CancellationToken.None);
+
+            if (vt.IsCompletedSuccessfully)
+            {
+                // Read the result to register as complete for the ValueTask
+                vt.GetAwaiter().GetResult();
+
+                callback(this, TdsEnums.SNI_SUCCESS);
+
+                if (disposeAfterWriteAsync)
+                {
+                    Dispose();
+                }
+
+                // Completed
+                return;
+            }
+
+            // Not complete or error call the async local function to complete
+            _ = WriteToStreamAsync(this, callback, provider, disposeAfterWriteAsync, vt);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.NetStandard.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.NetStandard.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Data.SqlClient.SNI
+{
+    internal partial class SNIPacket
+    {
+        /// <summary>
+        /// Read data from a stream asynchronously
+        /// </summary>
+        /// <param name="stream">Stream to read from</param>
+        /// <param name="callback">Completion callback</param>
+        public void ReadFromStreamAsync(Stream stream, SNIAsyncCallback callback)
+        {
+            // Treat local function as a static and pass all params otherwise as async will allocate
+            async Task ReadFromStreamAsync(SNIPacket packet, SNIAsyncCallback cb, Task<int> task)
+            {
+                bool error = false;
+                try
+                {
+                    packet._length = await task.ConfigureAwait(false);
+                    if (packet._length == 0)
+                    {
+                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, SNICommon.ConnTerminatedError, string.Empty);
+                        error = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InternalExceptionError, ex);
+                    error = true;
+                }
+
+                if (error)
+                {
+                    packet.Release();
+                }
+
+                cb(packet, error ? TdsEnums.SNI_ERROR : TdsEnums.SNI_SUCCESS);
+            }
+
+            Task<int> t = stream.ReadAsync(_data, 0, _capacity, CancellationToken.None);
+
+            if ((t.Status & TaskStatus.RanToCompletion) != 0)
+            {
+                _length = t.Result;
+                // Zero length to go via async local function as is error condition
+                if (_length > 0)
+                {
+                    callback(this, TdsEnums.SNI_SUCCESS);
+
+                    // Completed
+                    return;
+                }
+            }
+
+            // Not complete or error call the async local function to complete
+            _ = ReadFromStreamAsync(this, callback, t);
+        }
+
+        /// <summary>
+        /// Write data to a stream asynchronously
+        /// </summary>
+        /// <param name="stream">Stream to write to</param>
+        public void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback, SNIProviders provider, bool disposeAfterWriteAsync = false)
+        {
+            // Treat local function as a static and pass all params otherwise as async will allocate
+            async Task WriteToStreamAsync(SNIPacket packet, SNIAsyncCallback cb, SNIProviders providers, bool disposeAfter, Task task)
+            {
+                uint status = TdsEnums.SNI_SUCCESS;
+                try
+                {
+                    await task.ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(providers, SNICommon.InternalExceptionError, e);
+                    status = TdsEnums.SNI_ERROR;
+                }
+
+                cb(packet, status);
+
+                if (disposeAfter)
+                {
+                    packet.Dispose();
+                }
+            }
+
+            Task t = stream.WriteAsync(_data, 0, _length, CancellationToken.None);
+
+            if ((t.Status & TaskStatus.RanToCompletion) != 0)
+            {
+                // Read the result to register as complete for the Task
+                t.GetAwaiter().GetResult();
+
+                callback(this, TdsEnums.SNI_SUCCESS);
+
+                if (disposeAfterWriteAsync)
+                {
+                    Dispose();
+                }
+
+                // Completed
+                return;
+            }
+
+            // Not complete or error call the async local function to complete
+            _ = WriteToStreamAsync(this, callback, provider, disposeAfterWriteAsync, t);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -12,7 +12,7 @@ namespace System.Data.SqlClient.SNI
     /// <summary>
     /// SNI Packet
     /// </summary>
-    internal class SNIPacket : IDisposable, IEquatable<SNIPacket>
+    internal partial class SNIPacket : IDisposable, IEquatable<SNIPacket>
     {
         private byte[] _data;
         private int _length;
@@ -241,59 +241,6 @@ namespace System.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Read data from a stream asynchronously
-        /// </summary>
-        /// <param name="stream">Stream to read from</param>
-        /// <param name="callback">Completion callback</param>
-        public void ReadFromStreamAsync(Stream stream, SNIAsyncCallback callback)
-        {
-            // Treat local function as a static and pass all params otherwise as async will allocate
-            async Task ReadFromStreamAsync(SNIPacket packet, SNIAsyncCallback cb, ValueTask<int> valueTask)
-            {
-                bool error = false;
-                try
-                {
-                    packet._length = await valueTask.ConfigureAwait(false);
-                    if (packet._length == 0)
-                    {
-                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, SNICommon.ConnTerminatedError, string.Empty);
-                        error = true;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InternalExceptionError, ex);
-                    error = true;
-                }
-
-                if (error)
-                {
-                    packet.Release();
-                }
-
-                cb(packet, error ? TdsEnums.SNI_ERROR : TdsEnums.SNI_SUCCESS);
-            }
-
-            ValueTask<int> vt = stream.ReadAsync(new Memory<byte>(_data, 0, _capacity), CancellationToken.None);
-
-            if (vt.IsCompletedSuccessfully)
-            {
-                _length = vt.Result;
-                // Zero length to go via async local function as is error condition
-                if (_length > 0)
-                {
-                    callback(this, TdsEnums.SNI_SUCCESS);
-
-                    // Completed
-                    return;
-                }
-            }
-
-            // Not complete or error call the async local function to complete
-            _ = ReadFromStreamAsync(this, callback, vt);
-        }
-
-        /// <summary>
         /// Read data from a stream synchronously
         /// </summary>
         /// <param name="stream">Stream to read from</param>
@@ -309,56 +256,6 @@ namespace System.Data.SqlClient.SNI
         public void WriteToStream(Stream stream)
         {
             stream.Write(_data, 0, _length);
-        }
-
-        /// <summary>
-        /// Write data to a stream asynchronously
-        /// </summary>
-        /// <param name="stream">Stream to write to</param>
-        public void WriteToStreamAsync(Stream stream, SNIAsyncCallback callback, SNIProviders provider, bool disposeAfterWriteAsync = false)
-        {
-            // Treat local function as a static and pass all params otherwise as async will allocate
-            async Task WriteToStreamAsync(SNIPacket packet, SNIAsyncCallback cb, SNIProviders providers, bool disposeAfter, ValueTask valueTask)
-            {
-                uint status = TdsEnums.SNI_SUCCESS;
-                try
-                {
-                    await valueTask.ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    SNILoadHandle.SingletonInstance.LastError = new SNIError(providers, SNICommon.InternalExceptionError, e);
-                    status = TdsEnums.SNI_ERROR;
-                }
-
-                cb(packet, status);
-
-                if (disposeAfter)
-                {
-                    packet.Dispose();
-                }
-            }
-
-            ValueTask vt = stream.WriteAsync(new Memory<byte>(_data, 0, _length), CancellationToken.None);
-
-            if (vt.IsCompletedSuccessfully)
-            {
-                // Read the result to register as complete for the ValueTask
-                vt.GetAwaiter().GetResult();
-
-                callback(this, TdsEnums.SNI_SUCCESS);
-
-                if (disposeAfterWriteAsync)
-                {
-                    Dispose();
-                }
-
-                // Completed
-                return;
-            }
-
-            // Not complete or error call the async local function to complete
-            _ = WriteToStreamAsync(this, callback, provider, disposeAfterWriteAsync, vt);
         }
 
         /// <summary>


### PR DESCRIPTION
For `ReadFromStreamAsync(Stream stream, SNIAsyncCallback callback)`

`await stream.ReadAsync(new Memory<byte>(...))` 
is a more efficient path than 
`stream.ReadAsync(byte[], ...).ContinueWith(Task => ...)`

Move `WriteToStreamAsync(Stream stream, ...)` away from being `async void`

/cc @Wraith2 @saurabh500 @AfsanehR @keeratsingh @stephentoub 