### PR TITLE
Correctly honour the "breakOnFirstError" parameter 

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -406,8 +406,8 @@ namespace System.ComponentModel.DataAnnotations
             errors.AddRange(GetObjectPropertyValidationErrors(instance, validationContext, validateAllProperties,
                 breakOnFirstError));
 
-            // We only proceed to Step 2 if there are no errors
-            if (errors.Any())
+            // We only proceed to Step 2 if there are no errors OR breakOnFirstError is false
+            if (breakOnFirstError && errors.Any())
             {
                 return errors;
             }
@@ -416,8 +416,8 @@ namespace System.ComponentModel.DataAnnotations
             var attributes = _store.GetTypeValidationAttributes(validationContext);
             errors.AddRange(GetValidationErrors(instance, validationContext, attributes, breakOnFirstError));
 
-            // We only proceed to Step 3 if there are no errors
-            if (errors.Any())
+            // We only proceed to Step 3 if there are no errors OR breakOnFirstError is false
+            if (breakOnFirstError && errors.Any())
             {
                 return errors;
             }

--- a/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
@@ -148,8 +148,10 @@ namespace System.ComponentModel.DataAnnotations.Tests
             var validationResults = new List<ValidationResult>();
             Assert.False(
                 Validator.TryValidateObject(objectToBeValidated, validationContext, validationResults, true));
-            Assert.Equal(1, validationResults.Count);
+            Assert.Equal(2, validationResults.Count);
             Assert.Equal("ValidClassAttribute.IsValid failed for class of type " + typeof(InvalidToBeValidated).FullName, validationResults[0].ErrorMessage);
+            Assert.Equal("class Validate method failed", validationResults[1].ErrorMessage);
+
         }
 
         [Fact]
@@ -961,7 +963,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
         }
 
         [ValidClass]
-        public class InvalidToBeValidated
+        public class InvalidToBeValidated  : IValidatableObject
         {
             [ValidValueStringProperty]
             public string PropertyToBeTested { get; set; }
@@ -971,6 +973,11 @@ namespace System.ComponentModel.DataAnnotations.Tests
             [Required]
             [ValidValueStringProperty]
             public string PropertyWithRequiredAttribute { get; set; }
+
+            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+            {
+                return new List<ValidationResult> {new ValidationResult("class Validate method failed")};
+            }
         }
     }
 }


### PR DESCRIPTION
in the "Validator.GetObjectValidationErrors" method, so that the "IValidatableObject.Validate" method is called when "breakOnFirstError" is false and there are earlier validation-attribute-related errors.

No-where in the documentation does it say that you cannot mix attribute and class-based Validate methods. Therefore, the Validator should return ALL relevant ValidationResult objects when "breakOnFirstError" is set to false.