### PR TITLE
SentinelMethod.Equals should return reference equality

### DIFF
--- a/src/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Sentinels.cs
+++ b/src/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Sentinels.cs
@@ -33,7 +33,7 @@ namespace System.Reflection.TypeLoading
             public sealed override IEnumerable<CustomAttributeData> CustomAttributes => throw null;
             public sealed override bool IsConstructedGenericMethod => throw null;
             public sealed override bool IsGenericMethodDefinition => throw null;
-            public sealed override bool Equals(object obj) => throw null;
+            public sealed override bool Equals(object obj) => ReferenceEquals(this, obj);
             public sealed override MethodInfo GetGenericMethodDefinition() => throw null;
             public sealed override int GetHashCode() => throw null;
             public sealed override MethodBody GetMethodBody() => throw null;


### PR DESCRIPTION
Seen in https://github.com/dotnet/corefx/pull/34375#issuecomment-451650027

```
Unhandled Exception of Type System.NullReferenceException
Message :
System.NullReferenceException : Object reference not set to an instance of an object.

   at System.Reflection.TypeLoading.Sentinels.SentinelMethod.Equals(Object obj) in D:\j\workspace\windows-TGrou---33cbf18b\src\System.Reflection.MetadataLoadContext\src\System\Reflection\TypeLoading\General\Sentinels.cs:line 36
   at System.Reflection.TypeLoading.RoEvent.GetRoAddMethod() in D:\j\workspace\windows-TGrou---33cbf18b\src\System.Reflection.MetadataLoadContext\src\System\Reflection\TypeLoading\Events\RoEvent.cs:line 58
   at System.Reflection.TypeLoading.RoEvent.GetAddMethod(Boolean nonPublic) in D:\j\workspace\windows-TGrou---33cbf18b\src\System.Reflection.MetadataLoadContext\src\System\Reflection\TypeLoading\Events\RoEvent.cs:line 62
   at System.Reflection.Tests.EventTests.EventTest1() in D:\j\workspace\windows-TGrou---33cbf18b\src\System.Reflection.MetadataLoadContext\tests\src\Tests\Event\EventTests.cs:line 27
```
Blocking update of coreclr update in corefx

With "Support faster null checks" https://github.com/dotnet/coreclr/pull/21765 the .Equals override gets called so it should test since its overriden (or not be overriden); rather than just `throw null`


/cc @steveharter @jkotas @stephentoub 