### PR TITLE
Handle flowsuppressed context in FileSystemWatcher on OSX

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -347,9 +347,9 @@ namespace System.IO
             }
 
             private unsafe void FileSystemEventCallback(
-                FSEventStreamRef streamRef, 
-                IntPtr clientCallBackInfo, 
-                size_t numEvents, 
+                FSEventStreamRef streamRef,
+                IntPtr clientCallBackInfo,
+                size_t numEvents,
                 byte** eventPaths,
                 [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
                 Interop.EventStream.FSEventStreamEventFlags[] eventFlags,
@@ -369,133 +369,153 @@ namespace System.IO
                     return;
                 }
 
-                ExecutionContext.Run(_context, delegate
+                ExecutionContext context = _context;
+                if (context is null)
                 {
+                    // Flow suppressed, just run here
+                    ProcessEvent(numEvents.ToInt32(), eventPaths, eventFlags, eventIds, watcher);
+                }
+                else
+                {
+                    ExecutionContext.Run(
+                        context,
+                        (object o) => ((RunningInstance)o).ProcessEvent(numEvents.ToInt32(), eventPaths, eventFlags, eventIds, watcher),
+                        this);
+                }
+            }
 
-                    // Since renames come in pairs, when we find the first we need to search for the next one. Once we find it, we'll add it to this
-                    // list so when the for-loop comes across it, we'll skip it since it's already been processed as part of the original of the pair.
-                    List<FSEventStreamEventId> handledRenameEvents = null;
-                    Memory<char>[] events = new Memory<char>[numEvents.ToInt32()];
-                    ProcessEvents();
+            private unsafe void ProcessEvent(int numEvents,
+                byte** eventPaths,
+                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+                Interop.EventStream.FSEventStreamEventFlags[] eventFlags,
+                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+                FSEventStreamEventId[] eventIds,
+                FileSystemWatcher watcher
+            )
+            {
+                // Since renames come in pairs, when we find the first we need to search for the next one. Once we find it, we'll add it to this
+                // list so when the for-loop comes across it, we'll skip it since it's already been processed as part of the original of the pair.
+                List<FSEventStreamEventId> handledRenameEvents = null;
+                Memory<char>[] events = new Memory<char>[numEvents];
+                ProcessEvents();
 
-                    for (long i = 0; i < numEvents.ToInt32(); i++)
+                for (long i = 0; i < numEvents; i++)
+                {
+                    ReadOnlySpan<char> path = events[i].Span;
+                    Debug.Assert(path[path.Length - 1] != '/', "Trailing slashes on events is not supported");
+
+                    // Match Windows and don't notify us about changes to the Root folder
+                    if (_fullDirectory.Length >= path.Length && path.Equals(_fullDirectory.AsSpan(0, path.Length), StringComparison.OrdinalIgnoreCase))
                     {
-                        ReadOnlySpan<char> path = events[i].Span;
-                        Debug.Assert(path[path.Length - 1] != '/', "Trailing slashes on events is not supported");
-
-                        // Match Windows and don't notify us about changes to the Root folder
-                        if (_fullDirectory.Length >= path.Length && path.Equals(_fullDirectory.AsSpan(0, path.Length), StringComparison.OrdinalIgnoreCase))
-                        {
-                            continue;
-                        }
-
-                        WatcherChangeTypes eventType = 0;
-                        // First, we should check if this event should kick off a re-scan since we can't really rely on anything after this point if that is true
-                        if (ShouldRescanOccur(eventFlags[i]))
-                        {
-                            watcher.OnError(new ErrorEventArgs(new IOException(SR.FSW_BufferOverflow, (int)eventFlags[i])));
-                            break;
-                        }
-                        else if ((handledRenameEvents != null) && (handledRenameEvents.Contains(eventIds[i])))
-                        {
-                            // If this event is the second in a rename pair then skip it
-                            continue;
-                        }
-                        else if (CheckIfPathIsNested(path) && ((eventType = FilterEvents(eventFlags[i])) != 0))
-                        {
-                            // The base FileSystemWatcher does a match check against the relative path before combining with 
-                            // the root dir; however, null is special cased to signify the root dir, so check if we should use that.
-                            ReadOnlySpan<char> relativePath = ReadOnlySpan<char>.Empty;
-                            if (!path.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase))
-                            {
-                                // Remove the root directory to get the relative path
-                                relativePath = path.Slice(_fullDirectory.Length);
-                            }
-
-                            // Raise a notification for the event
-                            if (((eventType & WatcherChangeTypes.Changed) > 0))
-                            {
-                                watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Changed, relativePath);
-                            }
-                            if (((eventType & WatcherChangeTypes.Created) > 0))
-                            {
-                                watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Created, relativePath);
-                            }
-                            if (((eventType & WatcherChangeTypes.Deleted) > 0))
-                            {
-                                watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, relativePath);
-                            }
-                            if (((eventType & WatcherChangeTypes.Renamed) > 0))
-                            {
-                                // Find the rename that is paired to this rename, which should be the next rename in the list
-                                long pairedId = FindRenameChangePairedChange(i, eventFlags);
-                                if (pairedId == long.MinValue)
-                                {
-                                    // Getting here means we have a rename without a pair, meaning it should be a create for the 
-                                    // move from unwatched folder to watcher folder scenario or a move from the watcher folder out.
-                                    // Check if the item exists on disk to check which it is
-                                    // Don't send a new notification if we already sent one for this event.
-                                    if (DoesItemExist(path, IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile)))
-                                    {
-                                        if ((eventType & WatcherChangeTypes.Created) == 0)
-                                        {
-                                            watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Created, relativePath);
-                                        }
-                                    }
-                                    else if ((eventType & WatcherChangeTypes.Deleted) == 0)
-                                    {
-                                        watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, relativePath);
-                                    }
-                                }
-                                else
-                                {
-                                    // Remove the base directory prefix and add the paired event to the list of 
-                                    // events to skip and notify the user of the rename 
-                                    ReadOnlySpan<char> newPathRelativeName = events[pairedId].Span.Slice(_fullDirectory.Length);
-                                    watcher.NotifyRenameEventArgs(WatcherChangeTypes.Renamed, newPathRelativeName, relativePath);
-
-                                    // Create a new list, if necessary, and add the event
-                                    if (handledRenameEvents == null)
-                                    {
-                                        handledRenameEvents = new List<FSEventStreamEventId>();
-                                    }
-                                    handledRenameEvents.Add(eventIds[pairedId]);
-                                }
-                            }
-                        }
-
-                        ArraySegment<char> underlyingArray;
-                        if (MemoryMarshal.TryGetArray(events[i], out underlyingArray))
-                            ArrayPool<char>.Shared.Return(underlyingArray.Array);
+                        continue;
                     }
 
