### PR TITLE
Clean up HttpClientTest

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
 
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP will send default credentials based on manifest settings")]
     [PlatformSpecific(TestPlatforms.Windows)]
-    public abstract class DefaultCredentialsTest : HttpClientTestBase
+    public abstract class DefaultCredentialsTest : HttpClientHandlerTestBase
     {
         private static bool DomainJoinedTestsEnabled => !string.IsNullOrEmpty(Configuration.Http.DomainJoinedHttpHost);
 

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -20,7 +20,7 @@ namespace System.Net.Http.Functional.Tests
 
     [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
     [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
-    public abstract class DiagnosticsTest : HttpClientTestBase
+    public abstract class DiagnosticsTest : HttpClientHandlerTestBase
     {
         [Fact]
         public static void EventSource_ExistsWithCorrectId()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClient.SelectedSitesTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClient.SelectedSitesTest.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpClient_SelectedSites_Test : HttpClientTestBase
+    public abstract class HttpClient_SelectedSites_Test : HttpClientHandlerTestBase
     {
         public static bool IsSelectedSitesTestEnabled() 
         {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class HttpClientEKUTest : HttpClientTestBase
+    public abstract class HttpClientEKUTest : HttpClientHandlerTestBase
     {
         // Curl + OSX SecureTransport doesn't support the custom certificate callback.
         private static bool BackendSupportsCustomCertificateHandling =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -12,7 +12,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandlerTestBase
     {
         private static bool ClientSupportsDHECipherSuites => (!PlatformDetection.IsWindows || PlatformDetection.IsWindows10Version1607OrGreater);
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Asynchrony.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Asynchrony.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpClientHandler_Asynchrony_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_Asynchrony_Test : HttpClientHandlerTestBase
     {
         public static IEnumerable<object[]> ResponseHeadersRead_SynchronizationContextNotUsedByHandler_MemberData() =>
             from responseHeadersRead in new[] { false, true }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace System.Net.Http.Functional.Tests
 {
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Tests would need to be rewritten due to behavior differences with WinRT")]
-    public abstract class HttpClientHandler_Authentication_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_Authentication_Test : HttpClientHandlerTestBase
     {
         private const string Username = "testusername";
         private const string Password = "testpassword";

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AutoRedirect.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AutoRedirect.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class HttpClientHandlerTest_AutoRedirect : HttpClientTestBase
+    public abstract class HttpClientHandlerTest_AutoRedirect : HttpClientHandlerTestBase
     {
         readonly ITestOutputHelper _output;
         private const string ExpectedContent = "Test content";

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpClientHandler_Cancellation_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_Cancellation_Test : HttpClientHandlerTestBase
     {
         [Theory]
         [InlineData(false, CancellationMode.Token)]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class HttpClientHandler_ClientCertificates_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_ClientCertificates_Test : HttpClientHandlerTestBase
     {
         public bool CanTestCertificates =>
             Capability.IsTrustedRootCertificateInstalled() &&

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Decompression.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpClientHandler_Decompression_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_Decompression_Test : HttpClientHandlerTestBase
     {
         private readonly ITestOutputHelper _output;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class HttpClientHandler_DefaultProxyCredentials_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_DefaultProxyCredentials_Test : HttpClientHandlerTestBase
     {
         [Fact]
         public void Default_Get_Null()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
     using Configuration = System.Net.Test.Common.Configuration;
 
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP connection management behavior is different due to WinRT")]
-    public abstract class HttpClientHandler_MaxConnectionsPerServer_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_MaxConnectionsPerServer_Test : HttpClientHandlerTestBase
     {
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "MaxConnectionsPerServer either returns two or int.MaxValue depending if ctor of HttpClientHandlerTest executed first. Disabling cause of random xunit execution order.")]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientHandlerTestBase
     {
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]
         [Theory]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
     using Configuration = System.Net.Test.Common.Configuration;
 
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP HTTP stack doesn't support .Proxy property")]
-    public abstract class HttpClientHandler_Proxy_Test : HttpClientTestBase
+    public abstract class HttpClientHandler_Proxy_Test : HttpClientHandlerTestBase
     {
         private readonly ITestOutputHelper _output;
         

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ResponseDrain.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-   public abstract class HttpClientHandler_ResponseDrain_Test : HttpClientTestBase
+   public abstract class HttpClientHandler_ResponseDrain_Test : HttpClientHandlerTestBase
     {
         protected virtual void SetResponseDrainTimeout(HttpClientHandler handler, TimeSpan time) { }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -17,7 +17,7 @@ namespace System.Net.Http.Functional.Tests
     using Configuration = System.Net.Test.Common.Configuration;
 
     [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws PNSE for ServerCertificateCustomValidationCallback")]
-    public abstract partial class HttpClientHandler_ServerCertificates_Test : HttpClientTestBase
+    public abstract partial class HttpClientHandler_ServerCertificates_Test : HttpClientHandlerTestBase
     {
         private static bool ClientSupportsDHECipherSuites => (!PlatformDetection.IsWindows || PlatformDetection.IsWindows10Version1607OrGreater);
         private bool BackendSupportsCustomCertificateHandlingAndClientSupportsDHECipherSuites =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -17,7 +17,7 @@ namespace System.Net.Http.Functional.Tests
 
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "SslProtocols not supported on UAP")]
     [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "SslProtocols property requires .NET 4.7.2")]
-    public abstract partial class HttpClientHandler_SslProtocols_Test : HttpClientTestBase
+    public abstract partial class HttpClientHandler_SslProtocols_Test : HttpClientHandlerTestBase
     {
         [Fact]
         public void DefaultProtocols_MatchesExpected()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -26,7 +26,7 @@ namespace System.Net.Http.Functional.Tests
 
     // Note:  Disposing the HttpClient object automatically disposes the handler within. So, it is not necessary
     // to separately Dispose (or have a 'using' statement) for the handler.
-    public abstract class HttpClientHandlerTest : HttpClientTestBase
+    public abstract class HttpClientHandlerTest : HttpClientHandlerTestBase
     {
         readonly ITestOutputHelper _output;
         private const string ExpectedContent = "Test content";

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpClientTestBase : RemoteExecutorTestBase
+    public abstract class HttpClientHandlerTestBase : RemoteExecutorTestBase
     {
         protected virtual bool UseSocketsHttpHandler => true;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpClientMiniStress : HttpClientTestBase
+    public abstract class HttpClientMiniStress : HttpClientHandlerTestBase
     {
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(GetStressOptions))]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract partial class HttpClientTest
+    public sealed partial class HttpClientTest
     {
         [Fact]
         public async Task PatchAsync_Canceled_Throws()
@@ -41,7 +41,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void Dispose_UsePatchAfterDispose_Throws()
         {
-            HttpClient client = CreateHttpClient();
+            var client = new HttpClient(new CustomResponseHandler((r, c) => Task.FromResult(new HttpResponseMessage())));
             client.Dispose();
 
             Assert.Throws<ObjectDisposedException>(() => { client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])); });

--- a/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpCookieProtocolTests.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class HttpCookieProtocolTests : HttpClientTestBase
+    public abstract class HttpCookieProtocolTests : HttpClientHandlerTestBase
     {
         public static readonly object[][] EchoServers = Configuration.Http.EchoServers;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpProtocolTests : HttpClientTestBase
+    public abstract class HttpProtocolTests : HttpClientHandlerTestBase
     {
         protected virtual Stream GetStream(Stream s) => s;
         protected virtual Stream GetStream_ClientDisconnectOk(Stream s) => s;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public class HttpRequestMessageTest : HttpClientTestBase
+    public class HttpRequestMessageTest : HttpClientHandlerTestBase
     {
         Version _expectedRequestMessageVersion = !PlatformDetection.IsFullFramework ? new Version(2,0) : new Version(1, 1);
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpRetryProtocolTests : HttpClientTestBase
+    public abstract class HttpRetryProtocolTests : HttpClientHandlerTestBase
     {
         private static readonly string s_simpleContent = "Hello World\r\n";
 

--- a/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class IdnaProtocolTests : HttpClientTestBase
+    public abstract class IdnaProtocolTests : HttpClientHandlerTestBase
     {
         protected abstract bool SupportsIdna { get; }
 

--- a/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -21,11 +21,6 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => false;
     }
 
-    public sealed class PlatformHandler_HttpClientTest : HttpClientTest
-    {
-        protected override bool UseSocketsHttpHandler => false;
-    }
-
     public sealed class PlatformHandler_DiagnosticsTest : DiagnosticsTest
     {
         protected override bool UseSocketsHttpHandler => false;

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
 
     // Note:  Disposing the HttpClient object automatically disposes the handler within. So, it is not necessary
     // to separately Dispose (or have a 'using' statement) for the handler.
-    public abstract class PostScenarioTest : HttpClientTestBase
+    public abstract class PostScenarioTest : HttpClientHandlerTestBase
     {
         private const string ExpectedContent = "Test contest";
         private const string UserName = "user1";

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioUWPTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioUWPTest.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class PostScenarioUWPTest : HttpClientTestBase
+    public abstract class PostScenarioUWPTest : HttpClientHandlerTestBase
     {
         private readonly ITestOutputHelper _output;
 

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public abstract class ResponseStreamTest : HttpClientTestBase
+    public abstract class ResponseStreamTest : HttpClientHandlerTestBase
     {
         private readonly ITestOutputHelper _output;
         

--- a/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http.Functional.Tests
 {
     [ActiveIssue(26539)]    // Flaky test
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "HttpsTestServer not compatible on UAP")]
-    public abstract class SchSendAuxRecordHttpTest : HttpClientTestBase
+    public abstract class SchSendAuxRecordHttpTest : HttpClientHandlerTestBase
     {
         readonly ITestOutputHelper _output;
         

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public sealed class SocketsHttpHandler_HttpClientHandler_Http2_Test : HttpClientTestBase
+    public sealed class SocketsHttpHandler_HttpClientHandler_Http2_Test : HttpClientHandlerTestBase
     {
         protected override bool UseSocketsHttpHandler => true;
         public static bool SupportsAlpn => PlatformDetection.SupportsAlpn;

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -104,11 +104,6 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => true;
     }
 
-    public sealed class SocketsHttpHandler_HttpClientTest : HttpClientTest
-    {
-        protected override bool UseSocketsHttpHandler => true;
-    }
-
     public sealed class SocketsHttpHandler_DiagnosticsTest : DiagnosticsTest
     {
         protected override bool UseSocketsHttpHandler => true;

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -724,7 +724,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    public sealed class SocketsHttpHandler_ConnectionUpgrade_Test : HttpClientTestBase
+    public sealed class SocketsHttpHandler_ConnectionUpgrade_Test : HttpClientHandlerTestBase
     {
         protected override bool UseSocketsHttpHandler => true;
 
@@ -843,7 +843,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    public sealed class SocketsHttpHandler_Connect_Test : HttpClientTestBase
+    public sealed class SocketsHttpHandler_Connect_Test : HttpClientHandlerTestBase
     {
         protected override bool UseSocketsHttpHandler => true;
 
@@ -932,7 +932,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    public sealed class SocketsHttpHandler_HttpClientHandler_ConnectionPooling_Test : HttpClientTestBase
+    public sealed class SocketsHttpHandler_HttpClientHandler_ConnectionPooling_Test : HttpClientHandlerTestBase
     {
         protected override bool UseSocketsHttpHandler => true;
 
@@ -1553,7 +1553,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    public sealed class SocketsHttpHandler_ExternalConfiguration_Test : HttpClientTestBase
+    public sealed class SocketsHttpHandler_ExternalConfiguration_Test : HttpClientHandlerTestBase
     {
         private const string EnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER";
         private const string AppContextSettingName = "System.Net.Http.UseSocketsHttpHandler";

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -92,7 +92,7 @@
     <Compile Include="HttpClientHandlerTest.SslProtocols.Unix.cs" Condition="'$(TargetsUnix)' == 'true'" />
     <Compile Include="HttpClientHandlerTest.SslProtocols.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="DiagnosticsTests.cs" />
-    <Compile Include="HttpClientTestBase.cs" />
+    <Compile Include="HttpClientHandlerTestBase.cs" />
     <Compile Include="HttpClientTest.cs" />
     <Compile Include="HttpClientEKUTest.cs" />
     <Compile Include="HttpClientMiniStressTest.cs" />


### PR DESCRIPTION
HttpClientTest contains tests for the HttpClient class. Currently, it is mostly, but not entirely, independent of the actual HttpClientHandler used.

Clean this up so it no longer relies on the HttpClientHandler. This means:
(1) Moving a couple tests to HttpClientHandlerTest
(2) Modifying a few tests to use the mock handler instead of a real handler (most were already doing this)

With this change, HttpClientTest no longer needs to derive from HttpClientTestBase, so remove the dependency and handler-specific derivations.

Also, rename HttpClientTestBase to HttpClientHandlerTestBase.

There are two commits in this PR. The first contains all the significant code changes. The second is simply the rename from HttpClientTestBase -> HttpClientHandlerTestBase.

@dotnet/ncl 
