### PR TITLE
Enable helix telemetry for official builds and PRs

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -125,12 +125,9 @@ jobs:
           ${{ if and(ne(property.key, 'job'), ne(property.key, 'variables'), ne(property.key, 'enableMicrobuild')) }}:
             ${{ property.key }}: ${{ property.value }}
 
-        # enable helix telemetry
-        enableTelemetry: true
+        # enable helix telemetry -- we only send telemetry during official builds
+        enableTelemetry: ${{ parameters.isOfficialBuild }}
         helixRepo: corefx
-        ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-          # default value is build/product/ so only pass it when not in official build
-          helixType: build/ci/
 
         name: ${{ job.job }}
         workspace:

--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -17,7 +17,7 @@ parameters:
   # EACH JOB SHOULD INCLUDE THE FOLLOWING PROPERTIES (ASIDE FROM THE REQUIRED ONES IN THE JOB SCHEMA)
 
   # Required: as part of the strategy matrix, the following variables should be defined
-  #     _configuration: Debug | Release
+  #     _BuildConfig: Debug | Release
   #     _architecture: x64 | x86 | arm | arm64
   #     _framework: (netcoreapp, netfx, uap, etc).
   #     _helixQueues: Windows.Amd64 (Only needed if submitToHelix -> true.) -- Queues should be separated by + if multiple.
@@ -125,6 +125,13 @@ jobs:
           ${{ if and(ne(property.key, 'job'), ne(property.key, 'variables'), ne(property.key, 'enableMicrobuild')) }}:
             ${{ property.key }}: ${{ property.value }}
 
+        # enable helix telemetry
+        enableTelemetry: true
+        helixRepo: corefx
+        ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+          # default value is build/product/ so only pass it when not in official build
+          helixType: build/ci/
+
         name: ${{ job.job }}
         workspace:
           clean: all
@@ -144,7 +151,7 @@ jobs:
                     $(_commonArguments)
                     -framework $(_framework)
                     /p:ArchGroup=$(_architecture)
-                    /p:ConfigurationGroup=$(_configuration)
+                    /p:ConfigurationGroup=$(_BuildConfig)
                     /p:SkipTests=$(_skipTests)
                     /p:Outerloop=$(_outerloop)
                     /p:ArchiveTests=${{ job.submitToHelix }}
@@ -161,7 +168,7 @@ jobs:
               parameters:
                 targetOS: ${{ parameters.targetOS }}
                 archGroup: $(_architecture)
-                configuration: $(_configuration)
+                configuration: $(_BuildConfig)
                 helixQueues: $(_helixQueues)
                 msbuildScript: $(_msbuildCommand)
                 framework: $(_framework)
@@ -182,7 +189,7 @@ jobs:
             - task: PublishBuildArtifacts@1
               displayName: Publish packages to artifacts container
               inputs:
-                pathToPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_configuration)
+                pathToPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)
                 artifactName: packages
                 artifactType: container
               condition: and(succeeded(), ne(variables['_skipPublishPackages'], 'true'))

--- a/eng/pipelines/freebsd.yml
+++ b/eng/pipelines/freebsd.yml
@@ -11,7 +11,7 @@ jobs:
       strategy:
         matrix:
           x64_Release:
-            _configuration: Release
+            _BuildConfig: Release
             _architecture: x64
             _framework: netcoreapp
             _buildScriptPrefix: 'DotNetCoreSdkDir=/usr/local/dotnet/ DotNetRoot=/usr/local/dotnet/ '

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -18,7 +18,7 @@ jobs:
       strategy:
         matrix:
           x64_Release:
-            _configuration: Release
+            _BuildConfig: Release
             _architecture: x64
             _framework: netcoreapp
             _helixQueues: $(linuxDefaultQueues)
@@ -27,7 +27,7 @@ jobs:
             _buildExtraArguments: ''
 
           arm64_Release:
-            _configuration: Release
+            _BuildConfig: Release
             _architecture: arm64
             _framework: netcoreapp
             _helixQueues: $(linuxArm64Queues)
@@ -37,7 +37,7 @@ jobs:
           
           ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             musl_x64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x64
               _framework: netcoreapp
               _helixQueues: $(alpineQueues)
@@ -73,7 +73,7 @@ jobs:
         matrix:
           ${{ if eq(parameters.isOfficialBuild, 'false') }}:
             musl_x64_Debug:
-              _configuration: Debug
+              _BuildConfig: Debug
               _architecture: x64
               _framework: netcoreapp
               _dockerContainer: alpine_36_container
@@ -81,7 +81,7 @@ jobs:
               _buildExtraArguments: /p:RuntimeOS=linux-musl /p:PortableBuild=false
 
           arm_Release:
-            _configuration: Release
+            _BuildConfig: Release
             _architecture: arm
             _framework: netcoreapp
             _buildExtraArguments: /p:RuntimeOS=ubuntu.16.04

--- a/eng/pipelines/macos.yml
+++ b/eng/pipelines/macos.yml
@@ -19,14 +19,14 @@ jobs:
         matrix:
           ${{ if eq(parameters.isOfficialBuild, 'false') }}:
             x64_Debug:
