### PR TITLE
SqlClient improve managed memory usage

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
@@ -34,7 +34,7 @@ namespace System.Data.SqlClient.SNI
     /// <summary>
     /// SMUX packet header
     /// </summary>
-    internal class SNISMUXHeader
+    internal sealed class SNISMUXHeader
     {
         public const int HEADER_LENGTH = 16;
 
@@ -44,6 +44,46 @@ namespace System.Data.SqlClient.SNI
         public uint length;
         public uint sequenceNumber;
         public uint highwater;
+
+        public void Read(ReadOnlySpan<byte> bytes)
+        {
+            SMID = bytes[0];
+            flags = bytes[1];
+            sessionId = BitConverter.ToUInt16(bytes.Slice(2,2));
+            length = BitConverter.ToUInt32(bytes.Slice(4,4)) - SNISMUXHeader.HEADER_LENGTH;
+            sequenceNumber = BitConverter.ToUInt32(bytes.Slice(8,4));
+            highwater = BitConverter.ToUInt32(bytes.Slice(12,4));
+        }
+
+        public void Write(Span<byte> bytes)
+        {
+            uint value = highwater;
+            // access the highest element first to cause the largest range check in the jit, then fill in the rest of the value and carry on as normal
+            bytes[15] = (byte)((value >> 24) & 0xff);
+            bytes[12] = (byte)(value & 0xff); // BitConverter.GetBytes(_currentHeader.highwater).CopyTo(headerBytes, 12);
+            bytes[13] = (byte)((value >> 8) & 0xff);
+            bytes[14] = (byte)((value >> 16) & 0xff);
+
+            bytes[0] = SMID; // BitConverter.GetBytes(_currentHeader.SMID).CopyTo(headerBytes, 0);
+            bytes[1] = flags; // BitConverter.GetBytes(_currentHeader.flags).CopyTo(headerBytes, 1);
+
+            value = sessionId;
+            bytes[2] = (byte)(value & 0xff); // BitConverter.GetBytes(_currentHeader.sessionId).CopyTo(headerBytes, 2);
+            bytes[3] = (byte)((value >> 8) & 0xff);
+
+            value = length;
+            bytes[4] = (byte)(value & 0xff); // BitConverter.GetBytes(_currentHeader.length).CopyTo(headerBytes, 4);
+            bytes[5] = (byte)((value >> 8) & 0xff);
+            bytes[6] = (byte)((value >> 16) & 0xff);
+            bytes[7] = (byte)((value >> 24) & 0xff);
+
+            value = sequenceNumber;
+            bytes[8] = (byte)(value & 0xff); // BitConverter.GetBytes(_currentHeader.sequenceNumber).CopyTo(headerBytes, 8);
+            bytes[9] = (byte)((value >> 8) & 0xff);
+            bytes[10] = (byte)((value >> 16) & 0xff);
+            bytes[11] = (byte)((value >> 24) & 0xff);
+
+        }
     }
 
     /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
@@ -45,14 +45,14 @@ namespace System.Data.SqlClient.SNI
         public uint sequenceNumber;
         public uint highwater;
 
-        public void Read(ReadOnlySpan<byte> bytes)
+        public void Read(byte[] bytes)
         {
             SMID = bytes[0];
             flags = bytes[1];
-            sessionId = BitConverter.ToUInt16(bytes.Slice(2,2));
-            length = BitConverter.ToUInt32(bytes.Slice(4,4)) - SNISMUXHeader.HEADER_LENGTH;
-            sequenceNumber = BitConverter.ToUInt32(bytes.Slice(8,4));
-            highwater = BitConverter.ToUInt32(bytes.Slice(12,4));
+            sessionId = BitConverter.ToUInt16(bytes, 2);
+            length = BitConverter.ToUInt32(bytes, 4) - SNISMUXHeader.HEADER_LENGTH;
+            sequenceNumber = BitConverter.ToUInt32(bytes, 8);
+            highwater = BitConverter.ToUInt32(bytes, 12);
         }
 
         public void Write(Span<byte> bytes)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -16,12 +16,11 @@ namespace System.Data.SqlClient.SNI
         private readonly Guid _connectionId = Guid.NewGuid();
         private readonly Dictionary<int, SNIMarsHandle> _sessions = new Dictionary<int, SNIMarsHandle>();
         private readonly byte[] _headerBytes = new byte[SNISMUXHeader.HEADER_LENGTH];
