### PR TITLE
Expose/test/use string.Concat(ReadOnlySpan, ...)

### DIFF
--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -207,50 +207,17 @@ namespace System.Tests
             Assert.Equal(expected, s.AsSpan().Length);
         }
 
-        public static IEnumerable<object[]> Concat_Strings_TestData()
+        public static IEnumerable<object[]> Concat_Strings_LessThan2_GreaterThan4_TestData()
         {
+            // 0
             yield return new object[] { new string[0], "" };
 
+            // 1
             yield return new object[] { new string[] { "1" }, "1" };
             yield return new object[] { new string[] { null }, "" };
             yield return new object[] { new string[] { "" }, "" };
 
-            yield return new object[] { new string[] { "1", "2" }, "12" };
-            yield return new object[] { new string[] { null, "1" }, "1" };
-            yield return new object[] { new string[] { "", "1" }, "1" };
-            yield return new object[] { new string[] { "1", null }, "1" };
-            yield return new object[] { new string[] { "1", "" }, "1" };
-            yield return new object[] { new string[] { null, null }, "" };
-            yield return new object[] { new string[] { "", "" }, "" };
-
-            yield return new object[] { new string[] { "1", "2", "3" }, "123" };
-            yield return new object[] { new string[] { null, "1", "2" }, "12" };
-            yield return new object[] { new string[] { "", "1", "2" }, "12" };
-            yield return new object[] { new string[] { "1", null, "2" }, "12" };
-            yield return new object[] { new string[] { "1", "", "2" }, "12" };
-            yield return new object[] { new string[] { "1", "2", null }, "12" };
-            yield return new object[] { new string[] { "1", "2", "" }, "12" };
-            yield return new object[] { new string[] { null, "2", null }, "2" };
-            yield return new object[] { new string[] { "", "2", "" }, "2" };
-            yield return new object[] { new string[] { null, null, null }, "" };
-            yield return new object[] { new string[] { "", "", "" }, "" };
-
-            yield return new object[] { new string[] { "1", "2", "3", "4" }, "1234" };
-            yield return new object[] { new string[] { null, "1", "2", "3" }, "123" };
-            yield return new object[] { new string[] { "", "1", "2", "3" }, "123" };
-            yield return new object[] { new string[] { "1", null, "2", "3" }, "123" };
-            yield return new object[] { new string[] { "1", "", "2", "3" }, "123" };
-            yield return new object[] { new string[] { "1", "2", null, "3" }, "123" };
-            yield return new object[] { new string[] { "1", "2", "", "3" }, "123" };
-            yield return new object[] { new string[] { "1", "2", "3", null }, "123" };
-            yield return new object[] { new string[] { "1", "2", "3", "" }, "123" };
-            yield return new object[] { new string[] { "1", null, null, null }, "1" };
-            yield return new object[] { new string[] { "1", "", "", "" }, "1" };
-            yield return new object[] { new string[] { null, "1", null, "2" }, "12" };
-            yield return new object[] { new string[] { "", "1", "", "2" }, "12" };
-            yield return new object[] { new string[] { null, null, null, null }, "" };
-            yield return new object[] { new string[] { "", "", "", "" }, "" };
-
+            // 5
             yield return new object[] { new string[] { "1", "2", "3", "4", "5" }, "12345" };
             yield return new object[] { new string[] { null, "1", "2", "3", "4" }, "1234" };
             yield return new object[] { new string[] { "", "1", "2", "3", "4" }, "1234" };
@@ -267,11 +234,55 @@ namespace System.Tests
             yield return new object[] { new string[] { null, null, null, null, null }, "" };
             yield return new object[] { new string[] { "", "", "", "", "" }, "" };
 
+            // 7
             yield return new object[] { new string[] { "abcd", "efgh", "ijkl", "mnop", "qrst", "uvwx", "yz" }, "abcdefghijklmnopqrstuvwxyz" };
         }
 
