### PR TITLE
Remove syncroot fields from collections

### DIFF
--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -68,8 +68,7 @@ call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 :RunVCVars
 if "%VisualStudioVersion%"=="16.0" (
     goto :VS2019
-)
-else if "%VisualStudioVersion%"=="15.0" (
+) else if "%VisualStudioVersion%"=="15.0" (
     goto :VS2017
 ) else if "%VisualStudioVersion%"=="14.0" (
     goto :VS2015

--- a/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -29,8 +29,6 @@ namespace System.Collections
         private int _size; // Number of elements. Do not rename (binary serialization)
         private int _growFactor; // 100 == 1.0, 130 == 1.3, 200 == 2.0. Do not rename (binary serialization)
         private int _version; // Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
 
         private const int _MinimumGrow = 4;
         private const int _ShrinkThreshold = 32;
@@ -107,17 +105,7 @@ namespace System.Collections
             get { return false; }
         }
 
-        public virtual object SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    System.Threading.Interlocked.CompareExchange(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        public virtual object SyncRoot => this;
 
         // Removes all Objects from the queue.
         public virtual void Clear()

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -70,8 +70,6 @@ namespace System.Collections
         private IComparer comparer; // Do not rename (binary serialization)
         private KeyList keyList; // Do not rename (binary serialization)
         private ValueList valueList; // Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
 
         private const int _defaultCapacity = 16;
 
@@ -292,17 +290,7 @@ namespace System.Collections
         }
 
         // Synchronization root for this object.
-        public virtual object SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        public virtual object SyncRoot => this;
 
         // Removes all entries from this sorted list.
         public virtual void Clear()

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -27,8 +27,6 @@ namespace System.Collections
         private object[] _array; // Storage for stack elements. Do not rename (binary serialization)
         private int _size; // Number of items in the stack. Do not rename (binary serialization)
         private int _version; // Used to keep enumerator in sync w/ collection. Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
 
         private const int _defaultCapacity = 10;
 
@@ -79,17 +77,7 @@ namespace System.Collections
             get { return false; }
         }
 
-        public virtual object SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        public virtual object SyncRoot => this;
 
         // Removes all Objects from the Stack.
         public virtual void Clear()

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
@@ -19,8 +19,6 @@ namespace System.Collections.Specialized
         private int version; // Do not rename (binary serialization)
         private int count; // Do not rename (binary serialization)
         private readonly IComparer comparer; // Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
 
         public ListDictionary()
         {
@@ -146,17 +144,7 @@ namespace System.Collections.Specialized
             }
         }
 
