### PR TITLE
Don't include database name in TVP type name set by DeriveParameters

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -2209,8 +2209,7 @@ namespace System.Data.SqlClient
                         Debug.Assert(_activeConnection.IsKatmaiOrNewer, "Invalid datatype token received from pre-katmai server");
 
                         //read the type name
-                        p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeCatalogName]] + "." +
-                            r[colNames[(int)ProcParamsColIndex.TypeSchemaName]] + "." +
+                        p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeSchemaName]] + "." +
                             r[colNames[(int)ProcParamsColIndex.TypeName]];
                     }
 


### PR DESCRIPTION
fixes #34414 