### PR TITLE
Update pinvoke guidelines

### DIFF
--- a/Documentation/coding-guidelines/interop-pinvokes.md
+++ b/Documentation/coding-guidelines/interop-pinvokes.md
@@ -135,7 +135,7 @@ The following types, being pointers, do follow the width of the platform. Use `I
 | `LONG_PTR`                          |                                        |
 | `INT_PTR`                           |                                        |
 
-A C `void*` can be marshaled as either `IntPtr` or `UIntPtr`. Generally, it doesn't matter.
+A Windows `PVOID` which is a C `void*` can be marshaled as either `IntPtr` or `UIntPtr`. Generally, it doesn't matter.
 
 [Windows Data Types](http://msdn.microsoft.com/en-us/library/aa383751.aspx "MSDN")
 [Data Type Ranges](http://msdn.microsoft.com/en-us/library/s3f49ktz.aspx "MSDN")

--- a/Documentation/coding-guidelines/interop-pinvokes.md
+++ b/Documentation/coding-guidelines/interop-pinvokes.md
@@ -225,40 +225,9 @@ Blittable structs are much more performant as they they can simply be used direc
 
 Pointers to structs in definitions must either be passed by `ref` or use `unsafe` and `*`.
 
-The compiler or marshaler will make sure any pointers in your struct are correctly aligned. For this reason you may see seemingly "wrong" declarations that still work. For example a native struct looking like this:
+We always prefer to match the managed struct as closely as possible to the shape and names that are used in the official platform documentation or header.
 
-```C
-typedef struct {
-    LONG Something;
-    INT_PTR Reserved2[2];
-} MY_STRUCT;
-```
-
-should be represented as (we mark the undocumented members `private` so at the least the caller is prompted to think before choosing to use them):
-
-```c#
-    struct MY_STRUCT
-    {
-        public int Something;
-        private IntPtr Reserved1a;
-        private IntPtr Reserved1b;
-    }
-```
-but this would also function correctly
-```c#
-    struct MY_STRUCT
-    {
-        public IntPtr Something;
-        private IntPtr Reserved1a;
-        private IntPtr Reserved1b;
-    }
-```
-
-The `LONG` is always 32-bit wide, but `INT_PTR` changes in Width. How does this still work? The reason that `IntPtr` still works is that the next field happens to be a pointer, which must be aligned. To achieve that alignment, the compiler or marshaler would pad the preceding field to pointer width even if it is not declared as a pointer.
-
-Sometimes Windows headers have cosmetic glitches like this. In such cases and others, we always prefer to match the managed struct as closely as possible to the shape and names that are used in the official platform documentation or header.
-
-In the case above, the array of pointers `INT_PTR Reserved2[2]` had to be marshaled to two `IntPtr` fields, `Reserved1a` and `Reserved1b`. When the native array is a primitive type, we can use the `fixed` keyword to write it a little more cleanly. For example, `SYSTEM_PROCESS_INFORMATION` looks like this in the native header:
+An array like `INT_PTR Reserved1[2]` has to be marshaled to two `IntPtr` fields, `Reserved1a` and `Reserved1b`. When the native array is a primitive type, we can use the `fixed` keyword to write it a little more cleanly. For example, `SYSTEM_PROCESS_INFORMATION` looks like this in the native header:
 
 ```c
 typedef struct _SYSTEM_PROCESS_INFORMATION {

--- a/Documentation/coding-guidelines/interop-pinvokes.md
+++ b/Documentation/coding-guidelines/interop-pinvokes.md
@@ -135,10 +135,10 @@ The following types, being pointers, do follow the width of the platform. Use `I
 | `LONG_PTR`                          |                                        |
 | `INT_PTR`                           |                                        |
 
-A Windows `PVOID` which is a C `void*` can be marshaled as either `IntPtr` or `UIntPtr`. Generally, it doesn't matter.
+A Windows `PVOID` which is a C `void*` can be marshaled as either `IntPtr` or `UIntPtr` but we would prefer `void*`.
 
-[Windows Data Types](http://msdn.microsoft.com/en-us/library/aa383751.aspx "MSDN")
-[Data Type Ranges](http://msdn.microsoft.com/en-us/library/s3f49ktz.aspx "MSDN")
+[Windows Data Types](https://docs.microsoft.com/en-us/windows/desktop/WinProg/windows-data-types "MSDN")
+[Data Type Ranges](https://docs.microsoft.com/en-us/cpp/cpp/data-type-ranges?view=vs-2017 "MSDN")
 
 Blittable Types
 ---------------
@@ -242,15 +242,17 @@ All the members of this struct have the underlying type of pointer, so a correct
 ```c#
     struct PROCESS_BASIC_INFORMATION
     {
-        public IntPtr Reserved1; // or UIntPtr
+        private IntPtr Reserved1; // or UIntPtr
         public IntPtr PebBaseAddress;
-        public IntPtr Reserved2a;
-        public IntPtr Reserved2b;
+        private IntPtr Reserved2a;
+        private IntPtr Reserved2b;
         public IntPtr BasePriority;
         public UIntPtr UniqueProcessId;
-        public UIntPtr Reserved3;
+        private UIntPtr Reserved3;
     }
 ```
+
+We mark the undocumented members `private` so at the least the caller is prompted to think before choosing to use them.
 
 Under the covers, the first field in this struct is actually type `LONG` which would normally marshal as a 32-bit `int` in managed code. The reason that `IntPtr` still works is that the next field happens to be a pointer, which must be aligned. To
 achieve that alignment, the compiler or marshaler would pad the preceding field to pointer width even if it is not declared as a pointer.
@@ -272,7 +274,7 @@ typedef struct _SYSTEM_PROCESS_INFORMATION {
 In C#, we can write it like this:
 
 ```c#
-    internal unsafe struct SystemProcessInformation
+    internal unsafe struct SYSTEM_PROCESS_INFORMATION
     {
         internal uint NextEntryOffset;
         internal uint NumberOfThreads;
@@ -281,8 +283,6 @@ In C#, we can write it like this:
         ...
     }
 ```
-It makes sense to make the undocumented members `private`.
-
 
 Other References
 ----------------

--- a/Documentation/coding-guidelines/interop-pinvokes.md
+++ b/Documentation/coding-guidelines/interop-pinvokes.md
@@ -114,14 +114,14 @@ to Unix, where some of these types are wider on 64-bit, for example native `long
 | 32    | `LONG`           | `long`             | `int`    |                                      |
 | 32    | `ULONG`          | `unsigned long`    | `uint`   |                                      |
 | 32    | `DWORD`          | `unsigned long`    | `uint`   |                                      |
+| 64    | `QWORD`          | `__int64`          | `long`   |                                      |
 | 64    | `LARGE_INTEGER`  | `__int64`          | `long`   |                                      |
 | 64    | `LONGLONG`       | `__int64`          | `long`   |                                      |
 | 64    | `ULONGLONG`      | `unsigned __int64` | `ulong`  |                                      |
 | 64    | `ULARGE_INTEGER` | `unsigned __int64` | `ulong`  |                                      |
-| 8     | `UCHAR`          | `unsigned char`    | `byte`   |                                      |
 | 32    | `HRESULT`        | `long`             | `int`    |                                      |
 | 32    | `NTSTATUS`       | `long`             | `int`    |                                      |
-| 64    | `QWORD`          | `__int64`          | `long`   |                                      |
+
 
 The following types, being pointers, do follow the width of the platform. Use `IntPtr`/`UIntPtr` for these.
 

--- a/Documentation/coding-guidelines/interop-pinvokes.md
+++ b/Documentation/coding-guidelines/interop-pinvokes.md
@@ -24,11 +24,11 @@ Attributes
 | [`ExactSpelling`][4] | `true`             | Set this to true (default is false) and gain a slight perf benefit as the framework will avoid looking for an "A" or "W" version. (See NDirectMethodDesc::FindEntryPoint).|
 | [`CharSet`][5]       | Explicitly  use `CharSet.Unicode` or `CharSet.Ansi` when strings are present in the definition | This specifies marshalling behavior of strings and what `ExactSpelling` does when `false`. Be explicit with this one as the documented default is `CharSet.Ansi`. Note that `CharSet.Ansi` is actually UTF8 on Unix (`CharSet.Utf8` is coming). _Most_ of the time Windows uses Unicode while Unix uses UTF8. |
 
-[1]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.aspx "MSDN"
-[2]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.preservesig.aspx "MSDN"
-[3]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.setlasterror.aspx "MSDN"
-[4]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.exactspelling.aspx "MSDN"
-[5]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.charset.aspx "MSDN"
+[1]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.aspx
+[2]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.preservesig.aspx
+[3]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.setlasterror.aspx
+[4]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.exactspelling.aspx
+[5]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportattribute.charset.aspx
 
 Strings
 -------
@@ -56,7 +56,7 @@ If you *do* use `StringBuilder` one last gotcha is that the capacity does **not*
 
 **[USE]** Char arrays from `ArrayPool` or `StringBuffer`.
 
-[Default Marshalling for Strings](https://msdn.microsoft.com/en-us/library/s9ts558h.aspx "MSDN")
+[Default Marshalling for Strings](https://msdn.microsoft.com/en-us/library/s9ts558h.aspx)
 
 > ### Windows Specific
 
@@ -70,7 +70,7 @@ as `UnmanagedType.BSTR`.
 > - Pass in 5, get 4: The string is 4 characters long with a trailing null.
 > - Pass in 5, get 6: The string is 5 characters long, need a 6 character buffer to hold the null.
 
-> [Windows Data Types for Strings](http://msdn.microsoft.com/en-us/library/dd374131.aspx "MSDN")
+> [Windows Data Types for Strings](http://msdn.microsoft.com/en-us/library/dd374131.aspx)
 
 Booleans
 --------
@@ -79,7 +79,7 @@ Booleans are easy to mess up. The default marshalling for P/Invoke is as the Win
 
 `bool` is not a blittable type (see blitting below). As such, when defining structs it is recommended to use `Interop.BOOL.cs` for `BOOL` to get the best performance.
 
-[Default Marshalling for Boolean Types](https://msdn.microsoft.com/en-us/library/t2t3725f.aspx "MSDN")  
+[Default Marshalling for Boolean Types](https://msdn.microsoft.com/en-us/library/t2t3725f.aspx)  
 
 Guids
 -----
@@ -137,8 +137,9 @@ The following types, being pointers, do follow the width of the platform. Use `I
 
 A Windows `PVOID` which is a C `void*` can be marshaled as either `IntPtr` or `UIntPtr` but we would prefer `void*`.
 
-[Windows Data Types](https://docs.microsoft.com/en-us/windows/desktop/WinProg/windows-data-types "MSDN")
-[Data Type Ranges](https://docs.microsoft.com/en-us/cpp/cpp/data-type-ranges?view=vs-2017 "MSDN")
+[Windows Data Types](https://docs.microsoft.com/en-us/windows/desktop/WinProg/windows-data-types)
+
+[Data Type Ranges](https://docs.microsoft.com/en-us/cpp/cpp/data-type-ranges?view=vs-2017)
 
 Blittable Types
 ---------------
@@ -177,8 +178,8 @@ public struct UnicodeCharStruct
 You can see if a type is blittable by attempting to create a pinned `GCHandle`. If the type is not a string or considered blittable `GCHandle.Alloc` will throw an `ArgumentException`.
 
 
-[Blittable and Non-Blittable Types](https://msdn.microsoft.com/en-us/library/75dwhxf7.aspx "MSDN")  
-[Default Marshalling for Value Types](https://msdn.microsoft.com/en-us/library/0t2cwe11.aspx "MSDN")
+[Blittable and Non-Blittable Types](https://msdn.microsoft.com/en-us/library/75dwhxf7.aspx)  
+[Default Marshalling for Value Types](https://msdn.microsoft.com/en-us/library/0t2cwe11.aspx)
 
 Keeping Managed Objects Alive
 -----------------------------
@@ -186,7 +187,7 @@ Keeping Managed Objects Alive
 
 [`HandleRef`][6] allows the marshaller to keep an object alive for the duration of a P/Invoke. It can be used instead of `IntPtr` in method signatures. `SafeHandle` effectively replaces this class and should be used instead.
 
-[6]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.handleref.aspx "MSDN"
+[6]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.handleref.aspx
 
 [`GCHandle`][7] allows pinning a managed object and getting the native pointer to it. Basic pattern is:  
 
@@ -196,7 +197,7 @@ IntPtr ptr = handle.AddrOfPinnedObject();
 handle.Free();
 ```
 
-[7]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.gchandle.aspx "MSDN"
+[7]: https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.gchandle.aspx
 
 Pinning is not the default for `GCHandle`. The other major pattern is for passing a reference to a managed object through native code back to managed code (via a callback, typically). Here is the pattern:
 
@@ -255,7 +256,7 @@ In C#, we can write it like this:
 Other References
 ----------------
 
-[MarshalAs Attribute](http://msdn.microsoft.com/en-us/library/system.runtime.interopservices.marshalasattribute.aspx "MSDN")  
-[GetLastError and managed code](http://blogs.msdn.com/b/adam_nathan/archive/2003/04/25/56643.aspx "MSDN")  
-[Copying and Pinning](https://msdn.microsoft.com/en-us/library/23acw07k.aspx "MSDN")  
+[MarshalAs Attribute](http://msdn.microsoft.com/en-us/library/system.runtime.interopservices.marshalasattribute.aspx)  
+[GetLastError and managed code](http://blogs.msdn.com/b/adam_nathan/archive/2003/04/25/56643.aspx)  
+[Copying and Pinning](https://msdn.microsoft.com/en-us/library/23acw07k.aspx)  
 [Marshalling between Managed and Unmanaged Code (MSDN Magazine January 2008)](http://download.microsoft.com/download/3/A/7/3A7FA450-1F33-41F7-9E6D-3AA95B5A6AEA/MSDNMagazineJanuary2008en-us.chm) *This is a .chm download*  


### PR DESCRIPTION
Added some clarification on the width of types, on padding, and the `fixed` keyword. All these were things I had to figure out recently, so it would be useful to document for others.

It would also be nice to document when to use `UIntPtr` instead of `IntPtr`, when it isn't dictated by the native header - for example `void*`. Perhaps the guidance is to always use `IntPtr` but that can [overflow on cast](https://stackoverflow.com/a/13171595) so it could matter.