### PR TITLE
Fix DirectoryToBuild errors w trailing backslash

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -22,12 +22,12 @@ $defaultargs = "-restore -build -warnaserror:0"
 $possibleDirToBuild = if($ExtraArgs.Length -gt 0) { $ExtraArgs[0]; } else { $null }
 
 if ($possibleDirToBuild -ne $null) {
-  $dtb = $possibleDirToBuild
+  $dtb = $possibleDirToBuild.TrimEnd('\')
   if (Test-Path $dtb) {
     $ExtraArgs[0] = "/p:DirectoryToBuild=$(Resolve-Path $dtb)"
   }
   else {
-    $dtb = Join-Path "$PSSCriptRoot\..\src" $possibleDirToBuild
+    $dtb = Join-Path "$PSSCriptRoot\..\src" $dtb
     if (Test-Path $dtb) {
       $ExtraArgs[0] = "/p:DirectoryToBuild=$(Resolve-Path $dtb)"
     }


### PR DESCRIPTION
When using the root build script to build a particular project,
the command fails if the supplied project path has a trailiing
backslash and is not the last command.
I.e. `build src\System.Runtime\ /p:CoreCLROverridePath=...`

cc @safern