### PR TITLE
[release/2.1] Do not add Request-Id header when its added already

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -70,9 +70,10 @@ namespace System.Net.Http
                 );
             }
 
-            // If we are on at all, we propagate any activity information.  
+            // If we are on at all, we propagate any activity information
+            // unless tracing system or user injected Request-Id for backward compatibility reasons.
             Activity currentActivity = Activity.Current;
-            if (currentActivity != null)
+            if (currentActivity != null && !request.Headers.Contains(DiagnosticsHandlerLoggingStrings.RequestIdHeaderName))
             {
                 request.Headers.Add(DiagnosticsHandlerLoggingStrings.RequestIdHeaderName, currentActivity.Id);
                 //we expect baggage to be empty or contain a few items

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -43,7 +43,7 @@ namespace System.Net.Http.Functional.Tests
         /// This test must be in the same test collection as any others testing HttpClient/WinHttpHandler
         /// DiagnosticSources, since the global logging mechanism makes them conflict inherently.
         /// </remarks>
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceLogging()
         {
@@ -111,7 +111,7 @@ namespace System.Net.Http.Functional.Tests
         /// This test must be in the same test collection as any others testing HttpClient/WinHttpHandler
         /// DiagnosticSources, since the global logging mechanism makes them conflict inherently.
         /// </remarks>
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceNoLogging()
         {
@@ -167,7 +167,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(23771, TestPlatforms.AnyUnix)]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -214,7 +214,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString(), useSsl.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticExceptionLogging()
         {
@@ -260,7 +260,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(23209)]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledLogging()
         {
@@ -305,7 +305,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceActivityLogging()
         {
@@ -381,7 +381,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceActivityLoggingDoesNotOverwriteHeader()
         {
@@ -432,7 +432,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceUrlFilteredActivityLogging()
         {
@@ -473,7 +473,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticExceptionActivityLogging()
         {
@@ -519,7 +519,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSynchronousExceptionActivityLogging()
         {
@@ -581,7 +581,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceNewAndDeprecatedEventsLogging()
         {
@@ -620,7 +620,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticExceptionOnlyActivityLogging()
         {
@@ -658,7 +658,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticStopOnlyActivityLogging()
         {
@@ -696,7 +696,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ActiveIssue(23209)]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledActivityLogging()
         {


### PR DESCRIPTION
[edited by @danmosemsft ]

### Shiproom template

#### Description
This change prevents `Request-Id` header from being added by the [DiagnosticsHandler](https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L82) if it was already injected by tracing system.

This change allows a tracing system to implement backward compatibility with legacy correlation protocol after the new correlation protocol will be implemented in DiagnosticSource (3.0 timeframe).

See https://github.com/dotnet/corefx/issues/34299 for more details.

#### Customer Impact
Without this fix, after new DiagnosticSource is shipped, customers using new DiagnosticSource with 2.1 System.Net.Http AND forcing new [W3C distributed tracing protocol](https://github.com/w3c/distributed-tracing),  will not be able to correlate telemetry with other services that support legacy correlation protocol.
There will also be no workaround  for this.

#### Regression?
No.

#### Risk
Low.  @vancem : Note that the change is VERY small and safe (it is literally one line of code, that affects only one HTTP header (Request-id) and only if App-Insights did something (added one to override it)).   Thus it is very safe.  

#### Other options considered
* The Request-Id is current ‘standard’ for correlation supported by HttpClient, AspNetCore and Azure Application Insights, so using something else would have no effect on downstream services that expect Request-Id.
* We’ve discussed with Vance keeping DiagnosticSource in 3.0 backward compatible with HttpClient 2.1 and  after careful consideration decided that it would be a bad design choice, it would require additional public API surface changes.

### Comments from @vancem:
 Fundamentally.   App-Insights just wants its correlation features to work.   The thing that makes this problematic is that it needs the framework (in particular the HTTP subsystem), to help out (passing information in its headers), and sadly, there is non-trivial amount of industry-wide ‘churn’ on exactly how to do this.     Thus it requires changes to the framework if this churn is large enough (which it is at this time).    While many of the changes are covered by DiagnosticSource (which is as you point out of of band), some of the changes are in the HTTP logic, and thus part of the runtime.     Thus changes in how correlation information gets propagated can require runtime changes.        Moreover correlation by its very nature is about ‘big’ systems where it is likely that different parts evolve at different rates, and the requirement that everyone upgrade their runtime is likely to be an adoption-blocker.   
Looking at https://dotnet.microsoft.com/platform/support-policy/dotnet-core our only LTS runtime is 2.1.   Thus asking users to upgrade to the latest servicing of 2.1 is reasonable, at the present time it is unreasonable to ask them to upgrade to something beyond that (they lose their LTS).    
The alternative is to indicate that their new correlation work will not work until users upgrade to 3.0 (but frankly some would not do that until some post 3.0 build is declared LTS, which is quite a while from now).   
This is the driving force behind the desire for having the change in 2.1.
Just FYI,  Liudmila, Sergey and I met today and convinced me that with high likelihood they could achieve their goals with just this fix in V2.1 (the should not need another 2.1 fix in the future).   While there is always the possibility that we overlooked something, we did do some due diligence.
Dan: if you need me to offer more justification to Shiproom for this change let me know, I am solidly behind it.




<details>
  <summary>Original template</summary>
### Shiproom template

#### Description
This change prevents `Request-Id` header from being added by the [DiagnosticsHandler](https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L82) if it was already injected by tracing system.

This change allows a tracing system to implement backward compatibility with legacy correlation protocol after the new correlation protocol will be implemented in DiagnosticSource (3.0 timeframe).

See https://github.com/dotnet/corefx/issues/34299 for more details.

#### Customer Impact
Without this fix, after new DiagnosticSource is shipped, customers using new DiagnosticSource with 2.1 System.Net.Http AND forcing new [W3C distributed tracing protocol](https://github.com/w3c/distributed-tracing),  will not be able to correlate telemetry with other services that support legacy correlation protocol.
There will also be no workaround  for this.

#### Regression?
No.

#### Risk
Low. 

</details>