### PR TITLE
Add GenericLoopbackServer for HttpClient testing

### DIFF
--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -32,35 +32,6 @@ namespace System.Net.Test.Common
         }
     }
 
-    public sealed class Http11LoopbackServerFactory : LoopbackServerFactory
-    {
-        public static readonly Http11LoopbackServerFactory Singleton = new Http11LoopbackServerFactory();
-
-        public override Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync)
-        {
-            return LoopbackServer.CreateServerAsync((server, uri) => funcAsync(server, uri));
-        }
-
-        public override bool IsHttp11 => true;
-        public override bool IsHttp2 => false;
-    }
-
-    public sealed class Http2LoopbackServerFactory : LoopbackServerFactory
-    {
-        public static readonly Http2LoopbackServerFactory Singleton = new Http2LoopbackServerFactory();
-
-        public override async Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync)
-        {
-            using (var server = Http2LoopbackServer.CreateServer())
-            {
-                await funcAsync(server, server.Address);
-            }
-        }
-
-        public override bool IsHttp11 => false;
-        public override bool IsHttp2 => true;
-    }
-
     public abstract class GenericLoopbackServer : IDisposable
     {
         // Accept a new connection, process a single request and send the specified response, and gracefully close the connection.

--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace System.Net.Test.Common
+{
+    // Loopback server abstraction. 
+    // Tests that want to run over both HTTP/1.1 and HTTP/2 should use this instead of the protocol-specific loopback servers.
+
+    public abstract class LoopbackServerFactory
+    {
+        public abstract Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync);
+
+        public abstract bool IsHttp11 { get; }
+        public abstract bool IsHttp2 { get; }
+
+        // Common helper methods
+
+        public Task CreateClientAndServerAsync(Func<Uri, Task> clientFunc, Func<GenericLoopbackServer, Task> serverFunc)
+        {
+            return CreateServerAsync(async (server, uri) =>
+            {
+                Task clientTask = clientFunc(uri);
+                Task serverTask = serverFunc(server);
+
+                await new Task[] { clientTask, serverTask }.WhenAllOrAnyFailed();
+            });
+        }
+    }
+
+    public sealed class Http11LoopbackServerFactory : LoopbackServerFactory
+    {
+        public static readonly Http11LoopbackServerFactory Singleton = new Http11LoopbackServerFactory();
+
+        public override Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync)
+        {
+            return LoopbackServer.CreateServerAsync((server, uri) => funcAsync(server, uri));
+        }
+
+        public override bool IsHttp11 => true;
+        public override bool IsHttp2 => false;
+    }
+
+    public sealed class Http2LoopbackServerFactory : LoopbackServerFactory
+    {
+        public static readonly Http2LoopbackServerFactory Singleton = new Http2LoopbackServerFactory();
+
+        public override async Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync)
+        {
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                await funcAsync(server, server.Address);
+            }
+        }
+
+        public override bool IsHttp11 => false;
+        public override bool IsHttp2 => true;
+    }
+
+    public abstract class GenericLoopbackServer : IDisposable
+    {
+        // Accept a new connection, process a single request and send the specified response, and gracefully close the connection.
+        public abstract Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = null);
+
+        public abstract void Dispose();
+    }
+
+    public struct HttpHeaderData
+    {
+        public string Name { get; }
+        public string Value { get; }
+
+        public HttpHeaderData(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+    }
+
+    public class HttpRequestData
+    {
+        public string Method;
+        public string Path;
+        public List<HttpHeaderData> Headers { get; }
+
+        public HttpRequestData()
+        {
+            Headers = new List<HttpHeaderData>();
+        }
+
+        public string[] GetHeaderValues(string headerName)
+        {
+            return Headers.Where(h => h.Name.Equals(headerName, StringComparison.OrdinalIgnoreCase))
+                    .Select(h => h.Value)
+                    .ToArray();
+        }
+
+        public string GetSingleHeaderValue(string headerName)
+        {
+            string[] values = GetHeaderValues(headerName);
+            if (values.Length != 1)
+            {
+                throw new Exception($"Expected single value for {headerName} header, actual count: {values.Length}");
+            }
+
+            return values[0];
+        }
+
+        public int GetHeaderValueCount(string headerName)
+        {
+            return Headers.Where(h => h.Name.Equals(headerName, StringComparison.OrdinalIgnoreCase)).Count();
+        }
+    }
+}

--- a/src/Common/tests/System/Net/Http/Http2Frames.cs
+++ b/src/Common/tests/System/Net/Http/Http2Frames.cs
@@ -105,9 +105,9 @@ namespace System.Net.Test.Common
     public class DataFrame : Frame
     {
         public byte PadLength;
-        public byte[] Data;
+        public ReadOnlyMemory<byte> Data;
 
-        public DataFrame(byte[] data, FrameFlags flags, byte padLength, int streamId) :
+        public DataFrame(ReadOnlyMemory<byte> data, FrameFlags flags, byte padLength, int streamId) :
             base(0, FrameType.Data, flags, streamId)
         {
             Length = (flags & FrameFlags.Padded) == 0 ? data.Length : data.Length + padLength + 1;
@@ -133,11 +133,11 @@ namespace System.Net.Test.Common
             if (PaddedFlag)
             {
                 buffer[Frame.FrameHeaderLength] = PadLength;
-                Data.CopyTo(buffer.Slice(Frame.FrameHeaderLength + 1));
+                Data.Span.CopyTo(buffer.Slice(Frame.FrameHeaderLength + 1));
             }
             else
             {
-                Data.CopyTo(buffer.Slice(Frame.FrameHeaderLength));
+                Data.Span.CopyTo(buffer.Slice(Frame.FrameHeaderLength));
             }
         }
 
@@ -153,9 +153,9 @@ namespace System.Net.Test.Common
         public byte PadLength = 0;
         public int StreamDependency = 0;
         public byte Weight = 0;
-        public byte[] Data;
+        public Memory<byte> Data;
 
-        public HeadersFrame(byte[] data, FrameFlags flags, byte padLength, int streamDependency, byte weight, int streamId) :
+        public HeadersFrame(Memory<byte> data, FrameFlags flags, byte padLength, int streamDependency, byte weight, int streamId) :
             base(0, FrameType.Headers, flags, streamId)
         {
             Length = data.Length + (PaddedFlag ? padLength + 1 : 0) + (PriorityFlag ? 5 : 0);
@@ -198,7 +198,7 @@ namespace System.Net.Test.Common
 
                 buffer[idx++] = Weight;
             }
-            Data.CopyTo(buffer.Slice(idx));
+            Data.Span.CopyTo(buffer.Slice(idx));
         }
 
         public override string ToString()

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -632,4 +632,20 @@ namespace System.Net.Test.Common
         public bool UseSsl { get; set; } = true;
         public SslProtocols SslProtocols { get; set; } = SslProtocols.Tls12;
     }
