### PR TITLE
Re-enable GenerateGuidForType exception tests

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GenerateGuidForTypeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GenerateGuidForTypeTests.cs
@@ -79,14 +79,12 @@ namespace System.Runtime.InteropServices.Tests
         public class ClassWithGuidAttribute { }
 
         [Fact]
-        [ActiveIssue(30926, ~TargetFrameworkMonikers.NetFramework)]
         public void GenerateGuidForType_NullType_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("type", () => Marshal.GenerateGuidForType(null));
         }
 
         [Fact]
-        [ActiveIssue(30926, ~TargetFrameworkMonikers.NetFramework)]
         public void GenerateGuidForType_NotRuntimeType_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.Run);


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/21851
Fixes https://github.com/dotnet/corefx/issues/30926
cc: @AaronRobinsonMSFT, @jkoritzinsky