-                    this._context = ExecutionContext.Capture();
-
-                    void ProcessEvents()
+                    WatcherChangeTypes eventType = 0;
+                    // First, we should check if this event should kick off a re-scan since we can't really rely on anything after this point if that is true
+                    if (ShouldRescanOccur(eventFlags[i]))
                     {
-                        for (int i = 0; i < events.Length; i++)
+                        watcher.OnError(new ErrorEventArgs(new IOException(SR.FSW_BufferOverflow, (int)eventFlags[i])));
+                        break;
+                    }
+                    else if ((handledRenameEvents != null) && (handledRenameEvents.Contains(eventIds[i])))
+                    {
+                        // If this event is the second in a rename pair then skip it
+                        continue;
+                    }
+                    else if (CheckIfPathIsNested(path) && ((eventType = FilterEvents(eventFlags[i])) != 0))
+                    {
+                        // The base FileSystemWatcher does a match check against the relative path before combining with 
+                        // the root dir; however, null is special cased to signify the root dir, so check if we should use that.
+                        ReadOnlySpan<char> relativePath = ReadOnlySpan<char>.Empty;
+                        if (!path.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase))
                         {
-                            int byteCount = 0;
-                            Debug.Assert(eventPaths[i] != null);
-                            byte* temp = eventPaths[i];
+                            // Remove the root directory to get the relative path
+                            relativePath = path.Slice(_fullDirectory.Length);
+                        }
 
