### PR TITLE
Fix S.Drawing.Common perf runs

### DIFF
--- a/src/System.Drawing.Common/tests/Performance/Perf_Graphics_DrawBeziers.cs
+++ b/src/System.Drawing.Common/tests/Performance/Perf_Graphics_DrawBeziers.cs
@@ -11,7 +11,7 @@ namespace System.Drawing.Tests
     public class Perf_Graphics_DrawBeziers : RemoteExecutorTestBase
     {
         [Benchmark(InnerIterationCount = 10000)]
-        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.IsDrawingSupported))]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetIsDrawingSupported))]
         public void DrawBezier_Point()
         {
             Random r = new Random(1942);
@@ -34,7 +34,7 @@ namespace System.Drawing.Tests
         }
 
         [Benchmark(InnerIterationCount = 10000)]
-        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.IsDrawingSupported))]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetIsDrawingSupported))]
         public void DrawBezier_Points()
         {
             Point[] points =

--- a/src/System.Drawing.Common/tests/Performance/Perf_Graphics_Transforms.cs
+++ b/src/System.Drawing.Common/tests/Performance/Perf_Graphics_Transforms.cs
@@ -12,7 +12,7 @@ namespace System.Drawing.Tests
     public class Perf_Graphics_Transforms : RemoteExecutorTestBase
     {
         [Benchmark(InnerIterationCount = 10000)]
-        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.IsDrawingSupported), nameof(Helpers.IsNotUnix))] // Graphics.TransformPoints is not implemented in libgdiplus yet. See dotnet/corefx 20884
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetIsDrawingSupported), nameof(Helpers.IsNotUnix))] // Graphics.TransformPoints is not implemented in libgdiplus yet. See dotnet/corefx 20884
         public void TransformPoints()
         {
             Point[] points =

--- a/src/System.Drawing.Common/tests/Performance/Perf_Image_Load.cs
+++ b/src/System.Drawing.Common/tests/Performance/Perf_Image_Load.cs
@@ -13,7 +13,7 @@ namespace System.Drawing.Tests
     public class Perf_Image_Load : RemoteExecutorTestBase
     {
         [Benchmark(InnerIterationCount = 100)]
-        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.IsDrawingSupported))]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetIsDrawingSupported))]
         public void Bitmap_FromStream()
         {
             var files = CreateTestImageFiles();
@@ -40,7 +40,7 @@ namespace System.Drawing.Tests
         }
 
         [Benchmark(InnerIterationCount = 100)]
-        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.IsDrawingSupported))]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetIsDrawingSupported))]
         public void Image_FromStream()
         {
             var files = CreateTestImageFiles();
@@ -67,7 +67,7 @@ namespace System.Drawing.Tests
         }
 
         [Benchmark(InnerIterationCount = 100)]
-        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.IsDrawingSupported))]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetIsDrawingSupported))]
         public void Image_FromStream_NoValidation()
         {
             var files = CreateTestImageFiles();
@@ -94,7 +94,7 @@ namespace System.Drawing.Tests
         }
 
         [Benchmark(InnerIterationCount = 100)]
-        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.IsDrawingSupported))]
+        [ConditionalBenchmark(typeof(Helpers), nameof(Helpers.GetIsDrawingSupported))]
         public void Image_FromStream_NoValidation_Gif()
         {
             // GIF has extra logic looking for animated GIFs


### PR DESCRIPTION
Note: I will merge this as soon as CI is green to unblock perf runs which have been failing for more than two months.