### PR TITLE
Disable EventLogRecordTests.FormatDescription test that's failing frequently

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
@@ -28,6 +28,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [ActiveIssue(34547)]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [InlineData("System")]


### PR DESCRIPTION
cc: @danmosemsft, @maryamariyan 