### PR TITLE
Adding msbuild.sh to the root

### DIFF
--- a/msbuild.sh
+++ b/msbuild.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$working_tree_root/.dotnet/dotnet msbuild "$@"
+exit $?


### PR DESCRIPTION
Currently we are making this file on the run and we are using the path to dotnet as Tools/dotnetcli/dotnet which no longer exists and we are not able to run the tests individually for the projects
The latest path to dotnet is from the root only i.e  ./dotnet/dotnet

before
```
./Tools/msbuild.sh csprojpath /t:rebuildandtest (no longer working as path to dotnet has changed)
```
after
```
./msbuild.sh csprojpath /t:rebuildandtest
```