-
+        private readonly SNISMUXHeader _currentHeader = new SNISMUXHeader();
         private SNIHandle _lowerHandle;
         private ushort _nextSessionId = 0;
         private int _currentHeaderByteCount = 0;
         private int _dataBytesLeft = 0;
-        private SNISMUXHeader _currentHeader = new SNISMUXHeader();
         private SNIPacket _currentPacket;
 
         /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -93,43 +93,29 @@ namespace System.Data.SqlClient.SNI
         /// <param name="flags">SMUX header flags</param>
         private void SendControlPacket(SNISMUXFlags flags)
         {
-            byte[] headerBytes = null;
-
+            Span<byte> headerBytes = stackalloc byte[SNISMUXHeader.HEADER_LENGTH];
             lock (this)
             {
-                GetSMUXHeaderBytes(0, (byte)flags, ref headerBytes);
+                GetSMUXHeaderBytes(0, flags, headerBytes);
             }
 
-            SNIPacket packet = new SNIPacket();
-            packet.SetData(headerBytes, SNISMUXHeader.HEADER_LENGTH);
+            SNIPacket packet = new SNIPacket(SNISMUXHeader.HEADER_LENGTH);
+            packet.AppendData(headerBytes);
             
             _connection.Send(packet);
         }
 
-        /// <summary>
-        /// Generate SMUX header 
-        /// </summary>
-        /// <param name="length">Packet length</param>
-        /// <param name="flags">Packet flags</param>
-        /// <param name="headerBytes">Header in bytes</param>
-        private void GetSMUXHeaderBytes(int length, byte flags, ref byte[] headerBytes)
+        private void GetSMUXHeaderBytes(int length, SNISMUXFlags flags, Span<byte> bytes)
         {
-            headerBytes = new byte[SNISMUXHeader.HEADER_LENGTH];
-
             _currentHeader.SMID = 83;
-            _currentHeader.flags = flags;
+            _currentHeader.flags = (byte)flags;
             _currentHeader.sessionId = _sessionId;
             _currentHeader.length = (uint)SNISMUXHeader.HEADER_LENGTH + (uint)length;
-            _currentHeader.sequenceNumber = ((flags == (byte)SNISMUXFlags.SMUX_FIN) || (flags == (byte)SNISMUXFlags.SMUX_ACK)) ? _sequenceNumber - 1 : _sequenceNumber++;
+            _currentHeader.sequenceNumber = ((flags == SNISMUXFlags.SMUX_FIN) || (flags == SNISMUXFlags.SMUX_ACK)) ? _sequenceNumber - 1 : _sequenceNumber++;
             _currentHeader.highwater = _receiveHighwater;
             _receiveHighwaterLastAck = _currentHeader.highwater;
 
-            BitConverter.GetBytes(_currentHeader.SMID).CopyTo(headerBytes, 0);
-            BitConverter.GetBytes(_currentHeader.flags).CopyTo(headerBytes, 1);
-            BitConverter.GetBytes(_currentHeader.sessionId).CopyTo(headerBytes, 2);
-            BitConverter.GetBytes(_currentHeader.length).CopyTo(headerBytes, 4);
-            BitConverter.GetBytes(_currentHeader.sequenceNumber).CopyTo(headerBytes, 8);
-            BitConverter.GetBytes(_currentHeader.highwater).CopyTo(headerBytes, 12);
+            _currentHeader.Write(bytes);
         }
 
         /// <summary>