+
+    public sealed class Http2LoopbackServerFactory : LoopbackServerFactory
+    {
+        public static readonly Http2LoopbackServerFactory Singleton = new Http2LoopbackServerFactory();
+
+        public override async Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync)
+        {
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                await funcAsync(server, server.Address);
+            }
+        }
+
+        public override bool IsHttp11 => false;
+        public override bool IsHttp2 => true;
+    }
 }

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,7 +15,7 @@ using Xunit;
 
 namespace System.Net.Test.Common
 {
-    public class Http2LoopbackServer : IDisposable
+    public class Http2LoopbackServer : GenericLoopbackServer, IDisposable
     {
         private Socket _listenSocket;
         private Socket _connectionSocket;
@@ -285,6 +286,244 @@ namespace System.Net.Test.Common
             return frame.StreamId;
         }
 
+        private static (int bytesConsumed, int value) DecodeInteger(ReadOnlySpan<byte> headerBlock, byte prefixMask)
+        {
+            int value = headerBlock[0] & prefixMask;
+            if (value != prefixMask)
+            {
+                return (1, value);
+            }
+
+            byte b = headerBlock[1];
+            if ((b & 0b10000000) != 0)
+            {
+                throw new Exception("long integers currently not supported");
+            }
+            return (2, prefixMask + b);
+        }
+
+        private static int EncodeInteger(int value, byte prefix, byte prefixMask, Span<byte> headerBlock)
+        {
+            byte prefixLimit = (byte)(~prefixMask);
+
+            if (value < prefixLimit)
+            {
+                headerBlock[0] = (byte)(prefix | value);
+                return 1;
+            }
+
+            headerBlock[0] = (byte)(prefix | prefixLimit);
+            int bytesGenerated = 1;
+
+            value -= prefixLimit;
+
+            while (value >= 0x80)
+            {
+                headerBlock[bytesGenerated] = (byte)((value & 0x7F) | 0x80);
+                value = value >> 7;
+                bytesGenerated++;
+            }
+
+            headerBlock[bytesGenerated] = (byte)value;
+            bytesGenerated++;
+
+            return bytesGenerated;
+        }
+
+        private static (int bytesConsumed, string value) DecodeString(ReadOnlySpan<byte> headerBlock)
+        {
+            (int bytesConsumed, int stringLength) = DecodeInteger(headerBlock, 0b01111111);
+            if ((headerBlock[0] & 0b10000000) != 0)
+            {
+                // Huffman encoded
+                byte[] buffer = new byte[stringLength * 2];
+                int bytesDecoded = HuffmanDecoder.Decode(headerBlock.Slice(bytesConsumed, stringLength), buffer);
+                string value = Encoding.ASCII.GetString(buffer, 0, bytesDecoded);
+                return (bytesConsumed + stringLength, value);
+            }
+            else
+            {
+                string value = Encoding.ASCII.GetString(headerBlock.Slice(bytesConsumed, stringLength));
+                return (bytesConsumed + stringLength, value);
+            }
+        }
+
+        private static int EncodeString(string value, Span<byte> headerBlock)
+        {
+            int bytesGenerated = EncodeInteger(value.Length, 0, 0x80, headerBlock);
+
+            bytesGenerated += Encoding.ASCII.GetBytes(value.AsSpan(), headerBlock.Slice(bytesGenerated));
+
+            return bytesGenerated;
+        }
+
+        private static readonly HttpHeaderData[] s_staticTable = new HttpHeaderData[]
+        {
+            new HttpHeaderData(":authority", ""),
+            new HttpHeaderData(":method", "GET"),
+            new HttpHeaderData(":method", "POST"),
+            new HttpHeaderData(":path", "/"),
+            new HttpHeaderData(":path", "/index.html"),
+            new HttpHeaderData(":scheme", "http"),
+            new HttpHeaderData(":scheme", "https"),
+            new HttpHeaderData(":status", "200"),
+            new HttpHeaderData(":status", "204"),
+            new HttpHeaderData(":status", "206"),
+            new HttpHeaderData(":status", "304"),
+            new HttpHeaderData(":status", "400"),
+            new HttpHeaderData(":status", "404"),
+            new HttpHeaderData(":status", "500"),
+            new HttpHeaderData("accept-charset", ""),
+            new HttpHeaderData("accept-encoding", "gzip, deflate"),
+            new HttpHeaderData("accept-language", ""),
+            new HttpHeaderData("accept-ranges", ""),
+            new HttpHeaderData("accept", ""),
+            new HttpHeaderData("access-control-allow-origin", ""),
+            new HttpHeaderData("age", ""),
+            new HttpHeaderData("allow", ""),
+            new HttpHeaderData("authorization", ""),
+            new HttpHeaderData("cache-control", ""),
+            new HttpHeaderData("content-disposition", ""),
+            new HttpHeaderData("content-encoding", ""),
+            new HttpHeaderData("content-language", ""),
+            new HttpHeaderData("content-length", ""),
+            new HttpHeaderData("content-location", ""),
+            new HttpHeaderData("content-range", ""),
+            new HttpHeaderData("content-type", ""),
+            new HttpHeaderData("cookie", ""),
+            new HttpHeaderData("date", ""),
+            new HttpHeaderData("etag", ""),
+            new HttpHeaderData("expect", ""),
+            new HttpHeaderData("expires", ""),
+            new HttpHeaderData("from", ""),
+            new HttpHeaderData("host", ""),
+            new HttpHeaderData("if-match", ""),
+            new HttpHeaderData("if-modified-since", ""),
+            new HttpHeaderData("if-none-match", ""),
+            new HttpHeaderData("if-range", ""),
+            new HttpHeaderData("if-unmodifiedsince", ""),
+            new HttpHeaderData("last-modified", ""),
+            new HttpHeaderData("link", ""),
+            new HttpHeaderData("location", ""),
+            new HttpHeaderData("max-forwards", ""),
+            new HttpHeaderData("proxy-authenticate", ""),
+            new HttpHeaderData("proxy-authorization", ""),
+            new HttpHeaderData("range", ""),
+            new HttpHeaderData("referer", ""),
+            new HttpHeaderData("refresh", ""),
+            new HttpHeaderData("retry-after", ""),
+            new HttpHeaderData("server", ""),
+            new HttpHeaderData("set-cookie", ""),
+            new HttpHeaderData("strict-transport-security", ""),
+            new HttpHeaderData("transfer-encoding", ""),
+            new HttpHeaderData("user-agent", ""),
+            new HttpHeaderData("vary", ""),
+            new HttpHeaderData("via", ""),
+            new HttpHeaderData("www-authenticate", "")
+        };
+
+        private static HttpHeaderData GetHeaderForIndex(int index)
+        {
+            return s_staticTable[index - 1];
+        }
+
+        private static (int bytesConsumed, HttpHeaderData headerData) DecodeLiteralHeader(ReadOnlySpan<byte> headerBlock, byte prefixMask)
+        {
+            int i = 0;
+
+            (int bytesConsumed, int index) = DecodeInteger(headerBlock, prefixMask);
+            i += bytesConsumed;
+
+            string name;
+            if (index == 0)
+            {
+                (bytesConsumed, name) = DecodeString(headerBlock.Slice(i));
+                i += bytesConsumed;
+            }
+            else
+            {
+                name = GetHeaderForIndex(index).Name;
+            }
+
+            string value;
+            (bytesConsumed, value) = DecodeString(headerBlock.Slice(i));
+            i += bytesConsumed;
+
+            return (i, new HttpHeaderData(name, value));
+        }
+
+        private static (int bytesConsumed, HttpHeaderData headerData) DecodeHeader(ReadOnlySpan<byte> headerBlock)
+        {
+            int i = 0;
+
+            byte b = headerBlock[0];
+            if ((b & 0b10000000) != 0)
+            {
+                // Indexed header
+                (int bytesConsumed, int index) = DecodeInteger(headerBlock, 0b01111111);
+                i += bytesConsumed;
+
+                return (i, GetHeaderForIndex(index));
+            }
+            else if ((b & 0b11000000) == 0b01000000)
+            {
+                // Literal with indexing
+                return DecodeLiteralHeader(headerBlock, 0b00111111);
+            }
+            else if ((b & 0b11100000) == 0b00100000)
+            {
+                // Table size update
+                throw new Exception("table size update not supported");
+            }
+            else
+            {
+                // Literal, never indexed
+                return DecodeLiteralHeader(headerBlock, 0b00001111);
+            }
+        }
+
+        private static int EncodeHeader(HttpHeaderData headerData, Span<byte> headerBlock)
+        {
+            // Always encode as literal, no indexing
+            int bytesGenerated = EncodeInteger(0, 0, 0b11110000, headerBlock);
+            bytesGenerated += EncodeString(headerData.Name, headerBlock.Slice(bytesGenerated));
+            bytesGenerated += EncodeString(headerData.Value, headerBlock.Slice(bytesGenerated));
+            return bytesGenerated;
+        }
+
+        public async Task<(int streamId, HttpRequestData requestData)> ReadAndParseRequestHeaderAsync()
+        {
+            HttpRequestData requestData = new HttpRequestData();
+
+            // Receive HEADERS frame for request.
+            HeadersFrame headersFrame = (HeadersFrame) await ReadFrameAsync(TimeSpan.FromSeconds(30));
+            Assert.Equal(FrameFlags.EndHeaders | FrameFlags.EndStream, headersFrame.Flags);
+
+            int streamId = headersFrame.StreamId;
+
+            Memory<byte> data = headersFrame.Data;
+            int i = 0;
+            while (i < data.Length)
+            {
+                (int bytesConsumed, HttpHeaderData headerData) = DecodeHeader(data.Span.Slice(i));
+
+                requestData.Headers.Add(headerData);
+                i += bytesConsumed;
+            }
+
+            // Extract method and path
+            requestData.Method = requestData.GetSingleHeaderValue(":method");
+            requestData.Path = requestData.GetSingleHeaderValue(":path");
+
+            return (streamId, requestData);
+        }
+
+        public async Task SendGoAway(int lastStreamId)
+        {
+            GoAwayFrame frame = new GoAwayFrame(lastStreamId, 0, new byte[] { }, 0);
+            await WriteFrameAsync(frame).ConfigureAwait(false);
+        }
+
         public async Task SendDefaultResponseHeadersAsync(int streamId)
         {
             byte[] headers = new byte[] { 0x88 };   // Encoding for ":status: 200"
@@ -301,19 +540,88 @@ namespace System.Net.Test.Common
             await WriteFrameAsync(headersFrame).ConfigureAwait(false);
         }
 
-        public async Task SendResponseBodyAsync(int streamId, byte[] data, bool endStream = false)
+        public async Task SendResponseHeadersAsync(int streamId, bool endStream = true, HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null)
         {
-            DataFrame dataFrame = new DataFrame(data, endStream ? FrameFlags.EndStream : FrameFlags.None, 0, streamId);
+            // For now, only support headers that fit in a single frame
+            byte[] headerBlock = new byte[Frame.MaxFrameLength];
+            int bytesGenerated = 0;
+
+            string statusCodeString = ((int)statusCode).ToString();
+            bytesGenerated += EncodeHeader(new HttpHeaderData(":status", statusCodeString), headerBlock.AsSpan());
+
+            if (headers != null)
+            {
+                foreach (HttpHeaderData headerData in headers)
+                {
+                    bytesGenerated += EncodeHeader(headerData, headerBlock.AsSpan().Slice(bytesGenerated));
+                }
+            }
+
+            FrameFlags flags = FrameFlags.EndHeaders;
+            if (endStream)
+            {
+                flags |= FrameFlags.EndStream;
+            }
+
+            HeadersFrame headersFrame = new HeadersFrame(headerBlock.AsMemory().Slice(0, bytesGenerated), flags, 0, 0, 0, streamId);
+            await WriteFrameAsync(headersFrame).ConfigureAwait(false);
+        }
+
+        public async Task SendResponseDataAsync(int streamId, ReadOnlyMemory<byte> responseData, bool endStream)
+        {
+            DataFrame dataFrame = new DataFrame(responseData, endStream ? FrameFlags.EndStream : FrameFlags.None, 0, streamId);
             await WriteFrameAsync(dataFrame).ConfigureAwait(false);
         }
 
-        public void Dispose()
+        public async Task SendResponseBodyAsync(int streamId, ReadOnlyMemory<byte> responseBody)
+        {
+            // Only support response body if it fits in a single frame, for now
+            // In the future we should separate the body into chunks as needed,
+            // and if it's larger than the default window size, we will need to process window updates as well.
+            if (responseBody.Length > Frame.MaxFrameLength)
+            {
+                throw new Exception("Response body too long");
+            }
+
+            await SendResponseDataAsync(streamId, responseBody, true);
+        }
+
+        public override void Dispose()
         {
             if (_listenSocket != null)
             {
                 _listenSocket.Dispose();
                 _listenSocket = null;
             }
+        }
+
+        //
+        // GenericLoopbackServer implementation
+        //
+
+        public override async Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = null)
+        {
+            await EstablishConnectionAsync();
+
+            (int streamId, HttpRequestData requestData) = await ReadAndParseRequestHeaderAsync();
+
+            // We are about to close the connection, after we send the response.
+            // So, send a GOAWAY frame now so the client won't inadvertantly try to reuse the connection.
+            await SendGoAway(streamId);
+
+            if (content == null)
+            {
+                await SendResponseHeadersAsync(streamId, true, statusCode, headers);
+            }
+            else
+            {
+                await SendResponseHeadersAsync(streamId, false, statusCode, headers);
+                await SendResponseBodyAsync(streamId, Encoding.ASCII.GetBytes(content));
+            }
+
+            await WaitForConnectionShutdownAsync();
+
+            return requestData;
         }
     }
 

