### PR TITLE
Use HMAC_CTX_free() instead of free() on a HMAC_CTX*

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.c
@@ -31,7 +31,7 @@ HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_
 
     if (!ret)
     {
-        free(ctx);
+        HMAC_CTX_free(ctx);
         return NULL;
     }
 


### PR DESCRIPTION
This is a leftover from before the OpenSSL 1.0/1.1 hybridization. There
was no HMAC_CTX_free() in 1.0.

Fixes #34210

cc @bartonjs @stephentoub 