### PR TITLE
Removing some ApiCompat workarounds

### DIFF
--- a/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
+++ b/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
@@ -6,11 +6,4 @@
     <!-- use the most recent MS.NETCore.App we have from upstack -->
     <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
-  <ItemGroup Condition="'$(RuntimeIdentifier)' != ''">
-    <!-- The following types were moved into S.P.Corelib and can be removed
-         from this list after core-setup syncs: https://github.com/dotnet/corefx/issues/33487 -->
-    <IgnoredTypes Include="System.Buffers.StandardFormat" />
-    <IgnoredTypes Include="System.Buffers.Text.Utf8Formatter" />
-    <IgnoredTypes Include="System.Buffers.Text.Utf8Parser" />
-  </ItemGroup>
 </Project>

--- a/src/System.Runtime.Intrinsics/src/ApiCompatBaseline.netcoreappaot.txt
+++ b/src/System.Runtime.Intrinsics/src/ApiCompatBaseline.netcoreappaot.txt
@@ -1,5 +1,0 @@
-Compat issues with assembly System.Runtime.Intrinsics:
-TypesMustExist : Type 'System.Runtime.Intrinsics.Vector128' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Runtime.Intrinsics.Vector256' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Runtime.Intrinsics.Vector64' does not exist in the implementation but it does exist in the contract.
-Total Issues: 3


### PR DESCRIPTION
Now that all the various dependencies have been updated and have synced back, we can resolve https://github.com/dotnet/corefx/issues/33487 and https://github.com/dotnet/corefx/pull/34449#issuecomment-452520161

CC. @ericstj, @fiigii 