### PR TITLE
Implement Socket.Send/ReceiveAsync cancellation support

### DIFF
--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -233,6 +233,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Winsock\WSABuffer.cs">
       <Link>Interop\Windows\Winsock\WSABuffer.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.CancelIoEx.cs">
+      <Link>Common\Interop\Windows\Interop.CancelIoEx.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetFileCompletionNotificationModes.cs">
       <Link>Interop\Windows\kernel32\Interop.SetFileCompletionNotificationModes.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -851,6 +851,11 @@ namespace System.Net.Sockets
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
+        public static void CancelPendingOperations(Socket socket)
+        {
+            socket.SafeHandle.AsyncContext.Cancel(close: false);
+        }
+
         public static SocketError Listen(SafeSocketHandle handle, int backlog)
         {
             Interop.Error err = Interop.Sys.Listen(handle, backlog);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -93,6 +93,16 @@ namespace System.Net.Sockets
             return errorCode == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;
         }
 
+        public static unsafe void CancelPendingOperations(Socket socket)
+        {
+            // Ignore any failures; this is opportunistic cancellation only.
+            try
+            {
+                Interop.Kernel32.CancelIoEx(socket.SafeHandle, null);
+            }
+            catch { }
+        }
+
         public static SocketError Listen(SafeSocketHandle handle, int backlog)
         {
             SocketError errorCode = Interop.Winsock.listen(handle, backlog);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.netcoreapp.cs
@@ -34,6 +34,81 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        public async Task TCP_ReceiveCanceledDuringOperation_Throws()
+        {
+            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.BindToAnonymousPort(IPAddress.Loopback);
+                listener.Listen(1);
+
+                await client.ConnectAsync(listener.LocalEndPoint);
+                using (Socket server = await listener.AcceptAsync())
+                {
+                    ValueTask<int> vt1 = default, vt2 = default;
+                    CancellationTokenSource cts;
+
+                    for (int len = 0; len < 2; len++)
+                    {
+                        cts = new CancellationTokenSource();
+                        vt1 = server.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                        Assert.False(vt1.IsCompleted);
+                        cts.Cancel();
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt1);
+                    }
+
+                    for (int len = 0; len < 2; len++)
+                    {
+                        cts = new CancellationTokenSource();
+                        vt1 = server.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                        vt2 = server.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                        Assert.False(vt1.IsCompleted);
+                        Assert.False(vt2.IsCompleted);
+                        cts.Cancel();
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt1);
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt2);
+                    }
+
+                    await server.SendAsync((ReadOnlyMemory<byte>)new byte[1], SocketFlags.None);
+                    Assert.Equal(1, await client.ReceiveAsync((Memory<byte>)new byte[10], SocketFlags.None));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task UDP_ReceiveCanceledDuringOperation_Throws()
+        {
+            using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            {
+                client.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+                ValueTask<int> vt1 = default, vt2 = default;
+                CancellationTokenSource cts;
+
+                for (int len = 0; len < 2; len++)
+                {
+                    cts = new CancellationTokenSource();
+                    vt1 = client.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                    Assert.False(vt1.IsCompleted);
+                    cts.Cancel();
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt1);
+                }
+
+                for (int len = 0; len < 2; len++)
+                {
+                    cts = new CancellationTokenSource();
+                    vt1 = client.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                    vt2 = client.ReceiveAsync((Memory<byte>)new byte[len], SocketFlags.None, cts.Token);
+                    Assert.False(vt1.IsCompleted);
+                    Assert.False(vt2.IsCompleted);
+                    cts.Cancel();
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt1);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt2);
+                }
+            }
+        }
+
+        [Fact]
         public async Task DisposedSocket_ThrowsOperationCanceledException()
         {
             using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))


### PR DESCRIPTION
In .NET Core 2.1 we added Socket.Send/ReceiveAsync overloads that worked with {ReadOnly}Memory, and in doing so also added CancellationToken arguments, but in 2.1 those implementations only did an up-front check for cancellation and then ignored the token for the remainder of the operation.

This PR addresses that, mostly.  There are two main ways this could be done, both with their own upsides and downsides:
- Track the individual async operations in flight on a Socket.  This provides the most granularity, and does match best with CancellationToken being on the individual Send/ReceiveAsync calls.  However, it doesn't actually apply for TCP operations on Windows, where all pending operations are canceled regardless of whether CancelIoEx was targeted at a specific native overlapped or not.  And it increases the size of SocketAsyncEventArgs by several fields.  And in the scenarios we're aware of, cancellation is generally applied as part of some kind of teardown, where it's unlikely any other operations on the socket will matter after one is canceled.  And it requires tendrils into both the Windows and Unix implementations, in order to track things like the NativeOverlapped pointer on Windows.  It also would require significant work to plumb through to support operations implemented with the older APM implementations, which we do for the Task-based Send/ReceiveAsync when there's already a pending send/receive using the cached SocketAsyncEventArgs instance.
- Cancel all pending I/O on a socket when any operation on the socket is canceled.  This results in a much simpler solution, with very little platform-specific code and that doesn't need any additional fields on SocketAsyncEventArgs, and works regardless of how we've implemented the operation, since it applies to any I/O on the socket and doesn't require us to know the specific NativeOverlapped pointer.  It does sacrifice the fine-grained ability to cancel individual UDP operations on Windows, or any individual operation on Linux, without also canceling other pending operations on the same socket.

After many back and forths playing with both implementations, I've opted for the latter.  If in the future we decide it's not fine-grained enough, we could do the former.

Fixes #24430
cc: @geoffkizer, @davidsh, @wfurt 