### PR TITLE
Honour "breakOnFirstError" parameter

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -407,7 +407,7 @@ namespace System.ComponentModel.DataAnnotations
                 breakOnFirstError));
 
             // We only proceed to Step 2 if there are no errors
-            if (errors.Any())
+            if (breakOnFirstError && errors.Any())
             {
                 return errors;
             }
@@ -417,7 +417,7 @@ namespace System.ComponentModel.DataAnnotations
             errors.AddRange(GetValidationErrors(instance, validationContext, attributes, breakOnFirstError));
 
             // We only proceed to Step 3 if there are no errors
-            if (errors.Any())
+            if (breakOnFirstError && errors.Any())
             {
                 return errors;
             }


### PR DESCRIPTION
The "breakOnFirstError" parameter is not being honoured correctly in the "GetObjectValidationErrors" method. For example, if there are attribute-controlled validations on a model class which fail, then the "IValidatableObject.Validate" method, if there is one, is never called.