### PR TITLE
Fix passing null for credentials in SqlConnectionPoolKey

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -1471,7 +1471,7 @@ namespace System.Data.SqlClient
                 throw ADP.InvalidArgumentLength(nameof(newSecurePassword), TdsEnums.MAXLEN_NEWPASSWORD);
             }
 
-            SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential: null, accessToken: null);
+            SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential, accessToken: null);
 
             SqlConnectionString connectionOptions = SqlConnectionFactory.FindSqlConnectionOptions(key);
 
@@ -1509,7 +1509,7 @@ namespace System.Data.SqlClient
                 if (con != null)
                     con.Dispose();
             }
-            SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential: null, accessToken: null);
+            SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential, accessToken: null);
 
             SqlConnectionFactory.SingletonInstance.ClearPool(key);
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlCredentialTest/SqlCredentialTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlCredentialTest/SqlCredentialTest.cs
@@ -125,8 +125,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [CheckConnStrSetupFact]
         public static void OldCredentialsShouldFail()
         {
-            var user = "u" + Guid.NewGuid().ToString().Replace("-", "");
-            var passStr = "Pax561O$T5K#jD";
+            String user = "u" + Guid.NewGuid().ToString().Replace("-", "");
+            String passStr = "Pax561O$T5K#jD";
 
             try
             {
@@ -140,20 +140,24 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 SecureString password = new SecureString();
                 passStr.ToCharArray().ToList().ForEach(x => password.AppendChar(x));
                 password.MakeReadOnly();
+                SqlCredential credential = new SqlCredential(user, password);
 
-                using (SqlConnection conn1 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, password)))
-                using (SqlConnection conn2 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, password)))
-                using (SqlConnection conn3 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, password)))
-                using (SqlConnection conn4 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, password)))
+                using (SqlConnection conn1 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, credential))
+                using (SqlConnection conn2 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, credential))
+                using (SqlConnection conn3 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, credential))
+                using (SqlConnection conn4 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, credential))
                 {
                     conn1.Open();
                     conn2.Open();
                     conn3.Open();
                     conn4.Open();
 
-                    SqlConnection.ChangePassword(sqlConnectionStringBuilder.ConnectionString, "newPassWord");
-                    SqlConnection conn5 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, password));
-                    conn5.Open();
+                    SecureString NewPassword = new SecureString();
+                    "NewPassword".ToCharArray().ToList().ForEach(x => NewPassword.AppendChar(x));
+                    NewPassword.MakeReadOnly();
+                    SqlConnection.ChangePassword(sqlConnectionStringBuilder.ConnectionString, credential, NewPassword);
+                    SqlConnection conn5 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, NewPassword));
+                    Assert.Throws<SqlException>(() => conn5.Open());
                 }
             }
             finally

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlCredentialTest/SqlCredentialTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlCredentialTest/SqlCredentialTest.cs
@@ -156,8 +156,10 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     "NewPassword".ToCharArray().ToList().ForEach(x => NewPassword.AppendChar(x));
                     NewPassword.MakeReadOnly();
                     SqlConnection.ChangePassword(sqlConnectionStringBuilder.ConnectionString, credential, NewPassword);
-                    SqlConnection conn5 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, NewPassword));
-                    Assert.Throws<SqlException>(() => conn5.Open());
+                    using (SqlConnection conn5 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, password)))
+                    {
+                        Assert.Throws<SqlException>(() => conn5.Open());
+                    }
                 }
             }
             finally

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlCredentialTest/SqlCredentialTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlCredentialTest/SqlCredentialTest.cs
@@ -152,10 +152,10 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     conn3.Open();
                     conn4.Open();
 
-                    SecureString NewPassword = new SecureString();
-                    "NewPassword".ToCharArray().ToList().ForEach(x => NewPassword.AppendChar(x));
-                    NewPassword.MakeReadOnly();
-                    SqlConnection.ChangePassword(sqlConnectionStringBuilder.ConnectionString, credential, NewPassword);
+                    SecureString newPassword = new SecureString();
+                    "NewPassword".ToCharArray().ToList().ForEach(x => newPassword.AppendChar(x));
+                    newPassword.MakeReadOnly();
+                    SqlConnection.ChangePassword(sqlConnectionStringBuilder.ConnectionString, credential, newPassword);
                     using (SqlConnection conn5 = new SqlConnection(sqlConnectionStringBuilder.ConnectionString, new SqlCredential(user, password)))
                     {
                         Assert.Throws<SqlException>(() => conn5.Open());


### PR DESCRIPTION
Fixes #34205 
**Description**
Null is passed for credentials when calling SqlConnectionPoolKey ChangePassword method.

**Customer Impact**
Wrong connection pool gets cleared when calling ChangePassword using a SecureString. 

**Regression**
No, since this code path exists in .Net Framework and credential is mistakenly passed as null.

**Risk**
High. A password change may cause the connections from wrong pool to be killed causing unexpected application disruption. 
