### PR TITLE
Fix CVE-2019-0545: .NET Core Information Disclosure Vulnerability (.NET Core 3.0)

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -512,9 +512,45 @@ namespace System.Net.Http
                 var response = new HttpResponseMessage() { RequestMessage = request, Content = new HttpConnectionResponseContent() };
                 ParseStatusLine(await ReadNextResponseHeaderLineAsync().ConfigureAwait(false), response);
 
-                // If we sent an Expect: 100-continue header, handle the response accordingly. Note that the developer
-                // may have added an Expect: 100-continue header even if there is no Content.
-                if (hasExpectContinueHeader)
+                // Multiple 1xx responses handling.
+                // RFC 7231: A client MUST be able to parse one or more 1xx responses received prior to a final response,
+                // even if the client does not expect one. A user agent MAY ignore unexpected 1xx responses.
+                // In .NET Core, apart from 100 Continue, and 101 Switching Protocols, we will treat all other 1xx responses
+                // as unknown, and will discard them.
+                while ((int)response.StatusCode >= 100 && (int)response.StatusCode <= 199)
+                {
+                    // If other 1xx responses come before a expected 100 continue, we will wait for the 100 response before
+                    // sending request body (if any).
+                    if (allowExpect100ToContinue != null && response.StatusCode == HttpStatusCode.Continue)
+                    {
+                        allowExpect100ToContinue.TrySetResult(true);
+                        allowExpect100ToContinue = null;
+                    }
+                    else if (response.StatusCode == HttpStatusCode.SwitchingProtocols)
+                    {
+                        // 101 Upgrade is a final response as it's used to switch protocols with WebSockets handshake.
+                        // Will return a response object with status 101 and a raw connection stream later.
+                        // RFC 7230: If a server receives both an Upgrade and an Expect header field with the "100-continue" expectation,
+                        // the server MUST send a 100 (Continue) response before sending a 101 (Switching Protocols) response.
+                        // If server doesn't follow RFC, we treat 101 as a final response and stop waiting for 100 continue - as if server
+                        // never sends a 100-continue. The request body will be sent after expect100Timer expires.
+                        break;
+                    }
+
+                    // In case read hangs which eventually leads to connection timeout.
+                    if (NetEventSource.IsEnabled) Trace($"Current {response.StatusCode} response is an interim response or not expected, need to read for a final response.");
+
+                    // Discard headers that come with the interim 1xx responses.
+                    // RFC7231: 1xx responses are terminated by the first empty line after the status-line.
+                    while (!IsLineEmpty(await ReadNextResponseHeaderLineAsync().ConfigureAwait(false)));
+
+                    // Parse the status line for next response.
+                    ParseStatusLine(await ReadNextResponseHeaderLineAsync().ConfigureAwait(false), response);
+                }
+
+                // If we sent an Expect: 100-continue header, and didn't receive a 100-continue. Handle the final response accordingly.
+                // Note that the developer may have added an Expect: 100-continue header even if there is no Content.
+                if (allowExpect100ToContinue != null)
                 {
                     if ((int)response.StatusCode >= 300 &&
                         request.Content != null &&
@@ -533,22 +569,9 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        // For any success or informational status codes (including 100 continue), or for errors when the request content
-                        // length is known to be small, send the payload (if there is one... if there isn't, Content is null and thus
-                        // allowExpect100ToContinue is also null).
-                        allowExpect100ToContinue?.TrySetResult(true);
-
-                        // And if this was 100 continue, deal with the extra headers.
-                        if (response.StatusCode == HttpStatusCode.Continue)
-                        {
-                            // We got our continue header.  Read the subsequent empty line and parse the additional status line.
-                            if (!LineIsEmpty(await ReadNextResponseHeaderLineAsync().ConfigureAwait(false)))
-                            {
-                                ThrowInvalidHttpResponse();
-                            }
-
-                            ParseStatusLine(await ReadNextResponseHeaderLineAsync().ConfigureAwait(false), response);
-                        }
+                        // For any success status codes or for errors when the request content length is known to be small, send the payload
+                        // (if there is one... if there isn't, Content is null and thus allowExpect100ToContinue is also null, we won't get here).
+                        allowExpect100ToContinue.TrySetResult(true);
                     }
                 }
 
@@ -568,7 +591,7 @@ namespace System.Net.Http
                 while (true)
                 {
                     ArraySegment<byte> line = await ReadNextResponseHeaderLineAsync(foldedHeadersAllowed: true).ConfigureAwait(false);
-                    if (LineIsEmpty(line))
+                    if (IsLineEmpty(line))
                     {
                         break;
                     }
@@ -723,7 +746,7 @@ namespace System.Net.Http
             }, _weakThisRef);
         }
 
