### PR TITLE
Reuse GenAPI GenerateReferenceAssemblySource target

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -173,26 +173,6 @@
     <Message Importance="High" Condition="'$(ConfigurationErrorMsg)' != ''" Text="$(MSBuildProjectFullPath) ConfigurationErrorMessage: $(ConfigurationErrorMsg)" />
   </Target>
 
-  <Target Name="GenerateReferenceSource">
-    <PropertyGroup>
-      <_RefSourceFileOutputPath>$(MSBuildProjectDirectory)/../ref/$(AssemblyName).cs</_RefSourceFileOutputPath>
-      <_ExcludeAPIList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAPIList>
-      <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <_GenAPICmd>$(_GenAPICommand)</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) "@(IntermediateAssembly)"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --lib-path "$(RefPath)"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --out "$(_RefSourceFileOutputPath)"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --exclude-attributes-list "$(_ExcludeAPIList)"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --header-file "$(_LicenseHeaderTxtPath)"</_GenAPICmd>
-    </PropertyGroup>
-
-    <Exec Command="$(_GenAPICmd)" />
-    <Message Text="Generated reference assembly source code: $(_RefSourceFileOutputPath)" />
-  </Target>
-
   <Import Project="$(RepositoryEngineeringDir)/DisableSourceControlManagement.targets" Condition="'$(EnableSourceLink)' == 'false'" />
 
   <!-- Define this now until we can clean-up targets that depend on it in the packaging targets -->

--- a/Documentation/coding-guidelines/updating-ref-source.md
+++ b/Documentation/coding-guidelines/updating-ref-source.md
@@ -2,15 +2,15 @@ This document provides the steps you need to take to update the reference assemb
 
 ## For most assemblies within corefx
 1) Implement the API in the source assembly and [build it](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md#building-individual-libraries).
-2) Run the following command (from the src directory) `msbuild /t:GenerateReferenceSource` to update the reference assembly**.
+2) Run the following command (from the src directory) `msbuild /t:GenerateReferenceAssemblySource` to update the reference assembly**.
 3) Navigate to the ref directory and build the reference assembly.
 4) Add, build, and run tests.
 
-** **Note:** If you already added the new API to the reference source, re-generating it (after building the source assembly) will update it to be fully qualified  and placed in the correct order. This can be done by running the `GenerateReferenceSource` command from the ref directory.
+** **Note:** If you already added the new API to the reference source, re-generating it (after building the source assembly) will update it to be fully qualified  and placed in the correct order. This can be done by running the above command from the ref directory.
 
 ## For System.Runtime
 These steps can also be applied to some unique assemblies which depend on changes in System.Private.Corelib coming from [coreclr](https://github.com/dotnet/coreclr) (partial facades like [System.Memory](https://github.com/dotnet/corefx/blob/83711167ee74d2e87cf2d5ed3508c94044bb7edc/src/System.Memory/src/System.Memory.csproj#L6), for example).
 1) Build coreclr release.
 2) Build corefx release with coreclr bits (see [Testing with private CoreCLR bits](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md#testing-with-private-coreclr-bits) for more details).
-3) Run `msbuild /t:GenerateReferenceSource /p:ConfigurationGroup=Release` from the System.Runtime/ref directory.
+3) Run `msbuild /t:p:GenerateReferenceAssemblySource /p:ConfigurationGroup=Release` from the System.Runtime/ref directory.
 4) Filter out all unrelated changes and extract the changes you care about (ignore certain attributes being removed). Generally, this step is not required for other reference assemblies.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,49 +2,49 @@
 <Dependencies>
   <ProductDependencies></ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19054.13">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19057.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c6268efc7cfcb98197eb374bb01e1fadb5a7f6ed</Sha>
+      <Sha>2af148e2371f5ec8cb1214c339d86d0c665aeb12</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,14 +15,14 @@
     <MicrosoftDotNetXUnitExtensionsPackage>Microsoft.DotNet.XUnitExtensions</MicrosoftDotNetXUnitExtensionsPackage>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19054.13</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19054.13</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19054.13</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19054.13</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19054.13</MicrosoftDotNetXUnitExtensionsPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19054.13</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19054.13</MicrosoftDotNetCoreFxTestingPackageVersion>