+        public static IEnumerable<object[]> Concat_Strings_2_3_4_TestData()
+        {
+            // 2
+            yield return new object[] { new string[] { "1", "2" }, "12" };
+            yield return new object[] { new string[] { null, "1" }, "1" };
+            yield return new object[] { new string[] { "", "1" }, "1" };
+            yield return new object[] { new string[] { "1", null }, "1" };
+            yield return new object[] { new string[] { "1", "" }, "1" };
+            yield return new object[] { new string[] { null, null }, "" };
+            yield return new object[] { new string[] { "", "" }, "" };
+
+            // 3
+            yield return new object[] { new string[] { "1", "2", "3" }, "123" };
+            yield return new object[] { new string[] { null, "1", "2" }, "12" };
+            yield return new object[] { new string[] { "", "1", "2" }, "12" };
+            yield return new object[] { new string[] { "1", null, "2" }, "12" };
+            yield return new object[] { new string[] { "1", "", "2" }, "12" };
+            yield return new object[] { new string[] { "1", "2", null }, "12" };
+            yield return new object[] { new string[] { "1", "2", "" }, "12" };
+            yield return new object[] { new string[] { null, "2", null }, "2" };
+            yield return new object[] { new string[] { "", "2", "" }, "2" };
+            yield return new object[] { new string[] { null, null, null }, "" };
+            yield return new object[] { new string[] { "", "", "" }, "" };
+
+            // 4
+            yield return new object[] { new string[] { "1", "2", "3", "4" }, "1234" };
+            yield return new object[] { new string[] { null, "1", "2", "3" }, "123" };
+            yield return new object[] { new string[] { "", "1", "2", "3" }, "123" };
+            yield return new object[] { new string[] { "1", null, "2", "3" }, "123" };
+            yield return new object[] { new string[] { "1", "", "2", "3" }, "123" };
+            yield return new object[] { new string[] { "1", "2", null, "3" }, "123" };
+            yield return new object[] { new string[] { "1", "2", "", "3" }, "123" };
+            yield return new object[] { new string[] { "1", "2", "3", null }, "123" };
+            yield return new object[] { new string[] { "1", "2", "3", "" }, "123" };
+            yield return new object[] { new string[] { "1", null, null, null }, "1" };
+            yield return new object[] { new string[] { "1", "", "", "" }, "1" };
+            yield return new object[] { new string[] { null, "1", null, "2" }, "12" };
+            yield return new object[] { new string[] { "", "1", "", "2" }, "12" };
+            yield return new object[] { new string[] { null, null, null, null }, "" };
+            yield return new object[] { new string[] { "", "", "", "" }, "" };
+        }
+
         [Theory]
-        [MemberData(nameof(Concat_Strings_TestData))]
+        [MemberData(nameof(Concat_Strings_2_3_4_TestData))]
+        [MemberData(nameof(Concat_Strings_LessThan2_GreaterThan4_TestData))]
         public static void Concat_String(string[] values, string expected)
         {
             Action<string> validate = result =>

--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -306,6 +306,7 @@
     <Reference Include="System.Diagnostics.Tracing" />
     <Reference Include="System.Linq" />
     <Reference Include="System.Linq.Expressions" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.ObjectModel" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />

--- a/src/System.Data.Common/src/System/Data/XmlToDatasetMap.cs
+++ b/src/System.Data.Common/src/System/Data/XmlToDatasetMap.cs
@@ -535,7 +535,7 @@ namespace System.Data
                 tempColumnName = "_x0058_"; // upper case Xml... -> _x0058_ml...
             }
 
-            tempColumnName += col.ColumnName.Substring(1);
+            tempColumnName = string.Concat(tempColumnName, col.ColumnName.AsSpan(1));
 
             if (nameTable.Get(tempColumnName) == null)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
@@ -237,17 +237,17 @@ namespace System.Net.Http.Headers
 
             // If there is no whitespace between <type> and <subtype> in <type>/<subtype> get the media type using
             // one Substring call. Otherwise get substrings for <type> and <subtype> and combine them.
-            int mediatTypeLength = current + subtypeLength - startIndex;
-            if (typeLength + subtypeLength + 1 == mediatTypeLength)
+            int mediaTypeLength = current + subtypeLength - startIndex;
+            if (typeLength + subtypeLength + 1 == mediaTypeLength)
             {
-                mediaType = input.Substring(startIndex, mediatTypeLength);
+                mediaType = input.Substring(startIndex, mediaTypeLength);
             }
             else
             {
-                mediaType = input.Substring(startIndex, typeLength) + "/" + input.Substring(current, subtypeLength);
+                mediaType = string.Concat(input.AsSpan(startIndex, typeLength), "/", input.AsSpan(current, subtypeLength));
             }
 