--- a/src/Common/tests/System/Net/Http/HuffmanDecoder.cs
+++ b/src/Common/tests/System/Net/Http/HuffmanDecoder.cs
@@ -1,0 +1,163 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Test.Common
+{
+    // Stolen from product code
+    public static class HuffmanDecoder
+    {
+        private static readonly (int codeLength, int[] codes)[] s_decodingTable = new[]
+        {
+            (5, new[] { 48, 49, 50, 97, 99, 101, 105, 111, 115, 116 }),
+            (6, new[] { 32, 37, 45, 46, 47, 51, 52, 53, 54, 55, 56, 57, 61, 65, 95, 98, 100, 102, 103, 104, 108, 109, 110, 112, 114, 117 }),
+            (7, new[] { 58, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 89, 106, 107, 113, 118, 119, 120, 121, 122 }),
+            (8, new[] { 38, 42, 44, 59, 88, 90 }),
+            (10, new[] { 33, 34, 40, 41, 63 }),
+            (11, new[] { 39, 43, 124 }),
+            (12, new[] { 35, 62 }),
+            (13, new[] { 0, 36, 64, 91, 93, 126 }),
+            (14, new[] { 94, 125 }),
+            (15, new[] { 60, 96, 123 }),
+            (19, new[] { 92, 195, 208 }),
+            (20, new[] { 128, 130, 131, 162, 184, 194, 224, 226 }),
+            (21, new[] { 153, 161, 167, 172, 176, 177, 179, 209, 216, 217, 227, 229, 230 }),
+            (22, new[] { 129, 132, 133, 134, 136, 146, 154, 156, 160, 163, 164, 169, 170, 173, 178, 181, 185, 186, 187, 189, 190, 196, 198, 228, 232, 233 }),
+            (23, new[] { 1, 135, 137, 138, 139, 140, 141, 143, 147, 149, 150, 151, 152, 155, 157, 158, 165, 166, 168, 174, 175, 180, 182, 183, 188, 191, 197, 231, 239 }),
+            (24, new[] { 9, 142, 144, 145, 148, 159, 171, 206, 215, 225, 236, 237 }),
+            (25, new[] { 199, 207, 234, 235 }),
+            (26, new[] { 192, 193, 200, 201, 202, 205, 210, 213, 218, 219, 238, 240, 242, 243, 255 }),
+            (27, new[] { 203, 204, 211, 212, 214, 221, 222, 223, 241, 244, 245, 246, 247, 248, 250, 251, 252, 253, 254 }),
+            (28, new[] { 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127, 220, 249 }),
+            (30, new[] { 10, 13, 22, 256 })
+        };
+
+        /// <summary>
+        /// Decodes a Huffman encoded string from a byte array.
+        /// </summary>
+        /// <param name="src">The source byte array containing the encoded data.</param>
+        /// <param name="dst">The destination byte array to store the decoded data.</param>
+        /// <returns>The number of decoded symbols.</returns>
+        public static int Decode(ReadOnlySpan<byte> src, Span<byte> dst)
+        {
+            int i = 0;
+            int j = 0;
+            int lastDecodedBits = 0;
+            while (i < src.Length)
+            {
+                // Note that if lastDecodeBits is 3 or more, then we will only get 5 bits (or less)
+                // from src[i]. Thus we need to read 5 bytes here to ensure that we always have 
+                // at least 30 bits available for decoding.
+                // TODO ISSUE 31751: Rework this as part of Huffman perf improvements
+                uint next = (uint)(src[i] << 24 + lastDecodedBits);
+                next |= (i + 1 < src.Length ? (uint)(src[i + 1] << 16 + lastDecodedBits) : 0);
+                next |= (i + 2 < src.Length ? (uint)(src[i + 2] << 8 + lastDecodedBits) : 0);
+                next |= (i + 3 < src.Length ? (uint)(src[i + 3] << lastDecodedBits) : 0);
+                next |= (i + 4 < src.Length ? (uint)(src[i + 4] >> (8 - lastDecodedBits)) : 0);
+
+                uint ones = (uint)(int.MinValue >> (8 - lastDecodedBits - 1));
+                if (i == src.Length - 1 && lastDecodedBits > 0 && (next & ones) == ones)
+                {
+                    // The remaining 7 or less bits are all 1, which is padding.
+                    // We specifically check that lastDecodedBits > 0 because padding
+                    // longer than 7 bits should be treated as a decoding error.
+                    // http://httpwg.org/specs/rfc7541.html#rfc.section.5.2
+                    break;
+                }
+
+                // The longest possible symbol size is 30 bits. If we're at the last 4 bytes
+                // of the input, we need to make sure we pass the correct number of valid bits
+                // left, otherwise the trailing 0s in next may form a valid symbol.
+                int validBits = Math.Min(30, (8 - lastDecodedBits) + (src.Length - i - 1) * 8);
+                int ch = DecodeValue(next, validBits, out int decodedBits);
+
+                if (ch == -1)
+                {
+                    // No valid symbol could be decoded with the bits in next
+                    throw new Exception("huffman decoding error");
+                }
+                else if (ch == 256)
+                {
+                    // A Huffman-encoded string literal containing the EOS symbol MUST be treated as a decoding error.
+                    // http://httpwg.org/specs/rfc7541.html#rfc.section.5.2
+                    throw new Exception("huffman decoding error");
+                }
+
+                if (j == dst.Length)
+                {
+                    // Destination is too small.
+                    throw new Exception("huffman decoding error");
+                }
+
+                dst[j++] = (byte)ch;
+
+                // If we crossed a byte boundary, advance i so we start at the next byte that's not fully decoded.
+                lastDecodedBits += decodedBits;
+                i += lastDecodedBits / 8;
+
+                // Modulo 8 since we only care about how many bits were decoded in the last byte that we processed.
+                lastDecodedBits %= 8;
+            }
+
+            return j;
+        }
+
+        /// <summary>
+        /// Decodes a single symbol from a 32-bit word.
+        /// </summary>
+        /// <param name="data">A 32-bit word containing a Huffman encoded symbol.</param>
+        /// <param name="validBits">
+        /// The number of bits in <paramref name="data"/> that may contain an encoded symbol.
+        /// This is not the exact number of bits that encode the symbol. Instead, it prevents
+        /// decoding the lower bits of <paramref name="data"/> if they don't contain any
+        /// encoded data.
+        /// </param>
+        /// <param name="decodedBits">The number of bits decoded from <paramref name="data"/>.</param>
+        /// <returns>The decoded symbol.</returns>
+        private static int DecodeValue(uint data, int validBits, out int decodedBits)
+        {
+            // The code below implements the decoding logic for a canonical Huffman code.
+            //
+            // To decode a symbol, we scan the decoding table, which is sorted by ascending symbol bit length.
+            // For each bit length b, we determine the maximum b-bit encoded value, plus one (that is codeMax).
+            // This is done with the following logic:
+            //
+            // if we're at the first entry in the table,
+            //    codeMax = the # of symbols encoded in b bits
+            // else,
+            //    left-shift codeMax by the difference between b and the previous entry's bit length,
+            //    then increment codeMax by the # of symbols encoded in b bits
+            //
+            // Next, we look at the value v encoded in the highest b bits of data. If v is less than codeMax,
+            // those bits correspond to a Huffman encoded symbol. We find the corresponding decoded
+            // symbol in the list of values associated with bit length b in the decoding table by indexing it
+            // with codeMax - v.
+
+            int codeMax = 0;
+
+            for (int i = 0; i < s_decodingTable.Length && s_decodingTable[i].codeLength <= validBits; i++)
+            {
+                (int codeLength, int[] codes) = s_decodingTable[i];
+
+                if (i > 0)
+                {
+                    codeMax <<= codeLength - s_decodingTable[i - 1].codeLength;
+                }
+
+                codeMax += codes.Length;
+
+                int mask = int.MinValue >> (codeLength - 1);
+                long masked = (data & mask) >> (32 - codeLength);
+
+                if (masked < codeMax)
+                {
+                    decodedBits = codeLength;
+                    return codes[codes.Length - (codeMax - masked)];
+                }
+            }
+
+            decodedBits = 0;
+            return -1;
+        }
+    }
+}

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -151,7 +151,7 @@ namespace System.Net.Test.Common
             var sep = new char[] { ':' };
             foreach (string line in headers)
             {
-                string[] tokens = line.Split(sep , 2);
+                string[] tokens = line.Split(sep, 2);
                 if (name.Equals(tokens[0], StringComparison.InvariantCultureIgnoreCase))
                 {
                     return tokens[1].Trim();
@@ -333,7 +333,7 @@ namespace System.Net.Test.Common
             "Transfer-Encoding: chunked\r\n" +
             additionalHeaders +
             "\r\n" +
-            (string.IsNullOrEmpty(content) ? "" : string.Concat(content.Select(c => $"1\r\n{c}\r\n"))) + 
+            (string.IsNullOrEmpty(content) ? "" : string.Concat(content.Select(c => $"1\r\n{c}\r\n"))) +
             $"0\r\n" +
             $"\r\n";
 
@@ -360,7 +360,7 @@ namespace System.Net.Test.Common
             public string Username { get; set; }
             public string Domain { get; set; }
             public string Password { get; set; }
-            public bool IsProxy  { get; set; } = false;
+            public bool IsProxy { get; set; } = false;
         }
 
         public sealed class Connection : IDisposable
@@ -475,11 +475,26 @@ namespace System.Net.Test.Common
             // Skip first line since it's the status line
             foreach (var line in headerLines.Skip(1))
             {
-                splits = line.Split(": ", 2);
-                requestData.Headers.Add(new HttpHeaderData(splits[0], splits[1]));
+                int offset = line.IndexOf(':');
+                string name = line.Substring(0, offset);
+                string value = line.Substring(offset + 1).TrimStart();
+                requestData.Headers.Add(new HttpHeaderData(name, value));
             }
 
             return requestData;
         }