@@ -140,14 +126,14 @@ namespace System.Data.SqlClient.SNI
         private SNIPacket GetSMUXEncapsulatedPacket(SNIPacket packet)
         {
             uint xSequenceNumber = _sequenceNumber;
-            byte[] headerBytes = null;
-            GetSMUXHeaderBytes(packet.Length, (byte)SNISMUXFlags.SMUX_DATA, ref headerBytes);
+            Span<byte> header = stackalloc byte[SNISMUXHeader.HEADER_LENGTH];
+            GetSMUXHeaderBytes(packet.Length, SNISMUXFlags.SMUX_DATA, header);
 
-            SNIPacket smuxPacket = new SNIPacket(16 + packet.Length);
-            smuxPacket.Description = string.Format("({0}) SMUX packet {1}", packet.Description == null ? "" : packet.Description, xSequenceNumber);
-            smuxPacket.AppendData(headerBytes, 16);
+
+            SNIPacket smuxPacket = new SNIPacket(SNISMUXHeader.HEADER_LENGTH + packet.Length);
+            smuxPacket.AppendData(header);
             smuxPacket.AppendPacket(packet);
-
+            packet.Dispose();
             return smuxPacket;
         }
 
@@ -175,8 +161,9 @@ namespace System.Data.SqlClient.SNI
                     _ackEvent.Reset();
                 }
             }
+            SNIPacket encapsulatedPacket = GetSMUXEncapsulatedPacket(packet);
 
-            return _connection.Send(GetSMUXEncapsulatedPacket(packet));
+            return _connection.Send(encapsulatedPacket);
         }
 
         /// <summary>
@@ -187,8 +174,6 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         private uint InternalSendAsync(SNIPacket packet, SNIAsyncCallback callback)
         {
-            SNIPacket encapsulatedPacket = null;
-
             lock (this)
             {
                 if (_sequenceNumber >= _sendHighwater)
@@ -196,7 +181,7 @@ namespace System.Data.SqlClient.SNI
                     return TdsEnums.SNI_QUEUE_FULL;
                 }
 
-                encapsulatedPacket = GetSMUXEncapsulatedPacket(packet);
+                SNIPacket encapsulatedPacket = GetSMUXEncapsulatedPacket(packet);
 
                 if (callback != null)
                 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -20,7 +20,7 @@ namespace System.Data.SqlClient.SNI
         private int _offset;
         private string _description;
         private SNIAsyncCallback _completionCallback;
-        private bool _isBufferFromArrayPool = false;
+        private bool _isBufferFromArrayPool;
 
         public SNIPacket() { }
 
@@ -174,6 +174,12 @@ namespace System.Data.SqlClient.SNI
         {
             Buffer.BlockCopy(data, 0, _data, _length, size);
             _length += size;
+        }
+
+        public void AppendData(ReadOnlySpan<byte> data)
+        {
+            data.CopyTo(_data.AsSpan(_length));
+            _length += data.Length;
         }
 
         /// <summary>


### PR DESCRIPTION
The managed Tds implementation is only used on Unix where the native implementation cannot be used, this is for performance reasons. I've investigated and made some changes which improve the performance of the managed mode. There is a still a lot that can be done but I think they'll need to build on this start.

The release build now works so I can get inproc BDN numbers:

|      Method |     Mean |    Error |   StdDev |   Median | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------ |---------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
| SyncFloat32 | 235.2 ms | 4.871 ms | 12.31 ms | 228.8 ms |   3000.0000 |           - |           - |           593.75 KB |

|      Method |     Mean |    Error |   StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------ |---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
| SyncFloat32 | 229.9 ms | 3.993 ms | 3.540 ms |           - |           - |           - |           281.25 KB |

Which shows that there is a large improvement in memory usage. The numbers are a bit sterile though. Compare profiles from before where there is a gen0 roughly every 100ms.

![before](https://user-images.githubusercontent.com/13322696/50405553-7c24c800-07ae-11e9-8c7c-eafb450be3f4.PNG)

to after:

![after](https://user-images.githubusercontent.com/13322696/50405557-834bd600-07ae-11e9-9804-68878572eed6.PNG)

The changes are straightforward in terms of code changes even though it was tricky working out the right places to make them. Packets were being dropped without disposing them causing their rented arrays to be lost, this meant a lot of churn in array allocations. The mars mux header writing code was allocating a lot of temporary arrays so I replaced that code with a leaner version and stopped re-allocation of the header itself where it could be re-used.

The changes pass standard and manual sql tests.

/cc all the usual people, @saurabh500 @AfsanehR @keeratsingh 