### PR TITLE
Fix sorted list syncroot test

### DIFF
--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -1570,7 +1570,7 @@ namespace System.Collections.Tests
                 sortListMother.Add("Key_" + i, "Value_" + i);
             }
 
-            Assert.Equal(sortListMother.SyncRoot.GetType(), typeof(object));
+            Assert.Equal(sortListMother.SyncRoot.GetType(), typeof(SortedList));
 
             SortedList sortListSon = SortedList.Synchronized(sortListMother);
             _sortListGrandDaughter = SortedList.Synchronized(sortListSon);


### PR DESCRIPTION
Broken by https://github.com/dotnet/corefx/pull/34339 CI was green as it's an outer loop test.