### PR TITLE
Delete one-off AppDomain setter for uapaot first chance exception handler

### DIFF
--- a/src/System.Runtime.Extensions/src/System/AppDomain.cs
+++ b/src/System.Runtime.Extensions/src/System/AppDomain.cs
@@ -67,13 +67,7 @@ namespace System
 
         public event EventHandler<FirstChanceExceptionEventArgs> FirstChanceException
         {
-            add
-            {
-#if uapaot
-                AppContext.SetAppDomain(this);
-#endif
-                AppContext.FirstChanceException += value;
-            }
+            add { AppContext.FirstChanceException += value; }
             remove { AppContext.FirstChanceException -= value; }
         }
 


### PR DESCRIPTION
This should not be one-off. It should be either nowhere or everywhere.