### PR TITLE
Use VS2017 always as project generator in native build

### DIFF
--- a/src/Native/Windows/gen-buildsys-win.bat
+++ b/src/Native/Windows/gen-buildsys-win.bat
@@ -12,12 +12,9 @@ setlocal
 set __sourceDir=%~dp0
 set __ExtraCmakeParams=
 
-:: VS 2017 is the minimum supported toolset
-if "%__VSVersion%" == "vs2019" (
-  set __VSString=16 2019
-) else (
-  set __VSString=15 2017
-)
+:: VS 2017 is required to build native assets,
+:: once CMake supports 2019 as the project generator we can use that if installed in the local system
+set __VSString=15 2017
 
 :: Set the target architecture to a format cmake understands. ANYCPU defaults to x64
 if /i "%3" == "x86"     (set __VSString=%__VSString%)
@@ -47,7 +44,7 @@ GOTO :DONE
   echo "Usage..."
   echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion> <Target Architecture>"
   echo "Specify the path to the top level CMake file"
-  echo "Specify the VSVersion to be used - VS2017 or VS2019"
+  echo "Specify the VSVersion to be used - VS2017"
   echo "Specify the Target Architecture - AnyCPU, x86, x64, ARM, or ARM64."
   EXIT /B 1
 


### PR DESCRIPTION
In https://github.com/dotnet/corefx/pull/34381 we introduced: 
```
EXEC : CMake error : Could not create named generator Visual Studio 16 2019 Win64 [E:\repos\corefxCopy\corefx\src\Native\build-native.proj]
E:\repos\corefxCopy\corefx\src\Native\build-native.proj(46,5): error MSB3073: The command ""E:\repos\corefxCopy\corefx\src\Native\build-native.cmd" x64 Debug Windows_NT outconfig netcoreapp-Windows_NT-Debug-x64" exited with code 1.
```

When VS2019 is installed. It seems like CMake doesn't yet supports VS2019 as the project generator yet. 
https://github.com/Kitware/CMake/tree/master/Help/generator

cc: @danmosemsft 