+    }
+
+    public sealed class Http11LoopbackServerFactory : LoopbackServerFactory
+    {
+        public static readonly Http11LoopbackServerFactory Singleton = new Http11LoopbackServerFactory();
+
+        public override Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync)
+        {
+            return LoopbackServer.CreateServerAsync((server, uri) => funcAsync(server, uri));
+        }
+
+        public override bool IsHttp11 => true;
+        public override bool IsHttp2 => false;
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cookies.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cookies.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpCookieProtocolTests : HttpClientHandlerTestBase
+    public abstract class HttpClientHandlerTest_Cookies : HttpClientHandlerTestBase
     {
         private const string s_cookieName = "ABC";
         private const string s_cookieValue = "123";
@@ -675,7 +675,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    public abstract class HttpCookieProtocolTests_Http11 : HttpClientHandlerTestBase
+    public abstract class HttpClientHandlerTest_Cookies_Http11 : HttpClientHandlerTestBase
     {
         [Fact]
         public async Task GetAsync_ReceiveMultipleSetCookieHeaders_CookieAdded()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -591,7 +591,7 @@ namespace System.Net.Http.Functional.Tests
 
                 // Third response: Send headers, partial body
                 await server.SendDefaultResponseHeadersAsync(streamId3);
-                await server.SendResponseBodyAsync(streamId3, new byte[5], endStream: false);
+                await server.SendResponseDataAsync(streamId3, new byte[5], endStream: false);
 
                 // Send a GOAWAY frame that indicates that we will process all three streams
                 GoAwayFrame goAwayFrame = new GoAwayFrame(streamId3, 0, new byte[0], 0);
@@ -599,9 +599,9 @@ namespace System.Net.Http.Functional.Tests
 
                 // Finish sending responses
                 await server.SendDefaultResponseHeadersAsync(streamId1);
-                await server.SendResponseBodyAsync(streamId1, new byte[10], endStream: true);
-                await server.SendResponseBodyAsync(streamId2, new byte[10], endStream: true);
-                await server.SendResponseBodyAsync(streamId3, new byte[5], endStream: true);
+                await server.SendResponseDataAsync(streamId1, new byte[10], endStream: true);
+                await server.SendResponseDataAsync(streamId2, new byte[10], endStream: true);
+                await server.SendResponseDataAsync(streamId3, new byte[5], endStream: true);
 
                 // We will not send any more frames, so send EOF now, and ensure the client handles this properly.
                 server.ShutdownSend();

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
@@ -65,8 +65,12 @@ namespace System.Net.Http.Functional.Tests
             return field?.GetValue(handler);
         }
 
+#if netcoreapp
         protected LoopbackServerFactory LoopbackServerFactory => UseHttp2LoopbackServer ? 
                                                                 (LoopbackServerFactory)Http2LoopbackServerFactory.Singleton : 
                                                                 (LoopbackServerFactory)Http11LoopbackServerFactory.Singleton;
+#else
+        protected LoopbackServerFactory LoopbackServerFactory => Http11LoopbackServerFactory.Singleton;
+#endif
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -11,12 +11,8 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    using Configuration = System.Net.Test.Common.Configuration;
-
     public abstract class HttpCookieProtocolTests : HttpClientHandlerTestBase
     {
-        public static readonly object[][] EchoServers = Configuration.Http.EchoServers;
-
         private const string s_cookieName = "ABC";
         private const string s_cookieValue = "123";
         private const string s_expectedCookieHeaderValue = "ABC=123";
@@ -40,54 +36,52 @@ namespace System.Net.Http.Functional.Tests
 
         private static string GetCookieHeaderValue(string cookieName, string cookieValue) => $"{cookieName}={cookieValue}";
 
-
         [Fact]
         public async Task GetAsync_DefaultCoookieContainer_NoCookieSent()
         {
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
-            {
-                using (HttpClient client = CreateHttpClient())
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
                 {
-                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
-                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
-
-                    List<string> requestLines = await serverTask;
-
-                    Assert.Equal(0, requestLines.Count(s => s.StartsWith("Cookie:")));
-                }
-            });
+                    using (HttpClient client = CreateHttpClient())
+                    {
+                        await client.GetAsync(uri);
+                    }
+                },
+                async server =>
+                {
+                    HttpRequestData requestData = await server.HandleRequestAsync();
+                    Assert.Equal(0, requestData.GetHeaderValueCount("Cookie"));
+                });
         }
 
         [Theory]
         [MemberData(nameof(CookieNamesValuesAndUseCookies))]
         public async Task GetAsync_SetCookieContainer_CookieSent(string cookieName, string cookieValue, bool useCookies)
         {
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
-            {
-                HttpClientHandler handler = CreateHttpClientHandler();
-                handler.CookieContainer = CreateSingleCookieContainer(url, cookieName, cookieValue);
-                handler.UseCookies = useCookies;
-
-                using (HttpClient client = new HttpClient(handler))
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
                 {
-                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
-                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    handler.CookieContainer = CreateSingleCookieContainer(uri, cookieName, cookieValue);
+                    handler.UseCookies = useCookies;
 
-                    List<string> requestLines = await serverTask;
-
+                    using (HttpClient client = new HttpClient(handler))
+                    {
+                        await client.GetAsync(uri);
+                    }
+                },
+                async server =>
+                {
+                    HttpRequestData requestData = await server.HandleRequestAsync();
                     if (useCookies)
                     {
-                        Assert.Contains($"Cookie: {GetCookieHeaderValue(cookieName, cookieValue)}", requestLines);
-                        Assert.Equal(1, requestLines.Count(s => s.StartsWith("Cookie:")));
+                        Assert.Equal(GetCookieHeaderValue(cookieName, cookieValue), requestData.GetSingleHeaderValue("Cookie"));
                     }
                     else
                     {
-                        Assert.Equal(0, requestLines.Count(s => s.StartsWith("Cookie:")));
+                        Assert.Equal(0, requestData.GetHeaderValueCount("Cookie"));
                     }
-                }
-            });
+                });
         }
 
         [Fact]
