### PR TITLE
Modify FormatDescription test

### DIFF
--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
@@ -292,7 +292,14 @@ namespace System.Diagnostics.Eventing.Reader
             {
                 if (theValues.Length == i)
                     Array.Resize(ref theValues, i + 1);
-                theValues[i] = o.ToString();
+                if (o is EventProperty elp)
+                {
+                    theValues[i] = elp.Value.ToString();
+                }
+                else
+                {
+                    theValues[i] = o.ToString();
+                }
                 i++;
             }
 


### PR DESCRIPTION
Fixing test failure: https://github.com/dotnet/corefx/pull/33662#issuecomment-452371494

I had the wrong assumption on `FormatDescription`:
- `record.FormatDescription()` doesn't always return null
- `record.FormatDescription(new[] {"dummy"})` doesn't always throw exception

Instead I just assert input of null, empty enumerable and also passing no args to FormatDescription returns the same description string in all three cases.

Related to: https://github.com/dotnet/corefx/issues/34136
I made the fix explained in comment: https://github.com/dotnet/corefx/issues/34136#issuecomment-448055535
This addresses part of the issue explained in https://github.com/dotnet/corefx/issues/34136 but doesn't address the whole bug.

cc: @danmosemsft @Anipik 