-        public object SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    System.Threading.Interlocked.CompareExchange(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        public object SyncRoot => this;
 
         public ICollection Values
         {

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -30,7 +30,6 @@ namespace System.Collections.Specialized
         private volatile NameObjectEntry _nullKeyEntry;
         private KeysCollection _keys;
         private int _version;
-        private object _syncRoot;
 
         private static readonly StringComparer s_defaultComparer = CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase);
 
@@ -384,17 +383,7 @@ namespace System.Collections.Specialized
                 array.SetValue(e.Current, index++);
         }
 
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    System.Threading.Interlocked.CompareExchange(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        object ICollection.SyncRoot => this;
 
         bool ICollection.IsSynchronized
         {

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -29,7 +29,6 @@ namespace System.Collections.Specialized
         private int _initialCapacity;
         private IEqualityComparer _comparer;
         private bool _readOnly;
-        private object _syncRoot;
         private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.
 
         private const string KeyComparerName = "KeyComparer"; // Do not rename (binary serialization)
@@ -153,17 +152,7 @@ namespace System.Collections.Specialized
         /// <devdoc>
         /// The SyncRoot object.  Not used because IsSynchronized is false
         /// </devdoc>
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    System.Threading.Interlocked.CompareExchange(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        object ICollection.SyncRoot => this;
 
         /// <devdoc>
         /// Gets or sets the object at the specified index

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -18,8 +18,6 @@ namespace System.Collections
         private int[] m_array; // Do not rename (binary serialization)
         private int m_length; // Do not rename (binary serialization)
         private int _version; // Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
 
         private const int _ShrinkThreshold = 256;
 
@@ -676,17 +674,7 @@ namespace System.Collections
 
         public int Count => m_length;
 
-        public object SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    Threading.Interlocked.CompareExchange<object>(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        public object SyncRoot => this;
 
         public bool IsSynchronized => false;
 

--- a/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -18,7 +18,6 @@ namespace System.Collections.Generic
         internal LinkedListNode<T> head;
         internal int count;
         internal int version;
-        private object _syncRoot;
         private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.  
 
         // names for serialization
@@ -460,17 +459,7 @@ namespace System.Collections.Generic
             get { return false; }
         }
 
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    Threading.Interlocked.CompareExchange<object>(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        object ICollection.SyncRoot => this;
 
         void ICollection.CopyTo(Array array, int index)
         {

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -31,8 +31,6 @@ namespace System.Collections.Generic
         private int _tail;       // The index at which to enqueue if the queue isn't full.
         private int _size;       // Number of elements.
         private int _version;
-        [NonSerialized]
-        private object _syncRoot;
 
         private const int MinimumGrow = 4;
         private const int GrowFactor = 200;  // double each time
@@ -74,17 +72,7 @@ namespace System.Collections.Generic
             get { return false; }
         }
 
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    Threading.Interlocked.CompareExchange<object>(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        object ICollection.SyncRoot => this;
 
         // Removes all Objects from the queue.
         public void Clear()

--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -61,8 +61,6 @@ namespace System.Collections.Generic
         private IComparer<TKey> comparer; // Do not rename (binary serialization)
         private KeyList keyList; // Do not rename (binary serialization)
         private ValueList valueList; // Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
 
         private const int DefaultCapacity = 4;
 
@@ -399,17 +397,7 @@ namespace System.Collections.Generic
         }
 
         // Synchronization root for this object.
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    Threading.Interlocked.CompareExchange(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        object ICollection.SyncRoot => this;
 
         // Removes all entries from this sorted list.
         public void Clear()

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -54,8 +54,7 @@ namespace System.Collections.Generic
         private IComparer<T> comparer;
         private int count;
         private int version;
-        [NonSerialized]
-        private object _syncRoot;
+
         private SerializationInfo siInfo; // A temporary variable which we need during deserialization.
 
         private const string ComparerName = "Comparer"; // Do not rename (binary serialization)
@@ -293,18 +292,7 @@ namespace System.Collections.Generic
 
         bool ICollection.IsSynchronized => false;
 
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    Interlocked.CompareExchange(ref _syncRoot, new object(), null);
-                }
-
-                return _syncRoot;
-            }
-        }
+        object ICollection.SyncRoot => this;
 
         #endregion
 

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -30,8 +30,6 @@ namespace System.Collections.Generic
         private T[] _array; // Storage for stack elements. Do not rename (binary serialization)
         private int _size; // Number of items in the stack. Do not rename (binary serialization)
         private int _version; // Used to keep enumerator in sync w/ collection. Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
 
         private const int DefaultCapacity = 4;
 
@@ -68,17 +66,7 @@ namespace System.Collections.Generic
             get { return false; }
         }
 
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    Threading.Interlocked.CompareExchange<object>(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        object ICollection.SyncRoot => this;
 
         // Removes all Objects from the Stack.
         public void Clear()

--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -16,8 +16,7 @@ namespace System.Collections.ObjectModel
     public class ReadOnlyDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
         private readonly IDictionary<TKey, TValue> m_dictionary; // Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
+
         [NonSerialized]
         private KeyCollection _keys;
         [NonSerialized]
@@ -335,19 +334,8 @@ namespace System.Collections.ObjectModel
         {
             get
             {
-                if (_syncRoot == null)
-                {
-                    ICollection c = m_dictionary as ICollection;
-                    if (c != null)
-                    {
-                        _syncRoot = c.SyncRoot;
-                    }
-                    else
-                    {
-                        System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new object(), null);
-                    }
-                }
-                return _syncRoot;
+                ICollection c = m_dictionary as ICollection;
+                return c == null ? this : c.SyncRoot;
             }
         }
 
@@ -420,8 +408,6 @@ namespace System.Collections.ObjectModel
         public sealed class KeyCollection : ICollection<TKey>, ICollection, IReadOnlyCollection<TKey>
         {
             private readonly ICollection<TKey> _collection;
-            [NonSerialized]
-            private object _syncRoot;
 
             internal KeyCollection(ICollection<TKey> collection)
             {
@@ -505,19 +491,8 @@ namespace System.Collections.ObjectModel
             {
                 get
                 {
-                    if (_syncRoot == null)
-                    {
-                        ICollection c = _collection as ICollection;
-                        if (c != null)
-                        {
-                            _syncRoot = c.SyncRoot;
-                        }
-                        else
-                        {
-                            System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new object(), null);
-                        }
-                    }
-                    return _syncRoot;
+                    ICollection c = _collection as ICollection;
+                    return c == null ? this : c.SyncRoot;
                 }
             }
             #endregion
@@ -528,8 +503,6 @@ namespace System.Collections.ObjectModel
         public sealed class ValueCollection : ICollection<TValue>, ICollection, IReadOnlyCollection<TValue>
         {
             private readonly ICollection<TValue> _collection;
-            [NonSerialized]
-            private object _syncRoot;
 
             internal ValueCollection(ICollection<TValue> collection)
             {
@@ -613,21 +586,11 @@ namespace System.Collections.ObjectModel
             {
                 get
                 {
-                    if (_syncRoot == null)
-                    {
-                        ICollection c = _collection as ICollection;
-                        if (c != null)
-                        {
-                            _syncRoot = c.SyncRoot;
-                        }
-                        else
-                        {
-                            System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new object(), null);
-                        }
-                    }
-                    return _syncRoot;
+                    ICollection c = _collection as ICollection;
+                    return c == null ? this : c.SyncRoot;
                 }
             }
+
             #endregion ICollection Members
         }
     }

--- a/src/System.Runtime.Extensions/src/System/Collections/ArrayList.cs
+++ b/src/System.Runtime.Extensions/src/System/Collections/ArrayList.cs
@@ -33,8 +33,6 @@ namespace System.Collections
         private object[] _items; // Do not rename (binary serialization)
         private int _size; // Do not rename (binary serialization)
         private int _version; // Do not rename (binary serialization)
-        [NonSerialized]
-        private object _syncRoot;
 
         private const int _defaultCapacity = 4;
 
@@ -156,17 +154,7 @@ namespace System.Collections
         }
 
         // Synchronization root for this object.
-        public virtual object SyncRoot
-        {
-            get
-            {
-                if (_syncRoot == null)
-                {
-                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new object(), null);
-                }
-                return _syncRoot;
-            }
-        }
+        public virtual object SyncRoot => this;
 
         // Sets or Gets the element at the given index.
         // 


### PR DESCRIPTION
CoreFX part of https://github.com/dotnet/corefx/issues/34149. 
This is everything save (1) immutable collections, which I don't want to mess with (2) some marginal types and legacy libraries. 

Also fix a typo in build-native.cmd.