-            return mediatTypeLength;
+            return mediaTypeLength;
         }
 
         private static void CheckMediaTypeFormat(string mediaType, string parameterName)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpSystemProxy.cs
@@ -240,7 +240,7 @@ namespace System.Net.Http
                 {
                     idx += 5; // Skip "http=" so we can replace it with "http://"
                     int proxyLength = GetProxySubstringLength(value, idx);
-                    Uri.TryCreate("http://" + value.Substring(idx, proxyLength) , UriKind.Absolute, out insecureProxy);
+                    Uri.TryCreate(string.Concat("http://", value.AsSpan(idx, proxyLength)), UriKind.Absolute, out insecureProxy);
                 }
             }
 
@@ -249,7 +249,7 @@ namespace System.Net.Http
             {
                 idx += 8; // Skip "https://" so we can replace it with "http://"
                 int proxyLength = GetProxySubstringLength(value, idx);
-                Uri.TryCreate("http://" + value.Substring(idx, proxyLength) , UriKind.Absolute, out secureProxy);
+                Uri.TryCreate(string.Concat("http://", value.AsSpan(idx, proxyLength)), UriKind.Absolute, out secureProxy);
             }
 
             if (secureProxy == null)
@@ -259,7 +259,7 @@ namespace System.Net.Http
                 {
                     idx += 6; // Skip "https=" so we can replace it with "http://"
                     int proxyLength = GetProxySubstringLength(value, idx);
-                    Uri.TryCreate("http://" + value.Substring(idx, proxyLength) , UriKind.Absolute, out secureProxy);
+                    Uri.TryCreate(string.Concat("http://", value.AsSpan(idx, proxyLength)), UriKind.Absolute, out secureProxy);
                 }
             }
         }

--- a/src/System.Net.Requests/src/System.Net.Requests.csproj
+++ b/src/System.Net.Requests/src/System.Net.Requests.csproj
@@ -116,6 +116,7 @@
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Diagnostics.Tracing" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Net.Security" />

--- a/src/System.Net.Requests/src/System/Net/CommandStream.cs
+++ b/src/System.Net.Requests/src/System/Net/CommandStream.cs
@@ -207,7 +207,7 @@ namespace System.Net
                         {
                             int index = sendCommand.IndexOf(' ');
                             if (index != -1)
-                                sendCommand = sendCommand.Substring(0, index) + " ********";
+                                sendCommand = string.Concat(sendCommand.AsSpan(0, index), " ********");
                         }
                         if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Sending command {sendCommand}");
                     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
@@ -125,7 +125,7 @@ namespace System.Net.Sockets
             bool isAbstract = IsAbstract(_path);
             if (isAbstract)
             {
-                return "@" + _path.Substring(1);
+                return string.Concat("@", _path.AsSpan(1));
             }
             else
             {

--- a/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaDataType.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaDataType.cs
@@ -313,7 +313,7 @@ namespace System.Xml.Schema
 
             if (convert)
             {
-                canonicalUri = nameTable.Add(uri.Substring(0, offset) + CultureInfo.InvariantCulture.TextInfo.ToUpper(uri.Substring(offset, uri.Length - offset)));
+                canonicalUri = nameTable.Add(string.Concat(uri.AsSpan(0, offset), CultureInfo.InvariantCulture.TextInfo.ToUpper(uri.Substring(offset, uri.Length - offset))));
             }
             else
             {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -34,7 +34,7 @@ namespace System.Xml.Serialization
             if (identifier.Length <= 2)
                 return CultureInfo.InvariantCulture.TextInfo.ToUpper(identifier);
             else if (char.IsLower(identifier[0]))
-                return char.ToUpperInvariant(identifier[0]) + identifier.Substring(1);
+                return string.Concat(char.ToUpperInvariant(identifier[0]).ToString(), identifier.AsSpan(1));
             else
                 return identifier;
         }
@@ -48,7 +48,7 @@ namespace System.Xml.Serialization
             if (identifier.Length <= 2)
                 return CultureInfo.InvariantCulture.TextInfo.ToLower(identifier);
             else if (char.IsUpper(identifier[0]))
-                return char.ToLower(identifier[0]) + identifier.Substring(1);
+                return string.Concat(char.ToLower(identifier[0]).ToString(), identifier.AsSpan(1));
             else
                 return identifier;
         }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -822,8 +822,8 @@ namespace System.Xml.Serialization
                 }
                 else
                 {
-                    attr.Value = _r.LookupNamespace(attr.Value.Substring(0, colon)) + ":" +
-                        attr.Value.Substring(colon + 1);
+                    attr.Value = string.Concat(_r.LookupNamespace(attr.Value.Substring(0, colon)), ":",
+                        attr.Value.AsSpan(colon + 1));
                 }
             }
             return;

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -2316,6 +2316,9 @@ namespace System
         public static System.String Concat(System.String str0, System.String str1) { throw null; }
         public static System.String Concat(System.String str0, System.String str1, System.String str2) { throw null; }
         public static System.String Concat(System.String str0, System.String str1, System.String str2, System.String str3) { throw null; }
