### PR TITLE
Increasing Retries to 20

### DIFF
--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -43,7 +43,7 @@ namespace System.IO.Tests
         public FileInfo GetNonZeroNanoseconds()
         {
             FileInfo fileinfo = new FileInfo(GetTestFilePath());
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < 20; i++)
             {
                 fileinfo.Create().Dispose();
                 if (HasNonZeroNanoseconds(fileinfo.LastWriteTime))


### PR DESCRIPTION
We are not able to get a file with timestamp with nonzero nanosecond value which is causing the CI to fail for some PRs especially on windows 7 like 

https://github.com/dotnet/corefx/pull/34332

So just increasing the retries to get such a file.