@@ -100,31 +94,28 @@ namespace System.Net.Http.Functional.Tests
                 new Cookie("ABC", "123")
             };
 
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
-            {
-                HttpClientHandler handler = CreateHttpClientHandler();
-
-                var cookieContainer = new CookieContainer();
-                foreach (Cookie c in cookies)
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
                 {
-                    cookieContainer.Add(url, c);
-                }
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    var cookieContainer = new CookieContainer();
+                    foreach (Cookie c in cookies)
+                    {
+                        cookieContainer.Add(uri, c);
+                    }
+                    handler.CookieContainer = cookieContainer;
 
-                handler.CookieContainer = cookieContainer;
-
-                using (HttpClient client = new HttpClient(handler))
+                    using (HttpClient client = new HttpClient(handler))
+                    {
+                        await client.GetAsync(uri);
+                    }
+                },
+                async server =>
                 {
-                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
-                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
-
-                    List<string> requestLines = await serverTask;
-
-                    string expectedHeader = "Cookie: " + string.Join("; ", cookies.Select(c => $"{c.Name}={c.Value}").ToArray());
-                    Assert.Contains(expectedHeader, requestLines);
-                    Assert.Equal(1, requestLines.Count(s => s.StartsWith("Cookie:")));
-                }
-            });
+                    HttpRequestData requestData = await server.HandleRequestAsync();
+                    string expectedHeaderValue = string.Join("; ", cookies.Select(c => $"{c.Name}={c.Value}").ToArray());
+                    Assert.Equal(expectedHeaderValue, requestData.GetSingleHeaderValue("Cookie"));
+                });
         }
 
         [Fact]
@@ -136,91 +127,23 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
-            {
-                HttpClientHandler handler = CreateHttpClientHandler();
-                using (HttpClient client = new HttpClient(handler))
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
                 {
-                    HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
-                    requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    using (HttpClient client = new HttpClient(handler))
+                    {
+                        HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
+                        requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
 
-                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
-
-                    List<string> requestLines = await serverTask;
-
-                    Assert.Contains($"Cookie: {s_customCookieHeaderValue}", requestLines);
-                    Assert.Equal(1, requestLines.Count(s => s.StartsWith("Cookie:")));
-                }
-            });
-        }
-
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "HTTP/2 is not supported on NetFX, and manually added Cookie header will be ignored if sent with container cookies")]
-        [OuterLoop("Uses external server")]
-        [Theory, MemberData(nameof(EchoServers))]
-        public async Task SendAsync_RemoteServersWithCookies_Success(Uri remoteServer)
-        {
-            // CurlHandler: cookies from container are not sent if a Cookie header is manually added #26983.
-            if (IsCurlHandler) return;
-
-            var expectedVersion = new Version(1,1);
-            HttpClientHandler handler = CreateHttpClientHandler();
-
-            if (remoteServer.Host == Configuration.Http.Http2Host && BackendSupportsAlpn)
-            {
-                // Windows 10 Anniversary release a.k.a Windows 10 Version 1607 added support to native WinHTTP for HTTP/2 protocol support.
-                if (IsWinHttpHandler && !PlatformDetection.IsWindows10Version1607OrGreater) return;
-
-                expectedVersion = new Version(2,0);
-            }
-
-            using (HttpClient client = new HttpClient(handler))
-            {
-                var request = new HttpRequestMessage(HttpMethod.Get, remoteServer)
+                        await client.SendAsync(requestMessage);
+                    }
+                },
+                async server =>
                 {
-                    Version = expectedVersion,
-                };
-
-                // Make remote server send SetCookie header.
-                request.Headers.Add("X-SetCookie", "name=value");
-                request.Headers.Add("X-SetCookie", "name1=value1");
-                request.Headers.Add("X-SetCookie", "name2=value2");
-
-                using (HttpResponseMessage response = await client.SendAsync(request))
-                {
-                    Assert.Equal(expectedVersion, response.Version);
-                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-                    // Verify server sends back SetCookie header.
-                    Assert.Contains("Set-Cookie: name=value, name1=value1, name2=value2", response.Headers.ToString());
-
-                    // Server does not have any cookies yet.
-                    Assert.Contains("\"Cookies\": {}", await response.Content.ReadAsStringAsync());
-                }
-
-                // Send next request to see if the cookie has been wrote to the header.
-                var newRequest = new HttpRequestMessage(HttpMethod.Get, remoteServer)
-                {
-                    Version = expectedVersion,
-                };
-
-                // Send additional cookie (along with the ones from CookieContainer).
-                newRequest.Headers.Add("Cookie", "cookie=c1");
-
-                using (HttpResponseMessage response = await client.SendAsync(newRequest))
-                {
-                    Assert.Equal(expectedVersion, response.Version);
-                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-                    // Verify server received all cookies.
-                    string body = await response.Content.ReadAsStringAsync();
-                    Assert.Contains("\"Cookies\": ", body);
-                    Assert.Contains("\"name\": \"value\"", body);
-                    Assert.Contains("\"name1\": \"value1\"", body);
-                    Assert.Contains("\"name2\": \"value2\"", body);
-                    Assert.Contains("\"cookie\": \"c1\"", body);
-                }
-            }
+                    HttpRequestData requestData = await server.HandleRequestAsync();
+                    Assert.Equal(s_customCookieHeaderValue, requestData.GetSingleHeaderValue("Cookie"));
+                });
         }
 
         [ActiveIssue(30051, TargetFrameworkMonikers.Uap)]