-              _configuration: Debug
+              _BuildConfig: Debug
               _architecture: x64
               _framework: netcoreapp
               _helixQueues: $(macOSQueues)
 
           ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             x64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x64
               _framework: netcoreapp
               _helixQueues: $(macOSQueues)

--- a/eng/pipelines/redhat6.yml
+++ b/eng/pipelines/redhat6.yml
@@ -11,7 +11,7 @@ jobs:
       strategy:
         matrix:
           x64_Release:
-            _configuration: Release
+            _BuildConfig: Release
             _architecture: x64
             _framework: netcoreapp
             _buildExtraArguments: /p:RuntimeOS=rhel.6 /p:PortableBuild=false

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -20,25 +20,25 @@ jobs:
           # PR CI Matrix
           ${{ if eq(parameters.isOfficialBuild, 'false') }}:
             x64_Debug:
-              _configuration: Debug
+              _BuildConfig: Debug
               _architecture: x64
               _framework: netcoreapp
               _helixQueues: $(netcoreappWindowsQueues)+$(nanoQueues)
 
             x86_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x86
               _framework: netcoreapp
               _helixQueues: $(netcoreappWindowsQueues)
 
             NETFX_x86_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x86
               _framework: netfx
               _helixQueues: $(uapNetfxQueues)
 
             UWP_CoreCLR_x64_Debug:
-              _configuration: Debug
+              _BuildConfig: Debug
               _architecture: x64
               _framework: uap
               _helixQueues: $(uapNetfxQueues)
@@ -46,45 +46,45 @@ jobs:
           # Official build LEGS with HELIX Testing
           ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             x64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x64
               _framework: netcoreapp
               _helixQueues: $(netcoreappWindowsQueues)+$(nanoQueues)
 
             x86_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x86
               _framework: netcoreapp
               _helixQueues: $(netcoreappWindowsQueues)
 
             NETFX_x86_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x86
               _framework: netfx
               _helixQueues: $(uapNetfxQueues)
               _skipPublishPackages: true # In NETFX leg we don't produce packages
 
             NETFX_x64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x64
               _framework: netfx
               _helixQueues: $(uapNetfxQueues)
               _skipPublishPackages: true # In NETFX leg we don't produce packages
 
             UAP_x64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x64
               _framework: uap
               _helixQueues: $(uapNetfxQueues)
 
             UAP_x86_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x86
               _framework: uap
               _helixQueues: $(uapNetfxQueues)
 
             UAP_arm_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: arm
               _framework: uap
               _helixQueues: $(windowsArmQueue)
@@ -121,14 +121,14 @@ jobs:
           # PR Validation Matrix
           ${{ if eq(parameters.isOfficialBuild, 'false') }}:
             x64_Debug:
-              _configuration: Debug
+              _BuildConfig: Debug
               _architecture: x64
               _framework: allConfigurations
 
           # Official Build Matrix
           ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             x64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x64
               _framework: allConfigurations
 
@@ -146,7 +146,7 @@ jobs:
                   -ci
                   -$(_framework)
                   /p:ArchGroup=$(_architecture)
-                  /p:ConfigurationGroup=$(_configuration)
+                  /p:ConfigurationGroup=$(_BuildConfig)
                   /p:RuntimeOS=win10
                   $(_windowsOfficialBuildArguments)
                   $(_msbuildCommonParameters)
@@ -157,7 +157,7 @@ jobs:
                     -test
                     /p:TargetGroup=netstandard
                     /p:ArchGroup=$(_architecture)
-                    /p:ConfigurationGroup=$(_configuration)
+                    /p:ConfigurationGroup=$(_BuildConfig)
                     /p:SkipTests=true
             displayName: Build Netstandard Test Suite
           - script: build.cmd
@@ -165,7 +165,7 @@ jobs:
                     -test
                     -$(_framework)
                     /p:ArchGroup=$(_architecture)
-                    /p:ConfigurationGroup=$(_configuration)
+                    /p:ConfigurationGroup=$(_BuildConfig)
             displayName: Run Package Tests
 
     # TODO: UAPAOT official builds should send to helix using continuation runner.
@@ -176,38 +176,38 @@ jobs:
         matrix:
           ${{ if eq(parameters.isOfficialBuild, 'false') }}:
             UWP_NETNative_x86_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x86
               _framework: uapaot
 
           ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             arm_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: arm
               _framework: netcoreapp
 
             arm64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: arm64
               _framework: netcoreapp
 
             UAPAOT_x86_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x86
               _framework: uapaot
 
             UAPAOT_x64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: x64
               _framework: uapaot
 
             UAPAOT_arm_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: arm
               _framework: uapaot
 
             UAPAOT_arm64_Release:
-              _configuration: Release
+              _BuildConfig: Release
               _architecture: arm64
               _framework: uapaot
 


### PR DESCRIPTION
The _configuration to _BuildConfig change is because the arcade template that sends the telemetry uses _BuildConfig to retrieve the configuration. 

Fixes: https://github.com/dotnet/corefx/issues/34430

@MattGal do we care about this only on official builds?

cc: @danmosemsft 