-                            // Finds the position of null character.
-                            while(*temp != 0)
+                        // Raise a notification for the event
+                        if (((eventType & WatcherChangeTypes.Changed) > 0))
+                        {
+                            watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Changed, relativePath);
+                        }
+                        if (((eventType & WatcherChangeTypes.Created) > 0))
+                        {
+                            watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Created, relativePath);
+                        }
+                        if (((eventType & WatcherChangeTypes.Deleted) > 0))
+                        {
+                            watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, relativePath);
+                        }
+                        if (((eventType & WatcherChangeTypes.Renamed) > 0))
+                        {
+                            // Find the rename that is paired to this rename, which should be the next rename in the list
+                            long pairedId = FindRenameChangePairedChange(i, eventFlags);
+                            if (pairedId == long.MinValue)
                             {
-                                temp++;
-                                byteCount++;
+                                // Getting here means we have a rename without a pair, meaning it should be a create for the 
+                                // move from unwatched folder to watcher folder scenario or a move from the watcher folder out.
+                                // Check if the item exists on disk to check which it is
+                                // Don't send a new notification if we already sent one for this event.
+                                if (DoesItemExist(path, IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile)))
+                                {
+                                    if ((eventType & WatcherChangeTypes.Created) == 0)
+                                    {
+                                        watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Created, relativePath);
+                                    }
+                                }
+                                else if ((eventType & WatcherChangeTypes.Deleted) == 0)
+                                {
+                                    watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, relativePath);
+                                }
                             }
+                            else
+                            {
+                                // Remove the base directory prefix and add the paired event to the list of 
+                                // events to skip and notify the user of the rename 
+                                ReadOnlySpan<char> newPathRelativeName = events[pairedId].Span.Slice(_fullDirectory.Length);
+                                watcher.NotifyRenameEventArgs(WatcherChangeTypes.Renamed, newPathRelativeName, relativePath);
 
-                            Debug.Assert(byteCount > 0, "Empty events are not supported");
-                            events[i] = new Memory<char>(ArrayPool<char>.Shared.Rent(Encoding.UTF8.GetMaxCharCount(byteCount)));
-                            int charCount;
-
-                            // Converting an array of bytes to UTF-8 char array
-                            charCount = Encoding.UTF8.GetChars(new ReadOnlySpan<byte>(eventPaths[i], byteCount), events[i].Span);
-                            events[i] = events[i].Slice(0, charCount);
+                                // Create a new list, if necessary, and add the event
+                                if (handledRenameEvents == null)
+                                {
+                                    handledRenameEvents = new List<FSEventStreamEventId>();
+                                }
+                                handledRenameEvents.Add(eventIds[pairedId]);
+                            }
                         }
                     }
-                }, null);
+
+                    ArraySegment<char> underlyingArray;
+                    if (MemoryMarshal.TryGetArray(events[i], out underlyingArray))
+                        ArrayPool<char>.Shared.Return(underlyingArray.Array);
+                }
+
+                this._context = ExecutionContext.Capture();
+
+                void ProcessEvents()
+                {
+                    for (int i = 0; i < events.Length; i++)
+                    {
+                        int byteCount = 0;
+                        Debug.Assert(eventPaths[i] != null);
+                        byte* temp = eventPaths[i];
+
+                        // Finds the position of null character.
+                        while (*temp != 0)
+                        {
+                            temp++;
+                            byteCount++;
+                        }
+
+                        Debug.Assert(byteCount > 0, "Empty events are not supported");
+                        events[i] = new Memory<char>(ArrayPool<char>.Shared.Rent(Encoding.UTF8.GetMaxCharCount(byteCount)));
+                        int charCount;
+
+                        // Converting an array of bytes to UTF-8 char array
+                        charCount = Encoding.UTF8.GetChars(new ReadOnlySpan<byte>(eventPaths[i], byteCount), events[i].Span);
+                        events[i] = events[i].Slice(0, charCount);
+                    }
+                }
             }
 
             /// <summary>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -373,18 +373,18 @@ namespace System.IO
                 if (context is null)
                 {
                     // Flow suppressed, just run here
-                    ProcessEvent(numEvents.ToInt32(), eventPaths, eventFlags, eventIds, watcher);
+                    ProcessEvents(numEvents.ToInt32(), eventPaths, eventFlags, eventIds, watcher);
                 }
                 else
                 {
                     ExecutionContext.Run(
                         context,
-                        (object o) => ((RunningInstance)o).ProcessEvent(numEvents.ToInt32(), eventPaths, eventFlags, eventIds, watcher),
+                        (object o) => ((RunningInstance)o).ProcessEvents(numEvents.ToInt32(), eventPaths, eventFlags, eventIds, watcher),
                         this);
                 }
             }
 