-        private static bool LineIsEmpty(ArraySegment<byte> line) => line.Count == 0;
+        private static bool IsLineEmpty(ArraySegment<byte> line) => line.Count == 0;
 
         private async Task SendRequestContentAsync(HttpRequestMessage request, HttpContentWriteStream stream, CancellationToken cancellationToken)
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -342,7 +342,6 @@ namespace System.Net.Http
 
             _currentRequest = request;
             HttpMethod normalizedMethod = HttpMethod.Normalize(request.Method);
-            bool hasExpectContinueHeader = request.HasHeaders && request.Headers.ExpectContinue == true;
 
             Debug.Assert(!_canRetry);
             _canRetry = true;
@@ -451,6 +450,7 @@ namespace System.Net.Http
                 }
                 else
                 {
+                    bool hasExpectContinueHeader = request.HasHeaders && request.Headers.ExpectContinue == true;
                     if (NetEventSource.IsEnabled) Trace($"Request content is not null, start processing it. hasExpectContinueHeader = {hasExpectContinueHeader}");
 
                     // Send the body if there is one.  We prefer to serialize the sending of the content before
@@ -517,9 +517,9 @@ namespace System.Net.Http
                 // even if the client does not expect one. A user agent MAY ignore unexpected 1xx responses.
                 // In .NET Core, apart from 100 Continue, and 101 Switching Protocols, we will treat all other 1xx responses
                 // as unknown, and will discard them.
-                while ((int)response.StatusCode >= 100 && (int)response.StatusCode <= 199)
+                while ((uint)(response.StatusCode - 100) <= 199 - 100)
                 {
-                    // If other 1xx responses come before a expected 100 continue, we will wait for the 100 response before
+                    // If other 1xx responses come before an expected 100 continue, we will wait for the 100 response before
                     // sending request body (if any).
                     if (allowExpect100ToContinue != null && response.StatusCode == HttpStatusCode.Continue)
                     {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2019,12 +2019,8 @@ namespace System.Net.Http.Functional.Tests
             const string SetCookieExpected = "theme=light";
             const string ContentTypeHeaderExpected = "text/html";
 
-            const string CookieHeaderIgnored1 = "ignore_cookie=choco1";
-            const string CookieHeaderIgnored2 = "ignore_cookie=choco2";
             const string SetCookieIgnored1 = "hello=world";
             const string SetCookieIgnored2 = "net=core";
-            const string ContentTypeHeaderIgnored1 = "text/xml";
-            const string ContentTypeHeaderIgnored2 = "text/plain";
 
             // Set-Cookie header will not be ignored with CurlHandler.
             int containerCookiesCount = IsCurlHandler ? 3 : 1;
@@ -2059,9 +2055,9 @@ namespace System.Net.Http.Functional.Tests
                 {
                     // Send 100-Continue responses with additional headers.
                     await connection.ReadRequestHeaderAndSendResponseAsync(responseStatusCode, additionalHeaders:
-                        $"Cookie: {CookieHeaderIgnored1}\r\n" + $"Content-type: {ContentTypeHeaderIgnored1}\r\n" + $"Set-Cookie: {SetCookieIgnored1}\r\n");
+                        "Cookie: ignore_cookie=choco1\r\n" + "Content-type: text/xml\r\n" + $"Set-Cookie: {SetCookieIgnored1}\r\n");
                     await connection.SendResponseAsync(responseStatusCode, additionalHeaders:
-                        $"Cookie: {CookieHeaderIgnored2}\r\n" + $"Content-type: {ContentTypeHeaderIgnored2}\r\n" + $"Set-Cookie: {SetCookieIgnored2}\r\n");
+                        "Cookie: ignore_cookie=choco2\r\n" + "Content-type: text/plain\r\n" + $"Set-Cookie: {SetCookieIgnored2}\r\n");
 
                     var result = new char[TestString.Length];
                     await connection.Reader.ReadAsync(result, 0, TestString.Length);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1995,6 +1995,240 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        public static IEnumerable<object[]> Interim1xxStatusCode()
+        {
+            yield return new object[] { (HttpStatusCode) 100 }; // 100 Continue.
+            // 101 SwitchingProtocols will be treated as a final status code.
+            yield return new object[] { (HttpStatusCode) 102 }; // 102 Processing.
+            yield return new object[] { (HttpStatusCode) 103 }; // 103 EarlyHints.
+            yield return new object[] { (HttpStatusCode) 150 };
+            yield return new object[] { (HttpStatusCode) 180 };
+            yield return new object[] { (HttpStatusCode) 199 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Interim1xxStatusCode))]
+        public async Task SendAsync_1xxResponsesWithHeaders_InterimResponsesHeadersIgnored(HttpStatusCode responseStatusCode)
+        {
+            // Skip test on .NET Framework since it doesn't have the fix.
+            if (PlatformDetection.IsFullFramework && (int)responseStatusCode >= 102) return;
+
+            var clientFinished = new TaskCompletionSource<bool>();
+            const string TestString = "test";
+            const string CookieHeaderExpected = "yummy_cookie=choco";
+            const string SetCookieExpected = "theme=light";
+            const string ContentTypeHeaderExpected = "text/html";
+
+            const string CookieHeaderIgnored1 = "ignore_cookie=choco1";
+            const string CookieHeaderIgnored2 = "ignore_cookie=choco2";
+            const string SetCookieIgnored1 = "hello=world";
+            const string SetCookieIgnored2 = "net=core";
+            const string ContentTypeHeaderIgnored1 = "text/xml";
+            const string ContentTypeHeaderIgnored2 = "text/plain";
+
+            // Set-Cookie header will not be ignored with CurlHandler.
+            int containerCookiesCount = IsCurlHandler ? 3 : 1;
+            string containerCookiesExpected = IsCurlHandler ?
+                SetCookieIgnored1 + "; " + SetCookieIgnored2 + "; " + SetCookieExpected : SetCookieExpected;
+
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using (var handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri);
+                    initialMessage.Content = new StringContent(TestString);
+                    initialMessage.Headers.ExpectContinue = true;
+                    HttpResponseMessage response = await client.SendAsync(initialMessage);
+
+                    // Verify status code.
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    // Verify Cookie header.
+                    Assert.Equal(1, response.Headers.GetValues("Cookie").Count());
+                    Assert.Equal(CookieHeaderExpected, response.Headers.GetValues("Cookie").First().ToString());
+                    // Verify Set-Cookie header.
+                    Assert.Equal(containerCookiesCount, handler.CookieContainer.Count);
+                    Assert.Equal(containerCookiesExpected, handler.CookieContainer.GetCookieHeader(uri));
+                    // Verify Content-type header.
+                    Assert.Equal(ContentTypeHeaderExpected, response.Content.Headers.ContentType.ToString());
+                    clientFinished.SetResult(true);
+                }
+            }, async server =>
+            {
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    // Send 100-Continue responses with additional headers.
+                    await connection.ReadRequestHeaderAndSendResponseAsync(responseStatusCode, additionalHeaders:
+                        $"Cookie: {CookieHeaderIgnored1}\r\n" + $"Content-type: {ContentTypeHeaderIgnored1}\r\n" + $"Set-Cookie: {SetCookieIgnored1}\r\n");
+                    await connection.SendResponseAsync(responseStatusCode, additionalHeaders:
+                        $"Cookie: {CookieHeaderIgnored2}\r\n" + $"Content-type: {ContentTypeHeaderIgnored2}\r\n" + $"Set-Cookie: {SetCookieIgnored2}\r\n");
+
+                    var result = new char[TestString.Length];
+                    await connection.Reader.ReadAsync(result, 0, TestString.Length);
+                    Assert.Equal(TestString, new string(result));
+
+                    // Send final status code.
+                    await connection.SendResponseAsync(HttpStatusCode.OK, additionalHeaders:
+                        $"Cookie: {CookieHeaderExpected}\r\n" + $"Content-type: {ContentTypeHeaderExpected}\r\n" + $"Set-Cookie: {SetCookieExpected}\r\n");
+                    await clientFinished.Task;
+                });
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(Interim1xxStatusCode))]
+        public async Task SendAsync_Unexpected1xxResponses_DropAllInterimResponses(HttpStatusCode responseStatusCode)
+        {
+            // Skip test on .NET Framework since it doesn't have the fix.
+            if (PlatformDetection.IsFullFramework && (int)responseStatusCode >= 102) return;
+
+            var clientFinished = new TaskCompletionSource<bool>();
+            const string TestString = "test";
+
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using (var handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri);
+                    initialMessage.Content = new StringContent(TestString);
+                    // No ExpectContinue header.
+                    initialMessage.Headers.ExpectContinue = false;
+                    HttpResponseMessage response = await client.SendAsync(initialMessage);
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    clientFinished.SetResult(true);
+                }
+            }, async server =>
+            {
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    // Send unexpected 1xx responses.
+                    await connection.ReadRequestHeaderAndSendResponseAsync(responseStatusCode);
+                    await connection.SendResponseAsync(responseStatusCode);
+                    await connection.SendResponseAsync(responseStatusCode);
+
+                    var result = new char[TestString.Length];
+                    await connection.Reader.ReadAsync(result, 0, TestString.Length);
+                    Assert.Equal(TestString, new string(result));
+
+                    // Send final status code.
+                    await connection.SendResponseAsync(HttpStatusCode.OK);
+                    await clientFinished.Task;
+                });
+            });
+        }
+
+        [Fact]
+        public async Task SendAsync_MultipleExpected100Responses_ReceivesCorrectResponse()
+        {
+            var clientFinished = new TaskCompletionSource<bool>();
+            const string TestString = "test";
+            const string Valid100ContinueResponse = "HTTP/1.1 100 Continue\r\n\r\n";
+
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using (var handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri);
+                    initialMessage.Content = new StringContent(TestString);
+                    initialMessage.Headers.ExpectContinue = true;
+                    HttpResponseMessage response = await client.SendAsync(initialMessage);
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    clientFinished.SetResult(true);
+                }
+            }, async server =>
+            {
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    // Send multiple 100-Continue responses.
+                    await connection.ReadRequestHeaderAndSendCustomResponseAsync(
+                        string.Concat(Enumerable.Repeat(Valid100ContinueResponse, 3)));
+
+                    var result = new char[TestString.Length];
+                    await connection.Reader.ReadAsync(result, 0, TestString.Length);
+                    Assert.Equal(TestString, new string(result));
+
+                    // Send final status code.
+                    await connection.SendResponseAsync(HttpStatusCode.OK);
+                    await clientFinished.Task;
+                });
+            });
+        }
+
+        [Fact]
+        public async Task SendAsync_No100ContinueReceived_RequestBodySentEventually()
+        {
+            // CurlHandler will not send request body if it doesn't see 100-Continue.
+            // This is not correct. Per RFC 7231: A client that sends a 100-continue expectation is not required
+            // to wait for any specific length of time; such a client MAY proceed to send the message body even
+            // if it has not yet received a response.
+            if (IsCurlHandler) return;
+
+            var clientFinished = new TaskCompletionSource<bool>();
+            const string TestString = "test";
+
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using (var handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri);
+                    initialMessage.Content = new StringContent(TestString);
+                    initialMessage.Headers.ExpectContinue = true;
+                    HttpResponseMessage response = await client.SendAsync(initialMessage);
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    clientFinished.SetResult(true);
+                }
+            }, async server =>
+            {
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    // Send final status code 200.
+                    await connection.ReadRequestHeaderAndSendResponseAsync();
+
+                    var result = new char[TestString.Length];
+                    await connection.Reader.ReadAsync(result, 0, TestString.Length);
+                    Assert.Equal(TestString, new string(result));
+
+                    await clientFinished.Task;
+                });
+            });
+        }
+
+        [Fact]
+        public async Task SendAsync_101SwitchingProtocolsResponse_Success()
+        {
+            // WinHttpHandler and CurlHandler will hang, waiting for additional response.
+            // Other handlers will accept 101 as a final response.
+            if (IsWinHttpHandler || IsCurlHandler) return;
+
+            var clientFinished = new TaskCompletionSource<bool>();
+
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using (var handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    HttpResponseMessage response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead);
+                    Assert.Equal(HttpStatusCode.SwitchingProtocols, response.StatusCode);
+                    clientFinished.SetResult(true);
+                }
+            }, async server =>
+            {
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    // Send a valid 101 Switching Protocols response.
+                    await connection.ReadRequestHeaderAndSendCustomResponseAsync(
+                        "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n\r\n");
+                    await clientFinished.Task;
+                });
+            });
+        }
+
         [ActiveIssue(30061, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData(false)]


### PR DESCRIPTION
This PR fixes CVE-2019-0545: .NET Core Information Disclosure Vulnerability (#34428) for unreleased 3.0 branch.

Here is a summary for all 100-continue security related issues with SocketsHttpHandler:

1. #31412, #30311 and #31423 (external find): SocketsHttpHandler doesn't support response headers with a 100 status code.
2. #31413: SocketsHttpHandler doesn't support receiving multiple "100 continue" status responses.
a.	If the “100-continue” response is expected, we must handle it (or multiple instances of 100 responses).
b.	If not expected, parse and discard those responses.

@dotnet/ncl 

Close: #31412, #30311, #31423, #31413.