### PR TITLE
Fix testhost depproj chmod when win host restored

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -91,7 +91,7 @@
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="$(UseHardlink)" />
 
-    <Exec Command="chmod +x $(TestHostRootPath)dotnet" Condition="'$(RunningOnUnix)' == 'true'"/>
+    <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(RunningOnUnix)' == 'true'"/>
   </Target>
 
   <PropertyGroup>


### PR DESCRIPTION
When building on Linux, this `Exec` assumes a Linux configuration is restored so the testhost package it picks up will have `dotnet`. This fails with `-allconfigurations` when a Windows configuration is used and
the restore actually got `dotnet.exe`. This change detects whatever `dotnet` file was actually restored and runs `chmod` on that.

Fixes https://github.com/dotnet/corefx/issues/34183