-    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19054.13</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19054.13</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19057.9</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19057.9</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19057.9</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19057.9</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19057.9</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19057.9</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19057.9</MicrosoftDotNetCoreFxTestingPackageVersion>
+    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19057.9</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19057.9</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -189,8 +189,9 @@ function InitializeBuildTool {
   
   InitializeDotNetCli $restore
 
-  # return value
+  # return values
   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"  
+  _InitializeBuildToolCommand="msbuild"
 }
 
 function GetNuGetPackageCachePath {
@@ -283,7 +284,7 @@ function MSBuild {
     warnaserror_switch="/warnaserror"
   fi
 
-  "$_InitializeBuildTool" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error "$@"
+  "$_InitializeBuildTool" "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error "$@"
   lastexitcode=$?
 
   if [[ $lastexitcode != 0 ]]; then

--- a/global.json
+++ b/global.json
@@ -3,8 +3,8 @@
     "dotnet": "2.1.401"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19054.13",
-    "Microsoft.DotNet.Helix.Sdk": "1.0.0-beta.19054.13",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19057.9",
+    "Microsoft.DotNet.Helix.Sdk": "1.0.0-beta.19057.9",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview-27304-02"
   }
 }

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project InitialTargets="AddSkipGetTargetFrameworkToProjectReferences">
 
   <PropertyGroup>
@@ -12,6 +11,14 @@
   </PropertyGroup>
 
   <Import Project="..\Directory.Build.targets" />
+
+  <Target Name="AddSkipGetTargetFrameworkToProjectReferences" Condition="'@(ProjectReference)' != ''">
+    <ItemGroup>
+      <ProjectReference>
+        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      </ProjectReference>
+    </ItemGroup>
+  </Target>
 
   <PropertyGroup>
     <!--
@@ -26,21 +33,12 @@
 
   <!-- Settings for GenerateReferenceAssemblySource. -->
   <PropertyGroup>
-    <_ExcludeAPIList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAPIList>
     <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath>
     <GenAPITargetPath>$([MSBuild]::NormalizePath('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Directory.Build.props))', 'ref', '$(TargetName).cs'))</GenAPITargetPath>
     <GenAPILibPath>$(RefPath)</GenAPILibPath>
-    <GenAPIAdditionalParameters>--exclude-attributes-list "$(_ExcludeAPIList)" --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
+    <GenAPIAdditionalParameters>--exclude-attributes-list "$(ApiCompatExcludeAttributeList)" --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
     <SkipGenAPITargetPathFileWrite>true</SkipGenAPITargetPathFileWrite>
   </PropertyGroup>
-
-  <Target Name="AddSkipGetTargetFrameworkToProjectReferences" Condition="'@(ProjectReference)' != ''">
-    <ItemGroup>
-      <ProjectReference>
-        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-      </ProjectReference>
-    </ItemGroup>
-  </Target>
 
   <!--
   Hack workaround for not restoring each project. Instead, we turn off all the targets

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project InitialTargets="AddSkipGetTargetFrameworkToProjectReferences">
+
   <PropertyGroup>
     <ErrorIfBuildToolsRestoredFromIndividualProject Condition="!Exists('$(ToolsDir)')">true</ErrorIfBuildToolsRestoredFromIndividualProject>
 
@@ -11,14 +13,6 @@
 
   <Import Project="..\Directory.Build.targets" />
 
-  <Target Name="AddSkipGetTargetFrameworkToProjectReferences" Condition="'@(ProjectReference)' != ''">
-    <ItemGroup>
-      <ProjectReference>
-        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-      </ProjectReference>
-    </ItemGroup>
-  </Target>
-
   <PropertyGroup>
     <!--
     Hack workaround to skip the GenerateCompiledExpressionsTempFile target in
@@ -29,6 +23,24 @@
     <!-- Disable restoring of package references in our projects -->
     <RestoreProjectStyle>None</RestoreProjectStyle>
   </PropertyGroup>
+
+  <!-- Settings for GenerateReferenceAssemblySource. -->
+  <PropertyGroup>
+    <_ExcludeAPIList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAPIList>
+    <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath>
+    <GenAPITargetPath>$([MSBuild]::NormalizePath('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Directory.Build.props))', 'ref', '$(TargetName).cs'))</GenAPITargetPath>
+    <GenAPILibPath>$(RefPath)</GenAPILibPath>
+    <GenAPIAdditionalParameters>--exclude-attributes-list "$(_ExcludeAPIList)" --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
+    <SkipGenAPITargetPathFileWrite>true</SkipGenAPITargetPathFileWrite>
+  </PropertyGroup>
+
+  <Target Name="AddSkipGetTargetFrameworkToProjectReferences" Condition="'@(ProjectReference)' != ''">
+    <ItemGroup>
+      <ProjectReference>
+        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      </ProjectReference>
+    </ItemGroup>
+  </Target>
 
   <!--
   Hack workaround for not restoring each project. Instead, we turn off all the targets


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/33981
Fixes https://github.com/dotnet/corefx/issues/31193
Requires https://github.com/dotnet/arcade/pull/1701

I decided to still recommend the target as the property together with a build/rebuild target is to noisy as it also updates the ref sources of referenced projects.

Commit 2 is just a manual darc update.