### PR TITLE
Cleanup publish.proj to use arcade's target to push to blob feed

### DIFF
--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -43,13 +43,14 @@ jobs:
 
       - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
                 -warnaserror:0 -ci
-                /t:PublishToAzureBlobFeed
+                /t:PublishPackagesToBlobFeed
                 /p:ManifestBuildId=$(Build.BuildNumber)
                 /p:ManifestBranch=$(Build.SourceBranchName)
                 /p:ManifestCommit=$(Build.SourceVersion)
                 /p:ManifestRepoUri=$(Build.Repository.Uri)
                 /p:AccountKey=$(dotnetfeed-storage-access-key-1)
                 /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
+                /p:IncludeSymbolsOnPackagePublish=true
         displayName: Push to dotnet feed
 
       - task: PublishBuildArtifacts@1

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -8,8 +8,8 @@
 
   <PropertyGroup>
     <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">corefx</GitHubRepositoryName>
-    <AssetManifestFileName Condition="'$(AssetsManifestFileName)' == '' AND '$(ManifestBuildId)' != ''">$(GitHubRepositoryName)-$(ManifestBuildId)</AssetManifestFileName>
-    <AssetManifestFileName Condition="'$(AssetsManifestFileName)' == ''">$(GitHubRepositoryName)</AssetManifestFileName>
+    <AssetManifestFileName Condition="'$(AssetManifestFileName)' == '' AND '$(ManifestBuildId)' != ''">$(GitHubRepositoryName)-$(ManifestBuildId)</AssetManifestFileName>
+    <AssetManifestFileName Condition="'$(AssetManifestFileName)' == ''">$(GitHubRepositoryName)</AssetManifestFileName>
     <AssetManifestFilePath>$(ArtifactsDir)AssetManifests\$(AssetManifestFileName).xml</AssetManifestFilePath>
 
     <PackageOutputRoot Condition="'$(PackagesOutputRoot)' == ''">$(ArtifactsDir)/packages/</PackageOutputRoot>
@@ -38,27 +38,10 @@
       <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
     </SymbolPackagesToPublish>
 
+    <PackagesToPublish Condition="'$(IncludeSymbolsOnPackagePublish)' == 'true'" Include="@(SymbolPackagesToPublish)" />
+
     <PublishSymbolsDependsOn Include="SetupPublishSymbols" />
   </ItemGroup>
-
-  <Target Name="PublishToAzureBlobFeed">
-    <Error Condition="'@(PackagesToPublish)'==''" Text="PackagesToPublish for packages is empty." />
-
-    <!-- Include Symbols when publishing to blob feed so that the manifest contains symbols and we send all the assets to BAR -->
-    <ItemGroup>
-      <PackagesToPublish Include="@(SymbolPackagesToPublish)" />
-    </ItemGroup>
-
-    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
-                    AccountKey="$(AccountKey)"
-                    ItemsToPush="@(PackagesToPublish)"
-                    Overwrite="$(PublishOverwrite)"
-                    AssetManifestPath="$(AssetManifestFilePath)"
-                    ManifestBuildId="$(ManifestBuildId)"
-                    ManifestBranch="$(ManifestBranch)"
-                    ManifestCommit="$(ManifestCommit)"
-                    ManifestRepoUri="$(ManifestRepoUri)" />
-  </Target>
 
   <Target Name="NuGetPush">
 


### PR DESCRIPTION
Before: https://github.com/dotnet/arcade/pull/1620 we needed to call directly the msbuild task. Now we only need to call the target inside arcade and populate the right item with the packages to publish.

Testing in: https://dnceng.visualstudio.com/internal/_build/results?buildId=66803