+        public static System.String Concat(System.ReadOnlySpan<char> str0, System.ReadOnlySpan<char> str1) { throw null; }
+        public static System.String Concat(System.ReadOnlySpan<char> str0, System.ReadOnlySpan<char> str1, System.ReadOnlySpan<char> str2) { throw null; }
+        public static System.String Concat(System.ReadOnlySpan<char> str0, System.ReadOnlySpan<char> str1, System.ReadOnlySpan<char> str2, System.ReadOnlySpan<char> str3) { throw null; }
         public static System.String Concat(params string[] values) { throw null; }
         public static System.String Concat<T>(System.Collections.Generic.IEnumerable<T> values) { throw null; }
         public bool Contains(char value) { throw null; }

--- a/src/System.Runtime/tests/System/StringTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/StringTests.netcoreapp.cs
@@ -1003,5 +1003,24 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentException>("comparisonType", () => "foo".IndexOf('o', StringComparison.CurrentCulture - 1));
             AssertExtensions.Throws<ArgumentException>("comparisonType", () => "foo".IndexOf('o', StringComparison.OrdinalIgnoreCase + 1));
         }
+
+        [Theory]
+        [MemberData(nameof(Concat_Strings_2_3_4_TestData))]
+        public static void Concat_Spans(string[] values, string expected)
+        {
+            Assert.InRange(values.Length, 2, 4);
+
+            string result =
+                values.Length == 2 ? string.Concat(values[0].AsSpan(), values[1].AsSpan()) :
+                values.Length == 3 ? string.Concat(values[0].AsSpan(), values[1].AsSpan(), values[2].AsSpan()) :
+                string.Concat(values[0].AsSpan(), values[1].AsSpan(), values[2].AsSpan(), values[3].AsSpan());
+
+            if (result.Length == 0)
+            {
+                Assert.Same(string.Empty, result);
+            }
+
+            Assert.Equal(expected, result);
+        }
     }
 }

--- a/src/System.Web.HttpUtility/src/System.Web.HttpUtility.csproj
+++ b/src/System.Web.HttpUtility/src/System.Web.HttpUtility.csproj
@@ -18,6 +18,7 @@
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Globalization" />
     <Reference Include="System.IO" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Text.Encoding" />

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -639,7 +639,7 @@ namespace System.Web.Util
             int i = value.IndexOf('?');
             if (i >= 0)
             {
-                return UrlPathEncodeImpl(value.Substring(0, i)) + value.Substring(i);
+                return string.Concat(UrlPathEncodeImpl(value.Substring(0, i)), value.AsSpan(i));
             }
 
             // encode DBCS characters and spaces only


### PR DESCRIPTION
- Exposes string.Concat(ReadOnlySpan, …) overloads in ref
- Tests the overloads
- Adds use of the overloads in a handful of places across corefx (there are still likely more, this is just the result of a cursory search across a few projects)

Fixes https://github.com/dotnet/corefx/issues/34330
Depends on https://github.com/dotnet/coreclr/pull/21882