### PR TITLE
Fix runtime package build for -allconfigurations build on Linux

### DIFF
--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -17,7 +17,7 @@
        We'll add a RID for the current platform even if it isn't in the officially supported set -->
   <ItemGroup Condition="'@(OfficialBuildRID)' != ''">
     <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
-    <BuildRID Include="$(PackageRID)">
+    <BuildRID Include="$(PackageRID)" Condition="'$(BuildsEvenIfRIDNotOfficiallySupported)' == 'true'">
       <Platform Condition="'$(ArchGroup)' == 'x64'">amd64</Platform>
       <Platform Condition="'$(ArchGroup)' != 'x64'">$(ArchGroup)</Platform>
     </BuildRID>

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
@@ -37,4 +37,7 @@
       <Platform>wasm</Platform>
     </OfficialBuildRID>
   </ItemGroup>
+  <PropertyGroup>
+    <BuildsEvenIfRIDNotOfficiallySupported>true</BuildsEvenIfRIDNotOfficiallySupported>
+  </PropertyGroup>
 </Project>

--- a/pkg/dir.traversal.targets
+++ b/pkg/dir.traversal.targets
@@ -20,11 +20,19 @@
 
   <!-- When @(BuildRID) is set, filter the set of projects down to only those applicable to $(PackageRID) -->
   <Target Name="FilterProjectsPackageRID" Condition="'@(BuildRID)' != ''">
+    <!--
+      Include the runtime suffix ('-aot') when matching up package target runtimes with PackageRID.
+      This makes sure /p:PackageRID=linux-x64 only matches linux-x64, not linux-x64-aot.
+    -->
+    <PropertyGroup Condition="'$(PackageTargetRuntimeSuffix)' != ''">
+      <PackageTargetRuntimeSuffixWithDash>-$(PackageTargetRuntimeSuffix)</PackageTargetRuntimeSuffixWithDash>
+    </PropertyGroup>
+
     <ItemGroup>
       <!-- Build identity package, when SkipBuildIdentityPackage is not set -->
       <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '' AND '$(SkipBuildIdentityPackage)' != 'true'" />
       <!-- Build packages for current RID, when SkipBuildRuntimePackage is not set -->
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' AND '$(SkipBuildRuntimePackage)' != 'true'" />
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)$(PackageTargetRuntimeSuffixWithDash)' == '$(PackageRID)' AND '$(SkipBuildRuntimePackage)' != 'true'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I hit a few issues trying to get `-allconfigurations --pack /p:SkipBuildRuntimePackage=false /p:PackageRID=linux-x64` able to build on Linux (https://github.com/dotnet/source-build/issues/210) where the build tries to create some runtime packages that can't be built or don't make sense. More details in the commit messages.

This might be exploring new ground, since the official build builds runtime packages on separate legs than the `-allconfigurations` leg, but in source-build we need both `-allconfigurations` and runtime packages on the same machine. It seems to behave reasonably with these changes, though.