### PR TITLE
Fix runtime.depproj allconfigurations restore

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -234,14 +234,15 @@
     <_packageRID Condition="'$(PortableBuild)' == 'true'">$(_portableOS)-$(ArchGroup)</_packageRID>
     <_packageRID Condition="$(TargetGroup.StartsWith('uap'))">win10-$(ArchGroup)</_packageRID>
     <_packageRID Condition="$(TargetGroup.EndsWith('aot'))">$(_packageRID)-aot</_packageRID>
-    <PackageRID Condition="'$(PackageRID)' == ''">$(_packageRID)</PackageRID>
-    <PackageRID Condition="'$(PackageRID)' == ''">$(RuntimeOS)-$(ArchGroup)</PackageRID>
     <!--
-      Also store the generated default. Source-build passes a PackageRID, but we need to retain the
-      default info to restore runtime.depproj properly for the netcoreapp-Windows_NT configuration
-      to compile against for -allconfigurations.
+      Store the generated default separately from PackageRID to allow PackageRID override while
+      still being able to access the default value for the current configuration. For example,
+      source-build passes a PackageRID, but we need to retain the default info to restore
+      runtime.depproj properly for the netcoreapp-Windows_NT configuration.
     -->
-    <PackageRIDConfigurationDefault>$(_packageRID)</PackageRIDConfigurationDefault>
+    <PackageRIDConfigurationDefault Condition="'$(PackageRIDConfigurationDefault)' == ''">$(_packageRID)</PackageRIDConfigurationDefault>
+    <PackageRIDConfigurationDefault Condition="'$(PackageRIDConfigurationDefault)' == ''">$(RuntimeOS)-$(ArchGroup)</PackageRIDConfigurationDefault>
+    <PackageRID Condition="'$(PackageRID)' == ''">$(PackageRIDConfigurationDefault)</PackageRID>
   </PropertyGroup>
 
   <!-- Set some shortcuts for more terse conditions in project files -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -236,6 +236,12 @@
     <_packageRID Condition="$(TargetGroup.EndsWith('aot'))">$(_packageRID)-aot</_packageRID>
     <PackageRID Condition="'$(PackageRID)' == ''">$(_packageRID)</PackageRID>
     <PackageRID Condition="'$(PackageRID)' == ''">$(RuntimeOS)-$(ArchGroup)</PackageRID>
+    <!--
+      Also store the generated default. Source-build passes a PackageRID, but we need to retain the
+      default info to restore runtime.depproj properly for the netcoreapp-Windows_NT configuration
+      to compile against for -allconfigurations.
+    -->
+    <PackageRIDConfigurationDefault>$(_packageRID)</PackageRIDConfigurationDefault>
   </PropertyGroup>
 
   <!-- Set some shortcuts for more terse conditions in project files -->

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+    <!--
+      Use the configuration default for PackageRID. PackageRID might be overridden by the build
+      command, and interfere with this depproj in -allconfigurations mode.
+    -->
+    <RuntimeIdentifier>$(PackageRIDConfigurationDefault)</RuntimeIdentifier>
     <NoWarn>$(NoWarn);NU1603;NU1605</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsAOT)'=='true'">


### PR DESCRIPTION
Use default PackageRID for RuntimeIdentifier, not the overridden value from build args. In allconfigurations mode, using PackageRID can cause the wrong assets to be restored for other configurations.

---

I'm working on getting CoreFX to build on Linux with `-allconfigurations` (https://github.com/dotnet/source-build/issues/210) and found this issue when I set `/p:PackageRID` to produce packages for the right RID.

This line causes `PackageRID` to take effect for every configuration:

https://github.com/dotnet/corefx/blob/6d59e6ab54bb313ea5eb6a809dc64a7cebe8ee64/external/runtime/runtime.depproj#L4

For example, with PackageRID set to `linux-x64`, Linux CoreCLR assets are restored for the `netcoreapp-Windows_NT` configuration. That causes failures when building `System.Runtime.InteropServices.WindowsRuntime`. (The errors are GenAPI errors described at https://github.com/dotnet/corefx/pull/15357#issuecomment-274199963. The build tries to use a linux package for seeds rather than the win package.)

This PR uses the PackageRID that the build *would have* used if `/p:PackageRID` weren't passed, which fixes it in my tests (building/packing allconfigurations on centos).

---

@bartonjs, does this issue and fix look reasonable?

/cc @joperezr @ericstj 