### PR TITLE
Properly Dispose SocketAsyncEventArgs' FileStreams.

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -460,6 +460,9 @@ namespace System.Net.Sockets
             // OK to dispose now.
             FreeInternals();
 
+            // FileStreams may be created when using SendPacketsAsync - this Disposes them.
+            FinishOperationSendPackets();
+
             // Don't bother finalizing later.
             GC.SuppressFinalize(this);
         }
@@ -597,6 +600,14 @@ namespace System.Net.Sockets
                     currentSocket.Dispose();
                     _currentSocket = null;
                 }
+            }
+
+            switch (_completedOperation)
+            {
+                case SocketAsyncOperation.SendPackets:
+                    // We potentially own FileStreams that need to be disposed.
+                    FinishOperationSendPackets();
+                    break;
             }
 
             Complete();

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -384,6 +384,61 @@ namespace System.Net.Sockets.Tests
             SendPackets(type, new SendPacketsElement(TestFileName, 5, 10000), SocketError.InvalidArgument, 0);
         }
 
+        [Theory]
+        [InlineData(SocketImplementationType.APM)]
+        [InlineData(SocketImplementationType.Async)]
+        public void SendPacketsElement_FileStreamIsReleasedOnError(SocketImplementationType type)
+        {
+            // this test checks that FileStreams opened by the implementation of SendPacketsAsync
+            // are properly disposed of when the SendPacketsAsync operation fails asynchronously.
+            // To trigger this codepath we must call SendPacketsAsync with a wrong offset (to create an error), 
+            // and twice (to avoid synchronous completion).
+
+            SendPacketsElement[] elements = new[] { new SendPacketsElement(TestFileName, 50_000, 10) };
+            EventWaitHandle completed1 = new ManualResetEvent(false);
+            EventWaitHandle completed2 = new ManualResetEvent(false);
+
+            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out int port))
+            {
+                using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    sock.Connect(new IPEndPoint(_serverAddress, port));
+                    bool r1, r2;
+                    using (SocketAsyncEventArgs args1 = new SocketAsyncEventArgs())
+                    using (SocketAsyncEventArgs args2 = new SocketAsyncEventArgs())
+                    {
+                        args1.Completed += OnCompleted;
+                        args1.UserToken = completed1;
+                        args1.SendPacketsElements = elements;
+
+                        args2.Completed += OnCompleted;
+                        args2.UserToken = completed2;
+                        args2.SendPacketsElements = elements;
+
+                        r1 = sock.SendPacketsAsync(args1);
+                        r2 = sock.SendPacketsAsync(args2);
+
+                        if (r1)
+                        {
+                            Assert.True(completed1.WaitOne(TestSettings.PassingTestTimeout), "Timed out");
+                        }
+                        Assert.Equal(SocketError.InvalidArgument, args1.SocketError);
+
+                        if (r2)
+                        {
+                            Assert.True(completed2.WaitOne(TestSettings.PassingTestTimeout), "Timed out");
+                        }
+                        Assert.Equal(SocketError.InvalidArgument, args2.SocketError);
+
+                        using (var fs = new FileStream(TestFileName, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+                        {
+                            // If a SendPacketsAsync call did not dispose of its FileStreams, the FileStream ctor throws.
+                        }
+                    }
+                }
+            }
+        }
+
         #endregion Files
 
         #region Helpers

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -394,7 +394,8 @@ namespace System.Net.Sockets.Tests
             // To trigger this codepath we must call SendPacketsAsync with a wrong offset (to create an error), 
             // and twice (to avoid synchronous completion).
 
-            SendPacketsElement[] elements = new[] { new SendPacketsElement(TestFileName, 50_000, 10) };
+            SendPacketsElement[] goodElements = new[] { new SendPacketsElement(TestFileName, 0, 0) };
+            SendPacketsElement[] badElements = new[] { new SendPacketsElement(TestFileName, 50_000, 10) };
             EventWaitHandle completed1 = new ManualResetEvent(false);
             EventWaitHandle completed2 = new ManualResetEvent(false);
 
@@ -409,11 +410,11 @@ namespace System.Net.Sockets.Tests
                     {
                         args1.Completed += OnCompleted;
                         args1.UserToken = completed1;
-                        args1.SendPacketsElements = elements;
+                        args1.SendPacketsElements = goodElements;
 
                         args2.Completed += OnCompleted;
                         args2.UserToken = completed2;
-                        args2.SendPacketsElements = elements;
+                        args2.SendPacketsElements = badElements;
 
                         r1 = sock.SendPacketsAsync(args1);
                         r2 = sock.SendPacketsAsync(args2);
@@ -422,7 +423,7 @@ namespace System.Net.Sockets.Tests
                         {
                             Assert.True(completed1.WaitOne(TestSettings.PassingTestTimeout), "Timed out");
                         }
-                        Assert.Equal(SocketError.InvalidArgument, args1.SocketError);
+                        Assert.Equal(SocketError.Success, args1.SocketError);
 
                         if (r2)
                         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -387,6 +387,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The fix was made in coreclr that is not in netfx. See https://github.com/dotnet/corefx/pull/34331")]
         public void SendPacketsElement_FileStreamIsReleasedOnError(SocketImplementationType type)
         {
             // this test checks that FileStreams opened by the implementation of SendPacketsAsync

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -387,7 +387,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The fix was made in coreclr that is not in netfx. See https://github.com/dotnet/corefx/pull/34331")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The fix was made in corefx that is not in netfx. See https://github.com/dotnet/corefx/pull/34331")]
         public void SendPacketsElement_FileStreamIsReleasedOnError(SocketImplementationType type)
         {
             // this test checks that FileStreams opened by the implementation of SendPacketsAsync


### PR DESCRIPTION
`FileStream`s were not closed in the case of an asynchronous failure, which left the file open (and given it is opened with `FileShare.Read`, the file can't subsequently be written to).

I also added some code to Dispose the FileStreams in `SocketAsyncEventArgs.Dispose()`.