### PR TITLE
Mitigate potential case where allocated marshal data is aligned to th…

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
@@ -119,6 +119,19 @@ namespace System.Runtime.InteropServices.Tests
             };
 
             Assert.Equal(100, Marshal.ReadByte(structure, pointerOffset));
+
+            // The ReadByte() for object types does an explicit marshal which requires
+            // an allocation on each read. It can occur that the allocation is aligned
+            // on a byte boundary which would yield a value of 0. To mitigate the chance,
+            // marshal several times.
+            int readBytes = 0;
+            for (int i = 0; i < 3; ++i)
+            {
+                readBytes += Marshal.ReadByte(structure, stringOffset);
+            }
+
+            Assert.NotEqual(0, readBytes);
+
             Assert.Equal(3, Marshal.ReadByte(structure, arrayOffset + sizeof(byte) * 2));
         }
 

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
@@ -123,9 +123,10 @@ namespace System.Runtime.InteropServices.Tests
             // The ReadByte() for object types does an explicit marshal which requires
             // an allocation on each read. It can occur that the allocation is aligned
             // on a byte boundary which would yield a value of 0. To mitigate the chance,
-            // marshal several times.
+            // marshal several times, choosing 20 as an arbitrary value. If this test
+            // fails, we should reconsider whether it is worth the flakiness.
             int readBytes = 0;
-            for (int i = 0; i < 3; ++i)
+            for (int i = 0; i < 20; ++i)
             {
                 readBytes += Marshal.ReadByte(structure, stringOffset);
             }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
@@ -120,7 +120,19 @@ namespace System.Runtime.InteropServices.Tests
             };
 
             Assert.Equal(100, Marshal.ReadInt16(structure, pointerOffset));
-            Assert.NotEqual(0, Marshal.ReadInt16(structure, stringOffset));
+
+            // The ReadInt16() for object types does an explicit marshal which requires
+            // an allocation on each read. It can occur that the allocation is aligned
+            // on a 16-byte boundary which would yield a value of 0. To mitigate the chance,
+            // marshal several times.
+            int readShorts = 0;
+            for (int i = 0; i < 3; ++i)
+            {
+                readShorts += Marshal.ReadInt16(structure, stringOffset);
+            }
+
+            Assert.NotEqual(0, readShorts);
+
             Assert.Equal(3, Marshal.ReadInt16(structure, arrayOffset + sizeof(short) * 2));
         }
 

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
@@ -123,7 +123,7 @@ namespace System.Runtime.InteropServices.Tests
 
             // The ReadInt16() for object types does an explicit marshal which requires
             // an allocation on each read. It can occur that the allocation is aligned
-            // on a 16-byte boundary which would yield a value of 0. To mitigate the chance,
+            // on a 16-bit boundary which would yield a value of 0. To mitigate the chance,
             // marshal several times.
             int readShorts = 0;
             for (int i = 0; i < 3; ++i)

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
@@ -124,9 +124,10 @@ namespace System.Runtime.InteropServices.Tests
             // The ReadInt16() for object types does an explicit marshal which requires
             // an allocation on each read. It can occur that the allocation is aligned
             // on a 16-bit boundary which would yield a value of 0. To mitigate the chance,
-            // marshal several times.
+            // marshal several times, choosing 20 as an arbitrary value. If this test
+            // fails, we should reconsider whether it is worth the flakiness.
             int readShorts = 0;
-            for (int i = 0; i < 3; ++i)
+            for (int i = 0; i < 20; ++i)
             {
                 readShorts += Marshal.ReadInt16(structure, stringOffset);
             }


### PR DESCRIPTION
…e primitive being read.

 - Int16 and Int8.
