### PR TITLE
Disable tests using TestService on NETFX

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 namespace System.ServiceProcess.Tests
 {
     [OuterLoop(/* Modifies machine state */)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Persistent issues starting test service on NETFX")]
     public class ServiceBaseTests : IDisposable
     {
         private const int connectionTimeout = 30000;

--- a/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 namespace System.ServiceProcess.Tests
 {
     [OuterLoop(/* Modifies machine state */)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Persistent issues starting test service on NETFX")]
     public class ServiceControllerTests : IDisposable
     {
         private const int connectionTimeout = 30000;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34363

#32893 didn't help. Doesn't repro locally. I will just permanently disable all these tests that rely on the test service on .NET Framework. It is not very important that they run on .NET Framework.