### PR TITLE
Enable ILLinkClearInitLocals across corefx

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -481,4 +481,10 @@
   <!-- Use Roslyn Compilers to build -->
   <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false' and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
   <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)') and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
+
+  <!-- Additional optimizations -->
+  <PropertyGroup>
+    <!-- Clear the init locals flag on all src projects, except those in VB, where we can't use spans. -->
+    <ILLinkClearInitLocals Condition="'$(IsSourceProject)' == 'true' AND '$(Language)' != 'VB'">true</ILLinkClearInitLocals>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
+++ b/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
@@ -4,7 +4,6 @@
     <RootNamespace>Microsoft.Win32.Primitives</RootNamespace>
     <AssemblyName>Microsoft.Win32.Primitives</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->

--- a/src/System.Collections/src/System/Collections/Generic/BitHelper.cs
+++ b/src/System.Collections/src/System/Collections/Generic/BitHelper.cs
@@ -4,136 +4,38 @@
 
 namespace System.Collections.Generic
 {
-    /// <summary>
-    /// ABOUT:
-    /// Helps with operations that rely on bit marking to indicate whether an item in the 
-    /// collection should be added, removed, visited already, etc. 
-    /// 
-    /// BitHelper doesn't allocate the array; you must pass in an array or ints allocated on the 
-    /// stack or heap. ToIntArrayLength() tells you the int array size you must allocate. 
-    /// 
-    /// USAGE:
-    /// Suppose you need to represent a bit array of length (i.e. logical bit array length)
-    /// BIT_ARRAY_LENGTH. Then this is the suggested way to instantiate BitHelper:
-    /// ***************************************************************************
-    /// int intArrayLength = BitHelper.ToIntArrayLength(BIT_ARRAY_LENGTH);
-    /// BitHelper bitHelper;
-    /// if (intArrayLength less than stack alloc threshold)
-    ///     int* m_arrayPtr = stackalloc int[intArrayLength];
-    ///     bitHelper = new BitHelper(m_arrayPtr, intArrayLength);
-    /// else
-    ///     int[] m_arrayPtr = new int[intArrayLength];
-    ///     bitHelper = new BitHelper(m_arrayPtr, intArrayLength);
-    /// ***************************************************************************
-    /// 
-    /// IMPORTANT:
-    /// The second ctor args, length, should be specified as the length of the int array, not
-    /// the logical bit array. Because length is used for bounds checking into the int array,
-    /// it's especially important to get this correct for the stackalloc version. See the code 
-    /// samples above; this is the value gotten from ToIntArrayLength(). 
-    /// 
-    /// The length ctor argument is the only exception; for other methods -- MarkBit and 
-    /// IsMarked -- pass in values as indices into the logical bit array, and it will be mapped
-    /// to the position within the array of ints.
-    /// 
-    /// FUTURE OPTIMIZATIONS:
-    /// A method such as FindFirstMarked/Unmarked Bit would be useful for callers that operate 
-    /// on a bit array and then need to loop over it. In particular, if it avoided visiting 
-    /// every bit, it would allow good perf improvements when the bit array is sparse.
-    /// </summary>
-    internal unsafe sealed class BitHelper
-    {   // should not be serialized
-        private const byte MarkedBitFlag = 1;
-        private const byte IntSize = 32;
+    internal ref struct BitHelper
+    {
+        private const int IntSize = sizeof(int) * 8;
+        private readonly Span<int> _span;
 
-        // m_length of underlying int array (not logical bit array)
-        private readonly int _length;
-
-        // ptr to stack alloc'd array of ints
-        private readonly int* _arrayPtr;
-
-        // array of ints
-        private readonly int[] _array;
-
-        // whether to operate on stack alloc'd or heap alloc'd array 
-        private readonly bool _useStackAlloc;
-
-        /// <summary>
-        /// Instantiates a BitHelper with a heap alloc'd array of ints
-        /// </summary>
-        /// <param name="bitArrayPtr">Pointer to int array to hold bits</param>
-        /// <param name="length">length of int array</param>
-        internal BitHelper(int* bitArrayPtr, int length)
+        internal BitHelper(Span<int> span, bool clear)
         {
-            _arrayPtr = bitArrayPtr;
-            _length = length;
-            _useStackAlloc = true;
+            if (clear)
+            {
+                span.Clear();
+            }
+            _span = span;
         }
 
-        /// <summary>
-        /// Instantiates a BitHelper with a heap alloc'd array of ints
-        /// </summary>
-        /// <param name="bitArray">int array to hold bits</param>
-        /// <param name="length">length of int array</param>
-        internal BitHelper(int[] bitArray, int length)
-        {
-            _array = bitArray;
-            _length = length;
-        }
-
-        /// <summary>
-        /// Mark bit at specified position
-        /// </summary>
-        /// <param name="bitPosition"></param>
         internal void MarkBit(int bitPosition)
         {
             int bitArrayIndex = bitPosition / IntSize;
-            if (bitArrayIndex < _length && bitArrayIndex >= 0)
+            if ((uint)bitArrayIndex < (uint)_span.Length)
             {
-                int flag = (MarkedBitFlag << (bitPosition % IntSize));
-                if (_useStackAlloc)
-                {
-                    _arrayPtr[bitArrayIndex] |= flag;
-                }
-                else
-                {
-                    _array[bitArrayIndex] |= flag;
-                }
+                _span[bitArrayIndex] |= (1 << (bitPosition % IntSize));
             }
         }
 
-        /// <summary>
-        /// Is bit at specified position marked?
-        /// </summary>
-        /// <param name="bitPosition"></param>
-        /// <returns></returns>
         internal bool IsMarked(int bitPosition)
         {
             int bitArrayIndex = bitPosition / IntSize;
-            if (bitArrayIndex < _length && bitArrayIndex >= 0)
-            {
-                int flag = (MarkedBitFlag << (bitPosition % IntSize));
-                if (_useStackAlloc)
-                {
-                    return ((_arrayPtr[bitArrayIndex] & flag) != 0);
-                }
-                else
-                {
-                    return ((_array[bitArrayIndex] & flag) != 0);
-                }
-            }
-            return false;
+            return 
+                (uint)bitArrayIndex < (uint)_span.Length &&
+                (_span[bitArrayIndex] & (1 << (bitPosition % IntSize))) != 0;
         }
 
-        /// <summary>
-        /// How many ints must be allocated to represent n bits. Returns (n+31)/32, but 
-        /// avoids overflow
-        /// </summary>
-        /// <param name="n"></param>
-        /// <returns></returns>
-        internal static int ToIntArrayLength(int n)
-        {
-            return n > 0 ? ((n - 1) / IntSize + 1) : 0;
-        }
+        /// <summary>How many ints must be allocated to represent n bits. Returns (n+31)/32, but avoids overflow.</summary>
+        internal static int ToIntArrayLength(int n) => n > 0 ? ((n - 1) / IntSize + 1) : 0;
     }
 }

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1360,17 +1360,10 @@ namespace System.Collections.Generic
             int originalLastIndex = _lastIndex;
             int intArrayLength = BitHelper.ToIntArrayLength(originalLastIndex);
 
-            BitHelper bitHelper;
-            if (intArrayLength <= StackAllocThreshold)
-            {
-                int* bitArrayPtr = stackalloc int[intArrayLength];
-                bitHelper = new BitHelper(bitArrayPtr, intArrayLength);
-            }
-            else
-            {
-                int[] bitArray = new int[intArrayLength];
-                bitHelper = new BitHelper(bitArray, intArrayLength);
-            }
+            Span<int> span = stackalloc int[StackAllocThreshold];
+            BitHelper bitHelper = intArrayLength <= StackAllocThreshold ?
+                new BitHelper(span.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
 
             // mark if contains: find index of in slots array and mark corresponding element in bit array
             foreach (T item in other)
@@ -1465,24 +1458,15 @@ namespace System.Collections.Generic
             int originalLastIndex = _lastIndex;
             int intArrayLength = BitHelper.ToIntArrayLength(originalLastIndex);
 
-            BitHelper itemsToRemove;
-            BitHelper itemsAddedFromOther;
-            if (intArrayLength <= StackAllocThreshold / 2)
-            {
-                int* itemsToRemovePtr = stackalloc int[intArrayLength];
-                itemsToRemove = new BitHelper(itemsToRemovePtr, intArrayLength);
+            Span<int> itemsToRemoveSpan = stackalloc int[StackAllocThreshold / 2];
+            BitHelper itemsToRemove = intArrayLength <= StackAllocThreshold / 2 ?
+                new BitHelper(itemsToRemoveSpan.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
 
-                int* itemsAddedFromOtherPtr = stackalloc int[intArrayLength];
-                itemsAddedFromOther = new BitHelper(itemsAddedFromOtherPtr, intArrayLength);
-            }
-            else
-            {
-                int[] itemsToRemoveArray = new int[intArrayLength];
-                itemsToRemove = new BitHelper(itemsToRemoveArray, intArrayLength);
-
-                int[] itemsAddedFromOtherArray = new int[intArrayLength];
-                itemsAddedFromOther = new BitHelper(itemsAddedFromOtherArray, intArrayLength);
-            }
+            Span<int> itemsAddedFromOtherSpan = stackalloc int[StackAllocThreshold / 2];
+            BitHelper itemsAddedFromOther = intArrayLength <= StackAllocThreshold / 2 ?
+                new BitHelper(itemsAddedFromOtherSpan.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
 
             foreach (T item in other)
             {
@@ -1629,17 +1613,10 @@ namespace System.Collections.Generic
             int originalLastIndex = _lastIndex;
             int intArrayLength = BitHelper.ToIntArrayLength(originalLastIndex);
 
-            BitHelper bitHelper;
-            if (intArrayLength <= StackAllocThreshold)
-            {
-                int* bitArrayPtr = stackalloc int[intArrayLength];
-                bitHelper = new BitHelper(bitArrayPtr, intArrayLength);
-            }
-            else
-            {
-                int[] bitArray = new int[intArrayLength];
-                bitHelper = new BitHelper(bitArray, intArrayLength);
-            }
+            Span<int> span = stackalloc int[StackAllocThreshold];
+            BitHelper bitHelper = intArrayLength <= StackAllocThreshold ?
+                new BitHelper(span.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
 
             // count of items in other not found in this
             int unfoundCount = 0;

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1449,17 +1449,10 @@ namespace System.Collections.Generic
             int originalLastIndex = Count;
             int intArrayLength = BitHelper.ToIntArrayLength(originalLastIndex);
 
-            BitHelper bitHelper;
-            if (intArrayLength <= StackAllocThreshold)
-            {
-                int* bitArrayPtr = stackalloc int[intArrayLength];
-                bitHelper = new BitHelper(bitArrayPtr, intArrayLength);
-            }
-            else
-            {
-                int[] bitArray = new int[intArrayLength];
-                bitHelper = new BitHelper(bitArray, intArrayLength);
-            }
+            Span<int> span = stackalloc int[StackAllocThreshold];
+            BitHelper bitHelper = intArrayLength <= StackAllocThreshold ?
+                new BitHelper(span.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
 
             // count of items in other not found in this
             int UnfoundCount = 0;

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -6,7 +6,6 @@
     <NoWarn>$(NoWarn);CS1573</NoWarn>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <UWPCompatible Condition="'$(TargetGroup)' == 'uap' or '$(TargetGroup)' == 'uapaot'">true</UWPCompatible>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -5,7 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <OmitTransitiveCompileReferences>true</OmitTransitiveCompileReferences>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <!-- Compiled Source Files -->

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -3,7 +3,6 @@
     <ProjectGuid>{4BBC8F69-D03E-4432-AA8A-D458FA5B235A}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreappaot-Windows_NT-Debug;netcoreappaot-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -8,7 +8,6 @@
     <!-- Although we have a NS configuration, the actual UWP implementation is a shim over WinRT: so just validate against OneCore -->
     <UWPCompatible>false</UWPCompatible>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'net461'">

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -8,7 +8,6 @@
     <NoWarn>$(NoWarn);0436;CS1573</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);HTTP_DLL</DefineConstants>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'uap'">

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -3,7 +3,6 @@
     <AssemblyName>System.Net.NameResolution</AssemblyName>
     <ProjectGuid>{1714448C-211E-48C1-8B7E-4EE667D336A1}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <ProjectGuid>{3CA89D6C-F8D1-4813-9775-F8D249686E31}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <ProjectGuid>{8772BC91-7B55-49B9-94FA-4B1BE5BEAB55}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/System.Net.Requests/src/System.Net.Requests.csproj
+++ b/src/System.Net.Requests/src/System.Net.Requests.csproj
@@ -4,7 +4,6 @@
     <RootNamespace>System.Net.Requests</RootNamespace>
     <AssemblyName>System.Net.Requests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -3,7 +3,6 @@
     <AssemblyName>System.Net.Security</AssemblyName>
     <ProjectGuid>{89F37791-6254-4D60-AB96-ACD3CCA0E771}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsOSX)' == 'true' ">

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -3,7 +3,6 @@
     <AssemblyName>System.Net.Sockets</AssemblyName>
     <ProjectGuid>{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -3,7 +3,6 @@
     <ProjectGuid>{B8AD98AE-84C3-4313-B3F1-EE8BD5BFF69B}</ProjectGuid>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS1573</NoWarn>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -3,7 +3,6 @@
     <AssemblyName>System.Net.WebSockets.WebSocketProtocol</AssemblyName>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <ProjectGuid>{747BE014-7C1D-4460-95AF-B41C35717165}</ProjectGuid>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <NoWarn>$(NoWarn);CS1573</NoWarn>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Net.WebSockets/src/System.Net.WebSockets.csproj
+++ b/src/System.Net.WebSockets/src/System.Net.WebSockets.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>System.Net.WebSockets</AssemblyName>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS1573</NoWarn>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.csproj
@@ -3,7 +3,6 @@
     <ProjectGuid>{4AC5343E-6E31-4BA5-A795-0493AE7E9008}</ProjectGuid>
     <AssemblyName>System.Private.Uri</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreappaot-Windows_NT-Debug;netcoreappaot-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -6,7 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)'=='uapaot'">true</GenFacadesIgnoreMissingTypes>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreappaot-Windows_NT-Debug;netcoreappaot-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
@@ -118,7 +118,9 @@ namespace System.Numerics
                 if (coreLength < AllocationThreshold)
                 {
                     uint* fold = stackalloc uint[foldLength];
+                    new Span<uint>(fold, foldLength).Clear();
                     uint* core = stackalloc uint[coreLength];
+                    new Span<uint>(core, coreLength).Clear();
 
                     // ... compute z_a = a_1 + a_0 (call it fold...)
                     Add(valueHigh, valueHighLength,
@@ -299,8 +301,11 @@ namespace System.Numerics
                 if (coreLength < AllocationThreshold)
                 {
                     uint* leftFold = stackalloc uint[leftFoldLength];
+                    new Span<uint>(leftFold, leftFoldLength).Clear();
                     uint* rightFold = stackalloc uint[rightFoldLength];
+                    new Span<uint>(rightFold, rightFoldLength).Clear();
                     uint* core = stackalloc uint[coreLength];
+                    new Span<uint>(core, coreLength).Clear();
 
                     // ... compute z_a = a_1 + a_0 (call it fold...)
                     Add(leftHigh, leftHighLength,

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -3,7 +3,6 @@
     <ProjectGuid>{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}</ProjectGuid>
     <AssemblyName>System.Runtime</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetsAOT)'=='true' OR '$(TargetGroup)' == 'uap'">true</GenFacadesIgnoreMissingTypes>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreappaot-Windows_NT-Debug;netcoreappaot-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/FindPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/FindPal.cs
@@ -154,8 +154,9 @@ namespace Internal.Cryptography.Pal
                             byte[] extensionRawData = pV1Template->Value.ToByteArray();
                             if (!extensionRawData.DecodeObjectNoThrow(
                                 CryptDecodeObjectStructType.X509_UNICODE_ANY_STRING,
-                                delegate(void* pvDecoded)
+                                delegate(void* pvDecoded, int cbDecoded)
                                 {
+                                    Debug.Assert(cbDecoded >= sizeof(CERT_NAME_VALUE));
                                     CERT_NAME_VALUE* pNameValue = (CERT_NAME_VALUE*)pvDecoded;
                                     string actual = Marshal.PtrToStringUni(new IntPtr(pNameValue->Value.pbData));
                                     if (templateName.Equals(actual, StringComparison.OrdinalIgnoreCase))
@@ -176,8 +177,9 @@ namespace Internal.Cryptography.Pal
                             byte[] extensionRawData = pV2Template->Value.ToByteArray();
                             if (!extensionRawData.DecodeObjectNoThrow(
                                 CryptDecodeObjectStructType.X509_CERTIFICATE_TEMPLATE,
-                                delegate(void* pvDecoded)
+                                delegate(void* pvDecoded, int cbDecoded)
                                 {
+                                    Debug.Assert(cbDecoded >= sizeof(CERT_TEMPLATE_EXT));
                                     CERT_TEMPLATE_EXT* pTemplateExt = (CERT_TEMPLATE_EXT*)pvDecoded;
                                     string actual = Marshal.PtrToStringAnsi(pTemplateExt->pszObjId);
                                     string expectedOidValue =
@@ -245,8 +247,9 @@ namespace Internal.Cryptography.Pal
                     byte[] extensionRawData = pCertExtension->Value.ToByteArray();
                     if (!extensionRawData.DecodeObjectNoThrow(
                         CryptDecodeObjectStructType.X509_CERT_POLICIES,
-                        delegate(void* pvDecoded)
+                        delegate(void* pvDecoded, int cbDecoded)
                         {
+                            Debug.Assert(cbDecoded >= sizeof(CERT_POLICIES_INFO));
                             CERT_POLICIES_INFO* pCertPoliciesInfo = (CERT_POLICIES_INFO*)pvDecoded;
                             for (int i = 0; i < pCertPoliciesInfo->cPolicyInfo; i++)
                             {

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Helpers.cs
@@ -73,7 +73,7 @@ namespace Internal.Cryptography.Pal.Native
             return Encoding.ASCII.GetBytes(oid.Value);
         }
 
-        public unsafe delegate void DecodedObjectReceiver(void* pvDecodedObject);
+        public unsafe delegate void DecodedObjectReceiver(void* pvDecodedObject, int cbDecodedObject);
 
         public static void DecodeObject(this byte[] encoded, CryptDecodeObjectStructType lpszStructType, DecodedObjectReceiver receiver)
         {
@@ -89,7 +89,7 @@ namespace Internal.Cryptography.Pal.Native
                 if (!Interop.crypt32.CryptDecodeObjectPointer(CertEncodingType.All, lpszStructType, encoded, encoded.Length, CryptDecodeObjectFlags.None, (byte*)decoded, ref cb))
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
 
-                receiver(decoded);
+                receiver(decoded, cb);
             }
         }
 
@@ -107,7 +107,7 @@ namespace Internal.Cryptography.Pal.Native
                 if (!Interop.crypt32.CryptDecodeObjectPointer(CertEncodingType.All, lpszStructType, encoded, encoded.Length, CryptDecodeObjectFlags.None, (byte*)decoded, ref cb))
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
 
-                receiver(decoded);
+                receiver(decoded, cb);
             }
         }
 
@@ -125,7 +125,7 @@ namespace Internal.Cryptography.Pal.Native
                 if (!Interop.crypt32.CryptDecodeObjectPointer(CertEncodingType.All, lpszStructType, encoded, encoded.Length, CryptDecodeObjectFlags.None, (byte*)decoded, ref cb))
                     return false;
 
-                receiver(decoded);
+                receiver(decoded, cb);
             }
             return true;
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Helpers.cs
@@ -85,6 +85,7 @@ namespace Internal.Cryptography.Pal.Native
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
 
                 byte* decoded = stackalloc byte[cb];
+                new Span<byte>(decoded, cb).Clear();
                 if (!Interop.crypt32.CryptDecodeObjectPointer(CertEncodingType.All, lpszStructType, encoded, encoded.Length, CryptDecodeObjectFlags.None, (byte*)decoded, ref cb))
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
 
@@ -102,6 +103,7 @@ namespace Internal.Cryptography.Pal.Native
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
 
                 byte* decoded = stackalloc byte[cb];
+                new Span<byte>(decoded, cb).Clear();
                 if (!Interop.crypt32.CryptDecodeObjectPointer(CertEncodingType.All, lpszStructType, encoded, encoded.Length, CryptDecodeObjectFlags.None, (byte*)decoded, ref cb))
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
 
@@ -119,6 +121,7 @@ namespace Internal.Cryptography.Pal.Native
                     return false;
 
                 byte* decoded = stackalloc byte[cb];
+                new Span<byte>(decoded, cb).Clear();
                 if (!Interop.crypt32.CryptDecodeObjectPointer(CertEncodingType.All, lpszStructType, encoded, encoded.Length, CryptDecodeObjectFlags.None, (byte*)decoded, ref cb))
                     return false;
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
@@ -45,8 +45,9 @@ namespace Internal.Cryptography.Pal
                 uint keyUsagesAsUint = 0;
                 encoded.DecodeObject(
                     CryptDecodeObjectStructType.X509_KEY_USAGE,
-                    delegate (void* pvDecoded)
+                    delegate (void* pvDecoded, int cbDecoded)
                     {
+                        Debug.Assert(cbDecoded >= sizeof(CRYPT_BIT_BLOB));
                         CRYPT_BIT_BLOB* pBlob = (CRYPT_BIT_BLOB*)pvDecoded;
                         keyUsagesAsUint = 0;
                         if (pBlob->pbData != null)
@@ -89,8 +90,9 @@ namespace Internal.Cryptography.Pal
 
                 encoded.DecodeObject(
                     CryptDecodeObjectStructType.X509_BASIC_CONSTRAINTS,
-                    delegate (void* pvDecoded)
+                    delegate (void* pvDecoded, int cbDecoded)
                     {
+                        Debug.Assert(cbDecoded >= sizeof(CERT_BASIC_CONSTRAINTS_INFO));
                         CERT_BASIC_CONSTRAINTS_INFO* pBasicConstraints = (CERT_BASIC_CONSTRAINTS_INFO*)pvDecoded;
                         localCertificateAuthority = (pBasicConstraints->SubjectType.pbData[0] & CERT_BASIC_CONSTRAINTS_INFO.CERT_CA_SUBJECT_FLAG) != 0;
                         localHasPathLengthConstraint = pBasicConstraints->fPathLenConstraint != 0;
@@ -114,8 +116,9 @@ namespace Internal.Cryptography.Pal
 
                 encoded.DecodeObject(
                     CryptDecodeObjectStructType.X509_BASIC_CONSTRAINTS2,
-                    delegate (void* pvDecoded)
+                    delegate (void* pvDecoded, int cbDecoded)
                     {
+                        Debug.Assert(cbDecoded >= sizeof(CERT_BASIC_CONSTRAINTS2_INFO));
                         CERT_BASIC_CONSTRAINTS2_INFO* pBasicConstraints2 = (CERT_BASIC_CONSTRAINTS2_INFO*)pvDecoded;
                         localCertificateAuthority = pBasicConstraints2->fCA != 0;
                         localHasPathLengthConstraint = pBasicConstraints2->fPathLenConstraint != 0;
@@ -155,8 +158,9 @@ namespace Internal.Cryptography.Pal
             {
                 encoded.DecodeObject(
                     CryptDecodeObjectStructType.X509_ENHANCED_KEY_USAGE,
-                    delegate (void* pvDecoded)
+                    delegate (void* pvDecoded, int cbDecoded)
                     {
+                        Debug.Assert(cbDecoded >= sizeof(CERT_ENHKEY_USAGE));
                         CERT_ENHKEY_USAGE* pEnhKeyUsage = (CERT_ENHKEY_USAGE*)pvDecoded;
                         int count = pEnhKeyUsage->cUsageIdentifier;
                         for (int i = 0; i < count; i++)
@@ -192,8 +196,9 @@ namespace Internal.Cryptography.Pal
                 byte[] localSubjectKeyIdentifier = null;
                 encoded.DecodeObject(
                     Oids.SubjectKeyIdentifier,
-                    delegate (void* pvDecoded)
+                    delegate (void* pvDecoded, int cbDecoded)
                     {
+                        Debug.Assert(cbDecoded >= sizeof(CRYPTOAPI_BLOB));
                         CRYPTOAPI_BLOB* pBlob = (CRYPTOAPI_BLOB*)pvDecoded;
                         localSubjectKeyIdentifier = pBlob->ToByteArray();
                     }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
@@ -260,8 +260,9 @@ namespace Internal.Cryptography.Pal
 
                 encodedKeyValue.DecodeObject(
                     CryptDecodeObjectStructType.X509_DSS_PUBLICKEY,
-                    delegate (void* pvDecoded)
+                    delegate (void* pvDecoded, int cbDecoded)
                     {
+                        Debug.Assert(cbDecoded >= sizeof(CRYPTOAPI_BLOB));
                         CRYPTOAPI_BLOB* pBlob = (CRYPTOAPI_BLOB*)pvDecoded;
                         decodedKeyValue = pBlob->ToByteArray();
                     }
@@ -281,8 +282,9 @@ namespace Internal.Cryptography.Pal
             {
                 encodedParameters.DecodeObject(
                     CryptDecodeObjectStructType.X509_DSS_PARAMETERS,
-                    delegate (void* pvDecoded)
+                    delegate (void* pvDecoded, int cbDecoded)
                     {
+                        Debug.Assert(cbDecoded >= sizeof(CERT_DSS_PARAMETERS));
                         CERT_DSS_PARAMETERS* pCertDssParameters = (CERT_DSS_PARAMETERS*)pvDecoded;
                         pLocal = pCertDssParameters->p.ToByteArray();
                         qLocal = pCertDssParameters->q.ToByteArray();

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>System.Text.RegularExpressions</AssemblyName>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_COMPILED</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'netcoreappaot'">$(DefineConstants);FEATURE_COMPILEAPIS</DefineConstants>
-    <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreappaot-Debug;netcoreappaot-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>


### PR DESCRIPTION
Enabled for all projects except tests and VB (where we can't use spans anyway).

There's a chance there's still something uninitialized that needs to be that's slipped through, but I've done a bunch of outerloop test runs on both Windows and Linux and so hopefully have caught the vast majority (there were just a few, which I knew about as well from when looking at this previously).

cc: @ViktorHofer, @jkotas, @danmosemsft, @bartonjs, @safern 
Fixes https://github.com/dotnet/corefx/issues/26939