### PR TITLE
Remove UNC path check from System.Drawing.Icon.ExtractAssociatedIcon

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -178,11 +178,6 @@ namespace System.Drawing
                 uri = new Uri(filePath);
             }
 
-            if (uri.IsUnc)
-            {
-                throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(filePath), filePath));
-            }
-
             if (!uri.IsFile)
             {
                 return null;

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -388,13 +388,25 @@ namespace System.Drawing.Tests
             ExtractAssociatedIcon_FilePath_Success(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [PlatformSpecific(TestPlatforms.Windows)] // UNC
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Fix for #34122
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ExtractAssociatedIcon_UNCFilePath_Success()
         {
             string bitmapPath = Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico");
             string bitmapPathRoot = Path.GetPathRoot(bitmapPath);
             string bitmapUncPath = $"\\\\{Environment.MachineName}\\{bitmapPath.Substring(0, bitmapPathRoot.IndexOf(":"))}$\\{bitmapPath.Replace(bitmapPathRoot, "")}";
+
+            // Some path could not be accessible
+            // if so we just pass the test
+            try
+            {
+                File.Open(bitmapUncPath, FileMode.Open, FileAccess.Read, FileShare.Read).Dispose();
+            }
+            catch(IOException)
+            {
+                return;
+            }
 
             Assert.True(new Uri(bitmapUncPath).IsUnc);
 
@@ -423,7 +435,6 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentNullException, ArgumentException>("filePath", null, () => Icon.ExtractAssociatedIcon(null));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ExtractAssociatedIcon_InvalidFilePath_ThrowsArgumentException()
         {

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -385,7 +385,24 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ExtractAssociatedIcon_FilePath_Success()
         {
-            using (Icon icon = Icon.ExtractAssociatedIcon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            ExtractAssociatedIcon_FilePath_Success(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
+        }
+
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void ExtractAssociatedIcon_UNCFilePath_Success()
+        {
+            string bitmapPath = Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico");
+            string bitmapPathRoot = Path.GetPathRoot(bitmapPath);
+            string bitmapUncPath = $"\\\\{Environment.MachineName}\\{bitmapPath.Substring(0, bitmapPathRoot.IndexOf(":"))}$\\{bitmapPath.Replace(bitmapPathRoot, "")}";
+
+            Assert.True(new Uri(bitmapUncPath).IsUnc);
+
+            ExtractAssociatedIcon_FilePath_Success(bitmapUncPath);
+        }
+
+        private void ExtractAssociatedIcon_FilePath_Success(string filePath)
+        {
+            using (Icon icon = Icon.ExtractAssociatedIcon(filePath))
             {
                 Assert.Equal(32, icon.Width);
                 Assert.Equal(32, icon.Height);
@@ -406,12 +423,10 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
-        [InlineData("", "path")]
-        [InlineData("\\\\uncpath", null)]
-        public void ExtractAssociatedIcon_InvalidFilePath_ThrowsArgumentException(string filePath, string paramName)
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void ExtractAssociatedIcon_InvalidFilePath_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(paramName, null, () => Icon.ExtractAssociatedIcon(filePath));
+            AssertExtensions.Throws<ArgumentException>("path", null, () => Icon.ExtractAssociatedIcon(""));
         }
 
 

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -389,7 +389,7 @@ namespace System.Drawing.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)] // UNC
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Fix for #34122
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fix for #34122")]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ExtractAssociatedIcon_UNCFilePath_Success()
         {

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -388,6 +388,7 @@ namespace System.Drawing.Tests
             ExtractAssociatedIcon_FilePath_Success(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ExtractAssociatedIcon_UNCFilePath_Success()
         {


### PR DESCRIPTION
closes https://github.com/dotnet/corefx/issues/34122

/cc @safern @maryamariyan @danmosemsft 