-            private unsafe void ProcessEvent(int numEvents,
+            private unsafe void ProcessEvents(int numEvents,
                 byte** eventPaths,
                 Interop.EventStream.FSEventStreamEventFlags[] eventFlags,
                 FSEventStreamEventId[] eventIds,
@@ -394,7 +394,7 @@ namespace System.IO
                 // list so when the for-loop comes across it, we'll skip it since it's already been processed as part of the original of the pair.
                 List<FSEventStreamEventId> handledRenameEvents = null;
                 Memory<char>[] events = new Memory<char>[numEvents];
-                ProcessEvents();
+                ParseEvents();
 
                 for (long i = 0; i < numEvents; i++)
                 {
@@ -489,7 +489,7 @@ namespace System.IO
 
                 this._context = ExecutionContext.Capture();
 
-                void ProcessEvents()
+                void ParseEvents()
                 {
                     for (int i = 0; i < events.Length; i++)
                     {

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -386,12 +386,9 @@ namespace System.IO
 
             private unsafe void ProcessEvent(int numEvents,
                 byte** eventPaths,
-                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
                 Interop.EventStream.FSEventStreamEventFlags[] eventFlags,
-                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
                 FSEventStreamEventId[] eventIds,
-                FileSystemWatcher watcher
-            )
+                FileSystemWatcher watcher)
             {
                 // Since renames come in pairs, when we find the first we need to search for the next one. Once we find it, we'll add it to this
                 // list so when the for-loop comes across it, we'll skip it since it's already been processed as part of the original of the pair.

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
@@ -47,6 +47,45 @@ namespace System.IO.Tests
             });
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "#34017")]
+        [OuterLoop]
+        [Fact]
+        public void FileSystemWatcher_File_Create_SuppressedExecutionContextHandled()
+        {
+            ExecuteWithRetry(() =>
+            {
+                using (var watcher1 = new FileSystemWatcher(TestDirectory))
+                using (var watcher2 = new FileSystemWatcher(TestDirectory))
+                {
+                    string fileName = Path.Combine(TestDirectory, "file");
+                    watcher1.Filter = Path.GetFileName(fileName);
+                    watcher2.Filter = Path.GetFileName(fileName);
+
+                    var local = new AsyncLocal<int>();
+
+                    var tcs1 = new TaskCompletionSource<int>();
+                    watcher1.Created += (s, e) => tcs1.SetResult(local.Value);
+
+                    local.Value = 42;
+
+                    ExecutionContext.SuppressFlow();
+                    try
+                    {
+                        watcher1.EnableRaisingEvents = true;
+                    }
+                    finally
+                    {
+                        ExecutionContext.RestoreFlow();
+                    }
+
+                    File.Create(fileName).Dispose();
+                    tcs1.Task.Wait(WaitForExpectedEventTimeout);
+
+                    Assert.Equal(0, tcs1.Task.Result);
+                }
+            });
+        }
+
         [OuterLoop]
         [Fact]
         public void FileSystemWatcher_File_Create_NotAffectEachOther()

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
@@ -59,7 +59,6 @@ namespace System.IO.Tests
                 {
                     string fileName = Path.Combine(TestDirectory, "file");
                     watcher1.Filter = Path.GetFileName(fileName);
-                    watcher2.Filter = Path.GetFileName(fileName);
 
                     var local = new AsyncLocal<int>();
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
@@ -55,7 +55,6 @@ namespace System.IO.Tests
             ExecuteWithRetry(() =>
             {
                 using (var watcher1 = new FileSystemWatcher(TestDirectory))
-                using (var watcher2 = new FileSystemWatcher(TestDirectory))
                 {
                     string fileName = Path.Combine(TestDirectory, "file");
                     watcher1.Filter = Path.GetFileName(fileName);


### PR DESCRIPTION
Ignore whitespace diff is easier to see changes https://github.com/dotnet/corefx/pull/34438/files?w=1

Fixes https://github.com/dotnet/corefx/issues/34434

/cc @MaximLipnin @stephentoub @JeremyKuhne