### PR TITLE
Do not add Request-Id header when its added already

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -75,9 +75,10 @@ namespace System.Net.Http
                 );
             }
 
-            // If we are on at all, we propagate any activity information.  
+            // If we are on at all, we propagate any activity information
+            // unless tracing system or user injected Request-Id for backward compatibility reasons.
             Activity currentActivity = Activity.Current;
-            if (currentActivity != null)
+            if (currentActivity != null && !request.Headers.Contains(DiagnosticsHandlerLoggingStrings.RequestIdHeaderName))
             {
                 request.Headers.Add(DiagnosticsHandlerLoggingStrings.RequestIdHeaderName, currentActivity.Id);
                 //we expect baggage to be empty or contain a few items

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -88,7 +88,7 @@ namespace System.Net.Http.Functional.Tests
 
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
-                    diagnosticListenerObserver.Enable( s => !s.Contains("HttpRequestOut"));
+                    diagnosticListenerObserver.Enable(s => !s.Contains("HttpRequestOut"));
                     using (HttpClient client = CreateHttpClient(useSocketsHttpHandlerString))
                     {
                         client.GetAsync(Configuration.Http.RemoteEchoServer).Result.Dispose();
@@ -325,7 +325,7 @@ namespace System.Net.Http.Functional.Tests
                 var diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
                 {
                     if (kvp.Key.Equals("System.Net.Http.Request")) { requestLogged = true; }
-                    else if (kvp.Key.Equals("System.Net.Http.Response")) { responseLogged = true;}
+                    else if (kvp.Key.Equals("System.Net.Http.Response")) { responseLogged = true; }
                     else if (kvp.Key.Equals("System.Net.Http.Exception")) { exceptionLogged = true; }
                     else if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Start"))
                     {
@@ -382,6 +382,57 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external server")]
         [Fact]
+        public void SendAsync_ExpectedDiagnosticSourceActivityLoggingDoesNotOverwriteHeader()
+        {
+            RemoteInvoke(useSocketsHttpHandlerString =>
+            {
+                bool activityStartLogged = false;
+                bool activityStopLogged = false;
+
+                Activity parentActivity = new Activity("parent");
+                parentActivity.AddBaggage("correlationId", Guid.NewGuid().ToString());
+                parentActivity.Start();
+
+                string customRequestIdHeader = "|foo.bar.";
+                var diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
+                {
+                    if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Start"))
+                    {
+                        var request = GetPropertyValueFromAnonymousTypeInstance<HttpRequestMessage>(kvp.Value, "Request");
+                        request.Headers.Add("Request-Id", customRequestIdHeader);
+
+                        activityStartLogged = true;
+                    }
+                    else if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Stop"))
+                    {
+                        var request = GetPropertyValueFromAnonymousTypeInstance<HttpRequestMessage>(kvp.Value, "Request");
+                        Assert.Single(request.Headers.GetValues("Request-Id"));
+                        Assert.Equal(customRequestIdHeader, request.Headers.GetValues("Request-Id").Single());
+                        activityStopLogged = true;
+                    }
+                });
+
+                using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
+                {
+                    diagnosticListenerObserver.Enable();
+                    using (HttpClient client = CreateHttpClient(useSocketsHttpHandlerString))
+                    {
+                        client.GetAsync(Configuration.Http.RemoteEchoServer).Result.Dispose();
+                    }
+
+                    Assert.True(activityStartLogged, "HttpRequestOut.Start was not logged.");
+
+                    // Poll with a timeout since logging response is not synchronized with returning a response.
+                    WaitForTrue(() => activityStopLogged, TimeSpan.FromSeconds(1), "HttpRequestOut.Stop was not logged within 1 second timeout.");
+                    diagnosticListenerObserver.Disable();
+                }
+
+                return SuccessExitCode;
+            }, UseSocketsHttpHandler.ToString()).Dispose();
+        }
+
+        [OuterLoop("Uses external server")]
+        [Fact]
         public void SendAsync_ExpectedDiagnosticSourceUrlFilteredActivityLogging()
         {
             RemoteInvoke(useSocketsHttpHandlerString =>
@@ -391,8 +442,8 @@ namespace System.Net.Http.Functional.Tests
 
                 var diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
                 {
-                    if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Start")){activityStartLogged = true;}
-                    else if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Stop")) {activityStopLogged = true;}
+                    if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Start")) { activityStartLogged = true; }
+                    else if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Stop")) { activityStopLogged = true; }
                 });
 
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
@@ -570,7 +621,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     if (kvp.Key.Equals("System.Net.Http.Request")) { requestLogged = true; }
                     else if (kvp.Key.Equals("System.Net.Http.Response")) { responseLogged = true; }
-                    else if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Start")) { activityStartLogged = true;}
+                    else if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Start")) { activityStartLogged = true; }
                     else if (kvp.Key.Equals("System.Net.Http.HttpRequestOut.Stop")) { activityStopLogged = true; }
                 });
 


### PR DESCRIPTION
This change prevents Request-Id header from being added by the DiagnosticsHandler if it was already injected by tracing system.

This change allows a tracing system to implement backward compatibility with legacy correlation protocol after the new correlation protocol will be implemented in DiagnosticSource (3.0 timeframe).

See #34299 for more details.