### PR TITLE
Utf8JsonReader should store if parsed number contains exponent

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/JsonReaderState.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonReaderState.cs
@@ -22,6 +22,7 @@ namespace System.Text.Json
         internal int _maxDepth;
         internal bool _inObject;
         internal bool _isNotPrimitive;
+        internal bool _numberHasExponent;
         internal JsonTokenType _tokenType;
         internal JsonTokenType _previousTokenType;
         internal JsonReaderOptions _readerOptions;
@@ -69,6 +70,7 @@ namespace System.Text.Json
             _maxDepth = maxDepth;
             _inObject = default;
             _isNotPrimitive = default;
+            _numberHasExponent = default;
             _tokenType = default;
             _previousTokenType = default;
             _readerOptions = options;

--- a/src/System.Text.Json/src/System/Text/Json/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Utf8JsonReader.MultiSegment.cs
@@ -34,6 +34,7 @@ namespace System.Text.Json
             _maxDepth = state._maxDepth == 0 ? JsonReaderState.DefaultMaxDepth : state._maxDepth; // If max depth is not set, revert to the default depth.
             _inObject = state._inObject;
             _isNotPrimitive = state._isNotPrimitive;
+            _numberHasExponent = state._numberHasExponent;
             _tokenType = state._tokenType;
             _previousTokenType = state._previousTokenType;
             _readerOptions = state._readerOptions;
@@ -1108,6 +1109,7 @@ namespace System.Text.Json
             // TODO: https://github.com/dotnet/corefx/issues/33294
             Debug.Assert(data.Length > 0);
 
+            _numberHasExponent = false;
             SequencePosition startPosition = _currentPosition;
             int startConsumed = _consumed;
             consumed = 0;
@@ -1199,6 +1201,7 @@ namespace System.Text.Json
 
             Debug.Assert(nextByte == 'E' || nextByte == 'e');
             i++;
+            _numberHasExponent = true;
             _bytePositionInLine++;
 
             signResult = ConsumeSignMultiSegment(ref data, ref i);

--- a/src/System.Text.Json/src/System/Text/Json/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Utf8JsonReader.TryGet.cs
@@ -125,7 +125,7 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            char standardFormat = span.IndexOfAny((byte)'e', (byte)'E') >= 0 ? 'e' : default;
+            char standardFormat = _numberHasExponent ? 'e' : default;
             return Utf8Parser.TryParse(span, out value, out int bytesConsumed, standardFormat) && span.Length == bytesConsumed;
         }
 
@@ -147,7 +147,7 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            char standardFormat = span.IndexOfAny((byte)'e', (byte)'E') >= 0 ? 'e' : default;
+            char standardFormat = _numberHasExponent ? 'e' : default;
             return Utf8Parser.TryParse(span, out value, out int bytesConsumed, standardFormat) && span.Length == bytesConsumed;
         }
 
@@ -169,7 +169,7 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            char standardFormat = span.IndexOfAny((byte)'e', (byte)'E') >= 0 ? 'e' : default;
+            char standardFormat = _numberHasExponent ? 'e' : default;
             return Utf8Parser.TryParse(span, out value, out int bytesConsumed, standardFormat) && span.Length == bytesConsumed;
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Utf8JsonReader.cs
@@ -30,6 +30,7 @@ namespace System.Text.Json
         private int _maxDepth;
         private bool _inObject;
         private bool _isNotPrimitive;
+        private bool _numberHasExponent;
         private JsonTokenType _tokenType;
         private JsonTokenType _previousTokenType;
         private JsonReaderOptions _readerOptions;
@@ -130,6 +131,7 @@ namespace System.Text.Json
             _maxDepth = _maxDepth,
             _inObject = _inObject,
             _isNotPrimitive = _isNotPrimitive,
+            _numberHasExponent = _numberHasExponent,
             _tokenType = _tokenType,
             _previousTokenType = _previousTokenType,
             _readerOptions = _readerOptions,
@@ -160,6 +162,7 @@ namespace System.Text.Json
             _maxDepth = state._maxDepth == 0 ? JsonReaderState.DefaultMaxDepth : state._maxDepth; // If max depth is not set, revert to the default depth.
             _inObject = state._inObject;
             _isNotPrimitive = state._isNotPrimitive;
+            _numberHasExponent = state._numberHasExponent;
             _tokenType = state._tokenType;
             _previousTokenType = state._previousTokenType;
             _readerOptions = state._readerOptions;
@@ -900,6 +903,7 @@ namespace System.Text.Json
             // TODO: https://github.com/dotnet/corefx/issues/33294
             Debug.Assert(data.Length > 0);
 
+            _numberHasExponent = false;
             consumed = 0;
             int i = 0;
 
@@ -977,6 +981,7 @@ namespace System.Text.Json
 
             Debug.Assert(nextByte == 'E' || nextByte == 'e');
             i++;
+            _numberHasExponent = true;
 
             signResult = ConsumeSign(ref data, ref i);
             if (signResult == ConsumeNumberResult.NeedMoreData)


### PR DESCRIPTION
Partially addresses: https://github.com/dotnet/corefx/issues/33294#issuecomment-447984832

Stores, whether the most recently parsed number contains an exponent. This avoids another pass over the span to determine the format for the Utf8Parser.

/cc @ahsonkhan