@@ -233,33 +156,41 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            if (LoopbackServerFactory.IsHttp2 && UseSocketsHttpHandler)
             {
-                HttpClientHandler handler = CreateHttpClientHandler();
-                using (HttpClient client = new HttpClient(handler))
+                // ISSUE #34377: We are not handling multi-valued headers correctly
+                return;
+            }
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
                 {
-                    HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
-                    requestMessage.Headers.Add("Cookie", "A=1");
-                    requestMessage.Headers.Add("Cookie", "B=2");
-                    requestMessage.Headers.Add("Cookie", "C=3");
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    using (HttpClient client = new HttpClient(handler))
+                    {
+                        HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
+                        requestMessage.Headers.Add("Cookie", "A=1");
+                        requestMessage.Headers.Add("Cookie", "B=2");
+                        requestMessage.Headers.Add("Cookie", "C=3");
 
-                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
-
-                    List<string> requestLines = await serverTask;
-
-                    Assert.Equal(1, requestLines.Count(s => s.StartsWith("Cookie: ")));
+                        await client.SendAsync(requestMessage);
+                    }
+                },
+                async server =>
+                {
+                    HttpRequestData requestData = await server.HandleRequestAsync();
 
                     // Multiple Cookie header values are treated as any other header values and are 
                     // concatenated using ", " as the separator.
 
-                    var cookieValues = requestLines.Single(s => s.StartsWith("Cookie: ")).Substring(8).Split(new string[] { ", " }, StringSplitOptions.None);
+                    string cookieHeaderValue = requestData.GetSingleHeaderValue("Cookie");
+
+                    var cookieValues = cookieHeaderValue.Split(new string[] { ", " }, StringSplitOptions.None);
                     Assert.Contains("A=1", cookieValues);
                     Assert.Contains("B=2", cookieValues);
                     Assert.Contains("C=3", cookieValues);
                     Assert.Equal(3, cookieValues.Count());
-                }
-            });
+                });
         }
 
         [Fact]
@@ -278,7 +209,13 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            if (LoopbackServerFactory.IsHttp2 && UseSocketsHttpHandler)
+            {
+                // ISSUE #34377: We are not handling multi-valued headers correctly
+                return;
+            }
+
+            await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.CookieContainer = CreateSingleCookieContainer(url);
@@ -289,14 +226,13 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
+                    Task<HttpRequestData> serverTask = server.HandleRequestAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
-                    List<string> requestLines = await serverTask;
+                    HttpRequestData requestData = await serverTask;
+                    string cookieHeaderValue = requestData.GetSingleHeaderValue("Cookie");
 
-                    Assert.Equal(1, requestLines.Count(s => s.StartsWith("Cookie: ")));
-
-                    var cookies = requestLines.Single(s => s.StartsWith("Cookie: ")).Substring(8).Split(new string[] { "; " }, StringSplitOptions.None);
+                    var cookies = cookieHeaderValue.Split(new string[] { "; " }, StringSplitOptions.None);
                     Assert.Contains(s_expectedCookieHeaderValue, cookies);
                     Assert.Contains(s_customCookieHeaderValue, cookies);
                     Assert.Equal(2, cookies.Count());
@@ -321,7 +257,13 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            if (LoopbackServerFactory.IsHttp2 && UseSocketsHttpHandler)
+            {
+                // ISSUE #34377: We are not handling multi-valued headers correctly
+                return;
+            }
+
+            await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.CookieContainer = CreateSingleCookieContainer(url);
@@ -333,18 +275,17 @@ namespace System.Net.Http.Functional.Tests
                     requestMessage.Headers.Add("Cookie", "B=2");
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
+                    Task<HttpRequestData> serverTask = server.HandleRequestAsync();
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
-                    List<string> requestLines = await serverTask;
-
-                    Assert.Equal(1, requestLines.Count(s => s.StartsWith("Cookie: ")));
+                    HttpRequestData requestData = await serverTask;
+                    string cookieHeaderValue = requestData.GetSingleHeaderValue("Cookie");
 
                     // Multiple Cookie header values are treated as any other header values and are 
                     // concatenated using ", " as the separator.  The container cookie is concatenated to
                     // one of these values using the "; " cookie separator.
 
-                    var cookieValues = requestLines.Single(s => s.StartsWith("Cookie: ")).Substring(8).Split(new string[] { ", " }, StringSplitOptions.None);
+                    var cookieValues = cookieHeaderValue.Split(new string[] { ", " }, StringSplitOptions.None);
                     Assert.Equal(2, cookieValues.Count());
 
                     // Find container cookie and remove it so we can validate the rest of the cookie header values
@@ -376,7 +317,7 @@ namespace System.Net.Http.Functional.Tests
             const string path1 = "/foo";
             const string path2 = "/bar";
 
-            await LoopbackServer.CreateClientAndServerAsync(async url =>
+            await LoopbackServerFactory.CreateClientAndServerAsync(async url =>
             {
                 Uri url1 = new Uri(url, path1);
                 Uri url2 = new Uri(url, path2);
@@ -396,15 +337,11 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                List<string> request1Lines = await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.Found, $"Location: {path2}\r\n");
+                HttpRequestData requestData1 = await server.HandleRequestAsync(HttpStatusCode.Found, new HttpHeaderData[] { new HttpHeaderData("Location", path2) });
+                Assert.Equal("cookie1=value1", requestData1.GetSingleHeaderValue("Cookie"));
 
-                Assert.Contains($"Cookie: cookie1=value1", request1Lines);
-                Assert.Equal(1, request1Lines.Count(s => s.StartsWith("Cookie:")));
-
-                List<string> request2Lines = await server.AcceptConnectionSendResponseAndCloseAsync(content: s_simpleContent);
-
-                Assert.Contains($"Cookie: cookie2=value2", request2Lines);
-                Assert.Equal(1, request2Lines.Count(s => s.StartsWith("Cookie:")));
+                HttpRequestData requestData2 = await server.HandleRequestAsync(content: s_simpleContent);
+                Assert.Equal("cookie2=value2", requestData2.GetSingleHeaderValue("Cookie"));
             });
         }
 
