### PR TITLE
make test conditional on availability of Drawing instead of Nano plat…

### DIFF
--- a/src/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
+++ b/src/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
@@ -268,7 +268,7 @@ namespace System.Resources.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(EnglishImageResourceData))]
         public static void GetObject_Images(string key, object expectedValue)
         {
@@ -298,7 +298,7 @@ namespace System.Resources.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(EnglishImageResourceData))]
         public static void GetResourceSet_Images(string key, object expectedValue)
         {

--- a/src/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
+++ b/src/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
@@ -18,6 +18,9 @@
     <Compile Include="SatelliteContractVersionAttributeTests.cs" />
     <Compile Include="MissingSatelliteAssemblyException.cs" />
     <Compile Include="ResourceSetTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Drawing\Helpers.cs">
+        <Link>Common\System\Drawing\Helpers.cs</Link>
+    </Compile>
     <EmbeddedResource Include="Resources\TestResx.netstandard17.resources">
       <WithCulture>false</WithCulture>
       <Type>Non-Resx</Type>


### PR DESCRIPTION
fixes  #34075 Unable to load libgdiplus on Alpine

This also fixes other Unix flavors. We could add libgdi to Alpine CI but unless we make it hard dependency, tests should still pass without it. The new code makes it centralized and consistent. 

 