### PR TITLE
Using FUTIMENS instead of FUTIMES

### DIFF
--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -1283,8 +1283,7 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
     if (ret == 0)
     {
 #if HAVE_FUTIMENS
-        // futimens is prefered because it has a higher resolution and is 
-        // available on Android.
+        // futimens is prefered because it has a higher resolution.
         struct timespec origTimes[2];
         origTimes[0].tv_sec = (time_t)sourceStat.st_atime;
         origTimes[0].tv_nsec = ST_ATIME_NSEC(&sourceStat);
@@ -1292,7 +1291,6 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
         origTimes[1].tv_nsec = ST_MTIME_NSEC(&sourceStat);
         while ((ret = futimens(outFd, origTimes)) < 0 && errno == EINTR);
 #elif HAVE_FUTIMES
-        // futimes is a POSIX function and is not available on Android.
         struct timeval origTimes[2];
         origTimes[0].tv_sec = sourceStat.st_atime;
         origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat) / 1000;

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -1282,14 +1282,7 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
     while ((ret = fstat_(inFd, &sourceStat)) < 0 && errno == EINTR);
     if (ret == 0)
     {
-#if HAVE_FUTIMES
-        struct timeval origTimes[2];
-        origTimes[0].tv_sec = sourceStat.st_atime;
-        origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat) / 1000;
-        origTimes[1].tv_sec = sourceStat.st_mtime;
-        origTimes[1].tv_usec = ST_MTIME_NSEC(&sourceStat) / 1000;
-        while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
-#elif HAVE_FUTIMENS
+#if HAVE_FUTIMENS
         // futimes is not a POSIX function, and not available on Android,
         // but futimens is
         struct timespec origTimes[2];
@@ -1298,6 +1291,13 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
         origTimes[1].tv_sec = (time_t)sourceStat.st_mtime;
         origTimes[1].tv_nsec = ST_MTIME_NSEC(&sourceStat);
         while ((ret = futimens(outFd, origTimes)) < 0 && errno == EINTR);
+#elif HAVE_FUTIMES
+        struct timeval origTimes[2];
+        origTimes[0].tv_sec = sourceStat.st_atime;
+        origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat) / 1000;
+        origTimes[1].tv_sec = sourceStat.st_mtime;
+        origTimes[1].tv_usec = ST_MTIME_NSEC(&sourceStat) / 1000;
+        while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
 #endif
     }
     if (ret != 0)

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -1283,8 +1283,8 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
     if (ret == 0)
     {
 #if HAVE_FUTIMENS
-        // futimes is not a POSIX function, and not available on Android,
-        // but futimens is
+        // futimens is prefered because it has a higher resolution and is 
+        // available on Android.
         struct timespec origTimes[2];
         origTimes[0].tv_sec = (time_t)sourceStat.st_atime;
         origTimes[0].tv_nsec = ST_ATIME_NSEC(&sourceStat);
@@ -1292,6 +1292,7 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
         origTimes[1].tv_nsec = ST_MTIME_NSEC(&sourceStat);
         while ((ret = futimens(outFd, origTimes)) < 0 && errno == EINTR);
 #elif HAVE_FUTIMES
+        // futimes is a POSIX function and is not available on Android.
         struct timeval origTimes[2];
         origTimes[0].tv_sec = sourceStat.st_atime;
         origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat) / 1000;

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -126,7 +126,8 @@ namespace System.IO.Tests
         [ConditionalFact(nameof(isNotHFS))]
         public void CopyToNanoSecondsPresent()
         {
-            FileInfo input = GetNonZeroNanoSeconds();
+            FileInfo input = new FileInfo(GetTestFilePath());
+            input.Create().Dispose();
             FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
 
             output.Directory.Create();

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -18,9 +18,9 @@ namespace System.IO.Tests
             return new FileInfo(path);
         }
 
-        private static bool HasNonZeroNanoSeconds(DateTime dt) => dt.Ticks % 10 != 0;
+        private static bool HasNonZeroNanoseconds(DateTime dt) => dt.Ticks % 10 != 0;
         
-        public FileInfo GetNonZeroMilliSec()
+        public FileInfo GetNonZeroMilliseconds()
         {
             FileInfo fileinfo = new FileInfo(GetTestFilePath());
             for (int i = 0; i < 5; i++)
@@ -40,13 +40,13 @@ namespace System.IO.Tests
             return fileinfo;
         }
 
-        public FileInfo GetNonZeroNanoSeconds()
+        public FileInfo GetNonZeroNanoseconds()
         {
             FileInfo fileinfo = new FileInfo(GetTestFilePath());
             for (int i = 0; i < 5; i++)
             {
                 fileinfo.Create().Dispose();
-                if (HasNonZeroNanoSeconds(fileinfo.LastWriteTime))
+                if (HasNonZeroNanoseconds(fileinfo.LastWriteTime))
                     break;
 
                 // This case should only happen 1/10 times, unless the OS/Filesystem does
@@ -56,7 +56,7 @@ namespace System.IO.Tests
                 Thread.Sleep(123);
             }
             
-            Assert.True(HasNonZeroNanoSeconds(fileinfo.LastWriteTime), "Tests failed to create a file with non-zero nanoseconds.");
+            Assert.True(HasNonZeroNanoseconds(fileinfo.LastWriteTime), "Tests failed to create a file with non-zero nanoseconds.");
             return fileinfo;
         }
 