@@ -416,7 +353,7 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(CookieNamesValuesAndUseCookies))]
         public async Task GetAsync_ReceiveSetCookieHeader_CookieAdded(string cookieName, string cookieValue, bool useCookies)
         {
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.UseCookies = useCookies;
@@ -424,8 +361,8 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        HttpStatusCode.OK, $"Set-Cookie: {GetCookieHeaderValue(cookieName, cookieValue)}\r\n", s_simpleContent);
+                    Task<HttpRequestData> serverTask = server.HandleRequestAsync(
+                        HttpStatusCode.OK, new HttpHeaderData[] { new HttpHeaderData("Set-Cookie", GetCookieHeaderValue(cookieName, cookieValue)) }, s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     CookieCollection collection = handler.CookieContainer.GetCookies(url);
@@ -447,18 +384,21 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_ReceiveMultipleSetCookieHeaders_CookieAdded()
         {
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
 
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
+                    Task<HttpRequestData> serverTask = server.HandleRequestAsync(
                         HttpStatusCode.OK,
-                        $"Set-Cookie: A=1; Path=/\r\n" +
-                        $"Set-Cookie   : B=2; Path=/\r\n" + // space before colon to verify header is trimmed and recognized
-                        $"Set-Cookie:    C=3; Path=/\r\n",
+                        new HttpHeaderData[]
+                        {
+                            new HttpHeaderData("Set-Cookie", "A=1; Path=/"),
+                            new HttpHeaderData("Set-Cookie", "B=2; Path=/"),
+                            new HttpHeaderData("Set-Cookie", "C=3; Path=/")
+                        },
                         s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -481,7 +421,7 @@ namespace System.Net.Http.Functional.Tests
         {
             const string newCookieValue = "789";
 
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.CookieContainer = CreateSingleCookieContainer(url);
@@ -489,8 +429,10 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        HttpStatusCode.OK, $"Set-Cookie: {s_cookieName}={newCookieValue}\r\n", s_simpleContent);
+                    Task<HttpRequestData> serverTask = server.HandleRequestAsync(
+                        HttpStatusCode.OK,
+                        new HttpHeaderData[] { new HttpHeaderData("Set-Cookie", $"{s_cookieName}={newCookieValue}") },
+                        s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     CookieCollection collection = handler.CookieContainer.GetCookies(url);
@@ -505,7 +447,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_ReceiveSetCookieHeader_CookieRemoved()
         {
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.CookieContainer = CreateSingleCookieContainer(url);
@@ -513,8 +455,10 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
-                        HttpStatusCode.OK, $"Set-Cookie: {s_cookieName}=; Expires=Sun, 06 Nov 1994 08:49:37 GMT\r\n", s_simpleContent);
+                    Task<HttpRequestData> serverTask = server.HandleRequestAsync(
+                        HttpStatusCode.OK,
+                        new HttpHeaderData[] { new HttpHeaderData("Set-Cookie", $"{s_cookieName}=; Expires=Sun, 06 Nov 1994 08:49:37 GMT") },
+                        s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
                     CookieCollection collection = handler.CookieContainer.GetCookies(url);
@@ -533,18 +477,21 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
 
                 using (HttpClient client = new HttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
+                    Task<HttpRequestData> serverTask = server.HandleRequestAsync(
                         HttpStatusCode.OK,
-                        $"Set-Cookie: A=1; Path=/;Expires=asdfsadgads\r\n" +    // invalid Expires
-                        $"Set-Cookie: B=2; Path=/\r\n" + 
-                        $"Set-Cookie: C=3; Path=/\r\n",
+                        new HttpHeaderData[]
+                        {
+                            new HttpHeaderData("Set-Cookie", "A=1; Path=/;Expires=asdfsadgads"), // invalid Expires
+                            new HttpHeaderData("Set-Cookie", "B=2; Path=/"),
+                            new HttpHeaderData("Set-Cookie", "C=3; Path=/")
+                        },
                         s_simpleContent);
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
 
@@ -567,7 +514,7 @@ namespace System.Net.Http.Functional.Tests
             const string path1 = "/foo";
             const string path2 = "/bar";
 
-            await LoopbackServer.CreateClientAndServerAsync(async url =>
+            await LoopbackServerFactory.CreateClientAndServerAsync(async url =>
             {
                 Uri url1 = new Uri(url, path1);
 
@@ -592,16 +539,25 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                List<string> request1Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
-                    HttpStatusCode.Found, $"Location: {path2}\r\nSet-Cookie: A=1; Path=/\r\n");
+                HttpRequestData requestData1 = await server.HandleRequestAsync(
+                    HttpStatusCode.Found,
+                    new HttpHeaderData[]
+                    {
+                        new HttpHeaderData("Location", $"{path2}"),
+                        new HttpHeaderData("Set-Cookie", "A=1; Path=/")
+                    });
 
-                Assert.Equal(0, request1Lines.Count(s => s.StartsWith("Cookie:")));
+                Assert.Equal(0, requestData1.GetHeaderValueCount("Cookie"));
 
-                List<string> request2Lines = await server.AcceptConnectionSendResponseAndCloseAsync(
-                    HttpStatusCode.OK, $"Set-Cookie: B=2; Path=/\r\n", s_simpleContent);
+                HttpRequestData requestData2 = await server.HandleRequestAsync(
+                    HttpStatusCode.OK,
+                    new HttpHeaderData[]
+                    {
+                        new HttpHeaderData("Set-Cookie", "B=2; Path=/")
+                    },
+                    s_simpleContent);
 
-                Assert.Contains($"Cookie: A=1", request2Lines);
-                Assert.Equal(1, request2Lines.Count(s => s.StartsWith("Cookie:")));
+                Assert.Equal("A=1", requestData2.GetSingleHeaderValue("Cookie"));
             });
         }
 
@@ -616,7 +572,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            await LoopbackServer.CreateClientAndServerAsync(async url =>
+            await LoopbackServerFactory.CreateClientAndServerAsync(async url =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.Credentials = new NetworkCredential("user", "pass");
@@ -639,22 +595,25 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                await server.AcceptConnectionAsync(async connection =>
-                {
-                    List<string> request1Lines = await connection.ReadRequestHeaderAndSendResponseAsync(
-                        HttpStatusCode.Unauthorized,
-                        $"WWW-Authenticate: Basic realm=\"WallyWorld\"\r\nSet-Cookie: A=1; Path=/\r\n");
+                HttpRequestData requestData1 = await server.HandleRequestAsync(
+                    HttpStatusCode.Unauthorized,
+                    new HttpHeaderData[]
+                    {
+                        new HttpHeaderData("WWW-Authenticate", "Basic realm=\"WallyWorld\""),
+                        new HttpHeaderData("Set-Cookie", "A=1; Path=/")
+                    });
 
-                    Assert.Equal(0, request1Lines.Count(s => s.StartsWith("Cookie:")));
+                Assert.Equal(0, requestData1.GetHeaderValueCount("Cookie"));
 
-                    List<string> request2Lines = await connection.ReadRequestHeaderAndSendResponseAsync(
-                        HttpStatusCode.OK,
-                        $"Set-Cookie: B=2; Path=/\r\n",
-                        s_simpleContent);
+                HttpRequestData requestData2 = await server.HandleRequestAsync(
+                    HttpStatusCode.OK,
+                    new HttpHeaderData[]
+                    {
+                        new HttpHeaderData("Set-Cookie", "B=2; Path=/")
+                    },
+                    s_simpleContent);
 
-                    Assert.Contains($"Cookie: A=1", request2Lines);
-                    Assert.Equal(1, request2Lines.Count(s => s.StartsWith("Cookie:")));
-                });
+                Assert.Equal("A=1", requestData2.GetSingleHeaderValue("Cookie"));
             });
         }
 
@@ -713,6 +672,41 @@ namespace System.Net.Http.Functional.Tests
                 yield return new object[] { "foo", GenerateCookie(name: "foo", repeat: 'a', overallHeaderValueLength: 256), useCookies };
                 yield return new object[] { "foo", GenerateCookie(name: "foo", repeat: 'a', overallHeaderValueLength: 257), useCookies };
             }
+        }
+    }
+
+    public abstract class HttpCookieProtocolTests_Http11 : HttpClientHandlerTestBase
+    {
+        [Fact]
+        public async Task GetAsync_ReceiveMultipleSetCookieHeaders_CookieAdded()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpClientHandler handler = CreateHttpClientHandler();
+
+                using (HttpClient client = new HttpClient(handler))
+                {
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(
+                        HttpStatusCode.OK,
+                        $"Set-Cookie: A=1; Path=/\r\n" +
+                        $"Set-Cookie   : B=2; Path=/\r\n" + // space before colon to verify header is trimmed and recognized
+                        $"Set-Cookie:    C=3; Path=/\r\n",
+                        "Hello world!");
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    CookieCollection collection = handler.CookieContainer.GetCookies(url);
+                    Assert.Equal(3, collection.Count);
+
+                    // Convert to array so we can more easily process contents, since CookieCollection does not implement IEnumerable<Cookie>
+                    Cookie[] cookies = new Cookie[3];
+                    collection.CopyTo(cookies, 0);
+
+                    Assert.Contains(cookies, c => c.Name == "A" && c.Value == "1");
+                    Assert.Contains(cookies, c => c.Name == "B" && c.Value == "2");
+                    Assert.Contains(cookies, c => c.Name == "C" && c.Value == "3");
+                }
+            });
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Xunit;
 using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
