### PR TITLE
Remove unnecessary checks in ConsumeNumber (#33294)

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -647,21 +647,18 @@ namespace System.Text.Json
 
             if (_consumed >= (uint)_buffer.Length)
             {
+                Debug.Assert(IsLastSpan);
+
                 if (!_isNotPrimitive)
                 {
                     return true;
                 }
-                if (IsLastSpan || !GetNextSpan())
-                {
-                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, _buffer[_consumed - 1]);
-                }
+
+                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, _buffer[_consumed - 1]);
             }
 
-            // TODO: https://github.com/dotnet/corefx/issues/33294
-            if (JsonConstants.Delimiters.IndexOf(_buffer[_consumed]) < 0)
-            {
-                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, _buffer[_consumed]);
-            }
+            Debug.Assert(JsonConstants.Delimiters.IndexOf(_buffer[_consumed]) >= 0);
+
             return true;
         }
 
@@ -1306,7 +1303,7 @@ namespace System.Text.Json
                 if (IsLastSpan)
                 {
                     // A payload containing a single value: "0" is valid
-                    // If we are v with multi-value JSON,
+                    // If we are dealing with multi-value JSON,
                     // ConsumeNumber will validate that we have a delimiter following the "0".
                     return ConsumeNumberResult.Success;
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -649,11 +649,6 @@ namespace System.Text.Json
             {
                 Debug.Assert(IsLastSpan);
 
-                if (!_isNotPrimitive)
-                {
-                    return true;
-                }
-
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, _buffer[_consumed - 1]);
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -687,11 +687,6 @@ namespace System.Text.Json
             {
                 Debug.Assert(IsLastSpan);
 
-                if (!_isNotPrimitive)
-                {
-                    return true;
-                }
-
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, _buffer[_consumed - 1]);
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -685,22 +685,18 @@ namespace System.Text.Json
 
             if (_consumed >= (uint)_buffer.Length)
             {
+                Debug.Assert(IsLastSpan);
+
                 if (!_isNotPrimitive)
                 {
                     return true;
                 }
-                if (IsLastSpan)
-                {
-                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, _buffer[_consumed - 1]);
-                }
-                return false;
+
+                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, _buffer[_consumed - 1]);
             }
 
-            // TODO: https://github.com/dotnet/corefx/issues/33294
-            if (JsonConstants.Delimiters.IndexOf(_buffer[_consumed]) < 0)
-            {
-                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, _buffer[_consumed]);
-            }
+            Debug.Assert(JsonConstants.Delimiters.IndexOf(_buffer[_consumed]) >= 0);
+
             return true;
         }
 
@@ -1058,7 +1054,7 @@ namespace System.Text.Json
                 if (IsLastSpan)
                 {
                     // A payload containing a single value: "0" is valid
-                    // If we are v with multi-value JSON,
+                    // If we are dealing with multi-value JSON,
                     // ConsumeNumber will validate that we have a delimiter following the "0".
                     return ConsumeNumberResult.Success;
                 }


### PR DESCRIPTION
## Summary

Removes redundant checks in `ConsumeNumber` / `ConsumeNumberMultiSegment` which are ensured as postconditions of the wrapped method `TryGetNumber` / `TryGetNumberMultiSegment`. This adresses the most obvious optimization of #33294 (and fixes two typos in associated comments).

### ConsumeNumber
`TryGetNumber` returns `true` if and only if one of the following expressions is true:

- `_consumed < _buffer.Length && JsonConstants.Delimiters.IndexOf(_buffer[_consumed]) >= 0`
- `_consumed >= _buffer.Length && IsLastSpan`

The first expression represents the standard case; there is data left, and the parsed number is terminated with a delimiter. The second expression is only valid if a "primitive" (payload consisting of only a number) is being parsed.

The checks in `ConsumeNumber` have been reduced to the required minimum to ensure correctness. Especially the not inexpensive check `JsonConstants.Delimiters.IndexOf(_buffer[_consumed]) >= 0` could be removed (replaced with an assertion). I figured the introduced assertions make sense to ensure the postconditions of `TryGetNumber` don't change unnoticed.

### ConsumeNumberMultiSegment
A similar situation presents itself with `TryGetNumberMultiSegment`. It returns `true` if and  only if one of the following expressions is true:

- `_consumed < _buffer.Length && JsonConstants.Delimiters.IndexOf(_buffer[_consumed]) >= 0`
- `_consumed >= _buffer.Length && IsLastSpan && !GetNextSpan()`
- `_consumed >= _buffer.Length && IsLastSpan`

The first expression represents the standard case; there is data left, and the parsed number is terminated with a delimiter. The second and third expression is only valid if a "primitive" (payload consisting of only a number) is being parsed.

The checks in `ConsumeNumberMultiSegment` have been reduced to the required minimum to ensure correctness. Especially the not inexpensive check `JsonConstants.Delimiters.IndexOf(_buffer[_consumed]) >= 0` could be removed (replaced with an assertion). I figured the introduced assertions make sense to ensure the postconditions of `TryGetNumberMultiSegment` don't change unnoticed.


/cc @ahsonkhan