### PR TITLE
Update ubuntu arm64 queues to 1804 in official builds

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -59,11 +59,11 @@ jobs:
 
         - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
           - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open+Fedora.27.Amd64.Open
-          - linuxArm64Queues: Ubuntu.1604.Arm64.Open
+          - linuxArm64Queues: Ubuntu.1804.Arm64.Open
       
         - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
           - linuxDefaultQueues: Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+OpenSuse.42.Amd64+SLES.12.Amd64+SLES.15.Amd64+Fedora.27.Amd64+Fedora.28.Amd64
-          - linuxArm64Queues: Ubuntu.1604.Arm64
+          - linuxArm64Queues: Ubuntu.1804.Arm64
           - alpineQueues: Alpine.36.Amd64+Alpine.38.Amd64
 
     # Legs without helix testing


### PR DESCRIPTION
To follow what was done in: https://github.com/dotnet/corefx/pull/33439 updating the new official build system was missed. I'm also updating what is going to be used for the new CI system before we forget about it and miss it.

cc: @bartonjs 