@@ -139,6 +140,11 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => false;
     }
 
+    public sealed class PlatformHandler_HttpCookieProtocolTests_Http11 : HttpCookieProtocolTests_Http11
+    {
+        protected override bool UseSocketsHttpHandler => false;
+    }
+
     public sealed class PlatformHandler_HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientHandler_MaxResponseHeadersLength_Test
     {
         protected override bool UseSocketsHttpHandler => false;
@@ -154,11 +160,18 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => false;
     }
 
-// Enable this to run HTTP2 tests on platform handler
+    // Enable this to run HTTP2 tests on platform handler
 #if PLATFORM_HANDLER_HTTP2_TESTS
     public sealed class PlatformHandlerTest_Http2 : HttpClientHandlerTest_Http2
     {
         protected override bool UseSocketsHttpHandler => false;
+    }
+
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+    public sealed class PlatformHandlerTest_Cookies_Http2 : HttpCookieProtocolTests
+    {
+        protected override bool UseSocketsHttpHandler => false;
+        protected override bool UseHttp2LoopbackServer => true;
     }
 #endif
 }

--- a/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -135,12 +135,12 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => false;
     }
 
-    public sealed class PlatformHandler_HttpCookieProtocolTests : HttpCookieProtocolTests
+    public sealed class PlatformHandlerTest_Cookies : HttpClientHandlerTest_Cookies
     {
         protected override bool UseSocketsHttpHandler => false;
     }
 
-    public sealed class PlatformHandler_HttpCookieProtocolTests_Http11 : HttpCookieProtocolTests_Http11
+    public sealed class PlatformHandlerTest_Cookies_Http11 : HttpClientHandlerTest_Cookies_Http11
     {
         protected override bool UseSocketsHttpHandler => false;
     }
@@ -168,7 +168,7 @@ namespace System.Net.Http.Functional.Tests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-    public sealed class PlatformHandlerTest_Cookies_Http2 : HttpCookieProtocolTests
+    public sealed class PlatformHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {
         protected override bool UseSocketsHttpHandler => false;
         protected override bool UseHttp2LoopbackServer => true;

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -505,6 +505,11 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => true;
     }
 
+    public sealed class SocketsHttpHandler_HttpCookieProtocolTests_Http11 : HttpCookieProtocolTests_Http11
+    {
+        protected override bool UseSocketsHttpHandler => true;
+    }
+
     public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test : HttpClientHandler_Cancellation_Test
     {
         protected override bool UseSocketsHttpHandler => true;
@@ -1636,5 +1641,12 @@ namespace System.Net.Http.Functional.Tests
     public sealed class SocketsHttpHandlerTest_Http2 : HttpClientHandlerTest_Http2
     {
         protected override bool UseSocketsHttpHandler => true;
+    }
+
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+    public sealed class SocketsHttpHandlerTest_Cookies_Http2 : HttpCookieProtocolTests
+    {
+        protected override bool UseSocketsHttpHandler => true;
+        protected override bool UseHttp2LoopbackServer => true;
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -500,12 +500,12 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => true;
     }
 
-    public sealed class SocketsHttpHandler_HttpCookieProtocolTests : HttpCookieProtocolTests
+    public sealed class SocketsHttpHandlerTest_Cookies : HttpClientHandlerTest_Cookies
     {
         protected override bool UseSocketsHttpHandler => true;
     }
 
-    public sealed class SocketsHttpHandler_HttpCookieProtocolTests_Http11 : HttpCookieProtocolTests_Http11
+    public sealed class SocketsHttpHandlerTest_Cookies_Http11 : HttpClientHandlerTest_Cookies_Http11
     {
         protected override bool UseSocketsHttpHandler => true;
     }
@@ -1644,7 +1644,7 @@ namespace System.Net.Http.Functional.Tests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-    public sealed class SocketsHttpHandlerTest_Cookies_Http2 : HttpCookieProtocolTests
+    public sealed class SocketsHttpHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {
         protected override bool UseSocketsHttpHandler => true;
         protected override bool UseHttp2LoopbackServer => true;

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -103,7 +103,7 @@
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
     <Compile Include="HttpMethodTest.cs" />
-    <Compile Include="HttpCookieProtocolTests.cs" />
+    <Compile Include="HttpClientHandlerTest.Cookies.cs" />
     <Compile Include="HttpRetryProtocolTests.cs" />
     <Compile Include="IdnaProtocolTests.cs" />
     <Compile Include="HttpProtocolTests.cs" />

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -61,6 +61,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs">
       <Link>Common\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
+      <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Threading\TrackingSynchronizationContext.cs">
       <Link>Common\System\Threading\TrackingSynchronizationContext.cs</Link>
     </Compile>
@@ -136,6 +139,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Http\Http2LoopbackServer.cs">
       <Link>Common\System\Net\Http\Http2LoopbackServer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Http\HuffmanDecoder.cs">
+      <Link>Common\System\Net\Http\HuffmanDecoder.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -21,6 +21,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
+      <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>

--- a/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
+++ b/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
@@ -17,6 +17,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
+      <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
+      <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>


### PR DESCRIPTION
I'm posting this PR to get early feedback on the general direction here. I'd like to convert some more tests to use this model before I'm ready to merge.

This PR adds a "GenericLoopbackServer" base class that abstracts over different HTTP protocol versions (HTTP/1.1, HTTP2, more in the future). I've added basic implementations of this for HTTP/1.1 and HTTP/2. I've also converted the existing Cookie tests to use this model.

Some notes:

(1) Names aren't ideal. Existing "LoopbackServer" should probably become "Http11LoopbackServer". Feedback welcome.

(2) HTTP2 tests require disabling cert validation. I've done this by adding a bool argument to CreateHttpClientHandler. This isn't ideal; I keep modifying tests and forgetting to change this and then getting cert validation errors. I wish this was more automatic, but not sure how to do that.

(3) This tests platform handlers as well as SocketsHttpHandler. The main value here is to ensure consistent behavior across handlers. I've confirmed that the converted tests pass for WinHttpHandler.

(4) We're inconsistent about using LoopbackServer.CreateServerAsync vs LoopbackServer.CreateClientAndServerAsync. The former is more powerful, because you can interleave client and server logic; however, in many cases this isn't necessary, and using the latter makes the tests a bit simpler. I started by converting a few of the CreateServerAsync-based tests to use CreateClientAndServerAsync, but dropped this at some point because it was a lot of change. I'm looking for feedback about whether we care about this or not. I expect we're going to be doing a fair amount of this sort of conversion work for a variety of tests, so if the CreateClientAndServerAsync model is preferred, now is a good time to change tests.

(5) There's one test that was doing some HTTP/1.1-specific header formatting things. I ended up creating a generic test for this, but also leaving the HTTP/1.1 specific version. I'm not sure it's really adding anything, because we should be validating header processing in other tests; but I left it in just in case.

(6) As you can see, one implication is that nearly all tests end up as [Theory] instead of [Fact], because they take a LoopbackServerFactory parameter. I think this is fine, but it also has some messy implications -- lots of MemberData stuff will need to be modified to add this parameter.

(7) We could possibly add more variations of LoopbackServers in the future. One obvious example is HTTPS (with HTTP/1.1). For many tests this is probably just duplicative of HTTP/1.1, since 1.1 over SSL isn't really any different than plain HTTP/1.1. For other tests, though, it may be useful to run generically over an HTTP/1.1 SSL loopback server. For SSL tests, we probably want these to run for both HTTP/1.1 and HTTP/2; redirect tests do some things with secure->nonsecure redirects as well.

Another possibility here is to implement "loopback servers" that provide modified behavior, e.g. chunked encoded content for HTTP/1.1, or different header encoding approaches for HTTP/2. I'm not sure how far we want to go with this, as the matrix could get huge quickly, but it's interesting to consider.

(8) There was one existing remote server Cookie test. It didn't seem to be adding any value over the existing loopback tests, so I removed it.

@dotnet/ncl