@@ -112,7 +112,7 @@ namespace System.IO.Tests
         [ConditionalFact(nameof(isNotHFS))]
         public void CopyToMillisecondPresent()
         {
-            FileInfo input = GetNonZeroMilliSec();
+            FileInfo input = GetNonZeroMilliseconds();
             FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
 
             Assert.Equal(0, output.LastWriteTime.Millisecond);
@@ -124,7 +124,20 @@ namespace System.IO.Tests
         }
 
         [ConditionalFact(nameof(isNotHFS))]
-        public void CopyToNanoSecondsPresent()
+        public void CopyToNanosecondsPresent()
+        {
+            FileInfo input = GetNonZeroNanoseconds();
+            FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
+
+            output.Directory.Create();
+            output = input.CopyTo(output.FullName, true);
+
+            Assert.Equal(input.LastWriteTime.Ticks, output.LastWriteTime.Ticks);
+            Assert.True(HasNonZeroNanoseconds(output.LastWriteTime));
+        }
+
+        [ConditionalFact(nameof(isHFS))]
+        public void CopyToNanosecondsPresent_HFS()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
             input.Create().Dispose();
@@ -134,20 +147,7 @@ namespace System.IO.Tests
             output = input.CopyTo(output.FullName, true);
 
             Assert.Equal(input.LastWriteTime.Ticks, output.LastWriteTime.Ticks);
-            Assert.True(HasNonZeroNanoSeconds(output.LastWriteTime));
-        }
-
-        [ConditionalFact(nameof(isHFS))]
-        public void CopyToNanoSecondsPresent_HFS()
-        {
-            FileInfo input = GetNonZeroNanoSeconds();
-            FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
-
-            output.Directory.Create();
-            output = input.CopyTo(output.FullName, true);
-
-            Assert.Equal(input.LastWriteTime.Ticks, output.LastWriteTime.Ticks);
-            Assert.True(HasNonZeroNanoSeconds(output.LastWriteTime));
+            Assert.False(HasNonZeroNanoseconds(output.LastWriteTime));
         }
 
         [ConditionalFact(nameof(isHFS))]
@@ -165,7 +165,7 @@ namespace System.IO.Tests
         [ConditionalFact(nameof(isNotHFS))]
         public void MoveToMillisecondPresent()
         {
-            FileInfo input = GetNonZeroMilliSec();
+            FileInfo input = GetNonZeroMilliseconds();
             string dest = Path.Combine(input.DirectoryName, GetTestFileName());
 
             input.MoveTo(dest);

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -49,7 +49,7 @@ namespace System.IO.Tests
                 // not support nanosecond granularity.
 
                 // If it's 1/10, or low granularity, this may help:
-                Thread.Sleep(1234);
+                Thread.Sleep(123);
             }
             return fileinfo;
         }
@@ -109,12 +109,12 @@ namespace System.IO.Tests
             FileInfo input = GetNonZeroMilliSec();
             FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
 
+            Assert.Equal(0, output.LastWriteTime.Millisecond);
             output.Directory.Create();
             output = input.CopyTo(output.FullName, true);
 
-            Assert.Equal(input.LastWriteTime.Ticks, output.LastWriteTime.Ticks);
-            Assert.Equal(0, output.LastWriteTime.Ticks % 10);
-            Assert.Equal(0, input.LastWriteTime.Ticks % 10);
+            Assert.NotEqual(0, input.LastWriteTime.Millisecond);
+            Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
         [ConditionalFact(nameof(isNotHFS))]
@@ -140,7 +140,6 @@ namespace System.IO.Tests
             output.Directory.Create();
             output = input.CopyTo(output.FullName, true);
 
-            Assert.Equal(input.LastWriteTime.Ticks, output.LastWriteTime.Ticks);
             Assert.Equal(0, output.LastWriteTime.Ticks % 10);
             Assert.Equal(0, input.LastWriteTime.Ticks % 10);
         }

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -132,7 +132,7 @@ namespace System.IO.Tests
         }
 
         [ConditionalFact(nameof(isHFS))]
-        public void CopyToNanoSecondsPresent_OSX()
+        public void CopyToNanoSecondsPresent_HFS()
         {
             FileInfo input = GetNonZeroNanoSeconds();
             FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
@@ -140,7 +140,7 @@ namespace System.IO.Tests
             output.Directory.Create();
             output = input.CopyTo(output.FullName, true);
 
-            Assert.Equal(output.LastWriteTime.Ticks, input.LastWriteTime.Ticks);
+            Assert.Equal(input.LastWriteTime.Ticks, output.LastWriteTime.Ticks);
             Assert.Equal(0, output.LastWriteTime.Ticks % 10);
             Assert.Equal(0, input.LastWriteTime.Ticks % 10);
         }


### PR DESCRIPTION
When we copy a file, we attempt to copy the timestamp. We need to do this so that systems that compare the timestamps (such as an up-to-date check) do not see the new file as older. Windows does this automatically but for Unix we have to do it explicitly. We use either futimes or futimens. If both are available we currently prefer futimes even though futimens has better (nanosecond) granularity. This causes up-to-date checks to fail on file systems that support nanoseconds, because we see the nanoseconds on the "source" but the are zeros on the "destination". This PR changes the code to prefer futimens if both are available.


Related to https://github.com/dotnet/sdk/pull/2684

before 
```
        Condition(s) not met: "isHFS"
      System.IO.Tests.FileInfo_GetSetTimes.CopyToNanoSecondsPresent [FAIL]
        Assert.Equal() Failure
        Expected:   636816254491113521
        Actual: 636816254491113520
```