### PR TITLE
Improve handling of disallowed HTTP/2 frames

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2Frames.cs
+++ b/src/Common/tests/System/Net/Http/Http2Frames.cs
@@ -396,4 +396,42 @@ namespace System.Net.Test.Common
             return base.ToString() + $"\nEntry Count: {Entries.Count}";
         }
     }
+
+    public class GoAwayFrame : Frame
+    {
+        public int LastStreamId;
+        public int ErrorCode;
+        public byte[] AdditionalDebugData;
+
+        public GoAwayFrame(int lastStreamId, int errorCode, byte[] additionalDebugData, int streamId) :
+            base(additionalDebugData.Length + 8, FrameType.GoAway, FrameFlags.None, streamId)
+        {
+            LastStreamId = lastStreamId;
+            ErrorCode = errorCode;
+            AdditionalDebugData = additionalDebugData;
+        }
+
+        public static GoAwayFrame ReadFrom(Frame header, ReadOnlySpan<byte> buffer)
+        {
+            int lastStreamId = BinaryPrimitives.ReadInt32BigEndian(buffer);
+            int errorCode = BinaryPrimitives.ReadInt32BigEndian(buffer.Slice(4));
+            byte[] additionalDebugData = buffer.Slice(8).ToArray();
+
+            return new GoAwayFrame(lastStreamId, errorCode, additionalDebugData, header.StreamId);
+        }
+
+        public override void WriteTo(Span<byte> buffer)
+        {
+            base.WriteTo(buffer);
+
+            BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(Frame.FrameHeaderLength), LastStreamId);
+            BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(Frame.FrameHeaderLength + 4), ErrorCode);
+            AdditionalDebugData.CopyTo(buffer.Slice(Frame.FrameHeaderLength + 8));
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + $"\nLastStreamId: {LastStreamId}\nErrorCode: {ErrorCode}";
+        }
+    }
 }

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -139,6 +139,8 @@ namespace System.Net.Test.Common
                     return RstStreamFrame.ReadFrom(header, data);
                 case FrameType.Ping:
                     return PingFrame.ReadFrom(header, data);
+                case FrameType.GoAway:
+                    return GoAwayFrame.ReadFrom(header, data);
                 default:
                     return header;
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -237,9 +237,9 @@ namespace System.Net.Http
         // will result in a connection level error.
         private Http2Stream GetStream(int streamId)
         {
-            // If we implement support for Push Promise, this will need to be updated to
-            // track the highest stream ID used by the server in addition to the highest
-            // ID used by the client.
+            // TODO: ISSUE 34192: If we implement support for Push Promise, this will
+            // need to be updated to track the highest stream ID used by the server in
+            // addition to the highest ID used by the client.
             if (streamId <= 0 || streamId >= _nextStream)
             {
                 throw new Http2ProtocolException(Http2ProtocolErrorCode.ProtocolError);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -231,11 +231,16 @@ namespace System.Net.Http
             }
         }
 
-        // Note, this will return null for a streamId that's not in use.
+        // Note, this will return null for a streamId that's no longer in use.
         // Callers must check for this and send a RST_STREAM or ignore as appropriate.
+        // If the streamId is invalid or the stream is idle, calling this function
+        // will result in a connection level error.
         private Http2Stream GetStream(int streamId)
         {
-            if (streamId <= 0)
+            // If we implement support for Push Promise, this will need to be updated to
+            // track the highest stream ID used by the server in addition to the highest
+            // ID used by the client.
+            if (streamId <= 0 || streamId >= _nextStream)
             {
                 throw new Http2ProtocolException(Http2ProtocolErrorCode.ProtocolError);
             }
@@ -588,6 +593,13 @@ namespace System.Net.Http
             if (frameHeader.Length < FrameHeader.GoAwayMinLength)
             {
                 throw new Http2ProtocolException(Http2ProtocolErrorCode.FrameSizeError);
+            }
+
+            // GoAway frames always apply to the whole connection, never to a single stream.
+            // According to RFC 7540 section 6.8, this should be a connection error.
+            if (frameHeader.StreamId != 0)
+            {
+                throw new Http2ProtocolException(Http2ProtocolErrorCode.ProtocolError);
             }
 
             int lastValidStream = (int)((uint)((_incomingBuffer.ActiveSpan[0] << 24) | (_incomingBuffer.ActiveSpan[1] << 16) | (_incomingBuffer.ActiveSpan[2] << 8) | _incomingBuffer.ActiveSpan[3]) & 0x7FFFFFFF);


### PR DESCRIPTION
This change improves our HTTP/2 error handling to comply with the following two sections of the spec.

On handling unexpected frames in the idle state:
```
Receiving any frame other than HEADERS or PRIORITY on a stream in this state MUST be treated as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
```
And on stream level GoAway frames:
```
The GOAWAY frame applies to the connection, not a specific stream. An endpoint MUST treat a GOAWAY frame with a stream identifier other than 0x0 as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
```